### PR TITLE
Reintroduce the 100ms delay when polling worktree entries

### DIFF
--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -145,6 +145,7 @@ impl Worktree {
 
         if self.is_scanning() && !self.poll_scheduled {
             ctx.spawn(|this, mut ctx| async move {
+                smol::Timer::after(Duration::from_millis(100)).await;
                 this.update(&mut ctx, |this, ctx| {
                     this.poll_scheduled = false;
                     this.poll_entries(ctx);


### PR DESCRIPTION
Opening this as a PR for visibility. This regressed when I switched us over to the simplified async approach. I think it was causing us to contend on the mutex on during startup.