### PR TITLE
Try to run our CI on a mac mini in my closet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   tests:
     name: Tests
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
It looks like everything will have to be run through the Rosetta 2 emulator until GitHub rolls out support for the M1. For now, I just configured and run the runner with the `arch -x86_64` prefix. I think it's okay, and maybe by the time we really need to build on the M1 specifically, GitHub will have added support. This at least gets our builds going again without paying through the nose for a hosted runner.