### PR TITLE
Avoid server deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,6 +4308,7 @@ dependencies = [
  "rsa",
  "serde 1.0.125",
  "smol",
+ "smol-timeout",
  "tempdir",
  "zstd",
 ]
@@ -4865,6 +4866,16 @@ dependencies = [
  "blocking",
  "futures-lite",
  "once_cell",
+]
+
+[[package]]
+name = "smol-timeout"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847d777e2c6c166bad26264479e80a9820f3d364fcb4a0e23cd57bbfa8e94961"
+dependencies = [
+ "async-io",
+ "pin-project-lite 0.1.12",
 ]
 
 [[package]]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -20,6 +20,7 @@ prost = "0.8"
 rand = "0.8"
 rsa = "0.4"
 serde = { version = "1", features = ["derive"] }
+smol-timeout = "0.6"
 zstd = "0.9"
 
 [build-dependencies]


### PR DESCRIPTION
We learned that the server was deadlocking when trying to acquire the async lock that wraps the `store`. We've made two changes to address this:

1. Switch to a synchronous lock for the store. This type of lock is not `Send`, so the compiler prevents us from holding it across an `await` point. We found places in our code where the lock may not have been released before performing IO.
2. Added a timeout around writes to our web socket stream. We're concerned that currently, a slow client connection could cause writes to hang indefinitely, which would leak tasks in our executor even if we did address the deadlocking concern.

    We're not entirely sure that this is necessary - previously we've seen connections be terminated because of inactivity - but we're adding it as a defensive measure.