### PR TITLE
Fix panic when an entity's ref count is decremented to 0 and then is incremented again

### DIFF
--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -18,7 +18,7 @@ use smol::prelude::*;
 use std::{
     any::{type_name, Any, TypeId},
     cell::RefCell,
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
     fmt::{self, Debug},
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -1988,7 +1988,7 @@ pub struct ModelHandle<T> {
 
 impl<T: Entity> ModelHandle<T> {
     fn new(model_id: usize, ref_counts: &Arc<Mutex<RefCounts>>) -> Self {
-        ref_counts.lock().inc_entity(model_id);
+        ref_counts.lock().inc_model(model_id);
         Self {
             model_id,
             model_type: PhantomData,
@@ -2089,7 +2089,7 @@ impl<T: Entity> ModelHandle<T> {
 
 impl<T> Clone for ModelHandle<T> {
     fn clone(&self) -> Self {
-        self.ref_counts.lock().inc_entity(self.model_id);
+        self.ref_counts.lock().inc_model(self.model_id);
         Self {
             model_id: self.model_id,
             model_type: PhantomData,
@@ -2186,7 +2186,7 @@ pub struct ViewHandle<T> {
 
 impl<T: View> ViewHandle<T> {
     fn new(window_id: usize, view_id: usize, ref_counts: &Arc<Mutex<RefCounts>>) -> Self {
-        ref_counts.lock().inc_entity(view_id);
+        ref_counts.lock().inc_view(window_id, view_id);
         Self {
             window_id,
             view_id,
@@ -2298,7 +2298,9 @@ impl<T: View> ViewHandle<T> {
 
 impl<T> Clone for ViewHandle<T> {
     fn clone(&self) -> Self {
-        self.ref_counts.lock().inc_entity(self.view_id);
+        self.ref_counts
+            .lock()
+            .inc_view(self.window_id, self.view_id);
         Self {
             window_id: self.window_id,
             view_id: self.view_id,
@@ -2380,7 +2382,9 @@ impl AnyViewHandle {
 
 impl Clone for AnyViewHandle {
     fn clone(&self) -> Self {
-        self.ref_counts.lock().inc_entity(self.view_id);
+        self.ref_counts
+            .lock()
+            .inc_view(self.window_id, self.view_id);
         Self {
             window_id: self.window_id,
             view_id: self.view_id,
@@ -2392,7 +2396,10 @@ impl Clone for AnyViewHandle {
 
 impl<T: View> From<&ViewHandle<T>> for AnyViewHandle {
     fn from(handle: &ViewHandle<T>) -> Self {
-        handle.ref_counts.lock().inc_entity(handle.view_id);
+        handle
+            .ref_counts
+            .lock()
+            .inc_view(handle.window_id, handle.view_id);
         AnyViewHandle {
             window_id: handle.window_id,
             view_id: handle.view_id,
@@ -2433,7 +2440,7 @@ pub struct AnyModelHandle {
 
 impl<T: Entity> From<ModelHandle<T>> for AnyModelHandle {
     fn from(handle: ModelHandle<T>) -> Self {
-        handle.ref_counts.lock().inc_entity(handle.model_id);
+        handle.ref_counts.lock().inc_model(handle.model_id);
         Self {
             model_id: handle.model_id,
             ref_counts: handle.ref_counts.clone(),
@@ -2542,8 +2549,24 @@ struct RefCounts {
 }
 
 impl RefCounts {
-    fn inc_entity(&mut self, entity_id: usize) {
-        *self.entity_counts.entry(entity_id).or_insert(0) += 1;
+    fn inc_model(&mut self, model_id: usize) {
+        match self.entity_counts.entry(model_id) {
+            Entry::Occupied(mut entry) => *entry.get_mut() += 1,
+            Entry::Vacant(entry) => {
+                entry.insert(1);
+                self.dropped_models.remove(&model_id);
+            }
+        }
+    }
+
+    fn inc_view(&mut self, window_id: usize, view_id: usize) {
+        match self.entity_counts.entry(view_id) {
+            Entry::Occupied(mut entry) => *entry.get_mut() += 1,
+            Entry::Vacant(entry) => {
+                entry.insert(1);
+                self.dropped_views.remove(&(window_id, view_id));
+            }
+        }
     }
 
     fn inc_value(&mut self, tag_type_id: TypeId, id: usize) {

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -1066,6 +1066,7 @@ impl MutableAppContext {
                     }
                     self.remove_dropped_entities();
                 } else {
+                    self.remove_dropped_entities();
                     self.update_windows();
 
                     if self.pending_effects.is_empty() {

--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -1064,8 +1064,8 @@ impl MutableAppContext {
                             self.focus(window_id, view_id);
                         }
                     }
-                } else {
                     self.remove_dropped_entities();
+                } else {
                     self.update_windows();
 
                     if self.pending_effects.is_empty() {


### PR DESCRIPTION
When we drop the last handle to an entity, we don't actually remove it from the app state immediately. This is because a handle can really be dropped anywhere, and we don't want to give handles direct access to the app state. Instead, we track which entities have been dropped and then remove all dropped entities via a call to `remove_dropped_entities` after effects have been flushed.

This can lead to a situation where we have dropped an entity, but then an effect ends up calling an action on that entity before we have a chance to remove it. In this case, it's possible for the entity to get a handle to itself from the context, leading to a situation where the entity's ref count goes to 0 and then gets incremented back to 1. This led to issues when we tried to use the handle after eventually getting around to removing the "dropped" entity.

This PR addresses this situation in two ways. First, it ensures that we never remove an entity whose reference count has been incremented back to 1. To achieve this, whenever we increment a reference count above 0 for the first time, we remove its id from the set of dropped entities to avoid attempting to remove it.

To reduce the number of situations in which we decrement to 0 only to increment again, we also now call `remove_dropped_entities` after each effect is flushed rather than waiting until the end. This prevents situations in which one effect drops an entity but a subsequent effect causes that dropped entity to be notified. We'll remove the dropped entity and its observation before we process the notification. It's still possible for an entity to be dropped and restored within the context of applying a single effect, however, which is why it's important to still fix the `RefCounts` struct to avoid removing entities that have been restored.