### PR TITLE
Optimize querying folds

### DIFF
--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -373,39 +373,48 @@ impl Buffer {
 
         insertion_splits.insert(
             base_insertion.id,
-            SumTree::from_item(InsertionSplit {
-                fragment_id: FragmentId::min_value().clone(),
-                extent: 0,
-            }),
+            SumTree::from_item(
+                InsertionSplit {
+                    fragment_id: FragmentId::min_value().clone(),
+                    extent: 0,
+                },
+                &(),
+            ),
         );
-        fragments.push(Fragment {
-            id: FragmentId::min_value().clone(),
-            insertion: base_insertion.clone(),
-            text: base_insertion.text.slice(0..0),
-            deletions: Default::default(),
-            max_undos: Default::default(),
-            visible: true,
-        });
+        fragments.push(
+            Fragment {
+                id: FragmentId::min_value().clone(),
+                insertion: base_insertion.clone(),
+                text: base_insertion.text.slice(0..0),
+                deletions: Default::default(),
+                max_undos: Default::default(),
+                visible: true,
+            },
+            &(),
+        );
 
         if base_insertion.text.len() > 0 {
             let base_fragment_id =
                 FragmentId::between(&FragmentId::min_value(), &FragmentId::max_value());
 
-            insertion_splits
-                .get_mut(&base_insertion.id)
-                .unwrap()
-                .push(InsertionSplit {
+            insertion_splits.get_mut(&base_insertion.id).unwrap().push(
+                InsertionSplit {
                     fragment_id: base_fragment_id.clone(),
                     extent: base_insertion.text.len(),
-                });
-            fragments.push(Fragment {
-                id: base_fragment_id,
-                text: base_insertion.text.clone(),
-                insertion: base_insertion,
-                deletions: Default::default(),
-                max_undos: Default::default(),
-                visible: true,
-            });
+                },
+                &(),
+            );
+            fragments.push(
+                Fragment {
+                    id: base_fragment_id,
+                    text: base_insertion.text.clone(),
+                    insertion: base_insertion,
+                    deletions: Default::default(),
+                    max_undos: Default::default(),
+                    visible: true,
+                },
+                &(),
+            );
         }
 
         Self {
@@ -470,7 +479,7 @@ impl Buffer {
         let mut summary = TextSummary::default();
 
         let mut cursor = self.fragments.cursor::<usize, usize>();
-        cursor.seek(&range.start, SeekBias::Right);
+        cursor.seek(&range.start, SeekBias::Right, &());
 
         if let Some(fragment) = cursor.item() {
             let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
@@ -480,7 +489,7 @@ impl Buffer {
         }
 
         if range.end > *cursor.start() {
-            summary += cursor.summary::<TextSummary>(&range.end, SeekBias::Right);
+            summary += cursor.summary::<TextSummary>(&range.end, SeekBias::Right, &());
 
             if let Some(fragment) = cursor.item() {
                 let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
@@ -515,7 +524,7 @@ impl Buffer {
         let mut summary = TextSummary::default();
 
         let mut cursor = self.fragments.cursor::<usize, usize>();
-        cursor.seek(&range.start, SeekBias::Right);
+        cursor.seek(&range.start, SeekBias::Right, &());
 
         if let Some(fragment) = cursor.item() {
             let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
@@ -525,7 +534,7 @@ impl Buffer {
         }
 
         if range.end > *cursor.start() {
-            summary += cursor.summary::<TextSummary>(&range.end, SeekBias::Right);
+            summary += cursor.summary::<TextSummary>(&range.end, SeekBias::Right, &());
 
             if let Some(fragment) = cursor.item() {
                 let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
@@ -933,10 +942,10 @@ impl Buffer {
 
         let mut cursor = old_fragments.cursor::<FragmentIdRef, ()>();
         let mut new_fragments =
-            cursor.slice(&FragmentIdRef::new(&start_fragment_id), SeekBias::Left);
+            cursor.slice(&FragmentIdRef::new(&start_fragment_id), SeekBias::Left, &());
 
         if start_offset == cursor.item().unwrap().end_offset() {
-            new_fragments.push(cursor.item().unwrap().clone());
+            new_fragments.push(cursor.item().unwrap().clone(), &());
             cursor.next();
         }
 
@@ -975,30 +984,33 @@ impl Buffer {
                     None
                 };
                 if let Some(fragment) = before_range {
-                    new_fragments.push(fragment);
+                    new_fragments.push(fragment, &());
                 }
                 if let Some(fragment) = insertion {
-                    new_fragments.push(fragment);
+                    new_fragments.push(fragment, &());
                 }
                 if let Some(mut fragment) = within_range {
                     if fragment.was_visible(&version_in_range, &self.undo_map) {
                         fragment.deletions.insert(local_timestamp);
                         fragment.visible = false;
                     }
-                    new_fragments.push(fragment);
+                    new_fragments.push(fragment, &());
                 }
                 if let Some(fragment) = after_range {
-                    new_fragments.push(fragment);
+                    new_fragments.push(fragment, &());
                 }
             } else {
                 if new_text.is_some() && lamport_timestamp > fragment.insertion.lamport_timestamp {
-                    new_fragments.push(self.build_fragment_to_insert(
-                        cursor.prev_item().as_ref().unwrap(),
-                        Some(&fragment),
-                        new_text.take().unwrap(),
-                        local_timestamp,
-                        lamport_timestamp,
-                    ));
+                    new_fragments.push(
+                        self.build_fragment_to_insert(
+                            cursor.prev_item().as_ref().unwrap(),
+                            Some(&fragment),
+                            new_text.take().unwrap(),
+                            local_timestamp,
+                            lamport_timestamp,
+                        ),
+                        &(),
+                    );
                 }
 
                 if fragment.id < end_fragment_id
@@ -1007,23 +1019,26 @@ impl Buffer {
                     fragment.deletions.insert(local_timestamp);
                     fragment.visible = false;
                 }
-                new_fragments.push(fragment);
+                new_fragments.push(fragment, &());
             }
 
             cursor.next();
         }
 
         if let Some(new_text) = new_text {
-            new_fragments.push(self.build_fragment_to_insert(
-                cursor.prev_item().as_ref().unwrap(),
-                None,
-                new_text,
-                local_timestamp,
-                lamport_timestamp,
-            ));
+            new_fragments.push(
+                self.build_fragment_to_insert(
+                    cursor.prev_item().as_ref().unwrap(),
+                    None,
+                    new_text,
+                    local_timestamp,
+                    lamport_timestamp,
+                ),
+                &(),
+            );
         }
 
-        new_fragments.push_tree(cursor.slice(&last_id_ref, SeekBias::Right));
+        new_fragments.push_tree(cursor.slice(&last_id_ref, SeekBias::Right, &()), &());
         self.fragments = new_fragments;
         self.local_clock.observe(local_timestamp);
         self.lamport_clock.observe(lamport_timestamp);
@@ -1111,23 +1126,26 @@ impl Buffer {
             let mut insertion_splits = splits.cursor::<(), ()>().map(|s| &s.fragment_id).peekable();
 
             let first_split_id = insertion_splits.next().unwrap();
-            new_fragments = cursor.slice(&FragmentIdRef::new(first_split_id), SeekBias::Left);
+            new_fragments = cursor.slice(&FragmentIdRef::new(first_split_id), SeekBias::Left, &());
 
             loop {
                 let mut fragment = cursor.item().unwrap().clone();
                 fragment.visible = fragment.is_visible(&self.undo_map);
                 fragment.max_undos.observe(undo.id);
-                new_fragments.push(fragment);
+                new_fragments.push(fragment, &());
                 cursor.next();
                 if let Some(split_id) = insertion_splits.next() {
-                    new_fragments
-                        .push_tree(cursor.slice(&FragmentIdRef::new(split_id), SeekBias::Left));
+                    new_fragments.push_tree(
+                        cursor.slice(&FragmentIdRef::new(split_id), SeekBias::Left, &()),
+                        &(),
+                    );
                 } else {
                     break;
                 }
             }
         } else {
-            new_fragments = cursor.slice(&FragmentIdRef::new(&start_fragment_id), SeekBias::Left);
+            new_fragments =
+                cursor.slice(&FragmentIdRef::new(&start_fragment_id), SeekBias::Left, &());
             while let Some(fragment) = cursor.item() {
                 if fragment.id > end_fragment_id {
                     break;
@@ -1139,13 +1157,13 @@ impl Buffer {
                         fragment.visible = fragment.is_visible(&self.undo_map);
                         fragment.max_undos.observe(undo.id);
                     }
-                    new_fragments.push(fragment);
+                    new_fragments.push(fragment, &());
                     cursor.next();
                 }
             }
         }
 
-        new_fragments.push_tree(cursor.suffix());
+        new_fragments.push_tree(cursor.suffix(&()), &());
         drop(cursor);
         self.fragments = new_fragments;
 
@@ -1209,7 +1227,7 @@ impl Buffer {
             .get(&edit_id)
             .ok_or_else(|| anyhow!("invalid operation"))?;
         let mut cursor = split_tree.cursor::<usize, ()>();
-        cursor.seek(&offset, SeekBias::Left);
+        cursor.seek(&offset, SeekBias::Left, &());
         Ok(cursor
             .item()
             .ok_or_else(|| anyhow!("invalid operation"))?
@@ -1231,7 +1249,10 @@ impl Buffer {
         let old_fragments = self.fragments.clone();
         let mut cursor = old_fragments.cursor::<usize, usize>();
         let mut new_fragments = SumTree::new();
-        new_fragments.push_tree(cursor.slice(&cur_range.as_ref().unwrap().start, SeekBias::Right));
+        new_fragments.push_tree(
+            cursor.slice(&cur_range.as_ref().unwrap().start, SeekBias::Right, &()),
+            &(),
+        );
 
         let mut start_id = None;
         let mut start_offset = None;
@@ -1253,7 +1274,8 @@ impl Buffer {
                 .remove(&fragment.insertion.id)
                 .unwrap();
             let mut splits_cursor = old_split_tree.cursor::<usize, ()>();
-            let mut new_split_tree = splits_cursor.slice(&fragment.start_offset(), SeekBias::Right);
+            let mut new_split_tree =
+                splits_cursor.slice(&fragment.start_offset(), SeekBias::Right, &());
 
             // Find all splices that start or end within the current fragment. Then, split the
             // fragment and reassemble it in both trees accounting for the deleted and the newly
@@ -1266,11 +1288,14 @@ impl Buffer {
                     prefix.id =
                         FragmentId::between(&new_fragments.last().unwrap().id, &fragment.id);
                     fragment.set_start_offset(prefix.end_offset());
-                    new_fragments.push(prefix.clone());
-                    new_split_tree.push(InsertionSplit {
-                        extent: prefix.end_offset() - prefix.start_offset(),
-                        fragment_id: prefix.id,
-                    });
+                    new_fragments.push(prefix.clone(), &());
+                    new_split_tree.push(
+                        InsertionSplit {
+                            extent: prefix.end_offset() - prefix.start_offset(),
+                            fragment_id: prefix.id,
+                        },
+                        &(),
+                    );
                     fragment_start = range.start;
                 }
 
@@ -1294,7 +1319,7 @@ impl Buffer {
                             local_timestamp,
                             lamport_timestamp,
                         );
-                        new_fragments.push(new_fragment);
+                        new_fragments.push(new_fragment, &());
                     }
                 }
 
@@ -1310,11 +1335,14 @@ impl Buffer {
                             prefix.visible = false;
                         }
                         fragment.set_start_offset(prefix.end_offset());
-                        new_fragments.push(prefix.clone());
-                        new_split_tree.push(InsertionSplit {
-                            extent: prefix.end_offset() - prefix.start_offset(),
-                            fragment_id: prefix.id,
-                        });
+                        new_fragments.push(prefix.clone(), &());
+                        new_split_tree.push(
+                            InsertionSplit {
+                                extent: prefix.end_offset() - prefix.start_offset(),
+                                fragment_id: prefix.id,
+                            },
+                            &(),
+                        );
                         fragment_start = range.end;
                         end_id = Some(fragment.insertion.id);
                         end_offset = Some(fragment.start_offset());
@@ -1358,16 +1386,21 @@ impl Buffer {
                     break;
                 }
             }
-            new_split_tree.push(InsertionSplit {
-                extent: fragment.end_offset() - fragment.start_offset(),
-                fragment_id: fragment.id.clone(),
-            });
+            new_split_tree.push(
+                InsertionSplit {
+                    extent: fragment.end_offset() - fragment.start_offset(),
+                    fragment_id: fragment.id.clone(),
+                },
+                &(),
+            );
             splits_cursor.next();
-            new_split_tree
-                .push_tree(splits_cursor.slice(&old_split_tree.extent::<usize>(), SeekBias::Right));
+            new_split_tree.push_tree(
+                splits_cursor.slice(&old_split_tree.extent::<usize>(), SeekBias::Right, &()),
+                &(),
+            );
             self.insertion_splits
                 .insert(fragment.insertion.id, new_split_tree);
-            new_fragments.push(fragment);
+            new_fragments.push(fragment, &());
 
             // Scan forward until we find a fragment that is not fully contained by the current splice.
             cursor.next();
@@ -1383,7 +1416,7 @@ impl Buffer {
                             new_fragment.deletions.insert(local_timestamp);
                             new_fragment.visible = false;
                         }
-                        new_fragments.push(new_fragment);
+                        new_fragments.push(new_fragment, &());
                         cursor.next();
 
                         if range.end == fragment_end {
@@ -1425,7 +1458,8 @@ impl Buffer {
                 // and push all the fragments in between into the new tree.
                 if cur_range.as_ref().map_or(false, |r| r.start > fragment_end) {
                     new_fragments.push_tree(
-                        cursor.slice(&cur_range.as_ref().unwrap().start, SeekBias::Right),
+                        cursor.slice(&cur_range.as_ref().unwrap().start, SeekBias::Right, &()),
+                        &(),
                     );
                 }
             }
@@ -1457,11 +1491,13 @@ impl Buffer {
                     local_timestamp,
                     lamport_timestamp,
                 );
-                new_fragments.push(new_fragment);
+                new_fragments.push(new_fragment, &());
             }
         } else {
-            new_fragments
-                .push_tree(cursor.slice(&old_fragments.extent::<usize>(), SeekBias::Right));
+            new_fragments.push_tree(
+                cursor.slice(&old_fragments.extent::<usize>(), SeekBias::Right, &()),
+                &(),
+            );
         }
 
         self.fragments = new_fragments;
@@ -1519,32 +1555,43 @@ impl Buffer {
                 .remove(&fragment.insertion.id)
                 .unwrap();
             let mut cursor = old_split_tree.cursor::<usize, ()>();
-            let mut new_split_tree = cursor.slice(&fragment.start_offset(), SeekBias::Right);
+            let mut new_split_tree = cursor.slice(&fragment.start_offset(), SeekBias::Right, &());
 
             if let Some(ref fragment) = before_range {
-                new_split_tree.push(InsertionSplit {
-                    extent: range.start - fragment.start_offset(),
-                    fragment_id: fragment.id.clone(),
-                });
+                new_split_tree.push(
+                    InsertionSplit {
+                        extent: range.start - fragment.start_offset(),
+                        fragment_id: fragment.id.clone(),
+                    },
+                    &(),
+                );
             }
 
             if let Some(ref fragment) = within_range {
-                new_split_tree.push(InsertionSplit {
-                    extent: range.end - range.start,
-                    fragment_id: fragment.id.clone(),
-                });
+                new_split_tree.push(
+                    InsertionSplit {
+                        extent: range.end - range.start,
+                        fragment_id: fragment.id.clone(),
+                    },
+                    &(),
+                );
             }
 
             if let Some(ref fragment) = after_range {
-                new_split_tree.push(InsertionSplit {
-                    extent: fragment.end_offset() - range.end,
-                    fragment_id: fragment.id.clone(),
-                });
+                new_split_tree.push(
+                    InsertionSplit {
+                        extent: fragment.end_offset() - range.end,
+                        fragment_id: fragment.id.clone(),
+                    },
+                    &(),
+                );
             }
 
             cursor.next();
-            new_split_tree
-                .push_tree(cursor.slice(&old_split_tree.extent::<usize>(), SeekBias::Right));
+            new_split_tree.push_tree(
+                cursor.slice(&old_split_tree.extent::<usize>(), SeekBias::Right, &()),
+                &(),
+            );
 
             self.insertion_splits
                 .insert(fragment.insertion.id, new_split_tree);
@@ -1569,10 +1616,13 @@ impl Buffer {
         );
 
         let mut split_tree = SumTree::new();
-        split_tree.push(InsertionSplit {
-            extent: text.len(),
-            fragment_id: new_fragment_id.clone(),
-        });
+        split_tree.push(
+            InsertionSplit {
+                extent: text.len(),
+                fragment_id: new_fragment_id.clone(),
+            },
+            &(),
+        );
         self.insertion_splits.insert(local_timestamp, split_tree);
 
         Fragment::new(
@@ -1621,7 +1671,7 @@ impl Buffer {
         };
 
         let mut cursor = self.fragments.cursor::<usize, usize>();
-        cursor.seek(&offset, seek_bias);
+        cursor.seek(&offset, seek_bias, &());
         let fragment = cursor.item().unwrap();
         let offset_in_fragment = offset - cursor.start();
         let offset_in_insertion = fragment.start_offset() + offset_in_fragment;
@@ -1653,7 +1703,7 @@ impl Buffer {
                     .get(&insertion_id)
                     .ok_or_else(|| anyhow!("split does not exist for insertion id"))?;
                 let mut splits_cursor = splits.cursor::<usize, ()>();
-                splits_cursor.seek(offset, seek_bias);
+                splits_cursor.seek(offset, seek_bias, &());
                 splits_cursor
                     .item()
                     .ok_or_else(|| anyhow!("split offset is out of range"))
@@ -1681,13 +1731,13 @@ impl Buffer {
                     .get(&insertion_id)
                     .ok_or_else(|| anyhow!("split does not exist for insertion id"))?;
                 let mut splits_cursor = splits.cursor::<usize, ()>();
-                splits_cursor.seek(offset, seek_bias);
+                splits_cursor.seek(offset, seek_bias, &());
                 let split = splits_cursor
                     .item()
                     .ok_or_else(|| anyhow!("split offset is out of range"))?;
 
                 let mut fragments_cursor = self.fragments.cursor::<FragmentIdRef, TextSummary>();
-                fragments_cursor.seek(&FragmentIdRef::new(&split.fragment_id), SeekBias::Left);
+                fragments_cursor.seek(&FragmentIdRef::new(&split.fragment_id), SeekBias::Left, &());
                 let fragment = fragments_cursor
                     .item()
                     .ok_or_else(|| anyhow!("fragment id does not exist"))?;
@@ -1707,7 +1757,7 @@ impl Buffer {
     #[allow(dead_code)]
     pub fn point_for_offset(&self, offset: usize) -> Result<Point> {
         let mut fragments_cursor = self.fragments.cursor::<usize, TextSummary>();
-        fragments_cursor.seek(&offset, SeekBias::Left);
+        fragments_cursor.seek(&offset, SeekBias::Left, &());
         fragments_cursor
             .item()
             .ok_or_else(|| anyhow!("offset is out of range"))
@@ -1772,7 +1822,7 @@ impl<'a> sum_tree::Dimension<'a, FragmentSummary> for Point {
 impl<'a> CharIter<'a> {
     fn new(fragments: &'a SumTree<Fragment>, offset: usize) -> Self {
         let mut fragments_cursor = fragments.cursor::<usize, usize>();
-        fragments_cursor.seek(&offset, SeekBias::Right);
+        fragments_cursor.seek(&offset, SeekBias::Right, &());
         let fragment_chars = fragments_cursor.item().map_or("".chars(), |fragment| {
             let offset_in_fragment = offset - fragments_cursor.start();
             fragment.text[offset_in_fragment..].chars()
@@ -1809,7 +1859,7 @@ impl<'a> Iterator for CharIter<'a> {
 impl<'a> FragmentIter<'a> {
     fn new(fragments: &'a SumTree<Fragment>) -> Self {
         let mut cursor = fragments.cursor::<usize, usize>();
-        cursor.seek(&0, SeekBias::Right);
+        cursor.seek(&0, SeekBias::Right, &());
         Self {
             cursor,
             started: false,
@@ -2105,7 +2155,7 @@ impl sum_tree::Item for Fragment {
 impl sum_tree::Summary for FragmentSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
+    fn add_summary(&mut self, other: &Self, _: &()) {
         self.text_summary += &other.text_summary;
         debug_assert!(self.max_fragment_id <= other.max_fragment_id);
         self.max_fragment_id = other.max_fragment_id.clone();
@@ -2171,7 +2221,7 @@ impl sum_tree::Item for InsertionSplit {
 impl sum_tree::Summary for InsertionSplitSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
+    fn add_summary(&mut self, other: &Self, _: &()) {
         self.extent += other.extent;
     }
 }
@@ -2228,7 +2278,7 @@ pub trait ToOffset {
 impl ToOffset for Point {
     fn to_offset(&self, buffer: &Buffer) -> Result<usize> {
         let mut fragments_cursor = buffer.fragments.cursor::<Point, TextSummary>();
-        fragments_cursor.seek(self, SeekBias::Left);
+        fragments_cursor.seek(self, SeekBias::Left, &());
         fragments_cursor
             .item()
             .ok_or_else(|| anyhow!("point is out of range"))
@@ -2272,7 +2322,7 @@ impl ToPoint for Anchor {
 impl ToPoint for usize {
     fn to_point(&self, buffer: &Buffer) -> Result<Point> {
         let mut fragments_cursor = buffer.fragments.cursor::<usize, TextSummary>();
-        fragments_cursor.seek(&self, SeekBias::Left);
+        fragments_cursor.seek(&self, SeekBias::Left, &());
         fragments_cursor
             .item()
             .ok_or_else(|| anyhow!("offset is out of range"))

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -475,17 +475,17 @@ impl Buffer {
         if let Some(fragment) = cursor.item() {
             let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
             let summary_end = cmp::min(range.end - cursor.start(), fragment.len());
-            summary += &fragment.text.slice(summary_start..summary_end).summary();
+            summary += fragment.text.slice(summary_start..summary_end).summary();
             cursor.next();
         }
 
         if range.end > *cursor.start() {
-            summary += &cursor.summary::<TextSummary>(&range.end, SeekBias::Right);
+            summary += cursor.summary::<TextSummary>(&range.end, SeekBias::Right);
 
             if let Some(fragment) = cursor.item() {
                 let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
                 let summary_end = cmp::min(range.end - cursor.start(), fragment.len());
-                summary += &fragment.text.slice(summary_start..summary_end).summary();
+                summary += fragment.text.slice(summary_start..summary_end).summary();
             }
         }
 
@@ -520,17 +520,17 @@ impl Buffer {
         if let Some(fragment) = cursor.item() {
             let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
             let summary_end = cmp::min(range.end - cursor.start(), fragment.len());
-            summary += &fragment.text.slice(summary_start..summary_end).summary();
+            summary += fragment.text.slice(summary_start..summary_end).summary();
             cursor.next();
         }
 
         if range.end > *cursor.start() {
-            summary += &cursor.summary::<TextSummary>(&range.end, SeekBias::Right);
+            summary += cursor.summary::<TextSummary>(&range.end, SeekBias::Right);
 
             if let Some(fragment) = cursor.item() {
                 let summary_start = cmp::max(*cursor.start(), range.start) - cursor.start();
                 let summary_end = cmp::min(range.end - cursor.start(), fragment.len());
-                summary += &fragment.text.slice(summary_start..summary_end).summary();
+                summary += fragment.text.slice(summary_start..summary_end).summary();
             }
         }
 
@@ -2102,8 +2102,8 @@ impl sum_tree::Item for Fragment {
     }
 }
 
-impl<'a> AddAssign<&'a FragmentSummary> for FragmentSummary {
-    fn add_assign(&mut self, other: &Self) {
+impl sum_tree::Summary for FragmentSummary {
+    fn add_summary(&mut self, other: &Self) {
         self.text_summary += &other.text_summary;
         debug_assert!(self.max_fragment_id <= other.max_fragment_id);
         self.max_fragment_id = other.max_fragment_id.clone();
@@ -2166,8 +2166,8 @@ impl sum_tree::Item for InsertionSplit {
     }
 }
 
-impl<'a> AddAssign<&'a InsertionSplitSummary> for InsertionSplitSummary {
-    fn add_assign(&mut self, other: &Self) {
+impl sum_tree::Summary for InsertionSplitSummary {
+    fn add_summary(&mut self, other: &Self) {
         self.extent += other.extent;
     }
 }
@@ -3071,8 +3071,7 @@ mod tests {
                 let mut buffers = Vec::new();
                 let mut network = Network::new();
                 for i in 0..PEERS {
-                    let buffer =
-                        ctx.add_model(|_| Buffer::new(i as ReplicaId, base_text.as_str()));
+                    let buffer = ctx.add_model(|_| Buffer::new(i as ReplicaId, base_text.as_str()));
                     buffers.push(buffer);
                     replica_ids.push(i as u16);
                     network.add_peer(i as u16);

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -2105,7 +2105,7 @@ impl sum_tree::Item for Fragment {
 impl sum_tree::Summary for FragmentSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self) {
+    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
         self.text_summary += &other.text_summary;
         debug_assert!(self.max_fragment_id <= other.max_fragment_id);
         self.max_fragment_id = other.max_fragment_id.clone();
@@ -2171,7 +2171,7 @@ impl sum_tree::Item for InsertionSplit {
 impl sum_tree::Summary for InsertionSplitSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self) {
+    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
         self.extent += other.extent;
     }
 }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -2103,6 +2103,8 @@ impl sum_tree::Item for Fragment {
 }
 
 impl sum_tree::Summary for FragmentSummary {
+    type Context = ();
+
     fn add_summary(&mut self, other: &Self) {
         self.text_summary += &other.text_summary;
         debug_assert!(self.max_fragment_id <= other.max_fragment_id);
@@ -2167,6 +2169,8 @@ impl sum_tree::Item for InsertionSplit {
 }
 
 impl sum_tree::Summary for InsertionSplitSummary {
+    type Context = ();
+
     fn add_summary(&mut self, other: &Self) {
         self.extent += other.extent;
     }

--- a/zed/src/editor/buffer/text.rs
+++ b/zed/src/editor/buffer/text.rs
@@ -58,6 +58,12 @@ pub struct TextSummary {
     pub rightmost_point: Point,
 }
 
+impl sum_tree::Summary for TextSummary {
+    fn add_summary(&mut self, other: &Self) {
+        *self += other;
+    }
+}
+
 impl<'a> std::ops::AddAssign<&'a Self> for TextSummary {
     fn add_assign(&mut self, other: &'a Self) {
         let joined_line_len = self.lines.column + other.first_line_len;
@@ -85,8 +91,8 @@ impl std::ops::AddAssign<Self> for TextSummary {
 }
 
 impl<'a> sum_tree::Dimension<'a, TextSummary> for TextSummary {
-    fn add_summary(&mut self, summary: &TextSummary) {
-        *self += summary;
+    fn add_summary(&mut self, other: &TextSummary) {
+        *self += other;
     }
 }
 

--- a/zed/src/editor/buffer/text.rs
+++ b/zed/src/editor/buffer/text.rs
@@ -61,7 +61,7 @@ pub struct TextSummary {
 impl sum_tree::Summary for TextSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self) {
+    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
         *self += other;
     }
 }

--- a/zed/src/editor/buffer/text.rs
+++ b/zed/src/editor/buffer/text.rs
@@ -59,6 +59,8 @@ pub struct TextSummary {
 }
 
 impl sum_tree::Summary for TextSummary {
+    type Context = ();
+
     fn add_summary(&mut self, other: &Self) {
         *self += other;
     }

--- a/zed/src/editor/buffer/text.rs
+++ b/zed/src/editor/buffer/text.rs
@@ -61,7 +61,7 @@ pub struct TextSummary {
 impl sum_tree::Summary for TextSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
+    fn add_summary(&mut self, other: &Self, _: &()) {
         *self += other;
     }
 }
@@ -165,7 +165,7 @@ impl From<Arc<str>> for Text {
         }
 
         let mut tree = SumTree::new();
-        tree.extend(runs);
+        tree.extend(runs, &());
         Text {
             text,
             runs: tree,
@@ -239,13 +239,14 @@ impl Text {
 
     pub fn line_len(&self, row: u32) -> u32 {
         let mut cursor = self.runs.cursor::<usize, Point>();
-        cursor.seek(&self.range.start, SeekBias::Right);
+        cursor.seek(&self.range.start, SeekBias::Right, &());
         let absolute_row = cursor.start().row + row;
 
         let mut cursor = self.runs.cursor::<Point, usize>();
-        cursor.seek(&Point::new(absolute_row, 0), SeekBias::Right);
+        cursor.seek(&Point::new(absolute_row, 0), SeekBias::Right, &());
         let prefix_len = self.range.start.saturating_sub(*cursor.start());
-        let line_len = cursor.summary::<usize>(&Point::new(absolute_row + 1, 0), SeekBias::Left);
+        let line_len =
+            cursor.summary::<usize>(&Point::new(absolute_row + 1, 0), SeekBias::Left, &());
         let suffix_len = cursor.start().saturating_sub(self.range.end);
 
         line_len
@@ -270,14 +271,15 @@ impl Text {
             candidates.push(Point::new(0, self.line_len(0)));
             if lines.row > 1 {
                 let mut cursor = self.runs.cursor::<usize, Point>();
-                cursor.seek(&self.range.start, SeekBias::Right);
+                cursor.seek(&self.range.start, SeekBias::Right, &());
                 let absolute_start_row = cursor.start().row;
 
                 let mut cursor = self.runs.cursor::<Point, usize>();
-                cursor.seek(&Point::new(absolute_start_row + 1, 0), SeekBias::Right);
+                cursor.seek(&Point::new(absolute_start_row + 1, 0), SeekBias::Right, &());
                 let summary = cursor.summary::<TextSummary>(
                     &Point::new(absolute_start_row + lines.row, 0),
                     SeekBias::Left,
+                    &(),
                 );
 
                 candidates.push(Point::new(1, 0) + &summary.rightmost_point);
@@ -295,7 +297,7 @@ impl Text {
     pub fn offset_for_point(&self, point: Point) -> usize {
         let mut cursor = self.runs.cursor::<Point, TextSummary>();
         let abs_point = self.abs_point_for_offset(self.range.start) + &point;
-        cursor.seek(&abs_point, SeekBias::Right);
+        cursor.seek(&abs_point, SeekBias::Right, &());
         let overshoot = abs_point - &cursor.start().lines;
         let abs_offset = cursor.start().chars + overshoot.column as usize;
         abs_offset - self.range.start
@@ -315,14 +317,14 @@ impl Text {
 
     fn abs_point_for_offset(&self, offset: usize) -> Point {
         let mut cursor = self.runs.cursor::<usize, TextSummary>();
-        cursor.seek(&offset, SeekBias::Right);
+        cursor.seek(&offset, SeekBias::Right, &());
         let overshoot = (offset - cursor.start().chars) as u32;
         cursor.start().lines + &Point::new(0, overshoot)
     }
 
     fn abs_byte_offset_for_offset(&self, offset: usize) -> usize {
         let mut cursor = self.runs.cursor::<usize, TextSummary>();
-        cursor.seek(&offset, SeekBias::Right);
+        cursor.seek(&offset, SeekBias::Right, &());
         let overshoot = offset - cursor.start().chars;
         cursor.start().bytes + overshoot * cursor.item().map_or(0, |run| run.char_size()) as usize
     }

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -94,11 +94,11 @@ impl FoldMap {
         let buffer = self.buffer.read(ctx);
         for range in ranges.into_iter() {
             let range = range.start.to_offset(buffer)?..range.end.to_offset(buffer)?;
-            let fold = if range.start == range.end {
-                Fold(buffer.anchor_after(range.start)?..buffer.anchor_after(range.end)?)
-            } else {
-                Fold(buffer.anchor_after(range.start)?..buffer.anchor_before(range.end)?)
-            };
+            if range.start == range.end {
+                continue;
+            }
+
+            let fold = Fold(buffer.anchor_after(range.start)?..buffer.anchor_before(range.end)?);
             edits.push(Edit {
                 old_range: range.clone(),
                 new_range: range.clone(),

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -421,8 +421,8 @@ impl sum_tree::Item for Transform {
     }
 }
 
-impl<'a> std::ops::AddAssign<&'a Self> for TransformSummary {
-    fn add_assign(&mut self, other: &'a Self) {
+impl sum_tree::Summary for TransformSummary {
+    fn add_summary(&mut self, other: &Self) {
         self.buffer += &other.buffer;
         self.display += &other.display;
     }
@@ -430,7 +430,7 @@ impl<'a> std::ops::AddAssign<&'a Self> for TransformSummary {
 
 impl<'a> Dimension<'a, TransformSummary> for TransformSummary {
     fn add_summary(&mut self, summary: &'a TransformSummary) {
-        *self += summary;
+        sum_tree::Summary::add_summary(self, summary);
     }
 }
 

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -459,7 +459,7 @@ impl sum_tree::Item for Transform {
 impl sum_tree::Summary for TransformSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self) {
+    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
         self.buffer += &other.buffer;
         self.display += &other.display;
     }
@@ -467,7 +467,7 @@ impl sum_tree::Summary for TransformSummary {
 
 impl<'a> sum_tree::Dimension<'a, TransformSummary> for TransformSummary {
     fn add_summary(&mut self, summary: &'a TransformSummary) {
-        sum_tree::Summary::add_summary(self, summary);
+        sum_tree::Summary::add_summary(self, summary, None);
     }
 }
 
@@ -512,7 +512,7 @@ impl Default for FoldSummary {
 impl sum_tree::Summary for FoldSummary {
     type Context = Buffer;
 
-    fn add_summary_with_ctx(&mut self, other: &Self, buffer: Option<&Self::Context>) {
+    fn add_summary(&mut self, other: &Self, buffer: Option<&Self::Context>) {
         let buffer = buffer.unwrap();
         if other.min_start.cmp(&self.min_start, buffer).unwrap() == Ordering::Less {
             self.min_start = other.min_start.clone();

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -1,6 +1,6 @@
 mod fold_map;
 
-use super::{buffer, Anchor, AnchorRangeExt, Buffer, Edit, Point, TextSummary, ToOffset, ToPoint};
+use super::{buffer, Anchor, Buffer, Edit, Point, TextSummary, ToOffset, ToPoint};
 use anyhow::Result;
 pub use fold_map::BufferRows;
 use fold_map::{FoldMap, FoldMapSnapshot};

--- a/zed/src/operation_queue.rs
+++ b/zed/src/operation_queue.rs
@@ -68,7 +68,7 @@ impl<T: Operation> KeyedItem for T {
 impl Summary for OperationSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self) {
+    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
         assert!(self.key < other.key);
         self.key = other.key;
         self.len += other.len;

--- a/zed/src/operation_queue.rs
+++ b/zed/src/operation_queue.rs
@@ -66,6 +66,8 @@ impl<T: Operation> KeyedItem for T {
 }
 
 impl Summary for OperationSummary {
+    type Context = ();
+
     fn add_summary(&mut self, other: &Self) {
         assert!(self.key < other.key);
         self.key = other.key;

--- a/zed/src/operation_queue.rs
+++ b/zed/src/operation_queue.rs
@@ -32,7 +32,8 @@ impl<T: Operation> OperationQueue<T> {
     pub fn insert(&mut self, mut ops: Vec<T>) {
         ops.sort_by_key(|op| op.timestamp());
         ops.dedup_by_key(|op| op.timestamp());
-        self.0.edit(ops.into_iter().map(Edit::Insert).collect());
+        self.0
+            .edit(ops.into_iter().map(Edit::Insert).collect(), &());
     }
 
     pub fn drain(&mut self) -> Self {
@@ -68,7 +69,7 @@ impl<T: Operation> KeyedItem for T {
 impl Summary for OperationSummary {
     type Context = ();
 
-    fn add_summary(&mut self, other: &Self, _: Option<&Self::Context>) {
+    fn add_summary(&mut self, other: &Self, _: &()) {
         assert!(self.key < other.key);
         self.key = other.key;
         self.len += other.len;

--- a/zed/src/operation_queue.rs
+++ b/zed/src/operation_queue.rs
@@ -1,11 +1,8 @@
 use crate::{
-    sum_tree::{Cursor, Dimension, Edit, Item, KeyedItem, SumTree},
+    sum_tree::{Cursor, Dimension, Edit, Item, KeyedItem, SumTree, Summary},
     time,
 };
-use std::{
-    fmt::Debug,
-    ops::{Add, AddAssign},
-};
+use std::{fmt::Debug, ops::Add};
 
 pub trait Operation: Clone + Debug + Eq {
     fn timestamp(&self) -> time::Lamport;
@@ -68,8 +65,8 @@ impl<T: Operation> KeyedItem for T {
     }
 }
 
-impl<'a> AddAssign<&'a Self> for OperationSummary {
-    fn add_assign(&mut self, other: &Self) {
+impl Summary for OperationSummary {
+    fn add_summary(&mut self, other: &Self) {
         assert!(self.key < other.key);
         self.key = other.key;
         self.len += other.len;

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -560,7 +560,7 @@ where
                                             slice_items_summary
                                                 .as_mut()
                                                 .unwrap()
-                                                .add_summary_with_ctx(item_summary, ctx);
+                                                .add_summary(item_summary, ctx);
                                         }
                                         SeekAggregate::Summary(summary) => {
                                             summary.add_summary(item_summary);
@@ -679,7 +679,7 @@ where
                                         slice_items_summary
                                             .as_mut()
                                             .unwrap()
-                                            .add_summary_with_ctx(item_summary, ctx);
+                                            .add_summary(item_summary, ctx);
                                         slice_item_summaries.push(item_summary.clone());
                                     }
                                     SeekAggregate::Summary(summary) => {

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -511,7 +511,10 @@ where
                                         SeekAggregate::Slice(_) => {
                                             slice_items.push(item.clone());
                                             slice_item_summaries.push(item_summary.clone());
-                                            *slice_items_summary.as_mut().unwrap() += item_summary;
+                                            slice_items_summary
+                                                .as_mut()
+                                                .unwrap()
+                                                .add_summary(item_summary);
                                         }
                                         SeekAggregate::Summary(summary) => {
                                             summary.add_summary(item_summary);
@@ -621,7 +624,10 @@ where
                                     SeekAggregate::None => {}
                                     SeekAggregate::Slice(_) => {
                                         slice_items.push(item.clone());
-                                        *slice_items_summary.as_mut().unwrap() += item_summary;
+                                        slice_items_summary
+                                            .as_mut()
+                                            .unwrap()
+                                            .add_summary(item_summary);
                                         slice_item_summaries.push(item_summary.clone());
                                     }
                                     SeekAggregate::Summary(summary) => {

--- a/zed/src/sum_tree/mod.rs
+++ b/zed/src/sum_tree/mod.rs
@@ -73,7 +73,6 @@ impl<T: Item> SumTree<T> {
     #[allow(unused)]
     pub fn items(&self) -> Vec<T> {
         let mut cursor = self.cursor::<(), ()>();
-        cursor.descend_to_first_item(self, |_| true);
         cursor.cloned().collect()
     }
 
@@ -566,6 +565,7 @@ mod tests {
         for seed in 0..100 {
             use rand::{distributions, prelude::*};
 
+            dbg!(seed);
             let rng = &mut StdRng::seed_from_u64(seed);
 
             let mut tree = SumTree::<u8>::new();

--- a/zed/src/util.rs
+++ b/zed/src/util.rs
@@ -30,37 +30,6 @@ where
     }
 }
 
-pub fn find_insertion_index<'a, F, T, E>(slice: &'a [T], mut f: F) -> Result<usize, E>
-where
-    F: FnMut(&'a T) -> Result<Ordering, E>,
-{
-    use Ordering::*;
-
-    let s = slice;
-    let mut size = s.len();
-    if size == 0 {
-        return Ok(0);
-    }
-    let mut base = 0usize;
-    while size > 1 {
-        let half = size / 2;
-        let mid = base + half;
-        // mid is always in [0, size), that means mid is >= 0 and < size.
-        // mid >= 0: by definition
-        // mid < size: mid = size / 2 + size / 4 + size / 8 ...
-        let cmp = f(unsafe { s.get_unchecked(mid) })?;
-        base = if cmp == Greater { base } else { mid };
-        size -= half;
-    }
-    // base is always in [0, size) because base <= mid.
-    let cmp = f(unsafe { s.get_unchecked(base) })?;
-    if cmp == Equal {
-        Ok(base)
-    } else {
-        Ok(base + (cmp == Less) as usize)
-    }
-}
-
 pub struct RandomCharIter<T: Rng>(T);
 
 impl<T: Rng> RandomCharIter<T> {
@@ -84,14 +53,6 @@ impl<T: Rng> Iterator for RandomCharIter<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_find_insertion_index() {
-        assert_eq!(
-            find_insertion_index(&[0, 4, 8], |probe| Ok::<Ordering, ()>(probe.cmp(&2))),
-            Ok(1)
-        );
-    }
 
     #[test]
     fn test_extend_sorted() {

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -536,6 +536,8 @@ impl Default for EntrySummary {
 }
 
 impl sum_tree::Summary for EntrySummary {
+    type Context = ();
+
     fn add_summary(&mut self, rhs: &Self) {
         self.max_path = rhs.max_path.clone();
         self.file_count += rhs.file_count;

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -249,9 +249,10 @@ impl Snapshot {
 
     #[cfg(test)]
     pub fn paths(&self) -> impl Iterator<Item = &Arc<Path>> {
-        let mut cursor = self.entries.cursor::<(), ()>();
-        cursor.next();
-        cursor.map(|entry| entry.path())
+        self.entries
+            .cursor::<(), ()>()
+            .skip(1)
+            .map(|entry| entry.path())
     }
 
     pub fn visible_files(&self, start: usize) -> FileIter {
@@ -274,7 +275,7 @@ impl Snapshot {
 
     fn entry_for_path(&self, path: impl AsRef<Path>) -> Option<&Entry> {
         let mut cursor = self.entries.cursor::<_, ()>();
-        if cursor.seek(&PathSearch::Exact(path.as_ref()), SeekBias::Left) {
+        if cursor.seek(&PathSearch::Exact(path.as_ref()), SeekBias::Left, &()) {
             cursor.item()
         } else {
             None
@@ -296,7 +297,7 @@ impl Snapshot {
             self.ignores
                 .insert(ignore_dir_path.into(), (Arc::new(ignore), self.scan_id));
         }
-        self.entries.insert(entry);
+        self.entries.insert(entry, &());
     }
 
     fn populate_dir(
@@ -309,7 +310,7 @@ impl Snapshot {
 
         let mut parent_entry = self
             .entries
-            .get(&PathKey(parent_path.clone()))
+            .get(&PathKey(parent_path.clone()), &())
             .unwrap()
             .clone();
         if let Some(ignore) = ignore {
@@ -325,15 +326,15 @@ impl Snapshot {
         for entry in entries {
             edits.push(Edit::Insert(entry));
         }
-        self.entries.edit(edits);
+        self.entries.edit(edits, &());
     }
 
     fn remove_path(&mut self, path: &Path) {
         let new_entries = {
             let mut cursor = self.entries.cursor::<_, ()>();
-            let mut new_entries = cursor.slice(&PathSearch::Exact(path), SeekBias::Left);
-            cursor.seek_forward(&PathSearch::Successor(path), SeekBias::Left);
-            new_entries.push_tree(cursor.suffix());
+            let mut new_entries = cursor.slice(&PathSearch::Exact(path), SeekBias::Left, &());
+            cursor.seek_forward(&PathSearch::Successor(path), SeekBias::Left, &());
+            new_entries.push_tree(cursor.suffix(&()), &());
             new_entries
         };
         self.entries = new_entries;
@@ -538,7 +539,7 @@ impl Default for EntrySummary {
 impl sum_tree::Summary for EntrySummary {
     type Context = ();
 
-    fn add_summary(&mut self, rhs: &Self, _: Option<&Self::Context>) {
+    fn add_summary(&mut self, rhs: &Self, _: &()) {
         self.max_path = rhs.max_path.clone();
         self.file_count += rhs.file_count;
         self.visible_file_count += rhs.visible_file_count;
@@ -1068,7 +1069,7 @@ impl BackgroundScanner {
                 edits.push(Edit::Insert(entry));
             }
         }
-        self.snapshot.lock().entries.edit(edits);
+        self.snapshot.lock().entries.edit(edits, &());
     }
 
     fn fs_entry_for_path(&self, path: Arc<Path>, abs_path: &Path) -> Result<Option<Entry>> {
@@ -1164,13 +1165,13 @@ pub enum FileIter<'a> {
 impl<'a> FileIter<'a> {
     fn all(snapshot: &'a Snapshot, start: usize) -> Self {
         let mut cursor = snapshot.entries.cursor();
-        cursor.seek(&FileCount(start), SeekBias::Right);
+        cursor.seek(&FileCount(start), SeekBias::Right, &());
         Self::All(cursor)
     }
 
     fn visible(snapshot: &'a Snapshot, start: usize) -> Self {
         let mut cursor = snapshot.entries.cursor();
-        cursor.seek(&VisibleFileCount(start), SeekBias::Right);
+        cursor.seek(&VisibleFileCount(start), SeekBias::Right, &());
         Self::Visible(cursor)
     }
 
@@ -1178,11 +1179,11 @@ impl<'a> FileIter<'a> {
         match self {
             Self::All(cursor) => {
                 let ix = *cursor.start();
-                cursor.seek_forward(&FileCount(ix.0 + 1), SeekBias::Right);
+                cursor.seek_forward(&FileCount(ix.0 + 1), SeekBias::Right, &());
             }
             Self::Visible(cursor) => {
                 let ix = *cursor.start();
-                cursor.seek_forward(&VisibleFileCount(ix.0 + 1), SeekBias::Right);
+                cursor.seek_forward(&VisibleFileCount(ix.0 + 1), SeekBias::Right, &());
             }
         }
     }
@@ -1216,7 +1217,7 @@ struct ChildEntriesIter<'a> {
 impl<'a> ChildEntriesIter<'a> {
     fn new(parent_path: &'a Path, snapshot: &'a Snapshot) -> Self {
         let mut cursor = snapshot.entries.cursor();
-        cursor.seek(&PathSearch::Exact(parent_path), SeekBias::Right);
+        cursor.seek(&PathSearch::Exact(parent_path), SeekBias::Right, &());
         Self {
             parent_path,
             cursor,
@@ -1231,7 +1232,7 @@ impl<'a> Iterator for ChildEntriesIter<'a> {
         if let Some(item) = self.cursor.item() {
             if item.path().starts_with(self.parent_path) {
                 self.cursor
-                    .seek_forward(&PathSearch::Successor(item.path()), SeekBias::Left);
+                    .seek_forward(&PathSearch::Successor(item.path()), SeekBias::Left, &());
                 Some(item)
             } else {
                 None

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -538,7 +538,7 @@ impl Default for EntrySummary {
 impl sum_tree::Summary for EntrySummary {
     type Context = ();
 
-    fn add_summary(&mut self, rhs: &Self) {
+    fn add_summary(&mut self, rhs: &Self, _: Option<&Self::Context>) {
         self.max_path = rhs.max_path.clone();
         self.file_count += rhs.file_count;
         self.visible_file_count += rhs.visible_file_count;

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -24,7 +24,7 @@ use std::{
     fmt, fs,
     future::Future,
     io::{self, Read, Write},
-    ops::{AddAssign, Deref},
+    ops::Deref,
     os::unix::{ffi::OsStrExt, fs::MetadataExt},
     path::{Path, PathBuf},
     sync::{Arc, Weak},
@@ -535,8 +535,8 @@ impl Default for EntrySummary {
     }
 }
 
-impl<'a> AddAssign<&'a EntrySummary> for EntrySummary {
-    fn add_assign(&mut self, rhs: &'a EntrySummary) {
+impl sum_tree::Summary for EntrySummary {
+    fn add_summary(&mut self, rhs: &Self) {
         self.max_path = rhs.max_path.clone();
         self.file_count += rhs.file_count;
         self.visible_file_count += rhs.visible_file_count;


### PR DESCRIPTION
Prior to this pull request, folds were stored in a `Vec`. This required a linear scan in both `FoldMap::unfold` and `FoldMap::folds_in_range` to understand which folds intersected a given range, which is suboptimal when there are lots of folds but the user is only interested in a small range.

With this pull request, folds are now represented as a sequence of `Range<Anchor>` (ordered by `(start, Reverse(end))`) stored in a `SumTree`. This enables summarizing the min and max interval up the tree and efficiently skip all those subtrees that don't intersect a given range.

Given that we store folds as anchors and that we need to compare them with one another inside the tree in order to e.g. seek the cursor or compute the summary, we introduced a new `Summary` trait that contains a `Context` associated type. The `Context` is given by the user when mutating the tree or manipulating the cursor. In `FoldMap`'s case the context is a reference to `Buffer` that is used to resolve a `Fold`'s anchors and determine the min and max fold interval in a given subtree.

Note that we are also introducing a new `SeekDimension` trait. By default, this trait is already implemented for all dimensions that are `Ord`. However, for dimensions that require a `Context` to provide a meaningful `Ord` implementation, `SeekDimension` must be implemented manually in order to seek the cursor (see `Fold` for an example).

As a bonus, this pull request also adds coverage for `FoldMap::folds_in_range` and `FoldMap::unfold` in the randomized test. This was quite a big shred, but I am feeling good about the end result and we will need this `Context` abstraction to implement our planned optimizations on the `Buffer`, so this pull request should have laid the groundwork for that as well.

/cc: @maxbrunsfeld @nathansobo 