### PR TITLE
Improve handling of multibyte characters and optimize Rope some more

### DIFF
--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -600,8 +600,7 @@ impl Buffer {
     }
 
     pub fn text_summary_for_range(&self, range: Range<usize>) -> TextSummary {
-        // TODO: Use a dedicated ::summarize method in Rope.
-        self.visible_text.slice(range).summary()
+        self.visible_text.cursor(range.start).summary(range.end)
     }
 
     pub fn len(&self) -> usize {

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -26,8 +26,12 @@ impl Rope {
         let mut chunks = rope.chunks.cursor::<(), ()>();
         chunks.next();
         if let Some(chunk) = chunks.item() {
-            self.push(&chunk.0);
-            chunks.next();
+            if self.chunks.last().map_or(false, |c| c.0.len() < CHUNK_BASE)
+                || chunk.0.len() < CHUNK_BASE
+            {
+                self.push(&chunk.0);
+                chunks.next();
+            }
         }
 
         self.chunks.push_tree(chunks.suffix(&()), &());

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -56,7 +56,9 @@ impl Rope {
                     if last_chunk.0.len() + first_new_chunk_ref.0.len() <= 2 * CHUNK_BASE {
                         last_chunk.0.push_str(&first_new_chunk.take().unwrap().0);
                     } else {
-                        let text = [last_chunk.0, first_new_chunk_ref.0].concat();
+                        let mut text = ArrayString::<[_; 4 * CHUNK_BASE]>::new();
+                        text.push_str(&last_chunk.0);
+                        text.push_str(&first_new_chunk_ref.0);
                         let mut midpoint = text.len() / 2;
                         while !text.is_char_boundary(midpoint) {
                             midpoint += 1;

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -544,7 +544,7 @@ mod tests {
                     let byte_range = byte_range_for_char_range(&expected, start_ix..end_ix);
                     assert_eq!(
                         actual.cursor(start_ix).summary(end_ix),
-                        TextSummary::from(&expected[byte_range.start..byte_range.end])
+                        TextSummary::from(&expected[byte_range])
                     );
                 }
             }


### PR DESCRIPTION
As mentioned in Discord, this pull request introduces a few improvements to our handling of multi-byte characters:

- In cd1e5f1, we still determine where to split based on character boundaries but do so without exceeding a chunk's maximum capacity. This is possible because we are always splitting the concatenation of two chunks. So, in the worst case, we can still split the concatenation back to those two initial chunks. This allows setting the chunk's capacity to `2 * CHUNK_BASE` as opposed to `4 * CHUNK_BASE`.
- In 1190a87, we're switching back to using an `ArrayString` that's 4 times the size of the maximum chunk size. This is because we're merging two existing chunks, each having at most `2 * CHUNK_BASE` bytes. This saves a heap allocation when calling `push` which, alongside the `SmallVec` used to hold new chunks, guarantees we don't heap-allocate at all for strings smaller than `32 * CHUNK_BASE` bytes.

I had some spare time this weekend, so I ended up introducing a few more optimizations too:

- In 76a74e4, we're introducing a summarization method to the `rope::Cursor` so that we don't allocate a brand new `Rope` just to get its summary and then throw it away. This gets rid of a TODO we introduced with #61.
- In c9987f9, we only attempt to merge two chunks when either of them is underflowing. This saves some time when we append a complete rope to another complete rope.
- In 5f93d7f, we now return an error when referencing a `Point` that doesn't exist. This gets rid of another TODO introduced as part of #61.