### PR TITLE
Ignore events for held-down keys after a key combo is partially released

### DIFF
--- a/gpui/src/platform/event.rs
+++ b/gpui/src/platform/event.rs
@@ -5,6 +5,7 @@ pub enum Event {
     KeyDown {
         keystroke: Keystroke,
         chars: String,
+        is_held: bool,
     },
     ScrollWheel {
         position: Vector2F,

--- a/gpui/src/platform/mac/event.rs
+++ b/gpui/src/platform/mac/event.rs
@@ -70,6 +70,7 @@ impl Event {
                         key: unmodified_chars.into(),
                     },
                     chars,
+                    is_held: native_event.isARepeat() == YES,
                 })
             }
             NSEventType::NSLeftMouseDown => {


### PR DESCRIPTION
Fixes #45

There are some subtleties to handling keyboard events in the way users expect. Cocoa provides methods like [`interpretKeyEvents`](https://developer.apple.com/documentation/appkit/nsresponder/1531599-interpretkeyevents?language=objc) for doing this, but those methods work in terms of objective-C messages, so GPUI needs to reimplement some of this logic.

Holding a key down generally does the same thing as pressing that key rapidly. But when a key *combination* is held down, and then some of the modifiers are released, the normal behavior (as far as I can tell) is that the remaining keys that are still held down are then ignored. This PR adopts that conventional behavior in GPUI.

### Repro Steps:

* Start deleting characters by holding down `ctrl-h`
* Let go of `ctrl`, but keep holding down `h`

Before, the editor would rapidly insert `h` characters until you let go of `h`. Now, it doesn't do anything until you press a new key. You can let go of the key combination in any order.