### PR TITLE
Introduce `Cursor::seek_start` and `Cursor::seek_end`

### DIFF
--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -1679,9 +1679,7 @@ impl Buffer {
                 bias,
                 version,
             } => {
-                let mut cursor = self
-                    .fragments
-                    .cursor::<VersionedOffset, (VersionedOffset, usize)>();
+                let mut cursor = self.fragments.cursor::<VersionedOffset, usize>();
                 cursor.seek(
                     &VersionedOffset::Offset(*offset),
                     *bias,
@@ -1689,12 +1687,12 @@ impl Buffer {
                 );
                 let fragment = cursor.item().unwrap();
                 let overshoot = if fragment.visible {
-                    offset - cursor.start().0.offset()
+                    offset - cursor.seek_start().offset()
                 } else {
                     0
                 };
 
-                self.text_summary_for_range(0..cursor.start().1 + overshoot)
+                self.text_summary_for_range(0..cursor.start() + overshoot)
             }
         }
     }
@@ -1713,14 +1711,14 @@ impl Buffer {
             } => {
                 let mut cursor = self
                     .fragments
-                    .cursor::<VersionedOffset, (VersionedOffset, FragmentTextSummary)>();
+                    .cursor::<VersionedOffset, FragmentTextSummary>();
                 cursor.seek(
                     &VersionedOffset::Offset(*offset),
                     *bias,
                     &Some(version.clone()),
                 );
-                let overshoot = offset - cursor.start().0.offset();
-                let summary = cursor.start().1;
+                let overshoot = offset - cursor.seek_start().offset();
+                let summary = cursor.start();
                 summary.visible + summary.deleted + overshoot
             }
         }

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -1210,7 +1210,7 @@ impl Buffer {
             old_fragments.slice(&VersionedOffset::Offset(ranges[0].start), Bias::Left, &cx);
         new_ropes.push_tree(new_fragments.summary().text);
 
-        let mut fragment_start = old_fragments.start().offset();
+        let mut fragment_start = old_fragments.sum_start().offset();
         for range in ranges {
             let fragment_end = old_fragments.end(&cx).offset();
 
@@ -1219,7 +1219,7 @@ impl Buffer {
             if fragment_end < range.start {
                 // If the current fragment has been partially consumed, then consume the rest of it
                 // and advance to the next fragment before slicing.
-                if fragment_start > old_fragments.start().offset() {
+                if fragment_start > old_fragments.sum_start().offset() {
                     if fragment_end > fragment_start {
                         let mut suffix = old_fragments.item().unwrap().clone();
                         suffix.len = fragment_end - fragment_start;
@@ -1233,7 +1233,7 @@ impl Buffer {
                     old_fragments.slice(&VersionedOffset::Offset(range.start), Bias::Left, &cx);
                 new_ropes.push_tree(slice.summary().text);
                 new_fragments.push_tree(slice, &None);
-                fragment_start = old_fragments.start().offset();
+                fragment_start = old_fragments.sum_start().offset();
             }
 
             // If we are at the end of a non-concurrent fragment, advance to the next one.
@@ -1244,7 +1244,7 @@ impl Buffer {
                 new_ropes.push_fragment(&fragment, fragment.visible);
                 new_fragments.push(fragment, &None);
                 old_fragments.next(&cx);
-                fragment_start = old_fragments.start().offset();
+                fragment_start = old_fragments.sum_start().offset();
             }
 
             // Skip over insertions that are concurrent to this edit, but have a lower lamport
@@ -1312,7 +1312,7 @@ impl Buffer {
 
         // If the current fragment has been partially consumed, then consume the rest of it
         // and advance to the next fragment before slicing.
-        if fragment_start > old_fragments.start().offset() {
+        if fragment_start > old_fragments.sum_start().offset() {
             let fragment_end = old_fragments.end(&cx).offset();
             if fragment_end > fragment_start {
                 let mut suffix = old_fragments.item().unwrap().clone();
@@ -1539,7 +1539,7 @@ impl Buffer {
         let mut new_fragments = old_fragments.slice(&ranges[0].start, Bias::Right, &None);
         new_ropes.push_tree(new_fragments.summary().text);
 
-        let mut fragment_start = old_fragments.start().visible;
+        let mut fragment_start = old_fragments.sum_start().visible;
         for range in ranges {
             let fragment_end = old_fragments.end(&None).visible;
 
@@ -1548,7 +1548,7 @@ impl Buffer {
             if fragment_end < range.start {
                 // If the current fragment has been partially consumed, then consume the rest of it
                 // and advance to the next fragment before slicing.
-                if fragment_start > old_fragments.start().visible {
+                if fragment_start > old_fragments.sum_start().visible {
                     if fragment_end > fragment_start {
                         let mut suffix = old_fragments.item().unwrap().clone();
                         suffix.len = fragment_end - fragment_start;
@@ -1561,10 +1561,10 @@ impl Buffer {
                 let slice = old_fragments.slice(&range.start, Bias::Right, &None);
                 new_ropes.push_tree(slice.summary().text);
                 new_fragments.push_tree(slice, &None);
-                fragment_start = old_fragments.start().visible;
+                fragment_start = old_fragments.sum_start().visible;
             }
 
-            let full_range_start = range.start + old_fragments.start().deleted;
+            let full_range_start = range.start + old_fragments.sum_start().deleted;
 
             // Preserve any portion of the current fragment that precedes this range.
             if fragment_start < range.start {
@@ -1612,13 +1612,13 @@ impl Buffer {
                 }
             }
 
-            let full_range_end = range.end + old_fragments.start().deleted;
+            let full_range_end = range.end + old_fragments.sum_start().deleted;
             edit.ranges.push(full_range_start..full_range_end);
         }
 
         // If the current fragment has been partially consumed, then consume the rest of it
         // and advance to the next fragment before slicing.
-        if fragment_start > old_fragments.start().visible {
+        if fragment_start > old_fragments.sum_start().visible {
             let fragment_end = old_fragments.end(&None).visible;
             if fragment_end > fragment_start {
                 let mut suffix = old_fragments.item().unwrap().clone();
@@ -1663,7 +1663,7 @@ impl Buffer {
             let mut cursor = self.fragments.cursor::<usize, FragmentTextSummary>();
             cursor.seek(&offset, bias, &None);
             Anchor::Middle {
-                offset: offset + cursor.start().deleted,
+                offset: offset + cursor.sum_start().deleted,
                 bias,
                 version: self.version(),
             }
@@ -1692,7 +1692,7 @@ impl Buffer {
                     0
                 };
 
-                self.text_summary_for_range(0..cursor.start() + overshoot)
+                self.text_summary_for_range(0..cursor.sum_start() + overshoot)
             }
         }
     }
@@ -1718,7 +1718,7 @@ impl Buffer {
                     &Some(version.clone()),
                 );
                 let overshoot = offset - cursor.seek_start().offset();
-                let summary = cursor.start();
+                let summary = cursor.sum_start();
                 summary.visible + summary.deleted + overshoot
             }
         }

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -128,10 +128,10 @@ impl Rope {
 
     pub fn to_point(&self, offset: usize) -> Point {
         assert!(offset <= self.summary().bytes);
-        let mut cursor = self.chunks.cursor::<usize, TextSummary>();
+        let mut cursor = self.chunks.cursor::<usize, Point>();
         cursor.seek(&offset, Bias::Left, &());
-        let overshoot = offset - cursor.start().bytes;
-        cursor.start().lines
+        let overshoot = offset - cursor.seek_start();
+        *cursor.start()
             + cursor
                 .item()
                 .map_or(Point::zero(), |chunk| chunk.to_point(overshoot))
@@ -139,17 +139,17 @@ impl Rope {
 
     pub fn to_offset(&self, point: Point) -> usize {
         assert!(point <= self.summary().lines);
-        let mut cursor = self.chunks.cursor::<Point, TextSummary>();
+        let mut cursor = self.chunks.cursor::<Point, usize>();
         cursor.seek(&point, Bias::Left, &());
-        let overshoot = point - cursor.start().lines;
-        cursor.start().bytes + cursor.item().map_or(0, |chunk| chunk.to_offset(overshoot))
+        let overshoot = point - cursor.seek_start();
+        cursor.start() + cursor.item().map_or(0, |chunk| chunk.to_offset(overshoot))
     }
 
     pub fn clip_offset(&self, mut offset: usize, bias: Bias) -> usize {
-        let mut cursor = self.chunks.cursor::<usize, usize>();
+        let mut cursor = self.chunks.cursor::<usize, ()>();
         cursor.seek(&offset, Bias::Left, &());
         if let Some(chunk) = cursor.item() {
-            let mut ix = offset - cursor.start();
+            let mut ix = offset - cursor.seek_start();
             while !chunk.0.is_char_boundary(ix) {
                 match bias {
                     Bias::Left => {
@@ -169,11 +169,11 @@ impl Rope {
     }
 
     pub fn clip_point(&self, point: Point, bias: Bias) -> Point {
-        let mut cursor = self.chunks.cursor::<Point, Point>();
+        let mut cursor = self.chunks.cursor::<Point, ()>();
         cursor.seek(&point, Bias::Right, &());
         if let Some(chunk) = cursor.item() {
-            let overshoot = point - cursor.start();
-            *cursor.start() + chunk.clip_point(overshoot, bias)
+            let overshoot = point - cursor.seek_start();
+            *cursor.seek_start() + chunk.clip_point(overshoot, bias)
         } else {
             self.summary().lines
         }
@@ -190,7 +190,7 @@ impl<'a> From<&'a str> for Rope {
 
 pub struct Cursor<'a> {
     rope: &'a Rope,
-    chunks: sum_tree::Cursor<'a, Chunk, usize, usize>,
+    chunks: sum_tree::Cursor<'a, Chunk, usize, ()>,
     offset: usize,
 }
 
@@ -222,18 +222,18 @@ impl<'a> Cursor<'a> {
 
         let mut slice = Rope::new();
         if let Some(start_chunk) = self.chunks.item() {
-            let start_ix = self.offset - self.chunks.start();
-            let end_ix = cmp::min(end_offset, self.chunks.end(&())) - self.chunks.start();
+            let start_ix = self.offset - self.chunks.seek_start();
+            let end_ix = cmp::min(end_offset, self.chunks.seek_end(&())) - self.chunks.seek_start();
             slice.push(&start_chunk.0[start_ix..end_ix]);
         }
 
-        if end_offset > self.chunks.end(&()) {
+        if end_offset > self.chunks.seek_end(&()) {
             self.chunks.next(&());
             slice.append(Rope {
                 chunks: self.chunks.slice(&end_offset, Bias::Right, &()),
             });
             if let Some(end_chunk) = self.chunks.item() {
-                let end_ix = end_offset - self.chunks.start();
+                let end_ix = end_offset - self.chunks.seek_start();
                 slice.push(&end_chunk.0[..end_ix]);
             }
         }
@@ -247,16 +247,16 @@ impl<'a> Cursor<'a> {
 
         let mut summary = TextSummary::default();
         if let Some(start_chunk) = self.chunks.item() {
-            let start_ix = self.offset - self.chunks.start();
-            let end_ix = cmp::min(end_offset, self.chunks.end(&())) - self.chunks.start();
+            let start_ix = self.offset - self.chunks.seek_start();
+            let end_ix = cmp::min(end_offset, self.chunks.seek_end(&())) - self.chunks.seek_start();
             summary = TextSummary::from(&start_chunk.0[start_ix..end_ix]);
         }
 
-        if end_offset > self.chunks.end(&()) {
+        if end_offset > self.chunks.seek_end(&()) {
             self.chunks.next(&());
             summary += &self.chunks.summary(&end_offset, Bias::Right, &());
             if let Some(end_chunk) = self.chunks.item() {
-                let end_ix = end_offset - self.chunks.start();
+                let end_ix = end_offset - self.chunks.seek_start();
                 summary += TextSummary::from(&end_chunk.0[..end_ix]);
             }
         }
@@ -274,7 +274,7 @@ impl<'a> Cursor<'a> {
 }
 
 pub struct Chunks<'a> {
-    chunks: sum_tree::Cursor<'a, Chunk, usize, usize>,
+    chunks: sum_tree::Cursor<'a, Chunk, usize, ()>,
     range: Range<usize>,
 }
 
@@ -286,11 +286,11 @@ impl<'a> Chunks<'a> {
     }
 
     pub fn offset(&self) -> usize {
-        self.range.start.max(*self.chunks.start())
+        self.range.start.max(*self.chunks.seek_start())
     }
 
     pub fn seek(&mut self, offset: usize) {
-        if offset >= self.chunks.end(&()) {
+        if offset >= self.chunks.seek_end(&()) {
             self.chunks.seek_forward(&offset, Bias::Right, &());
         } else {
             self.chunks.seek(&offset, Bias::Right, &());
@@ -300,10 +300,10 @@ impl<'a> Chunks<'a> {
 
     pub fn peek(&self) -> Option<&'a str> {
         if let Some(chunk) = self.chunks.item() {
-            let offset = *self.chunks.start();
+            let offset = *self.chunks.seek_start();
             if self.range.end > offset {
-                let start = self.range.start.saturating_sub(*self.chunks.start());
-                let end = self.range.end - self.chunks.start();
+                let start = self.range.start.saturating_sub(*self.chunks.seek_start());
+                let end = self.range.end - self.chunks.seek_start();
                 return Some(&chunk.0[start..chunk.0.len().min(end)]);
             }
         }

--- a/zed/src/editor/buffer/rope.rs
+++ b/zed/src/editor/buffer/rope.rs
@@ -131,7 +131,7 @@ impl Rope {
         let mut cursor = self.chunks.cursor::<usize, Point>();
         cursor.seek(&offset, Bias::Left, &());
         let overshoot = offset - cursor.seek_start();
-        *cursor.start()
+        *cursor.sum_start()
             + cursor
                 .item()
                 .map_or(Point::zero(), |chunk| chunk.to_point(overshoot))
@@ -142,7 +142,7 @@ impl Rope {
         let mut cursor = self.chunks.cursor::<Point, usize>();
         cursor.seek(&point, Bias::Left, &());
         let overshoot = point - cursor.seek_start();
-        cursor.start() + cursor.item().map_or(0, |chunk| chunk.to_offset(overshoot))
+        cursor.sum_start() + cursor.item().map_or(0, |chunk| chunk.to_offset(overshoot))
     }
 
     pub fn clip_offset(&self, mut offset: usize, bias: Bias) -> usize {

--- a/zed/src/sum_tree.rs
+++ b/zed/src/sum_tree.rs
@@ -651,7 +651,7 @@ mod tests {
                 cursor.seek(&Count(pos), Bias::Right, &());
 
                 for i in 0..10 {
-                    assert_eq!(cursor.start().0, pos);
+                    assert_eq!(cursor.sum_start().0, pos);
 
                     if pos > 0 {
                         assert_eq!(cursor.prev_item().unwrap(), &reference_items[pos - 1]);
@@ -710,7 +710,7 @@ mod tests {
         );
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), None);
-        assert_eq!(cursor.start(), &Sum(0));
+        assert_eq!(cursor.sum_start(), &Sum(0));
 
         // Single-element tree
         let mut tree = SumTree::<u8>::new();
@@ -722,23 +722,23 @@ mod tests {
         );
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
-        assert_eq!(cursor.start(), &Sum(0));
+        assert_eq!(cursor.sum_start(), &Sum(0));
 
         cursor.next(&());
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&1));
-        assert_eq!(cursor.start(), &Sum(1));
+        assert_eq!(cursor.sum_start(), &Sum(1));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
-        assert_eq!(cursor.start(), &Sum(0));
+        assert_eq!(cursor.sum_start(), &Sum(0));
 
         let mut cursor = tree.cursor::<Count, Sum>();
         assert_eq!(cursor.slice(&Count(1), Bias::Right, &()).items(&()), [1]);
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&1));
-        assert_eq!(cursor.start(), &Sum(1));
+        assert_eq!(cursor.sum_start(), &Sum(1));
 
         cursor.seek(&Count(0), Bias::Right, &());
         assert_eq!(
@@ -749,7 +749,7 @@ mod tests {
         );
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&1));
-        assert_eq!(cursor.start(), &Sum(1));
+        assert_eq!(cursor.sum_start(), &Sum(1));
 
         // Multiple-element tree
         let mut tree = SumTree::new();
@@ -759,68 +759,68 @@ mod tests {
         assert_eq!(cursor.slice(&Count(2), Bias::Right, &()).items(&()), [1, 2]);
         assert_eq!(cursor.item(), Some(&3));
         assert_eq!(cursor.prev_item(), Some(&2));
-        assert_eq!(cursor.start(), &Sum(3));
+        assert_eq!(cursor.sum_start(), &Sum(3));
 
         cursor.next(&());
         assert_eq!(cursor.item(), Some(&4));
         assert_eq!(cursor.prev_item(), Some(&3));
-        assert_eq!(cursor.start(), &Sum(6));
+        assert_eq!(cursor.sum_start(), &Sum(6));
 
         cursor.next(&());
         assert_eq!(cursor.item(), Some(&5));
         assert_eq!(cursor.prev_item(), Some(&4));
-        assert_eq!(cursor.start(), &Sum(10));
+        assert_eq!(cursor.sum_start(), &Sum(10));
 
         cursor.next(&());
         assert_eq!(cursor.item(), Some(&6));
         assert_eq!(cursor.prev_item(), Some(&5));
-        assert_eq!(cursor.start(), &Sum(15));
+        assert_eq!(cursor.sum_start(), &Sum(15));
 
         cursor.next(&());
         cursor.next(&());
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&6));
-        assert_eq!(cursor.start(), &Sum(21));
+        assert_eq!(cursor.sum_start(), &Sum(21));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&6));
         assert_eq!(cursor.prev_item(), Some(&5));
-        assert_eq!(cursor.start(), &Sum(15));
+        assert_eq!(cursor.sum_start(), &Sum(15));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&5));
         assert_eq!(cursor.prev_item(), Some(&4));
-        assert_eq!(cursor.start(), &Sum(10));
+        assert_eq!(cursor.sum_start(), &Sum(10));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&4));
         assert_eq!(cursor.prev_item(), Some(&3));
-        assert_eq!(cursor.start(), &Sum(6));
+        assert_eq!(cursor.sum_start(), &Sum(6));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&3));
         assert_eq!(cursor.prev_item(), Some(&2));
-        assert_eq!(cursor.start(), &Sum(3));
+        assert_eq!(cursor.sum_start(), &Sum(3));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&2));
         assert_eq!(cursor.prev_item(), Some(&1));
-        assert_eq!(cursor.start(), &Sum(1));
+        assert_eq!(cursor.sum_start(), &Sum(1));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
-        assert_eq!(cursor.start(), &Sum(0));
+        assert_eq!(cursor.sum_start(), &Sum(0));
 
         cursor.prev(&());
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), None);
-        assert_eq!(cursor.start(), &Sum(0));
+        assert_eq!(cursor.sum_start(), &Sum(0));
 
         cursor.next(&());
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
-        assert_eq!(cursor.start(), &Sum(0));
+        assert_eq!(cursor.sum_start(), &Sum(0));
 
         let mut cursor = tree.cursor::<Count, Sum>();
         assert_eq!(
@@ -831,7 +831,7 @@ mod tests {
         );
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&6));
-        assert_eq!(cursor.start(), &Sum(21));
+        assert_eq!(cursor.sum_start(), &Sum(21));
 
         cursor.seek(&Count(3), Bias::Right, &());
         assert_eq!(
@@ -842,7 +842,7 @@ mod tests {
         );
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&6));
-        assert_eq!(cursor.start(), &Sum(21));
+        assert_eq!(cursor.sum_start(), &Sum(21));
 
         // Seeking can bias left or right
         cursor.seek(&Count(1), Bias::Left, &());

--- a/zed/src/sum_tree.rs
+++ b/zed/src/sum_tree.rs
@@ -37,18 +37,6 @@ impl<'a, T: Summary> Dimension<'a, T> for () {
     fn add_summary(&mut self, _: &'a T, _: &T::Context) {}
 }
 
-impl<'a, S, D1, D2> Dimension<'a, S> for (D1, D2)
-where
-    S: Summary,
-    D1: Dimension<'a, S>,
-    D2: Dimension<'a, S>,
-{
-    fn add_summary(&mut self, summary: &'a S, cx: &S::Context) {
-        self.0.add_summary(summary, cx);
-        self.1.add_summary(summary, cx);
-    }
-}
-
 pub trait SeekDimension<'a, T: Summary>: Dimension<'a, T> {
     fn cmp(&self, other: &Self, cx: &T::Context) -> Ordering;
 }

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -45,6 +45,10 @@ where
         self.sum_dimension = U::default();
     }
 
+    pub fn seek_start(&self) -> &S {
+        &self.seek_dimension
+    }
+
     pub fn start(&self) -> &U {
         &self.sum_dimension
     }

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -59,17 +59,17 @@ where
         }
     }
 
-    pub fn start(&self) -> &U {
+    pub fn sum_start(&self) -> &U {
         &self.sum_dimension
     }
 
     pub fn end(&self, cx: &<T::Summary as Summary>::Context) -> U {
         if let Some(item_summary) = self.item_summary() {
-            let mut end = self.start().clone();
+            let mut end = self.sum_start().clone();
             end.add_summary(item_summary, cx);
             end
         } else {
-            self.start().clone()
+            self.sum_start().clone()
         }
     }
 
@@ -627,7 +627,7 @@ where
     }
 
     pub fn start(&self) -> &U {
-        self.cursor.start()
+        self.cursor.sum_start()
     }
 
     pub fn item(&self) -> Option<&'a T> {

--- a/zed/src/sum_tree/cursor.rs
+++ b/zed/src/sum_tree/cursor.rs
@@ -49,6 +49,16 @@ where
         &self.seek_dimension
     }
 
+    pub fn seek_end(&self, cx: &<T::Summary as Summary>::Context) -> S {
+        if let Some(item_summary) = self.item_summary() {
+            let mut end = self.seek_start().clone();
+            end.add_summary(item_summary, cx);
+            end
+        } else {
+            self.seek_start().clone()
+        }
+    }
+
     pub fn start(&self) -> &U {
         &self.sum_dimension
     }

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -1290,8 +1290,8 @@ impl WorktreeHandle for ModelHandle<Worktree> {
 }
 
 pub enum FileIter<'a> {
-    All(Cursor<'a, Entry, FileCount, FileCount>),
-    Visible(Cursor<'a, Entry, VisibleFileCount, VisibleFileCount>),
+    All(Cursor<'a, Entry, FileCount, ()>),
+    Visible(Cursor<'a, Entry, VisibleFileCount, ()>),
 }
 
 impl<'a> FileIter<'a> {
@@ -1310,11 +1310,11 @@ impl<'a> FileIter<'a> {
     fn next_internal(&mut self) {
         match self {
             Self::All(cursor) => {
-                let ix = *cursor.start();
+                let ix = *cursor.seek_start();
                 cursor.seek_forward(&FileCount(ix.0 + 1), Bias::Right, &());
             }
             Self::Visible(cursor) => {
-                let ix = *cursor.start();
+                let ix = *cursor.seek_start();
                 cursor.seek_forward(&VisibleFileCount(ix.0 + 1), Bias::Right, &());
             }
         }


### PR DESCRIPTION
Our codebase contains a pattern that is pretty frequent when using a `SumTree`: we typically seek in one dimension, compute an overshoot with respect to that dimension and then add such overshoot to a second sum dimension. However, given that `Cursor` wouldn't expose the seek dimension, we would perform the same computation twice as part of the sum dimension so that we could determine the overshoot as explained above. This is especially bad for dimensions whose `add_summary` method is non-trivial, e.g. `VersionedOffset` where we have to inspect a version vector in order to properly determine how much the dimension should advance forward.

This pull request renames `Cursor::{start,end}` to `Cursor::{sum_start,sum_end}` and it introduces `Cursor::{seek_start,seek_end}`. As part of this, I audited all the code paths that contained that double computation and used the new `seek_start` and `seek_end` methods there too.

/cc: @nathansobo @maxbrunsfeld 