### PR TITLE
Allow opening files from the CLI and from the File > Open menu

### DIFF
--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -1717,6 +1717,10 @@ impl<'a, T: View> ViewContext<'a, T> {
         self.window_id
     }
 
+    pub fn foreground(&self) -> &Rc<executor::Foreground> {
+        self.app.foreground_executor()
+    }
+
     pub fn background_executor(&self) -> &Arc<executor::Background> {
         &self.app.ctx.background
     }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -18,11 +18,12 @@ use crate::{
     worktree::FileHandle,
 };
 use anyhow::{anyhow, Result};
-use gpui::{Entity, ModelContext};
+use gpui::{AppContext, Entity, ModelContext};
 use lazy_static::lazy_static;
 use rand::prelude::*;
 use std::{
     cmp,
+    ffi::OsString,
     hash::BuildHasher,
     iter::{self, Iterator},
     ops::{AddAssign, Range},
@@ -445,6 +446,10 @@ impl Buffer {
             local_clock: time::Local::new(replica_id),
             lamport_clock: time::Lamport::new(replica_id),
         }
+    }
+
+    pub fn file_name(&self, ctx: &AppContext) -> Option<OsString> {
+        self.file.as_ref().and_then(|file| file.file_name(ctx))
     }
 
     pub fn path(&self) -> Option<Arc<Path>> {

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -1362,11 +1362,8 @@ impl workspace::ItemView for BufferView {
     }
 
     fn title(&self, app: &AppContext) -> std::string::String {
-        if let Some(path) = self.buffer.read(app).path() {
-            path.file_name()
-                .expect("buffer's path is always to a file")
-                .to_string_lossy()
-                .into()
+        if let Some(name) = self.buffer.read(app).file_name(app) {
+            name.to_string_lossy().into()
         } else {
             "untitled".into()
         }

--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -275,7 +275,9 @@ impl FileFinder {
     ) {
         match event {
             Event::Selected(tree_id, path) => {
-                workspace_view.open_entry((*tree_id, path.clone()), ctx);
+                workspace_view
+                    .open_entry((*tree_id, path.clone()), ctx)
+                    .map(|d| d.detach());
                 workspace_view.dismiss_modal(ctx);
             }
             Event::Dismissed => {

--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -33,8 +33,7 @@ pub struct FileFinder {
     latest_search_did_cancel: bool,
     latest_search_query: String,
     matches: Vec<PathMatch>,
-    include_root_name: bool,
-    selected: Option<Arc<Path>>,
+    selected: Option<(usize, Arc<Path>)>,
     cancel_flag: Arc<AtomicBool>,
     list_state: UniformListState,
 }
@@ -147,101 +146,110 @@ impl FileFinder {
         index: usize,
         app: &AppContext,
     ) -> Option<ElementBox> {
-        let tree_id = path_match.tree_id;
+        self.labels_for_match(path_match, app).map(
+            |(file_name, file_name_positions, full_path, full_path_positions)| {
+                let settings = smol::block_on(self.settings.read());
+                let highlight_color = ColorU::from_u32(0x304ee2ff);
+                let bold = *Properties::new().weight(Weight::BOLD);
+                let mut container = Container::new(
+                    Flex::row()
+                        .with_child(
+                            Container::new(
+                                LineBox::new(
+                                    settings.ui_font_family,
+                                    settings.ui_font_size,
+                                    Svg::new("icons/file-16.svg").boxed(),
+                                )
+                                .boxed(),
+                            )
+                            .with_padding_right(6.0)
+                            .boxed(),
+                        )
+                        .with_child(
+                            Expanded::new(
+                                1.0,
+                                Flex::column()
+                                    .with_child(
+                                        Label::new(
+                                            file_name.to_string(),
+                                            settings.ui_font_family,
+                                            settings.ui_font_size,
+                                        )
+                                        .with_highlights(highlight_color, bold, file_name_positions)
+                                        .boxed(),
+                                    )
+                                    .with_child(
+                                        Label::new(
+                                            full_path,
+                                            settings.ui_font_family,
+                                            settings.ui_font_size,
+                                        )
+                                        .with_highlights(highlight_color, bold, full_path_positions)
+                                        .boxed(),
+                                    )
+                                    .boxed(),
+                            )
+                            .boxed(),
+                        )
+                        .boxed(),
+                )
+                .with_uniform_padding(6.0);
 
-        self.worktree(tree_id, app).map(|tree| {
-            let prefix = if self.include_root_name {
+                let selected_index = self.selected_index();
+                if index == selected_index || index < self.matches.len() - 1 {
+                    container =
+                        container.with_border(Border::bottom(1.0, ColorU::from_u32(0xdbdbdcff)));
+                }
+
+                if index == selected_index {
+                    container = container.with_background_color(ColorU::from_u32(0xdbdbdcff));
+                }
+
+                let entry = (path_match.tree_id, path_match.path.clone());
+                EventHandler::new(container.boxed())
+                    .on_mouse_down(move |ctx| {
+                        ctx.dispatch_action("file_finder:select", entry.clone());
+                        true
+                    })
+                    .named("match")
+            },
+        )
+    }
+
+    fn labels_for_match(
+        &self,
+        path_match: &PathMatch,
+        app: &AppContext,
+    ) -> Option<(String, Vec<usize>, String, Vec<usize>)> {
+        self.worktree(path_match.tree_id, app).map(|tree| {
+            let prefix = if path_match.include_root_name {
                 tree.root_name()
             } else {
                 ""
             };
-            let path = path_match.path.clone();
+
             let path_string = path_match.path.to_string_lossy();
-            let file_name = path_match
-                .path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy();
-
+            let full_path = [prefix, path_string.as_ref()].join("");
             let path_positions = path_match.positions.clone();
+
+            let file_name = path_match.path.file_name().map_or_else(
+                || prefix.to_string(),
+                |file_name| file_name.to_string_lossy().to_string(),
+            );
             let file_name_start =
-                prefix.len() + path_string.chars().count() - file_name.chars().count();
-            let mut file_name_positions = Vec::new();
-            file_name_positions.extend(path_positions.iter().filter_map(|pos| {
-                if pos >= &file_name_start {
-                    Some(pos - file_name_start)
-                } else {
-                    None
-                }
-            }));
-
-            let settings = smol::block_on(self.settings.read());
-            let highlight_color = ColorU::from_u32(0x304ee2ff);
-            let bold = *Properties::new().weight(Weight::BOLD);
-
-            let mut full_path = prefix.to_string();
-            full_path.push_str(&path_string);
-
-            let mut container = Container::new(
-                Flex::row()
-                    .with_child(
-                        Container::new(
-                            LineBox::new(
-                                settings.ui_font_family,
-                                settings.ui_font_size,
-                                Svg::new("icons/file-16.svg").boxed(),
-                            )
-                            .boxed(),
-                        )
-                        .with_padding_right(6.0)
-                        .boxed(),
-                    )
-                    .with_child(
-                        Expanded::new(
-                            1.0,
-                            Flex::column()
-                                .with_child(
-                                    Label::new(
-                                        file_name.to_string(),
-                                        settings.ui_font_family,
-                                        settings.ui_font_size,
-                                    )
-                                    .with_highlights(highlight_color, bold, file_name_positions)
-                                    .boxed(),
-                                )
-                                .with_child(
-                                    Label::new(
-                                        full_path,
-                                        settings.ui_font_family,
-                                        settings.ui_font_size,
-                                    )
-                                    .with_highlights(highlight_color, bold, path_positions)
-                                    .boxed(),
-                                )
-                                .boxed(),
-                        )
-                        .boxed(),
-                    )
-                    .boxed(),
-            )
-            .with_uniform_padding(6.0);
-
-            let selected_index = self.selected_index();
-            if index == selected_index || index < self.matches.len() - 1 {
-                container =
-                    container.with_border(Border::bottom(1.0, ColorU::from_u32(0xdbdbdcff)));
-            }
-
-            if index == selected_index {
-                container = container.with_background_color(ColorU::from_u32(0xdbdbdcff));
-            }
-
-            EventHandler::new(container.boxed())
-                .on_mouse_down(move |ctx| {
-                    ctx.dispatch_action("file_finder:select", (tree_id, path.clone()));
-                    true
+                prefix.chars().count() + path_string.chars().count() - file_name.chars().count();
+            let file_name_positions = path_positions
+                .iter()
+                .filter_map(|pos| {
+                    if pos >= &file_name_start {
+                        Some(pos - file_name_start)
+                    } else {
+                        None
+                    }
                 })
-                .named("match")
+                .collect();
+
+            (file_name, file_name_positions, full_path, path_positions)
         })
     }
 
@@ -298,7 +306,6 @@ impl FileFinder {
             latest_search_did_cancel: false,
             latest_search_query: String::new(),
             matches: Vec::new(),
-            include_root_name: false,
             selected: None,
             cancel_flag: Arc::new(AtomicBool::new(false)),
             list_state: UniformListState::new(),
@@ -335,7 +342,9 @@ impl FileFinder {
     fn selected_index(&self) -> usize {
         if let Some(selected) = self.selected.as_ref() {
             for (ix, path_match) in self.matches.iter().enumerate() {
-                if path_match.path.as_ref() == selected.as_ref() {
+                if (path_match.tree_id, path_match.path.as_ref())
+                    == (selected.0, selected.1.as_ref())
+                {
                     return ix;
                 }
             }
@@ -347,7 +356,8 @@ impl FileFinder {
         let mut selected_index = self.selected_index();
         if selected_index > 0 {
             selected_index -= 1;
-            self.selected = Some(self.matches[selected_index].path.clone());
+            let mat = &self.matches[selected_index];
+            self.selected = Some((mat.tree_id, mat.path.clone()));
         }
         self.list_state.scroll_to(selected_index);
         ctx.notify();
@@ -357,7 +367,8 @@ impl FileFinder {
         let mut selected_index = self.selected_index();
         if selected_index + 1 < self.matches.len() {
             selected_index += 1;
-            self.selected = Some(self.matches[selected_index].path.clone());
+            let mat = &self.matches[selected_index];
+            self.selected = Some((mat.tree_id, mat.path.clone()));
         }
         self.list_state.scroll_to(selected_index);
         ctx.notify();
@@ -403,7 +414,7 @@ impl FileFinder {
                 pool,
             );
             let did_cancel = cancel_flag.load(atomic::Ordering::Relaxed);
-            (search_id, include_root_name, did_cancel, query, matches)
+            (search_id, did_cancel, query, matches)
         });
 
         ctx.spawn(task, Self::update_matches).detach();
@@ -411,13 +422,7 @@ impl FileFinder {
 
     fn update_matches(
         &mut self,
-        (search_id, include_root_name, did_cancel, query, matches): (
-            usize,
-            bool,
-            bool,
-            String,
-            Vec<PathMatch>,
-        ),
+        (search_id, did_cancel, query, matches): (usize, bool, String, Vec<PathMatch>),
         ctx: &mut ViewContext<Self>,
     ) {
         if search_id >= self.latest_search_id {
@@ -429,7 +434,6 @@ impl FileFinder {
             }
             self.latest_search_query = query;
             self.latest_search_did_cancel = did_cancel;
-            self.include_root_name = include_root_name;
             self.list_state.scroll_to(self.selected_index());
             ctx.notify();
         }
@@ -454,20 +458,16 @@ mod tests {
     };
     use gpui::App;
     use serde_json::json;
-    use smol::fs;
+    use std::fs;
     use tempdir::TempDir;
 
     #[test]
     fn test_matching_paths() {
         App::test_async((), |mut app| async move {
             let tmp_dir = TempDir::new("example").unwrap();
-            fs::create_dir(tmp_dir.path().join("a")).await.unwrap();
-            fs::write(tmp_dir.path().join("a/banana"), "banana")
-                .await
-                .unwrap();
-            fs::write(tmp_dir.path().join("a/bandana"), "bandana")
-                .await
-                .unwrap();
+            fs::create_dir(tmp_dir.path().join("a")).unwrap();
+            fs::write(tmp_dir.path().join("a/banana"), "banana").unwrap();
+            fs::write(tmp_dir.path().join("a/bandana"), "bandana").unwrap();
             app.update(|ctx| {
                 super::init(ctx);
                 editor::init(ctx);
@@ -560,7 +560,6 @@ mod tests {
                 finder.update_matches(
                     (
                         finder.latest_search_id,
-                        true,
                         true, // did-cancel
                         query.clone(),
                         vec![matches[1].clone(), matches[3].clone()],
@@ -573,7 +572,6 @@ mod tests {
                 finder.update_matches(
                     (
                         finder.latest_search_id,
-                        true,
                         true, // did-cancel
                         query.clone(),
                         vec![matches[0].clone(), matches[2].clone(), matches[3].clone()],
@@ -582,6 +580,79 @@ mod tests {
                 );
 
                 assert_eq!(finder.matches, matches[0..4])
+            });
+        });
+    }
+
+    #[test]
+    fn test_single_file_worktrees() {
+        App::test_async((), |mut app| async move {
+            let temp_dir = TempDir::new("test-single-file-worktrees").unwrap();
+            let dir_path = temp_dir.path().join("the-parent-dir");
+            let file_path = dir_path.join("the-file");
+            fs::create_dir(&dir_path).unwrap();
+            fs::write(&file_path, "").unwrap();
+
+            let settings = settings::channel(&app.font_cache()).unwrap().1;
+            let workspace = app.add_model(|ctx| Workspace::new(vec![file_path], ctx));
+            app.read(|ctx| workspace.read(ctx).worktree_scans_complete(ctx))
+                .await;
+            let (_, finder) =
+                app.add_window(|ctx| FileFinder::new(settings, workspace.clone(), ctx));
+
+            // Even though there is only one worktree, that worktree's filename
+            // is included in the matching, because the worktree is a single file.
+            finder.update(&mut app, |f, ctx| f.spawn_search("thf".into(), ctx));
+            finder.condition(&app, |f, _| f.matches.len() == 1).await;
+
+            app.read(|ctx| {
+                let finder = finder.read(ctx);
+                let (file_name, file_name_positions, full_path, full_path_positions) =
+                    finder.labels_for_match(&finder.matches[0], ctx).unwrap();
+
+                assert_eq!(file_name, "the-file");
+                assert_eq!(file_name_positions, &[0, 1, 4]);
+                assert_eq!(full_path, "the-file");
+                assert_eq!(full_path_positions, &[0, 1, 4]);
+            });
+
+            // Since the worktree root is a file, searching for its name followed by a slash does
+            // not match anything.
+            finder.update(&mut app, |f, ctx| f.spawn_search("thf/".into(), ctx));
+            finder.condition(&app, |f, _| f.matches.len() == 0).await;
+        });
+    }
+
+    #[test]
+    fn test_multiple_matches_with_same_relative_path() {
+        App::test_async((), |mut app| async move {
+            let tmp_dir = temp_tree(json!({
+                "dir1": { "a.txt": "" },
+                "dir2": { "a.txt": "" }
+            }));
+            let settings = settings::channel(&app.font_cache()).unwrap().1;
+            let workspace = app.add_model(|ctx| {
+                Workspace::new(
+                    vec![tmp_dir.path().join("dir1"), tmp_dir.path().join("dir2")],
+                    ctx,
+                )
+            });
+            app.read(|ctx| workspace.read(ctx).worktree_scans_complete(ctx))
+                .await;
+            let (_, finder) =
+                app.add_window(|ctx| FileFinder::new(settings, workspace.clone(), ctx));
+
+            // Run a search that matches two files with the same relative path.
+            finder.update(&mut app, |f, ctx| f.spawn_search("a.t".into(), ctx));
+            finder.condition(&app, |f, _| f.matches.len() == 2).await;
+
+            // Can switch between different matches with the same relative path.
+            finder.update(&mut app, |f, ctx| {
+                assert_eq!(f.selected_index(), 0);
+                f.select_next(&(), ctx);
+                assert_eq!(f.selected_index(), 1);
+                f.select_prev(&(), ctx);
+                assert_eq!(f.selected_index(), 0);
             });
         });
     }

--- a/zed/src/workspace/mod.rs
+++ b/zed/src/workspace/mod.rs
@@ -52,7 +52,7 @@ fn open_paths(params: &OpenParams, app: &mut MutableAppContext) {
         if let Some(handle) = app.root_view::<WorkspaceView>(window_id) {
             if handle.update(app, |view, ctx| {
                 if view.contains_paths(&params.paths, ctx.as_ref()) {
-                    view.open_paths(&params.paths, ctx.as_mut());
+                    view.open_paths(&params.paths, ctx);
                     log::info!("open paths on existing workspace");
                     true
                 } else {
@@ -67,8 +67,12 @@ fn open_paths(params: &OpenParams, app: &mut MutableAppContext) {
     log::info!("open new workspace");
 
     // Add a new workspace if necessary
-    let workspace = app.add_model(|ctx| Workspace::new(params.paths.clone(), ctx));
-    app.add_window(|ctx| WorkspaceView::new(workspace, params.settings.clone(), ctx));
+    let workspace = app.add_model(|ctx| Workspace::new(vec![], ctx));
+    app.add_window(|ctx| {
+        let view = WorkspaceView::new(workspace, params.settings.clone(), ctx);
+        view.open_paths(&params.paths, ctx);
+        view
+    });
 }
 
 fn quit(_: &(), app: &mut MutableAppContext) {

--- a/zed/src/workspace/mod.rs
+++ b/zed/src/workspace/mod.rs
@@ -52,7 +52,8 @@ fn open_paths(params: &OpenParams, app: &mut MutableAppContext) {
         if let Some(handle) = app.root_view::<WorkspaceView>(window_id) {
             if handle.update(app, |view, ctx| {
                 if view.contains_paths(&params.paths, ctx.as_ref()) {
-                    view.open_paths(&params.paths, ctx);
+                    let open_paths = view.open_paths(&params.paths, ctx);
+                    ctx.foreground().spawn(open_paths).detach();
                     log::info!("open paths on existing workspace");
                     true
                 } else {
@@ -70,7 +71,8 @@ fn open_paths(params: &OpenParams, app: &mut MutableAppContext) {
     let workspace = app.add_model(|ctx| Workspace::new(vec![], ctx));
     app.add_window(|ctx| {
         let view = WorkspaceView::new(workspace, params.settings.clone(), ctx);
-        view.open_paths(&params.paths, ctx);
+        let open_paths = view.open_paths(&params.paths, ctx);
+        ctx.foreground().spawn(open_paths).detach();
         view
     });
 }

--- a/zed/src/workspace/workspace_view.rs
+++ b/zed/src/workspace/workspace_view.rs
@@ -3,7 +3,8 @@ use crate::{settings::Settings, watch};
 use futures_core::{future::LocalBoxFuture, Future};
 use gpui::{
     color::rgbu, elements::*, json::to_string_pretty, keymap::Binding, AnyViewHandle, AppContext,
-    ClipboardItem, Entity, ModelHandle, MutableAppContext, View, ViewContext, ViewHandle,
+    ClipboardItem, Entity, EntityTask, ModelHandle, MutableAppContext, View, ViewContext,
+    ViewHandle,
 };
 use log::error;
 use std::{
@@ -223,11 +224,12 @@ impl WorkspaceView {
         }
     }
 
+    #[must_use]
     pub fn open_entry(
         &mut self,
         entry: (usize, Arc<Path>),
         ctx: &mut ViewContext<Self>,
-    ) -> Option<impl Future<Output = ()>> {
+    ) -> Option<EntityTask<()>> {
         if self.loading_entries.contains(&entry) {
             return None;
         }


### PR DESCRIPTION
This PR allows Zed to open files directly from CLI and from the `File > Open` menu, without having to use the file finder.

### Tasks

* [x] Running `zed [files...]` opens all of the given files (creating single-file worktrees)
* [x] Selecting a set of files in the `File > Open` dialog opens all of those files 
* [x] The file finder displays single-file worktrees nicely
* [x] The file finder handles multiple files with the same relative path, within different worktrees