### PR TITLE
Initial editor keybindings

### DIFF
--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -73,7 +73,7 @@ impl Selection {
         }
     }
 
-    pub fn buffer_row_range(&self, map: &DisplayMap, ctx: &AppContext) -> Range<u32> {
+    pub fn buffer_rows_for_display_rows(&self, map: &DisplayMap, ctx: &AppContext) -> Range<u32> {
         let display_start = self.start.to_display_point(map, ctx).unwrap();
         let buffer_start = DisplayPoint::new(display_start.row(), 0)
             .to_buffer_point(map, Bias::Left, ctx)

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -1,7 +1,7 @@
 use crate::{
     editor::{
         buffer::{Anchor, Buffer, Point, ToPoint},
-        display_map::DisplayMap,
+        display_map::{Bias, DisplayMap},
         DisplayPoint,
     },
     time,
@@ -71,5 +71,28 @@ impl Selection {
         } else {
             start..end
         }
+    }
+
+    pub fn buffer_row_range(&self, map: &DisplayMap, ctx: &AppContext) -> Range<u32> {
+        let display_start = self.start.to_display_point(map, ctx).unwrap();
+        let buffer_start = DisplayPoint::new(display_start.row(), 0)
+            .to_buffer_point(map, Bias::Left, ctx)
+            .unwrap();
+
+        let mut display_end = self.end.to_display_point(map, ctx).unwrap();
+        if display_end != map.max_point(ctx)
+            && display_start.row() != display_end.row()
+            && display_end.column() == 0
+        {
+            *display_end.row_mut() -= 1;
+        }
+        let buffer_end = DisplayPoint::new(
+            display_end.row(),
+            map.line_len(display_end.row(), ctx).unwrap(),
+        )
+        .to_buffer_point(map, Bias::Left, ctx)
+        .unwrap();
+
+        buffer_start.row..buffer_end.row + 1
     }
 }

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -31,6 +31,7 @@ pub fn init(app: &mut MutableAppContext) {
     app.add_bindings(vec![
         Binding::new("backspace", "buffer:backspace", Some("BufferView")),
         Binding::new("delete", "buffer:delete", Some("BufferView")),
+        Binding::new("ctrl-d", "buffer:delete", Some("BufferView")),
         Binding::new("enter", "buffer:newline", Some("BufferView")),
         Binding::new("ctrl-shift-K", "buffer:delete_line", Some("BufferView")),
         Binding::new("cmd-x", "buffer:cut", Some("BufferView")),

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -796,24 +796,20 @@ impl BufferView {
     }
 
     pub fn select_up(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
-        if self.single_line {
-            ctx.propagate_action();
-        } else {
-            let mut selections = self.selections(ctx.as_ref()).to_vec();
-            {
-                let app = ctx.as_ref();
-                let buffer = self.buffer.read(app);
-                let map = self.display_map.read(app);
-                for selection in &mut selections {
-                    let head = selection.head().to_display_point(map, app).unwrap();
-                    let (head, goal_column) =
-                        movement::up(map, head, selection.goal_column, app).unwrap();
-                    selection.set_head(&buffer, map.anchor_before(head, Bias::Left, app).unwrap());
-                    selection.goal_column = goal_column;
-                }
+        let mut selections = self.selections(ctx.as_ref()).to_vec();
+        {
+            let app = ctx.as_ref();
+            let buffer = self.buffer.read(app);
+            let map = self.display_map.read(app);
+            for selection in &mut selections {
+                let head = selection.head().to_display_point(map, app).unwrap();
+                let (head, goal_column) =
+                    movement::up(map, head, selection.goal_column, app).unwrap();
+                selection.set_head(&buffer, map.anchor_before(head, Bias::Left, app).unwrap());
+                selection.goal_column = goal_column;
             }
-            self.update_selections(selections, true, ctx);
         }
+        self.update_selections(selections, true, ctx);
     }
 
     pub fn move_down(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
@@ -845,24 +841,20 @@ impl BufferView {
     }
 
     pub fn select_down(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
-        if self.single_line {
-            ctx.propagate_action();
-        } else {
-            let mut selections = self.selections(ctx.as_ref()).to_vec();
-            {
-                let app = ctx.as_ref();
-                let buffer = self.buffer.read(app);
-                let map = self.display_map.read(app);
-                for selection in &mut selections {
-                    let head = selection.head().to_display_point(map, app).unwrap();
-                    let (head, goal_column) =
-                        movement::down(map, head, selection.goal_column, app).unwrap();
-                    selection.set_head(&buffer, map.anchor_before(head, Bias::Right, app).unwrap());
-                    selection.goal_column = goal_column;
-                }
+        let mut selections = self.selections(ctx.as_ref()).to_vec();
+        {
+            let app = ctx.as_ref();
+            let buffer = self.buffer.read(app);
+            let map = self.display_map.read(app);
+            for selection in &mut selections {
+                let head = selection.head().to_display_point(map, app).unwrap();
+                let (head, goal_column) =
+                    movement::down(map, head, selection.goal_column, app).unwrap();
+                selection.set_head(&buffer, map.anchor_before(head, Bias::Right, app).unwrap());
+                selection.goal_column = goal_column;
             }
-            self.update_selections(selections, true, ctx);
         }
+        self.update_selections(selections, true, ctx);
     }
 
     pub fn move_to_beginning(&mut self, _: &(), ctx: &mut ViewContext<Self>) {

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -1934,6 +1934,47 @@ mod tests {
     }
 
     #[test]
+    fn test_delete_lines() {
+        App::test((), |app| {
+            let settings = settings::channel(&app.font_cache()).unwrap().1;
+            let buffer = app.add_model(|ctx| Buffer::new(0, "abc\ndef\nghi\n", ctx));
+            let (_, view) = app.add_window(|ctx| BufferView::for_buffer(buffer, settings, ctx));
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[
+                        DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1),
+                        DisplayPoint::new(1, 0)..DisplayPoint::new(1, 1),
+                        DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0),
+                    ],
+                    ctx,
+                )
+                .unwrap();
+                view.delete_line(&(), ctx);
+            });
+            assert_eq!(view.read(app).text(app.as_ref()), "ghi");
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1),
+                    DisplayPoint::new(0, 3)..DisplayPoint::new(0, 3)
+                ]
+            );
+
+            // view.undo(&(), ctx);
+            // view.select_display_ranges(
+            //     &[
+            //         DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1),
+            //         DisplayPoint::new(1, 0)..DisplayPoint::new(1, 1),
+            //         DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0),
+            //     ],
+            //     ctx,
+            // )
+            // .unwrap();
+            // });
+        });
+    }
+
+    #[test]
     fn test_clipboard() {
         App::test((), |app| {
             let buffer = app.add_model(|ctx| Buffer::new(0, "one two three four five six ", ctx));

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -67,6 +67,20 @@ impl DisplayMap {
         Ok(chars.take_while(|c| *c != '\n').collect())
     }
 
+    pub fn line_indent(&self, display_row: u32, app: &AppContext) -> Result<(u32, bool)> {
+        let mut indent = 0;
+        let mut is_blank = true;
+        for c in self.chars_at(DisplayPoint::new(display_row, 0), app)? {
+            if c == ' ' {
+                indent += 1;
+            } else {
+                is_blank = c == '\n';
+                break;
+            }
+        }
+        Ok((indent, is_blank))
+    }
+
     pub fn chars_at<'a>(&'a self, point: DisplayPoint, app: &'a AppContext) -> Result<Chars<'a>> {
         let column = point.column() as usize;
         let (point, to_next_stop) = point.collapse_tabs(self, Bias::Left, app)?;

--- a/zed/src/editor/mod.rs
+++ b/zed/src/editor/mod.rs
@@ -12,14 +12,11 @@ use display_map::*;
 use std::{cmp, ops::Range};
 
 trait RangeExt<T> {
-    fn sorted(&self) -> (T, T);
+    fn sorted(&self) -> Range<T>;
 }
 
 impl<T: Ord + Clone> RangeExt<T> for Range<T> {
-    fn sorted(&self) -> (T, T) {
-        (
-            cmp::min(&self.start, &self.end).clone(),
-            cmp::max(&self.start, &self.end).clone(),
-        )
+    fn sorted(&self) -> Self {
+        cmp::min(&self.start, &self.end).clone()..cmp::max(&self.start, &self.end).clone()
     }
 }

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -58,3 +58,24 @@ pub fn down(
 
     Ok((point, goal_column))
 }
+
+pub fn line_beginning(
+    map: &DisplayMap,
+    point: DisplayPoint,
+    toggle_indent: bool,
+    app: &AppContext,
+) -> Result<DisplayPoint> {
+    let (indent, is_blank) = map.line_indent(point.row(), app)?;
+    if toggle_indent && !is_blank && point.column() != indent {
+        Ok(DisplayPoint::new(point.row(), indent))
+    } else {
+        Ok(DisplayPoint::new(point.row(), 0))
+    }
+}
+
+pub fn line_end(map: &DisplayMap, point: DisplayPoint, app: &AppContext) -> Result<DisplayPoint> {
+    Ok(DisplayPoint::new(
+        point.row(),
+        map.line_len(point.row(), app)?,
+    ))
+}


### PR DESCRIPTION
Refs #25 

This doesn't cover all the items we listed in the aforementioned issue, but I figured it would be good to open smaller pull requests as opposed to implementing everything in one fell swoop. In particular, this pull request introduces the following actions:

- `select_all`
- `delete`
- `move_to_beginning`
- `move_to_end`
- `select_to_beginning`
- `select_to_end`
- `delete_line`
- `duplicate_line`
- `move_to_beginning_of_line`
- `move_to_end_of_line`
- `select_to_beginning_of_line`
- `select_to_end_of_line`
- `delete_to_beginning_of_line`
- `delete_to_end_of_line`

Moreover - as I was testing the various interactions - I fixed a couple of bugs:

- Selecting up or down in single-line editor will now correctly select things before/after the cursor's tail. This is now consistent with how most single-line editors work.
- Backspace and delete were broken when we had backward selections and would always delete one extra character. I fixed this and changed the existing tests to account for reverse selections too.

@maxbrunsfeld @nathansobo: I wrote tests for all the methods above, but I'd love if you guys could test it out manually and help me check whether things feel correct. I would especially encourage testing the behavior of `delete_line` because its behavior in Atom/VS Code is quite subtle but I wanted to match it nonetheless because it felt the most intuitive. 