### PR TITLE
Reduce instantiation of generic functions

### DIFF
--- a/gpui/src/app.rs
+++ b/gpui/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
     elements::ElementBox,
-    executor,
+    executor::{self, Task},
     keymap::{self, Keystroke},
     platform::{self, CursorStyle, Platform, PromptLevel, WindowOptions},
     presenter::Presenter,
@@ -8,7 +8,6 @@ use crate::{
     AssetCache, AssetSource, ClipboardItem, FontCache, PathPromptOptions, TextLayoutCache,
 };
 use anyhow::{anyhow, Result};
-use async_task::Task;
 use keymap::MatchResult;
 use parking_lot::Mutex;
 use platform::Event;

--- a/gpui/src/presenter.rs
+++ b/gpui/src/presenter.rs
@@ -7,7 +7,7 @@ use crate::{
     platform::Event,
     text_layout::TextLayoutCache,
     Action, AnyAction, AssetCache, ElementBox, Entity, FontSystem, ModelHandle, ReadModel,
-    ReadView, Scene, UpdateView, View, ViewHandle,
+    ReadView, Scene, View, ViewHandle,
 };
 use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
@@ -261,16 +261,6 @@ impl<'a> DerefMut for LayoutContext<'a> {
 impl<'a> ReadView for LayoutContext<'a> {
     fn read_view<T: View>(&self, handle: &ViewHandle<T>) -> &T {
         self.app.read_view(handle)
-    }
-}
-
-impl<'a> UpdateView for LayoutContext<'a> {
-    fn update_view<T, F, S>(&mut self, handle: &ViewHandle<T>, update: F) -> S
-    where
-        T: View,
-        F: FnOnce(&mut T, &mut crate::ViewContext<T>) -> S,
-    {
-        self.app.update_view(handle, update)
     }
 }
 


### PR DESCRIPTION
Opening this PR early, as something of a dumping ground for our compile-time optimization efforts. I'm leaving some notes in the body, feel free to edit these @nathansobo, @as-cii.

### Links

* [Intro to rustc's self profiler](https://blog.rust-lang.org/inside-rust/2020/02/25/intro-rustc-self-profile.html)
* [Fast Rust Builds](https://matklad.github.io/2021/09/04/fast-rust-builds.html)

### Profiling notes

* Install some rust profiling tools:
    ```
    cargo install --git https://github.com/rust-lang/measureme crox flamegraph summarize
    cargo install cargo-llvm-lines
    ```
* Build zed with profiling (generates a trace file) and summarize the trace:
    ```
    cargo rustc -p zed --lib -- -Zself-profile
    summarize summarize zed-82037.mm_profdata
    ```
* Count the LLVM lines generated during compilation:
    ```
    cargo llvm-lines -p zed --lib
    ```

### Initial findings

* Most time seems to be spent in LLVM codegen and monomorphization. Some time seems to be spent in macro expansion. Results from a `summarize` invocation above after a one-line change in `editor.rs`:

    | Item                                             | Self time | % of total time | Time     |
    |--------------------------------------------------|-----------|-----------------|----|
    | LLVM_module_codegen_emit_obj                     | 7.87s     | 33.323          | 7.87s    |
    | LLVM_passes                                      | 4.38s     | 18.559          | 4.38s    |
    | codegen_module                                   | 2.05s     | 8.688           | 2.48s    |
    | finish_ongoing_codegen                           | 1.61s     | 6.819           | 1.68s    |
    | monomorphization_collector_graph_walk            | 932.22ms  | 3.948           | 2.10s    |
    | expand_crate                                     | 567.86ms  | 2.405           | 765.07ms |

* Most of the LLVM output is from `async_task`, and a few of our own generic functions:

    ```
    Lines           Copies        Function name
    -----           ------        -------------
    2902530 (100%)  74507 (100%)  (TOTAL)
     322908 (11.1%)   482 (0.6%)  async_task::raw::RawTask<F,T,S>::run
     201476 (6.9%)   4338 (5.8%)  async_task::utils::abort_on_panic
     144118 (5.0%)    482 (0.6%)  <async_task::raw::RawTask<F,T,S>::run::Guard<F,T,S> as core::ops::drop::Drop>::drop
      61696 (2.1%)    482 (0.6%)  async_task::raw::RawTask<F,T,S>::wake_by_ref
      57840 (2.0%)    482 (0.6%)  async_task::raw::RawTask<F,T,S>::task_layout
      56590 (1.9%)    482 (0.6%)  async_task::raw::RawTask<F,T,S>::allocate
      50128 (1.7%)    482 (0.6%)  async_task::raw::RawTask<F,T,S>::wake
      36442 (1.3%)     43 (0.1%)  gpui::sum_tree::cursor::Cursor<T,D>::seek_internal
      31330 (1.1%)    482 (0.6%)  async_task::raw::RawTask<F,T,S>::schedule
      28764 (1.0%)    155 (0.2%)  <gpui::app::MutableAppContext as gpui::app::UpdateModel>::update_model
      26510 (0.9%)    482 (0.6%)  async_task::raw::RawTask<F,T,S>::drop_waker
      25736 (0.9%)    470 (0.6%)  alloc::alloc::box_free
      24029 (0.8%)    453 (0.6%)  core::result::Result<T,E>::map_err
     ...
    ``` 

### Changes

* Removed the type parameters from `Cursor::seek_internal`. Shrank our LLVM code by ~11k lines (.3%)
* Boxed all futures and their results before passing them to `async_task` to avoid instantiating several `async_task` functions on every async code path.
* Used dynamic dispatch for `update_model` `update_view`, `read_model_with`, `read_view_with` methods in `app.rs` to avoid per-call instantiation of those methods.

### Improvements

We've reduced the total number of LLVM bitcode lines from  2902530 to 1713333, a 41% reduction.

This improves our build times marginally, but not as much as we thought it would. It does however prevent linear growth of bitcode going forward as we add more async code paths and interactions with model and view handles.

```
  Lines           Copies        Function name
  -----           ------        -------------
  1713333 (100%)  53827 (100%)  (TOTAL)
    24029 (1.4%)    453 (0.8%)  core::result::Result<T,E>::map_err
    21364 (1.2%)    113 (0.2%)  arrayvec::arrayvec::ArrayVec<T,_>::extend_from_iter
    19959 (1.2%)     30 (0.1%)  gpui::sum_tree::cursor::Cursor<T,D>::seek_internal
    17756 (1.0%)    372 (0.7%)  core::mem::replace
    17733 (1.0%)    319 (0.6%)  alloc::alloc::box_free
    16642 (1.0%)    489 (0.9%)  core::ops::function::FnOnce::call_once
    15161 (0.9%)    301 (0.6%)  <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
    13795 (0.8%)     89 (0.2%)  alloc::raw_vec::RawVec<T,A>::grow_amortized
    13315 (0.8%)    130 (0.2%)  <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
    13244 (0.8%)    301 (0.6%)  core::pin::Pin<&mut T>::map_unchecked_mut
    11652 (0.7%)    226 (0.4%)  core::option::Option<T>::map
    10595 (0.6%)     12 (0.0%)  zrpc::peer::Peer::request_internal::{{closure}}
     9699 (0.6%)    527 (1.0%)  core::ptr::read
     9636 (0.6%)     14 (0.0%)  async_task::raw::RawTask<F,T,S>::run
     9280 (0.5%)     58 (0.1%)  prost::encoding::merge_loop
     9258 (0.5%)    378 (0.7%)  core::ops::function::FnOnce::call_once{{vtable.shim}}
     9083 (0.5%)    105 (0.2%)  core::iter::traits::iterator::Iterator::fold
     9030 (0.5%)     67 (0.1%)  gpui::executor::any_local_future::{{closure}}
     8590 (0.5%)    483 (0.9%)  core::option::Option<T>::unwrap
     8218 (0.5%)      9 (0.0%)  gpui::sum_tree::SumTree<T>::push_tree_recursive
     8133 (0.5%)     25 (0.0%)  gpui::sum_tree::cursor::Cursor<T,D>::next_internal
     8048 (0.5%)     68 (0.1%)  gpui::keymap::Binding::new
     7791 (0.5%)     53 (0.1%)  alloc::raw_vec::RawVec<T,A>::allocate_in
     7569 (0.4%)     86 (0.2%)  alloc::vec::Vec<T,A>::extend_desugared
     7452 (0.4%)    542 (1.0%)  core::intrinsics::copy_nonoverlapping
     7098 (0.4%)    865 (1.6%)  core::pin::Pin<P>::new_unchecked
     6859 (0.4%)    158 (0.3%)  core::result::Result<T,E>::unwrap
     6550 (0.4%)    111 (0.2%)  core::iter::adapters::map::map_fold::{{closure}}
     6450 (0.4%)     86 (0.2%)  gpui::app::MutableAppContext::add_action::{{closure}}
     6400 (0.4%)    146 (0.3%)  <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
     6370 (0.4%)     91 (0.2%)  core::alloc::layout::Layout::array
     6363 (0.4%)    119 (0.2%)  core::result::Result<T,E>::map
     6265 (0.4%)     11 (0.0%)  core::slice::sort::partition_in_blocks
```