### PR TITLE
Maximize new windows

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -12,7 +12,7 @@ use crate::{
     fonts::{FontId, GlyphId, Metrics as FontMetrics, Properties as FontProperties},
     geometry::{
         rect::{RectF, RectI},
-        vector::{vec2f, Vector2F},
+        vector::Vector2F,
     },
     text_layout::{LineLayout, RunStyle},
     AnyAction, ClipboardItem, Menu, Scene,
@@ -105,11 +105,18 @@ pub trait WindowContext {
     fn present_scene(&mut self, scene: Scene);
 }
 
+#[derive(Debug)]
 pub struct WindowOptions<'a> {
-    pub bounds: RectF,
+    pub bounds: WindowBounds,
     pub title: Option<&'a str>,
     pub titlebar_appears_transparent: bool,
     pub traffic_light_position: Option<Vector2F>,
+}
+
+#[derive(Debug)]
+pub enum WindowBounds {
+    Maximized,
+    Fixed(RectF),
 }
 
 pub struct PathPromptOptions {
@@ -157,7 +164,7 @@ pub trait FontSystem: Send + Sync {
 impl<'a> Default for WindowOptions<'a> {
     fn default() -> Self {
         Self {
-            bounds: RectF::new(Default::default(), vec2f(1024.0, 768.0)),
+            bounds: WindowBounds::Maximized,
             title: Default::default(),
             titlebar_appears_transparent: Default::default(),
             traffic_light_position: Default::default(),

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -1,8 +1,10 @@
-use super::CursorStyle;
-use crate::{AnyAction, ClipboardItem};
+use super::{CursorStyle, WindowBounds};
+use crate::{
+    geometry::vector::{vec2f, Vector2F},
+    AnyAction, ClipboardItem,
+};
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
-use pathfinder_geometry::vector::Vector2F;
 use std::{
     any::Any,
     cell::RefCell,
@@ -112,7 +114,10 @@ impl super::Platform for Platform {
         options: super::WindowOptions,
         _executor: Rc<super::executor::Foreground>,
     ) -> Box<dyn super::Window> {
-        Box::new(Window::new(options.bounds.size()))
+        Box::new(Window::new(match options.bounds {
+            WindowBounds::Maximized => vec2f(1024., 768.),
+            WindowBounds::Fixed(rect) => rect.size(),
+        }))
     }
 
     fn key_window_id(&self) -> Option<usize> {

--- a/crates/zed/src/lib.rs
+++ b/crates/zed/src/lib.rs
@@ -10,9 +10,9 @@ pub use client;
 pub use editor;
 use gpui::{
     action,
-    geometry::{rect::RectF, vector::vec2f},
+    geometry::vector::vec2f,
     keymap::Binding,
-    platform::WindowOptions,
+    platform::{WindowBounds, WindowOptions},
     ModelHandle, MutableAppContext, PathPromptOptions, Task, ViewContext,
 };
 pub use lsp;
@@ -122,6 +122,7 @@ fn open_paths(action: &OpenPaths, cx: &mut MutableAppContext) -> Task<()> {
     let (_, workspace) = cx.add_window(window_options(), |cx| {
         build_workspace(&WorkspaceParams::from(app_state.as_ref()), cx)
     });
+    // cx.resize_window(window_id);
     workspace.update(cx, |workspace, cx| {
         workspace.open_paths(&action.0.paths, cx)
     })
@@ -164,7 +165,7 @@ fn build_workspace(params: &WorkspaceParams, cx: &mut ViewContext<Workspace>) ->
 
 fn window_options() -> WindowOptions<'static> {
     WindowOptions {
-        bounds: RectF::new(vec2f(0., 0.), vec2f(1024., 768.)),
+        bounds: WindowBounds::Maximized,
         title: None,
         titlebar_appears_transparent: true,
         traffic_light_position: Some(vec2f(8., 8.)),


### PR DESCRIPTION
Closes #239

At some point, we'll want to store the sizes of all of the users' windows, and preserve them after a restart. But for now, I think the best default when opening a new window is to maximize it. It makes Zed feel like a more serious app.