### PR TITLE
Give the MouseEventHandlers for each tab bar their own id

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2418,6 +2418,10 @@ impl<'a, T: View> RenderContext<'a, T> {
     pub fn handle(&self) -> WeakViewHandle<T> {
         WeakViewHandle::new(self.window_id, self.view_id)
     }
+
+    pub fn view_id(&self) -> usize {
+        self.view_id
+    }
 }
 
 impl AsRef<AppContext> for &AppContext {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -182,7 +182,7 @@ impl Pane {
         let theme = &settings.theme;
 
         enum Tabs {}
-        let tabs = MouseEventHandler::new::<Tabs, _, _, _>(0, cx, |mouse_state, cx| {
+        let tabs = MouseEventHandler::new::<Tabs, _, _, _>(cx.view_id(), cx, |mouse_state, cx| {
             let mut row = Flex::row();
             for (ix, item) in self.items.iter().enumerate() {
                 let is_active = ix == self.active_item;


### PR DESCRIPTION
Fixes #220 

This fixes a beachball where we oscillate back and forth between hovered and unhovered due to confusing two different tab bars as the same tab bar.