### PR TITLE
Ensure key window is a GPUIWindow before returning its id

### DIFF
--- a/gpui/src/platform/mac/window.rs
+++ b/gpui/src/platform/mac/window.rs
@@ -245,11 +245,11 @@ impl Window {
         unsafe {
             let app = NSApplication::sharedApplication(nil);
             let key_window: id = msg_send![app, keyWindow];
-            if key_window.is_null() {
-                None
-            } else {
+            if msg_send![key_window, isKindOfClass: WINDOW_CLASS] {
                 let id = get_window_state(&*key_window).borrow().id;
                 Some(id)
+            } else {
+                None
             }
         }
     }


### PR DESCRIPTION
Fixes #131 

Previously, when calling `Platform::key_window_id` we would retrieve the application's key window with the assumption it was a `GPUIWindow`, returning `None` only when no windows were open. However, when opening a system dialog (like a file picker), the key window becomes the dialog itself and will therefore be of kind e.g. `NSOpenPanel`, `NSSavePanel`, etc. This caused a panic because we would try to retrieve our custom `windowState` ivar from a system window.

With this pull request we will now ensure that the key window is indeed an instance of `GPUIWindow` and return `None` if it isn't. I audited other code paths that access the `windowState` ivar but they all look reasonable, as we only access the state of windows in response to their events. Since we only register event listeners for `GPUIWindow`s we are guaranteed that we'll be able to access `windowState`.

/cc: @maxbrunsfeld