### PR TITLE
Dispatch global actions only once when triggering a menu item

### DIFF
--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -141,12 +141,13 @@ impl App {
                 {
                     let presenter = presenter.clone();
                     let path = presenter.borrow().dispatch_path(ctx.as_ref());
-                    if ctx.dispatch_action_any(key_window_id, &path, command, arg.unwrap_or(&())) {
-                        return;
-                    }
+                    ctx.dispatch_action_any(key_window_id, &path, command, arg.unwrap_or(&()));
+                } else {
+                    ctx.dispatch_global_action_any(command, arg.unwrap_or(&()));
                 }
+            } else {
+                ctx.dispatch_global_action_any(command, arg.unwrap_or(&()));
             }
-            ctx.dispatch_global_action_any(command, arg.unwrap_or(&()));
         }));
 
         app.0.borrow_mut().weak_self = Some(Rc::downgrade(&app.0));


### PR DESCRIPTION
Previously we would dispatch the same global action more than once because we would invoke `dispatch_action_any` _and_
`dispatch_global_action_any`. However, the former already takes care of going through the global action handlers when no entity in the dispatch path handled the action.

/cc: @nathansobo @maxbrunsfeld 