### PR TITLE
Fix flaky `zrpc::tests::peer::test_io_error` test

### DIFF
--- a/zrpc/src/peer.rs
+++ b/zrpc/src/peer.rs
@@ -115,7 +115,7 @@ impl Peer {
         let connection_state = ConnectionState {
             outgoing_tx,
             next_message_id: Default::default(),
-            response_channels: Default::default(),
+            response_channels: Arc::new(Mutex::new(Some(Default::default()))),
         };
         let mut writer = MessageStream::new(connection.tx);
         let mut reader = MessageStream::new(connection.rx);


### PR DESCRIPTION
Fixes #175 

As a byproduct, I caught a (minor) bug that could cause a request to never complete due to a racy interaction between requests and the shutting down of a connection. With these changes, when closing a connection we will now  *take* `response_channels` as opposed to clearing them, to ensure that `Peer::request` can't succeed in both adding the oneshot channel in `response_channels` map _and_ submit the message onto the `outgoing_tx` channel.

As part of this pull request, we are also streamlining how connections get closed by unifying all the exit code paths of the IO handling future.