### PR TITLE
Handle buffers' files changing on disk from outside of Zed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+
+[[package]]
 name = "simplecss"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,6 +2973,7 @@ dependencies = [
  "seahash",
  "serde 1.0.125",
  "serde_json 1.0.64",
+ "similar",
  "simplelog",
  "smallvec",
  "smol",

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -578,7 +578,7 @@ impl MutableAppContext {
         self.platform.set_menus(menus);
     }
 
-    pub fn prompt<F>(
+    fn prompt<F>(
         &self,
         window_id: usize,
         level: PromptLevel,

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -343,6 +343,23 @@ impl TestAppContext {
     pub fn did_prompt_for_new_path(&self) -> bool {
         self.1.as_ref().did_prompt_for_new_path()
     }
+
+    pub fn simulate_prompt_answer(&self, window_id: usize, answer: usize) {
+        let mut state = self.0.borrow_mut();
+        let (_, window) = state
+            .presenters_and_platform_windows
+            .get_mut(&window_id)
+            .unwrap();
+        let test_window = window
+            .as_any_mut()
+            .downcast_mut::<platform::test::Window>()
+            .unwrap();
+        let callback = test_window
+            .last_prompt
+            .take()
+            .expect("prompt was not called");
+        (callback)(answer);
+    }
 }
 
 impl UpdateModel for TestAppContext {

--- a/gpui/src/lib.rs
+++ b/gpui/src/lib.rs
@@ -24,7 +24,7 @@ pub mod color;
 pub mod json;
 pub mod keymap;
 mod platform;
-pub use platform::{Event, PathPromptOptions};
+pub use platform::{Event, PathPromptOptions, PromptLevel};
 pub use presenter::{
     AfterLayoutContext, Axis, DebugContext, EventContext, LayoutContext, PaintContext,
     SizeConstraint, Vector2FExt,

--- a/gpui/src/platform/mac/window.rs
+++ b/gpui/src/platform/mac/window.rs
@@ -27,6 +27,7 @@ use objc::{
 use pathfinder_geometry::vector::vec2f;
 use smol::Timer;
 use std::{
+    any::Any,
     cell::{Cell, RefCell},
     convert::TryInto,
     ffi::c_void,
@@ -263,6 +264,10 @@ impl Drop for Window {
 }
 
 impl platform::Window for Window {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn on_event(&mut self, callback: Box<dyn FnMut(Event)>) {
         self.0.as_ref().borrow_mut().event_callback = Some(callback);
     }

--- a/gpui/src/platform/mod.rs
+++ b/gpui/src/platform/mod.rs
@@ -71,6 +71,13 @@ pub trait Window: WindowContext {
     fn on_event(&mut self, callback: Box<dyn FnMut(Event)>);
     fn on_resize(&mut self, callback: Box<dyn FnMut(&mut dyn WindowContext)>);
     fn on_close(&mut self, callback: Box<dyn FnOnce()>);
+    fn prompt(
+        &self,
+        level: PromptLevel,
+        msg: &str,
+        answers: &[&str],
+        done_fn: Box<dyn FnOnce(usize)>,
+    );
 }
 
 pub trait WindowContext {
@@ -88,6 +95,12 @@ pub struct PathPromptOptions {
     pub files: bool,
     pub directories: bool,
     pub multiple: bool,
+}
+
+pub enum PromptLevel {
+    Info,
+    Warning,
+    Critical,
 }
 
 pub trait FontSystem: Send + Sync {

--- a/gpui/src/platform/mod.rs
+++ b/gpui/src/platform/mod.rs
@@ -68,6 +68,7 @@ pub trait Dispatcher: Send + Sync {
 }
 
 pub trait Window: WindowContext {
+    fn as_any_mut(&mut self) -> &mut dyn Any;
     fn on_event(&mut self, callback: Box<dyn FnMut(Event)>);
     fn on_resize(&mut self, callback: Box<dyn FnMut(&mut dyn WindowContext)>);
     fn on_close(&mut self, callback: Box<dyn FnOnce()>);

--- a/gpui/src/platform/test.rs
+++ b/gpui/src/platform/test.rs
@@ -163,6 +163,8 @@ impl super::Window for Window {
     fn on_close(&mut self, callback: Box<dyn FnOnce()>) {
         self.close_handlers.push(callback);
     }
+
+    fn prompt(&self, _: crate::PromptLevel, _: &str, _: &[&str], _: Box<dyn FnOnce(usize)>) {}
 }
 
 pub(crate) fn platform() -> Platform {

--- a/gpui/src/platform/test.rs
+++ b/gpui/src/platform/test.rs
@@ -24,6 +24,7 @@ pub struct Window {
     event_handlers: Vec<Box<dyn FnMut(super::Event)>>,
     resize_handlers: Vec<Box<dyn FnMut(&mut dyn super::WindowContext)>>,
     close_handlers: Vec<Box<dyn FnOnce()>>,
+    pub(crate) last_prompt: RefCell<Option<Box<dyn FnOnce(usize)>>>,
 }
 
 impl Platform {
@@ -123,6 +124,7 @@ impl Window {
             close_handlers: Vec::new(),
             scale_factor: 1.0,
             current_scene: None,
+            last_prompt: RefCell::new(None),
         }
     }
 }
@@ -152,6 +154,10 @@ impl super::WindowContext for Window {
 }
 
 impl super::Window for Window {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn on_event(&mut self, callback: Box<dyn FnMut(crate::Event)>) {
         self.event_handlers.push(callback);
     }
@@ -164,7 +170,9 @@ impl super::Window for Window {
         self.close_handlers.push(callback);
     }
 
-    fn prompt(&self, _: crate::PromptLevel, _: &str, _: &[&str], _: Box<dyn FnOnce(usize)>) {}
+    fn prompt(&self, _: crate::PromptLevel, _: &str, _: &[&str], f: Box<dyn FnOnce(usize)>) {
+        self.last_prompt.replace(Some(f));
+    }
 }
 
 pub(crate) fn platform() -> Platform {

--- a/zed/Cargo.toml
+++ b/zed/Cargo.toml
@@ -34,6 +34,7 @@ rand = "0.8.3"
 rust-embed = "5.9.0"
 seahash = "4.1"
 serde = {version = "1", features = ["derive"]}
+similar = "1.3"
 simplelog = "0.9"
 smallvec = "1.6.1"
 smol = "1.2.5"

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -3263,7 +3263,9 @@ mod tests {
         // Becaues the buffer is modified, it doesn't reload from disk, but is
         // marked as having a conflict.
         buffer
-            .condition(&app, |buffer, _| buffer.has_conflict())
+            .condition_with_duration(Duration::from_millis(500), &app, |buffer, _| {
+                buffer.has_conflict()
+            })
             .await;
     }
 

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -2401,6 +2401,7 @@ impl BufferView {
             buffer::Event::Dirtied => ctx.emit(Event::Dirtied),
             buffer::Event::Saved => ctx.emit(Event::Saved),
             buffer::Event::FileHandleChanged => ctx.emit(Event::FileHandleChanged),
+            buffer::Event::Reloaded => ctx.emit(Event::FileHandleChanged),
         }
     }
 }
@@ -2504,6 +2505,10 @@ impl workspace::ItemView for BufferView {
 
     fn is_dirty(&self, ctx: &AppContext) -> bool {
         self.buffer.read(ctx).is_dirty()
+    }
+
+    fn has_conflict(&self, ctx: &AppContext) -> bool {
+        self.buffer.read(ctx).has_conflict()
     }
 }
 

--- a/zed/src/workspace.rs
+++ b/zed/src/workspace.rs
@@ -119,6 +119,9 @@ pub trait ItemView: View {
     fn is_dirty(&self, _: &AppContext) -> bool {
         false
     }
+    fn has_conflict(&self, _: &AppContext) -> bool {
+        false
+    }
     fn save(
         &mut self,
         _: Option<FileHandle>,
@@ -157,6 +160,7 @@ pub trait ItemViewHandle: Send + Sync {
     fn id(&self) -> usize;
     fn to_any(&self) -> AnyViewHandle;
     fn is_dirty(&self, ctx: &AppContext) -> bool;
+    fn has_conflict(&self, ctx: &AppContext) -> bool;
     fn save(
         &self,
         file: Option<FileHandle>,
@@ -245,6 +249,10 @@ impl<T: ItemView> ItemViewHandle for ViewHandle<T> {
 
     fn is_dirty(&self, ctx: &AppContext) -> bool {
         self.read(ctx).is_dirty(ctx)
+    }
+
+    fn has_conflict(&self, ctx: &AppContext) -> bool {
+        self.read(ctx).has_conflict(ctx)
     }
 
     fn id(&self) -> usize {


### PR DESCRIPTION
Fixes #52

* [x] Allow buffers to observe changes to files' contents with `FileHandle::observe_from_model`. Before, this callback would only be called when a file was moved or deleted. Now, we store an `mtime` on each `FileHandle` so that content changes are also reported.
* [x] Add a `Buffer::set_text_via_diff` method that takes a string of new text, computes a corresponding diff in a background thread, and applies that diff to the buffer.
* [x] When there's an on-disk change to the file of an unmodified buffer, update the buffer to reflect the new contents.
* [x] Add a `has_conflict` method to `Workspace::Item` trait. Use that method to give special visual treatment to buffers that have in-memory changes *and* on-disk changes since they were loaded. Right now, we show a red dot for these files, instead of a blue dot.
* [x] When attempting to save a pane item with conflicts, show a confirm dialog saying something like *"This file has changed on disk since you started editing it. Do you want to overwrite it?"* Only perform the save if the user clicks confirm.

