### PR TITLE
Decouple our fs module from details of the Worktree

### DIFF
--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -15,11 +15,12 @@ use sqlx::{
 use std::{path::Path, sync::Arc};
 use zed::{
     editor::Editor,
+    fs::{FakeFs, Fs as _},
     language::LanguageRegistry,
     rpc::Client,
     settings,
     test::Channel,
-    worktree::{FakeFs, Fs as _, Worktree},
+    worktree::Worktree,
 };
 use zrpc::{ForegroundRouter, Peer, Router};
 

--- a/zed/src/editor/buffer.rs
+++ b/zed/src/editor/buffer.rs
@@ -2732,9 +2732,10 @@ impl ToPoint for usize {
 mod tests {
     use super::*;
     use crate::{
+        fs::RealFs,
         test::{build_app_state, temp_tree},
         util::RandomCharIter,
-        worktree::{RealFs, Worktree, WorktreeHandle},
+        worktree::{Worktree, WorktreeHandle as _},
     };
     use gpui::ModelHandle;
     use rand::prelude::*;

--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -457,9 +457,9 @@ mod tests {
     use super::*;
     use crate::{
         editor,
+        fs::FakeFs,
         test::{build_app_state, temp_tree},
         workspace::Workspace,
-        worktree::FakeFs,
     };
     use serde_json::json;
     use std::fs;

--- a/zed/src/fs.rs
+++ b/zed/src/fs.rs
@@ -1,4 +1,4 @@
-use super::Rope;
+use super::editor::Rope;
 use anyhow::{anyhow, Result};
 use fsevent::EventStream;
 use futures::{Stream, StreamExt};

--- a/zed/src/lib.rs
+++ b/zed/src/lib.rs
@@ -3,6 +3,7 @@ use zrpc::ForegroundRouter;
 pub mod assets;
 pub mod editor;
 pub mod file_finder;
+pub mod fs;
 pub mod language;
 pub mod menus;
 mod operation_queue;
@@ -21,7 +22,7 @@ pub struct AppState {
     pub languages: std::sync::Arc<language::LanguageRegistry>,
     pub rpc_router: std::sync::Arc<ForegroundRouter>,
     pub rpc: rpc::Client,
-    pub fs: std::sync::Arc<dyn worktree::Fs>,
+    pub fs: std::sync::Arc<dyn fs::Fs>,
 }
 
 pub fn init(cx: &mut gpui::MutableAppContext) {

--- a/zed/src/main.rs
+++ b/zed/src/main.rs
@@ -6,9 +6,11 @@ use log::LevelFilter;
 use simplelog::SimpleLogger;
 use std::{fs, path::PathBuf, sync::Arc};
 use zed::{
-    self, assets, editor, file_finder, language, menus, rpc, settings,
+    self, assets, editor, file_finder,
+    fs::RealFs,
+    language, menus, rpc, settings,
     workspace::{self, OpenParams},
-    worktree::{self, RealFs},
+    worktree::{self},
     AppState,
 };
 use zrpc::ForegroundRouter;

--- a/zed/src/test.rs
+++ b/zed/src/test.rs
@@ -1,6 +1,4 @@
-use crate::{
-    language::LanguageRegistry, rpc, settings, time::ReplicaId, worktree::RealFs, AppState,
-};
+use crate::{fs::RealFs, language::LanguageRegistry, rpc, settings, time::ReplicaId, AppState};
 use gpui::AppContext;
 use std::{
     path::{Path, PathBuf},

--- a/zed/src/workspace.rs
+++ b/zed/src/workspace.rs
@@ -3,10 +3,11 @@ pub mod pane_group;
 
 use crate::{
     editor::{Buffer, Editor},
+    fs::Fs,
     language::LanguageRegistry,
     rpc,
     settings::Settings,
-    worktree::{File, Fs, Worktree},
+    worktree::{File, Worktree},
     AppState,
 };
 use anyhow::{anyhow, Result};
@@ -921,8 +922,9 @@ mod tests {
     use super::*;
     use crate::{
         editor::Editor,
+        fs::FakeFs,
         test::{build_app_state, temp_tree},
-        worktree::{FakeFs, WorktreeHandle},
+        worktree::WorktreeHandle,
     };
     use serde_json::json;
     use std::{collections::HashSet, fs};

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -37,7 +37,10 @@ use std::{
     future::Future,
     ops::Deref,
     path::{Path, PathBuf},
-    sync::{atomic::AtomicUsize, Arc},
+    sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        Arc,
+    },
     time::{Duration, SystemTime},
 };
 use zrpc::{ForegroundRouter, PeerId, TypedEnvelope};
@@ -588,12 +591,11 @@ impl LocalWorktree {
             .file_name()
             .map_or(String::new(), |f| f.to_string_lossy().to_string());
         let root_char_bag = root_name.chars().map(|c| c.to_ascii_lowercase()).collect();
-        let entry = fs
-            .entry(root_char_bag, &next_entry_id, path.clone(), &abs_path)
+        let metadata = fs
+            .metadata(&abs_path)
             .await?
             .ok_or_else(|| anyhow!("root entry does not exist"))?;
-        let is_dir = entry.is_dir();
-        if is_dir {
+        if metadata.is_dir {
             root_name.push('/');
         }
 
@@ -612,7 +614,19 @@ impl LocalWorktree {
                 removed_entry_ids: Default::default(),
                 next_entry_id: Arc::new(next_entry_id),
             };
-            snapshot.insert_entry(entry);
+            snapshot.insert_entry(Entry {
+                id: snapshot.next_entry_id.fetch_add(1, SeqCst),
+                kind: if metadata.is_dir {
+                    EntryKind::PendingDir
+                } else {
+                    EntryKind::File(char_bag_for_path(root_char_bag, &path))
+                },
+                path: Arc::from(path),
+                inode: metadata.ino,
+                mtime: metadata.mtime,
+                is_symlink: metadata.is_symlink,
+                is_ignored: false,
+            });
 
             let tree = Self {
                 snapshot: snapshot.clone(),
@@ -1558,6 +1572,27 @@ pub enum EntryKind {
 }
 
 impl Entry {
+    fn new(
+        path: Arc<Path>,
+        metadata: &fs::Metadata,
+        next_entry_id: &AtomicUsize,
+        root_char_bag: CharBag,
+    ) -> Self {
+        Self {
+            id: next_entry_id.fetch_add(1, SeqCst),
+            kind: if metadata.is_dir {
+                EntryKind::PendingDir
+            } else {
+                EntryKind::File(char_bag_for_path(root_char_bag, &path))
+            },
+            path,
+            inode: metadata.ino,
+            mtime: metadata.mtime,
+            is_symlink: metadata.is_symlink,
+            is_ignored: false,
+        }
+    }
+
     pub fn path(&self) -> &Arc<Path> {
         &self.path
     }
@@ -1878,32 +1913,27 @@ impl BackgroundScanner {
         let mut ignore_stack = job.ignore_stack.clone();
         let mut new_ignore = None;
 
-        let mut child_entries = self
-            .fs
-            .child_entries(
-                root_char_bag,
-                next_entry_id.as_ref(),
-                &job.path,
-                &job.abs_path,
-            )
-            .await?;
-        while let Some(child_entry) = child_entries.next().await {
-            let mut child_entry = match child_entry {
-                Ok(child_entry) => child_entry,
+        let mut child_paths = self.fs.read_dir(&job.abs_path).await?;
+        while let Some(child_abs_path) = child_paths.next().await {
+            let child_abs_path = match child_abs_path {
+                Ok(child_abs_path) => child_abs_path,
                 Err(error) => {
                     log::error!("error processing entry {:?}", error);
                     continue;
                 }
             };
-            let child_name = child_entry.path.file_name().unwrap();
-            let child_abs_path = job.abs_path.join(&child_name);
-            let child_path = child_entry.path.clone();
+            let child_name = child_abs_path.file_name().unwrap();
+            let child_path: Arc<Path> = job.path.join(child_name).into();
+            let child_metadata = match self.fs.metadata(&child_abs_path).await? {
+                Some(metadata) => metadata,
+                None => continue,
+            };
 
             // If we find a .gitignore, add it to the stack of ignores used to determine which paths are ignored
             if child_name == *GITIGNORE {
                 let (ignore, err) = Gitignore::new(&child_abs_path);
                 if let Some(err) = err {
-                    log::error!("error in ignore file {:?} - {:?}", child_entry.path, err);
+                    log::error!("error in ignore file {:?} - {:?}", child_name, err);
                 }
                 let ignore = Arc::new(ignore);
                 ignore_stack = ignore_stack.append(job.path.clone(), ignore.clone());
@@ -1926,7 +1956,14 @@ impl BackgroundScanner {
                 }
             }
 
-            if child_entry.is_dir() {
+            let mut child_entry = Entry::new(
+                child_path.clone(),
+                &child_metadata,
+                &next_entry_id,
+                root_char_bag,
+            );
+
+            if child_metadata.is_dir {
                 let is_ignored = ignore_stack.is_path_ignored(&child_path, true);
                 child_entry.is_ignored = is_ignored;
                 new_entries.push(child_entry);
@@ -1999,22 +2036,18 @@ impl BackgroundScanner {
                 }
             };
 
-            match self
-                .fs
-                .entry(
-                    snapshot.root_char_bag,
-                    &next_entry_id,
-                    path.clone(),
-                    &event.path,
-                )
-                .await
-            {
-                Ok(Some(mut fs_entry)) => {
-                    let is_dir = fs_entry.is_dir();
-                    let ignore_stack = snapshot.ignore_stack_for_path(&path, is_dir);
+            match self.fs.metadata(&event.path).await {
+                Ok(Some(metadata)) => {
+                    let ignore_stack = snapshot.ignore_stack_for_path(&path, metadata.is_dir);
+                    let mut fs_entry = Entry::new(
+                        path.clone(),
+                        &metadata,
+                        snapshot.next_entry_id.as_ref(),
+                        snapshot.root_char_bag,
+                    );
                     fs_entry.is_ignored = ignore_stack.is_all();
                     snapshot.insert_entry(fs_entry);
-                    if is_dir {
+                    if metadata.is_dir {
                         scan_queue_tx
                             .send(ScanJob {
                                 abs_path: event.path,
@@ -2166,10 +2199,14 @@ async fn refresh_entry(
         root_char_bag = snapshot.root_char_bag;
         next_entry_id = snapshot.next_entry_id.clone();
     }
-    let entry = fs
-        .entry(root_char_bag, &next_entry_id, path, abs_path)
-        .await?
-        .ok_or_else(|| anyhow!("could not read saved file metadata"))?;
+    let entry = Entry::new(
+        path,
+        &fs.metadata(abs_path)
+            .await?
+            .ok_or_else(|| anyhow!("could not read saved file metadata"))?,
+        &next_entry_id,
+        root_char_bag,
+    );
     Ok(snapshot.lock().insert_entry(entry))
 }
 
@@ -2918,16 +2955,14 @@ mod tests {
                 root_char_bag: Default::default(),
                 next_entry_id: next_entry_id.clone(),
             };
-            initial_snapshot.insert_entry(
-                smol::block_on(fs.entry(
-                    Default::default(),
-                    &next_entry_id,
-                    Path::new("").into(),
-                    root_dir.path().into(),
-                ))
-                .unwrap()
-                .unwrap(),
-            );
+            initial_snapshot.insert_entry(Entry::new(
+                Path::new("").into(),
+                &smol::block_on(fs.metadata(root_dir.path()))
+                    .unwrap()
+                    .unwrap(),
+                &next_entry_id,
+                Default::default(),
+            ));
             let mut scanner = BackgroundScanner::new(
                 Arc::new(Mutex::new(initial_snapshot.clone())),
                 notify_tx,

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -621,7 +621,7 @@ impl LocalWorktree {
                     EntryKind::File(char_bag_for_path(root_char_bag, &path))
                 },
                 path: Arc::from(path),
-                inode: metadata.ino,
+                inode: metadata.inode,
                 mtime: metadata.mtime,
                 is_symlink: metadata.is_symlink,
                 is_ignored: false,
@@ -1585,7 +1585,7 @@ impl Entry {
                 EntryKind::File(char_bag_for_path(root_char_bag, &path))
             },
             path,
-            inode: metadata.ino,
+            inode: metadata.inode,
             mtime: metadata.mtime,
             is_symlink: metadata.is_symlink,
             is_ignored: false,

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -613,19 +613,12 @@ impl LocalWorktree {
                 removed_entry_ids: Default::default(),
                 next_entry_id: Arc::new(next_entry_id),
             };
-            snapshot.insert_entry(Entry {
-                id: snapshot.next_entry_id.fetch_add(1, SeqCst),
-                kind: if metadata.is_dir {
-                    EntryKind::PendingDir
-                } else {
-                    EntryKind::File(char_bag_for_path(root_char_bag, &path))
-                },
-                path: Arc::from(path),
-                inode: metadata.inode,
-                mtime: metadata.mtime,
-                is_symlink: metadata.is_symlink,
-                is_ignored: false,
-            });
+            snapshot.insert_entry(Entry::new(
+                path.into(),
+                &metadata,
+                &snapshot.next_entry_id,
+                snapshot.root_char_bag,
+            ));
 
             let tree = Self {
                 snapshot: snapshot.clone(),

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -1,11 +1,11 @@
 mod char_bag;
-mod fs;
 mod fuzzy;
 mod ignore;
 
 use self::{char_bag::CharBag, ignore::IgnoreStack};
 use crate::{
     editor::{self, Buffer, History, Operation, Rope},
+    fs::{self, Fs},
     language::LanguageRegistry,
     rpc::{self, proto},
     sum_tree::{self, Cursor, Edit, SumTree},
@@ -14,7 +14,6 @@ use crate::{
 };
 use ::ignore::gitignore::Gitignore;
 use anyhow::{anyhow, Result};
-pub use fs::*;
 use futures::{Stream, StreamExt};
 pub use fuzzy::{match_paths, PathMatch};
 use gpui::{
@@ -2571,6 +2570,7 @@ mod tests {
     use super::*;
     use crate::test::*;
     use anyhow::Result;
+    use fs::RealFs;
     use rand::prelude::*;
     use serde_json::json;
     use std::time::UNIX_EPOCH;


### PR DESCRIPTION
This is a small refactor that makes the `Fs` trait more of a direct shim for the standard `fs` APIs, instead of containing some of our implementation logic for the worktree (dealing with CharBag for fuzzy matching, and `id` for rename detection).