### PR TITLE
Implement word boundary movement/selection/deletion

### DIFF
--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -35,6 +35,16 @@ pub fn init(app: &mut MutableAppContext) {
         Binding::new("enter", "buffer:newline", Some("BufferView")),
         Binding::new("ctrl-shift-K", "buffer:delete_line", Some("BufferView")),
         Binding::new(
+            "alt-backspace",
+            "buffer:delete_to_previous_word_boundary",
+            Some("BufferView"),
+        ),
+        Binding::new(
+            "alt-delete",
+            "buffer:delete_to_next_word_boundary",
+            Some("BufferView"),
+        ),
+        Binding::new(
             "cmd-backspace",
             "buffer:delete_to_beginning_of_line",
             Some("BufferView"),
@@ -143,6 +153,14 @@ pub fn init(app: &mut MutableAppContext) {
     app.add_action("buffer:backspace", BufferView::backspace);
     app.add_action("buffer:delete", BufferView::delete);
     app.add_action("buffer:delete_line", BufferView::delete_line);
+    app.add_action(
+        "buffer:delete_to_previous_word_boundary",
+        BufferView::delete_to_previous_word_boundary,
+    );
+    app.add_action(
+        "buffer:delete_to_next_word_boundary",
+        BufferView::delete_to_next_word_boundary,
+    );
     app.add_action(
         "buffer:delete_to_beginning_of_line",
         BufferView::delete_to_beginning_of_line,
@@ -1156,6 +1174,13 @@ impl BufferView {
         self.update_selections(selections, true, ctx);
     }
 
+    pub fn delete_to_previous_word_boundary(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        self.start_transaction(ctx);
+        self.select_to_previous_word_boundary(&(), ctx);
+        self.backspace(&(), ctx);
+        self.end_transaction(ctx);
+    }
+
     pub fn move_to_next_word_boundary(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
         let app = ctx.as_ref();
         let mut selections = self.selections(app).to_vec();
@@ -1189,6 +1214,13 @@ impl BufferView {
             }
         }
         self.update_selections(selections, true, ctx);
+    }
+
+    pub fn delete_to_next_word_boundary(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        self.start_transaction(ctx);
+        self.select_to_next_word_boundary(&(), ctx);
+        self.delete(&(), ctx);
+        self.end_transaction(ctx);
     }
 
     pub fn move_to_beginning_of_line(&mut self, _: &(), ctx: &mut ViewContext<Self>) {

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -55,6 +55,11 @@ pub fn init(app: &mut MutableAppContext) {
         Binding::new("left", "buffer:move_left", Some("BufferView")),
         Binding::new("right", "buffer:move_right", Some("BufferView")),
         Binding::new(
+            "alt-left",
+            "buffer:move_to_previous_word_boundary",
+            Some("BufferView"),
+        ),
+        Binding::new(
             "alt-right",
             "buffer:move_to_next_word_boundary",
             Some("BufferView"),
@@ -146,6 +151,10 @@ pub fn init(app: &mut MutableAppContext) {
     app.add_action("buffer:move_down", BufferView::move_down);
     app.add_action("buffer:move_left", BufferView::move_left);
     app.add_action("buffer:move_right", BufferView::move_right);
+    app.add_action(
+        "buffer:move_to_previous_word_boundary",
+        BufferView::move_to_previous_word_boundary,
+    );
     app.add_action(
         "buffer:move_to_next_word_boundary",
         BufferView::move_to_next_word_boundary,
@@ -1089,6 +1098,24 @@ impl BufferView {
                     movement::down(map, head, selection.goal_column, app).unwrap();
                 selection.set_head(&buffer, map.anchor_before(head, Bias::Right, app).unwrap());
                 selection.goal_column = goal_column;
+            }
+        }
+        self.update_selections(selections, true, ctx);
+    }
+
+    pub fn move_to_previous_word_boundary(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        let app = ctx.as_ref();
+        let mut selections = self.selections(app).to_vec();
+        {
+            let map = self.display_map.read(app);
+            for selection in &mut selections {
+                let head = selection.head().to_display_point(map, app).unwrap();
+                let new_head = movement::prev_word_boundary(map, head, app).unwrap();
+                let anchor = map.anchor_before(new_head, Bias::Left, app).unwrap();
+                selection.start = anchor.clone();
+                selection.end = anchor;
+                selection.reversed = false;
+                selection.goal_column = None;
             }
         }
         self.update_selections(selections, true, ctx);

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -2358,6 +2358,188 @@ mod tests {
     }
 
     #[test]
+    fn test_prev_next_word_boundary() {
+        App::test((), |app| {
+            let buffer = app
+                .add_model(|ctx| Buffer::new(0, "use std::str::{foo, bar}\n\n  {baz.qux()}", ctx));
+            let settings = settings::channel(&app.font_cache()).unwrap().1;
+            let (_, view) = app.add_window(|ctx| BufferView::for_buffer(buffer, settings, ctx));
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[
+                        DisplayPoint::new(0, 11)..DisplayPoint::new(0, 11),
+                        DisplayPoint::new(2, 4)..DisplayPoint::new(2, 4),
+                    ],
+                    ctx,
+                )
+                .unwrap();
+            });
+
+            view.update(app, |view, ctx| {
+                view.move_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 9)..DisplayPoint::new(0, 9),
+                    DisplayPoint::new(2, 3)..DisplayPoint::new(2, 3),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.move_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 7)..DisplayPoint::new(0, 7),
+                    DisplayPoint::new(2, 2)..DisplayPoint::new(2, 2),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.move_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 4)..DisplayPoint::new(0, 4),
+                    DisplayPoint::new(2, 0)..DisplayPoint::new(2, 0),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.move_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 3)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(1, 0)..DisplayPoint::new(1, 0),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.move_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 0)..DisplayPoint::new(0, 0),
+                    DisplayPoint::new(0, 24)..DisplayPoint::new(0, 24),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.move_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 0)..DisplayPoint::new(0, 0),
+                    DisplayPoint::new(0, 23)..DisplayPoint::new(0, 23),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.move_to_next_word_boundary(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 3)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(0, 24)..DisplayPoint::new(0, 24),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.move_to_next_word_boundary(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 4)..DisplayPoint::new(0, 4),
+                    DisplayPoint::new(1, 0)..DisplayPoint::new(1, 0),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.move_to_next_word_boundary(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 7)..DisplayPoint::new(0, 7),
+                    DisplayPoint::new(2, 0)..DisplayPoint::new(2, 0),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.move_to_next_word_boundary(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 9)..DisplayPoint::new(0, 9),
+                    DisplayPoint::new(2, 2)..DisplayPoint::new(2, 2),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.move_right(&(), ctx);
+                view.select_to_previous_word_boundary(&(), ctx);
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 10)..DisplayPoint::new(0, 9),
+                    DisplayPoint::new(2, 3)..DisplayPoint::new(2, 2),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.select_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 10)..DisplayPoint::new(0, 7),
+                    DisplayPoint::new(2, 3)..DisplayPoint::new(2, 0),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.select_to_next_word_boundary(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 10)..DisplayPoint::new(0, 9),
+                    DisplayPoint::new(2, 3)..DisplayPoint::new(2, 2),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.delete_to_next_word_boundary(&(), ctx));
+            assert_eq!(
+                view.read(app).text(app.as_ref()),
+                "use std::s::{foo, bar}\n\n  {az.qux()}"
+            );
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 10)..DisplayPoint::new(0, 10),
+                    DisplayPoint::new(2, 3)..DisplayPoint::new(2, 3),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.delete_to_previous_word_boundary(&(), ctx)
+            });
+            assert_eq!(
+                view.read(app).text(app.as_ref()),
+                "use std::::{foo, bar}\n\n  az.qux()}"
+            );
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                &[
+                    DisplayPoint::new(0, 9)..DisplayPoint::new(0, 9),
+                    DisplayPoint::new(2, 2)..DisplayPoint::new(2, 2),
+                ]
+            );
+        });
+    }
+
+    #[test]
     fn test_backspace() {
         App::test((), |app| {
             let buffer = app.add_model(|ctx| {

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -119,7 +119,7 @@ pub fn next_word_boundary(
 ) -> Result<DisplayPoint> {
     let mut prev_c = None;
     for c in map.chars_at(point, app)? {
-        if prev_c.is_some() && (c == '\n' || char_kind(prev_c.unwrap()) != char_kind(c)) {
+        if prev_c.is_some() && char_kind(prev_c.unwrap()) != char_kind(c) {
             break;
         }
 

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -119,7 +119,7 @@ pub fn next_word_boundary(
 ) -> Result<DisplayPoint> {
     let mut prev_c = None;
     for c in map.chars_at(point, app)? {
-        if prev_c.is_some() && char_kind(prev_c.unwrap()) != char_kind(c) {
+        if prev_c.is_some() && (c == '\n' || char_kind(prev_c.unwrap()) != char_kind(c)) {
             break;
         }
 
@@ -136,13 +136,16 @@ pub fn next_word_boundary(
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 enum CharKind {
+    Newline,
     Whitespace,
     Punctuation,
     Word,
 }
 
 fn char_kind(c: char) -> CharKind {
-    if c.is_whitespace() {
+    if c == '\n' {
+        CharKind::Newline
+    } else if c.is_whitespace() {
         CharKind::Whitespace
     } else if c.is_alphanumeric() || c == '_' {
         CharKind::Word

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -79,3 +79,42 @@ pub fn line_end(map: &DisplayMap, point: DisplayPoint, app: &AppContext) -> Resu
         map.line_len(point.row(), app)?,
     ))
 }
+
+pub fn prev_word_boundary(
+    map: &DisplayMap,
+    point: DisplayPoint,
+    app: &AppContext,
+) -> Result<DisplayPoint> {
+    todo!()
+}
+
+pub fn next_word_boundary(
+    map: &DisplayMap,
+    mut point: DisplayPoint,
+    app: &AppContext,
+) -> Result<DisplayPoint> {
+    let mut prev_c = None;
+    for c in map.chars_at(point, app)? {
+        if prev_c.is_some() && (c == '\n' || is_word_char(prev_c.unwrap()) != is_word_char(c)) {
+            break;
+        }
+
+        if c == '\n' {
+            *point.row_mut() += 1;
+            *point.column_mut() = 0;
+        } else {
+            *point.column_mut() += 1;
+        }
+        prev_c = Some(c);
+    }
+    Ok(point)
+}
+
+fn is_word_char(c: char) -> bool {
+    match c {
+        '/' | '\\' | '(' | ')' | '"' | '\'' | ':' | ',' | '.' | ';' | '<' | '>' | '~' | '!'
+        | '@' | '#' | '$' | '%' | '^' | '&' | '*' | '|' | '+' | '=' | '[' | ']' | '{' | '}'
+        | '`' | '?' | '-' | '…' | ' ' | '\n' => false,
+        _ => true,
+    }
+}


### PR DESCRIPTION
Refs #25 

This pull request implements the following commands: 

- `delete_to_previous_word_boundary`
- `delete_to_next_word_boundary`
- `select_to_previous_word_boundary`
- `select_to_next_word_boundary`
- `move_to_previous_word_boundary`
- `move_to_next_word_boundary`

## UX

![Kapture 2021-04-30 at 10 36 18](https://user-images.githubusercontent.com/482957/116670416-fcbbea80-a99f-11eb-8f15-f171c7ae0302.gif)


## Implementation notes

Moving to the next boundary works by scanning the text forward (in display coordinates) and skipping over at least one character, stopping when a different kind of character is found after the ones that have already been scanned.

My initial thought was to implement movement to the previous boundary in the same manner, where we'd have a backward iterator and scan characters in reverse from the selection's head until finding a word boundary. However, implementing a backward iterator for the `DisplayMap` is non-trivial, as expanding tabs going backwards requires access to information about what's before the line, which is doable but requires an allocation and felt a lot less elegant than the forward scanning implementation.

Ultimately, I realized that even when scanning a line forward and constructing the left-to-right iterator, we still need to expand tabs, which means linearly scanning the line from its beginning. This happens also when converting an `Anchor` to a `DisplayPoint`. Therefore, to determine what the word boundary prior to a given point is, I decided to take a different approach: scanning the line from its beginning and keeping track of the closest word boundary to the left of the point. @maxbrunsfeld and I tested this with a pretty long line and the performance cost was in line with the other movement operations.

There are alternative approaches to this: specifically, I could see an argument being made for _not_ using display coordinates and instead introducing a third coordinate system that accounts for folds (and soft wraps when we'll have them) but ignores tabs. After all, you can't position your cursor within a hard tab anyway, so there's no point in expanding it in the first place. Note that this is true for horizontal movements in general, but not for vertical ones where the column needs to account for the expanded tabs.

Alternatively, there's probably a way of indexing more information about the tabs at the cost of more memory so that scanning the whole line is not needed for tab expansion.

After discussing both approaches with @maxbrunsfeld, we felt like the added cognitive cost of either solution wasn't worth it right now and that we should maybe revisit if this whole-line scanning approach ever becomes a problem.