### PR TITLE
Relay the saved mtime when saving a buffer

### DIFF
--- a/zed-rpc/proto/zed.proto
+++ b/zed-rpc/proto/zed.proto
@@ -109,6 +109,7 @@ message BufferSaved {
     uint64 worktree_id = 1;
     uint64 buffer_id = 2;
     repeated VectorClockEntry version = 3;
+    Timestamp mtime = 4;
 }
 
 message User {


### PR DESCRIPTION
Fixes #105 

With this pull request we will transmit the saved `mtime` alongside the version that the buffer was last saved at. Without doing so, we would never update the `saved_mtime` field on the buffer, thus causing the buffer to be in a conflicting state when the remote worktree's `File` got updated with the new mtime.

/cc: @maxbrunsfeld @nathansobo 