### PR TITLE
Fix incorrect rendering when window moves between displays with different scale factors

### DIFF
--- a/crates/gpui/src/platform/mac/renderer.rs
+++ b/crates/gpui/src/platform/mac/renderer.rs
@@ -40,6 +40,7 @@ impl Renderer {
     pub fn new(
         device: metal::Device,
         pixel_format: metal::MTLPixelFormat,
+        scale_factor: f32,
         fonts: Arc<dyn platform::FontSystem>,
     ) -> Self {
         let library = device
@@ -64,7 +65,7 @@ impl Renderer {
             MTLResourceOptions::StorageModeManaged,
         );
 
-        let sprite_cache = SpriteCache::new(device.clone(), vec2i(1024, 768), fonts);
+        let sprite_cache = SpriteCache::new(device.clone(), vec2i(1024, 768), scale_factor, fonts);
         let image_cache = ImageCache::new(device.clone(), vec2i(1024, 768));
         let path_atlases =
             AtlasAllocator::new(device.clone(), build_path_atlas_texture_descriptor());
@@ -522,6 +523,8 @@ impl Renderer {
             return;
         }
 
+        self.sprite_cache.set_scale_factor(scale_factor);
+
         let mut sprites_by_atlas = HashMap::new();
 
         for glyph in glyphs {
@@ -530,7 +533,6 @@ impl Renderer {
                 glyph.font_size,
                 glyph.id,
                 glyph.origin,
-                scale_factor,
             ) {
                 // Snap sprite to pixel grid.
                 let origin = (glyph.origin * scale_factor).floor() + sprite.offset.to_f32();

--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -12,6 +12,7 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 struct GlyphDescriptor {
     font_id: FontId,
     font_size: OrderedFloat<f32>,
+    scale_factor: OrderedFloat<f32>,
     glyph_id: GlyphId,
     subpixel_variant: (u8, u8),
 }
@@ -86,6 +87,7 @@ impl SpriteCache {
             .entry(GlyphDescriptor {
                 font_id,
                 font_size: OrderedFloat(font_size),
+                scale_factor: OrderedFloat(scale_factor),
                 glyph_id,
                 subpixel_variant,
             })

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -205,7 +205,12 @@ impl Window {
                 synthetic_drag_counter: 0,
                 executor,
                 scene_to_render: Default::default(),
-                renderer: Renderer::new(device.clone(), PIXEL_FORMAT, fonts),
+                renderer: Renderer::new(
+                    device.clone(),
+                    PIXEL_FORMAT,
+                    get_scale_factor(native_window),
+                    fonts,
+                ),
                 command_queue: device.new_command_queue(),
                 last_fresh_keydown: None,
                 layer,
@@ -405,10 +410,7 @@ impl platform::WindowContext for WindowState {
     }
 
     fn scale_factor(&self) -> f32 {
-        unsafe {
-            let screen: id = msg_send![self.native_window, screen];
-            NSScreen::backingScaleFactor(screen) as f32
-        }
+        get_scale_factor(self.native_window)
     }
 
     fn titlebar_height(&self) -> f32 {
@@ -424,6 +426,13 @@ impl platform::WindowContext for WindowState {
         unsafe {
             let _: () = msg_send![self.native_window.contentView(), setNeedsDisplay: YES];
         }
+    }
+}
+
+fn get_scale_factor(native_window: id) -> f32 {
+    unsafe {
+        let screen: id = msg_send![native_window, screen];
+        NSScreen::backingScaleFactor(screen) as f32
     }
 }
 


### PR DESCRIPTION
Fixes #234

This PR fixes incorrect rendering of glyphs and icons that would occur when moving a Zed window between different monitors. The problem was that we were caching rendered glyphs without regard to their scale factor.

On the first commit, I simply incorporate the current `scale_factor` into the cache key that represents each glyph.

But then I thought that this seemed wasteful, since a window can only be rendered on one screen at at time, and the window's `scale_factor` does not change frequently. So in the second commit, I store the `scale_factor` as state on the `SpriteCache`, and invalidate the entire cache whenever the scale factor changes. I think this second approach makes more sense, but I might be missing something.