### PR TITLE
Implement toggle-comments

### DIFF
--- a/crates/buffer/src/lib.rs
+++ b/crates/buffer/src/lib.rs
@@ -564,6 +564,10 @@ impl Buffer {
         self.content().line_len(row)
     }
 
+    pub fn is_line_blank(&self, row: u32) -> bool {
+        self.content().is_line_blank(row)
+    }
+
     pub fn max_point(&self) -> Point {
         self.visible_text.max_point()
     }
@@ -1557,6 +1561,10 @@ impl Snapshot {
         self.content().line_len(row)
     }
 
+    pub fn is_line_blank(&self, row: u32) -> bool {
+        self.content().is_line_blank(row)
+    }
+
     pub fn indent_column_for_line(&self, row: u32) -> u32 {
         self.content().indent_column_for_line(row)
     }
@@ -1574,8 +1582,7 @@ impl Snapshot {
     }
 
     pub fn text_for_range<T: ToOffset>(&self, range: Range<T>) -> Chunks {
-        let range = range.start.to_offset(self)..range.end.to_offset(self);
-        self.visible_text.chunks_in_range(range)
+        self.content().text_for_range(range)
     }
 
     pub fn text_summary_for_range<T>(&self, range: Range<T>) -> TextSummary
@@ -1723,6 +1730,11 @@ impl<'a> Content<'a> {
             Point::new(row + 1, 0).to_offset(self) - 1
         };
         (row_end_offset - row_start_offset) as u32
+    }
+
+    fn is_line_blank(&self, row: u32) -> bool {
+        self.text_for_range(Point::new(row, 0)..Point::new(row, self.line_len(row)))
+            .all(|chunk| chunk.matches(|c: char| !c.is_whitespace()).next().is_none())
     }
 
     pub fn indent_column_for_line(&self, row: u32) -> u32 {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -14,6 +14,7 @@ pub struct LanguageConfig {
     pub name: String,
     pub path_suffixes: Vec<String>,
     pub brackets: Vec<BracketPair>,
+    pub line_comment: Option<String>,
     pub language_server: Option<LanguageServerConfig>,
 }
 
@@ -113,6 +114,10 @@ impl Language {
 
     pub fn name(&self) -> &str {
         self.config.name.as_str()
+    }
+
+    pub fn line_comment_prefix(&self) -> Option<&str> {
+        self.config.line_comment.as_deref()
     }
 
     pub fn start_server(

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -1654,11 +1654,6 @@ impl Snapshot {
         None
     }
 
-    fn is_line_blank(&self, row: u32) -> bool {
-        self.text_for_range(Point::new(row, 0)..Point::new(row, self.line_len(row)))
-            .all(|chunk| chunk.matches(|c: char| !c.is_whitespace()).next().is_none())
-    }
-
     pub fn chunks<'a, T: ToOffset>(
         &'a self,
         range: Range<T>,

--- a/crates/zed/languages/rust/config.toml
+++ b/crates/zed/languages/rust/config.toml
@@ -1,5 +1,6 @@
 name = "Rust"
 path_suffixes = ["rs"]
+line_comment = "// "
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
Fixes #240

The key-binding is `cmd-/`, like in VS Code.