### PR TITLE
Improve file finder behavior when opening large directories like `~` or `/`

### DIFF
--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -422,13 +422,13 @@ impl FileFinder {
     ) {
         if search_id >= self.latest_search_id {
             self.latest_search_id = search_id;
-            if did_cancel && self.latest_search_did_cancel && query == self.latest_search_query {
+            if self.latest_search_did_cancel && query == self.latest_search_query {
                 util::extend_sorted(&mut self.matches, matches.into_iter(), 100, |a, b| b.cmp(a));
             } else {
                 self.matches = matches;
-                self.latest_search_did_cancel = did_cancel;
-                self.latest_search_query = query;
             }
+            self.latest_search_query = query;
+            self.latest_search_did_cancel = did_cancel;
             self.include_root_name = include_root_name;
             self.list_state.scroll_to(self.selected_index());
             ctx.notify();

--- a/zed/src/worktree/fuzzy.rs
+++ b/zed/src/worktree/fuzzy.rs
@@ -36,13 +36,17 @@ impl Eq for PathMatch {}
 
 impl PartialOrd for PathMatch {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.score.partial_cmp(&other.score)
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for PathMatch {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or(Ordering::Equal)
+        self.score
+            .partial_cmp(&other.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| self.tree_id.cmp(&other.tree_id))
+            .then_with(|| Arc::as_ptr(&self.path).cmp(&Arc::as_ptr(&other.path)))
     }
 }
 
@@ -150,7 +154,7 @@ where
         .flatten()
         .map(|r| r.0)
         .collect::<Vec<_>>();
-    results.sort_unstable_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    results.sort_unstable_by(|a, b| b.cmp(&a));
     results.truncate(max_results);
     results
 }


### PR DESCRIPTION
When opening a large directory in Zed, and using the file finder during the initial worktree scan, I noticed that the file finder results appear to constantly reshuffle. This was because every 100ms, the worktree would update and we would re-run our fuzzy search, cancelling the previous search. Each cancelled search would return a random subset of the available matches (due to each thread bailing out of its loop at a slightly different time).

### Stable result order

In this PR, I've ensured that the results stay stable in this situation. When a search is cancelled, and its query matches the *previous* cancelled query, rather than discarding the old results, I merge the new results into the old results in an ordered way. This way, the results may slightly improve over time as new matches are discovered, but they won't randomly shuffle.

### Matching optimization

While doing this, I profiled the fuzzy search process to make sure I hadn't regressed performance. In the flame graph, I noticed that a lot of CPU time was being spent in `match_paths`, just merging the results from each worker thread's call to `match_single_tree_paths`:

![Screen Shot 2021-04-27 at 2 45 33 PM](https://user-images.githubusercontent.com/326587/116316940-87fe6b80-a767-11eb-9532-d8f85dac042e.png)

Previously, each worker thread used a `BinaryHeap` to manage its matches, but then those binary heaps were merged into a vec by calling `collect` on the (unordered) binary heap iterator, followed by `slice::sort_unstable_by` and `Vec::truncate`. So while I was here, I optimized that code path, replacing the `BinaryHeaps` with sorted vectors. This allows us to merge the per-thread results in a way that reuses each thread's existing sorting, rather than needing to sort after-the fact.

☝️  This optimization probably only matters for very large directories (where each thread's result set can be fairly large), but in that situation, it improves things significantly: `match_paths` itself no longer shows up in the profile: we only see the existing `match_single_tree_paths` calls.