### PR TITLE
Implement `select_line` and `split_selection_into_lines`

### DIFF
--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -75,6 +75,7 @@ impl Selection {
 
     pub fn buffer_rows_for_display_rows(
         &self,
+        expand_if_ends_at_line_start: bool,
         map: &DisplayMap,
         ctx: &AppContext,
     ) -> (Range<u32>, Range<u32>) {
@@ -84,7 +85,8 @@ impl Selection {
             .unwrap();
 
         let mut display_end = self.end.to_display_point(map, ctx).unwrap();
-        if display_end.row() != map.max_point(ctx).row()
+        if !expand_if_ends_at_line_start
+            && display_end.row() != map.max_point(ctx).row()
             && display_start.row() != display_end.row()
             && display_end.column() == 0
         {

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -75,7 +75,7 @@ impl Selection {
 
     pub fn buffer_rows_for_display_rows(
         &self,
-        expand_if_ends_at_line_start: bool,
+        include_end_if_at_line_start: bool,
         map: &DisplayMap,
         ctx: &AppContext,
     ) -> (Range<u32>, Range<u32>) {
@@ -85,7 +85,7 @@ impl Selection {
             .unwrap();
 
         let mut display_end = self.end.to_display_point(map, ctx).unwrap();
-        if !expand_if_ends_at_line_start
+        if !include_end_if_at_line_start
             && display_end.row() != map.max_point(ctx).row()
             && display_start.row() != display_end.row()
             && display_end.column() == 0

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -1952,9 +1952,8 @@ impl BufferView {
             .selections(ctx.as_ref())
             .iter()
             .map(|s| s.range(buffer).sorted())
-            .collect::<Vec<_>>();
-        self.display_map.fold(ranges, ctx.as_ref()).unwrap();
-        ctx.notify();
+            .collect();
+        self.fold_ranges(ranges, ctx);
     }
 
     fn fold_ranges<T: ToOffset>(&mut self, ranges: Vec<Range<T>>, ctx: &mut ViewContext<Self>) {

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -1692,13 +1692,15 @@ impl BufferView {
     }
 
     pub fn split_selection_into_lines(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        use super::RangeExt;
+
         let app = ctx.as_ref();
         let buffer = self.buffer.read(app);
 
         let mut to_unfold = Vec::new();
         let mut new_selections = Vec::new();
         for selection in self.selections(app) {
-            let range = selection.range(buffer);
+            let range = selection.range(buffer).sorted();
             if range.start.row != range.end.row {
                 new_selections.push(Selection {
                     start: selection.start.clone(),
@@ -3446,7 +3448,7 @@ mod tests {
 
             view.update(app, |view, ctx| {
                 view.select_display_ranges(
-                    &[DisplayPoint::new(0, 1)..DisplayPoint::new(4, 0)],
+                    &[DisplayPoint::new(4, 0)..DisplayPoint::new(0, 1)],
                     ctx,
                 )
                 .unwrap();

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -139,6 +139,7 @@ pub fn init(app: &mut MutableAppContext) {
         ),
         Binding::new("cmd-shift-down", "buffer:select_to_end", Some("BufferView")),
         Binding::new("cmd-a", "buffer:select_all", Some("BufferView")),
+        Binding::new("cmd-l", "buffer:select_line", Some("BufferView")),
         Binding::new("pageup", "buffer:page_up", Some("BufferView")),
         Binding::new("pagedown", "buffer:page_down", Some("BufferView")),
         Binding::new("alt-cmd-[", "buffer:fold", Some("BufferView")),
@@ -229,6 +230,7 @@ pub fn init(app: &mut MutableAppContext) {
     );
     app.add_action("buffer:select_to_end", BufferView::select_to_end);
     app.add_action("buffer:select_all", BufferView::select_all);
+    app.add_action("buffer:select_line", BufferView::select_line);
     app.add_action("buffer:page_up", BufferView::page_up);
     app.add_action("buffer:page_down", BufferView::page_down);
     app.add_action("buffer:fold", BufferView::fold);
@@ -712,7 +714,8 @@ impl BufferView {
 
         let mut selections = self.selections(app).iter().peekable();
         while let Some(selection) = selections.next() {
-            let (mut rows, _) = selection.buffer_rows_for_display_rows(&self.display_map, app);
+            let (mut rows, _) =
+                selection.buffer_rows_for_display_rows(false, &self.display_map, app);
             let goal_display_column = selection
                 .head()
                 .to_display_point(&self.display_map, app)
@@ -722,7 +725,7 @@ impl BufferView {
             // Accumulate contiguous regions of rows that we want to delete.
             while let Some(next_selection) = selections.peek() {
                 let (next_rows, _) =
-                    next_selection.buffer_rows_for_display_rows(&self.display_map, app);
+                    next_selection.buffer_rows_for_display_rows(false, &self.display_map, app);
                 if next_rows.start <= rows.end {
                     rows.end = next_rows.end;
                     selections.next().unwrap();
@@ -803,10 +806,11 @@ impl BufferView {
         let mut selections_iter = selections.iter_mut().peekable();
         while let Some(selection) = selections_iter.next() {
             // Avoid duplicating the same lines twice.
-            let (mut rows, _) = selection.buffer_rows_for_display_rows(&self.display_map, app);
+            let (mut rows, _) =
+                selection.buffer_rows_for_display_rows(false, &self.display_map, app);
             while let Some(next_selection) = selections_iter.peek() {
                 let (next_rows, _) =
-                    next_selection.buffer_rows_for_display_rows(&self.display_map, app);
+                    next_selection.buffer_rows_for_display_rows(false, &self.display_map, app);
                 if next_rows.start <= rows.end - 1 {
                     rows.end = next_rows.end;
                     selections_iter.next().unwrap();
@@ -860,10 +864,10 @@ impl BufferView {
             // Accumulate contiguous regions of rows that we want to move.
             contiguous_selections.push(selection.range(buffer));
             let (mut buffer_rows, mut display_rows) =
-                selection.buffer_rows_for_display_rows(&self.display_map, app);
+                selection.buffer_rows_for_display_rows(false, &self.display_map, app);
             while let Some(next_selection) = selections.peek() {
                 let (next_buffer_rows, next_display_rows) =
-                    next_selection.buffer_rows_for_display_rows(&self.display_map, app);
+                    next_selection.buffer_rows_for_display_rows(false, &self.display_map, app);
                 if next_buffer_rows.start <= buffer_rows.end {
                     buffer_rows.end = next_buffer_rows.end;
                     display_rows.end = next_display_rows.end;
@@ -950,10 +954,10 @@ impl BufferView {
             // Accumulate contiguous regions of rows that we want to move.
             contiguous_selections.push(selection.range(buffer));
             let (mut buffer_rows, mut display_rows) =
-                selection.buffer_rows_for_display_rows(&self.display_map, app);
+                selection.buffer_rows_for_display_rows(false, &self.display_map, app);
             while let Some(next_selection) = selections.peek() {
                 let (next_buffer_rows, next_display_rows) =
-                    next_selection.buffer_rows_for_display_rows(&self.display_map, app);
+                    next_selection.buffer_rows_for_display_rows(false, &self.display_map, app);
                 if next_buffer_rows.start <= buffer_rows.end {
                     buffer_rows.end = next_buffer_rows.end;
                     display_rows.end = next_display_rows.end;
@@ -1660,6 +1664,22 @@ impl BufferView {
             goal_column: None,
         };
         self.update_selections(vec![selection], false, ctx);
+    }
+
+    pub fn select_line(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        let app = ctx.as_ref();
+        let buffer = self.buffer.read(app);
+        let mut selections = self.selections(app).to_vec();
+        let max_point = buffer.max_point();
+        for selection in &mut selections {
+            let (rows, _) = selection.buffer_rows_for_display_rows(true, &self.display_map, app);
+            selection.start = buffer.anchor_before(Point::new(rows.start, 0)).unwrap();
+            selection.end = buffer
+                .anchor_before(cmp::min(max_point, Point::new(rows.end, 0)))
+                .unwrap();
+            selection.reversed = false;
+        }
+        self.update_selections(selections, true, ctx);
     }
 
     pub fn selections_in_range<'a>(
@@ -3280,6 +3300,51 @@ mod tests {
             assert_eq!(
                 view.read(app).selection_ranges(app.as_ref()),
                 &[DisplayPoint::new(0, 0)..DisplayPoint::new(2, 3)]
+            );
+        });
+    }
+
+    #[test]
+    fn test_select_line() {
+        App::test((), |app| {
+            let settings = settings::channel(&app.font_cache()).unwrap().1;
+            let buffer = app.add_model(|_| Buffer::new(0, sample_text(6, 5)));
+            let (_, view) =
+                app.add_window(|ctx| BufferView::for_buffer(buffer, None, settings, ctx));
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[
+                        DisplayPoint::new(0, 0)..DisplayPoint::new(0, 1),
+                        DisplayPoint::new(0, 2)..DisplayPoint::new(0, 2),
+                        DisplayPoint::new(1, 0)..DisplayPoint::new(1, 0),
+                        DisplayPoint::new(4, 2)..DisplayPoint::new(4, 2),
+                    ],
+                    ctx,
+                )
+                .unwrap();
+                view.select_line(&(), ctx);
+            });
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 0)..DisplayPoint::new(2, 0),
+                    DisplayPoint::new(4, 0)..DisplayPoint::new(5, 0),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.select_line(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 0)..DisplayPoint::new(3, 0),
+                    DisplayPoint::new(4, 0)..DisplayPoint::new(5, 5),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.select_line(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![DisplayPoint::new(0, 0)..DisplayPoint::new(5, 5)]
             );
         });
     }


### PR DESCRIPTION
Refs #25 

As per the pull request's title, with these changes Zed now understands two new commands:

- `buffer_view:select_line` (bound to `cmd-l`)
- `buffer_view:split_selection_into_lines` (bound to `cmd-shift-l`)

Note that in 1c2f549 I slightly changed the behavior of fold intersection queries to be more precise with respect to the endpoints of the given range (see the commit for more details).

/cc: @nathansobo @maxbrunsfeld 