### PR TITLE
Move line up and down

### DIFF
--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -84,7 +84,7 @@ impl Selection {
             .unwrap();
 
         let mut display_end = self.end.to_display_point(map, ctx).unwrap();
-        if display_end != map.max_point(ctx)
+        if display_end.row() != map.max_point(ctx).row()
             && display_start.row() != display_end.row()
             && display_end.column() == 0
         {

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -73,7 +73,11 @@ impl Selection {
         }
     }
 
-    pub fn buffer_rows_for_display_rows(&self, map: &DisplayMap, ctx: &AppContext) -> Range<u32> {
+    pub fn buffer_rows_for_display_rows(
+        &self,
+        map: &DisplayMap,
+        ctx: &AppContext,
+    ) -> (Range<u32>, Range<u32>) {
         let display_start = self.start.to_display_point(map, ctx).unwrap();
         let buffer_start = DisplayPoint::new(display_start.row(), 0)
             .to_buffer_point(map, Bias::Left, ctx)
@@ -93,6 +97,9 @@ impl Selection {
         .to_buffer_point(map, Bias::Left, ctx)
         .unwrap();
 
-        buffer_start.row..buffer_end.row + 1
+        (
+            buffer_start.row..buffer_end.row + 1,
+            display_start.row()..display_end.row() + 1,
+        )
     }
 }

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -169,6 +169,13 @@ impl FoldMap {
         false
     }
 
+    pub fn to_buffer_offset(&self, point: DisplayPoint, app: &AppContext) -> Result<usize> {
+        let mut cursor = self.transforms.cursor::<DisplayPoint, TransformSummary>();
+        cursor.seek(&point, SeekBias::Right);
+        let overshoot = point.0 - cursor.start().display.lines;
+        (cursor.start().buffer.lines + overshoot).to_offset(self.buffer.read(app))
+    }
+
     pub fn to_display_offset(
         &self,
         point: DisplayPoint,

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -269,7 +269,7 @@ impl FoldMap {
                     let next_edit = edits.next().unwrap();
                     delta += next_edit.delta();
 
-                    if next_edit.old_range.end > edit.old_range.end {
+                    if next_edit.old_range.end >= edit.old_range.end {
                         edit.old_range.end = next_edit.old_range.end;
                         cursor.seek(&edit.old_range.end, SeekBias::Right);
                         cursor.next();
@@ -566,14 +566,14 @@ mod tests {
                 assert_eq!(map.text(app.as_ref()), "abcde…ijkl");
 
                 // Create an fold adjacent to the start of the first fold.
-                map.fold(vec![1..1, 2..5], app.as_ref()).unwrap();
+                map.fold(vec![0..1, 2..5], app.as_ref()).unwrap();
                 map.check_invariants(app.as_ref());
-                assert_eq!(map.text(app.as_ref()), "ab…ijkl");
+                assert_eq!(map.text(app.as_ref()), "…b…ijkl");
 
                 // Create an fold adjacent to the end of the first fold.
                 map.fold(vec![11..11, 8..10], app.as_ref()).unwrap();
                 map.check_invariants(app.as_ref());
-                assert_eq!(map.text(app.as_ref()), "ab…kl");
+                assert_eq!(map.text(app.as_ref()), "…b…kl");
             }
 
             {
@@ -677,10 +677,8 @@ mod tests {
                 });
                 let mut map = FoldMap::new(buffer.clone(), app.as_ref());
 
-                for op_ix in 0..operations {
-                    dbg!(op_ix);
-
-                    log::info!("Text: {:?}", buffer.read(app).text());
+                for _ in 0..operations {
+                    log::info!("text: {:?}", buffer.read(app).text());
                     {
                         let buffer = buffer.read(app);
 
@@ -691,7 +689,7 @@ mod tests {
                             let start = rng.gen_range(0..end + 1);
                             fold_ranges.push(start..end);
                         }
-                        log::info!("Folding {:?}", fold_ranges);
+                        log::info!("folding {:?}", fold_ranges);
                         map.fold(fold_ranges.clone(), app.as_ref()).unwrap();
                         map.check_invariants(app.as_ref());
 
@@ -714,7 +712,7 @@ mod tests {
                         buffer.randomly_edit(&mut rng, edit_count, Some(ctx));
                         buffer.edits_since(start_version).collect::<Vec<_>>()
                     });
-                    log::info!("Editing {:?}", edits);
+                    log::info!("editing {:?}", edits);
                     map.apply_edits(&edits, app.as_ref()).unwrap();
                     map.check_invariants(app.as_ref());
 

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -34,6 +34,13 @@ impl DisplayMap {
         }
     }
 
+    pub fn folds_in_range<T>(&self, range: Range<T>, app: &AppContext) -> Result<&[Range<Anchor>]>
+    where
+        T: ToOffset,
+    {
+        self.fold_map.folds_in_range(range, app)
+    }
+
     pub fn fold<T: ToOffset>(
         &mut self,
         ranges: impl IntoIterator<Item = Range<T>>,

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -179,6 +179,11 @@ impl DisplayPoint {
             .to_buffer_point(self.collapse_tabs(map, bias, app)?.0))
     }
 
+    pub fn to_buffer_offset(self, map: &DisplayMap, bias: Bias, app: &AppContext) -> Result<usize> {
+        map.fold_map
+            .to_buffer_offset(self.collapse_tabs(map, bias, app)?.0, app)
+    }
+
     fn expand_tabs(mut self, map: &DisplayMap, app: &AppContext) -> Result<Self> {
         let chars = map
             .fold_map


### PR DESCRIPTION
This PR implements commands to move line(s) up and down. It also fixed a bug in the fold map related to creating a fold that ends adjacent to an existing fold. @as-cii did most of the work.