### PR TITLE
Fix panic when fuzzy-matching on a `Worktree` that contains no files

### DIFF
--- a/zed/src/worktree/fuzzy.rs
+++ b/zed/src/worktree/fuzzy.rs
@@ -64,18 +64,21 @@ pub async fn match_paths<'a, T>(
 where
     T: Clone + Send + Iterator<Item = &'a Snapshot> + 'a,
 {
+    let path_count: usize = if include_ignored {
+        snapshots.clone().map(Snapshot::file_count).sum()
+    } else {
+        snapshots.clone().map(Snapshot::visible_file_count).sum()
+    };
+    if path_count == 0 {
+        return Vec::new();
+    }
+
     let lowercase_query = query.to_lowercase().chars().collect::<Vec<_>>();
     let query = query.chars().collect::<Vec<_>>();
 
     let lowercase_query = &lowercase_query;
     let query = &query;
     let query_chars = CharBag::from(&lowercase_query[..]);
-
-    let path_count: usize = if include_ignored {
-        snapshots.clone().map(Snapshot::file_count).sum()
-    } else {
-        snapshots.clone().map(Snapshot::visible_file_count).sum()
-    };
 
     let num_cpus = background.num_cpus().min(path_count);
     let segment_size = (path_count + num_cpus - 1) / num_cpus;


### PR DESCRIPTION
As part of our work on the deterministic executor, in c4e37dc we fixed a bug that occurred when there were more CPUs than paths to fuzzy-match on.

However, that introduced another bug that caused Zed to panic when trying to calculate how many paths should be fuzzy-matched by each available worker thread for worktrees that didn't contain any file.

To fix the panic, this pull request adds a guard clause at the beginning of `fuzzy::match_paths` that bails out early if the vector of paths to search is empty.

/cc: @nathansobo @maxbrunsfeld 