### PR TITLE
Fix error when saving an untitled file outside of any existing worktree

### DIFF
--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -3,7 +3,7 @@ use crate::{
     settings::Settings,
     util,
     workspace::Workspace,
-    worktree::{match_paths, PathMatch, Worktree},
+    worktree::{match_paths, PathMatch},
 };
 use gpui::{
     color::ColorF,
@@ -132,9 +132,12 @@ impl FileFinder {
                 let finder = finder.read(cx);
                 let start = range.start;
                 range.end = cmp::min(range.end, finder.matches.len());
-                items.extend(finder.matches[range].iter().enumerate().filter_map(
-                    move |(i, path_match)| finder.render_match(path_match, start + i, cx),
-                ));
+                items.extend(
+                    finder.matches[range]
+                        .iter()
+                        .enumerate()
+                        .map(move |(i, path_match)| finder.render_match(path_match, start + i)),
+                );
             },
         );
 
@@ -143,128 +146,108 @@ impl FileFinder {
             .named("matches")
     }
 
-    fn render_match(
-        &self,
-        path_match: &PathMatch,
-        index: usize,
-        cx: &AppContext,
-    ) -> Option<ElementBox> {
+    fn render_match(&self, path_match: &PathMatch, index: usize) -> ElementBox {
         let settings = self.settings.borrow();
         let theme = &settings.theme.ui;
-        self.labels_for_match(path_match, cx).map(
-            |(file_name, file_name_positions, full_path, full_path_positions)| {
-                let bold = *Properties::new().weight(Weight::BOLD);
-                let selected_index = self.selected_index();
-                let mut container = Container::new(
-                    Flex::row()
-                        .with_child(
-                            Container::new(
-                                LineBox::new(
+        let (file_name, file_name_positions, full_path, full_path_positions) =
+            self.labels_for_match(path_match);
+        let bold = *Properties::new().weight(Weight::BOLD);
+        let selected_index = self.selected_index();
+        let mut container = Container::new(
+            Flex::row()
+                .with_child(
+                    Container::new(
+                        LineBox::new(
+                            settings.ui_font_family,
+                            settings.ui_font_size,
+                            Svg::new("icons/file-16.svg").boxed(),
+                        )
+                        .boxed(),
+                    )
+                    .with_padding_right(6.0)
+                    .boxed(),
+                )
+                .with_child(
+                    Expanded::new(
+                        1.0,
+                        Flex::column()
+                            .with_child(
+                                Label::new(
+                                    file_name.to_string(),
                                     settings.ui_font_family,
                                     settings.ui_font_size,
-                                    Svg::new("icons/file-16.svg").boxed(),
+                                )
+                                .with_default_color(theme.modal_match_text.0)
+                                .with_highlights(
+                                    theme.modal_match_text_highlight.0,
+                                    bold,
+                                    file_name_positions,
                                 )
                                 .boxed(),
                             )
-                            .with_padding_right(6.0)
-                            .boxed(),
-                        )
-                        .with_child(
-                            Expanded::new(
-                                1.0,
-                                Flex::column()
-                                    .with_child(
-                                        Label::new(
-                                            file_name.to_string(),
-                                            settings.ui_font_family,
-                                            settings.ui_font_size,
-                                        )
-                                        .with_default_color(theme.modal_match_text.0)
-                                        .with_highlights(
-                                            theme.modal_match_text_highlight.0,
-                                            bold,
-                                            file_name_positions,
-                                        )
-                                        .boxed(),
-                                    )
-                                    .with_child(
-                                        Label::new(
-                                            full_path,
-                                            settings.ui_font_family,
-                                            settings.ui_font_size,
-                                        )
-                                        .with_default_color(theme.modal_match_text.0)
-                                        .with_highlights(
-                                            theme.modal_match_text_highlight.0,
-                                            bold,
-                                            full_path_positions,
-                                        )
-                                        .boxed(),
-                                    )
-                                    .boxed(),
+                            .with_child(
+                                Label::new(
+                                    full_path,
+                                    settings.ui_font_family,
+                                    settings.ui_font_size,
+                                )
+                                .with_default_color(theme.modal_match_text.0)
+                                .with_highlights(
+                                    theme.modal_match_text_highlight.0,
+                                    bold,
+                                    full_path_positions,
+                                )
+                                .boxed(),
                             )
                             .boxed(),
-                        )
-                        .boxed(),
+                    )
+                    .boxed(),
                 )
-                .with_uniform_padding(6.0)
-                .with_background_color(if index == selected_index {
-                    theme.modal_match_background_active.0
-                } else {
-                    theme.modal_match_background.0
-                });
-
-                if index == selected_index || index < self.matches.len() - 1 {
-                    container =
-                        container.with_border(Border::bottom(1.0, theme.modal_match_border));
-                }
-
-                let entry = (path_match.tree_id, path_match.path.clone());
-                EventHandler::new(container.boxed())
-                    .on_mouse_down(move |cx| {
-                        cx.dispatch_action("file_finder:select", entry.clone());
-                        true
-                    })
-                    .named("match")
-            },
+                .boxed(),
         )
+        .with_uniform_padding(6.0)
+        .with_background_color(if index == selected_index {
+            theme.modal_match_background_active.0
+        } else {
+            theme.modal_match_background.0
+        });
+
+        if index == selected_index || index < self.matches.len() - 1 {
+            container = container.with_border(Border::bottom(1.0, theme.modal_match_border));
+        }
+
+        let entry = (path_match.tree_id, path_match.path.clone());
+        EventHandler::new(container.boxed())
+            .on_mouse_down(move |cx| {
+                cx.dispatch_action("file_finder:select", entry.clone());
+                true
+            })
+            .named("match")
     }
 
-    fn labels_for_match(
-        &self,
-        path_match: &PathMatch,
-        cx: &AppContext,
-    ) -> Option<(String, Vec<usize>, String, Vec<usize>)> {
-        self.worktree(path_match.tree_id, cx).map(|tree| {
-            let prefix = if path_match.include_root_name {
-                tree.root_name()
-            } else {
-                ""
-            };
+    fn labels_for_match(&self, path_match: &PathMatch) -> (String, Vec<usize>, String, Vec<usize>) {
+        let path_string = path_match.path.to_string_lossy();
+        let full_path = [path_match.path_prefix.as_ref(), path_string.as_ref()].join("");
+        let path_positions = path_match.positions.clone();
 
-            let path_string = path_match.path.to_string_lossy();
-            let full_path = [prefix, path_string.as_ref()].join("");
-            let path_positions = path_match.positions.clone();
+        let file_name = path_match.path.file_name().map_or_else(
+            || path_match.path_prefix.to_string(),
+            |file_name| file_name.to_string_lossy().to_string(),
+        );
+        let file_name_start = path_match.path_prefix.chars().count() + path_string.chars().count()
+            - file_name.chars().count();
+        let file_name_positions = path_positions
+            .iter()
+            .filter_map(|pos| {
+                if pos >= &file_name_start {
+                    Some(pos - file_name_start)
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-            let file_name = path_match.path.file_name().map_or_else(
-                || prefix.to_string(),
-                |file_name| file_name.to_string_lossy().to_string(),
-            );
-            let file_name_start =
-                prefix.chars().count() + path_string.chars().count() - file_name.chars().count();
-            let file_name_positions = path_positions
-                .iter()
-                .filter_map(|pos| {
-                    if pos >= &file_name_start {
-                        Some(pos - file_name_start)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            (file_name, file_name_positions, full_path, path_positions)
-        })
+        (file_name, file_name_positions, full_path, path_positions)
     }
 
     fn toggle(workspace_view: &mut Workspace, _: &(), cx: &mut ViewContext<Workspace>) {
@@ -418,11 +401,9 @@ impl FileFinder {
         self.cancel_flag = Arc::new(AtomicBool::new(false));
         let cancel_flag = self.cancel_flag.clone();
         Some(cx.spawn(|this, mut cx| async move {
-            let include_root_name = snapshots.len() > 1;
             let matches = match_paths(
-                snapshots.iter(),
+                &snapshots,
                 &query,
-                include_root_name,
                 false,
                 false,
                 100,
@@ -454,15 +435,6 @@ impl FileFinder {
             self.list_state.scroll_to(self.selected_index());
             cx.notify();
         }
-    }
-
-    fn worktree<'a>(&'a self, tree_id: usize, cx: &'a AppContext) -> Option<&'a Worktree> {
-        self.workspace
-            .upgrade(cx)?
-            .read(cx)
-            .worktrees()
-            .get(&tree_id)
-            .map(|worktree| worktree.read(cx))
     }
 }
 
@@ -651,7 +623,7 @@ mod tests {
             assert_eq!(finder.matches.len(), 1);
 
             let (file_name, file_name_positions, full_path, full_path_positions) =
-                finder.labels_for_match(&finder.matches[0], cx).unwrap();
+                finder.labels_for_match(&finder.matches[0]);
             assert_eq!(file_name, "the-file");
             assert_eq!(file_name_positions, &[0, 1, 4]);
             assert_eq!(full_path, "the-file");

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -586,17 +586,11 @@ impl LocalWorktree {
 
         // After determining whether the root entry is a file or a directory, populate the
         // snapshot's "root name", which will be used for the purpose of fuzzy matching.
-        let mut root_name = abs_path
+        let root_name = abs_path
             .file_name()
             .map_or(String::new(), |f| f.to_string_lossy().to_string());
         let root_char_bag = root_name.chars().map(|c| c.to_ascii_lowercase()).collect();
-        let metadata = fs
-            .metadata(&abs_path)
-            .await?
-            .ok_or_else(|| anyhow!("root entry does not exist"))?;
-        if metadata.is_dir {
-            root_name.push('/');
-        }
+        let metadata = fs.metadata(&abs_path).await?;
 
         let (scan_states_tx, scan_states_rx) = smol::channel::unbounded();
         let (mut last_scan_state_tx, last_scan_state_rx) = watch::channel_with(ScanState::Scanning);
@@ -613,12 +607,14 @@ impl LocalWorktree {
                 removed_entry_ids: Default::default(),
                 next_entry_id: Arc::new(next_entry_id),
             };
-            snapshot.insert_entry(Entry::new(
-                path.into(),
-                &metadata,
-                &snapshot.next_entry_id,
-                snapshot.root_char_bag,
-            ));
+            if let Some(metadata) = metadata {
+                snapshot.insert_entry(Entry::new(
+                    path.into(),
+                    &metadata,
+                    &snapshot.next_entry_id,
+                    snapshot.root_char_bag,
+                ));
+            }
 
             let tree = Self {
                 snapshot: snapshot.clone(),
@@ -1229,12 +1225,10 @@ impl Snapshot {
         ChildEntriesIter::new(path, self)
     }
 
-    pub fn root_entry(&self) -> &Entry {
-        self.entry_for_path("").unwrap()
+    pub fn root_entry(&self) -> Option<&Entry> {
+        self.entry_for_path("")
     }
 
-    /// Returns the filename of the snapshot's root, plus a trailing slash if the snapshot's root is
-    /// a directory.
     pub fn root_name(&self) -> &str {
         &self.root_name
     }
@@ -1856,8 +1850,8 @@ impl BackgroundScanner {
             let snapshot = self.snapshot.lock();
             root_char_bag = snapshot.root_char_bag;
             next_entry_id = snapshot.next_entry_id.clone();
-            is_dir = snapshot.root_entry().is_dir();
-        }
+            is_dir = snapshot.root_entry().map_or(false, |e| e.is_dir())
+        };
 
         if is_dir {
             let path: Arc<Path> = Arc::from(Path::new(""));
@@ -2605,22 +2599,20 @@ mod tests {
 
         cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
             .await;
-        let snapshot = cx.read(|cx| {
+        let snapshots = [cx.read(|cx| {
             let tree = tree.read(cx);
             assert_eq!(tree.file_count(), 5);
             assert_eq!(
                 tree.inode_for_path("fennel/grape"),
                 tree.inode_for_path("finnochio/grape")
             );
-
             tree.snapshot()
-        });
+        })];
         let results = cx
             .read(|cx| {
                 match_paths(
-                    Some(&snapshot).into_iter(),
+                    &snapshots,
                     "bna",
-                    false,
                     false,
                     false,
                     10,
@@ -2662,17 +2654,16 @@ mod tests {
 
         cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
             .await;
-        let snapshot = cx.read(|cx| {
+        let snapshots = [cx.read(|cx| {
             let tree = tree.read(cx);
             assert_eq!(tree.file_count(), 0);
             tree.snapshot()
-        });
+        })];
         let results = cx
             .read(|cx| {
                 match_paths(
-                    Some(&snapshot).into_iter(),
+                    &snapshots,
                     "dir",
-                    false,
                     false,
                     false,
                     10,


### PR DESCRIPTION
Fixes #119

Previously, we didn't allow creating worktrees for non-existent paths. So when saving an untitled buffer outside of any existing worktree, we would fail to add a worktree for the new file. This PR changes the `LocalWorktree` so that it is valid to have a non-existent root entry.

This change had some downstream consequences involving the file finder. Previously, on constructing the worktree, we checked whether the root entry was directory or a file. We used this to precompute a `root_name` which would be used as a prefix when fuzzy-matching. For directories, the root name had a trailing slash, and for files it didn't.

I have refactored the way that we compute this "root prefix" for fuzzy matching purposes. Whereas before, it was computed in two places (once when matching and then again when displaying the matches), it is now computed in only one place: `match_paths`. This prefix is then reused when displaying the matches, via another `Arc` on each `PathMatch`.

There's a lot of whitespace-only changes in the diff, mainly because we no longer need to retrieve the Worktree when rendering a path match.