### PR TITLE
Represent edit positions and anchors as versioned offsets

### DIFF
--- a/zed/src/editor.rs
+++ b/zed/src/editor.rs
@@ -723,9 +723,7 @@ impl Editor {
         let mut new_selections = Vec::new();
         self.buffer.update(cx, |buffer, cx| {
             let edit_ranges = old_selections.iter().map(|(_, range)| range.clone());
-            if let Err(error) = buffer.edit(edit_ranges, text.as_str(), Some(cx)) {
-                log::error!("error inserting text: {}", error);
-            };
+            buffer.edit(edit_ranges, text.as_str(), Some(cx));
             let text_len = text.len() as isize;
             let mut delta = 0_isize;
             new_selections = old_selections

--- a/zed/src/editor.rs
+++ b/zed/src/editor.rs
@@ -5,7 +5,7 @@ pub mod movement;
 
 use crate::{
     settings::{Settings, StyleId},
-    util::post_inc,
+    util::{post_inc, Bias},
     workspace,
     worktree::FileHandle,
 };
@@ -4135,12 +4135,6 @@ mod tests {
         let point = DisplayPoint::new(row as u32, column as u32);
         point..point
     }
-}
-
-#[derive(Copy, Clone)]
-pub enum Bias {
-    Left,
-    Right,
 }
 
 trait RangeExt<T> {

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -326,14 +326,6 @@ struct Diff {
     changes: Vec<(ChangeTag, usize)>,
 }
 
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct Insertion {
-    id: time::Local,
-    parent_id: time::Local,
-    offset_in_parent: usize,
-    lamport_timestamp: time::Lamport,
-}
-
 #[derive(Eq, PartialEq, Clone, Debug)]
 struct Fragment {
     len: usize,

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -2258,17 +2258,14 @@ impl<'a> sum_tree::SeekDimension<'a, FragmentSummary> for VersionedOffset {
     }
 }
 
-impl<'a> sum_tree::Dimension<'a, FragmentSummary> for (VersionedOffset, usize) {
+impl<'a, T, U> sum_tree::Dimension<'a, FragmentSummary> for (T, U)
+where
+    T: sum_tree::Dimension<'a, FragmentSummary>,
+    U: sum_tree::Dimension<'a, FragmentSummary>,
+{
     fn add_summary(&mut self, summary: &'a FragmentSummary, cx: &Option<time::Global>) {
         self.0.add_summary(summary, cx);
-        self.1 += summary.text.visible;
-    }
-}
-
-impl<'a> sum_tree::Dimension<'a, FragmentSummary> for (VersionedOffset, FullOffset) {
-    fn add_summary(&mut self, summary: &'a FragmentSummary, cx: &Option<time::Global>) {
-        self.0.add_summary(summary, cx);
-        self.1 .0 += summary.text.visible + summary.text.deleted;
+        self.1.add_summary(summary, cx);
     }
 }
 

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -1455,11 +1455,14 @@ impl Buffer {
         let mut fragment_start = old_fragments.start().visible;
         for range in ranges {
             if range.start > old_fragments.end(&None).visible {
-                if old_fragments.end(&None).visible > fragment_start {
-                    let mut suffix = old_fragments.item().unwrap().clone();
-                    suffix.len = old_fragments.end(&None).visible - fragment_start;
-                    new_ropes.push_fragment(&suffix, suffix.visible);
-                    new_fragments.push(suffix, &None);
+                if fragment_start > old_fragments.start().visible {
+                    let fragment_end = old_fragments.end(&None).visible;
+                    if fragment_end > fragment_start {
+                        let mut suffix = old_fragments.item().unwrap().clone();
+                        suffix.len = fragment_end - fragment_start;
+                        new_ropes.push_fragment(&suffix, suffix.visible);
+                        new_fragments.push(suffix, &None);
+                    }
                     old_fragments.next(&None);
                 }
 
@@ -1517,24 +1520,24 @@ impl Buffer {
             edit.ranges.push(full_range_start..full_range_end);
         }
 
-        let fragment_end = old_fragments.end(&None).visible;
-        if fragment_end > fragment_start {
-            let mut suffix = old_fragments.item().unwrap().clone();
-            suffix.len = fragment_end - fragment_start;
-            new_ropes.push_fragment(&suffix, suffix.visible);
-            new_fragments.push(suffix, &None);
-        }
-        if old_fragments.item().is_some() {
+        if fragment_start > old_fragments.start().visible {
+            let fragment_end = old_fragments.end(&None).visible;
+            if fragment_end > fragment_start {
+                let mut suffix = old_fragments.item().unwrap().clone();
+                suffix.len = fragment_end - fragment_start;
+                new_ropes.push_fragment(&suffix, suffix.visible);
+                new_fragments.push(suffix, &None);
+            }
             old_fragments.next(&None);
         }
 
         let suffix = old_fragments.suffix(&None);
         new_ropes.push_tree(suffix.summary().text);
         new_fragments.push_tree(suffix, &None);
-        let (visible_text, deleted_text) = new_ropes.finish();
-        drop(old_fragments);
 
+        drop(old_fragments);
         self.fragments = new_fragments;
+        let (visible_text, deleted_text) = new_ropes.finish();
         self.visible_text = visible_text;
         self.deleted_text = deleted_text;
         edit

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -3108,9 +3108,9 @@ mod tests {
                         mutation_count -= 1;
                     }
                     51..=70 if mutation_count != 0 => {
-                        // let ops = buffer.randomly_undo_redo(&mut rng);
-                        // network.broadcast(replica_id, ops, &mut rng);
-                        // mutation_count -= 1;
+                        let ops = buffer.randomly_undo_redo(&mut rng);
+                        network.broadcast(replica_id, ops, &mut rng);
+                        mutation_count -= 1;
                     }
                     71..=100 if network.has_unreceived(replica_id) => {
                         let ops = network.receive(replica_id, &mut rng);

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -1376,15 +1376,6 @@ impl Buffer {
 
                     old_fragments.next(&version);
                     end_offset = old_fragments.end(&version).offset();
-
-                    // Skip over any fragments that were not present when the edit occurred.
-                    // let newer_fragments = old_fragments.slice(
-                    //     &old_fragments.end(&version),
-                    //     SeekBias::Right,
-                    //     &version,
-                    // );
-                    // new_ropes.push_tree(newer_fragments.summary().text);
-                    // new_fragments.push_tree(newer_fragments, &None);
                 } else {
                     break;
                 }

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -462,12 +462,10 @@ impl Buffer {
         let mut fragments = SumTree::new();
 
         let visible_text = Rope::from(history.base_text.as_ref());
-        let mut local_clock = time::Local::new(replica_id);
-
         if visible_text.len() > 0 {
             fragments.push(
                 Fragment {
-                    insertion_id: local_clock.tick(),
+                    insertion_id: Default::default(),
                     len: visible_text.len(),
                     deletions: Default::default(),
                     max_undos: Default::default(),
@@ -496,7 +494,7 @@ impl Buffer {
             deferred_ops: OperationQueue::new(),
             deferred_replicas: HashSet::default(),
             replica_id,
-            local_clock,
+            local_clock: time::Local::new(replica_id),
             lamport_clock: time::Lamport::new(replica_id),
         };
         result.reparse(cx);

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -1445,8 +1445,7 @@ impl Buffer {
             id: local_timestamp,
             version: self.version(),
             ranges: Vec::with_capacity(ranges.len()),
-            // TODO: avoid cloning here
-            new_text: new_text.clone(),
+            new_text: None,
         };
 
         let mut new_ropes =
@@ -1555,6 +1554,7 @@ impl Buffer {
         self.fragments = new_fragments;
         self.visible_text = visible_text;
         self.deleted_text = deleted_text;
+        edit.new_text = new_text;
         edit
     }
 

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -2128,17 +2128,6 @@ impl<'a> sum_tree::SeekDimension<'a, FragmentSummary> for VersionedOffset {
     }
 }
 
-impl<'a, T, U> sum_tree::Dimension<'a, FragmentSummary> for (T, U)
-where
-    T: sum_tree::Dimension<'a, FragmentSummary>,
-    U: sum_tree::Dimension<'a, FragmentSummary>,
-{
-    fn add_summary(&mut self, summary: &'a FragmentSummary, cx: &Option<time::Global>) {
-        self.0.add_summary(summary, cx);
-        self.1.add_summary(summary, cx);
-    }
-}
-
 impl Operation {
     fn replica_id(&self) -> ReplicaId {
         self.lamport_timestamp().replica_id

--- a/zed/src/editor/buffer/anchor.rs
+++ b/zed/src/editor/buffer/anchor.rs
@@ -63,21 +63,27 @@ impl Anchor {
                 Anchor::Middle {
                     offset: self_offset,
                     bias: self_bias,
-                    version: self_version,
+                    ..
                 },
                 Anchor::Middle {
                     offset: other_offset,
                     bias: other_bias,
-                    version: other_version,
+                    ..
                 },
             ) => {
-                let offset_comparison = if self_version == other_version {
-                    self_offset.cmp(other_offset)
-                } else {
-                    self.to_offset(buffer).cmp(&other.to_offset(buffer))
-                };
-
-                offset_comparison.then_with(|| self_bias.cmp(other_bias))
+                dbg!(
+                    self,
+                    other,
+                    self_offset,
+                    other_offset,
+                    buffer.fragment_ix_for_anchor(self),
+                    buffer.fragment_ix_for_anchor(other)
+                );
+                buffer
+                    .fragment_ix_for_anchor(self)
+                    .cmp(&buffer.fragment_ix_for_anchor(other))
+                    .then_with(|| self_offset.cmp(&other_offset))
+                    .then_with(|| self_bias.cmp(other_bias))
             }
         })
     }

--- a/zed/src/editor/buffer/anchor.rs
+++ b/zed/src/editor/buffer/anchor.rs
@@ -1,5 +1,5 @@
 use super::{Buffer, ToOffset};
-use crate::time;
+use crate::{sum_tree, time};
 use anyhow::Result;
 use std::{cmp::Ordering, ops::Range};
 
@@ -14,10 +14,19 @@ pub enum Anchor {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum AnchorBias {
     Left,
     Right,
+}
+
+impl AnchorBias {
+    pub fn to_seek_bias(self) -> sum_tree::SeekBias {
+        match self {
+            AnchorBias::Left => sum_tree::SeekBias::Left,
+            AnchorBias::Right => sum_tree::SeekBias::Right,
+        }
+    }
 }
 
 impl PartialOrd for AnchorBias {

--- a/zed/src/editor/buffer/anchor.rs
+++ b/zed/src/editor/buffer/anchor.rs
@@ -1,4 +1,4 @@
-use super::{Buffer, ToOffset};
+use super::Buffer;
 use crate::{sum_tree, time};
 use anyhow::Result;
 use std::{cmp::Ordering, ops::Range};
@@ -61,30 +61,15 @@ impl Anchor {
             (Anchor::End, _) | (_, Anchor::Start) => Ordering::Greater,
             (
                 Anchor::Middle {
-                    offset: self_offset,
-                    bias: self_bias,
-                    ..
+                    bias: self_bias, ..
                 },
                 Anchor::Middle {
-                    offset: other_offset,
-                    bias: other_bias,
-                    ..
+                    bias: other_bias, ..
                 },
-            ) => {
-                dbg!(
-                    self,
-                    other,
-                    self_offset,
-                    other_offset,
-                    buffer.fragment_ix_for_anchor(self),
-                    buffer.fragment_ix_for_anchor(other)
-                );
-                buffer
-                    .fragment_ix_for_anchor(self)
-                    .cmp(&buffer.fragment_ix_for_anchor(other))
-                    .then_with(|| self_offset.cmp(&other_offset))
-                    .then_with(|| self_bias.cmp(other_bias))
-            }
+            ) => buffer
+                .fragment_ix_for_anchor(self)
+                .cmp(&buffer.fragment_ix_for_anchor(other))
+                .then_with(|| self_bias.cmp(&other_bias)),
         })
     }
 

--- a/zed/src/editor/buffer/anchor.rs
+++ b/zed/src/editor/buffer/anchor.rs
@@ -61,15 +61,26 @@ impl Anchor {
             (Anchor::End, _) | (_, Anchor::Start) => Ordering::Greater,
             (
                 Anchor::Middle {
-                    bias: self_bias, ..
+                    offset: self_offset,
+                    bias: self_bias,
+                    version: self_version,
                 },
                 Anchor::Middle {
-                    bias: other_bias, ..
+                    offset: other_offset,
+                    bias: other_bias,
+                    version: other_version,
                 },
-            ) => buffer
-                .full_offset_for_anchor(self)
-                .cmp(&buffer.full_offset_for_anchor(other))
-                .then_with(|| self_bias.cmp(&other_bias)),
+            ) => {
+                let offset_comparison = if self_version == other_version {
+                    self_offset.cmp(other_offset)
+                } else {
+                    buffer
+                        .full_offset_for_anchor(self)
+                        .cmp(&buffer.full_offset_for_anchor(other))
+                };
+
+                offset_comparison.then_with(|| self_bias.cmp(&other_bias))
+            }
         })
     }
 

--- a/zed/src/editor/buffer/anchor.rs
+++ b/zed/src/editor/buffer/anchor.rs
@@ -67,8 +67,8 @@ impl Anchor {
                     bias: other_bias, ..
                 },
             ) => buffer
-                .fragment_ix_for_anchor(self)
-                .cmp(&buffer.fragment_ix_for_anchor(other))
+                .full_offset_for_anchor(self)
+                .cmp(&buffer.full_offset_for_anchor(other))
                 .then_with(|| self_bias.cmp(&other_bias)),
         })
     }

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -213,7 +213,12 @@ impl<'a> Cursor<'a> {
     }
 
     pub fn slice(&mut self, end_offset: usize) -> Rope {
-        debug_assert!(end_offset >= self.offset);
+        debug_assert!(
+            end_offset >= self.offset,
+            "cannot slice backwards from {} to {}",
+            self.offset,
+            end_offset
+        );
 
         let mut slice = Rope::new();
         if let Some(start_chunk) = self.chunks.item() {

--- a/zed/src/editor/display_map/fold_map.rs
+++ b/zed/src/editor/display_map/fold_map.rs
@@ -1,12 +1,13 @@
 use super::{
     buffer::{AnchorRangeExt, TextSummary},
-    Anchor, Bias, Buffer, DisplayPoint, Edit, Point, ToOffset,
+    Anchor, Buffer, DisplayPoint, Edit, Point, ToOffset,
 };
 use crate::{
     editor::buffer,
     settings::StyleId,
-    sum_tree::{self, Cursor, FilterCursor, SeekBias, SumTree},
+    sum_tree::{self, Cursor, FilterCursor, SumTree},
     time,
+    util::Bias,
 };
 use gpui::{AppContext, ModelHandle};
 use parking_lot::{Mutex, MutexGuard};
@@ -125,7 +126,7 @@ impl FoldMap {
             let mut new_tree = SumTree::new();
             let mut cursor = self.folds.cursor::<_, ()>();
             for fold in folds {
-                new_tree.push_tree(cursor.slice(&fold, SeekBias::Right, buffer), buffer);
+                new_tree.push_tree(cursor.slice(&fold, Bias::Right, buffer), buffer);
                 new_tree.push(fold, buffer);
             }
             new_tree.push_tree(cursor.suffix(buffer), buffer);
@@ -173,7 +174,7 @@ impl FoldMap {
             let mut cursor = self.folds.cursor::<_, ()>();
             let mut folds = SumTree::new();
             for fold_ix in fold_ixs_to_delete {
-                folds.push_tree(cursor.slice(&fold_ix, SeekBias::Right, buffer), buffer);
+                folds.push_tree(cursor.slice(&fold_ix, Bias::Right, buffer), buffer);
                 cursor.next(buffer);
             }
             folds.push_tree(cursor.suffix(buffer), buffer);
@@ -210,14 +211,14 @@ impl FoldMap {
         let offset = offset.to_offset(buffer);
         let transforms = self.sync(cx);
         let mut cursor = transforms.cursor::<usize, usize>();
-        cursor.seek(&offset, SeekBias::Right, &());
+        cursor.seek(&offset, Bias::Right, &());
         cursor.item().map_or(false, |t| t.display_text.is_some())
     }
 
     pub fn is_line_folded(&self, display_row: u32, cx: &AppContext) -> bool {
         let transforms = self.sync(cx);
         let mut cursor = transforms.cursor::<DisplayPoint, DisplayPoint>();
-        cursor.seek(&DisplayPoint::new(display_row, 0), SeekBias::Right, &());
+        cursor.seek(&DisplayPoint::new(display_row, 0), Bias::Right, &());
         while let Some(transform) = cursor.item() {
             if transform.display_text.is_some() {
                 return true;
@@ -242,7 +243,7 @@ impl FoldMap {
     pub fn to_buffer_point(&self, display_point: DisplayPoint, cx: &AppContext) -> Point {
         let transforms = self.sync(cx);
         let mut cursor = transforms.cursor::<DisplayPoint, TransformSummary>();
-        cursor.seek(&display_point, SeekBias::Right, &());
+        cursor.seek(&display_point, Bias::Right, &());
         let overshoot = display_point.0 - cursor.start().display.lines;
         cursor.start().buffer.lines + overshoot
     }
@@ -250,7 +251,7 @@ impl FoldMap {
     pub fn to_display_point(&self, point: Point, cx: &AppContext) -> DisplayPoint {
         let transforms = self.sync(cx);
         let mut cursor = transforms.cursor::<Point, TransformSummary>();
-        cursor.seek(&point, SeekBias::Right, &());
+        cursor.seek(&point, Bias::Right, &());
         let overshoot = point - cursor.start().buffer.lines;
         DisplayPoint(cmp::min(
             cursor.start().display.lines + overshoot,
@@ -275,17 +276,14 @@ impl FoldMap {
         let mut new_transforms = SumTree::new();
         let mut transforms = self.transforms.lock();
         let mut cursor = transforms.cursor::<usize, usize>();
-        cursor.seek(&0, SeekBias::Right, &());
+        cursor.seek(&0, Bias::Right, &());
 
         while let Some(mut edit) = edits.next() {
-            new_transforms.push_tree(
-                cursor.slice(&edit.old_range.start, SeekBias::Left, &()),
-                &(),
-            );
+            new_transforms.push_tree(cursor.slice(&edit.old_range.start, Bias::Left, &()), &());
             edit.new_range.start -= edit.old_range.start - cursor.start();
             edit.old_range.start = *cursor.start();
 
-            cursor.seek(&edit.old_range.end, SeekBias::Right, &());
+            cursor.seek(&edit.old_range.end, Bias::Right, &());
             cursor.next(&());
 
             let mut delta = edit.delta();
@@ -302,7 +300,7 @@ impl FoldMap {
 
                     if next_edit.old_range.end >= edit.old_range.end {
                         edit.old_range.end = next_edit.old_range.end;
-                        cursor.seek(&edit.old_range.end, SeekBias::Right, &());
+                        cursor.seek(&edit.old_range.end, Bias::Right, &());
                         cursor.next(&());
                     }
                 } else {
@@ -315,7 +313,7 @@ impl FoldMap {
 
             let anchor = buffer.anchor_before(edit.new_range.start);
             let mut folds_cursor = self.folds.cursor::<_, ()>();
-            folds_cursor.seek(&Fold(anchor..Anchor::End), SeekBias::Left, buffer);
+            folds_cursor.seek(&Fold(anchor..Anchor::End), Bias::Left, buffer);
             let mut folds = iter::from_fn(move || {
                 let item = folds_cursor
                     .item()
@@ -432,7 +430,7 @@ impl FoldMapSnapshot {
 
         let display_point = Point::new(start_row, 0);
         let mut cursor = self.transforms.cursor();
-        cursor.seek(&DisplayPoint(display_point), SeekBias::Left, &());
+        cursor.seek(&DisplayPoint(display_point), Bias::Left, &());
 
         BufferRows {
             display_point,
@@ -446,7 +444,7 @@ impl FoldMapSnapshot {
 
     pub fn chunks_at(&self, offset: DisplayOffset) -> Chunks {
         let mut transform_cursor = self.transforms.cursor::<DisplayOffset, TransformSummary>();
-        transform_cursor.seek(&offset, SeekBias::Right, &());
+        transform_cursor.seek(&offset, Bias::Right, &());
         let overshoot = offset.0 - transform_cursor.start().display.bytes;
         let buffer_offset = transform_cursor.start().buffer.bytes + overshoot;
         Chunks {
@@ -459,11 +457,11 @@ impl FoldMapSnapshot {
     pub fn highlighted_chunks(&mut self, range: Range<DisplayOffset>) -> HighlightedChunks {
         let mut transform_cursor = self.transforms.cursor::<DisplayOffset, TransformSummary>();
 
-        transform_cursor.seek(&range.end, SeekBias::Right, &());
+        transform_cursor.seek(&range.end, Bias::Right, &());
         let overshoot = range.end.0 - transform_cursor.start().display.bytes;
         let buffer_end = transform_cursor.start().buffer.bytes + overshoot;
 
-        transform_cursor.seek(&range.start, SeekBias::Right, &());
+        transform_cursor.seek(&range.start, Bias::Right, &());
         let overshoot = range.start.0 - transform_cursor.start().display.bytes;
         let buffer_start = transform_cursor.start().buffer.bytes + overshoot;
 
@@ -484,7 +482,7 @@ impl FoldMapSnapshot {
 
     pub fn to_display_offset(&self, point: DisplayPoint) -> DisplayOffset {
         let mut cursor = self.transforms.cursor::<DisplayPoint, TransformSummary>();
-        cursor.seek(&point, SeekBias::Right, &());
+        cursor.seek(&point, Bias::Right, &());
         let overshoot = point.0 - cursor.start().display.lines;
         let mut offset = cursor.start().display.bytes;
         if !overshoot.is_zero() {
@@ -500,7 +498,7 @@ impl FoldMapSnapshot {
 
     pub fn to_buffer_offset(&self, point: DisplayPoint) -> usize {
         let mut cursor = self.transforms.cursor::<DisplayPoint, TransformSummary>();
-        cursor.seek(&point, SeekBias::Right, &());
+        cursor.seek(&point, Bias::Right, &());
         let overshoot = point.0 - cursor.start().display.lines;
         self.buffer
             .to_offset(cursor.start().buffer.lines + overshoot)
@@ -509,7 +507,7 @@ impl FoldMapSnapshot {
     #[cfg(test)]
     pub fn clip_offset(&self, offset: DisplayOffset, bias: Bias) -> DisplayOffset {
         let mut cursor = self.transforms.cursor::<DisplayOffset, TransformSummary>();
-        cursor.seek(&offset, SeekBias::Right, &());
+        cursor.seek(&offset, Bias::Right, &());
         if let Some(transform) = cursor.item() {
             let transform_start = cursor.start().display.bytes;
             if transform.display_text.is_some() {
@@ -534,7 +532,7 @@ impl FoldMapSnapshot {
 
     pub fn clip_point(&self, point: DisplayPoint, bias: Bias) -> DisplayPoint {
         let mut cursor = self.transforms.cursor::<DisplayPoint, TransformSummary>();
-        cursor.seek(&point, SeekBias::Right, &());
+        cursor.seek(&point, Bias::Right, &());
         if let Some(transform) = cursor.item() {
             let transform_start = cursor.start().display.lines;
             if transform.display_text.is_some() {

--- a/zed/src/operation_queue.rs
+++ b/zed/src/operation_queue.rs
@@ -89,7 +89,7 @@ impl<'a> Add<&'a Self> for OperationSummary {
 }
 
 impl<'a> Dimension<'a, OperationSummary> for OperationKey {
-    fn add_summary(&mut self, summary: &OperationSummary) {
+    fn add_summary(&mut self, summary: &OperationSummary, _: &()) {
         assert!(*self <= summary.key);
         *self = summary.key;
     }

--- a/zed/src/sum_tree.rs
+++ b/zed/src/sum_tree.rs
@@ -29,11 +29,11 @@ pub trait Summary: Default + Clone + fmt::Debug {
 }
 
 pub trait Dimension<'a, S: Summary>: Clone + fmt::Debug + Default {
-    fn add_summary(&mut self, _summary: &'a S);
+    fn add_summary(&mut self, _summary: &'a S, _: &S::Context);
 }
 
 impl<'a, T: Summary> Dimension<'a, T> for () {
-    fn add_summary(&mut self, _: &'a T) {}
+    fn add_summary(&mut self, _: &'a T, _: &T::Context) {}
 }
 
 pub trait SeekDimension<'a, T: Summary>: Dimension<'a, T> {
@@ -71,9 +71,15 @@ impl<T: Item> SumTree<T> {
     }
 
     #[allow(unused)]
-    pub fn items(&self) -> Vec<T> {
+    pub fn items(&self, cx: &<T::Summary as Summary>::Context) -> Vec<T> {
+        let mut items = Vec::new();
         let mut cursor = self.cursor::<(), ()>();
-        cursor.cloned().collect()
+        cursor.next(cx);
+        while let Some(item) = cursor.item() {
+            items.push(item.clone());
+            cursor.next(cx);
+        }
+        items
     }
 
     pub fn cursor<'a, S, U>(&'a self) -> Cursor<T, S, U>
@@ -84,12 +90,16 @@ impl<T: Item> SumTree<T> {
         Cursor::new(self)
     }
 
-    pub fn filter<'a, F, U>(&'a self, filter_node: F) -> FilterCursor<F, T, U>
+    pub fn filter<'a, F, U>(
+        &'a self,
+        filter_node: F,
+        cx: &<T::Summary as Summary>::Context,
+    ) -> FilterCursor<F, T, U>
     where
         F: Fn(&T::Summary) -> bool,
         U: Dimension<'a, T::Summary>,
     {
-        FilterCursor::new(self, filter_node)
+        FilterCursor::new(self, filter_node, cx)
     }
 
     #[allow(dead_code)]
@@ -141,11 +151,14 @@ impl<T: Item> SumTree<T> {
         }
     }
 
-    pub fn extent<'a, D: Dimension<'a, T::Summary>>(&'a self) -> D {
+    pub fn extent<'a, D: Dimension<'a, T::Summary>>(
+        &'a self,
+        cx: &<T::Summary as Summary>::Context,
+    ) -> D {
         let mut extent = D::default();
         match self.0.as_ref() {
             Node::Internal { summary, .. } | Node::Leaf { summary, .. } => {
-                extent.add_summary(summary);
+                extent.add_summary(summary, cx);
             }
         }
         extent
@@ -434,7 +447,7 @@ impl<T: KeyedItem> SumTree<T> {
                 if let Some(old_item) = old_item {
                     if old_item.key() == new_key {
                         removed.push(old_item.clone());
-                        cursor.next();
+                        cursor.next(cx);
                     }
                 }
 
@@ -580,7 +593,10 @@ mod tests {
         tree2.extend(50..100, &());
 
         tree1.push_tree(tree2, &());
-        assert_eq!(tree1.items(), (0..20).chain(50..100).collect::<Vec<u8>>());
+        assert_eq!(
+            tree1.items(&()),
+            (0..20).chain(50..100).collect::<Vec<u8>>()
+        );
     }
 
     #[test]
@@ -596,16 +612,16 @@ mod tests {
             tree.extend(rng.sample_iter(distributions::Standard).take(count), &());
 
             for _ in 0..5 {
-                let splice_end = rng.gen_range(0..tree.extent::<Count>().0 + 1);
+                let splice_end = rng.gen_range(0..tree.extent::<Count>(&()).0 + 1);
                 let splice_start = rng.gen_range(0..splice_end + 1);
                 let count = rng.gen_range(0..3);
-                let tree_end = tree.extent::<Count>();
+                let tree_end = tree.extent::<Count>(&());
                 let new_items = rng
                     .sample_iter(distributions::Standard)
                     .take(count)
                     .collect::<Vec<u8>>();
 
-                let mut reference_items = tree.items();
+                let mut reference_items = tree.items(&());
                 reference_items.splice(splice_start..splice_end, new_items.clone());
 
                 tree = {
@@ -617,11 +633,12 @@ mod tests {
                     new_tree
                 };
 
-                assert_eq!(tree.items(), reference_items);
+                assert_eq!(tree.items(&()), reference_items);
 
-                let mut filter_cursor = tree.filter::<_, Count>(|summary| summary.contains_even);
+                let mut filter_cursor =
+                    tree.filter::<_, Count>(|summary| summary.contains_even, &());
                 let mut reference_filter = tree
-                    .items()
+                    .items(&())
                     .into_iter()
                     .enumerate()
                     .filter(|(_, item)| (item & 1) == 0);
@@ -629,11 +646,11 @@ mod tests {
                     let (reference_index, reference_item) = reference_filter.next().unwrap();
                     assert_eq!(actual_item, &reference_item);
                     assert_eq!(filter_cursor.start().0, reference_index);
-                    filter_cursor.next();
+                    filter_cursor.next(&());
                 }
                 assert!(reference_filter.next().is_none());
 
-                let mut pos = rng.gen_range(0..tree.extent::<Count>().0 + 1);
+                let mut pos = rng.gen_range(0..tree.extent::<Count>(&()).0 + 1);
                 let mut before_start = false;
                 let mut cursor = tree.cursor::<Count, Count>();
                 cursor.seek(&Count(pos), SeekBias::Right, &());
@@ -654,13 +671,13 @@ mod tests {
                     }
 
                     if i < 5 {
-                        cursor.next();
+                        cursor.next(&());
                         if pos < reference_items.len() {
                             pos += 1;
                             before_start = false;
                         }
                     } else {
-                        cursor.prev();
+                        cursor.prev(&());
                         if pos == 0 {
                             before_start = true;
                         }
@@ -670,7 +687,7 @@ mod tests {
             }
 
             for _ in 0..10 {
-                let end = rng.gen_range(0..tree.extent::<Count>().0 + 1);
+                let end = rng.gen_range(0..tree.extent::<Count>(&()).0 + 1);
                 let start = rng.gen_range(0..end + 1);
                 let start_bias = if rng.gen() {
                     SeekBias::Left
@@ -701,7 +718,7 @@ mod tests {
         let tree = SumTree::<u8>::new();
         let mut cursor = tree.cursor::<Count, Sum>();
         assert_eq!(
-            cursor.slice(&Count(0), SeekBias::Right, &()).items(),
+            cursor.slice(&Count(0), SeekBias::Right, &()).items(&()),
             Vec::<u8>::new()
         );
         assert_eq!(cursor.item(), None);
@@ -713,25 +730,28 @@ mod tests {
         tree.extend(vec![1], &());
         let mut cursor = tree.cursor::<Count, Sum>();
         assert_eq!(
-            cursor.slice(&Count(0), SeekBias::Right, &()).items(),
+            cursor.slice(&Count(0), SeekBias::Right, &()).items(&()),
             Vec::<u8>::new()
         );
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.start(), &Sum(0));
 
-        cursor.next();
+        cursor.next(&());
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&1));
         assert_eq!(cursor.start(), &Sum(1));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.start(), &Sum(0));
 
         let mut cursor = tree.cursor::<Count, Sum>();
-        assert_eq!(cursor.slice(&Count(1), SeekBias::Right, &()).items(), [1]);
+        assert_eq!(
+            cursor.slice(&Count(1), SeekBias::Right, &()).items(&()),
+            [1]
+        );
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&1));
         assert_eq!(cursor.start(), &Sum(1));
@@ -739,8 +759,8 @@ mod tests {
         cursor.seek(&Count(0), SeekBias::Right, &());
         assert_eq!(
             cursor
-                .slice(&tree.extent::<Count>(), SeekBias::Right, &())
-                .items(),
+                .slice(&tree.extent::<Count>(&()), SeekBias::Right, &())
+                .items(&()),
             [1]
         );
         assert_eq!(cursor.item(), None);
@@ -753,70 +773,70 @@ mod tests {
         let mut cursor = tree.cursor::<Count, Sum>();
 
         assert_eq!(
-            cursor.slice(&Count(2), SeekBias::Right, &()).items(),
+            cursor.slice(&Count(2), SeekBias::Right, &()).items(&()),
             [1, 2]
         );
         assert_eq!(cursor.item(), Some(&3));
         assert_eq!(cursor.prev_item(), Some(&2));
         assert_eq!(cursor.start(), &Sum(3));
 
-        cursor.next();
+        cursor.next(&());
         assert_eq!(cursor.item(), Some(&4));
         assert_eq!(cursor.prev_item(), Some(&3));
         assert_eq!(cursor.start(), &Sum(6));
 
-        cursor.next();
+        cursor.next(&());
         assert_eq!(cursor.item(), Some(&5));
         assert_eq!(cursor.prev_item(), Some(&4));
         assert_eq!(cursor.start(), &Sum(10));
 
-        cursor.next();
+        cursor.next(&());
         assert_eq!(cursor.item(), Some(&6));
         assert_eq!(cursor.prev_item(), Some(&5));
         assert_eq!(cursor.start(), &Sum(15));
 
-        cursor.next();
-        cursor.next();
+        cursor.next(&());
+        cursor.next(&());
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&6));
         assert_eq!(cursor.start(), &Sum(21));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&6));
         assert_eq!(cursor.prev_item(), Some(&5));
         assert_eq!(cursor.start(), &Sum(15));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&5));
         assert_eq!(cursor.prev_item(), Some(&4));
         assert_eq!(cursor.start(), &Sum(10));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&4));
         assert_eq!(cursor.prev_item(), Some(&3));
         assert_eq!(cursor.start(), &Sum(6));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&3));
         assert_eq!(cursor.prev_item(), Some(&2));
         assert_eq!(cursor.start(), &Sum(3));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&2));
         assert_eq!(cursor.prev_item(), Some(&1));
         assert_eq!(cursor.start(), &Sum(1));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.start(), &Sum(0));
 
-        cursor.prev();
+        cursor.prev(&());
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.start(), &Sum(0));
 
-        cursor.next();
+        cursor.next(&());
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.start(), &Sum(0));
@@ -824,9 +844,9 @@ mod tests {
         let mut cursor = tree.cursor::<Count, Sum>();
         assert_eq!(
             cursor
-                .slice(&tree.extent::<Count>(), SeekBias::Right, &())
-                .items(),
-            tree.items()
+                .slice(&tree.extent::<Count>(&()), SeekBias::Right, &())
+                .items(&()),
+            tree.items(&())
         );
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&6));
@@ -835,8 +855,8 @@ mod tests {
         cursor.seek(&Count(3), SeekBias::Right, &());
         assert_eq!(
             cursor
-                .slice(&tree.extent::<Count>(), SeekBias::Right, &())
-                .items(),
+                .slice(&tree.extent::<Count>(&()), SeekBias::Right, &())
+                .items(&()),
             [4, 5, 6]
         );
         assert_eq!(cursor.item(), None);
@@ -852,15 +872,15 @@ mod tests {
         // Slicing without resetting starts from where the cursor is parked at.
         cursor.seek(&Count(1), SeekBias::Right, &());
         assert_eq!(
-            cursor.slice(&Count(3), SeekBias::Right, &()).items(),
+            cursor.slice(&Count(3), SeekBias::Right, &()).items(&()),
             vec![2, 3]
         );
         assert_eq!(
-            cursor.slice(&Count(6), SeekBias::Left, &()).items(),
+            cursor.slice(&Count(6), SeekBias::Left, &()).items(&()),
             vec![4, 5]
         );
         assert_eq!(
-            cursor.slice(&Count(6), SeekBias::Right, &()).items(),
+            cursor.slice(&Count(6), SeekBias::Right, &()).items(&()),
             vec![6]
         );
     }
@@ -870,7 +890,7 @@ mod tests {
         let mut tree = SumTree::<u8>::new();
 
         let removed = tree.edit(vec![Edit::Insert(1), Edit::Insert(2), Edit::Insert(0)], &());
-        assert_eq!(tree.items(), vec![0, 1, 2]);
+        assert_eq!(tree.items(&()), vec![0, 1, 2]);
         assert_eq!(removed, Vec::<u8>::new());
         assert_eq!(tree.get(&0, &()), Some(&0));
         assert_eq!(tree.get(&1, &()), Some(&1));
@@ -878,7 +898,7 @@ mod tests {
         assert_eq!(tree.get(&4, &()), None);
 
         let removed = tree.edit(vec![Edit::Insert(2), Edit::Insert(4), Edit::Remove(0)], &());
-        assert_eq!(tree.items(), vec![1, 2, 4]);
+        assert_eq!(tree.items(&()), vec![1, 2, 4]);
         assert_eq!(removed, vec![0, 2]);
         assert_eq!(tree.get(&0, &()), None);
         assert_eq!(tree.get(&1, &()), Some(&1));
@@ -933,19 +953,19 @@ mod tests {
     }
 
     impl<'a> Dimension<'a, IntegersSummary> for u8 {
-        fn add_summary(&mut self, summary: &IntegersSummary) {
+        fn add_summary(&mut self, summary: &IntegersSummary, _: &()) {
             *self = summary.max;
         }
     }
 
     impl<'a> Dimension<'a, IntegersSummary> for Count {
-        fn add_summary(&mut self, summary: &IntegersSummary) {
+        fn add_summary(&mut self, summary: &IntegersSummary, _: &()) {
             self.0 += summary.count.0;
         }
     }
 
     impl<'a> Dimension<'a, IntegersSummary> for Sum {
-        fn add_summary(&mut self, summary: &IntegersSummary) {
+        fn add_summary(&mut self, summary: &IntegersSummary, _: &()) {
             self.0 += summary.sum.0;
         }
     }

--- a/zed/src/sum_tree.rs
+++ b/zed/src/sum_tree.rs
@@ -36,6 +36,18 @@ impl<'a, T: Summary> Dimension<'a, T> for () {
     fn add_summary(&mut self, _: &'a T, _: &T::Context) {}
 }
 
+impl<'a, S, D1, D2> Dimension<'a, S> for (D1, D2)
+where
+    S: Summary,
+    D1: Dimension<'a, S>,
+    D2: Dimension<'a, S>,
+{
+    fn add_summary(&mut self, summary: &'a S, cx: &S::Context) {
+        self.0.add_summary(summary, cx);
+        self.1.add_summary(summary, cx);
+    }
+}
+
 pub trait SeekDimension<'a, T: Summary>: Dimension<'a, T> {
     fn cmp(&self, other: &Self, cx: &T::Context) -> Ordering;
 }

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -229,9 +229,8 @@ where
                         ..
                     } => {
                         if !descend {
-                            let summary = &child_summaries[entry.index];
-                            entry.seek_dimension.add_summary(summary, cx);
-                            entry.sum_dimension.add_summary(summary, cx);
+                            entry.seek_dimension = self.seek_dimension.clone();
+                            entry.sum_dimension = self.sum_dimension.clone();
                             entry.index += 1;
                         }
 

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -413,7 +413,12 @@ where
         D: Dimension<'a, T::Summary>,
     {
         if let Some(target) = target {
-            debug_assert!(target.cmp(&self.seek_dimension, cx) >= Ordering::Equal);
+            debug_assert!(
+                target.cmp(&self.seek_dimension, cx) >= Ordering::Equal,
+                "cannot seek backward from {:?} to {:?}",
+                self.seek_dimension,
+                target
+            );
         }
 
         if !self.did_seek {

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -345,7 +345,7 @@ where
     S: SeekDimension<'a, T::Summary>,
     U: Dimension<'a, T::Summary>,
 {
-    pub fn seek(&mut self, pos: &S, bias: SeekBias, cx: &<T::Summary as Summary>::Context) -> bool {
+    pub fn seek(&mut self, pos: &S, bias: Bias, cx: &<T::Summary as Summary>::Context) -> bool {
         self.reset();
         self.seek_internal::<()>(Some(pos), bias, &mut SeekAggregate::None, cx)
     }
@@ -353,7 +353,7 @@ where
     pub fn seek_forward(
         &mut self,
         pos: &S,
-        bias: SeekBias,
+        bias: Bias,
         cx: &<T::Summary as Summary>::Context,
     ) -> bool {
         self.seek_internal::<()>(Some(pos), bias, &mut SeekAggregate::None, cx)
@@ -362,7 +362,7 @@ where
     pub fn slice(
         &mut self,
         end: &S,
-        bias: SeekBias,
+        bias: Bias,
         cx: &<T::Summary as Summary>::Context,
     ) -> SumTree<T> {
         let mut slice = SeekAggregate::Slice(SumTree::new());
@@ -376,7 +376,7 @@ where
 
     pub fn suffix(&mut self, cx: &<T::Summary as Summary>::Context) -> SumTree<T> {
         let mut slice = SeekAggregate::Slice(SumTree::new());
-        self.seek_internal::<()>(None, SeekBias::Right, &mut slice, cx);
+        self.seek_internal::<()>(None, Bias::Right, &mut slice, cx);
         if let SeekAggregate::Slice(slice) = slice {
             slice
         } else {
@@ -384,12 +384,7 @@ where
         }
     }
 
-    pub fn summary<D>(
-        &mut self,
-        end: &S,
-        bias: SeekBias,
-        cx: &<T::Summary as Summary>::Context,
-    ) -> D
+    pub fn summary<D>(&mut self, end: &S, bias: Bias, cx: &<T::Summary as Summary>::Context) -> D
     where
         D: Dimension<'a, T::Summary>,
     {
@@ -405,7 +400,7 @@ where
     fn seek_internal<D>(
         &mut self,
         target: Option<&S>,
-        bias: SeekBias,
+        bias: Bias,
         aggregate: &mut SeekAggregate<T, D>,
         cx: &<T::Summary as Summary>::Context,
     ) -> bool
@@ -453,7 +448,7 @@ where
                         let comparison =
                             target.map_or(Ordering::Greater, |t| t.cmp(&child_end, cx));
                         if comparison == Ordering::Greater
-                            || (comparison == Ordering::Equal && bias == SeekBias::Right)
+                            || (comparison == Ordering::Equal && bias == Bias::Right)
                         {
                             self.seek_dimension = child_end;
                             self.sum_dimension.add_summary(child_summary, cx);
@@ -503,7 +498,7 @@ where
                         let comparison =
                             target.map_or(Ordering::Greater, |t| t.cmp(&child_end, cx));
                         if comparison == Ordering::Greater
-                            || (comparison == Ordering::Equal && bias == SeekBias::Right)
+                            || (comparison == Ordering::Equal && bias == Bias::Right)
                         {
                             self.seek_dimension = child_end;
                             self.sum_dimension.add_summary(item_summary, cx);
@@ -560,7 +555,7 @@ where
         debug_assert!(self.stack.is_empty() || self.stack.last().unwrap().tree.0.is_leaf());
 
         let mut end = self.seek_dimension.clone();
-        if bias == SeekBias::Left {
+        if bias == Bias::Left {
             if let Some(summary) = self.item_summary() {
                 end.add_summary(summary, cx);
             }

--- a/zed/src/time.rs
+++ b/zed/src/time.rs
@@ -81,9 +81,23 @@ impl Global {
         }
     }
 
-    pub fn observe_all(&mut self, other: &Self) {
+    pub fn join(&mut self, other: &Self) {
         for timestamp in other.0.iter() {
             self.observe(*timestamp);
+        }
+    }
+
+    pub fn meet(&mut self, other: &Self) {
+        for timestamp in other.0.iter() {
+            if let Some(entry) = self
+                .0
+                .iter_mut()
+                .find(|t| t.replica_id == timestamp.replica_id)
+            {
+                entry.value = cmp::min(entry.value, timestamp.value);
+            } else {
+                self.0.push(*timestamp);
+            }
         }
     }
 

--- a/zed/src/time.rs
+++ b/zed/src/time.rs
@@ -15,7 +15,7 @@ pub struct Local {
     pub value: Seq,
 }
 
-#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 pub struct Lamport {
     pub replica_id: ReplicaId,
     pub value: Seq,
@@ -136,6 +136,21 @@ impl PartialOrd for Global {
         }
 
         Some(global_ordering)
+    }
+}
+
+impl Ord for Lamport {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Use the replica id to break ties between concurrent events.
+        self.value
+            .cmp(&other.value)
+            .then_with(|| self.replica_id.cmp(&other.replica_id))
+    }
+}
+
+impl PartialOrd for Lamport {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/zed/src/time.rs
+++ b/zed/src/time.rs
@@ -54,7 +54,7 @@ impl<'a> AddAssign<&'a Local> for Local {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq)]
 pub struct Global(SmallVec<[Local; 3]>);
 
 impl Global {

--- a/zed/src/time.rs
+++ b/zed/src/time.rs
@@ -1,6 +1,7 @@
 use smallvec::SmallVec;
 use std::cmp::{self, Ordering};
 use std::ops::{Add, AddAssign};
+use std::slice;
 
 pub type ReplicaId = u16;
 pub type Seq = u32;
@@ -107,6 +108,10 @@ impl Global {
 
     pub fn changed_since(&self, other: &Self) -> bool {
         self.0.iter().any(|t| t.value > other.get(t.replica_id))
+    }
+
+    pub fn iter(&self) -> slice::Iter<Local> {
+        self.0.iter()
     }
 }
 

--- a/zed/src/util.rs
+++ b/zed/src/util.rs
@@ -1,6 +1,29 @@
 use rand::prelude::*;
 use std::cmp::Ordering;
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub enum Bias {
+    Left,
+    Right,
+}
+
+impl PartialOrd for Bias {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Bias {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Left, Self::Left) => Ordering::Equal,
+            (Self::Left, Self::Right) => Ordering::Less,
+            (Self::Right, Self::Right) => Ordering::Equal,
+            (Self::Right, Self::Left) => Ordering::Greater,
+        }
+    }
+}
+
 pub fn post_inc(value: &mut usize) -> usize {
     let prev = *value;
     *value += 1;

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -603,7 +603,7 @@ impl Default for PathKey {
 }
 
 impl<'a> sum_tree::Dimension<'a, EntrySummary> for PathKey {
-    fn add_summary(&mut self, summary: &'a EntrySummary) {
+    fn add_summary(&mut self, summary: &'a EntrySummary, _: &()) {
         self.0 = summary.max_path.clone();
     }
 }
@@ -643,7 +643,7 @@ impl<'a> Default for PathSearch<'a> {
 }
 
 impl<'a: 'b, 'b> sum_tree::Dimension<'a, EntrySummary> for PathSearch<'b> {
-    fn add_summary(&mut self, summary: &'a EntrySummary) {
+    fn add_summary(&mut self, summary: &'a EntrySummary, _: &()) {
         *self = Self::Exact(summary.max_path.as_ref());
     }
 }
@@ -652,7 +652,7 @@ impl<'a: 'b, 'b> sum_tree::Dimension<'a, EntrySummary> for PathSearch<'b> {
 pub struct FileCount(usize);
 
 impl<'a> sum_tree::Dimension<'a, EntrySummary> for FileCount {
-    fn add_summary(&mut self, summary: &'a EntrySummary) {
+    fn add_summary(&mut self, summary: &'a EntrySummary, _: &()) {
         self.0 += summary.file_count;
     }
 }
@@ -661,7 +661,7 @@ impl<'a> sum_tree::Dimension<'a, EntrySummary> for FileCount {
 pub struct VisibleFileCount(usize);
 
 impl<'a> sum_tree::Dimension<'a, EntrySummary> for VisibleFileCount {
-    fn add_summary(&mut self, summary: &'a EntrySummary) {
+    fn add_summary(&mut self, summary: &'a EntrySummary, _: &()) {
         self.0 += summary.visible_file_count;
     }
 }

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -4,7 +4,8 @@ mod ignore;
 
 use crate::{
     editor::{History, Rope},
-    sum_tree::{self, Cursor, Edit, SeekBias, SumTree},
+    sum_tree::{self, Cursor, Edit, SumTree},
+    util::Bias,
 };
 use ::ignore::gitignore::Gitignore;
 use anyhow::{Context, Result};
@@ -295,7 +296,7 @@ impl Snapshot {
         }
         let path = path.as_ref();
         let mut cursor = self.entries.cursor::<_, ()>();
-        if cursor.seek(&PathSearch::Exact(path), SeekBias::Left, &()) {
+        if cursor.seek(&PathSearch::Exact(path), Bias::Left, &()) {
             let entry = cursor.item().unwrap();
             if entry.path.as_ref() == path {
                 return matches!(entry.kind, EntryKind::PendingDir);
@@ -310,7 +311,7 @@ impl Snapshot {
 
     fn entry_for_path(&self, path: impl AsRef<Path>) -> Option<&Entry> {
         let mut cursor = self.entries.cursor::<_, ()>();
-        if cursor.seek(&PathSearch::Exact(path.as_ref()), SeekBias::Left, &()) {
+        if cursor.seek(&PathSearch::Exact(path.as_ref()), Bias::Left, &()) {
             cursor.item()
         } else {
             None
@@ -367,8 +368,8 @@ impl Snapshot {
     fn remove_path(&mut self, path: &Path) {
         let new_entries = {
             let mut cursor = self.entries.cursor::<_, ()>();
-            let mut new_entries = cursor.slice(&PathSearch::Exact(path), SeekBias::Left, &());
-            cursor.seek_forward(&PathSearch::Successor(path), SeekBias::Left, &());
+            let mut new_entries = cursor.slice(&PathSearch::Exact(path), Bias::Left, &());
+            cursor.seek_forward(&PathSearch::Successor(path), Bias::Left, &());
             new_entries.push_tree(cursor.suffix(&()), &());
             new_entries
         };
@@ -1296,13 +1297,13 @@ pub enum FileIter<'a> {
 impl<'a> FileIter<'a> {
     fn all(snapshot: &'a Snapshot, start: usize) -> Self {
         let mut cursor = snapshot.entries.cursor();
-        cursor.seek(&FileCount(start), SeekBias::Right, &());
+        cursor.seek(&FileCount(start), Bias::Right, &());
         Self::All(cursor)
     }
 
     fn visible(snapshot: &'a Snapshot, start: usize) -> Self {
         let mut cursor = snapshot.entries.cursor();
-        cursor.seek(&VisibleFileCount(start), SeekBias::Right, &());
+        cursor.seek(&VisibleFileCount(start), Bias::Right, &());
         Self::Visible(cursor)
     }
 
@@ -1310,11 +1311,11 @@ impl<'a> FileIter<'a> {
         match self {
             Self::All(cursor) => {
                 let ix = *cursor.start();
-                cursor.seek_forward(&FileCount(ix.0 + 1), SeekBias::Right, &());
+                cursor.seek_forward(&FileCount(ix.0 + 1), Bias::Right, &());
             }
             Self::Visible(cursor) => {
                 let ix = *cursor.start();
-                cursor.seek_forward(&VisibleFileCount(ix.0 + 1), SeekBias::Right, &());
+                cursor.seek_forward(&VisibleFileCount(ix.0 + 1), Bias::Right, &());
             }
         }
     }
@@ -1348,7 +1349,7 @@ struct ChildEntriesIter<'a> {
 impl<'a> ChildEntriesIter<'a> {
     fn new(parent_path: &'a Path, snapshot: &'a Snapshot) -> Self {
         let mut cursor = snapshot.entries.cursor();
-        cursor.seek(&PathSearch::Exact(parent_path), SeekBias::Right, &());
+        cursor.seek(&PathSearch::Exact(parent_path), Bias::Right, &());
         Self {
             parent_path,
             cursor,
@@ -1363,7 +1364,7 @@ impl<'a> Iterator for ChildEntriesIter<'a> {
         if let Some(item) = self.cursor.item() {
             if item.path().starts_with(self.parent_path) {
                 self.cursor
-                    .seek_forward(&PathSearch::Successor(item.path()), SeekBias::Left, &());
+                    .seek_forward(&PathSearch::Successor(item.path()), Bias::Left, &());
                 Some(item)
             } else {
                 None


### PR DESCRIPTION
Prior to this pull request, `Buffer` tracked how each insertion was split after subsequent edits. This was necessary because we represented a remote edit as a logical insertion id and a range into that insertion. Similarly, an anchor tracked a position within a logical insertion. Resolving a logical position to an actual offset required two tree traversal: one traversal to get the `FragmentId` of the insertion split spanning the offset, and one traversal to locate that fragment (using the `FragmentId`) in the tree tracking the current location of each fragment.

This approach didn't lend itself very well to batching (the order of a logical insertion id didn't match the order of fragments in the tree) and was problematic in some pathological cases where the user kept inserting between two existing fragments (i.e.,  generating a new `FragmentId` halved the remaining id space).

With these changes, edits and anchors rely less on the structure of the tree and more on the power of version vectors. Notice how the amount of information expressed with the above system can be also described in terms of an offset rooted at a particular version. By using a new `VersionedOffset` dimension for the tree and summarizing which insertions are present within a given node, we are now able to seek and slice the fragments tree as if it didn't include fragments newer or concurrent to the version which offset was at. This enables positions to be represented under a stable coordinate system that isn't susceptible to changes.

Moreover, these changes also allow users to send diffs to each other containing more than a single edit. In fact, knowing what the other person has seen so far (again, using a version vector), we can scan the local tree and produce a list of changes that can then be applied (in order) on the remote side.

We redesigned this part of the codebase in preparation to #6 and the architecture outlined in #80.