### PR TITLE
Fix URL to `PathBuf` conversion in `mac::Platform`

### DIFF
--- a/gpui/src/platform/mac/platform.rs
+++ b/gpui/src/platform/mac/platform.rs
@@ -317,15 +317,10 @@ impl platform::Platform for MacPlatform {
             let block = ConcreteBlock::new(move |response: NSModalResponse| {
                 let result = if response == NSModalResponse::NSModalResponseOk {
                     let url = panel.URL();
-                    let string = url.absoluteString();
-                    let string = std::ffi::CStr::from_ptr(string.UTF8String())
+                    let path = std::ffi::CStr::from_ptr(url.path().UTF8String())
                         .to_string_lossy()
                         .to_string();
-                    if let Some(path) = string.strip_prefix("file://") {
-                        Some(PathBuf::from(path))
-                    } else {
-                        None
-                    }
+                    Some(PathBuf::from(path))
                 } else {
                     None
                 };

--- a/gpui/src/platform/mac/platform.rs
+++ b/gpui/src/platform/mac/platform.rs
@@ -283,13 +283,10 @@ impl platform::Platform for MacPlatform {
                     let urls = panel.URLs();
                     for i in 0..urls.count() {
                         let url = urls.objectAtIndex(i);
-                        let string = url.absoluteString();
-                        let string = std::ffi::CStr::from_ptr(string.UTF8String())
+                        let path = std::ffi::CStr::from_ptr(url.path().UTF8String())
                             .to_string_lossy()
                             .to_string();
-                        if let Some(path) = string.strip_prefix("file://") {
-                            result.push(PathBuf::from(path));
-                        }
+                        result.push(PathBuf::from(path));
                     }
                     Some(result)
                 } else {


### PR DESCRIPTION
Fixes #99 

Previously we were using `[URL absoluteString]` to convert the URIs returned from the open and save panels into `PathBuf`s. However, getting the absolute string will leave the path into a URL-encoded form, which was causing errors when trying to open or save files that contained a whitespace in them because it was being escaped as `%20`.

Given that we are working with local files, this pull request uses [`[URL path]`](https://developer.apple.com/documentation/foundation/url/1779812-path) instead, which will re-encode the URL into a well-formed path when it starts with `file://`.