### PR TITLE
Introduce a few optimizations to `SumTree` and `Buffer`

### DIFF
--- a/gpui/Cargo.toml
+++ b/gpui/Cargo.toml
@@ -23,7 +23,7 @@ scoped-pool = {path = "../scoped_pool"}
 seahash = "4.1"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_json = "1.0.64"
-smallvec = "1.6.1"
+smallvec = {version = "1.6", features = ["union"]}
 smol = "1.2"
 tiny-skia = "0.5"
 tree-sitter = "0.17"

--- a/zed/Cargo.toml
+++ b/zed/Cargo.toml
@@ -36,7 +36,7 @@ seahash = "4.1"
 serde = {version = "1", features = ["derive"]}
 similar = "1.3"
 simplelog = "0.9"
-smallvec = "1.6.1"
+smallvec = {version = "1.6", features = ["union"]}
 smol = "1.2.5"
 
 [dev-dependencies]

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -1900,15 +1900,13 @@ impl Buffer {
                     .item()
                     .ok_or_else(|| anyhow!("split offset is out of range"))?;
 
-                let mut fragments_cursor = self
-                    .fragments
-                    .cursor::<FragmentIdRef, FragmentTextSummary>();
+                let mut fragments_cursor = self.fragments.cursor::<FragmentIdRef, usize>();
                 fragments_cursor.seek(&FragmentIdRef::new(&split.fragment_id), SeekBias::Left, &());
                 let fragment = fragments_cursor
                     .item()
                     .ok_or_else(|| anyhow!("fragment id does not exist"))?;
 
-                let mut ix = fragments_cursor.start().clone().visible;
+                let mut ix = *fragments_cursor.start();
                 if fragment.visible {
                     ix += offset - fragment.range_in_insertion.start;
                 }
@@ -2316,7 +2314,7 @@ impl Default for InsertionSplitSummary {
 
 impl<'a> sum_tree::Dimension<'a, InsertionSplitSummary> for usize {
     fn add_summary(&mut self, summary: &InsertionSplitSummary) {
-        *self += &summary.extent;
+        *self += summary.extent;
     }
 }
 


### PR DESCRIPTION
As per the title, this pull request introduces a few of optimizations:

- 781aa92 removes unnecessary summarization when converting from an `Anchor` to `TextSummary`
- 84e0efe revisits some parts of the `SumTree` to avoid unnecessary heap allocations that showed up in the profiler when mutating the tree a lot (e.g., multi-cursor insertion)
- a8ece75 implements `time::Global` in terms of a `SmallVec` instead of using a `HashMap`. The theory is that version vectors are going to be small most of the time, especially as soon as we introduce an optimization that will let us only track concurrent versions, thus preventing the version vector from growing indefinitely over time in the tree.