### PR TITLE
Use deterministic executor in randomized synchronous tests

### DIFF
--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -118,26 +118,6 @@ pub struct TestAppContext {
 }
 
 impl App {
-    pub fn test<T, F: FnOnce(&mut MutableAppContext) -> T>(
-        foreground_platform: Rc<platform::test::ForegroundPlatform>,
-        platform: Arc<dyn Platform>,
-        font_cache: Arc<FontCache>,
-        f: F,
-    ) -> T {
-        let foreground = Rc::new(executor::Foreground::test());
-        let cx = Rc::new(RefCell::new(MutableAppContext::new(
-            foreground,
-            Arc::new(executor::Background::new()),
-            platform,
-            foreground_platform,
-            font_cache,
-            (),
-        )));
-        cx.borrow_mut().weak_self = Some(Rc::downgrade(&cx));
-        let mut cx = cx.borrow_mut();
-        f(&mut *cx)
-    }
-
     pub fn new(asset_source: impl AssetSource) -> Result<Self> {
         let platform = platform::current::platform();
         let foreground_platform = platform::current::foreground_platform();
@@ -723,7 +703,10 @@ impl MutableAppContext {
             if let Some(arg) = arg.downcast_ref() {
                 handler(arg, cx);
             } else {
-                log::error!("Could not downcast argument for global action {}", name_clone);
+                log::error!(
+                    "Could not downcast argument for global action {}",
+                    name_clone
+                );
             }
         });
 


### PR DESCRIPTION
Previously, synchronous tests were creating a real `Background` executor in each randomized iteration. On CI, this was causing [builds](https://github.com/zed-industries/zed/pull/121/checks?check_run_id=3204832056) to fail due to an inability to spawn any more threads:

```
thread 'sum_tree::tests::test_random' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }', gpui/src/executor.rs:423:18
stack backtrace:

...

   4: gpui::executor::Background::new
             at /Users/zedci/actions-runner-2/_work/zed/zed/gpui/src/executor.rs:420:13
   5: gpui::app::App::test
             at /Users/zedci/actions-runner-2/_work/zed/zed/gpui/src/app.rs:130:22
   6: zed::sum_tree::tests::test_random::{{closure}}
             at ./src/sum_tree.rs:606:5
```

Now we use the deterministic executor in synchronous tests as well as the async ones. The sync and async code paths are now a bit more similar, in that they both set up their context via `TestAppContext::new`. I removed the `App::test` helper function.