### PR TITLE
Include debug symbols in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ core-graphics = {git = "https://github.com/servo/core-foundation-rs", rev = "e9a
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[profile.release]
+debug = true


### PR DESCRIPTION
This is useful for profiling and instrumentation. It might cost us something in terms of build time, but we rarely build in release mode for local development, and when we do we typically want to benchmark a certain piece of code, which requires this flag anyway.