### PR TITLE
Ensure all bytes are written when saving a buffer

### DIFF
--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -208,7 +208,7 @@ impl Worktree {
             let file = fs::File::create(&abs_path)?;
             let mut writer = io::BufWriter::with_capacity(buffer_size, &file);
             for chunk in content.chunks() {
-                writer.write(chunk.as_bytes())?;
+                writer.write_all(chunk.as_bytes())?;
             }
             writer.flush()?;
 


### PR DESCRIPTION
In the process of working on the RPC system, I noticed that our `save` implementation was subtly broken. I didn't run into any issue with it, but figured we should fix it real quick before it pops out in production.

This pull request replaces `write` with `write_all` to ensure all the bytes are actually written to disk, as `write` might only save a prefix of the in-memory buffer.

/cc: @nathansobo @maxbrunsfeld 