### PR TITLE
Retry flaky `test_soft_wraps` 5 times before giving up

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -619,7 +619,7 @@ mod tests {
         }
     }
 
-    #[gpui::test]
+    #[gpui::test(retries = 5)]
     fn test_soft_wraps(cx: &mut MutableAppContext) {
         cx.foreground().set_block_on_ticks(usize::MAX..=usize::MAX);
         cx.foreground().forbid_parking();


### PR DESCRIPTION
Closes #231 

We have other tests that rely on loading fonts that intermittently fail on CI and for which we used the same mitigation.