### PR TITLE
Implement `add_selection_above`, `add_selection_below` and `cancel`

### DIFF
--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -3285,14 +3285,14 @@ mod tests {
                         start: self.anchor_before(range.end)?,
                         end: self.anchor_before(range.start)?,
                         reversed: true,
-                        goal_column: None,
+                        goal: SelectionGoal::None,
                     });
                 } else {
                     selections.push(Selection {
                         start: self.anchor_after(range.start)?,
                         end: self.anchor_before(range.end)?,
                         reversed: false,
-                        goal_column: None,
+                        goal: SelectionGoal::None,
                     });
                 }
             }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -2378,8 +2378,11 @@ mod tests {
     use super::*;
     use cmp::Ordering;
     use gpui::App;
-    use std::collections::BTreeMap;
     use std::{cell::RefCell, rc::Rc};
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{self, AtomicUsize},
+    };
 
     #[test]
     fn test_edit() {
@@ -3275,6 +3278,8 @@ mod tests {
         where
             I: IntoIterator<Item = Range<usize>>,
         {
+            static NEXT_SELECTION_ID: AtomicUsize = AtomicUsize::new(0);
+
             let mut ranges = ranges.into_iter().collect::<Vec<_>>();
             ranges.sort_unstable_by_key(|range| range.start);
 
@@ -3282,6 +3287,7 @@ mod tests {
             for range in ranges {
                 if range.start > range.end {
                     selections.push(Selection {
+                        id: NEXT_SELECTION_ID.fetch_add(1, atomic::Ordering::SeqCst),
                         start: self.anchor_before(range.end)?,
                         end: self.anchor_before(range.start)?,
                         reversed: true,
@@ -3289,6 +3295,7 @@ mod tests {
                     });
                 } else {
                     selections.push(Selection {
+                        id: NEXT_SELECTION_ID.fetch_add(1, atomic::Ordering::SeqCst),
                         start: self.anchor_after(range.start)?,
                         end: self.anchor_before(range.end)?,
                         reversed: false,

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -12,12 +12,19 @@ use std::{cmp::Ordering, mem, ops::Range};
 pub type SelectionSetId = time::Lamport;
 pub type SelectionsVersion = usize;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SelectionGoal {
+    None,
+    Column(u32),
+    ColumnRange { start: u32, end: u32 },
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Selection {
     pub start: Anchor,
     pub end: Anchor,
     pub reversed: bool,
-    pub goal_column: Option<u32>,
+    pub goal: SelectionGoal,
 }
 
 impl Selection {

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -21,6 +21,7 @@ pub enum SelectionGoal {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Selection {
+    pub id: usize,
     pub start: Anchor,
     pub end: Anchor,
     pub reversed: bool,

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -153,12 +153,12 @@ pub fn init(app: &mut MutableAppContext) {
         ),
         Binding::new(
             "ctrl-shift-up",
-            "buffer:add_cursor_above",
+            "buffer:add_selection_above",
             Some("BufferView"),
         ),
         Binding::new(
             "ctrl-shift-down",
-            "buffer:add_cursor_below",
+            "buffer:add_selection_below",
             Some("BufferView"),
         ),
         Binding::new("pageup", "buffer:page_up", Some("BufferView")),
@@ -257,8 +257,14 @@ pub fn init(app: &mut MutableAppContext) {
         "buffer:split_selection_into_lines",
         BufferView::split_selection_into_lines,
     );
-    app.add_action("buffer:add_cursor_above", BufferView::add_cursor_above);
-    app.add_action("buffer:add_cursor_below", BufferView::add_cursor_below);
+    app.add_action(
+        "buffer:add_selection_above",
+        BufferView::add_selection_above,
+    );
+    app.add_action(
+        "buffer:add_selection_below",
+        BufferView::add_selection_below,
+    );
     app.add_action("buffer:page_up", BufferView::page_up);
     app.add_action("buffer:page_down", BufferView::page_down);
     app.add_action("buffer:fold", BufferView::fold);
@@ -1780,15 +1786,15 @@ impl BufferView {
         self.update_selections(new_selections, true, ctx);
     }
 
-    pub fn add_cursor_above(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
-        self.add_cursor(true, ctx);
+    pub fn add_selection_above(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        self.add_selection(true, ctx);
     }
 
-    pub fn add_cursor_below(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
-        self.add_cursor(false, ctx);
+    pub fn add_selection_below(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
+        self.add_selection(false, ctx);
     }
 
-    pub fn add_cursor(&mut self, above: bool, ctx: &mut ViewContext<Self>) {
+    pub fn add_selection(&mut self, above: bool, ctx: &mut ViewContext<Self>) {
         use super::RangeExt;
 
         let app = ctx.as_ref();

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -151,12 +151,12 @@ pub fn init(app: &mut MutableAppContext) {
             Some("BufferView"),
         ),
         Binding::new(
-            "ctrl-shift-up",
+            "cmd-alt-up",
             "buffer:add_selection_above",
             Some("BufferView"),
         ),
         Binding::new(
-            "ctrl-shift-down",
+            "cmd-alt-down",
             "buffer:add_selection_below",
             Some("BufferView"),
         ),

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -558,7 +558,11 @@ impl BufferView {
                 self.update_selections(vec![pending_selection], true, ctx);
             }
         } else {
-            let oldest_selection = selections.iter().min_by_key(|s| s.id).unwrap().clone();
+            let mut oldest_selection = selections.iter().min_by_key(|s| s.id).unwrap().clone();
+            if selections.len() == 1 {
+                oldest_selection.start = oldest_selection.head().clone();
+                oldest_selection.end = oldest_selection.head().clone();
+            }
             self.update_selections(vec![oldest_selection], true, ctx);
         }
     }

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -3756,6 +3756,167 @@ mod tests {
         });
     }
 
+    #[test]
+    fn test_add_selection_above_below() {
+        App::test((), |app| {
+            let settings = settings::channel(&app.font_cache()).unwrap().1;
+            let buffer = app.add_model(|ctx| Buffer::new(0, "abc\ndefghi\n\njk\nlmno\n", ctx));
+            let (_, view) = app.add_window(|ctx| BufferView::for_buffer(buffer, settings, ctx));
+
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3)],
+                    ctx,
+                )
+                .unwrap();
+            });
+            view.update(app, |view, ctx| view.add_selection_above(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 3)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3)
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_above(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 3)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3)
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3)]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3),
+                    DisplayPoint::new(4, 3)..DisplayPoint::new(4, 3)
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3),
+                    DisplayPoint::new(4, 3)..DisplayPoint::new(4, 3)
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[DisplayPoint::new(1, 4)..DisplayPoint::new(1, 3)],
+                    ctx,
+                )
+                .unwrap();
+            });
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(1, 4)..DisplayPoint::new(1, 3),
+                    DisplayPoint::new(4, 4)..DisplayPoint::new(4, 3)
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(1, 4)..DisplayPoint::new(1, 3),
+                    DisplayPoint::new(4, 4)..DisplayPoint::new(4, 3)
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_above(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![DisplayPoint::new(1, 4)..DisplayPoint::new(1, 3)]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_above(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![DisplayPoint::new(1, 4)..DisplayPoint::new(1, 3)]
+            );
+
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[DisplayPoint::new(0, 1)..DisplayPoint::new(1, 4)],
+                    ctx,
+                )
+                .unwrap();
+            });
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 1)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(1, 1)..DisplayPoint::new(1, 4),
+                    DisplayPoint::new(3, 1)..DisplayPoint::new(3, 2),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 1)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(1, 1)..DisplayPoint::new(1, 4),
+                    DisplayPoint::new(3, 1)..DisplayPoint::new(3, 2),
+                    DisplayPoint::new(4, 1)..DisplayPoint::new(4, 4),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_above(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 1)..DisplayPoint::new(0, 3),
+                    DisplayPoint::new(1, 1)..DisplayPoint::new(1, 4),
+                    DisplayPoint::new(3, 1)..DisplayPoint::new(3, 2),
+                ]
+            );
+
+            view.update(app, |view, ctx| {
+                view.select_display_ranges(
+                    &[DisplayPoint::new(4, 3)..DisplayPoint::new(1, 1)],
+                    ctx,
+                )
+                .unwrap();
+            });
+            view.update(app, |view, ctx| view.add_selection_above(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(0, 3)..DisplayPoint::new(0, 1),
+                    DisplayPoint::new(1, 3)..DisplayPoint::new(1, 1),
+                    DisplayPoint::new(3, 2)..DisplayPoint::new(3, 1),
+                    DisplayPoint::new(4, 3)..DisplayPoint::new(4, 1),
+                ]
+            );
+
+            view.update(app, |view, ctx| view.add_selection_below(&(), ctx));
+            assert_eq!(
+                view.read(app).selection_ranges(app.as_ref()),
+                vec![
+                    DisplayPoint::new(1, 3)..DisplayPoint::new(1, 1),
+                    DisplayPoint::new(3, 2)..DisplayPoint::new(3, 1),
+                    DisplayPoint::new(4, 3)..DisplayPoint::new(4, 1),
+                ]
+            );
+        });
+    }
+
     impl BufferView {
         fn selection_ranges(&self, app: &AppContext) -> Vec<Range<DisplayPoint>> {
             self.selections_in_range(DisplayPoint::zero()..self.max_point(app), app)

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -1,4 +1,4 @@
-use super::{DisplayMap, DisplayPoint};
+use super::{DisplayMap, DisplayPoint, SelectionGoal};
 use anyhow::Result;
 use gpui::AppContext;
 use std::cmp;
@@ -27,36 +27,44 @@ pub fn right(map: &DisplayMap, mut point: DisplayPoint, app: &AppContext) -> Res
 pub fn up(
     map: &DisplayMap,
     mut point: DisplayPoint,
-    goal_column: Option<u32>,
+    goal: SelectionGoal,
     app: &AppContext,
-) -> Result<(DisplayPoint, Option<u32>)> {
-    let goal_column = goal_column.or(Some(point.column()));
+) -> Result<(DisplayPoint, SelectionGoal)> {
+    let goal_column = if let SelectionGoal::Column(column) = goal {
+        column
+    } else {
+        point.column()
+    };
     if point.row() > 0 {
         *point.row_mut() -= 1;
-        *point.column_mut() = cmp::min(goal_column.unwrap(), map.line_len(point.row(), app)?);
+        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app)?);
     } else {
         point = DisplayPoint::new(0, 0);
     }
 
-    Ok((point, goal_column))
+    Ok((point, SelectionGoal::Column(goal_column)))
 }
 
 pub fn down(
     map: &DisplayMap,
     mut point: DisplayPoint,
-    goal_column: Option<u32>,
+    goal: SelectionGoal,
     app: &AppContext,
-) -> Result<(DisplayPoint, Option<u32>)> {
-    let goal_column = goal_column.or(Some(point.column()));
+) -> Result<(DisplayPoint, SelectionGoal)> {
+    let goal_column = if let SelectionGoal::Column(column) = goal {
+        column
+    } else {
+        point.column()
+    };
     let max_point = map.max_point(app);
     if point.row() < max_point.row() {
         *point.row_mut() += 1;
-        *point.column_mut() = cmp::min(goal_column.unwrap(), map.line_len(point.row(), app)?)
+        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app)?)
     } else {
         point = max_point;
     }
 
-    Ok((point, goal_column))
+    Ok((point, SelectionGoal::Column(goal_column)))
 }
 
 pub fn line_beginning(


### PR DESCRIPTION
Refs #25 

As per the title, this pull request implements:

- Cancel. If there are multiple selections, running this command will reduce all selections to one (the least recent one). If only one selection is left, this command will turn the selection into a cursor.
- Adding selections above and below. This is similar to VS Code's columnar selection in that it will skip over lines that don't intersect the given column range and when starting with a multi-line selection it will first break it into multiple lines. If there are multiple selections only the first one is honored, and adding new selections is stateful, e.g. adding a selection below can be undone by adding a selection above and vice versa.

A gif worth a thousand words:

![Kapture 2021-05-11 at 12 49 08](https://user-images.githubusercontent.com/482957/117804056-9bc1cb80-b257-11eb-8cd7-83a222d00572.gif)
