### PR TITLE
Merge selections correctly when selecting larger syntax node

### DIFF
--- a/zed/src/editor.rs
+++ b/zed/src/editor.rs
@@ -4044,7 +4044,7 @@ mod tests {
         });
         assert_eq!(
             view.read_with(&cx, |view, cx| view.selection_ranges(cx)),
-            &[DisplayPoint::new(0, 0)..DisplayPoint::new(5, 0)]
+            &[DisplayPoint::new(5, 0)..DisplayPoint::new(0, 0)]
         );
 
         // Trying to expand the selected syntax node one more time has no effect.
@@ -4053,7 +4053,7 @@ mod tests {
         });
         assert_eq!(
             view.read_with(&cx, |view, cx| view.selection_ranges(cx)),
-            &[DisplayPoint::new(0, 0)..DisplayPoint::new(5, 0)]
+            &[DisplayPoint::new(5, 0)..DisplayPoint::new(0, 0)]
         );
 
         view.update(&mut cx, |view, cx| {


### PR DESCRIPTION
When running this command with multiple cursors, if one of them was at a later position in the buffer but lying on a shallower node, it could happen that its start could move prior to cursors that were before it but lying on a deeper node.

This could cause the selection merging algorithm to mistakenly keep some selections even if they overlapped. With this pull request we now sort selections prior to merging them in `Editor::select_larger_syntax_node`.