### PR TITLE
Use our own scoped_pool implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,12 +449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1056,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
- "scopeguard 1.1.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1714,13 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-pool"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a3a15e704545ce59ed2b5c60a5d32bda4d7869befb8b36667b658a6c00b43"
+version = "0.0.1"
 dependencies = [
- "crossbeam",
- "scopeguard 0.1.2",
- "variance",
+ "crossbeam-channel 0.5.0",
 ]
 
 [[package]]
@@ -1728,12 +1718,6 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
-name = "scopeguard"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a076157c1e2dc561d8de585151ee6965d910dd4dcb5dabb7ae3e83981a6c57"
 
 [[package]]
 name = "scopeguard"
@@ -2137,12 +2121,6 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
-
-[[package]]
-name = "variance"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abfc2be1fb59663871379ea884fd81de80c496f2274e021c01d6fe56cd77b05"
 
 [[package]]
 name = "vec-arena"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ version = "2.0.2"
 dependencies = [
  "bitflags",
  "fsevent-sys",
+ "parking_lot",
  "tempdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["zed", "gpui", "fsevent"]
+members = ["zed", "gpui", "fsevent", "scoped_pool"]
 
 [patch.crates-io]
 async-task = {git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e"}

--- a/fsevent/Cargo.toml
+++ b/fsevent/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1"
 fsevent-sys = "3.0.2"
+parking_lot = "0.11.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/fsevent/examples/events.rs
+++ b/fsevent/examples/events.rs
@@ -5,12 +5,12 @@ fn main() {
     let paths = args().skip(1).collect::<Vec<_>>();
     let paths = paths.iter().map(Path::new).collect::<Vec<_>>();
     assert!(paths.len() > 0, "Must pass 1 or more paths as arguments");
-    let stream = EventStream::new(&paths, Duration::from_millis(100), |events| {
+    let (stream, _handle) = EventStream::new(&paths, Duration::from_millis(100));
+    stream.run(|events| {
         eprintln!("event batch");
         for event in events {
             eprintln!("  {:?}", event);
         }
         true
     });
-    stream.run();
 }

--- a/gpui/Cargo.toml
+++ b/gpui/Cargo.toml
@@ -18,7 +18,7 @@ postage = {version = "0.4.1", features = ["futures-traits"]}
 rand = "0.8.3"
 replace_with = "0.1.7"
 resvg = "0.14"
-scoped-pool = "1.0.0"
+scoped-pool = {path = "../scoped_pool"}
 seahash = "4.1"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_json = "1.0.64"

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -411,7 +411,7 @@ impl MutableAppContext {
                 windows: HashMap::new(),
                 ref_counts: Arc::new(Mutex::new(RefCounts::default())),
                 background: Arc::new(executor::Background::new()),
-                thread_pool: scoped_pool::Pool::new(num_cpus::get()),
+                thread_pool: scoped_pool::Pool::new(num_cpus::get(), "app"),
             },
             actions: HashMap::new(),
             global_actions: HashMap::new(),

--- a/scoped_pool/Cargo.toml
+++ b/scoped_pool/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "scoped-pool"
+version = "0.0.1"
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+crossbeam-channel = "0.5"

--- a/scoped_pool/src/lib.rs
+++ b/scoped_pool/src/lib.rs
@@ -21,11 +21,11 @@ struct Request {
 }
 
 impl Pool {
-    pub fn new(thread_count: usize, name: &str) -> Self {
+    pub fn new(thread_count: usize, name: impl AsRef<str>) -> Self {
         let (req_tx, req_rx) = chan::unbounded();
         for i in 0..thread_count {
             thread::Builder::new()
-                .name(format!("scoped_pool {} {}", name, i))
+                .name(format!("scoped_pool {} {}", name.as_ref(), i))
                 .spawn({
                     let req_rx = req_rx.clone();
                     move || loop {

--- a/scoped_pool/src/lib.rs
+++ b/scoped_pool/src/lib.rs
@@ -1,0 +1,188 @@
+use crossbeam_channel as chan;
+use std::{marker::PhantomData, mem::transmute, thread};
+
+#[derive(Clone)]
+pub struct Pool {
+    req_tx: chan::Sender<Request>,
+    thread_count: usize,
+}
+
+pub struct Scope<'a> {
+    req_count: usize,
+    req_tx: chan::Sender<Request>,
+    resp_tx: chan::Sender<()>,
+    resp_rx: chan::Receiver<()>,
+    phantom: PhantomData<&'a ()>,
+}
+
+struct Request {
+    callback: Box<dyn FnOnce() + Send + 'static>,
+    resp_tx: chan::Sender<()>,
+}
+
+impl Pool {
+    pub fn new(thread_count: usize, name: &str) -> Self {
+        let (req_tx, req_rx) = chan::unbounded();
+        for i in 0..thread_count {
+            thread::Builder::new()
+                .name(format!("scoped_pool {} {}", name, i))
+                .spawn({
+                    let req_rx = req_rx.clone();
+                    move || loop {
+                        match req_rx.recv() {
+                            Err(_) => break,
+                            Ok(Request { callback, resp_tx }) => {
+                                callback();
+                                resp_tx.send(()).ok();
+                            }
+                        }
+                    }
+                })
+                .expect("scoped_pool: failed to spawn thread");
+        }
+        Self {
+            req_tx,
+            thread_count,
+        }
+    }
+
+    pub fn thread_count(&self) -> usize {
+        self.thread_count
+    }
+
+    pub fn scoped<'scope, F, R>(&self, scheduler: F) -> R
+    where
+        F: FnOnce(&mut Scope<'scope>) -> R,
+    {
+        let (resp_tx, resp_rx) = chan::bounded(1);
+        let mut scope = Scope {
+            resp_tx,
+            resp_rx,
+            req_count: 0,
+            phantom: PhantomData,
+            req_tx: self.req_tx.clone(),
+        };
+        let result = scheduler(&mut scope);
+        scope.wait();
+        result
+    }
+}
+
+impl<'scope> Scope<'scope> {
+    pub fn execute<F>(&mut self, callback: F)
+    where
+        F: FnOnce() + Send + 'scope,
+    {
+        // Transmute the callback's lifetime to be 'static. This is safe because in ::wait,
+        // we block until all the callbacks have been called and dropped.
+        let callback = unsafe {
+            transmute::<Box<dyn FnOnce() + Send + 'scope>, Box<dyn FnOnce() + Send + 'static>>(
+                Box::new(callback),
+            )
+        };
+
+        self.req_count += 1;
+        self.req_tx
+            .send(Request {
+                callback,
+                resp_tx: self.resp_tx.clone(),
+            })
+            .unwrap();
+    }
+
+    fn wait(&self) {
+        for _ in 0..self.req_count {
+            self.resp_rx.recv().unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_execute() {
+        let pool = Pool::new(3, "test");
+
+        {
+            let vec = Mutex::new(Vec::new());
+            pool.scoped(|scope| {
+                for _ in 0..3 {
+                    scope.execute(|| {
+                        for i in 0..5 {
+                            vec.lock().unwrap().push(i);
+                        }
+                    });
+                }
+            });
+
+            let mut vec = vec.into_inner().unwrap();
+            vec.sort_unstable();
+            assert_eq!(vec, [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4])
+        }
+    }
+
+    #[test]
+    fn test_clone_send_and_execute() {
+        let pool = Pool::new(3, "test");
+
+        let mut threads = Vec::new();
+        for _ in 0..3 {
+            threads.push(thread::spawn({
+                let pool = pool.clone();
+                move || {
+                    let vec = Mutex::new(Vec::new());
+                    pool.scoped(|scope| {
+                        for _ in 0..3 {
+                            scope.execute(|| {
+                                for i in 0..5 {
+                                    vec.lock().unwrap().push(i);
+                                }
+                            });
+                        }
+                    });
+                    let mut vec = vec.into_inner().unwrap();
+                    vec.sort_unstable();
+                    assert_eq!(vec, [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4])
+                }
+            }));
+        }
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_share_and_execute() {
+        let pool = Arc::new(Pool::new(3, "test"));
+
+        let mut threads = Vec::new();
+        for _ in 0..3 {
+            threads.push(thread::spawn({
+                let pool = pool.clone();
+                move || {
+                    let vec = Mutex::new(Vec::new());
+                    pool.scoped(|scope| {
+                        for _ in 0..3 {
+                            scope.execute(|| {
+                                for i in 0..5 {
+                                    vec.lock().unwrap().push(i);
+                                }
+                            });
+                        }
+                    });
+                    let mut vec = vec.into_inner().unwrap();
+                    vec.sort_unstable();
+                    assert_eq!(vec, [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4])
+                }
+            }));
+        }
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
### Background

We're seeing memory errors when [running tests on CI](https://github.com/zed-industries/zed/runs/2393222634?check_suite_focus=true). It appears that they are caused by a call to [`Pool::shutdown`](https://github.com/zed-industries/zed/blob/265ad900344c2cd21cf5f2abc9a6b8efc4f1fa31/zed/src/worktree.rs#L849) that we're doing, in an attempt to stop worker threads when dropping a worktree.

We added this call because `scoped_pool` does not clean up its threads automatically via RAII. You have to call `shutdown`. The docs mention the possibility of deadlocks if you do this at the wrong time, but they don't indicate that the method can actually cause memory corruption 😞 .

### Fix

This PR replaces the [`scoped_pool`](https://github.com/reem/rust-scoped-pool) crate with our own very simple implementation of a similar API. 

API similarities:
* Same `Pool::scoped` method for creating a `Scope` with a fixed lifetime and blocking until its jobs have completed.
* Same `Scope::execute` method for spawning a job in the thread pool.
* `Pool` is `Send`, `Sync`, and `Clone`.

API differences:
* (minor) `Pool::new` always takes a name string that is used to tag the thread.
* (minor) Rename `Pool::workers` to `Pool::thread_count` (I just think that's clearer)
* (major) Worker threads are automatically halted when there are no more clones of their owning `Pool`
* (major) For now, the `Scope` object has more restrictions. `Scope::execute` borrows the scope mutably. This works fine for our current usages. We could relax it in the future.

### Implementation

I tried to keep the implementation super simple, using only `crossbeam_channel` for synchronization. It could probably be optimized.