### PR TITLE
Perform code signing with Apple-issued certificate on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
       MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
+      APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
     steps:
       - name: Install Rust x86_64-apple-darwin target
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
   bundle:
     name: Bundle app
     runs-on: self-hosted
+    env:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
     steps:
       - name: Install Rust x86_64-apple-darwin target
         uses: actions-rs/toolchain@v1

--- a/script/bundle
+++ b/script/bundle
@@ -17,7 +17,20 @@ cargo build --release --target aarch64-apple-darwin
 lipo -create target/x86_64-apple-darwin/release/Zed target/aarch64-apple-darwin/release/Zed -output target/x86_64-apple-darwin/release/bundle/osx/Zed.app/Contents/MacOS/zed
 
 # Sign the app bundle with an ad-hoc signature so it runs on the M1. We need a real certificate but this works for now.
-codesign --force --deep -s - target/x86_64-apple-darwin/release/bundle/osx/Zed.app
+if [[ -z $MACOS_CERTIFICATE || -z $MACOS_CERTIFICATE_PASSWORD ]]; then
+    echo "Missing MACOS_CERTIFICATE and MACOS_CERTIFICATE_PASSWORD environment variables – performing ad-hoc signature"
+    codesign --force --deep -s - target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+else
+    echo "Signing bundle with Apple-issued certificate"
+    security create-keychain -p $MACOS_CERTIFICATE_PASSWORD zed.keychain || echo ""
+    security unlock-keychain -p $MACOS_CERTIFICATE_PASSWORD zed.keychain
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
+    echo $MACOS_CERTIFICATE | base64 --decode > /tmp/zed-certificate.p12
+    security import /tmp/zed-certificate.p12 -k zed.keychain -P $MACOS_CERTIFICATE_PASSWORD -T /usr/bin/codesign
+    rm /tmp/zed-certificate.p12
+    security default-keychain -s zed.keychain
+    /usr/bin/codesign --force -s "Zed Industries, Inc." target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+fi
 
 # Create a DMG
 mkdir -p target/release

--- a/script/bundle
+++ b/script/bundle
@@ -17,10 +17,7 @@ cargo build --release --target aarch64-apple-darwin
 lipo -create target/x86_64-apple-darwin/release/Zed target/aarch64-apple-darwin/release/Zed -output target/x86_64-apple-darwin/release/bundle/osx/Zed.app/Contents/MacOS/zed
 
 # Sign the app bundle with an ad-hoc signature so it runs on the M1. We need a real certificate but this works for now.
-if [[ -z $MACOS_CERTIFICATE || -z $MACOS_CERTIFICATE_PASSWORD ]]; then
-    echo "Missing MACOS_CERTIFICATE and MACOS_CERTIFICATE_PASSWORD environment variables – performing ad-hoc signature"
-    codesign --force --deep -s - target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
-else
+if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then
     echo "Signing bundle with Apple-issued certificate"
     security create-keychain -p $MACOS_CERTIFICATE_PASSWORD zed.keychain || echo ""
     security default-keychain -s zed.keychain
@@ -29,12 +26,24 @@ else
     security import /tmp/zed-certificate.p12 -k zed.keychain -P $MACOS_CERTIFICATE_PASSWORD -T /usr/bin/codesign
     rm /tmp/zed-certificate.p12
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
-    /usr/bin/codesign --force -s "Zed Industries, Inc." target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+    /usr/bin/codesign --force --deep --timestamp --options runtime --sign "Zed Industries, Inc." target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+    security default-keychain -s login.keychain
+else
+    echo "One or more of the following variables are missing: MACOS_CERTIFICATE, MACOS_CERTIFICATE_PASSWORD, APPLE_NOTARIZATION_USERNAME, APPLE_NOTARIZATION_PASSWORD"
+    echo "Performing an ad-hoc signature, but this bundle should not be distributed"
+    codesign --force --deep --sign - target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
 fi
 
 # Create a DMG
+echo "Creating DMG"
 mkdir -p target/release
 hdiutil create -volname Zed -srcfolder target/x86_64-apple-darwin/release/bundle/osx -ov -format UDZO target/release/Zed.dmg
+
+if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then
+    echo "Notarizing DMG with Apple"
+    npm install -g notarize-cli
+    npx notarize-cli --file target/release/Zed.dmg --bundle-id dev.zed.Zed --username $APPLE_NOTARIZATION_USERNAME --password $APPLE_NOTARIZATION_PASSWORD
+fi
 
 # If -o option is specified, open the target/release directory in Finder to reveal the DMG
 while getopts o flag

--- a/script/bundle
+++ b/script/bundle
@@ -23,12 +23,12 @@ if [[ -z $MACOS_CERTIFICATE || -z $MACOS_CERTIFICATE_PASSWORD ]]; then
 else
     echo "Signing bundle with Apple-issued certificate"
     security create-keychain -p $MACOS_CERTIFICATE_PASSWORD zed.keychain || echo ""
+    security default-keychain -s zed.keychain
     security unlock-keychain -p $MACOS_CERTIFICATE_PASSWORD zed.keychain
-    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
     echo $MACOS_CERTIFICATE | base64 --decode > /tmp/zed-certificate.p12
     security import /tmp/zed-certificate.p12 -k zed.keychain -P $MACOS_CERTIFICATE_PASSWORD -T /usr/bin/codesign
     rm /tmp/zed-certificate.p12
-    security default-keychain -s zed.keychain
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
     /usr/bin/codesign --force -s "Zed Industries, Inc." target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
 fi
 


### PR DESCRIPTION
This PR updates `script/bundle` to perform code signing with an Apple-issued certificate followed by notarization. The resulting DMG should be kosher to distribute without hassle for users.