### PR TITLE
Compress RPC messages using zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -2613,6 +2616,15 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -6037,4 +6049,34 @@ dependencies = [
  "serde 1.0.125",
  "smol",
  "tempdir",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.9.0+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/zed/src/worktree.rs
+++ b/zed/src/worktree.rs
@@ -42,7 +42,7 @@ use std::{
         atomic::{AtomicUsize, Ordering::SeqCst},
         Arc,
     },
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, SystemTime},
 };
 use zrpc::{PeerId, TypedEnvelope};
 
@@ -1072,14 +1072,9 @@ impl LocalWorktree {
             };
 
             let remote_id = share_request.worktree.as_ref().unwrap().id;
-            let t0 = Instant::now();
             let share_response = rpc.request(share_request).await?;
 
-            log::info!(
-                "sharing worktree {:?} - took {:?}",
-                share_response,
-                t0.elapsed()
-            );
+            log::info!("sharing worktree {:?}", share_response);
             let (snapshots_to_send_tx, snapshots_to_send_rx) =
                 smol::channel::unbounded::<Snapshot>();
 
@@ -1142,8 +1137,7 @@ impl LocalWorktree {
         let snapshot = self.snapshot();
         let root_name = self.root_name.clone();
         cx.background().spawn(async move {
-            let t0 = Instant::now();
-            let result = remote_id.await.map(|id| {
+            remote_id.await.map(|id| {
                 let entries = snapshot
                     .entries_by_path
                     .cursor::<(), ()>()
@@ -1157,9 +1151,7 @@ impl LocalWorktree {
                         entries,
                     }),
                 }
-            });
-            eprintln!("computing share request: {:?}", t0.elapsed());
-            result
+            })
         })
     }
 }

--- a/zrpc/Cargo.toml
+++ b/zrpc/Cargo.toml
@@ -20,6 +20,7 @@ prost = "0.7"
 rand = "0.8"
 rsa = "0.4"
 serde = { version = "1", features = ["derive"] }
+zstd = "0.9"
 
 [build-dependencies]
 prost-build = { git = "https://github.com/tokio-rs/prost", rev = "6cf97ea422b09d98de34643c4dda2d4f8b7e23e6" }

--- a/zrpc/src/lib.rs
+++ b/zrpc/src/lib.rs
@@ -5,4 +5,4 @@ pub mod proto;
 pub use conn::Connection;
 pub use peer::*;
 
-pub const PROTOCOL_VERSION: u32 = 0;
+pub const PROTOCOL_VERSION: u32 = 1;


### PR DESCRIPTION
Closes #108 

This pull request adds compression to `MessageStream` using zstd at level 4 which, empirically, seems to yield a nice balance between size and speed. This is a breaking change and so we're bumping the protocol to version 1.