### PR TITLE
Speed up login by avoiding unnecessary access token verification

### DIFF
--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -263,11 +263,13 @@ async fn post_sign_out(mut request: Request) -> tide::Result {
     Ok(tide::Redirect::new("/").into())
 }
 
+const MAX_ACCESS_TOKENS_TO_STORE: usize = 8;
+
 pub async fn create_access_token(db: &db::Db, user_id: UserId) -> tide::Result<String> {
     let access_token = zed_auth::random_token();
     let access_token_hash =
         hash_access_token(&access_token).context("failed to hash access token")?;
-    db.create_access_token_hash(user_id, access_token_hash)
+    db.create_access_token_hash(user_id, &access_token_hash, MAX_ACCESS_TOKENS_TO_STORE)
         .await?;
     Ok(access_token)
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -162,25 +162,48 @@ impl Db {
     pub async fn create_access_token_hash(
         &self,
         user_id: UserId,
-        access_token_hash: String,
+        access_token_hash: &str,
+        max_access_token_count: usize,
     ) -> Result<()> {
         test_support!(self, {
-            let query = "
-            INSERT INTO access_tokens (user_id, hash)
-            VALUES ($1, $2)
-        ";
-            sqlx::query(query)
+            let insert_query = "
+                INSERT INTO access_tokens (user_id, hash)
+                VALUES ($1, $2);
+            ";
+            let cleanup_query = "
+                DELETE FROM access_tokens
+                WHERE id IN (
+                    SELECT id from access_tokens
+                    WHERE user_id = $1
+                    ORDER BY id DESC
+                    OFFSET $3
+                )
+            ";
+
+            let mut tx = self.pool.begin().await?;
+            sqlx::query(insert_query)
                 .bind(user_id.0)
                 .bind(access_token_hash)
-                .execute(&self.pool)
-                .await
-                .map(drop)
+                .execute(&mut tx)
+                .await?;
+            sqlx::query(cleanup_query)
+                .bind(user_id.0)
+                .bind(access_token_hash)
+                .bind(max_access_token_count as u32)
+                .execute(&mut tx)
+                .await?;
+            tx.commit().await
         })
     }
 
     pub async fn get_access_token_hashes(&self, user_id: UserId) -> Result<Vec<String>> {
         test_support!(self, {
-            let query = "SELECT hash FROM access_tokens WHERE user_id = $1";
+            let query = "
+                SELECT hash
+                FROM access_tokens
+                WHERE user_id = $1
+                ORDER BY id DESC
+            ";
             sqlx::query_scalar(query)
                 .bind(user_id.0)
                 .fetch_all(&self.pool)
@@ -635,5 +658,37 @@ pub mod tests {
         assert_ne!(msg1_id, msg2_id);
         assert_eq!(msg1_id, msg3_id);
         assert_eq!(msg2_id, msg4_id);
+    }
+
+    #[gpui::test]
+    async fn test_create_access_tokens() {
+        let test_db = TestDb::new();
+        let db = test_db.db();
+        let user = db.create_user("the-user", false).await.unwrap();
+
+        db.create_access_token_hash(user, "h1", 3).await.unwrap();
+        db.create_access_token_hash(user, "h2", 3).await.unwrap();
+        assert_eq!(
+            db.get_access_token_hashes(user).await.unwrap(),
+            &["h2".to_string(), "h1".to_string()]
+        );
+
+        db.create_access_token_hash(user, "h3", 3).await.unwrap();
+        assert_eq!(
+            db.get_access_token_hashes(user).await.unwrap(),
+            &["h3".to_string(), "h2".to_string(), "h1".to_string(),]
+        );
+
+        db.create_access_token_hash(user, "h4", 3).await.unwrap();
+        assert_eq!(
+            db.get_access_token_hashes(user).await.unwrap(),
+            &["h4".to_string(), "h3".to_string(), "h2".to_string(),]
+        );
+
+        db.create_access_token_hash(user, "h5", 3).await.unwrap();
+        assert_eq!(
+            db.get_access_token_hashes(user).await.unwrap(),
+            &["h5".to_string(), "h4".to_string(), "h3".to_string()]
+        );
     }
 }


### PR DESCRIPTION
Signing in through the zed app is sometimes very slow. The slowdown happens when authenticating a websocket connection, and is due to the server is performing `scrypt` hash comparisons on a large number of access tokens.

### Problem

Every time a user signs in via the web browser (as opposed to using credentials from their keychain), the server creates a *new* access token for that user. We can't reuse old access tokens, because that would require storing the access token itself in our database, which we don't want to do - we treat access tokens like auto-generated passwords.

So previously, the user's set of access tokens grew without bound, and we always tried to verify the tokens from oldest to newest.

### Fix

1. I've added some logic so that we only keep a limited number of access token hashes (currently 8) for a given user. This way, we won't do an unbounded number of expensive computations during a login attempt.

    The drawback of this is that it's *possible* that we could purge an access token that's still in use. If you you sign into Zed on one computer, cache the credentials in your keychain, and then sign in *repeatedly* on a different computer without caching the credentials, your first computer's session might be forced to re-authenticate eventually. This doesn't seem that bad to me though, since re-authenticating is a pretty smooth experience.

2. I changed the *fetching* of the access tokens so that newer tokens are returned first. This way, in the common case where you *just* authenticated, the server will succeed after only one token hash.