### PR TITLE
Ensure that the bundle runs on macOS versions < 11.0

### DIFF
--- a/gpui/build.rs
+++ b/gpui/build.rs
@@ -56,6 +56,7 @@ fn compile_metal_shaders() {
             "macosx",
             "metal",
             "-gline-tables-only",
+            "-mmacosx-version-min=10.14",
             "-MO",
             "-c",
             shader_path,

--- a/zed/Cargo.toml
+++ b/zed/Cargo.toml
@@ -49,3 +49,4 @@ unindent = "0.1.7"
 icon = ["app-icon@2x.png", "app-icon.png"]
 identifier = "dev.zed.Zed"
 name = "Zed"
+osx_minimum_system_version = "10.14"

--- a/zed/build.rs
+++ b/zed/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.14");
+}


### PR DESCRIPTION
Right now, I use macOS 10.15 (Catalina). I semi-arbitrarily picked a minimum version of 10.14 (Mojave).

There's a little bit of duplication, but I'm not sure whether it's worth the complexity to remove it.