### PR TITLE
Pass scalar lengths and include colors when specifying styling runs during text layout

### DIFF
--- a/gpui/examples/text.rs
+++ b/gpui/examples/text.rs
@@ -82,11 +82,11 @@ impl gpui::Element for TextElement {
             text,
             font_size,
             &[
-                (0..1, normal),
-                (1..2, bold),
-                (2..3, normal),
-                (3..4, bold),
-                (4..text.len(), normal),
+                (1, normal, ColorU::default()),
+                (1, bold, ColorU::default()),
+                (1, normal, ColorU::default()),
+                (1, bold, ColorU::default()),
+                (text.len() - 4, normal, ColorU::default()),
             ],
         );
 
@@ -95,12 +95,7 @@ impl gpui::Element for TextElement {
             background: Some(ColorU::white()),
             ..Default::default()
         });
-        line.paint(
-            bounds.origin(),
-            bounds,
-            &[(0..text.len(), ColorU::black())],
-            ctx,
-        );
+        line.paint(bounds.origin(), bounds, ctx);
     }
 
     fn dispatch_event(

--- a/gpui/src/elements/label.rs
+++ b/gpui/src/elements/label.rs
@@ -220,17 +220,13 @@ mod tests {
         assert_eq!(
             runs.as_slice(),
             &[
-                (3, menlo_regular, black),
-                (1, menlo_bold, red),
-                (1, menlo_regular, black),
-                (1, menlo_bold, red),
-                (3, menlo_regular, black),
-                (1, menlo_bold, red),
-                (5, menlo_regular, black),
-                (1, menlo_bold, red),
-                (2, menlo_regular, black),
-                (1, menlo_bold, red),
-                (15, menlo_regular, black),
+                (".α".len(), menlo_regular, black),
+                ("βγ".len(), menlo_bold, red),
+                ("δ".len(), menlo_regular, black),
+                ("ε".len(), menlo_bold, red),
+                (".ⓐ".len(), menlo_regular, black),
+                ("ⓑⓒ".len(), menlo_bold, red),
+                ("ⓓⓔ.abcde.".len(), menlo_regular, black),
             ]
         );
     }

--- a/gpui/src/platform/mac/fonts.rs
+++ b/gpui/src/platform/mac/fonts.rs
@@ -231,7 +231,7 @@ impl FontSystemState {
             let mut utf8_ix = 0;
             let mut utf16_ix = 0;
             for (run_len, font_id) in font_runs {
-                let utf8_end = utf16_ix + run_len;
+                let utf8_end = utf8_ix + run_len;
                 let utf16_start = utf16_ix;
                 while utf8_ix < utf8_end {
                     let (next_utf8_ix, next_utf16_ix) = utf8_and_utf16_ixs.next().unwrap();

--- a/gpui/src/platform/mac/fonts.rs
+++ b/gpui/src/platform/mac/fonts.rs
@@ -1,4 +1,5 @@
 use crate::{
+    color::ColorU,
     fonts::{FontId, GlyphId, Metrics, Properties},
     geometry::{
         rect::{RectF, RectI},
@@ -6,7 +7,7 @@ use crate::{
         vector::{vec2f, vec2i, Vector2F},
     },
     platform,
-    text_layout::{Glyph, Line, Run},
+    text_layout::{Glyph, LineLayout, Run},
 };
 use cocoa::appkit::{CGFloat, CGPoint};
 use core_foundation::{
@@ -21,7 +22,7 @@ use core_graphics::{
 use core_text::{line::CTLine, string_attributes::kCTFontAttributeName};
 use font_kit::{canvas::RasterizationOptions, hinting::HintingOptions, source::SystemSource};
 use parking_lot::RwLock;
-use std::{char, convert::TryFrom};
+use std::{cell::RefCell, char, convert::TryFrom};
 
 #[allow(non_upper_case_globals)]
 const kCGImageAlphaOnly: u32 = 7;
@@ -80,8 +81,8 @@ impl platform::FontSystem for FontSystem {
         &self,
         text: &str,
         font_size: f32,
-        runs: &[(std::ops::Range<usize>, FontId)],
-    ) -> Line {
+        runs: &[(usize, FontId, ColorU)],
+    ) -> LineLayout {
         self.0.read().layout_str(text, font_size, runs)
     }
 }
@@ -185,8 +186,8 @@ impl FontSystemState {
         &self,
         text: &str,
         font_size: f32,
-        runs: &[(std::ops::Range<usize>, FontId)],
-    ) -> Line {
+        runs: &[(usize, FontId, ColorU)],
+    ) -> LineLayout {
         let font_id_attr_name = CFString::from_static_string("zed_font_id");
 
         let len = text.len();
@@ -205,16 +206,34 @@ impl FontSystemState {
             let mut utf8_and_utf16_ixs = utf8_and_utf16_ixs.clone();
             string.replace_str(&CFString::new(text), CFRange::init(0, 0));
 
+            let last_run: RefCell<Option<(usize, FontId)>> = Default::default();
+            let font_runs = runs
+                .iter()
+                .filter_map(|(len, font_id, _)| {
+                    let mut last_run = last_run.borrow_mut();
+                    if let Some((last_len, last_font_id)) = last_run.as_mut() {
+                        if font_id == last_font_id {
+                            *last_len += *len;
+                            None
+                        } else {
+                            let result = (*last_len, *last_font_id);
+                            *last_len = *len;
+                            *last_font_id = *font_id;
+                            Some(result)
+                        }
+                    } else {
+                        *last_run = Some((*len, *font_id));
+                        None
+                    }
+                })
+                .chain(std::iter::from_fn(|| last_run.borrow_mut().take()));
+
             let mut utf8_ix = 0;
             let mut utf16_ix = 0;
-            for (range, font_id) in runs {
-                while utf8_ix < range.start {
-                    let (next_utf8_ix, next_utf16_ix) = utf8_and_utf16_ixs.next().unwrap();
-                    utf8_ix = next_utf8_ix;
-                    utf16_ix = next_utf16_ix;
-                }
+            for (run_len, font_id) in font_runs {
+                let utf8_end = utf16_ix + run_len;
                 let utf16_start = utf16_ix;
-                while utf8_ix < range.end {
+                while utf8_ix < utf8_end {
                     let (next_utf8_ix, next_utf16_ix) = utf8_and_utf16_ixs.next().unwrap();
                     utf8_ix = next_utf8_ix;
                     utf16_ix = next_utf16_ix;
@@ -279,7 +298,7 @@ impl FontSystemState {
         }
 
         let typographic_bounds = line.get_typographic_bounds();
-        Line {
+        LineLayout {
             width: typographic_bounds.width as f32,
             ascent: typographic_bounds.ascent as f32,
             descent: typographic_bounds.descent as f32,
@@ -308,9 +327,9 @@ mod tests {
             "hello world",
             16.0,
             &[
-                (0..2, menlo_bold),
-                (2..6, menlo_italic),
-                (6..11, menlo_regular),
+                (2, menlo_bold, Default::default()),
+                (4, menlo_italic, Default::default()),
+                (5, menlo_regular, Default::default()),
             ],
         );
         assert_eq!(line.runs.len(), 3);
@@ -336,9 +355,9 @@ mod tests {
             text,
             16.0,
             &[
-                (0..9, zapfino_regular),
-                (9..22, menlo_regular),
-                (22..text.len(), zapfino_regular),
+                (9, zapfino_regular, ColorU::default()),
+                (13, menlo_regular, ColorU::default()),
+                (text.len() - 22, zapfino_regular, ColorU::default()),
             ],
         );
         assert_eq!(

--- a/gpui/src/platform/mod.rs
+++ b/gpui/src/platform/mod.rs
@@ -8,20 +8,20 @@ pub mod current {
 }
 
 use crate::{
+    color::ColorU,
     executor,
     fonts::{FontId, GlyphId, Metrics as FontMetrics, Properties as FontProperties},
     geometry::{
         rect::{RectF, RectI},
         vector::Vector2F,
     },
-    text_layout::Line,
+    text_layout::LineLayout,
     ClipboardItem, Menu, Scene,
 };
 use async_task::Runnable;
 pub use event::Event;
 use std::{
     any::Any,
-    ops::Range,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -122,5 +122,10 @@ pub trait FontSystem: Send + Sync {
         subpixel_shift: Vector2F,
         scale_factor: f32,
     ) -> Option<(RectI, Vec<u8>)>;
-    fn layout_str(&self, text: &str, font_size: f32, runs: &[(Range<usize>, FontId)]) -> Line;
+    fn layout_str(
+        &self,
+        text: &str,
+        font_size: f32,
+        runs: &[(usize, FontId, ColorU)],
+    ) -> LineLayout;
 }

--- a/gpui/src/text_layout.rs
+++ b/gpui/src/text_layout.rs
@@ -200,8 +200,8 @@ impl Line {
         }
     }
 
-    pub fn paint(&self, origin: Vector2F, bounds: RectF, ctx: &mut PaintContext) {
-        let padding_top = (bounds.height() - self.layout.ascent - self.layout.descent) / 2.;
+    pub fn paint(&self, origin: Vector2F, visible_bounds: RectF, ctx: &mut PaintContext) {
+        let padding_top = (visible_bounds.height() - self.layout.ascent - self.layout.descent) / 2.;
         let baseline_origin = vec2f(0., padding_top + self.layout.ascent);
 
         let mut color_runs = self.color_runs.iter();
@@ -217,10 +217,10 @@ impl Line {
             for glyph in &run.glyphs {
                 let glyph_origin = baseline_origin + glyph.position;
 
-                if glyph_origin.x() + max_glyph_width < bounds.origin().x() {
+                if glyph_origin.x() + max_glyph_width < visible_bounds.origin().x() {
                     continue;
                 }
-                if glyph_origin.x() > bounds.upper_right().x() {
+                if glyph_origin.x() > visible_bounds.upper_right().x() {
                     break;
                 }
 

--- a/zed/src/editor/buffer_element.rs
+++ b/zed/src/editor/buffer_element.rs
@@ -14,10 +14,7 @@ use gpui::{
 use json::json;
 use smallvec::SmallVec;
 use std::cmp::Ordering;
-use std::{
-    cmp::{self},
-    sync::Arc,
-};
+use std::cmp::{self};
 
 pub struct BufferElement {
     view: WeakViewHandle<BufferView>,
@@ -188,13 +185,12 @@ impl BufferElement {
         for (ix, line) in layout.line_number_layouts.iter().enumerate() {
             let line_origin = rect.origin()
                 + vec2f(
-                    rect.width() - line.width - layout.gutter_padding,
+                    rect.width() - line.width() - layout.gutter_padding,
                     ix as f32 * line_height - (scroll_top % line_height),
                 );
             line.paint(
                 line_origin,
-                RectF::new(vec2f(0., 0.), vec2f(line.width, line_height)),
-                &[(0..line.len, ColorU::black())],
+                RectF::new(vec2f(0., 0.), vec2f(line.width(), line_height)),
                 ctx,
             );
         }
@@ -259,7 +255,7 @@ impl BufferElement {
                                         + line_layout.x_for_index(range_end.column() as usize)
                                         - scroll_left
                                 } else {
-                                    content_origin.x() + line_layout.width + corner_radius * 2.0
+                                    content_origin.x() + line_layout.width() + corner_radius * 2.0
                                         - scroll_left
                                 },
                             }
@@ -292,7 +288,6 @@ impl BufferElement {
             line.paint(
                 content_origin + vec2f(-scroll_left, row as f32 * line_height - scroll_top),
                 RectF::new(vec2f(scroll_left, 0.), vec2f(bounds.width(), line_height)),
-                &[(0..line.len, ColorU::black())],
                 ctx,
             );
         }
@@ -377,8 +372,8 @@ impl Element for BufferElement {
                 }
                 Ok(layouts) => {
                     for line in &layouts {
-                        if line.width > max_visible_line_width {
-                            max_visible_line_width = line.width;
+                        if line.width() > max_visible_line_width {
+                            max_visible_line_width = line.width();
                         }
                     }
 
@@ -506,8 +501,8 @@ pub struct LayoutState {
     gutter_size: Vector2F,
     gutter_padding: f32,
     text_size: Vector2F,
-    line_layouts: Vec<Arc<text_layout::Line>>,
-    line_number_layouts: Vec<Arc<text_layout::Line>>,
+    line_layouts: Vec<text_layout::Line>,
+    line_number_layouts: Vec<text_layout::Line>,
     max_visible_line_width: f32,
     autoscroll_horizontally: bool,
 }
@@ -524,7 +519,7 @@ impl LayoutState {
         let longest_line_width = view
             .layout_line(row, font_cache, layout_cache, app)
             .unwrap()
-            .width;
+            .width();
         longest_line_width.max(self.max_visible_line_width) + view.em_width(font_cache)
     }
 

--- a/zed/src/editor/buffer_view.rs
+++ b/zed/src/editor/buffer_view.rs
@@ -5,9 +5,10 @@ use super::{
 use crate::{settings::Settings, util::post_inc, workspace, worktree::FileHandle};
 use anyhow::Result;
 use gpui::{
-    fonts::Properties as FontProperties, geometry::vector::Vector2F, keymap::Binding, text_layout,
-    AppContext, ClipboardItem, Element, ElementBox, Entity, FontCache, ModelHandle,
-    MutableAppContext, Task, TextLayoutCache, View, ViewContext, WeakViewHandle,
+    color::ColorU, fonts::Properties as FontProperties, geometry::vector::Vector2F,
+    keymap::Binding, text_layout, AppContext, ClipboardItem, Element, ElementBox, Entity,
+    FontCache, ModelHandle, MutableAppContext, Task, TextLayoutCache, View, ViewContext,
+    WeakViewHandle,
 };
 use parking_lot::Mutex;
 use postage::watch;
@@ -448,7 +449,7 @@ impl BufferView {
         viewport_width: f32,
         scroll_width: f32,
         max_glyph_width: f32,
-        layouts: &[Arc<text_layout::Line>],
+        layouts: &[text_layout::Line],
         ctx: &AppContext,
     ) {
         let mut target_left = std::f32::INFINITY;
@@ -2077,9 +2078,9 @@ impl BufferView {
             .layout_str(
                 "1".repeat(digit_count).as_str(),
                 font_size,
-                &[(0..digit_count, font_id)],
+                &[(digit_count, font_id, ColorU::black())],
             )
-            .width)
+            .width())
     }
 
     pub fn layout_line_numbers(
@@ -2088,7 +2089,7 @@ impl BufferView {
         font_cache: &FontCache,
         layout_cache: &TextLayoutCache,
         ctx: &AppContext,
-    ) -> Result<Vec<Arc<text_layout::Line>>> {
+    ) -> Result<Vec<text_layout::Line>> {
         let settings = self.settings.borrow();
         let font_size = settings.buffer_font_size;
         let font_id =
@@ -2114,7 +2115,7 @@ impl BufferView {
             layouts.push(layout_cache.layout_str(
                 &line_number,
                 font_size,
-                &[(0..line_number.len(), font_id)],
+                &[(line_number.len(), font_id, ColorU::black())],
             ));
         }
 
@@ -2127,7 +2128,7 @@ impl BufferView {
         font_cache: &FontCache,
         layout_cache: &TextLayoutCache,
         ctx: &AppContext,
-    ) -> Result<Vec<Arc<text_layout::Line>>> {
+    ) -> Result<Vec<text_layout::Line>> {
         rows.end = cmp::min(rows.end, self.display_map.max_point(ctx).row() + 1);
         if rows.start >= rows.end {
             return Ok(Vec::new());
@@ -2151,7 +2152,7 @@ impl BufferView {
                 layouts.push(layout_cache.layout_str(
                     &line,
                     font_size,
-                    &[(0..line.len(), font_id)],
+                    &[(line.len(), font_id, ColorU::black())],
                 ));
                 line.clear();
                 row += 1;
@@ -2171,7 +2172,7 @@ impl BufferView {
         font_cache: &FontCache,
         layout_cache: &TextLayoutCache,
         app: &AppContext,
-    ) -> Result<Arc<text_layout::Line>> {
+    ) -> Result<text_layout::Line> {
         let settings = self.settings.borrow();
         let font_id =
             font_cache.select_font(settings.buffer_font_family, &FontProperties::new())?;
@@ -2181,7 +2182,7 @@ impl BufferView {
         Ok(layout_cache.layout_str(
             &line,
             settings.buffer_font_size,
-            &[(0..self.line_len(row, app) as usize, font_id)],
+            &[(self.line_len(row, app) as usize, font_id, ColorU::black())],
         ))
     }
 


### PR DESCRIPTION
This PR is laying the foundation for syntax highlighting.

It changes how we specify runs of styling when calling `TextLayoutCache::layout_str`. Previously, you would pass a `runs` argument of type `&[Range<usize>, FontId]`. Colors where specified separately when painting the line.

For syntax highlighting, we realized it would be helpful to unify our handling of colors and fonts in a single interface. So now you pass a `ColorU` in addition to the `FontId` as part of each run. We still ignore colors for the purposes of caching the text layouts by coalescing contiguous runs with the same font before calling into CoreText.

Additionally, rather than specifying a start and end range for each run, you now simply pass the run's length in bytes.