### PR TITLE
Allow creating untitled buffers and saving them to new files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "cocoa"
 version = "0.24.0"
-source = "git+https://github.com/servo/core-foundation-rs?rev=e9a65bb15d591ec22649e03659db8095d4f2dd60#e9a65bb15d591ec22649e03659db8095d4f2dd60"
+source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
 dependencies = [
  "bitflags 1.2.1",
  "block",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "cocoa-foundation"
 version = "0.1.0"
-source = "git+https://github.com/servo/core-foundation-rs?rev=e9a65bb15d591ec22649e03659db8095d4f2dd60#e9a65bb15d591ec22649e03659db8095d4f2dd60"
+source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
 dependencies = [
  "bitflags 1.2.1",
  "block",
@@ -499,7 +499,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "core-foundation"
 version = "0.9.1"
-source = "git+https://github.com/servo/core-foundation-rs?rev=e9a65bb15d591ec22649e03659db8095d4f2dd60#e9a65bb15d591ec22649e03659db8095d4f2dd60"
+source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -508,12 +508,12 @@ dependencies = [
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.2"
-source = "git+https://github.com/servo/core-foundation-rs?rev=e9a65bb15d591ec22649e03659db8095d4f2dd60#e9a65bb15d591ec22649e03659db8095d4f2dd60"
+source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
 
 [[package]]
 name = "core-graphics"
 version = "0.22.2"
-source = "git+https://github.com/servo/core-foundation-rs?rev=e9a65bb15d591ec22649e03659db8095d4f2dd60#e9a65bb15d591ec22649e03659db8095d4f2dd60"
+source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "core-graphics-types"
 version = "0.1.1"
-source = "git+https://github.com/servo/core-foundation-rs?rev=e9a65bb15d591ec22649e03659db8095d4f2dd60#e9a65bb15d591ec22649e03659db8095d4f2dd60"
+source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "cocoa"
 version = "0.24.0"
-source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
+source = "git+https://github.com/servo/core-foundation-rs?rev=025dcb3c0d1ef01530f57ef65f3b1deb948f5737#025dcb3c0d1ef01530f57ef65f3b1deb948f5737"
 dependencies = [
  "bitflags 1.2.1",
  "block",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "cocoa-foundation"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
+source = "git+https://github.com/servo/core-foundation-rs?rev=025dcb3c0d1ef01530f57ef65f3b1deb948f5737#025dcb3c0d1ef01530f57ef65f3b1deb948f5737"
 dependencies = [
  "bitflags 1.2.1",
  "block",
@@ -499,7 +499,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "core-foundation"
 version = "0.9.1"
-source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
+source = "git+https://github.com/servo/core-foundation-rs?rev=025dcb3c0d1ef01530f57ef65f3b1deb948f5737#025dcb3c0d1ef01530f57ef65f3b1deb948f5737"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -508,12 +508,12 @@ dependencies = [
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.2"
-source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
+source = "git+https://github.com/servo/core-foundation-rs?rev=025dcb3c0d1ef01530f57ef65f3b1deb948f5737#025dcb3c0d1ef01530f57ef65f3b1deb948f5737"
 
 [[package]]
 name = "core-graphics"
 version = "0.22.2"
-source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
+source = "git+https://github.com/servo/core-foundation-rs?rev=025dcb3c0d1ef01530f57ef65f3b1deb948f5737#025dcb3c0d1ef01530f57ef65f3b1deb948f5737"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "core-graphics-types"
 version = "0.1.1"
-source = "git+https://github.com/zed-industries/core-foundation-rs?rev=39e1e0eeef11a17cf49aa6a500c37e665d967d2a#39e1e0eeef11a17cf49aa6a500c37e665d967d2a"
+source = "git+https://github.com/servo/core-foundation-rs?rev=025dcb3c0d1ef01530f57ef65f3b1deb948f5737#025dcb3c0d1ef01530f57ef65f3b1deb948f5737"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ members = ["zed", "gpui", "fsevent", "scoped_pool"]
 async-task = {git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e"}
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457
-cocoa = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
-cocoa-foundation = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
-core-foundation = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
-core-graphics = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
+cocoa = {git = "https://github.com/servo/core-foundation-rs", rev = "025dcb3c0d1ef01530f57ef65f3b1deb948f5737"}
+cocoa-foundation = {git = "https://github.com/servo/core-foundation-rs", rev = "025dcb3c0d1ef01530f57ef65f3b1deb948f5737"}
+core-foundation = {git = "https://github.com/servo/core-foundation-rs", rev = "025dcb3c0d1ef01530f57ef65f3b1deb948f5737"}
+core-graphics = {git = "https://github.com/servo/core-foundation-rs", rev = "025dcb3c0d1ef01530f57ef65f3b1deb948f5737"}
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["zed", "gpui", "fsevent", "scoped_pool"]
 [patch.crates-io]
 async-task = {git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e"}
 
-# TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/454
-cocoa = {git = "https://github.com/servo/core-foundation-rs", rev = "e9a65bb15d591ec22649e03659db8095d4f2dd60"}
-cocoa-foundation = {git = "https://github.com/servo/core-foundation-rs", rev = "e9a65bb15d591ec22649e03659db8095d4f2dd60"}
-core-foundation = {git = "https://github.com/servo/core-foundation-rs", rev = "e9a65bb15d591ec22649e03659db8095d4f2dd60"}
-core-graphics = {git = "https://github.com/servo/core-foundation-rs", rev = "e9a65bb15d591ec22649e03659db8095d4f2dd60"}
+# TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457
+cocoa = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
+cocoa-foundation = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
+core-foundation = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
+core-graphics = {git = "https://github.com/zed-industries/core-foundation-rs", rev = "39e1e0eeef11a17cf49aa6a500c37e665d967d2a"}
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -2100,7 +2100,7 @@ impl<T: Entity> ModelHandle<T> {
         }
     }
 
-    fn downgrade(&self) -> WeakModelHandle<T> {
+    pub fn downgrade(&self) -> WeakModelHandle<T> {
         WeakModelHandle::new(self.model_id)
     }
 
@@ -2264,6 +2264,15 @@ impl<T: Entity> WeakModelHandle<T> {
             Some(ModelHandle::new(self.model_id, &app.ref_counts))
         } else {
             None
+        }
+    }
+}
+
+impl<T> Clone for WeakModelHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            model_id: self.model_id,
+            model_type: PhantomData,
         }
     }
 }

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -339,6 +339,10 @@ impl TestAppContext {
     pub fn simulate_new_path_selection(&self, result: impl FnOnce(PathBuf) -> Option<PathBuf>) {
         self.1.as_ref().simulate_new_path_selection(result);
     }
+
+    pub fn did_prompt_for_new_path(&self) -> bool {
+        self.1.as_ref().did_prompt_for_new_path()
+    }
 }
 
 impl UpdateModel for TestAppContext {

--- a/gpui/src/platform/mod.rs
+++ b/gpui/src/platform/mod.rs
@@ -19,7 +19,13 @@ use crate::{
 };
 use async_task::Runnable;
 pub use event::Event;
-use std::{any::Any, ops::Range, path::PathBuf, rc::Rc, sync::Arc};
+use std::{
+    any::Any,
+    ops::Range,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
 
 pub trait Platform {
     fn on_menu_command(&self, callback: Box<dyn FnMut(&str, Option<&dyn Any>)>);
@@ -44,6 +50,11 @@ pub trait Platform {
         &self,
         options: PathPromptOptions,
         done_fn: Box<dyn FnOnce(Option<Vec<std::path::PathBuf>>)>,
+    );
+    fn prompt_for_new_path(
+        &self,
+        directory: &Path,
+        done_fn: Box<dyn FnOnce(Option<std::path::PathBuf>)>,
     );
     fn quit(&self);
     fn write_to_clipboard(&self, item: ClipboardItem);

--- a/gpui/src/platform/test.rs
+++ b/gpui/src/platform/test.rs
@@ -1,6 +1,6 @@
 use crate::ClipboardItem;
 use pathfinder_geometry::vector::Vector2F;
-use std::{any::Any, cell::RefCell, rc::Rc, sync::Arc};
+use std::{any::Any, cell::RefCell, path::Path, rc::Rc, sync::Arc};
 
 struct Platform {
     dispatcher: Arc<dyn super::Dispatcher>,
@@ -76,6 +76,8 @@ impl super::Platform for Platform {
         _: Box<dyn FnOnce(Option<Vec<std::path::PathBuf>>)>,
     ) {
     }
+
+    fn prompt_for_new_path(&self, _: &Path, _: Box<dyn FnOnce(Option<std::path::PathBuf>)>) {}
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
         *self.current_clipboard_item.borrow_mut() = Some(item);

--- a/gpui/src/platform/test.rs
+++ b/gpui/src/platform/test.rs
@@ -1,11 +1,18 @@
 use crate::ClipboardItem;
 use pathfinder_geometry::vector::Vector2F;
-use std::{any::Any, cell::RefCell, path::Path, rc::Rc, sync::Arc};
+use std::{
+    any::Any,
+    cell::RefCell,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
 
-struct Platform {
+pub(crate) struct Platform {
     dispatcher: Arc<dyn super::Dispatcher>,
     fonts: Arc<dyn super::FontSystem>,
     current_clipboard_item: RefCell<Option<ClipboardItem>>,
+    last_prompt_for_new_path_args: RefCell<Option<(PathBuf, Box<dyn FnOnce(Option<PathBuf>)>)>>,
 }
 
 struct Dispatcher;
@@ -23,8 +30,20 @@ impl Platform {
         Self {
             dispatcher: Arc::new(Dispatcher),
             fonts: Arc::new(super::current::FontSystem::new()),
-            current_clipboard_item: RefCell::new(None),
+            current_clipboard_item: Default::default(),
+            last_prompt_for_new_path_args: Default::default(),
         }
+    }
+
+    pub(crate) fn simulate_new_path_selection(
+        &self,
+        result: impl FnOnce(PathBuf) -> Option<PathBuf>,
+    ) {
+        let (dir_path, callback) = self
+            .last_prompt_for_new_path_args
+            .take()
+            .expect("prompt_for_new_path was not called");
+        callback(result(dir_path));
     }
 }
 
@@ -77,7 +96,9 @@ impl super::Platform for Platform {
     ) {
     }
 
-    fn prompt_for_new_path(&self, _: &Path, _: Box<dyn FnOnce(Option<std::path::PathBuf>)>) {}
+    fn prompt_for_new_path(&self, path: &Path, f: Box<dyn FnOnce(Option<std::path::PathBuf>)>) {
+        *self.last_prompt_for_new_path_args.borrow_mut() = Some((path.to_path_buf(), f));
+    }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
         *self.current_clipboard_item.borrow_mut() = Some(item);
@@ -134,6 +155,6 @@ impl super::Window for Window {
     }
 }
 
-pub fn platform() -> impl super::Platform {
+pub(crate) fn platform() -> Platform {
     Platform::new()
 }

--- a/gpui/src/platform/test.rs
+++ b/gpui/src/platform/test.rs
@@ -45,6 +45,10 @@ impl Platform {
             .expect("prompt_for_new_path was not called");
         callback(result(dir_path));
     }
+
+    pub(crate) fn did_prompt_for_new_path(&self) -> bool {
+        self.last_prompt_for_new_path_args.borrow().is_some()
+    }
 }
 
 impl super::Platform for Platform {

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -484,7 +484,9 @@ impl Buffer {
         file: Option<FileHandle>,
         ctx: &mut ModelContext<Buffer>,
     ) {
-        self.file = file;
+        if file.is_some() {
+            self.file = file;
+        }
         self.saved_version = version;
         ctx.emit(Event::Saved);
     }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -436,7 +436,7 @@ impl Buffer {
         &mut self,
         file: &FileHandle,
         ctx: &mut ModelContext<Self>,
-    ) -> LocalBoxFuture<'static, Result<()>> {
+    ) -> LocalBoxFuture<'static, Result<u64>> {
         let snapshot = self.snapshot();
         let version = self.version.clone();
         let save_task = file.save(snapshot, ctx.as_ref());

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -3123,8 +3123,7 @@ mod tests {
                 let mut buffers = Vec::new();
                 let mut network = Network::new();
                 for i in 0..PEERS {
-                    let buffer =
-                        ctx.add_model(|_| Buffer::new(i as ReplicaId, base_text.as_str()));
+                    let buffer = ctx.add_model(|_| Buffer::new(i as ReplicaId, base_text.as_str()));
                     buffers.push(buffer);
                     replica_ids.push(i as u16);
                     network.add_peer(i as u16);

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -8,6 +8,7 @@ use futures_core::future::LocalBoxFuture;
 pub use point::*;
 use seahash::SeaHasher;
 pub use selection::*;
+use smol::future::FutureExt;
 pub use text::*;
 
 use crate::{
@@ -64,6 +65,7 @@ pub struct Buffer {
     last_edit: time::Local,
     undo_map: UndoMap,
     history: History,
+    file: Option<FileHandle>,
     selections: HashMap<SelectionSetId, Arc<[Selection]>>,
     pub selections_last_update: SelectionsVersion,
     deferred_ops: OperationQueue<Operation>,
@@ -351,15 +353,33 @@ pub struct UndoOperation {
 }
 
 impl Buffer {
-    pub fn new<T: Into<Arc<str>>>(replica_id: ReplicaId, base_text: T) -> Self {
-        Self::build(replica_id, History::new(base_text.into()))
+    pub fn new<T: Into<Arc<str>>>(
+        replica_id: ReplicaId,
+        base_text: T,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        Self::build(replica_id, History::new(base_text.into()), None, ctx)
     }
 
-    pub fn from_history(replica_id: ReplicaId, history: History) -> Self {
-        Self::build(replica_id, history)
+    pub fn from_history(
+        replica_id: ReplicaId,
+        history: History,
+        file: Option<FileHandle>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        Self::build(replica_id, history, file, ctx)
     }
 
-    fn build(replica_id: ReplicaId, history: History) -> Self {
+    fn build(
+        replica_id: ReplicaId,
+        history: History,
+        file: Option<FileHandle>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        if let Some(file) = file.as_ref() {
+            file.observe_from_model(ctx, |_, _, ctx| ctx.emit(Event::FileHandleChanged));
+        }
+
         let mut insertion_splits = HashMap::default();
         let mut fragments = SumTree::new();
 
@@ -416,6 +436,7 @@ impl Buffer {
             last_edit: time::Local::default(),
             undo_map: Default::default(),
             history,
+            file,
             selections: HashMap::default(),
             selections_last_update: 0,
             deferred_ops: OperationQueue::new(),
@@ -432,24 +453,38 @@ impl Buffer {
         }
     }
 
-    pub fn save(
-        &mut self,
-        file: &FileHandle,
-        ctx: &mut ModelContext<Self>,
-    ) -> LocalBoxFuture<'static, Result<u64>> {
-        let snapshot = self.snapshot();
-        let version = self.version.clone();
-        let save_task = file.save(snapshot, ctx.as_ref());
-        let task = ctx.spawn(save_task, |me, save_result, ctx| {
-            if save_result.is_ok() {
-                me.did_save(version, ctx);
-            }
-            save_result
-        });
-        Box::pin(task)
+    pub fn file(&self) -> Option<&FileHandle> {
+        self.file.as_ref()
     }
 
-    fn did_save(&mut self, version: time::Global, ctx: &mut ModelContext<Buffer>) {
+    pub fn save(
+        &mut self,
+        new_file: Option<FileHandle>,
+        ctx: &mut ModelContext<Self>,
+    ) -> LocalBoxFuture<'static, Result<()>> {
+        let snapshot = self.snapshot();
+        let version = self.version.clone();
+        if let Some(file) = new_file.as_ref().or(self.file.as_ref()) {
+            let save_task = file.save(snapshot, ctx.as_ref());
+            ctx.spawn(save_task, |me, save_result, ctx| {
+                if save_result.is_ok() {
+                    me.did_save(version, new_file, ctx);
+                }
+                save_result
+            })
+            .boxed_local()
+        } else {
+            async { Ok(()) }.boxed_local()
+        }
+    }
+
+    fn did_save(
+        &mut self,
+        version: time::Global,
+        file: Option<FileHandle>,
+        ctx: &mut ModelContext<Buffer>,
+    ) {
+        self.file = file;
         self.saved_version = version;
         ctx.emit(Event::Saved);
     }
@@ -1737,6 +1772,7 @@ impl Clone for Buffer {
             selections: self.selections.clone(),
             selections_last_update: self.selections_last_update.clone(),
             deferred_ops: self.deferred_ops.clone(),
+            file: self.file.clone(),
             deferred_replicas: self.deferred_replicas.clone(),
             replica_id: self.replica_id,
             local_clock: self.local_clock.clone(),
@@ -2296,8 +2332,8 @@ mod tests {
     #[test]
     fn test_edit() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let mut buffer = Buffer::new(0, "abc");
+            ctx.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "abc", ctx);
                 assert_eq!(buffer.text(), "abc");
                 buffer.edit(vec![3..3], "def", None).unwrap();
                 assert_eq!(buffer.text(), "abcdef");
@@ -2321,8 +2357,8 @@ mod tests {
             let buffer_1_events = Rc::new(RefCell::new(Vec::new()));
             let buffer_2_events = Rc::new(RefCell::new(Vec::new()));
 
-            let buffer1 = app.add_model(|_| Buffer::new(0, "abcdef"));
-            let buffer2 = app.add_model(|_| Buffer::new(1, "abcdef"));
+            let buffer1 = app.add_model(|ctx| Buffer::new(0, "abcdef", ctx));
+            let buffer2 = app.add_model(|ctx| Buffer::new(1, "abcdef", ctx));
             let mut buffer_ops = Vec::new();
             buffer1.update(app, |buffer, ctx| {
                 let buffer_1_events = buffer_1_events.clone();
@@ -2408,8 +2444,8 @@ mod tests {
                 let mut reference_string = RandomCharIter::new(&mut rng)
                     .take(reference_string_len)
                     .collect::<String>();
-                ctx.add_model(|_| {
-                    let mut buffer = Buffer::new(0, reference_string.as_str());
+                ctx.add_model(|ctx| {
+                    let mut buffer = Buffer::new(0, reference_string.as_str(), ctx);
                     let mut buffer_versions = Vec::new();
                     for _i in 0..10 {
                         let (old_ranges, new_text, _) = buffer.randomly_mutate(rng, None);
@@ -2494,8 +2530,8 @@ mod tests {
     #[test]
     fn test_line_len() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let mut buffer = Buffer::new(0, "");
+            ctx.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "", ctx);
                 buffer.edit(vec![0..0], "abcd\nefg\nhij", None).unwrap();
                 buffer.edit(vec![12..12], "kl\nmno", None).unwrap();
                 buffer.edit(vec![18..18], "\npqrs\n", None).unwrap();
@@ -2516,8 +2552,8 @@ mod tests {
     #[test]
     fn test_rightmost_point() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let mut buffer = Buffer::new(0, "");
+            ctx.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "", ctx);
                 assert_eq!(buffer.rightmost_point().row, 0);
                 buffer.edit(vec![0..0], "abcd\nefg\nhij", None).unwrap();
                 assert_eq!(buffer.rightmost_point().row, 0);
@@ -2537,8 +2573,8 @@ mod tests {
     #[test]
     fn test_text_summary_for_range() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let buffer = Buffer::new(0, "ab\nefg\nhklm\nnopqrs\ntuvwxyz");
+            ctx.add_model(|ctx| {
+                let buffer = Buffer::new(0, "ab\nefg\nhklm\nnopqrs\ntuvwxyz", ctx);
                 let text = Text::from(buffer.text());
                 assert_eq!(
                     buffer.text_summary_for_range(1..3),
@@ -2568,8 +2604,8 @@ mod tests {
     #[test]
     fn test_chars_at() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let mut buffer = Buffer::new(0, "");
+            ctx.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "", ctx);
                 buffer.edit(vec![0..0], "abcd\nefgh\nij", None).unwrap();
                 buffer.edit(vec![12..12], "kl\nmno", None).unwrap();
                 buffer.edit(vec![18..18], "\npqrs", None).unwrap();
@@ -2591,7 +2627,7 @@ mod tests {
                 assert_eq!(chars.collect::<String>(), "PQrs");
 
                 // Regression test:
-                let mut buffer = Buffer::new(0, "");
+                let mut buffer = Buffer::new(0, "", ctx);
                 buffer.edit(vec![0..0], "[workspace]\nmembers = [\n    \"xray_core\",\n    \"xray_server\",\n    \"xray_cli\",\n    \"xray_wasm\",\n]\n", None).unwrap();
                 buffer.edit(vec![60..60], "\n", None).unwrap();
 
@@ -2720,8 +2756,8 @@ mod tests {
     #[test]
     fn test_anchors() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let mut buffer = Buffer::new(0, "");
+            ctx.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "", ctx);
                 buffer.edit(vec![0..0], "abc", None).unwrap();
                 let left_anchor = buffer.anchor_before(2).unwrap();
                 let right_anchor = buffer.anchor_after(2).unwrap();
@@ -2885,8 +2921,8 @@ mod tests {
     #[test]
     fn test_anchors_at_start_and_end() {
         App::test((), |ctx| {
-            ctx.add_model(|_| {
-                let mut buffer = Buffer::new(0, "");
+            ctx.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "", ctx);
                 let before_start_anchor = buffer.anchor_before(0).unwrap();
                 let after_end_anchor = buffer.anchor_after(0).unwrap();
 
@@ -2913,7 +2949,7 @@ mod tests {
     #[test]
     fn test_is_modified() {
         App::test((), |app| {
-            let model = app.add_model(|_| Buffer::new(0, "abc"));
+            let model = app.add_model(|ctx| Buffer::new(0, "abc", ctx));
             let events = Rc::new(RefCell::new(Vec::new()));
 
             // initially, the buffer isn't dirty.
@@ -2945,7 +2981,7 @@ mod tests {
                 );
                 events.borrow_mut().clear();
 
-                buffer.did_save(buffer.version(), ctx);
+                buffer.did_save(buffer.version(), None, ctx);
             });
 
             // after saving, the buffer is not dirty, and emits a saved event.
@@ -3000,8 +3036,8 @@ mod tests {
     #[test]
     fn test_undo_redo() {
         App::test((), |app| {
-            app.add_model(|_| {
-                let mut buffer = Buffer::new(0, "1234");
+            app.add_model(|ctx| {
+                let mut buffer = Buffer::new(0, "1234", ctx);
 
                 let edit1 = buffer.edit(vec![1..1], "abx", None).unwrap();
                 let edit2 = buffer.edit(vec![3..4], "yzef", None).unwrap();
@@ -3037,9 +3073,9 @@ mod tests {
     #[test]
     fn test_history() {
         App::test((), |app| {
-            app.add_model(|_| {
+            app.add_model(|ctx| {
                 let mut now = Instant::now();
-                let mut buffer = Buffer::new(0, "123456");
+                let mut buffer = Buffer::new(0, "123456", ctx);
 
                 let (set_id, _) = buffer
                     .add_selection_set(buffer.selections_from_ranges(vec![4..4]).unwrap(), None);
@@ -3123,7 +3159,8 @@ mod tests {
                 let mut buffers = Vec::new();
                 let mut network = Network::new();
                 for i in 0..PEERS {
-                    let buffer = ctx.add_model(|_| Buffer::new(i as ReplicaId, base_text.as_str()));
+                    let buffer =
+                        ctx.add_model(|ctx| Buffer::new(i as ReplicaId, base_text.as_str(), ctx));
                     buffers.push(buffer);
                     replica_ids.push(i as u16);
                     network.add_peer(i as u16);

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -2058,6 +2058,10 @@ impl BufferView {
             buffer::Event::FileHandleChanged => ctx.emit(Event::FileHandleChanged),
         }
     }
+
+    pub fn file(&self) -> Option<&FileHandle> {
+        self.file.as_ref()
+    }
 }
 
 pub enum Event {
@@ -2138,7 +2142,7 @@ impl workspace::ItemView for BufferView {
         &mut self,
         new_file: Option<FileHandle>,
         ctx: &mut ViewContext<Self>,
-    ) -> LocalBoxFuture<'static, Result<()>> {
+    ) -> LocalBoxFuture<'static, Result<u64>> {
         if let Some(file) = new_file.as_ref().or(self.file.as_ref()) {
             let save = self.buffer.update(ctx, |b, ctx| b.save(file, ctx));
             ctx.spawn(save, move |this, result, ctx| {
@@ -2151,7 +2155,7 @@ impl workspace::ItemView for BufferView {
             })
             .boxed_local()
         } else {
-            Box::pin(async { Ok(()) })
+            Box::pin(async { Err(anyhow::anyhow!("can't save a buffer with no file")) })
         }
     }
 

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -6,11 +6,10 @@ use crate::{settings::Settings, watch, workspace, worktree::FileHandle};
 use anyhow::Result;
 use futures_core::future::LocalBoxFuture;
 use gpui::{
-    fonts::Properties as FontProperties, keymap::Binding, text_layout, AppContext, ClipboardItem,
-    Element, ElementBox, Entity, FontCache, ModelHandle, MutableAppContext, View, ViewContext,
-    WeakViewHandle,
+    fonts::Properties as FontProperties, geometry::vector::Vector2F, keymap::Binding, text_layout,
+    AppContext, ClipboardItem, Element, ElementBox, Entity, FontCache, ModelHandle,
+    MutableAppContext, TextLayoutCache, View, ViewContext, WeakViewHandle,
 };
-use gpui::{geometry::vector::Vector2F, TextLayoutCache};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -2135,7 +2134,14 @@ impl workspace::ItemView for BufferView {
         Some(clone)
     }
 
-    fn save(&self, ctx: &mut ViewContext<Self>) -> LocalBoxFuture<'static, Result<()>> {
+    fn save(
+        &mut self,
+        file: Option<FileHandle>,
+        ctx: &mut ViewContext<Self>,
+    ) -> LocalBoxFuture<'static, Result<()>> {
+        if file.is_some() {
+            self.file = file;
+        }
         if let Some(file) = self.file.as_ref() {
             self.buffer
                 .update(ctx, |buffer, ctx| buffer.save(file, ctx))

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -505,7 +505,7 @@ mod tests {
     #[test]
     fn test_basic_folds() {
         App::test((), |app| {
-            let buffer = app.add_model(|_| Buffer::new(0, sample_text(5, 6)));
+            let buffer = app.add_model(|ctx| Buffer::new(0, sample_text(5, 6), ctx));
             let mut map = FoldMap::new(buffer.clone(), app.as_ref());
 
             map.fold(
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     fn test_adjacent_folds() {
         App::test((), |app| {
-            let buffer = app.add_model(|_| Buffer::new(0, "abcdefghijkl"));
+            let buffer = app.add_model(|ctx| Buffer::new(0, "abcdefghijkl", ctx));
 
             {
                 let mut map = FoldMap::new(buffer.clone(), app.as_ref());
@@ -600,7 +600,7 @@ mod tests {
     #[test]
     fn test_overlapping_folds() {
         App::test((), |app| {
-            let buffer = app.add_model(|_| Buffer::new(0, sample_text(5, 6)));
+            let buffer = app.add_model(|ctx| Buffer::new(0, sample_text(5, 6), ctx));
             let mut map = FoldMap::new(buffer.clone(), app.as_ref());
             map.fold(
                 vec![
@@ -619,7 +619,7 @@ mod tests {
     #[test]
     fn test_merging_folds_via_edit() {
         App::test((), |app| {
-            let buffer = app.add_model(|_| Buffer::new(0, sample_text(5, 6)));
+            let buffer = app.add_model(|ctx| Buffer::new(0, sample_text(5, 6), ctx));
             let mut map = FoldMap::new(buffer.clone(), app.as_ref());
 
             map.fold(
@@ -670,10 +670,10 @@ mod tests {
             let mut rng = StdRng::seed_from_u64(seed);
 
             App::test((), |app| {
-                let buffer = app.add_model(|_| {
+                let buffer = app.add_model(|ctx| {
                     let len = rng.gen_range(0..10);
                     let text = RandomCharIter::new(&mut rng).take(len).collect::<String>();
-                    Buffer::new(0, text)
+                    Buffer::new(0, text, ctx)
                 });
                 let mut map = FoldMap::new(buffer.clone(), app.as_ref());
 
@@ -749,7 +749,7 @@ mod tests {
     fn test_buffer_rows() {
         App::test((), |app| {
             let text = sample_text(6, 6) + "\n";
-            let buffer = app.add_model(|_| Buffer::new(0, text));
+            let buffer = app.add_model(|ctx| Buffer::new(0, text, ctx));
 
             let mut map = FoldMap::new(buffer.clone(), app.as_ref());
 

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -324,7 +324,7 @@ mod tests {
     fn test_chars_at() {
         App::test((), |app| {
             let text = sample_text(6, 6);
-            let buffer = app.add_model(|_| Buffer::new(0, text));
+            let buffer = app.add_model(|ctx| Buffer::new(0, text, ctx));
             let map = app.add_model(|ctx| DisplayMap::new(buffer.clone(), 4, ctx));
             buffer
                 .update(app, |buffer, ctx| {
@@ -391,7 +391,7 @@ mod tests {
     #[test]
     fn test_max_point() {
         App::test((), |app| {
-            let buffer = app.add_model(|_| Buffer::new(0, "aaa\n\t\tbbb"));
+            let buffer = app.add_model(|ctx| Buffer::new(0, "aaa\n\t\tbbb", ctx));
             let map = app.add_model(|ctx| DisplayMap::new(buffer.clone(), 4, ctx));
             assert_eq!(
                 map.read(app).max_point(app.as_ref()),

--- a/zed/src/menus.rs
+++ b/zed/src/menus.rs
@@ -24,12 +24,21 @@ pub fn menus(settings: Receiver<Settings>) -> Vec<Menu<'static>> {
         },
         Menu {
             name: "File",
-            items: vec![MenuItem::Action {
-                name: "Open…",
-                keystroke: Some("cmd-o"),
-                action: "workspace:open",
-                arg: Some(Box::new(settings)),
-            }],
+            items: vec![
+                MenuItem::Action {
+                    name: "New",
+                    keystroke: Some("cmd-n"),
+                    action: "workspace:new_file",
+                    arg: None,
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Open…",
+                    keystroke: Some("cmd-o"),
+                    action: "workspace:open",
+                    arg: Some(Box::new(settings)),
+                },
+            ],
         },
         Menu {
             name: "Edit",


### PR DESCRIPTION
This PR adds a `File > New` menu item (bound to `cmd-n`) for creating new files in Zed. When you save a new file, you're prompted for a path.

/cc @nathansobo @as-cii 