### PR TITLE
Specify UI editor fonts via the theme instead of the settings

### DIFF
--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -2335,6 +2335,16 @@ impl<V: View> ReadModel for RenderContext<'_, V> {
     }
 }
 
+impl<V: View> UpdateModel for RenderContext<'_, V> {
+    fn update_model<T, F, S>(&mut self, handle: &ModelHandle<T>, update: F) -> S
+    where
+        T: Entity,
+        F: FnOnce(&mut T, &mut ModelContext<T>) -> S,
+    {
+        self.app.update_model(handle, update)
+    }
+}
+
 impl<M> AsRef<AppContext> for ViewContext<'_, M> {
     fn as_ref(&self) -> &AppContext {
         &self.app.cx

--- a/gpui/src/font_cache.rs
+++ b/gpui/src/font_cache.rs
@@ -17,7 +17,7 @@ use std::{
 pub struct FamilyId(usize);
 
 struct Family {
-    name: String,
+    name: Arc<str>,
     font_ids: Vec<FontId>,
 }
 
@@ -49,7 +49,7 @@ impl FontCache {
         }))
     }
 
-    pub fn family_name(&self, family_id: FamilyId) -> Result<String> {
+    pub fn family_name(&self, family_id: FamilyId) -> Result<Arc<str>> {
         self.0
             .read()
             .families
@@ -62,7 +62,7 @@ impl FontCache {
         for name in names {
             let state = self.0.upgradable_read();
 
-            if let Some(ix) = state.families.iter().position(|f| f.name == *name) {
+            if let Some(ix) = state.families.iter().position(|f| f.name.as_ref() == *name) {
                 return Ok(FamilyId(ix));
             }
 
@@ -81,7 +81,7 @@ impl FontCache {
                 }
 
                 state.families.push(Family {
-                    name: String::from(*name),
+                    name: Arc::from(*name),
                     font_ids,
                 });
                 return Ok(family_id);

--- a/gpui/src/font_cache.rs
+++ b/gpui/src/font_cache.rs
@@ -141,8 +141,8 @@ impl FontCache {
 
     pub fn bounding_box(&self, font_id: FontId, font_size: f32) -> Vector2F {
         let bounding_box = self.metric(font_id, |m| m.bounding_box);
-        let width = self.scale_metric(bounding_box.width(), font_id, font_size);
-        let height = self.scale_metric(bounding_box.height(), font_id, font_size);
+        let width = bounding_box.width() * self.em_scale(font_id, font_size);
+        let height = bounding_box.height() * self.em_scale(font_id, font_size);
         vec2f(width, height)
     }
 
@@ -154,28 +154,28 @@ impl FontCache {
             glyph_id = state.fonts.glyph_for_char(font_id, 'm').unwrap();
             bounds = state.fonts.typographic_bounds(font_id, glyph_id).unwrap();
         }
-        self.scale_metric(bounds.width(), font_id, font_size)
+        bounds.width() * self.em_scale(font_id, font_size)
     }
 
     pub fn line_height(&self, font_id: FontId, font_size: f32) -> f32 {
         let height = self.metric(font_id, |m| m.bounding_box.height());
-        self.scale_metric(height, font_id, font_size)
+        (height * self.em_scale(font_id, font_size)).ceil()
     }
 
     pub fn cap_height(&self, font_id: FontId, font_size: f32) -> f32 {
-        self.scale_metric(self.metric(font_id, |m| m.cap_height), font_id, font_size)
+        self.metric(font_id, |m| m.cap_height) * self.em_scale(font_id, font_size)
     }
 
     pub fn ascent(&self, font_id: FontId, font_size: f32) -> f32 {
-        self.scale_metric(self.metric(font_id, |m| m.ascent), font_id, font_size)
+        self.metric(font_id, |m| m.ascent) * self.em_scale(font_id, font_size)
     }
 
     pub fn descent(&self, font_id: FontId, font_size: f32) -> f32 {
-        self.scale_metric(self.metric(font_id, |m| -m.descent), font_id, font_size)
+        self.metric(font_id, |m| -m.descent) * self.em_scale(font_id, font_size)
     }
 
-    pub fn scale_metric(&self, metric: f32, font_id: FontId, font_size: f32) -> f32 {
-        metric * font_size / self.metric(font_id, |m| m.units_per_em as f32)
+    pub fn em_scale(&self, font_id: FontId, font_size: f32) -> f32 {
+        font_size / self.metric(font_id, |m| m.units_per_em as f32)
     }
 
     pub fn line_wrapper(self: &Arc<Self>, font_id: FontId, font_size: f32) -> LineWrapperHandle {

--- a/gpui/src/fonts.rs
+++ b/gpui/src/fonts.rs
@@ -127,6 +127,22 @@ impl TextStyle {
             }
         })
     }
+
+    pub fn line_height(&self, font_cache: &FontCache) -> f32 {
+        font_cache.line_height(self.font_id, self.font_size)
+    }
+
+    pub fn em_width(&self, font_cache: &FontCache) -> f32 {
+        font_cache.em_width(self.font_id, self.font_size)
+    }
+
+    pub fn descent(&self, font_cache: &FontCache) -> f32 {
+        font_cache.metric(self.font_id, |m| m.descent) * self.em_scale(font_cache)
+    }
+
+    fn em_scale(&self, font_cache: &FontCache) -> f32 {
+        font_cache.em_scale(self.font_id, self.font_size)
+    }
 }
 
 impl From<TextStyle> for HighlightStyle {

--- a/gpui/src/fonts.rs
+++ b/gpui/src/fonts.rs
@@ -126,6 +126,16 @@ impl TextStyle {
     }
 }
 
+impl From<TextStyle> for HighlightStyle {
+    fn from(other: TextStyle) -> Self {
+        Self {
+            color: other.color,
+            font_properties: other.font_properties,
+            underline: other.underline,
+        }
+    }
+}
+
 impl HighlightStyle {
     fn from_json(json: HighlightStyleJson) -> Self {
         let font_properties = properties_from_json(json.weight, json.italic);

--- a/gpui/src/fonts.rs
+++ b/gpui/src/fonts.rs
@@ -1,5 +1,6 @@
 use crate::{
     color::Color,
+    font_cache::FamilyId,
     json::{json, ToJson},
     text_layout::RunStyle,
     FontCache,
@@ -22,6 +23,7 @@ pub type GlyphId = u32;
 pub struct TextStyle {
     pub color: Color,
     pub font_family_name: Arc<str>,
+    pub font_family_id: FamilyId,
     pub font_id: FontId,
     pub font_size: f32,
     pub font_properties: Properties,
@@ -85,11 +87,12 @@ impl TextStyle {
         font_cache: &FontCache,
     ) -> anyhow::Result<Self> {
         let font_family_name = font_family_name.into();
-        let family_id = font_cache.load_family(&[&font_family_name])?;
-        let font_id = font_cache.select_font(family_id, &font_properties)?;
+        let font_family_id = font_cache.load_family(&[&font_family_name])?;
+        let font_id = font_cache.select_font(font_family_id, &font_properties)?;
         Ok(Self {
             color,
             font_family_name,
+            font_family_id,
             font_id,
             font_size,
             font_properties,

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -1121,7 +1121,9 @@ mod tests {
             .unwrap();
 
         // Create a selection set as client B and see that selection set as client A.
-        let editor_b = cx_b.add_view(window_b, |cx| Editor::for_buffer(buffer_b, settings, cx));
+        let editor_b = cx_b.add_view(window_b, |cx| {
+            Editor::for_buffer(buffer_b, settings, |_| Default::default(), cx)
+        });
         buffer_a
             .condition(&cx_a, |buffer, _| buffer.selection_sets().count() == 1)
             .await;

--- a/server/src/rpc.rs
+++ b/server/src/rpc.rs
@@ -1037,7 +1037,7 @@ mod tests {
     };
     use zed::{
         channel::{Channel, ChannelDetails, ChannelList},
-        editor::{Editor, Insert},
+        editor::{Editor, EditorStyle, Insert},
         fs::{FakeFs, Fs as _},
         language::LanguageRegistry,
         rpc::{self, Client, Credentials, EstablishConnectionError},
@@ -1122,7 +1122,12 @@ mod tests {
 
         // Create a selection set as client B and see that selection set as client A.
         let editor_b = cx_b.add_view(window_b, |cx| {
-            Editor::for_buffer(buffer_b, settings, |_| Default::default(), cx)
+            Editor::for_buffer(
+                buffer_b,
+                settings,
+                |cx| EditorStyle::test(cx.font_cache()),
+                cx,
+            )
         });
         buffer_a
             .condition(&cx_a, |buffer, _| buffer.selection_sets().count() == 1)

--- a/zed/assets/themes/_base.toml
+++ b/zed/assets/themes/_base.toml
@@ -107,8 +107,8 @@ shadow = { offset = [0, 2], blur = 16, color = "$shadow.0" }
 background = "$surface.1"
 corner_radius = 6
 padding = { left = 8, right = 8, top = 7, bottom = 7 }
-text = "$text.0.color"
-placeholder_text = "$text.2.color"
+text = "$text.0"
+placeholder_text = "$text.2"
 selection = "$selection.host"
 border = { width = 1, color = "$border.0" }
 
@@ -132,8 +132,8 @@ border = { width = 1, color = "$border.0" }
 background = "$surface.1"
 corner_radius = 6
 padding = { left = 16, right = 16, top = 7, bottom = 7 }
-text = "$text.0.color"
-placeholder_text = "$text.2.color"
+text = "$text.0"
+placeholder_text = "$text.2"
 selection = "$selection.host"
 border = { width = 1, color = "$border.0" }
 
@@ -153,7 +153,7 @@ background = "$state.hover"
 text = "$text.0"
 
 [editor]
-text = "$text.1.color"
+text = "$text.1"
 background = "$surface.1"
 gutter_background = "$surface.1"
 active_line_background = "$state.active_line"

--- a/zed/src/chat_panel.rs
+++ b/zed/src/chat_panel.rs
@@ -54,10 +54,15 @@ impl ChatPanel {
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let input_editor = cx.add_view(|cx| {
-            Editor::auto_height(4, settings.clone(), cx).with_style({
-                let settings = settings.clone();
-                move |_| settings.borrow().theme.chat_panel.input_editor.as_editor()
-            })
+            Editor::auto_height(
+                4,
+                settings.clone(),
+                {
+                    let settings = settings.clone();
+                    move |_| settings.borrow().theme.chat_panel.input_editor.as_editor()
+                },
+                cx,
+            )
         });
         let channel_select = cx.add_view(|cx| {
             let channel_list = channel_list.clone();

--- a/zed/src/editor.rs
+++ b/zed/src/editor.rs
@@ -282,7 +282,7 @@ pub enum EditorMode {
 pub struct EditorStyle {
     pub text: HighlightStyle,
     #[serde(default)]
-    pub placeholder_text: HighlightStyle,
+    pub placeholder_text: Option<HighlightStyle>,
     pub background: Color,
     pub selection: SelectionStyle,
     pub gutter_background: Color,
@@ -2468,7 +2468,7 @@ impl Snapshot {
                 .skip(rows.start as usize)
                 .take(rows.len());
             let font_id = font_cache
-                .select_font(self.font_family, &style.placeholder_text.font_properties)?;
+                .select_font(self.font_family, &style.placeholder_text().font_properties)?;
             return Ok(placeholder_lines
                 .into_iter()
                 .map(|line| {
@@ -2479,7 +2479,7 @@ impl Snapshot {
                             line.len(),
                             RunStyle {
                                 font_id,
-                                color: style.placeholder_text.color,
+                                color: style.placeholder_text().color,
                                 underline: false,
                             },
                         )],
@@ -2596,6 +2596,12 @@ impl Snapshot {
     }
 }
 
+impl EditorStyle {
+    fn placeholder_text(&self) -> &HighlightStyle {
+        self.placeholder_text.as_ref().unwrap_or(&self.text)
+    }
+}
+
 impl Default for EditorStyle {
     fn default() -> Self {
         Self {
@@ -2604,11 +2610,7 @@ impl Default for EditorStyle {
                 font_properties: Default::default(),
                 underline: false,
             },
-            placeholder_text: HighlightStyle {
-                color: Color::from_u32(0x00ff00ff),
-                font_properties: Default::default(),
-                underline: false,
-            },
+            placeholder_text: None,
             background: Default::default(),
             gutter_background: Default::default(),
             active_line_background: Default::default(),

--- a/zed/src/editor.rs
+++ b/zed/src/editor.rs
@@ -17,10 +17,9 @@ pub use display_map::DisplayPoint;
 use display_map::*;
 pub use element::*;
 use gpui::{
-    action, color::Color, font_cache::FamilyId, fonts::TextStyle, geometry::vector::Vector2F,
+    action, color::Color, fonts::TextStyle, geometry::vector::Vector2F,
     keymap::Binding, text_layout, AppContext, ClipboardItem, Element, ElementBox, Entity,
-    ModelHandle, MutableAppContext, RenderContext, Task, View, ViewContext,
-    WeakViewHandle,
+    ModelHandle, MutableAppContext, RenderContext, Task, View, ViewContext, WeakViewHandle,
 };
 use postage::watch;
 use serde::{Deserialize, Serialize};
@@ -318,8 +317,6 @@ pub struct Snapshot {
     pub display_snapshot: DisplayMapSnapshot,
     pub placeholder_text: Option<Arc<str>>,
     pub theme: Arc<Theme>,
-    pub font_family: FamilyId,
-    pub font_size: f32,
     is_focused: bool,
     scroll_position: Vector2F,
     scroll_top_anchor: Anchor,
@@ -436,8 +433,6 @@ impl Editor {
             scroll_top_anchor: self.scroll_top_anchor.clone(),
             theme: settings.theme.clone(),
             placeholder_text: self.placeholder_text.clone(),
-            font_family: settings.buffer_font_family,
-            font_size: settings.buffer_font_size,
             is_focused: self
                 .handle
                 .upgrade(cx)

--- a/zed/src/editor.rs
+++ b/zed/src/editor.rs
@@ -5,7 +5,7 @@ pub mod movement;
 
 use crate::{
     settings::{HighlightId, Settings},
-    theme::{EditorStyle, Theme},
+    theme::Theme,
     time::ReplicaId,
     util::{post_inc, Bias},
     workspace,
@@ -20,7 +20,7 @@ use gpui::{
     action,
     color::Color,
     font_cache::FamilyId,
-    fonts::Properties as FontProperties,
+    fonts::{HighlightStyle, Properties as FontProperties},
     geometry::vector::Vector2F,
     keymap::Binding,
     text_layout::{self, RunStyle},
@@ -276,6 +276,26 @@ pub enum EditorMode {
     SingleLine,
     AutoHeight { max_lines: usize },
     Full,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct EditorStyle {
+    pub text: HighlightStyle,
+    #[serde(default)]
+    pub placeholder_text: HighlightStyle,
+    pub background: Color,
+    pub selection: SelectionStyle,
+    pub gutter_background: Color,
+    pub active_line_background: Color,
+    pub line_number: Color,
+    pub line_number_active: Color,
+    pub guest_selections: Vec<SelectionStyle>,
+}
+
+#[derive(Clone, Copy, Default, Deserialize)]
+pub struct SelectionStyle {
+    pub cursor: Color,
+    pub selection: Color,
 }
 
 pub struct Editor {
@@ -2566,6 +2586,30 @@ impl Snapshot {
 
     pub fn next_row_boundary(&self, point: DisplayPoint) -> (DisplayPoint, Point) {
         self.display_snapshot.next_row_boundary(point)
+    }
+}
+
+impl Default for EditorStyle {
+    fn default() -> Self {
+        Self {
+            text: HighlightStyle {
+                color: Color::from_u32(0xff0000ff),
+                font_properties: Default::default(),
+                underline: false,
+            },
+            placeholder_text: HighlightStyle {
+                color: Color::from_u32(0x00ff00ff),
+                font_properties: Default::default(),
+                underline: false,
+            },
+            background: Default::default(),
+            gutter_background: Default::default(),
+            active_line_background: Default::default(),
+            line_number: Default::default(),
+            line_number_active: Default::default(),
+            selection: Default::default(),
+            guest_selections: Default::default(),
+        }
     }
 }
 

--- a/zed/src/editor/display_map.rs
+++ b/zed/src/editor/display_map.rs
@@ -8,8 +8,8 @@ use gpui::{Entity, ModelContext, ModelHandle};
 use postage::watch;
 use std::ops::Range;
 use tab_map::TabMap;
-pub use wrap_map::BufferRows;
 use wrap_map::WrapMap;
+pub use wrap_map::{BufferRows, HighlightedChunks};
 
 pub struct DisplayMap {
     buffer: ModelHandle<Buffer>,

--- a/zed/src/editor/display_map.rs
+++ b/zed/src/editor/display_map.rs
@@ -2,10 +2,9 @@ mod fold_map;
 mod tab_map;
 mod wrap_map;
 
-use super::{buffer, Anchor, Bias, Buffer, Point, Settings, ToOffset, ToPoint};
+use super::{buffer, Anchor, Bias, Buffer, Point, ToOffset, ToPoint};
 use fold_map::FoldMap;
-use gpui::{Entity, ModelContext, ModelHandle};
-use postage::watch;
+use gpui::{fonts::FontId, Entity, ModelContext, ModelHandle};
 use std::ops::Range;
 use tab_map::TabMap;
 use wrap_map::WrapMap;
@@ -25,13 +24,16 @@ impl Entity for DisplayMap {
 impl DisplayMap {
     pub fn new(
         buffer: ModelHandle<Buffer>,
-        settings: watch::Receiver<Settings>,
+        tab_size: usize,
+        font_id: FontId,
+        font_size: f32,
         wrap_width: Option<f32>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
         let (fold_map, snapshot) = FoldMap::new(buffer.clone(), cx);
-        let (tab_map, snapshot) = TabMap::new(snapshot, settings.borrow().tab_size);
-        let wrap_map = cx.add_model(|cx| WrapMap::new(snapshot, settings, wrap_width, cx));
+        let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
+        let wrap_map =
+            cx.add_model(|cx| WrapMap::new(snapshot, font_id, font_size, wrap_width, cx));
         cx.observe(&wrap_map, |_, _, cx| cx.notify()).detach();
         DisplayMap {
             buffer,
@@ -83,6 +85,11 @@ impl DisplayMap {
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits);
         self.wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
+    }
+
+    pub fn set_font(&self, font_id: FontId, font_size: f32, cx: &mut ModelContext<Self>) {
+        self.wrap_map
+            .update(cx, |map, cx| map.set_font(font_id, font_size, cx));
     }
 
     pub fn set_wrap_width(&self, width: Option<f32>, cx: &mut ModelContext<Self>) -> bool {
@@ -367,12 +374,12 @@ mod tests {
             .unwrap_or(10);
 
         let font_cache = cx.font_cache().clone();
-        let settings = Settings {
-            tab_size: rng.gen_range(1..=4),
-            buffer_font_family: font_cache.load_family(&["Helvetica"]).unwrap(),
-            buffer_font_size: 14.0,
-            ..cx.read(Settings::test)
-        };
+        let tab_size = rng.gen_range(1..=4);
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
         let max_wrap_width = 300.0;
         let mut wrap_width = if rng.gen_bool(0.1) {
             None
@@ -380,7 +387,7 @@ mod tests {
             Some(rng.gen_range(0.0..=max_wrap_width))
         };
 
-        log::info!("tab size: {}", settings.tab_size);
+        log::info!("tab size: {}", tab_size);
         log::info!("wrap width: {:?}", wrap_width);
 
         let buffer = cx.add_model(|cx| {
@@ -388,9 +395,10 @@ mod tests {
             let text = RandomCharIter::new(&mut rng).take(len).collect::<String>();
             Buffer::new(0, text, cx)
         });
-        let settings = watch::channel_with(settings).1;
 
-        let map = cx.add_model(|cx| DisplayMap::new(buffer.clone(), settings, wrap_width, cx));
+        let map = cx.add_model(|cx| {
+            DisplayMap::new(buffer.clone(), tab_size, font_id, font_size, wrap_width, cx)
+        });
         let (_observer, notifications) = Observer::new(&map, &mut cx);
         let mut fold_count = 0;
 
@@ -529,26 +537,27 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_soft_wraps(mut cx: gpui::TestAppContext) {
+    fn test_soft_wraps(cx: &mut MutableAppContext) {
         cx.foreground().set_block_on_ticks(usize::MAX..=usize::MAX);
         cx.foreground().forbid_parking();
 
         let font_cache = cx.font_cache();
 
-        let settings = Settings {
-            buffer_font_family: font_cache.load_family(&["Helvetica"]).unwrap(),
-            buffer_font_size: 12.0,
-            tab_size: 4,
-            ..cx.read(Settings::test)
-        };
+        let tab_size = 4;
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 12.0;
         let wrap_width = Some(64.);
 
         let text = "one two three four five\nsix seven eight";
         let buffer = cx.add_model(|cx| Buffer::new(0, text.to_string(), cx));
-        let (mut settings_tx, settings_rx) = watch::channel_with(settings);
-        let map = cx.add_model(|cx| DisplayMap::new(buffer.clone(), settings_rx, wrap_width, cx));
+        let map = cx.add_model(|cx| {
+            DisplayMap::new(buffer.clone(), tab_size, font_id, font_size, wrap_width, cx)
+        });
 
-        let snapshot = map.update(&mut cx, |map, cx| map.snapshot(cx));
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
         assert_eq!(
             snapshot.chunks_at(0).collect::<String>(),
             "one two \nthree four \nfive\nsix seven \neight"
@@ -592,23 +601,21 @@ mod tests {
             (DisplayPoint::new(2, 4), SelectionGoal::Column(10))
         );
 
-        buffer.update(&mut cx, |buffer, cx| {
+        buffer.update(cx, |buffer, cx| {
             let ix = buffer.text().find("seven").unwrap();
             buffer.edit(vec![ix..ix], "and ", cx);
         });
 
-        let snapshot = map.update(&mut cx, |map, cx| map.snapshot(cx));
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
         assert_eq!(
             snapshot.chunks_at(1).collect::<String>(),
             "three four \nfive\nsix and \nseven eight"
         );
 
         // Re-wrap on font size changes
-        settings_tx.borrow_mut().buffer_font_size += 3.;
+        map.update(cx, |map, cx| map.set_font(font_id, font_size + 3., cx));
 
-        map.next_notification(&mut cx).await;
-
-        let snapshot = map.update(&mut cx, |map, cx| map.snapshot(cx));
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
         assert_eq!(
             snapshot.chunks_at(1).collect::<String>(),
             "three \nfour five\nsix and \nseven \neight"
@@ -619,11 +626,16 @@ mod tests {
     fn test_chunks_at(cx: &mut gpui::MutableAppContext) {
         let text = sample_text(6, 6);
         let buffer = cx.add_model(|cx| Buffer::new(0, text, cx));
-        let settings = watch::channel_with(Settings {
-            tab_size: 4,
-            ..Settings::test(cx)
+        let tab_size = 4;
+        let family_id = cx.font_cache().load_family(&["Helvetica"]).unwrap();
+        let font_id = cx
+            .font_cache()
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+        let map = cx.add_model(|cx| {
+            DisplayMap::new(buffer.clone(), tab_size, font_id, font_size, None, cx)
         });
-        let map = cx.add_model(|cx| DisplayMap::new(buffer.clone(), settings.1, None, cx));
         buffer.update(cx, |buffer, cx| {
             buffer.edit(
                 vec![
@@ -695,13 +707,16 @@ mod tests {
         });
         buffer.condition(&cx, |buf, _| !buf.is_parsing()).await;
 
-        let settings = cx.update(|cx| {
-            watch::channel_with(Settings {
-                tab_size: 2,
-                ..Settings::test(cx)
-            })
-        });
-        let map = cx.add_model(|cx| DisplayMap::new(buffer, settings.1, None, cx));
+        let tab_size = 2;
+        let font_cache = cx.font_cache();
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+
+        let map =
+            cx.add_model(|cx| DisplayMap::new(buffer, tab_size, font_id, font_size, None, cx));
         assert_eq!(
             cx.update(|cx| highlighted_chunks(0..5, &map, &theme, cx)),
             vec![
@@ -782,15 +797,16 @@ mod tests {
         buffer.condition(&cx, |buf, _| !buf.is_parsing()).await;
 
         let font_cache = cx.font_cache();
-        let settings = cx.update(|cx| {
-            watch::channel_with(Settings {
-                tab_size: 4,
-                buffer_font_family: font_cache.load_family(&["Courier"]).unwrap(),
-                buffer_font_size: 16.0,
-                ..Settings::test(cx)
-            })
-        });
-        let map = cx.add_model(|cx| DisplayMap::new(buffer, settings.1, Some(40.0), cx));
+
+        let tab_size = 4;
+        let family_id = font_cache.load_family(&["Courier"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 16.0;
+
+        let map = cx
+            .add_model(|cx| DisplayMap::new(buffer, tab_size, font_id, font_size, Some(40.0), cx));
         assert_eq!(
             cx.update(|cx| highlighted_chunks(0..5, &map, &theme, cx)),
             [
@@ -825,11 +841,17 @@ mod tests {
         let text = "\n'a', 'α',\t'✋',\t'❎', '🍐'\n";
         let display_text = "\n'a', 'α',   '✋',    '❎', '🍐'\n";
         let buffer = cx.add_model(|cx| Buffer::new(0, text, cx));
-        let settings = watch::channel_with(Settings {
-            tab_size: 4,
-            ..Settings::test(cx)
+
+        let tab_size = 4;
+        let font_cache = cx.font_cache();
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+        let map = cx.add_model(|cx| {
+            DisplayMap::new(buffer.clone(), tab_size, font_id, font_size, None, cx)
         });
-        let map = cx.add_model(|cx| DisplayMap::new(buffer.clone(), settings.1, None, cx));
         let map = map.update(cx, |map, cx| map.snapshot(cx));
 
         assert_eq!(map.text(), display_text);
@@ -863,11 +885,17 @@ mod tests {
     fn test_tabs_with_multibyte_chars(cx: &mut gpui::MutableAppContext) {
         let text = "✅\t\tα\nβ\t\n🏀β\t\tγ";
         let buffer = cx.add_model(|cx| Buffer::new(0, text, cx));
-        let settings = watch::channel_with(Settings {
-            tab_size: 4,
-            ..Settings::test(cx)
+        let tab_size = 4;
+        let font_cache = cx.font_cache();
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+
+        let map = cx.add_model(|cx| {
+            DisplayMap::new(buffer.clone(), tab_size, font_id, font_size, None, cx)
         });
-        let map = cx.add_model(|cx| DisplayMap::new(buffer.clone(), settings.1, None, cx));
         let map = map.update(cx, |map, cx| map.snapshot(cx));
         assert_eq!(map.text(), "✅       α\nβ   \n🏀β      γ");
         assert_eq!(
@@ -924,11 +952,16 @@ mod tests {
     #[gpui::test]
     fn test_max_point(cx: &mut gpui::MutableAppContext) {
         let buffer = cx.add_model(|cx| Buffer::new(0, "aaa\n\t\tbbb", cx));
-        let settings = watch::channel_with(Settings {
-            tab_size: 4,
-            ..Settings::test(cx)
+        let tab_size = 4;
+        let font_cache = cx.font_cache();
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+        let map = cx.add_model(|cx| {
+            DisplayMap::new(buffer.clone(), tab_size, font_id, font_size, None, cx)
         });
-        let map = cx.add_model(|cx| DisplayMap::new(buffer.clone(), settings.1, None, cx));
         assert_eq!(
             map.update(cx, |map, cx| map.snapshot(cx)).max_point(),
             DisplayPoint::new(1, 11)

--- a/zed/src/editor/element.rs
+++ b/zed/src/editor/element.rs
@@ -1,5 +1,7 @@
-use super::{DisplayPoint, Editor, EditorMode, Insert, Scroll, Select, SelectPhase, Snapshot};
-use crate::{theme::EditorStyle, time::ReplicaId};
+use super::{
+    DisplayPoint, Editor, EditorMode, EditorStyle, Insert, Scroll, Select, SelectPhase, Snapshot,
+};
+use crate::time::ReplicaId;
 use gpui::{
     color::Color,
     geometry::{

--- a/zed/src/editor/element.rs
+++ b/zed/src/editor/element.rs
@@ -1,7 +1,8 @@
 use super::{
     DisplayPoint, Editor, EditorMode, EditorStyle, Insert, Scroll, Select, SelectPhase, Snapshot,
+    MAX_LINE_LEN,
 };
-use crate::time::ReplicaId;
+use crate::{theme::HighlightId, time::ReplicaId};
 use gpui::{
     color::Color,
     geometry::{
@@ -11,7 +12,7 @@ use gpui::{
     },
     json::{self, ToJson},
     keymap::Keystroke,
-    text_layout::{self, TextLayoutCache},
+    text_layout::{self, RunStyle, TextLayoutCache},
     AppContext, Axis, Border, Element, Event, EventContext, FontCache, LayoutContext,
     MutableAppContext, PaintContext, Quad, Scene, SizeConstraint, ViewContext, WeakViewHandle,
 };
@@ -20,6 +21,7 @@ use smallvec::SmallVec;
 use std::{
     cmp::{self, Ordering},
     collections::{BTreeMap, HashMap},
+    fmt::Write,
     ops::Range,
 };
 
@@ -376,6 +378,176 @@ impl EditorElement {
 
         cx.scene.pop_layer();
     }
+
+    fn max_line_number_width(&self, snapshot: &Snapshot, cx: &LayoutContext) -> f32 {
+        let digit_count = (snapshot.buffer_row_count() as f32).log10().floor() as usize + 1;
+
+        cx.text_layout_cache
+            .layout_str(
+                "1".repeat(digit_count).as_str(),
+                self.style.text.font_size,
+                &[(
+                    digit_count,
+                    RunStyle {
+                        font_id: self.style.text.font_id,
+                        color: Color::black(),
+                        underline: false,
+                    },
+                )],
+            )
+            .width()
+    }
+
+    fn layout_line_numbers(
+        &self,
+        rows: Range<u32>,
+        active_rows: &BTreeMap<u32, bool>,
+        snapshot: &Snapshot,
+        cx: &LayoutContext,
+    ) -> Vec<Option<text_layout::Line>> {
+        let mut layouts = Vec::with_capacity(rows.len());
+        let mut line_number = String::new();
+        for (ix, (buffer_row, soft_wrapped)) in snapshot
+            .buffer_rows(rows.start)
+            .take((rows.end - rows.start) as usize)
+            .enumerate()
+        {
+            let display_row = rows.start + ix as u32;
+            let color = if active_rows.contains_key(&display_row) {
+                self.style.line_number_active
+            } else {
+                self.style.line_number
+            };
+            if soft_wrapped {
+                layouts.push(None);
+            } else {
+                line_number.clear();
+                write!(&mut line_number, "{}", buffer_row + 1).unwrap();
+                layouts.push(Some(cx.text_layout_cache.layout_str(
+                    &line_number,
+                    self.style.text.font_size,
+                    &[(
+                        line_number.len(),
+                        RunStyle {
+                            font_id: self.style.text.font_id,
+                            color,
+                            underline: false,
+                        },
+                    )],
+                )));
+            }
+        }
+
+        layouts
+    }
+
+    fn layout_lines(
+        &mut self,
+        mut rows: Range<u32>,
+        snapshot: &mut Snapshot,
+        cx: &LayoutContext,
+    ) -> Vec<text_layout::Line> {
+        rows.end = cmp::min(rows.end, snapshot.max_point().row() + 1);
+        if rows.start >= rows.end {
+            return Vec::new();
+        }
+
+        // When the editor is empty and unfocused, then show the placeholder.
+        if snapshot.is_empty() && !snapshot.is_focused() {
+            let placeholder_style = self.style.placeholder_text();
+            let placeholder_text = snapshot.placeholder_text();
+            let placeholder_lines = placeholder_text
+                .as_ref()
+                .map_or("", AsRef::as_ref)
+                .split('\n')
+                .skip(rows.start as usize)
+                .take(rows.len());
+            return placeholder_lines
+                .map(|line| {
+                    cx.text_layout_cache.layout_str(
+                        line,
+                        placeholder_style.font_size,
+                        &[(
+                            line.len(),
+                            RunStyle {
+                                font_id: placeholder_style.font_id,
+                                color: placeholder_style.color,
+                                underline: false,
+                            },
+                        )],
+                    )
+                })
+                .collect();
+        }
+
+        let mut prev_font_properties = self.style.text.font_properties.clone();
+        let mut prev_font_id = self.style.text.font_id;
+
+        let theme = snapshot.theme().clone();
+        let mut layouts = Vec::with_capacity(rows.len());
+        let mut line = String::new();
+        let mut styles = Vec::new();
+        let mut row = rows.start;
+        let mut line_exceeded_max_len = false;
+        let chunks = snapshot.highlighted_chunks_for_rows(rows.clone());
+
+        'outer: for (chunk, style_ix) in chunks.chain(Some(("\n", HighlightId::default()))) {
+            for (ix, mut line_chunk) in chunk.split('\n').enumerate() {
+                if ix > 0 {
+                    layouts.push(cx.text_layout_cache.layout_str(
+                        &line,
+                        self.style.text.font_size,
+                        &styles,
+                    ));
+                    line.clear();
+                    styles.clear();
+                    row += 1;
+                    line_exceeded_max_len = false;
+                    if row == rows.end {
+                        break 'outer;
+                    }
+                }
+
+                if !line_chunk.is_empty() && !line_exceeded_max_len {
+                    let style = theme
+                        .syntax
+                        .highlight_style(style_ix)
+                        .unwrap_or(self.style.text.clone().into());
+                    // Avoid a lookup if the font properties match the previous ones.
+                    let font_id = if style.font_properties == prev_font_properties {
+                        prev_font_id
+                    } else {
+                        cx.font_cache
+                            .select_font(self.style.text.font_family_id, &style.font_properties)
+                            .unwrap_or(self.style.text.font_id)
+                    };
+
+                    if line.len() + line_chunk.len() > MAX_LINE_LEN {
+                        let mut chunk_len = MAX_LINE_LEN - line.len();
+                        while !line_chunk.is_char_boundary(chunk_len) {
+                            chunk_len -= 1;
+                        }
+                        line_chunk = &line_chunk[..chunk_len];
+                        line_exceeded_max_len = true;
+                    }
+
+                    line.push_str(line_chunk);
+                    styles.push((
+                        line_chunk.len(),
+                        RunStyle {
+                            font_id,
+                            color: style.color,
+                            underline: style.underline,
+                        },
+                    ));
+                    prev_font_id = font_id;
+                    prev_font_properties = style.font_properties;
+                }
+            }
+        }
+
+        layouts
+    }
 }
 
 impl Element for EditorElement {
@@ -392,30 +564,22 @@ impl Element for EditorElement {
             unimplemented!("we don't yet handle an infinite width constraint on buffer elements");
         }
 
-        let font_cache = &cx.font_cache;
-        let layout_cache = &cx.text_layout_cache;
         let snapshot = self.snapshot(cx.app);
-        let line_height = snapshot.line_height(font_cache);
+        let line_height = self.style.text.line_height(cx.font_cache);
 
         let gutter_padding;
         let gutter_width;
         if snapshot.mode == EditorMode::Full {
-            gutter_padding = snapshot.em_width(cx.font_cache);
-            match snapshot.max_line_number_width(cx.font_cache, cx.text_layout_cache) {
-                Err(error) => {
-                    log::error!("error computing max line number width: {}", error);
-                    return (size, None);
-                }
-                Ok(width) => gutter_width = width + gutter_padding * 2.0,
-            }
+            gutter_padding = self.style.text.em_width(cx.font_cache);
+            gutter_width = self.max_line_number_width(&snapshot, cx) + gutter_padding * 2.0;
         } else {
             gutter_padding = 0.0;
             gutter_width = 0.0
         };
 
         let text_width = size.x() - gutter_width;
-        let text_offset = vec2f(-snapshot.font_descent(cx.font_cache), 0.);
-        let em_width = snapshot.em_width(font_cache);
+        let text_offset = vec2f(-self.style.text.descent(cx.font_cache), 0.);
+        let em_width = self.style.text.em_width(cx.font_cache);
         let overscroll = vec2f(em_width, 0.);
         let wrap_width = text_width - text_offset.x() - overscroll.x() - em_width;
         let snapshot = self.update_view(cx.app, |view, cx| {
@@ -490,51 +654,18 @@ impl Element for EditorElement {
         });
 
         let line_number_layouts = if snapshot.mode == EditorMode::Full {
-            let settings = self
-                .view
-                .upgrade(cx.app)
-                .unwrap()
-                .read(cx.app)
-                .settings
-                .borrow();
-            match snapshot.layout_line_numbers(
-                start_row..end_row,
-                &active_rows,
-                cx.font_cache,
-                cx.text_layout_cache,
-                &settings.theme,
-            ) {
-                Err(error) => {
-                    log::error!("error laying out line numbers: {}", error);
-                    return (size, None);
-                }
-                Ok(layouts) => layouts,
-            }
+            self.layout_line_numbers(start_row..end_row, &active_rows, &snapshot, cx)
         } else {
             Vec::new()
         };
 
         let mut max_visible_line_width = 0.0;
-        let line_layouts = match snapshot.layout_lines(
-            start_row..end_row,
-            &self.style,
-            font_cache,
-            layout_cache,
-        ) {
-            Err(error) => {
-                log::error!("error laying out lines: {}", error);
-                return (size, None);
+        let line_layouts = self.layout_lines(start_row..end_row, &mut snapshot, cx);
+        for line in &line_layouts {
+            if line.width() > max_visible_line_width {
+                max_visible_line_width = line.width();
             }
-            Ok(layouts) => {
-                for line in &layouts {
-                    if line.width() > max_visible_line_width {
-                        max_visible_line_width = line.width();
-                    }
-                }
-
-                layouts
-            }
-        };
+        }
 
         let mut layout = LayoutState {
             size,
@@ -544,6 +675,7 @@ impl Element for EditorElement {
             overscroll,
             text_offset,
             snapshot,
+            style: self.style.clone(),
             active_rows,
             line_layouts,
             line_number_layouts,
@@ -553,15 +685,18 @@ impl Element for EditorElement {
             max_visible_line_width,
         };
 
+        let scroll_max = layout.scroll_max(cx.font_cache, cx.text_layout_cache).x();
+        let scroll_width = layout.scroll_width(cx.text_layout_cache);
+        let max_glyph_width = self.style.text.em_width(&cx.font_cache);
         self.update_view(cx.app, |view, cx| {
-            let clamped = view.clamp_scroll_left(layout.scroll_max(font_cache, layout_cache).x());
+            let clamped = view.clamp_scroll_left(scroll_max);
             let autoscrolled;
             if autoscroll_horizontally {
                 autoscrolled = view.autoscroll_horizontally(
                     start_row,
                     layout.text_size.x(),
-                    layout.scroll_width(font_cache, layout_cache),
-                    layout.snapshot.em_width(font_cache),
+                    scroll_width,
+                    max_glyph_width,
                     &layout.line_layouts,
                     cx,
                 );
@@ -661,6 +796,7 @@ pub struct LayoutState {
     gutter_size: Vector2F,
     gutter_padding: f32,
     text_size: Vector2F,
+    style: EditorStyle,
     snapshot: Snapshot,
     active_rows: BTreeMap<u32, bool>,
     line_layouts: Vec<text_layout::Line>,
@@ -674,25 +810,51 @@ pub struct LayoutState {
 }
 
 impl LayoutState {
-    fn scroll_width(&self, font_cache: &FontCache, layout_cache: &TextLayoutCache) -> f32 {
+    fn scroll_width(&self, layout_cache: &TextLayoutCache) -> f32 {
         let row = self.snapshot.longest_row();
-        let longest_line_width = self
-            .snapshot
-            .layout_line(row, font_cache, layout_cache)
-            .unwrap()
-            .width();
+        let longest_line_width = self.layout_line(row, &self.snapshot, layout_cache).width();
         longest_line_width.max(self.max_visible_line_width) + self.overscroll.x()
     }
 
     fn scroll_max(&self, font_cache: &FontCache, layout_cache: &TextLayoutCache) -> Vector2F {
         let text_width = self.text_size.x();
-        let scroll_width = self.scroll_width(font_cache, layout_cache);
-        let em_width = self.snapshot.em_width(font_cache);
+        let scroll_width = self.scroll_width(layout_cache);
+        let em_width = self.style.text.em_width(font_cache);
         let max_row = self.snapshot.max_point().row();
 
         vec2f(
             ((scroll_width - text_width) / em_width).max(0.0),
             max_row.saturating_sub(1) as f32,
+        )
+    }
+
+    pub fn layout_line(
+        &self,
+        row: u32,
+        snapshot: &Snapshot,
+        layout_cache: &TextLayoutCache,
+    ) -> text_layout::Line {
+        let mut line = snapshot.line(row);
+
+        if line.len() > MAX_LINE_LEN {
+            let mut len = MAX_LINE_LEN;
+            while !line.is_char_boundary(len) {
+                len -= 1;
+            }
+            line.truncate(len);
+        }
+
+        layout_cache.layout_str(
+            &line,
+            self.style.text.font_size,
+            &[(
+                snapshot.line_len(row) as usize,
+                RunStyle {
+                    font_id: self.style.text.font_id,
+                    color: Color::black(),
+                    underline: false,
+                },
+            )],
         )
     }
 }
@@ -865,4 +1027,43 @@ fn scale_vertical_mouse_autoscroll_delta(delta: f32) -> f32 {
 
 fn scale_horizontal_mouse_autoscroll_delta(delta: f32) -> f32 {
     delta.powf(1.2) / 300.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        editor::{Buffer, Editor, EditorStyle},
+        settings,
+        test::sample_text,
+    };
+
+    #[gpui::test]
+    fn test_layout_line_numbers(cx: &mut gpui::MutableAppContext) {
+        let font_cache = cx.font_cache().clone();
+        let settings = settings::test(&cx).1;
+        let style = EditorStyle::test(&font_cache);
+
+        let buffer = cx.add_model(|cx| Buffer::new(0, sample_text(6, 6), cx));
+        let (window_id, editor) = cx.add_window(Default::default(), |cx| {
+            Editor::for_buffer(
+                buffer,
+                settings.clone(),
+                {
+                    let style = style.clone();
+                    move |_| style.clone()
+                },
+                cx,
+            )
+        });
+        let element = EditorElement::new(editor.downgrade(), style);
+
+        let layouts = editor.update(cx, |editor, cx| {
+            let snapshot = editor.snapshot(cx);
+            let mut presenter = cx.build_presenter(window_id, 30.);
+            let mut layout_cx = presenter.build_layout_context(false, cx);
+            element.layout_line_numbers(0..6, &Default::default(), &snapshot, &mut layout_cx)
+        });
+        assert_eq!(layouts.len(), 6);
+    }
 }

--- a/zed/src/editor/movement.rs
+++ b/zed/src/editor/movement.rs
@@ -180,16 +180,21 @@ fn char_kind(c: char) -> CharKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        editor::{display_map::DisplayMap, Buffer},
-        test::test_app_state,
-    };
+    use crate::editor::{display_map::DisplayMap, Buffer};
 
     #[gpui::test]
     fn test_prev_next_word_boundary_multibyte(cx: &mut gpui::MutableAppContext) {
-        let settings = test_app_state(cx).settings.clone();
+        let tab_size = 4;
+        let family_id = cx.font_cache().load_family(&["Helvetica"]).unwrap();
+        let font_id = cx
+            .font_cache()
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+
         let buffer = cx.add_model(|cx| Buffer::new(0, "a bcΔ defγ", cx));
-        let display_map = cx.add_model(|cx| DisplayMap::new(buffer, settings, None, cx));
+        let display_map =
+            cx.add_model(|cx| DisplayMap::new(buffer, tab_size, font_id, font_size, None, cx));
         let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
         assert_eq!(
             prev_word_boundary(&snapshot, DisplayPoint::new(0, 12)).unwrap(),

--- a/zed/src/file_finder.rs
+++ b/zed/src/file_finder.rs
@@ -275,10 +275,14 @@ impl FileFinder {
         cx.observe(&workspace, Self::workspace_updated).detach();
 
         let query_editor = cx.add_view(|cx| {
-            Editor::single_line(settings.clone(), cx).with_style({
-                let settings = settings.clone();
-                move |_| settings.borrow().theme.selector.input_editor.as_editor()
-            })
+            Editor::single_line(
+                settings.clone(),
+                {
+                    let settings = settings.clone();
+                    move |_| settings.borrow().theme.selector.input_editor.as_editor()
+                },
+                cx,
+            )
         });
         cx.subscribe(&query_editor, Self::on_query_editor_event)
             .detach();

--- a/zed/src/theme.rs
+++ b/zed/src/theme.rs
@@ -164,7 +164,8 @@ pub struct InputEditorStyle {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub text: HighlightStyle,
-    pub placeholder_text: HighlightStyle,
+    #[serde(default)]
+    pub placeholder_text: Option<HighlightStyle>,
     pub selection: SelectionStyle,
 }
 

--- a/zed/src/theme.rs
+++ b/zed/src/theme.rs
@@ -163,9 +163,9 @@ pub struct ContainedLabel {
 pub struct InputEditorStyle {
     #[serde(flatten)]
     pub container: ContainerStyle,
-    pub text: HighlightStyle,
+    pub text: TextStyle,
     #[serde(default)]
-    pub placeholder_text: Option<HighlightStyle>,
+    pub placeholder_text: Option<TextStyle>,
     pub selection: SelectionStyle,
 }
 
@@ -196,7 +196,11 @@ impl InputEditorStyle {
                 .background_color
                 .unwrap_or(Color::transparent_black()),
             selection: self.selection,
-            ..Default::default()
+            gutter_background: Default::default(),
+            active_line_background: Default::default(),
+            line_number: Default::default(),
+            line_number_active: Default::default(),
+            guest_selections: Default::default(),
         }
     }
 }

--- a/zed/src/theme.rs
+++ b/zed/src/theme.rs
@@ -2,6 +2,7 @@ mod highlight_map;
 mod resolution;
 mod theme_registry;
 
+use crate::editor::{EditorStyle, SelectionStyle};
 use anyhow::Result;
 use gpui::{
     color::Color,
@@ -159,32 +160,12 @@ pub struct ContainedLabel {
 }
 
 #[derive(Clone, Deserialize)]
-pub struct EditorStyle {
-    pub text: HighlightStyle,
-    #[serde(default)]
-    pub placeholder_text: HighlightStyle,
-    pub background: Color,
-    pub selection: SelectionStyle,
-    pub gutter_background: Color,
-    pub active_line_background: Color,
-    pub line_number: Color,
-    pub line_number_active: Color,
-    pub guest_selections: Vec<SelectionStyle>,
-}
-
-#[derive(Clone, Deserialize)]
 pub struct InputEditorStyle {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub text: HighlightStyle,
     pub placeholder_text: HighlightStyle,
     pub selection: SelectionStyle,
-}
-
-#[derive(Clone, Copy, Default, Deserialize)]
-pub struct SelectionStyle {
-    pub cursor: Color,
-    pub selection: Color,
 }
 
 impl SyntaxTheme {
@@ -201,30 +182,6 @@ impl SyntaxTheme {
     #[cfg(test)]
     pub fn highlight_name(&self, id: HighlightId) -> Option<&str> {
         self.highlights.get(id.0 as usize).map(|e| e.0.as_str())
-    }
-}
-
-impl Default for EditorStyle {
-    fn default() -> Self {
-        Self {
-            text: HighlightStyle {
-                color: Color::from_u32(0xff0000ff),
-                font_properties: Default::default(),
-                underline: false,
-            },
-            placeholder_text: HighlightStyle {
-                color: Color::from_u32(0x00ff00ff),
-                font_properties: Default::default(),
-                underline: false,
-            },
-            background: Default::default(),
-            gutter_background: Default::default(),
-            active_line_background: Default::default(),
-            line_number: Default::default(),
-            line_number_active: Default::default(),
-            selection: Default::default(),
-            guest_selections: Default::default(),
-        }
     }
 }
 

--- a/zed/src/theme_selector.rs
+++ b/zed/src/theme_selector.rs
@@ -58,10 +58,14 @@ impl ThemeSelector {
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let query_editor = cx.add_view(|cx| {
-            Editor::single_line(settings.clone(), cx).with_style({
-                let settings = settings.clone();
-                move |_| settings.borrow().theme.selector.input_editor.as_editor()
-            })
+            Editor::single_line(
+                settings.clone(),
+                {
+                    let settings = settings.clone();
+                    move |_| settings.borrow().theme.selector.input_editor.as_editor()
+                },
+                cx,
+            )
         });
 
         cx.subscribe(&query_editor, Self::on_query_editor_event)


### PR DESCRIPTION
Previously, changing the font family or size of the main editors would also affect editors in other parts of the UI. This PR changes `EditorStyle` to take a full `TextStyle` which includes the font family and size. This allows editors used in the UI to have their font specified in the theme. For content editors, we override the font based on the settings.

In the future, we can control the font size in the UI editors via a user-controllable UI scale factor that affects the entire UI.