### PR TITLE
Prompt for paths asynchronously to avoid double borrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "async-std",
  "async-task",
  "bindgen",
+ "block",
  "cc",
  "cocoa",
  "core-foundation",

--- a/gpui/Cargo.toml
+++ b/gpui/Cargo.toml
@@ -37,6 +37,7 @@ simplelog = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 anyhow = "1"
+block = "0.1"
 cocoa = "0.24"
 core-foundation = "0.9"
 core-graphics = "0.22.2"

--- a/gpui/src/platform/mod.rs
+++ b/gpui/src/platform/mod.rs
@@ -40,7 +40,11 @@ pub trait Platform {
         executor: Rc<executor::Foreground>,
     ) -> Box<dyn Window>;
     fn key_window_id(&self) -> Option<usize>;
-    fn prompt_for_paths(&self, options: PathPromptOptions) -> Option<Vec<PathBuf>>;
+    fn prompt_for_paths(
+        &self,
+        options: PathPromptOptions,
+        done_fn: Box<dyn FnOnce(Option<Vec<std::path::PathBuf>>)>,
+    );
     fn quit(&self);
     fn write_to_clipboard(&self, item: ClipboardItem);
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;

--- a/gpui/src/platform/test.rs
+++ b/gpui/src/platform/test.rs
@@ -70,8 +70,11 @@ impl super::Platform for Platform {
 
     fn quit(&self) {}
 
-    fn prompt_for_paths(&self, _: super::PathPromptOptions) -> Option<Vec<std::path::PathBuf>> {
-        None
+    fn prompt_for_paths(
+        &self,
+        _: super::PathPromptOptions,
+        _: Box<dyn FnOnce(Option<Vec<std::path::PathBuf>>)>,
+    ) {
     }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {

--- a/zed/src/workspace/mod.rs
+++ b/zed/src/workspace/mod.rs
@@ -29,19 +29,19 @@ pub struct OpenParams {
 }
 
 fn open(settings: &Receiver<Settings>, ctx: &mut MutableAppContext) {
-    if let Some(paths) = ctx.platform().prompt_for_paths(PathPromptOptions {
-        files: true,
-        directories: true,
-        multiple: true,
-    }) {
-        ctx.dispatch_global_action(
-            "workspace:open_paths",
-            OpenParams {
-                paths,
-                settings: settings.clone(),
-            },
-        );
-    }
+    let settings = settings.clone();
+    ctx.prompt_for_paths(
+        PathPromptOptions {
+            files: true,
+            directories: true,
+            multiple: true,
+        },
+        move |paths, ctx| {
+            if let Some(paths) = paths {
+                ctx.dispatch_global_action("workspace:open_paths", OpenParams { paths, settings });
+            }
+        },
+    );
 }
 
 fn open_paths(params: &OpenParams, app: &mut MutableAppContext) {


### PR DESCRIPTION
This pull request fixes a double borrow error caused by the modal dialog not using the same event loop as the app, which was causing Zed to process events while having a modal open, which in turn meant having an outstanding borrow to the app struct.

With these changes, we will now use the [asynchronous dialog API](https://developer.apple.com/documentation/appkit/nssavepanel/1527007-beginwithcompletionhandler?language=objc) and use the foreground executor to schedule the completion of the dialog interaction.

/cc: @nathansobo @maxbrunsfeld 