### PR TITLE
Structure buffer APIs in terms of strings and byte counts instead of chars and character counts

### DIFF
--- a/gpui/src/elements/label.rs
+++ b/gpui/src/elements/label.rs
@@ -73,7 +73,7 @@ impl Element for Label {
             .font_cache
             .select_font(self.family_id, &self.font_properties)
             .unwrap();
-        let text_len = self.text.chars().count();
+        let text_len = self.text.len();
         let mut styles;
         let mut colors;
         if let Some(highlights) = self.highlights.as_ref() {

--- a/gpui/src/elements/label.rs
+++ b/gpui/src/elements/label.rs
@@ -196,19 +196,27 @@ impl ToJson for Highlights {
 
 #[cfg(test)]
 mod tests {
+    use font_kit::properties::Weight;
+
     use super::*;
 
     #[crate::test(self)]
     fn test_layout_label_with_highlights(app: &mut crate::MutableAppContext) {
-        let family_id = app.font_cache().load_family(&["Menlo"]).unwrap();
-        let font_id = app
+        let menlo = app.font_cache().load_family(&["Menlo"]).unwrap();
+        let menlo_regular = app
             .font_cache()
-            .select_font(family_id, &Properties::new())
+            .select_font(menlo, &Properties::new())
             .unwrap();
+        let menlo_bold = app
+            .font_cache()
+            .select_font(menlo, Properties::new().weight(Weight::BOLD))
+            .unwrap();
+        let black = ColorU::black();
+        let red = ColorU::new(255, 0, 0, 255);
 
-        let label = Label::new(".αβγδε.ⓐⓑⓒⓓⓔ.abcde.".to_string(), family_id, 12.0).with_highlights(
-            ColorU::black(),
-            Properties::new(),
+        let label = Label::new(".αβγδε.ⓐⓑⓒⓓⓔ.abcde.".to_string(), menlo, 12.0).with_highlights(
+            red,
+            *Properties::new().weight(Weight::BOLD),
             vec![
                 ".α".len(),
                 ".αβ".len(),
@@ -218,7 +226,29 @@ mod tests {
             ],
         );
 
-        let (styles, colors) = label.layout_text(app.font_cache().as_ref(), font_id);
-        assert_eq!(styles, &[]);
+        let (styles, colors) = label.layout_text(app.font_cache().as_ref(), menlo_regular);
+        assert_eq!(styles.len(), colors.len());
+
+        let mut spans = Vec::new();
+        for ((style_range, font_id), (color_range, color)) in styles.into_iter().zip(colors) {
+            assert_eq!(style_range, color_range);
+            spans.push((style_range, font_id, color));
+        }
+        assert_eq!(
+            spans,
+            &[
+                (0..3, menlo_regular, black),
+                (3..4, menlo_bold, red),
+                (4..5, menlo_regular, black),
+                (5..6, menlo_bold, red),
+                (6..9, menlo_regular, black),
+                (9..10, menlo_bold, red),
+                (10..15, menlo_regular, black),
+                (15..16, menlo_bold, red),
+                (16..18, menlo_regular, black),
+                (18..19, menlo_bold, red),
+                (19..34, menlo_regular, black)
+            ]
+        );
     }
 }

--- a/zed/src/editor/buffer/anchor.rs
+++ b/zed/src/editor/buffer/anchor.rs
@@ -70,24 +70,24 @@ impl Anchor {
         })
     }
 
-    pub fn bias_left(&self, buffer: &Buffer) -> Result<Anchor> {
+    pub fn bias_left(&self, buffer: &Buffer) -> Anchor {
         match self {
             Anchor::Start
             | Anchor::Middle {
                 bias: AnchorBias::Left,
                 ..
-            } => Ok(self.clone()),
+            } => self.clone(),
             _ => buffer.anchor_before(self),
         }
     }
 
-    pub fn bias_right(&self, buffer: &Buffer) -> Result<Anchor> {
+    pub fn bias_right(&self, buffer: &Buffer) -> Anchor {
         match self {
             Anchor::End
             | Anchor::Middle {
                 bias: AnchorBias::Right,
                 ..
-            } => Ok(self.clone()),
+            } => self.clone(),
             _ => buffer.anchor_after(self),
         }
     }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -11,6 +11,7 @@ pub use selection::*;
 use similar::{ChangeTag, TextDiff};
 
 use crate::{
+    editor::Bias,
     operation_queue::{self, OperationQueue},
     sum_tree::{self, FilterCursor, SeekBias, SumTree},
     time::{self, ReplicaId},
@@ -1865,12 +1866,12 @@ impl Buffer {
         }
     }
 
-    pub fn next_char_boundary(&self, offset: usize) -> usize {
-        self.visible_text.next_char_boundary(offset)
+    pub fn clip_point(&self, point: Point, bias: Bias) -> Point {
+        self.visible_text.clip_point(point, bias)
     }
 
-    pub fn prev_char_boundary(&self, offset: usize) -> usize {
-        self.visible_text.prev_char_boundary(offset)
+    pub fn clip_offset(&self, offset: usize, bias: Bias) -> usize {
+        self.visible_text.clip_offset(offset, bias)
     }
 }
 
@@ -3232,8 +3233,8 @@ mod tests {
 
     impl Buffer {
         fn random_byte_range(&mut self, start_offset: usize, rng: &mut impl Rng) -> Range<usize> {
-            let end = self.next_char_boundary(rng.gen_range(start_offset..=self.len()));
-            let start = self.prev_char_boundary(rng.gen_range(start_offset..=end));
+            let end = self.clip_offset(rng.gen_range(start_offset..=self.len()), Bias::Right);
+            let start = self.clip_offset(rng.gen_range(start_offset..=end), Bias::Left);
             start..end
         }
 

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -643,11 +643,11 @@ impl Buffer {
         self.visible_text.chunks_in_range(start..end)
     }
 
-    pub fn chars(&self) -> rope::Chars {
+    pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
         self.chars_at(0)
     }
 
-    pub fn chars_at<T: ToOffset>(&self, position: T) -> rope::Chars {
+    pub fn chars_at<T: ToOffset>(&self, position: T) -> impl Iterator<Item = char> + '_ {
         let offset = position.to_offset(self);
         self.visible_text.chars_at(offset)
     }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -14,13 +14,11 @@ use crate::{
     operation_queue::{self, OperationQueue},
     sum_tree::{self, FilterCursor, SeekBias, SumTree},
     time::{self, ReplicaId},
-    util::RandomCharIter,
     worktree::FileHandle,
 };
 use anyhow::{anyhow, Result};
 use gpui::{AppContext, Entity, ModelContext, Task};
 use lazy_static::lazy_static;
-use rand::prelude::*;
 use std::{
     cmp,
     hash::BuildHasher,
@@ -607,15 +605,14 @@ impl Buffer {
         self.fragments.extent::<usize>()
     }
 
-    pub fn line_len(&self, row: u32) -> Result<u32> {
-        let row_start_offset = Point::new(row, 0).to_offset(self)?;
+    pub fn line_len(&self, row: u32) -> u32 {
+        let row_start_offset = Point::new(row, 0).to_offset(self);
         let row_end_offset = if row >= self.max_point().row {
             self.len()
         } else {
-            Point::new(row + 1, 0).to_offset(self)? - 1
+            Point::new(row + 1, 0).to_offset(self) - 1
         };
-
-        Ok((row_end_offset - row_start_offset) as u32)
+        (row_end_offset - row_start_offset) as u32
     }
 
     pub fn rightmost_point(&self) -> Point {
@@ -630,33 +627,32 @@ impl Buffer {
         self.visible_text.max_point()
     }
 
-    pub fn line(&self, row: u32) -> Result<String> {
-        Ok(self
-            .chars_at(Point::new(row, 0))?
+    pub fn line(&self, row: u32) -> String {
+        self.chars_at(Point::new(row, 0))
             .take_while(|c| *c != '\n')
-            .collect())
+            .collect()
     }
 
     pub fn text(&self) -> String {
-        self.chars().collect()
+        self.text_for_range(0..self.len()).collect()
     }
 
     pub fn text_for_range<'a, T: ToOffset>(
         &'a self,
         range: Range<T>,
-    ) -> Result<impl 'a + Iterator<Item = char>> {
-        let start = range.start.to_offset(self)?;
-        let end = range.end.to_offset(self)?;
-        Ok(self.chars_at(start)?.take(end - start))
+    ) -> impl 'a + Iterator<Item = &'a str> {
+        let start = range.start.to_offset(self);
+        let end = range.end.to_offset(self);
+        self.visible_text.chunks_in_range(start..end)
     }
 
     pub fn chars(&self) -> rope::Chars {
-        self.chars_at(0).unwrap()
+        self.chars_at(0)
     }
 
-    pub fn chars_at<T: ToOffset>(&self, position: T) -> Result<rope::Chars> {
-        let offset = position.to_offset(self)?;
-        Ok(self.visible_text.chars_at(offset))
+    pub fn chars_at<T: ToOffset>(&self, position: T) -> rope::Chars {
+        let offset = position.to_offset(self);
+        self.visible_text.chars_at(offset)
     }
 
     pub fn selections_changed_since(&self, since: SelectionsVersion) -> bool {
@@ -763,8 +759,8 @@ impl Buffer {
 
         let old_ranges = old_ranges
             .into_iter()
-            .map(|range| Ok(range.start.to_offset(self)?..range.end.to_offset(self)?))
-            .collect::<Result<Vec<Range<usize>>>>()?;
+            .map(|range| range.start.to_offset(self)..range.end.to_offset(self))
+            .collect::<Vec<Range<usize>>>();
 
         let has_new_text = new_text.is_some();
         let ops = self.splice_fragments(
@@ -800,50 +796,6 @@ impl Buffer {
         if !was_dirty {
             ctx.emit(Event::Dirtied);
         }
-    }
-
-    pub fn simulate_typing<T: Rng>(&mut self, rng: &mut T) {
-        let end = rng.gen_range(0..self.len() + 1);
-        let start = rng.gen_range(0..end + 1);
-        let mut range = start..end;
-
-        let new_text_len = rng.gen_range(0..100);
-        let new_text: String = RandomCharIter::new(&mut *rng).take(new_text_len).collect();
-
-        for char in new_text.chars() {
-            self.edit(Some(range.clone()), char.to_string().as_str(), None)
-                .unwrap();
-            range = range.end + 1..range.end + 1;
-        }
-    }
-
-    pub fn randomly_edit<T>(
-        &mut self,
-        rng: &mut T,
-        old_range_count: usize,
-        ctx: Option<&mut ModelContext<Self>>,
-    ) -> (Vec<Range<usize>>, String, Vec<Operation>)
-    where
-        T: Rng,
-    {
-        let mut old_ranges: Vec<Range<usize>> = Vec::new();
-        for _ in 0..old_range_count {
-            let last_end = old_ranges.last().map_or(0, |last_range| last_range.end + 1);
-            if last_end > self.len() {
-                break;
-            }
-            let end = rng.gen_range(last_end..self.len() + 1);
-            let start = rng.gen_range(last_end..end + 1);
-            old_ranges.push(start..end);
-        }
-        let new_text_len = rng.gen_range(0..10);
-        let new_text: String = RandomCharIter::new(&mut *rng).take(new_text_len).collect();
-
-        let operations = self
-            .edit(old_ranges.iter().cloned(), new_text.as_str(), ctx)
-            .unwrap();
-
-        (old_ranges, new_text, operations)
     }
 
     pub fn add_selection_set(
@@ -1777,8 +1729,7 @@ impl Buffer {
                 .unwrap_or(&FragmentId::max_value()),
         );
 
-        // TODO: extent could be expressed in bytes, which would save a linear scan.
-        let range_in_insertion = 0..text.chars().count();
+        let range_in_insertion = 0..text.len();
         let mut split_tree = SumTree::new();
         split_tree.push(
             InsertionSplit {
@@ -1801,33 +1752,31 @@ impl Buffer {
         )
     }
 
-    pub fn anchor_before<T: ToOffset>(&self, position: T) -> Result<Anchor> {
+    pub fn anchor_before<T: ToOffset>(&self, position: T) -> Anchor {
         self.anchor_at(position, AnchorBias::Left)
     }
 
-    pub fn anchor_after<T: ToOffset>(&self, position: T) -> Result<Anchor> {
+    pub fn anchor_after<T: ToOffset>(&self, position: T) -> Anchor {
         self.anchor_at(position, AnchorBias::Right)
     }
 
-    pub fn anchor_at<T: ToOffset>(&self, position: T, bias: AnchorBias) -> Result<Anchor> {
-        let offset = position.to_offset(self)?;
+    pub fn anchor_at<T: ToOffset>(&self, position: T, bias: AnchorBias) -> Anchor {
+        let offset = position.to_offset(self);
         let max_offset = self.len();
-        if offset > max_offset {
-            return Err(anyhow!("offset is out of range"));
-        }
+        assert!(offset <= max_offset, "offset is out of range");
 
         let seek_bias;
         match bias {
             AnchorBias::Left => {
                 if offset == 0 {
-                    return Ok(Anchor::Start);
+                    return Anchor::Start;
                 } else {
                     seek_bias = SeekBias::Left;
                 }
             }
             AnchorBias::Right => {
                 if offset == max_offset {
-                    return Ok(Anchor::End);
+                    return Anchor::End;
                 } else {
                     seek_bias = SeekBias::Right;
                 }
@@ -1844,7 +1793,7 @@ impl Buffer {
             offset: offset_in_insertion,
             bias,
         };
-        Ok(anchor)
+        anchor
     }
 
     fn fragment_id_for_anchor(&self, anchor: &Anchor) -> Result<&FragmentId> {
@@ -1876,10 +1825,10 @@ impl Buffer {
         }
     }
 
-    fn summary_for_anchor(&self, anchor: &Anchor) -> Result<TextSummary> {
+    fn summary_for_anchor(&self, anchor: &Anchor) -> TextSummary {
         match anchor {
-            Anchor::Start => Ok(TextSummary::default()),
-            Anchor::End => Ok(self.text_summary()),
+            Anchor::Start => TextSummary::default(),
+            Anchor::End => self.text_summary(),
             Anchor::Middle {
                 insertion_id,
                 offset,
@@ -1893,24 +1842,20 @@ impl Buffer {
                 let splits = self
                     .insertion_splits
                     .get(&insertion_id)
-                    .ok_or_else(|| anyhow!("split does not exist for insertion id"))?;
+                    .expect("split does not exist for insertion id");
                 let mut splits_cursor = splits.cursor::<usize, ()>();
                 splits_cursor.seek(offset, seek_bias, &());
-                let split = splits_cursor
-                    .item()
-                    .ok_or_else(|| anyhow!("split offset is out of range"))?;
+                let split = splits_cursor.item().expect("split offset is out of range");
 
                 let mut fragments_cursor = self.fragments.cursor::<FragmentIdRef, usize>();
                 fragments_cursor.seek(&FragmentIdRef::new(&split.fragment_id), SeekBias::Left, &());
-                let fragment = fragments_cursor
-                    .item()
-                    .ok_or_else(|| anyhow!("fragment id does not exist"))?;
+                let fragment = fragments_cursor.item().expect("fragment id does not exist");
 
                 let mut ix = *fragments_cursor.start();
                 if fragment.visible {
                     ix += offset - fragment.range_in_insertion.start;
                 }
-                Ok(self.text_summary_for_range(0..ix))
+                self.text_summary_for_range(0..ix)
             }
         }
     }
@@ -1921,6 +1866,14 @@ impl Buffer {
         } else {
             Err(anyhow!("offset out of bounds"))
         }
+    }
+
+    pub fn next_char_boundary(&self, offset: usize) -> usize {
+        self.visible_text.next_char_boundary(offset)
+    }
+
+    pub fn prev_char_boundary(&self, offset: usize) -> usize {
+        self.visible_text.prev_char_boundary(offset)
     }
 }
 
@@ -2352,45 +2305,45 @@ impl operation_queue::Operation for Operation {
 }
 
 pub trait ToOffset {
-    fn to_offset(&self, buffer: &Buffer) -> Result<usize>;
+    fn to_offset(&self, buffer: &Buffer) -> usize;
 }
 
 impl ToOffset for Point {
-    fn to_offset(&self, buffer: &Buffer) -> Result<usize> {
+    fn to_offset(&self, buffer: &Buffer) -> usize {
         buffer.visible_text.to_offset(*self)
     }
 }
 
 impl ToOffset for usize {
-    fn to_offset(&self, _: &Buffer) -> Result<usize> {
-        Ok(*self)
+    fn to_offset(&self, _: &Buffer) -> usize {
+        *self
     }
 }
 
 impl ToOffset for Anchor {
-    fn to_offset(&self, buffer: &Buffer) -> Result<usize> {
-        Ok(buffer.summary_for_anchor(self)?.chars)
+    fn to_offset(&self, buffer: &Buffer) -> usize {
+        buffer.summary_for_anchor(self).bytes
     }
 }
 
 impl<'a> ToOffset for &'a Anchor {
-    fn to_offset(&self, buffer: &Buffer) -> Result<usize> {
-        Ok(buffer.summary_for_anchor(self)?.chars)
+    fn to_offset(&self, buffer: &Buffer) -> usize {
+        buffer.summary_for_anchor(self).bytes
     }
 }
 
 pub trait ToPoint {
-    fn to_point(&self, buffer: &Buffer) -> Result<Point>;
+    fn to_point(&self, buffer: &Buffer) -> Point;
 }
 
 impl ToPoint for Anchor {
-    fn to_point(&self, buffer: &Buffer) -> Result<Point> {
-        Ok(buffer.summary_for_anchor(self)?.lines)
+    fn to_point(&self, buffer: &Buffer) -> Point {
+        buffer.summary_for_anchor(self).lines
     }
 }
 
 impl ToPoint for usize {
-    fn to_point(&self, buffer: &Buffer) -> Result<Point> {
+    fn to_point(&self, buffer: &Buffer) -> Point {
         buffer.visible_text.to_point(*self)
     }
 }
@@ -2400,13 +2353,15 @@ mod tests {
     use super::*;
     use crate::{
         test::temp_tree,
+        util::RandomCharIter,
         worktree::{Worktree, WorktreeHandle},
     };
-    use cmp::Ordering;
     use gpui::App;
+    use rand::prelude::*;
     use serde_json::json;
     use std::{
         cell::RefCell,
+        cmp::Ordering,
         collections::BTreeMap,
         fs,
         rc::Rc,
@@ -2506,12 +2461,7 @@ mod tests {
                 for _i in 0..10 {
                     let (old_ranges, new_text, _) = buffer.randomly_mutate(rng, None);
                     for old_range in old_ranges.iter().rev() {
-                        reference_string = reference_string
-                            .chars()
-                            .take(old_range.start)
-                            .chain(new_text.chars())
-                            .chain(reference_string.chars().skip(old_range.end))
-                            .collect();
+                        reference_string.replace_range(old_range.clone(), &new_text);
                     }
                     assert_eq!(buffer.text(), reference_string);
 
@@ -2525,7 +2475,7 @@ mod tests {
 
                         for (len, rows) in &line_lengths {
                             for row in rows {
-                                assert_eq!(buffer.line_len(*row).unwrap(), *len);
+                                assert_eq!(buffer.line_len(*row), *len);
                             }
                         }
 
@@ -2537,22 +2487,14 @@ mod tests {
                     }
 
                     for _ in 0..5 {
-                        let end = rng.gen_range(0..buffer.len() + 1);
-                        let start = rng.gen_range(0..end + 1);
-
-                        let line_lengths = line_lengths_in_range(&buffer, start..end);
+                        let range = buffer.random_byte_range(0, rng);
+                        let line_lengths = line_lengths_in_range(&buffer, range.clone());
                         let (longest_column, longest_rows) =
                             line_lengths.iter().next_back().unwrap();
-                        let range_sum = buffer.text_summary_for_range(start..end);
+                        let range_sum = buffer.text_summary_for_range(range.clone());
                         assert_eq!(range_sum.rightmost_point.column, *longest_column);
                         assert!(longest_rows.contains(&range_sum.rightmost_point.row));
-                        let range_text = buffer
-                            .text()
-                            .chars()
-                            .skip(start)
-                            .take(end - start)
-                            .collect::<String>();
-                        assert_eq!(range_sum.chars, range_text.chars().count());
+                        let range_text = &buffer.text()[range];
                         assert_eq!(range_sum.bytes, range_text.len());
                     }
 
@@ -2571,7 +2513,7 @@ mod tests {
                         let old_len = old_range.end - old_range.start;
                         let new_len = new_range.end - new_range.start;
                         let old_start = (old_range.start as isize + delta) as usize;
-                        let new_text: String = buffer.text_for_range(new_range).unwrap().collect();
+                        let new_text: String = buffer.text_for_range(new_range).collect();
                         old_buffer
                             .edit(Some(old_start..old_start + old_len), new_text, None)
                             .unwrap();
@@ -2595,13 +2537,12 @@ mod tests {
             buffer.edit(vec![18..18], "\npqrs\n", None).unwrap();
             buffer.edit(vec![18..21], "\nPQ", None).unwrap();
 
-            assert_eq!(buffer.line_len(0).unwrap(), 4);
-            assert_eq!(buffer.line_len(1).unwrap(), 3);
-            assert_eq!(buffer.line_len(2).unwrap(), 5);
-            assert_eq!(buffer.line_len(3).unwrap(), 3);
-            assert_eq!(buffer.line_len(4).unwrap(), 4);
-            assert_eq!(buffer.line_len(5).unwrap(), 0);
-            assert!(buffer.line_len(6).is_err());
+            assert_eq!(buffer.line_len(0), 4);
+            assert_eq!(buffer.line_len(1), 3);
+            assert_eq!(buffer.line_len(2), 5);
+            assert_eq!(buffer.line_len(3), 3);
+            assert_eq!(buffer.line_len(4), 4);
+            assert_eq!(buffer.line_len(5), 0);
             buffer
         });
     }
@@ -2632,7 +2573,6 @@ mod tests {
             assert_eq!(
                 buffer.text_summary_for_range(1..3),
                 TextSummary {
-                    chars: 2,
                     bytes: 2,
                     lines: Point::new(1, 0),
                     first_line_len: 1,
@@ -2642,7 +2582,6 @@ mod tests {
             assert_eq!(
                 buffer.text_summary_for_range(1..12),
                 TextSummary {
-                    chars: 11,
                     bytes: 11,
                     lines: Point::new(3, 0),
                     first_line_len: 1,
@@ -2652,7 +2591,6 @@ mod tests {
             assert_eq!(
                 buffer.text_summary_for_range(0..20),
                 TextSummary {
-                    chars: 20,
                     bytes: 20,
                     lines: Point::new(4, 1),
                     first_line_len: 2,
@@ -2662,7 +2600,6 @@ mod tests {
             assert_eq!(
                 buffer.text_summary_for_range(0..22),
                 TextSummary {
-                    chars: 22,
                     bytes: 22,
                     lines: Point::new(4, 3),
                     first_line_len: 2,
@@ -2672,7 +2609,6 @@ mod tests {
             assert_eq!(
                 buffer.text_summary_for_range(7..22),
                 TextSummary {
-                    chars: 15,
                     bytes: 15,
                     lines: Point::new(2, 3),
                     first_line_len: 4,
@@ -2692,19 +2628,19 @@ mod tests {
             buffer.edit(vec![18..18], "\npqrs", None).unwrap();
             buffer.edit(vec![18..21], "\nPQ", None).unwrap();
 
-            let chars = buffer.chars_at(Point::new(0, 0)).unwrap();
+            let chars = buffer.chars_at(Point::new(0, 0));
             assert_eq!(chars.collect::<String>(), "abcd\nefgh\nijkl\nmno\nPQrs");
 
-            let chars = buffer.chars_at(Point::new(1, 0)).unwrap();
+            let chars = buffer.chars_at(Point::new(1, 0));
             assert_eq!(chars.collect::<String>(), "efgh\nijkl\nmno\nPQrs");
 
-            let chars = buffer.chars_at(Point::new(2, 0)).unwrap();
+            let chars = buffer.chars_at(Point::new(2, 0));
             assert_eq!(chars.collect::<String>(), "ijkl\nmno\nPQrs");
 
-            let chars = buffer.chars_at(Point::new(3, 0)).unwrap();
+            let chars = buffer.chars_at(Point::new(3, 0));
             assert_eq!(chars.collect::<String>(), "mno\nPQrs");
 
-            let chars = buffer.chars_at(Point::new(4, 0)).unwrap();
+            let chars = buffer.chars_at(Point::new(4, 0));
             assert_eq!(chars.collect::<String>(), "PQrs");
 
             // Regression test:
@@ -2712,7 +2648,7 @@ mod tests {
             buffer.edit(vec![0..0], "[workspace]\nmembers = [\n    \"xray_core\",\n    \"xray_server\",\n    \"xray_cli\",\n    \"xray_wasm\",\n]\n", None).unwrap();
             buffer.edit(vec![60..60], "\n", None).unwrap();
 
-            let chars = buffer.chars_at(Point::new(6, 0)).unwrap();
+            let chars = buffer.chars_at(Point::new(6, 0));
             assert_eq!(chars.collect::<String>(), "    \"xray_wasm\",\n]\n");
 
             buffer
@@ -2744,103 +2680,79 @@ mod tests {
         ctx.add_model(|ctx| {
             let mut buffer = Buffer::new(0, "", ctx);
             buffer.edit(vec![0..0], "abc", None).unwrap();
-            let left_anchor = buffer.anchor_before(2).unwrap();
-            let right_anchor = buffer.anchor_after(2).unwrap();
+            let left_anchor = buffer.anchor_before(2);
+            let right_anchor = buffer.anchor_after(2);
 
             buffer.edit(vec![1..1], "def\n", None).unwrap();
             assert_eq!(buffer.text(), "adef\nbc");
-            assert_eq!(left_anchor.to_offset(&buffer).unwrap(), 6);
-            assert_eq!(right_anchor.to_offset(&buffer).unwrap(), 6);
-            assert_eq!(
-                left_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 1 }
-            );
-            assert_eq!(
-                right_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 1 }
-            );
+            assert_eq!(left_anchor.to_offset(&buffer), 6);
+            assert_eq!(right_anchor.to_offset(&buffer), 6);
+            assert_eq!(left_anchor.to_point(&buffer), Point { row: 1, column: 1 });
+            assert_eq!(right_anchor.to_point(&buffer), Point { row: 1, column: 1 });
 
             buffer.edit(vec![2..3], "", None).unwrap();
             assert_eq!(buffer.text(), "adf\nbc");
-            assert_eq!(left_anchor.to_offset(&buffer).unwrap(), 5);
-            assert_eq!(right_anchor.to_offset(&buffer).unwrap(), 5);
-            assert_eq!(
-                left_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 1 }
-            );
-            assert_eq!(
-                right_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 1 }
-            );
+            assert_eq!(left_anchor.to_offset(&buffer), 5);
+            assert_eq!(right_anchor.to_offset(&buffer), 5);
+            assert_eq!(left_anchor.to_point(&buffer), Point { row: 1, column: 1 });
+            assert_eq!(right_anchor.to_point(&buffer), Point { row: 1, column: 1 });
 
             buffer.edit(vec![5..5], "ghi\n", None).unwrap();
             assert_eq!(buffer.text(), "adf\nbghi\nc");
-            assert_eq!(left_anchor.to_offset(&buffer).unwrap(), 5);
-            assert_eq!(right_anchor.to_offset(&buffer).unwrap(), 9);
-            assert_eq!(
-                left_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 1 }
-            );
-            assert_eq!(
-                right_anchor.to_point(&buffer).unwrap(),
-                Point { row: 2, column: 0 }
-            );
+            assert_eq!(left_anchor.to_offset(&buffer), 5);
+            assert_eq!(right_anchor.to_offset(&buffer), 9);
+            assert_eq!(left_anchor.to_point(&buffer), Point { row: 1, column: 1 });
+            assert_eq!(right_anchor.to_point(&buffer), Point { row: 2, column: 0 });
 
             buffer.edit(vec![7..9], "", None).unwrap();
             assert_eq!(buffer.text(), "adf\nbghc");
-            assert_eq!(left_anchor.to_offset(&buffer).unwrap(), 5);
-            assert_eq!(right_anchor.to_offset(&buffer).unwrap(), 7);
-            assert_eq!(
-                left_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 1 },
-            );
-            assert_eq!(
-                right_anchor.to_point(&buffer).unwrap(),
-                Point { row: 1, column: 3 }
-            );
+            assert_eq!(left_anchor.to_offset(&buffer), 5);
+            assert_eq!(right_anchor.to_offset(&buffer), 7);
+            assert_eq!(left_anchor.to_point(&buffer), Point { row: 1, column: 1 },);
+            assert_eq!(right_anchor.to_point(&buffer), Point { row: 1, column: 3 });
 
             // Ensure anchoring to a point is equivalent to anchoring to an offset.
             assert_eq!(
-                buffer.anchor_before(Point { row: 0, column: 0 }).unwrap(),
-                buffer.anchor_before(0).unwrap()
+                buffer.anchor_before(Point { row: 0, column: 0 }),
+                buffer.anchor_before(0)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 0, column: 1 }).unwrap(),
-                buffer.anchor_before(1).unwrap()
+                buffer.anchor_before(Point { row: 0, column: 1 }),
+                buffer.anchor_before(1)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 0, column: 2 }).unwrap(),
-                buffer.anchor_before(2).unwrap()
+                buffer.anchor_before(Point { row: 0, column: 2 }),
+                buffer.anchor_before(2)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 0, column: 3 }).unwrap(),
-                buffer.anchor_before(3).unwrap()
+                buffer.anchor_before(Point { row: 0, column: 3 }),
+                buffer.anchor_before(3)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 1, column: 0 }).unwrap(),
-                buffer.anchor_before(4).unwrap()
+                buffer.anchor_before(Point { row: 1, column: 0 }),
+                buffer.anchor_before(4)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 1, column: 1 }).unwrap(),
-                buffer.anchor_before(5).unwrap()
+                buffer.anchor_before(Point { row: 1, column: 1 }),
+                buffer.anchor_before(5)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 1, column: 2 }).unwrap(),
-                buffer.anchor_before(6).unwrap()
+                buffer.anchor_before(Point { row: 1, column: 2 }),
+                buffer.anchor_before(6)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 1, column: 3 }).unwrap(),
-                buffer.anchor_before(7).unwrap()
+                buffer.anchor_before(Point { row: 1, column: 3 }),
+                buffer.anchor_before(7)
             );
             assert_eq!(
-                buffer.anchor_before(Point { row: 1, column: 4 }).unwrap(),
-                buffer.anchor_before(8).unwrap()
+                buffer.anchor_before(Point { row: 1, column: 4 }),
+                buffer.anchor_before(8)
             );
 
             // Comparison between anchors.
-            let anchor_at_offset_0 = buffer.anchor_before(0).unwrap();
-            let anchor_at_offset_1 = buffer.anchor_before(1).unwrap();
-            let anchor_at_offset_2 = buffer.anchor_before(2).unwrap();
+            let anchor_at_offset_0 = buffer.anchor_before(0);
+            let anchor_at_offset_1 = buffer.anchor_before(1);
+            let anchor_at_offset_2 = buffer.anchor_before(2);
 
             assert_eq!(
                 anchor_at_offset_0
@@ -2906,24 +2818,24 @@ mod tests {
     fn test_anchors_at_start_and_end(ctx: &mut gpui::MutableAppContext) {
         ctx.add_model(|ctx| {
             let mut buffer = Buffer::new(0, "", ctx);
-            let before_start_anchor = buffer.anchor_before(0).unwrap();
-            let after_end_anchor = buffer.anchor_after(0).unwrap();
+            let before_start_anchor = buffer.anchor_before(0);
+            let after_end_anchor = buffer.anchor_after(0);
 
             buffer.edit(vec![0..0], "abc", None).unwrap();
             assert_eq!(buffer.text(), "abc");
-            assert_eq!(before_start_anchor.to_offset(&buffer).unwrap(), 0);
-            assert_eq!(after_end_anchor.to_offset(&buffer).unwrap(), 3);
+            assert_eq!(before_start_anchor.to_offset(&buffer), 0);
+            assert_eq!(after_end_anchor.to_offset(&buffer), 3);
 
-            let after_start_anchor = buffer.anchor_after(0).unwrap();
-            let before_end_anchor = buffer.anchor_before(3).unwrap();
+            let after_start_anchor = buffer.anchor_after(0);
+            let before_end_anchor = buffer.anchor_before(3);
 
             buffer.edit(vec![3..3], "def", None).unwrap();
             buffer.edit(vec![0..0], "ghi", None).unwrap();
             assert_eq!(buffer.text(), "ghiabcdef");
-            assert_eq!(before_start_anchor.to_offset(&buffer).unwrap(), 0);
-            assert_eq!(after_start_anchor.to_offset(&buffer).unwrap(), 3);
-            assert_eq!(before_end_anchor.to_offset(&buffer).unwrap(), 6);
-            assert_eq!(after_end_anchor.to_offset(&buffer).unwrap(), 9);
+            assert_eq!(before_start_anchor.to_offset(&buffer), 0);
+            assert_eq!(after_start_anchor.to_offset(&buffer), 3);
+            assert_eq!(before_end_anchor.to_offset(&buffer), 6);
+            assert_eq!(after_end_anchor.to_offset(&buffer), 9);
             buffer
         });
     }
@@ -3062,9 +2974,7 @@ mod tests {
             buffer.add_selection_set(
                 (0..3)
                     .map(|row| {
-                        let anchor = buffer
-                            .anchor_at(Point::new(row, 0), AnchorBias::Right)
-                            .unwrap();
+                        let anchor = buffer.anchor_at(Point::new(row, 0), AnchorBias::Right);
                         Selection {
                             id: row as usize,
                             start: anchor.clone(),
@@ -3104,7 +3014,7 @@ mod tests {
                 .iter()
                 .map(|selection| {
                     assert_eq!(selection.start, selection.end);
-                    selection.start.to_point(&buffer).unwrap()
+                    selection.start.to_point(&buffer)
                 })
                 .collect::<Vec<_>>();
             assert_eq!(
@@ -3324,6 +3234,39 @@ mod tests {
     }
 
     impl Buffer {
+        fn random_byte_range(&mut self, start_offset: usize, rng: &mut impl Rng) -> Range<usize> {
+            let end = self.next_char_boundary(rng.gen_range(start_offset..=self.len()));
+            let start = self.prev_char_boundary(rng.gen_range(start_offset..=end));
+            start..end
+        }
+
+        pub fn randomly_edit<T>(
+            &mut self,
+            rng: &mut T,
+            old_range_count: usize,
+            ctx: Option<&mut ModelContext<Self>>,
+        ) -> (Vec<Range<usize>>, String, Vec<Operation>)
+        where
+            T: Rng,
+        {
+            let mut old_ranges: Vec<Range<usize>> = Vec::new();
+            for _ in 0..old_range_count {
+                let last_end = old_ranges.last().map_or(0, |last_range| last_range.end + 1);
+                if last_end > self.len() {
+                    break;
+                }
+                old_ranges.push(self.random_byte_range(last_end, rng));
+            }
+            let new_text_len = rng.gen_range(0..10);
+            let new_text: String = RandomCharIter::new(&mut *rng).take(new_text_len).collect();
+
+            let operations = self
+                .edit(old_ranges.iter().cloned(), new_text.as_str(), ctx)
+                .unwrap();
+
+            (old_ranges, new_text, operations)
+        }
+
         pub fn randomly_mutate<T>(
             &mut self,
             rng: &mut T,
@@ -3349,9 +3292,7 @@ mod tests {
             } else {
                 let mut ranges = Vec::new();
                 for _ in 0..5 {
-                    let start = rng.gen_range(0..self.len() + 1);
-                    let end = rng.gen_range(0..self.len() + 1);
-                    ranges.push(start..end);
+                    ranges.push(self.random_byte_range(0, rng));
                 }
                 let new_selections = self.selections_from_ranges(ranges).unwrap();
 
@@ -3391,16 +3332,16 @@ mod tests {
                 if range.start > range.end {
                     selections.push(Selection {
                         id: NEXT_SELECTION_ID.fetch_add(1, atomic::Ordering::SeqCst),
-                        start: self.anchor_before(range.end)?,
-                        end: self.anchor_before(range.start)?,
+                        start: self.anchor_before(range.end),
+                        end: self.anchor_before(range.start),
                         reversed: true,
                         goal: SelectionGoal::None,
                     });
                 } else {
                     selections.push(Selection {
                         id: NEXT_SELECTION_ID.fetch_add(1, atomic::Ordering::SeqCst),
-                        start: self.anchor_after(range.start)?,
-                        end: self.anchor_before(range.end)?,
+                        start: self.anchor_after(range.start),
+                        end: self.anchor_before(range.end),
                         reversed: false,
                         goal: SelectionGoal::None,
                     });
@@ -3414,8 +3355,8 @@ mod tests {
                 .selections(set_id)?
                 .iter()
                 .map(move |selection| {
-                    let start = selection.start.to_offset(self).unwrap();
-                    let end = selection.end.to_offset(self).unwrap();
+                    let start = selection.start.to_offset(self);
+                    let end = selection.end.to_offset(self);
                     if selection.reversed {
                         end..start
                     } else {
@@ -3452,17 +3393,9 @@ mod tests {
 
     fn line_lengths_in_range(buffer: &Buffer, range: Range<usize>) -> BTreeMap<u32, HashSet<u32>> {
         let mut lengths = BTreeMap::new();
-        for (row, line) in buffer
-            .text()
-            .chars()
-            .skip(range.start)
-            .take(range.len())
-            .collect::<String>()
-            .lines()
-            .enumerate()
-        {
+        for (row, line) in buffer.text()[range.start..range.end].lines().enumerate() {
             lengths
-                .entry(line.chars().count() as u32)
+                .entry(line.len() as u32)
                 .or_insert(HashSet::default())
                 .insert(row as u32);
         }

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -5,7 +5,7 @@ mod selection;
 
 pub use anchor::*;
 pub use point::*;
-pub use rope::{Rope, TextSummary};
+pub use rope::{ChunksIter, Rope, TextSummary};
 use seahash::SeaHasher;
 pub use selection::*;
 use similar::{ChangeTag, TextDiff};
@@ -637,10 +637,7 @@ impl Buffer {
         self.text_for_range(0..self.len()).collect()
     }
 
-    pub fn text_for_range<'a, T: ToOffset>(
-        &'a self,
-        range: Range<T>,
-    ) -> impl 'a + Iterator<Item = &'a str> {
+    pub fn text_for_range<'a, T: ToOffset>(&'a self, range: Range<T>) -> ChunksIter<'a> {
         let start = range.start.to_offset(self);
         let end = range.end.to_offset(self);
         self.visible_text.chunks_in_range(start..end)

--- a/zed/src/editor/buffer/mod.rs
+++ b/zed/src/editor/buffer/mod.rs
@@ -2525,7 +2525,8 @@ mod tests {
                     lines: Point::new(1, 0),
                     first_line_chars: 1,
                     last_line_chars: 0,
-                    rightmost_point: Point::new(0, 1),
+                    rightmost_row: 0,
+                    rightmost_row_chars: 1,
                 }
             );
             assert_eq!(
@@ -2535,7 +2536,8 @@ mod tests {
                     lines: Point::new(3, 0),
                     first_line_chars: 1,
                     last_line_chars: 0,
-                    rightmost_point: Point::new(2, 4),
+                    rightmost_row: 2,
+                    rightmost_row_chars: 4,
                 }
             );
             assert_eq!(
@@ -2545,7 +2547,8 @@ mod tests {
                     lines: Point::new(4, 1),
                     first_line_chars: 2,
                     last_line_chars: 1,
-                    rightmost_point: Point::new(3, 6),
+                    rightmost_row: 3,
+                    rightmost_row_chars: 6,
                 }
             );
             assert_eq!(
@@ -2555,7 +2558,8 @@ mod tests {
                     lines: Point::new(4, 3),
                     first_line_chars: 2,
                     last_line_chars: 3,
-                    rightmost_point: Point::new(3, 6),
+                    rightmost_row: 3,
+                    rightmost_row_chars: 6,
                 }
             );
             assert_eq!(
@@ -2565,7 +2569,8 @@ mod tests {
                     lines: Point::new(2, 3),
                     first_line_chars: 4,
                     last_line_chars: 3,
-                    rightmost_point: Point::new(1, 6),
+                    rightmost_row: 1,
+                    rightmost_row_chars: 6,
                 }
             );
             buffer

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -392,7 +392,8 @@ pub struct TextSummary {
     pub lines: Point,
     pub first_line_chars: u32,
     pub last_line_chars: u32,
-    pub rightmost_point: Point,
+    pub rightmost_row: u32,
+    pub rightmost_row_chars: u32,
 }
 
 impl<'a> From<&'a str> for TextSummary {
@@ -400,7 +401,8 @@ impl<'a> From<&'a str> for TextSummary {
         let mut lines = Point::new(0, 0);
         let mut first_line_chars = 0;
         let mut last_line_chars = 0;
-        let mut rightmost_point = Point::new(0, 0);
+        let mut rightmost_row = 0;
+        let mut rightmost_row_chars = 0;
         for c in text.chars() {
             if c == '\n' {
                 lines.row += 1;
@@ -415,8 +417,9 @@ impl<'a> From<&'a str> for TextSummary {
                 first_line_chars = last_line_chars;
             }
 
-            if last_line_chars > rightmost_point.column {
-                rightmost_point = Point::new(lines.row, last_line_chars);
+            if last_line_chars > rightmost_row_chars {
+                rightmost_row = lines.row;
+                rightmost_row_chars = last_line_chars;
             }
         }
 
@@ -425,7 +428,8 @@ impl<'a> From<&'a str> for TextSummary {
             lines,
             first_line_chars,
             last_line_chars,
-            rightmost_point,
+            rightmost_row,
+            rightmost_row_chars,
         }
     }
 }
@@ -441,11 +445,13 @@ impl sum_tree::Summary for TextSummary {
 impl<'a> std::ops::AddAssign<&'a Self> for TextSummary {
     fn add_assign(&mut self, other: &'a Self) {
         let joined_chars = self.last_line_chars + other.first_line_chars;
-        if joined_chars > self.rightmost_point.column {
-            self.rightmost_point = Point::new(self.lines.row, joined_chars);
+        if joined_chars > self.rightmost_row_chars {
+            self.rightmost_row = self.lines.row;
+            self.rightmost_row_chars = joined_chars;
         }
-        if other.rightmost_point.column > self.rightmost_point.column {
-            self.rightmost_point = self.lines + other.rightmost_point;
+        if other.rightmost_row_chars > self.rightmost_row_chars {
+            self.rightmost_row = self.lines.row + other.rightmost_row;
+            self.rightmost_row_chars = other.rightmost_row_chars;
         }
 
         if self.lines.row == 0 {

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -335,6 +335,9 @@ impl Chunk {
         let mut point = Point::new(0, 0);
         for ch in self.0.chars() {
             if point >= target {
+                if point > target {
+                    panic!("point {:?} is inside of character {:?}", target, ch);
+                }
                 break;
             }
 
@@ -346,8 +349,6 @@ impl Chunk {
             }
             offset += ch.len_utf8();
         }
-
-        assert_eq!(point, target);
         offset
     }
 }

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -1,8 +1,8 @@
 use crate::{
     editor::{
         buffer::{Anchor, Buffer, Point, ToPoint},
-        display_map::{Bias, DisplayMap},
-        DisplayPoint,
+        display_map::DisplayMap,
+        Bias, DisplayPoint,
     },
     time,
 };

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -72,8 +72,8 @@ impl Selection {
     }
 
     pub fn display_range(&self, map: &DisplayMap, app: &AppContext) -> Range<DisplayPoint> {
-        let start = self.start.to_display_point(map, app).unwrap();
-        let end = self.end.to_display_point(map, app).unwrap();
+        let start = self.start.to_display_point(map, app);
+        let end = self.end.to_display_point(map, app);
         if self.reversed {
             end..start
         } else {
@@ -87,12 +87,11 @@ impl Selection {
         map: &DisplayMap,
         ctx: &AppContext,
     ) -> (Range<u32>, Range<u32>) {
-        let display_start = self.start.to_display_point(map, ctx).unwrap();
-        let buffer_start = DisplayPoint::new(display_start.row(), 0)
-            .to_buffer_point(map, Bias::Left, ctx)
-            .unwrap();
+        let display_start = self.start.to_display_point(map, ctx);
+        let buffer_start =
+            DisplayPoint::new(display_start.row(), 0).to_buffer_point(map, Bias::Left, ctx);
 
-        let mut display_end = self.end.to_display_point(map, ctx).unwrap();
+        let mut display_end = self.end.to_display_point(map, ctx);
         if !include_end_if_at_line_start
             && display_end.row() != map.max_point(ctx).row()
             && display_start.row() != display_end.row()
@@ -100,12 +99,8 @@ impl Selection {
         {
             *display_end.row_mut() -= 1;
         }
-        let buffer_end = DisplayPoint::new(
-            display_end.row(),
-            map.line_len(display_end.row(), ctx).unwrap(),
-        )
-        .to_buffer_point(map, Bias::Left, ctx)
-        .unwrap();
+        let buffer_end = DisplayPoint::new(display_end.row(), map.line_len(display_end.row(), ctx))
+            .to_buffer_point(map, Bias::Left, ctx);
 
         (
             buffer_start.row..buffer_end.row + 1,

--- a/zed/src/editor/buffer/selection.rs
+++ b/zed/src/editor/buffer/selection.rs
@@ -62,8 +62,8 @@ impl Selection {
     }
 
     pub fn range(&self, buffer: &Buffer) -> Range<Point> {
-        let start = self.start.to_point(buffer).unwrap();
-        let end = self.end.to_point(buffer).unwrap();
+        let start = self.start.to_point(buffer);
+        let end = self.end.to_point(buffer);
         if self.reversed {
             end..start
         } else {

--- a/zed/src/editor/buffer_element.rs
+++ b/zed/src/editor/buffer_element.rs
@@ -520,7 +520,7 @@ impl LayoutState {
         layout_cache: &TextLayoutCache,
         app: &AppContext,
     ) -> f32 {
-        let row = view.rightmost_point(app).row();
+        let row = view.rightmost_row(app);
         let longest_line_width = view
             .layout_line(row, font_cache, layout_cache, app)
             .unwrap()

--- a/zed/src/editor/buffer_element.rs
+++ b/zed/src/editor/buffer_element.rs
@@ -569,7 +569,7 @@ impl PaintState {
         let column = if x >= 0.0 {
             line.index_for_x(x)
                 .map(|ix| ix as u32)
-                .unwrap_or(view.line_len(row, app).unwrap())
+                .unwrap_or(view.line_len(row, app))
         } else {
             0
         };

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -3207,7 +3207,7 @@ mod tests {
                 &[
                     DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1),
                     DisplayPoint::new(3, 1)..DisplayPoint::new(3, 1),
-                    DisplayPoint::new(3, 2)..DisplayPoint::new(4, 2),
+                    DisplayPoint::new(3, 2)..DisplayPoint::new(4, 3),
                     DisplayPoint::new(5, 0)..DisplayPoint::new(5, 2),
                 ],
                 ctx,
@@ -3229,7 +3229,7 @@ mod tests {
             vec![
                 DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1),
                 DisplayPoint::new(2, 1)..DisplayPoint::new(2, 1),
-                DisplayPoint::new(2, 2)..DisplayPoint::new(3, 2),
+                DisplayPoint::new(2, 2)..DisplayPoint::new(3, 3),
                 DisplayPoint::new(4, 0)..DisplayPoint::new(4, 2)
             ]
         );
@@ -3244,7 +3244,7 @@ mod tests {
             vec![
                 DisplayPoint::new(1, 1)..DisplayPoint::new(1, 1),
                 DisplayPoint::new(3, 1)..DisplayPoint::new(3, 1),
-                DisplayPoint::new(3, 2)..DisplayPoint::new(4, 2),
+                DisplayPoint::new(3, 2)..DisplayPoint::new(4, 3),
                 DisplayPoint::new(5, 0)..DisplayPoint::new(5, 2)
             ]
         );
@@ -3259,7 +3259,7 @@ mod tests {
             vec![
                 DisplayPoint::new(2, 1)..DisplayPoint::new(2, 1),
                 DisplayPoint::new(3, 1)..DisplayPoint::new(3, 1),
-                DisplayPoint::new(3, 2)..DisplayPoint::new(4, 2),
+                DisplayPoint::new(3, 2)..DisplayPoint::new(4, 3),
                 DisplayPoint::new(5, 0)..DisplayPoint::new(5, 2)
             ]
         );
@@ -3274,7 +3274,7 @@ mod tests {
             vec![
                 DisplayPoint::new(1, 1)..DisplayPoint::new(1, 1),
                 DisplayPoint::new(2, 1)..DisplayPoint::new(2, 1),
-                DisplayPoint::new(2, 2)..DisplayPoint::new(3, 2),
+                DisplayPoint::new(2, 2)..DisplayPoint::new(3, 3),
                 DisplayPoint::new(4, 0)..DisplayPoint::new(4, 2)
             ]
         );
@@ -3489,7 +3489,7 @@ mod tests {
                     DisplayPoint::new(0, 0)..DisplayPoint::new(0, 1),
                     DisplayPoint::new(0, 2)..DisplayPoint::new(0, 2),
                     DisplayPoint::new(1, 0)..DisplayPoint::new(1, 0),
-                    DisplayPoint::new(4, 2)..DisplayPoint::new(4, 2),
+                    DisplayPoint::new(4, 4)..DisplayPoint::new(4, 4),
                 ],
                 ctx,
             )
@@ -3511,7 +3511,7 @@ mod tests {
                 DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1),
                 DisplayPoint::new(0, 2)..DisplayPoint::new(0, 2),
                 DisplayPoint::new(1, 0)..DisplayPoint::new(1, 0),
-                DisplayPoint::new(4, 2)..DisplayPoint::new(4, 2)
+                DisplayPoint::new(4, 4)..DisplayPoint::new(4, 4)
             ]
         );
 

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -2140,23 +2140,26 @@ impl BufferView {
 
         let mut layouts = Vec::with_capacity(rows.len());
         let mut line = String::new();
-        let mut line_len = 0;
         let mut row = rows.start;
         let snapshot = self.display_map.snapshot(ctx);
-        let chars = snapshot.chars_at(DisplayPoint::new(rows.start, 0), ctx);
-        for char in chars.chain(Some('\n')) {
-            if char == '\n' {
-                layouts.push(layout_cache.layout_str(&line, font_size, &[(0..line_len, font_id)]));
+        let chunks = snapshot.chunks_at(DisplayPoint::new(rows.start, 0), ctx);
+        for (chunk_row, chunk_line) in chunks
+            .chain(Some("\n"))
+            .flat_map(|chunk| chunk.split("\n").enumerate())
+        {
+            if chunk_row > 0 {
+                layouts.push(layout_cache.layout_str(
+                    &line,
+                    font_size,
+                    &[(0..line.chars().count(), font_id)],
+                ));
                 line.clear();
-                line_len = 0;
                 row += 1;
                 if row == rows.end {
                     break;
                 }
-            } else {
-                line_len += 1;
-                line.push(char);
             }
+            line.push_str(chunk_line);
         }
 
         Ok(layouts)

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -2015,8 +2015,8 @@ impl BufferView {
         self.display_map.line_len(display_row, ctx)
     }
 
-    pub fn rightmost_point(&self, ctx: &AppContext) -> DisplayPoint {
-        self.display_map.rightmost_point(ctx)
+    pub fn rightmost_row(&self, ctx: &AppContext) -> u32 {
+        self.display_map.rightmost_row(ctx)
     }
 
     pub fn max_point(&self, ctx: &AppContext) -> DisplayPoint {

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -411,7 +411,6 @@ impl BufferView {
             .unwrap()
             .head()
             .to_display_point(&self.display_map, app)
-            .unwrap()
             .row() as f32;
         let last_cursor_bottom = self
             .selections(app)
@@ -419,7 +418,6 @@ impl BufferView {
             .unwrap()
             .head()
             .to_display_point(&self.display_map, app)
-            .unwrap()
             .row() as f32
             + 1.0;
 
@@ -456,13 +454,10 @@ impl BufferView {
         let mut target_left = std::f32::INFINITY;
         let mut target_right = 0.0_f32;
         for selection in self.selections(ctx) {
-            let head = selection
-                .head()
-                .to_display_point(&self.display_map, ctx)
-                .unwrap();
+            let head = selection.head().to_display_point(&self.display_map, ctx);
             let start_column = head.column().saturating_sub(3);
             let end_column = cmp::min(
-                self.display_map.line_len(head.row(), ctx).unwrap(),
+                self.display_map.line_len(head.row(), ctx),
                 head.column() + 3,
             );
             target_left = target_left
@@ -508,8 +503,7 @@ impl BufferView {
 
         let cursor = self
             .display_map
-            .anchor_before(position, Bias::Left, ctx.as_ref())
-            .unwrap();
+            .anchor_before(position, Bias::Left, ctx.as_ref());
         let selection = Selection {
             id: post_inc(&mut self.next_selection_id),
             start: cursor.clone(),
@@ -535,8 +529,7 @@ impl BufferView {
         let buffer = self.buffer.read(ctx);
         let cursor = self
             .display_map
-            .anchor_before(position, Bias::Left, ctx.as_ref())
-            .unwrap();
+            .anchor_before(position, Bias::Left, ctx.as_ref());
         if let Some(selection) = self.pending_selection.as_mut() {
             selection.set_head(buffer, cursor);
         } else {
@@ -627,10 +620,10 @@ impl BufferView {
                 id: post_inc(&mut self.next_selection_id),
                 start: self
                     .display_map
-                    .anchor_before(start, Bias::Left, ctx.as_ref())?,
+                    .anchor_before(start, Bias::Left, ctx.as_ref()),
                 end: self
                     .display_map
-                    .anchor_before(end, Bias::Left, ctx.as_ref())?,
+                    .anchor_before(end, Bias::Left, ctx.as_ref()),
                 reversed,
                 goal: SelectionGoal::None,
             });
@@ -700,16 +693,12 @@ impl BufferView {
                 if range.start == range.end {
                     let head = selection
                         .head()
-                        .to_display_point(&self.display_map, ctx.as_ref())
-                        .unwrap();
-                    let cursor = self
-                        .display_map
-                        .anchor_before(
-                            movement::left(&self.display_map, head, ctx.as_ref()).unwrap(),
-                            Bias::Left,
-                            ctx.as_ref(),
-                        )
-                        .unwrap();
+                        .to_display_point(&self.display_map, ctx.as_ref());
+                    let cursor = self.display_map.anchor_before(
+                        movement::left(&self.display_map, head, ctx.as_ref()).unwrap(),
+                        Bias::Left,
+                        ctx.as_ref(),
+                    );
                     selection.set_head(&buffer, cursor);
                     selection.goal = SelectionGoal::None;
                 }
@@ -731,16 +720,12 @@ impl BufferView {
                 if range.start == range.end {
                     let head = selection
                         .head()
-                        .to_display_point(&self.display_map, ctx.as_ref())
-                        .unwrap();
-                    let cursor = self
-                        .display_map
-                        .anchor_before(
-                            movement::right(&self.display_map, head, ctx.as_ref()).unwrap(),
-                            Bias::Right,
-                            ctx.as_ref(),
-                        )
-                        .unwrap();
+                        .to_display_point(&self.display_map, ctx.as_ref());
+                    let cursor = self.display_map.anchor_before(
+                        movement::right(&self.display_map, head, ctx.as_ref()).unwrap(),
+                        Bias::Right,
+                        ctx.as_ref(),
+                    );
                     selection.set_head(&buffer, cursor);
                     selection.goal = SelectionGoal::None;
                 }
@@ -768,7 +753,6 @@ impl BufferView {
             let goal_display_column = selection
                 .head()
                 .to_display_point(&self.display_map, app)
-                .unwrap()
                 .column();
 
             // Accumulate contiguous regions of rows that we want to delete.
@@ -799,19 +783,16 @@ impl BufferView {
                 cursor_buffer_row = rows.start.saturating_sub(1);
             }
 
-            let mut cursor = Point::new(cursor_buffer_row, 0)
-                .to_display_point(&self.display_map, app)
-                .unwrap();
+            let mut cursor =
+                Point::new(cursor_buffer_row, 0).to_display_point(&self.display_map, app);
             *cursor.column_mut() = cmp::min(
                 goal_display_column,
-                self.display_map.line_len(cursor.row(), app).unwrap(),
+                self.display_map.line_len(cursor.row(), app),
             );
 
             new_cursors.push((
                 selection.id,
-                cursor
-                    .to_buffer_point(&self.display_map, Bias::Left, app)
-                    .unwrap(),
+                cursor.to_buffer_point(&self.display_map, Bias::Left, app),
             ));
             edit_ranges.push(edit_start..edit_end);
         }
@@ -937,9 +918,8 @@ impl BufferView {
                     .to_offset(buffer);
 
                 let prev_row_display_start = DisplayPoint::new(display_rows.start - 1, 0);
-                let prev_row_start = prev_row_display_start
-                    .to_buffer_offset(&self.display_map, Bias::Left, app)
-                    .unwrap();
+                let prev_row_start =
+                    prev_row_display_start.to_buffer_offset(&self.display_map, Bias::Left, app);
 
                 let mut text = String::new();
                 text.extend(buffer.text_for_range(start..end));
@@ -950,7 +930,6 @@ impl BufferView {
                 let row_delta = buffer_rows.start
                     - prev_row_display_start
                         .to_buffer_point(&self.display_map, Bias::Left, app)
-                        .unwrap()
                         .row;
 
                 // Move selections up.
@@ -961,7 +940,7 @@ impl BufferView {
 
                 // Move folds up.
                 old_folds.push(start..end);
-                for fold in self.display_map.folds_in_range(start..end, app).unwrap() {
+                for fold in self.display_map.folds_in_range(start..end, app) {
                     let mut start = fold.start.to_point(buffer);
                     let mut end = fold.end.to_point(buffer);
                     start.row -= row_delta;
@@ -1024,11 +1003,10 @@ impl BufferView {
 
                 let next_row_display_end = DisplayPoint::new(
                     display_rows.end,
-                    self.display_map.line_len(display_rows.end, app).unwrap(),
+                    self.display_map.line_len(display_rows.end, app),
                 );
-                let next_row_end = next_row_display_end
-                    .to_buffer_offset(&self.display_map, Bias::Right, app)
-                    .unwrap();
+                let next_row_end =
+                    next_row_display_end.to_buffer_offset(&self.display_map, Bias::Right, app);
 
                 let mut text = String::new();
                 text.push('\n');
@@ -1038,7 +1016,6 @@ impl BufferView {
 
                 let row_delta = next_row_display_end
                     .to_buffer_point(&self.display_map, Bias::Right, app)
-                    .unwrap()
                     .row
                     - buffer_rows.end
                     + 1;
@@ -1051,7 +1028,7 @@ impl BufferView {
 
                 // Move folds down.
                 old_folds.push(start..end);
-                for fold in self.display_map.folds_in_range(start..end, app).unwrap() {
+                for fold in self.display_map.folds_in_range(start..end, app) {
                     let mut start = fold.start.to_point(buffer);
                     let mut end = fold.end.to_point(buffer);
                     start.row += row_delta;
@@ -1217,26 +1194,17 @@ impl BufferView {
         let mut selections = self.selections(app).to_vec();
         {
             for selection in &mut selections {
-                let start = selection
-                    .start
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
-                let end = selection
-                    .end
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let start = selection.start.to_display_point(&self.display_map, app);
+                let end = selection.end.to_display_point(&self.display_map, app);
 
                 if start != end {
                     selection.end = selection.start.clone();
                 } else {
-                    let cursor = self
-                        .display_map
-                        .anchor_before(
-                            movement::left(&self.display_map, start, app).unwrap(),
-                            Bias::Left,
-                            app,
-                        )
-                        .unwrap();
+                    let cursor = self.display_map.anchor_before(
+                        movement::left(&self.display_map, start, app).unwrap(),
+                        Bias::Left,
+                        app,
+                    );
                     selection.start = cursor.clone();
                     selection.end = cursor;
                 }
@@ -1254,16 +1222,12 @@ impl BufferView {
             for selection in &mut selections {
                 let head = selection
                     .head()
-                    .to_display_point(&self.display_map, ctx.as_ref())
-                    .unwrap();
-                let cursor = self
-                    .display_map
-                    .anchor_before(
-                        movement::left(&self.display_map, head, ctx.as_ref()).unwrap(),
-                        Bias::Left,
-                        ctx.as_ref(),
-                    )
-                    .unwrap();
+                    .to_display_point(&self.display_map, ctx.as_ref());
+                let cursor = self.display_map.anchor_before(
+                    movement::left(&self.display_map, head, ctx.as_ref()).unwrap(),
+                    Bias::Left,
+                    ctx.as_ref(),
+                );
                 selection.set_head(&buffer, cursor);
                 selection.goal = SelectionGoal::None;
             }
@@ -1276,26 +1240,17 @@ impl BufferView {
         {
             let app = ctx.as_ref();
             for selection in &mut selections {
-                let start = selection
-                    .start
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
-                let end = selection
-                    .end
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let start = selection.start.to_display_point(&self.display_map, app);
+                let end = selection.end.to_display_point(&self.display_map, app);
 
                 if start != end {
                     selection.start = selection.end.clone();
                 } else {
-                    let cursor = self
-                        .display_map
-                        .anchor_before(
-                            movement::right(&self.display_map, end, app).unwrap(),
-                            Bias::Right,
-                            app,
-                        )
-                        .unwrap();
+                    let cursor = self.display_map.anchor_before(
+                        movement::right(&self.display_map, end, app).unwrap(),
+                        Bias::Right,
+                        app,
+                    );
                     selection.start = cursor.clone();
                     selection.end = cursor;
                 }
@@ -1314,16 +1269,12 @@ impl BufferView {
             for selection in &mut selections {
                 let head = selection
                     .head()
-                    .to_display_point(&self.display_map, ctx.as_ref())
-                    .unwrap();
-                let cursor = self
-                    .display_map
-                    .anchor_before(
-                        movement::right(&self.display_map, head, app).unwrap(),
-                        Bias::Right,
-                        app,
-                    )
-                    .unwrap();
+                    .to_display_point(&self.display_map, ctx.as_ref());
+                let cursor = self.display_map.anchor_before(
+                    movement::right(&self.display_map, head, app).unwrap(),
+                    Bias::Right,
+                    app,
+                );
                 selection.set_head(&buffer, cursor);
                 selection.goal = SelectionGoal::None;
             }
@@ -1339,24 +1290,15 @@ impl BufferView {
             {
                 let app = ctx.as_ref();
                 for selection in &mut selections {
-                    let start = selection
-                        .start
-                        .to_display_point(&self.display_map, app)
-                        .unwrap();
-                    let end = selection
-                        .end
-                        .to_display_point(&self.display_map, app)
-                        .unwrap();
+                    let start = selection.start.to_display_point(&self.display_map, app);
+                    let end = selection.end.to_display_point(&self.display_map, app);
                     if start != end {
                         selection.goal = SelectionGoal::None;
                     }
 
                     let (start, goal) =
                         movement::up(&self.display_map, start, selection.goal, app).unwrap();
-                    let cursor = self
-                        .display_map
-                        .anchor_before(start, Bias::Left, app)
-                        .unwrap();
+                    let cursor = self.display_map.anchor_before(start, Bias::Left, app);
                     selection.start = cursor.clone();
                     selection.end = cursor;
                     selection.goal = goal;
@@ -1373,17 +1315,12 @@ impl BufferView {
             let app = ctx.as_ref();
             let buffer = self.buffer.read(app);
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let (head, goal) =
                     movement::up(&self.display_map, head, selection.goal, app).unwrap();
                 selection.set_head(
                     &buffer,
-                    self.display_map
-                        .anchor_before(head, Bias::Left, app)
-                        .unwrap(),
+                    self.display_map.anchor_before(head, Bias::Left, app),
                 );
                 selection.goal = goal;
             }
@@ -1399,24 +1336,15 @@ impl BufferView {
             {
                 let app = ctx.as_ref();
                 for selection in &mut selections {
-                    let start = selection
-                        .start
-                        .to_display_point(&self.display_map, app)
-                        .unwrap();
-                    let end = selection
-                        .end
-                        .to_display_point(&self.display_map, app)
-                        .unwrap();
+                    let start = selection.start.to_display_point(&self.display_map, app);
+                    let end = selection.end.to_display_point(&self.display_map, app);
                     if start != end {
                         selection.goal = SelectionGoal::None;
                     }
 
                     let (start, goal) =
                         movement::down(&self.display_map, end, selection.goal, app).unwrap();
-                    let cursor = self
-                        .display_map
-                        .anchor_before(start, Bias::Right, app)
-                        .unwrap();
+                    let cursor = self.display_map.anchor_before(start, Bias::Right, app);
                     selection.start = cursor.clone();
                     selection.end = cursor;
                     selection.goal = goal;
@@ -1433,17 +1361,12 @@ impl BufferView {
             let app = ctx.as_ref();
             let buffer = self.buffer.read(app);
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let (head, goal) =
                     movement::down(&self.display_map, head, selection.goal, app).unwrap();
                 selection.set_head(
                     &buffer,
-                    self.display_map
-                        .anchor_before(head, Bias::Right, app)
-                        .unwrap(),
+                    self.display_map.anchor_before(head, Bias::Right, app),
                 );
                 selection.goal = goal;
             }
@@ -1456,15 +1379,9 @@ impl BufferView {
         let mut selections = self.selections(app).to_vec();
         {
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head = movement::prev_word_boundary(&self.display_map, head, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.start = anchor.clone();
                 selection.end = anchor;
                 selection.reversed = false;
@@ -1480,15 +1397,9 @@ impl BufferView {
         {
             let buffer = self.buffer.read(ctx);
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head = movement::prev_word_boundary(&self.display_map, head, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.set_head(buffer, anchor);
                 selection.goal = SelectionGoal::None;
             }
@@ -1508,15 +1419,9 @@ impl BufferView {
         let mut selections = self.selections(app).to_vec();
         {
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head = movement::next_word_boundary(&self.display_map, head, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.start = anchor.clone();
                 selection.end = anchor;
                 selection.reversed = false;
@@ -1532,15 +1437,9 @@ impl BufferView {
         {
             let buffer = self.buffer.read(ctx);
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head = movement::next_word_boundary(&self.display_map, head, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.set_head(buffer, anchor);
                 selection.goal = SelectionGoal::None;
             }
@@ -1560,16 +1459,10 @@ impl BufferView {
         let mut selections = self.selections(app).to_vec();
         {
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head =
                     movement::line_beginning(&self.display_map, head, true, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.start = anchor.clone();
                 selection.end = anchor;
                 selection.reversed = false;
@@ -1589,16 +1482,10 @@ impl BufferView {
         {
             let buffer = self.buffer.read(ctx);
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head =
                     movement::line_beginning(&self.display_map, head, *toggle_indent, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.set_head(buffer, anchor);
                 selection.goal = SelectionGoal::None;
             }
@@ -1618,15 +1505,9 @@ impl BufferView {
         let mut selections = self.selections(app).to_vec();
         {
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head = movement::line_end(&self.display_map, head, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.start = anchor.clone();
                 selection.end = anchor;
                 selection.reversed = false;
@@ -1642,15 +1523,9 @@ impl BufferView {
         {
             let buffer = self.buffer.read(ctx);
             for selection in &mut selections {
-                let head = selection
-                    .head()
-                    .to_display_point(&self.display_map, app)
-                    .unwrap();
+                let head = selection.head().to_display_point(&self.display_map, app);
                 let new_head = movement::line_end(&self.display_map, head, app).unwrap();
-                let anchor = self
-                    .display_map
-                    .anchor_before(new_head, Bias::Left, app)
-                    .unwrap();
+                let anchor = self.display_map.anchor_before(new_head, Bias::Left, app);
                 selection.set_head(buffer, anchor);
                 selection.goal = SelectionGoal::None;
             }
@@ -1878,20 +1753,14 @@ impl BufferView {
         ctx: &AppContext,
     ) -> Option<Selection> {
         let is_empty = columns.start == columns.end;
-        let line_len = self.display_map.line_len(row, ctx).unwrap();
+        let line_len = self.display_map.line_len(row, ctx);
         if columns.start < line_len || (is_empty && columns.start == line_len) {
             let start = DisplayPoint::new(row, columns.start);
             let end = DisplayPoint::new(row, cmp::min(columns.end, line_len));
             Some(Selection {
                 id: post_inc(&mut self.next_selection_id),
-                start: self
-                    .display_map
-                    .anchor_before(start, Bias::Left, ctx)
-                    .unwrap(),
-                end: self
-                    .display_map
-                    .anchor_before(end, Bias::Left, ctx)
-                    .unwrap(),
+                start: self.display_map.anchor_before(start, Bias::Left, ctx),
+                end: self.display_map.anchor_before(end, Bias::Left, ctx),
                 reversed,
                 goal: SelectionGoal::ColumnRange {
                     start: columns.start,
@@ -1908,10 +1777,7 @@ impl BufferView {
         range: Range<DisplayPoint>,
         app: &'a AppContext,
     ) -> impl 'a + Iterator<Item = Range<DisplayPoint>> {
-        let start = self
-            .display_map
-            .anchor_before(range.start, Bias::Left, app)
-            .unwrap();
+        let start = self.display_map.anchor_before(range.start, Bias::Left, app);
         let start_index = self.selection_insertion_index(&start, app);
         let pending_selection = self.pending_selection.as_ref().and_then(|s| {
             let selection_range = s.display_range(&self.display_map, app);
@@ -2030,14 +1896,13 @@ impl BufferView {
             let buffer_start_row = range
                 .start
                 .to_buffer_point(&self.display_map, Bias::Left, app)
-                .unwrap()
                 .row;
 
             for row in (0..=range.end.row()).rev() {
                 if self.is_line_foldable(row, app)
                     && !self.display_map.is_line_folded(row, ctx.as_ref())
                 {
-                    let fold_range = self.foldable_range_for_line(row, app).unwrap();
+                    let fold_range = self.foldable_range_for_line(row, app);
                     if fold_range.end.row >= buffer_start_row {
                         fold_ranges.push(fold_range);
                         if row <= range.start.row() {
@@ -2063,12 +1928,10 @@ impl BufferView {
                 let range = s.display_range(&self.display_map, app).sorted();
                 let mut start = range
                     .start
-                    .to_buffer_point(&self.display_map, Bias::Left, app)
-                    .unwrap();
+                    .to_buffer_point(&self.display_map, Bias::Left, app);
                 let mut end = range
                     .end
-                    .to_buffer_point(&self.display_map, Bias::Left, app)
-                    .unwrap();
+                    .to_buffer_point(&self.display_map, Bias::Left, app);
                 start.column = 0;
                 end.column = buffer.line_len(end.row);
                 start..end
@@ -2082,13 +1945,12 @@ impl BufferView {
         if display_row >= max_point.row() {
             false
         } else {
-            let (start_indent, is_blank) = self.display_map.line_indent(display_row, app).unwrap();
+            let (start_indent, is_blank) = self.display_map.line_indent(display_row, app);
             if is_blank {
                 false
             } else {
                 for display_row in display_row + 1..=max_point.row() {
-                    let (indent, is_blank) =
-                        self.display_map.line_indent(display_row, app).unwrap();
+                    let (indent, is_blank) = self.display_map.line_indent(display_row, app);
                     if !is_blank {
                         return indent > start_indent;
                     }
@@ -2098,23 +1960,23 @@ impl BufferView {
         }
     }
 
-    fn foldable_range_for_line(&self, start_row: u32, app: &AppContext) -> Result<Range<Point>> {
+    fn foldable_range_for_line(&self, start_row: u32, app: &AppContext) -> Range<Point> {
         let max_point = self.max_point(app);
 
-        let (start_indent, _) = self.display_map.line_indent(start_row, app)?;
-        let start = DisplayPoint::new(start_row, self.line_len(start_row, app)?);
+        let (start_indent, _) = self.display_map.line_indent(start_row, app);
+        let start = DisplayPoint::new(start_row, self.line_len(start_row, app));
         let mut end = None;
         for row in start_row + 1..=max_point.row() {
-            let (indent, is_blank) = self.display_map.line_indent(row, app)?;
+            let (indent, is_blank) = self.display_map.line_indent(row, app);
             if !is_blank && indent <= start_indent {
-                end = Some(DisplayPoint::new(row - 1, self.line_len(row - 1, app)?));
+                end = Some(DisplayPoint::new(row - 1, self.line_len(row - 1, app)));
                 break;
             }
         }
 
         let end = end.unwrap_or(max_point);
-        return Ok(start.to_buffer_point(&self.display_map, Bias::Left, app)?
-            ..end.to_buffer_point(&self.display_map, Bias::Left, app)?);
+        return start.to_buffer_point(&self.display_map, Bias::Left, app)
+            ..end.to_buffer_point(&self.display_map, Bias::Left, app);
     }
 
     pub fn fold_selected_ranges(&mut self, _: &(), ctx: &mut ViewContext<Self>) {
@@ -2131,7 +1993,7 @@ impl BufferView {
 
     fn fold_ranges<T: ToOffset>(&mut self, ranges: Vec<Range<T>>, ctx: &mut ViewContext<Self>) {
         if !ranges.is_empty() {
-            self.display_map.fold(ranges, ctx.as_ref()).unwrap();
+            self.display_map.fold(ranges, ctx.as_ref());
             *self.autoscroll_requested.lock() = true;
             ctx.notify();
         }
@@ -2139,17 +2001,17 @@ impl BufferView {
 
     fn unfold_ranges<T: ToOffset>(&mut self, ranges: Vec<Range<T>>, ctx: &mut ViewContext<Self>) {
         if !ranges.is_empty() {
-            self.display_map.unfold(ranges, ctx.as_ref()).unwrap();
+            self.display_map.unfold(ranges, ctx.as_ref());
             *self.autoscroll_requested.lock() = true;
             ctx.notify();
         }
     }
 
-    pub fn line(&self, display_row: u32, ctx: &AppContext) -> Result<String> {
+    pub fn line(&self, display_row: u32, ctx: &AppContext) -> String {
         self.display_map.line(display_row, ctx)
     }
 
-    pub fn line_len(&self, display_row: u32, ctx: &AppContext) -> Result<u32> {
+    pub fn line_len(&self, display_row: u32, ctx: &AppContext) -> u32 {
         self.display_map.line_len(display_row, ctx)
     }
 
@@ -2244,7 +2106,7 @@ impl BufferView {
         for buffer_row in self
             .display_map
             .snapshot(ctx)
-            .buffer_rows(start_row as u32)?
+            .buffer_rows(start_row as u32)
             .take(line_count)
         {
             line_number.clear();
@@ -2281,9 +2143,7 @@ impl BufferView {
         let mut line_len = 0;
         let mut row = rows.start;
         let snapshot = self.display_map.snapshot(ctx);
-        let chars = snapshot
-            .chars_at(DisplayPoint::new(rows.start, 0), ctx)
-            .unwrap();
+        let chars = snapshot.chars_at(DisplayPoint::new(rows.start, 0), ctx);
         for char in chars.chain(Some('\n')) {
             if char == '\n' {
                 layouts.push(layout_cache.layout_str(&line, font_size, &[(0..line_len, font_id)]));
@@ -2313,12 +2173,12 @@ impl BufferView {
         let font_id =
             font_cache.select_font(settings.buffer_font_family, &FontProperties::new())?;
 
-        let line = self.line(row, app)?;
+        let line = self.line(row, app);
 
         Ok(layout_cache.layout_str(
             &line,
             settings.buffer_font_size,
-            &[(0..self.line_len(row, app)? as usize, font_id)],
+            &[(0..self.line_len(row, app) as usize, font_id)],
         ))
     }
 

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -2151,7 +2151,7 @@ impl BufferView {
                 layouts.push(layout_cache.layout_str(
                     &line,
                     font_size,
-                    &[(0..line.chars().count(), font_id)],
+                    &[(0..line.len(), font_id)],
                 ));
                 line.clear();
                 row += 1;

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -67,8 +67,8 @@ impl FoldMap {
         DisplayPoint(self.sync(ctx).summary().display.lines)
     }
 
-    pub fn rightmost_point(&self, ctx: &AppContext) -> DisplayPoint {
-        DisplayPoint(self.sync(ctx).summary().display.rightmost_point)
+    pub fn rightmost_row(&self, ctx: &AppContext) -> u32 {
+        self.sync(ctx).summary().display.rightmost_point.row
     }
 
     pub fn folds_in_range<'a, T>(
@@ -989,7 +989,13 @@ mod tests {
                     assert_eq!(line_len, line.len() as u32);
                 }
 
-                let rightmost_point = map.rightmost_point(app.as_ref());
+                let rightmost_row = map.rightmost_row(app.as_ref());
+                let rightmost_char_column = expected_text
+                    .split('\n')
+                    .nth(rightmost_row as usize)
+                    .unwrap()
+                    .chars()
+                    .count();
                 let mut display_point = DisplayPoint::new(0, 0);
                 let mut display_offset = DisplayOffset(0);
                 let mut char_column = 0;
@@ -1024,10 +1030,13 @@ mod tests {
                         char_column += 1;
                     }
                     display_offset.0 += c.len_utf8();
-                    if char_column > rightmost_point.column() {
+                    if char_column > rightmost_char_column {
                         panic!(
-                            "invalid rightmost point {:?}, found point {:?} (char column: {})",
-                            rightmost_point, display_point, char_column
+                            "invalid rightmost row {:?} (chars {}), found row {:?} (chars: {})",
+                            rightmost_row,
+                            rightmost_char_column,
+                            display_point.row(),
+                            char_column
                         );
                     }
                 }

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -68,7 +68,7 @@ impl FoldMap {
     }
 
     pub fn rightmost_row(&self, ctx: &AppContext) -> u32 {
-        self.sync(ctx).summary().display.rightmost_point.row
+        self.sync(ctx).summary().display.rightmost_row
     }
 
     pub fn folds_in_range<'a, T>(
@@ -340,7 +340,8 @@ impl FoldMap {
                                     lines,
                                     first_line_chars: chars,
                                     last_line_chars: chars,
-                                    rightmost_point: Point::new(0, chars),
+                                    rightmost_row: 0,
+                                    rightmost_row_chars: chars,
                                 },
                                 buffer: buffer.text_summary_for_range(fold.start..fold.end),
                             },

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -118,9 +118,10 @@ impl DisplayMap {
         bias: Bias,
         app: &AppContext,
     ) -> Result<Anchor> {
-        self.buffer
+        Ok(self
+            .buffer
             .read(app)
-            .anchor_before(point.to_buffer_point(self, bias, app)?)
+            .anchor_before(point.to_buffer_point(self, bias, app)?))
     }
 
     pub fn anchor_after(
@@ -129,9 +130,10 @@ impl DisplayMap {
         bias: Bias,
         app: &AppContext,
     ) -> Result<Anchor> {
-        self.buffer
+        Ok(self
+            .buffer
             .read(app)
-            .anchor_after(point.to_buffer_point(self, bias, app)?)
+            .anchor_after(point.to_buffer_point(self, bias, app)?))
     }
 }
 
@@ -222,8 +224,9 @@ impl DisplayPoint {
     }
 
     pub fn to_buffer_offset(self, map: &DisplayMap, bias: Bias, ctx: &AppContext) -> Result<usize> {
-        map.fold_map
-            .to_buffer_offset(self.collapse_tabs(&map, bias, ctx)?.0, ctx)
+        Ok(map
+            .fold_map
+            .to_buffer_offset(self.collapse_tabs(&map, bias, ctx)?.0, ctx))
     }
 
     fn expand_tabs(self, map: &DisplayMap, ctx: &AppContext) -> Result<Self> {
@@ -253,7 +256,7 @@ impl Point {
 
 impl Anchor {
     pub fn to_display_point(&self, map: &DisplayMap, app: &AppContext) -> Result<DisplayPoint> {
-        self.to_point(map.buffer.read(app))?
+        self.to_point(map.buffer.read(app))
             .to_display_point(map, app)
     }
 }

--- a/zed/src/editor/display_map/mod.rs
+++ b/zed/src/editor/display_map/mod.rs
@@ -109,8 +109,8 @@ impl DisplayMap {
         self.fold_map.max_point(ctx).expand_tabs(self, ctx)
     }
 
-    pub fn rightmost_point(&self, ctx: &AppContext) -> DisplayPoint {
-        self.fold_map.rightmost_point(ctx)
+    pub fn rightmost_row(&self, ctx: &AppContext) -> u32 {
+        self.fold_map.rightmost_row(ctx)
     }
 
     pub fn anchor_before(&self, point: DisplayPoint, bias: Bias, app: &AppContext) -> Anchor {

--- a/zed/src/editor/mod.rs
+++ b/zed/src/editor/mod.rs
@@ -11,6 +11,12 @@ pub use display_map::DisplayPoint;
 use display_map::*;
 use std::{cmp, ops::Range};
 
+#[derive(Copy, Clone)]
+pub enum Bias {
+    Left,
+    Right,
+}
+
 trait RangeExt<T> {
     fn sorted(&self) -> Range<T>;
 }

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -114,7 +114,7 @@ pub fn prev_word_boundary(
             }
 
             prev_c = Some(c);
-            column += 1;
+            column += c.len_utf8() as u32;
         }
         Ok(boundary)
     }
@@ -135,7 +135,7 @@ pub fn next_word_boundary(
             *point.row_mut() += 1;
             *point.column_mut() = 0;
         } else {
-            *point.column_mut() += 1;
+            *point.column_mut() += c.len_utf8() as u32;
         }
         prev_c = Some(c);
     }

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -16,7 +16,12 @@ pub fn left(map: &DisplayMap, mut point: DisplayPoint, app: &AppContext) -> Resu
 pub fn right(map: &DisplayMap, mut point: DisplayPoint, app: &AppContext) -> Result<DisplayPoint> {
     let max_column = map.line_len(point.row(), app);
     if point.column() < max_column {
-        *point.column_mut() += 1;
+        *point.column_mut() += map
+            .snapshot(app)
+            .chars_at(point, app)
+            .next()
+            .unwrap()
+            .len_utf8() as u32;
     } else if point.row() < map.max_point(app).row() {
         *point.row_mut() += 1;
         *point.column_mut() = 0;
@@ -35,9 +40,13 @@ pub fn up(
     } else {
         point.column()
     };
+
+    let map = map.snapshot(app);
+    let char_column = map.column_to_chars(point.row(), goal_column, app);
+
     if point.row() > 0 {
         *point.row_mut() -= 1;
-        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app));
+        *point.column_mut() = map.column_from_chars(point.row(), char_column, app);
     } else {
         point = DisplayPoint::new(0, 0);
     }
@@ -56,10 +65,14 @@ pub fn down(
     } else {
         point.column()
     };
+
     let max_point = map.max_point(app);
+    let map = map.snapshot(app);
+    let char_column = map.column_to_chars(point.row(), goal_column, app);
+
     if point.row() < max_point.row() {
         *point.row_mut() += 1;
-        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app))
+        *point.column_mut() = map.column_from_chars(point.row(), char_column, app);
     } else {
         point = max_point;
     }

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -8,13 +8,13 @@ pub fn left(map: &DisplayMap, mut point: DisplayPoint, app: &AppContext) -> Resu
         *point.column_mut() -= 1;
     } else if point.row() > 0 {
         *point.row_mut() -= 1;
-        *point.column_mut() = map.line_len(point.row(), app)?;
+        *point.column_mut() = map.line_len(point.row(), app);
     }
     Ok(point)
 }
 
 pub fn right(map: &DisplayMap, mut point: DisplayPoint, app: &AppContext) -> Result<DisplayPoint> {
-    let max_column = map.line_len(point.row(), app).unwrap();
+    let max_column = map.line_len(point.row(), app);
     if point.column() < max_column {
         *point.column_mut() += 1;
     } else if point.row() < map.max_point(app).row() {
@@ -37,7 +37,7 @@ pub fn up(
     };
     if point.row() > 0 {
         *point.row_mut() -= 1;
-        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app)?);
+        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app));
     } else {
         point = DisplayPoint::new(0, 0);
     }
@@ -59,7 +59,7 @@ pub fn down(
     let max_point = map.max_point(app);
     if point.row() < max_point.row() {
         *point.row_mut() += 1;
-        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app)?)
+        *point.column_mut() = cmp::min(goal_column, map.line_len(point.row(), app))
     } else {
         point = max_point;
     }
@@ -73,7 +73,7 @@ pub fn line_beginning(
     toggle_indent: bool,
     app: &AppContext,
 ) -> Result<DisplayPoint> {
-    let (indent, is_blank) = map.line_indent(point.row(), app)?;
+    let (indent, is_blank) = map.line_indent(point.row(), app);
     if toggle_indent && !is_blank && point.column() != indent {
         Ok(DisplayPoint::new(point.row(), indent))
     } else {
@@ -84,7 +84,7 @@ pub fn line_beginning(
 pub fn line_end(map: &DisplayMap, point: DisplayPoint, app: &AppContext) -> Result<DisplayPoint> {
     Ok(DisplayPoint::new(
         point.row(),
-        map.line_len(point.row(), app)?,
+        map.line_len(point.row(), app),
     ))
 }
 
@@ -98,13 +98,13 @@ pub fn prev_word_boundary(
             Ok(DisplayPoint::new(0, 0))
         } else {
             let row = point.row() - 1;
-            Ok(DisplayPoint::new(row, map.line_len(row, app)?))
+            Ok(DisplayPoint::new(row, map.line_len(row, app)))
         }
     } else {
         let mut boundary = DisplayPoint::new(point.row(), 0);
         let mut column = 0;
         let mut prev_c = None;
-        for c in map.snapshot(app).chars_at(boundary, app)? {
+        for c in map.snapshot(app).chars_at(boundary, app) {
             if column >= point.column() {
                 break;
             }
@@ -126,7 +126,7 @@ pub fn next_word_boundary(
     app: &AppContext,
 ) -> Result<DisplayPoint> {
     let mut prev_c = None;
-    for c in map.snapshot(app).chars_at(point, app)? {
+    for c in map.snapshot(app).chars_at(point, app) {
         if prev_c.is_some() && (c == '\n' || char_kind(prev_c.unwrap()) != char_kind(c)) {
             break;
         }

--- a/zed/src/util.rs
+++ b/zed/src/util.rs
@@ -1,21 +1,6 @@
 use rand::prelude::*;
 use std::{cmp::Ordering, ops::Range};
 
-pub fn byte_range_for_char_range(text: impl AsRef<str>, char_range: Range<usize>) -> Range<usize> {
-    let text = text.as_ref();
-    let mut result = text.len()..text.len();
-    for (i, (offset, _)) in text.char_indices().enumerate() {
-        if i == char_range.start {
-            result.start = offset;
-        }
-        if i == char_range.end {
-            result.end = offset;
-            break;
-        }
-    }
-    result
-}
-
 pub fn post_inc(value: &mut usize) -> usize {
     let prev = *value;
     *value += 1;

--- a/zed/src/util.rs
+++ b/zed/src/util.rs
@@ -1,5 +1,5 @@
 use rand::prelude::*;
-use std::{cmp::Ordering, ops::Range};
+use std::cmp::Ordering;
 
 pub fn post_inc(value: &mut usize) -> usize {
     let prev = *value;
@@ -33,6 +33,7 @@ where
 pub struct RandomCharIter<T: Rng>(T);
 
 impl<T: Rng> RandomCharIter<T> {
+    #[cfg(test)]
     pub fn new(rng: T) -> Self {
         Self(rng)
     }

--- a/zed/src/worktree/fuzzy.rs
+++ b/zed/src/worktree/fuzzy.rs
@@ -321,14 +321,18 @@ fn score_match(
         return 0.0;
     }
 
-    let path_len = path.len() + prefix.len();
+    let path_len = prefix.len() + path.len();
     let mut cur_start = 0;
     let mut byte_ix = 0;
     let mut char_ix = 0;
     for i in 0..query.len() {
         let match_char_ix = best_position_matrix[i * path_len + cur_start];
         while char_ix < match_char_ix {
-            byte_ix += path[char_ix].len_utf8();
+            let ch = prefix
+                .get(char_ix)
+                .or_else(|| path.get(char_ix - prefix.len()))
+                .unwrap();
+            byte_ix += ch.len_utf8();
             char_ix += 1;
         }
         cur_start = match_char_ix + 1;


### PR DESCRIPTION
* [x] Change Buffer APIs to panic on out-of-bounds access, instead of returning `Result`
* [x] Introduce text-access iterator APIs that return string chunks instead of chars
  * [x] `Rope::chunks_in_range`
  * [x] `FoldMap::chunks_at`
  * [x] `DisplayMap::chunks_at`
* [x] Stop counting characters in the `Rope`
* [x] Change `FontSystem::layout_str` to accept and return runs with *byte* ranges instead of character counts
* [x] Change `FileFinder` to pass byte indices to string layout methods
* [x] Change `Label` element to handle byte indices for highlights
* [x] Decide how to deal with `rightmost_point`