### PR TITLE
Replace easy-parallel with scoped-pool for path searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +931,7 @@ dependencies = [
  "rand 0.8.3",
  "replace_with",
  "resvg",
+ "scoped-pool",
  "seahash",
  "serde",
  "serde_json",
@@ -1067,7 +1074,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
- "scopeguard",
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -1677,10 +1684,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-pool"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817a3a15e704545ce59ed2b5c60a5d32bda4d7869befb8b36667b658a6c00b43"
+dependencies = [
+ "crossbeam",
+ "scopeguard 0.1.2",
+ "variance",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a076157c1e2dc561d8de585151ee6965d910dd4dcb5dabb7ae3e83981a6c57"
 
 [[package]]
 name = "scopeguard"
@@ -2073,6 +2097,12 @@ checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
 dependencies = [
  "ctor",
 ]
+
+[[package]]
+name = "variance"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abfc2be1fb59663871379ea884fd81de80c496f2274e021c01d6fe56cd77b05"
 
 [[package]]
 name = "vec-arena"

--- a/gpui/Cargo.toml
+++ b/gpui/Cargo.toml
@@ -18,8 +18,9 @@ pathfinder_geometry = "0.5"
 rand = "0.8.3"
 replace_with = "0.1.7"
 resvg = "0.14"
+scoped-pool = "1.0.0"
 seahash = "4.1"
-serde = { version = "1.0.125", features = ["derive"] }
+serde = {version = "1.0.125", features = ["derive"]}
 serde_json = "1.0.64"
 smallvec = "1.6.1"
 smol = "1.2"

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -414,6 +414,7 @@ impl MutableAppContext {
                 windows: HashMap::new(),
                 ref_counts: Arc::new(Mutex::new(RefCounts::default())),
                 background: Arc::new(executor::Background::new()),
+                scoped_pool: scoped_pool::Pool::new(num_cpus::get()),
             },
             actions: HashMap::new(),
             global_actions: HashMap::new(),
@@ -1336,6 +1337,7 @@ pub struct AppContext {
     windows: HashMap<usize, Window>,
     background: Arc<executor::Background>,
     ref_counts: Arc<Mutex<RefCounts>>,
+    scoped_pool: scoped_pool::Pool,
 }
 
 impl AppContext {
@@ -1373,6 +1375,10 @@ impl AppContext {
 
     pub fn background_executor(&self) -> &Arc<executor::Background> {
         &self.background
+    }
+
+    pub fn scoped_pool(&self) -> &scoped_pool::Pool {
+        &self.scoped_pool
     }
 }
 

--- a/gpui/src/lib.rs
+++ b/gpui/src/lib.rs
@@ -29,3 +29,4 @@ pub use presenter::{
     AfterLayoutContext, Axis, DebugContext, EventContext, LayoutContext, PaintContext,
     SizeConstraint, Vector2FExt,
 };
+pub use scoped_pool;

--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -347,7 +347,7 @@ impl FileFinder {
     fn spawn_search(&mut self, query: String, ctx: &mut ViewContext<Self>) {
         let worktrees = self.worktrees(ctx.as_ref());
         let search_id = util::post_inc(&mut self.search_count);
-        let pool = ctx.app().scoped_pool().clone();
+        let pool = ctx.as_ref().scoped_pool().clone();
         let task = ctx.background_executor().spawn(async move {
             let matches = match_paths(worktrees.as_slice(), &query, false, false, 100, pool);
             (search_id, matches)

--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -347,8 +347,9 @@ impl FileFinder {
     fn spawn_search(&mut self, query: String, ctx: &mut ViewContext<Self>) {
         let worktrees = self.worktrees(ctx.as_ref());
         let search_id = util::post_inc(&mut self.search_count);
+        let pool = ctx.app().scoped_pool().clone();
         let task = ctx.background_executor().spawn(async move {
-            let matches = match_paths(worktrees.as_slice(), &query, false, false, 100);
+            let matches = match_paths(worktrees.as_slice(), &query, false, false, 100, pool);
             (search_id, matches)
         });
 


### PR DESCRIPTION
The easy-parallel crate spawned new threads on each call, which was resulting in spawning a ton of threads every time we ran a path match query. Instead, I'm installing a scoped-pool that we can use in a similar way to easy-parallel but with a bounded number of threads that live for the lifetime of the app.