### PR TITLE
Configure production containers to allow performance monitoring

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -22,16 +22,16 @@ if [[ ! -f $ENV_FILE ]]; then
   exit 1
 fi
 
-if [[ -n $(git status --short) ]]; then
-  echo "Cannot deploy with uncommited changes"
+if [[ $ZED_KUBE_NAMESPACE == "production" && -n $(git status --short) ]]; then
+  echo "Cannot deploy uncommited changes to production"
   exit 1
 fi
 
 git_sha=$(git rev-parse HEAD)
-export ZED_IMAGE_ID=registry.digitalocean.com/zed/zed-server:${ZED_KUBE_NAMESPACE}-${git_sha}
+export ZED_IMAGE_ID="registry.digitalocean.com/zed/zed-server:${ZED_KUBE_NAMESPACE}-${git_sha}"
 export $(cat $ENV_FILE)
 
-docker build . --tag $ZED_IMAGE_ID
-docker push $ZED_IMAGE_ID
+docker build . --tag "$ZED_IMAGE_ID"
+docker push "$ZED_IMAGE_ID"
 
 envsubst < server/k8s/manifest.template.yml | kubectl apply -f -

--- a/script/kube-shell
+++ b/script/kube-shell
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $# < 1 ]]; then
+  echo "Usage: $0 [production|staging|...]"
+  exit 1
+fi
+
+export ZED_KUBE_NAMESPACE=$1
+
+pod=$(kubectl --namespace=${ZED_KUBE_NAMESPACE} get pods --selector=app=zed --output=jsonpath='{.items[*].metadata.name}')
+exec kubectl --namespace $ZED_KUBE_NAMESPACE exec --tty --stdin $pod -- /bin/bash

--- a/server/k8s/manifest.template.yml
+++ b/server/k8s/manifest.template.yml
@@ -76,3 +76,8 @@ spec:
                 secretKeyRef:
                   name: github
                   key: privateKey
+          securityContext:
+            capabilities:
+              # FIXME - Switch to the more restrictive `PERFMON` capability.
+              # This capability isn't yet available in a stable version of Debian.
+              add: ["SYS_ADMIN"]


### PR DESCRIPTION
After a recent mysterious production outage where the RPC endpoint become unresponsive, we decided that we should configure the production containers so that it's possible to run `perf(1)` on the zed-server and collect function call stats.

In order to run `perf`, your OS user needs to have certain capabilities enabled. In recent versions of Linux, there is a specific capability,`CAP_PERFMON`, which just enables the `perf`-related syscalls. Unfortunately, our current production docker image is based on Debian, and the latest version of Debian (released earlier in 2021) uses an older version of Linux that doesn't have `CAP_PERFMON`.  So the only way to enable `perf` is to grant the much more course-grained `CAP_SYS_ADMIN` capability. That's what we've done in this PR.

Enabling `CAP_SYS_ADMIN` is probably not optimal from a security perspective. In the long term (i.e. before we have paying customers), we should either upgrade to a newer version of Debian, or switch to some other Linux distribution that tracks a more recent version of the Kernel. But for now, this will make it possible for us to do  more debugging  next time we encounter a mysterious hang in production.