### PR TITLE
Improve support for selecting text via the mouse

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -169,7 +169,7 @@ impl DisplayMap {
 }
 
 pub struct DisplayMapSnapshot {
-    buffer_snapshot: language::Snapshot,
+    pub buffer_snapshot: language::Snapshot,
     folds_snapshot: fold_map::Snapshot,
     tabs_snapshot: tab_map::Snapshot,
     wraps_snapshot: wrap_map::Snapshot,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -55,8 +55,8 @@ impl EditorElement {
     fn mouse_down(
         &self,
         position: Vector2F,
+        alt: bool,
         shift: bool,
-        cmd: bool,
         mut click_count: usize,
         layout: &mut LayoutState,
         paint: &mut PaintState,
@@ -79,7 +79,7 @@ impl EditorElement {
         } else {
             cx.dispatch_action(Select(SelectPhase::Begin {
                 position,
-                add: cmd,
+                add: alt,
                 click_count,
             }));
         }
@@ -861,10 +861,11 @@ impl Element for EditorElement {
             match event {
                 Event::LeftMouseDown {
                     position,
+                    alt,
                     shift,
-                    cmd,
                     click_count,
-                } => self.mouse_down(*position, *shift, *cmd, *click_count, layout, paint, cx),
+                    ..
+                } => self.mouse_down(*position, *alt, *shift, *click_count, layout, paint, cx),
                 Event::LeftMouseUp { position } => self.mouse_up(*position, cx),
                 Event::LeftMouseDragged { position } => {
                     self.mouse_dragged(*position, layout, paint, cx)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -70,6 +70,15 @@ impl EditorElement {
                 click_count,
             }));
             true
+        } else if paint.gutter_bounds.contains_point(position) {
+            let snapshot = self.snapshot(cx.app);
+            let position = paint.point_for_position(&snapshot, layout, position);
+            cx.dispatch_action(Select(SelectPhase::Begin {
+                position,
+                add: cmd,
+                click_count: 3,
+            }));
+            true
         } else {
             false
         }
@@ -829,6 +838,7 @@ impl Element for EditorElement {
 
             Some(PaintState {
                 bounds,
+                gutter_bounds,
                 text_bounds,
             })
         } else {
@@ -955,6 +965,7 @@ impl LayoutState {
 
 pub struct PaintState {
     bounds: RectF,
+    gutter_bounds: RectF,
     text_bounds: RectF,
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1,6 +1,6 @@
 use super::{
     DisplayPoint, DisplayRow, Editor, EditorMode, EditorSettings, EditorStyle, Input, Scroll,
-    Select, SelectMode, SelectPhase, Snapshot, MAX_LINE_LEN,
+    Select, SelectPhase, Snapshot, MAX_LINE_LEN,
 };
 use clock::ReplicaId;
 use gpui::{
@@ -56,7 +56,7 @@ impl EditorElement {
         &self,
         position: Vector2F,
         cmd: bool,
-        count: usize,
+        click_count: usize,
         layout: &mut LayoutState,
         paint: &mut PaintState,
         cx: &mut EventContext,
@@ -64,16 +64,10 @@ impl EditorElement {
         if paint.text_bounds.contains_point(position) {
             let snapshot = self.snapshot(cx.app);
             let position = paint.point_for_position(&snapshot, layout, position);
-            let mode = match count {
-                1 => SelectMode::Character,
-                2 => SelectMode::Word,
-                3 => SelectMode::Line,
-                _ => SelectMode::All,
-            };
             cx.dispatch_action(Select(SelectPhase::Begin {
                 position,
                 add: cmd,
-                mode,
+                click_count,
             }));
             true
         } else {
@@ -855,8 +849,8 @@ impl Element for EditorElement {
                 Event::LeftMouseDown {
                     position,
                     cmd,
-                    count,
-                } => self.mouse_down(*position, *cmd, *count, layout, paint, cx),
+                    click_count,
+                } => self.mouse_down(*position, *cmd, *click_count, layout, paint, cx),
                 Event::LeftMouseUp { position } => self.mouse_up(*position, cx),
                 Event::LeftMouseDragged { position } => {
                     self.mouse_dragged(*position, layout, paint, cx)

--- a/crates/editor/src/lib.rs
+++ b/crates/editor/src/lib.rs
@@ -751,6 +751,16 @@ impl Editor {
 
         if !add {
             self.update_selections::<usize>(Vec::new(), false, cx);
+        } else if click_count > 1 {
+            // Remove the newest selection since it was only added as part of this multi-click.
+            let newest_selection = self.newest_selection::<usize>(cx);
+            self.update_selections::<usize>(
+                self.selections(cx)
+                    .filter(|selection| selection.id != newest_selection.id)
+                    .collect(),
+                false,
+                cx,
+            )
         }
 
         self.pending_selection = Some(PendingSelection { selection, mode });

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -1,5 +1,7 @@
-use super::{Bias, DisplayMapSnapshot, DisplayPoint, SelectionGoal};
+use super::{Bias, DisplayMapSnapshot, DisplayPoint, SelectionGoal, ToDisplayPoint};
 use anyhow::Result;
+use buffer::ToPoint;
+use std::{cmp, ops::Range};
 
 pub fn left(map: &DisplayMapSnapshot, mut point: DisplayPoint) -> Result<DisplayPoint> {
     if point.column() > 0 {
@@ -113,10 +115,7 @@ pub fn line_end(map: &DisplayMapSnapshot, point: DisplayPoint) -> Result<Display
     Ok(map.clip_point(line_end, Bias::Left))
 }
 
-pub fn prev_word_boundary(
-    map: &DisplayMapSnapshot,
-    mut point: DisplayPoint,
-) -> Result<DisplayPoint> {
+pub fn prev_word_boundary(map: &DisplayMapSnapshot, mut point: DisplayPoint) -> DisplayPoint {
     let mut line_start = 0;
     if point.row() > 0 {
         if let Some(indent) = map.soft_wrap_indent(point.row() - 1) {
@@ -126,7 +125,7 @@ pub fn prev_word_boundary(
 
     if point.column() == line_start {
         if point.row() == 0 {
-            return Ok(DisplayPoint::new(0, 0));
+            return DisplayPoint::new(0, 0);
         } else {
             let row = point.row() - 1;
             point = map.clip_point(DisplayPoint::new(row, map.line_len(row)), Bias::Left);
@@ -152,13 +151,10 @@ pub fn prev_word_boundary(
         prev_char_kind = char_kind;
         column += c.len_utf8() as u32;
     }
-    Ok(boundary)
+    boundary
 }
 
-pub fn next_word_boundary(
-    map: &DisplayMapSnapshot,
-    mut point: DisplayPoint,
-) -> Result<DisplayPoint> {
+pub fn next_word_boundary(map: &DisplayMapSnapshot, mut point: DisplayPoint) -> DisplayPoint {
     let mut prev_char_kind = None;
     for c in map.chars_at(point) {
         let char_kind = char_kind(c);
@@ -182,14 +178,46 @@ pub fn next_word_boundary(
         }
         prev_char_kind = Some(char_kind);
     }
-    Ok(point)
+    point
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+pub fn surrounding_word(map: &DisplayMapSnapshot, point: DisplayPoint) -> Range<DisplayPoint> {
+    let mut start = map.clip_point(point, Bias::Left).to_offset(map, Bias::Left);
+    let mut end = start;
+
+    let text = map.buffer_snapshot.text();
+    let mut next_chars = text.chars_at(start).peekable();
+    let mut prev_chars = text.reversed_chars_at(start).peekable();
+    let word_kind = cmp::max(
+        prev_chars.peek().copied().map(char_kind),
+        next_chars.peek().copied().map(char_kind),
+    );
+
+    for ch in prev_chars {
+        if Some(char_kind(ch)) == word_kind {
+            start -= ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    for ch in next_chars {
+        if Some(char_kind(ch)) == word_kind {
+            end += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    start.to_point(&map.buffer_snapshot).to_display_point(map)
+        ..end.to_point(&map.buffer_snapshot).to_display_point(map)
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 enum CharKind {
     Newline,
-    Whitespace,
     Punctuation,
+    Whitespace,
     Word,
 }
 
@@ -225,45 +253,117 @@ mod tests {
             cx.add_model(|cx| DisplayMap::new(buffer, tab_size, font_id, font_size, None, cx));
         let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
         assert_eq!(
-            prev_word_boundary(&snapshot, DisplayPoint::new(0, 12)).unwrap(),
+            prev_word_boundary(&snapshot, DisplayPoint::new(0, 12)),
             DisplayPoint::new(0, 7)
         );
         assert_eq!(
-            prev_word_boundary(&snapshot, DisplayPoint::new(0, 7)).unwrap(),
+            prev_word_boundary(&snapshot, DisplayPoint::new(0, 7)),
             DisplayPoint::new(0, 2)
         );
         assert_eq!(
-            prev_word_boundary(&snapshot, DisplayPoint::new(0, 6)).unwrap(),
+            prev_word_boundary(&snapshot, DisplayPoint::new(0, 6)),
             DisplayPoint::new(0, 2)
         );
         assert_eq!(
-            prev_word_boundary(&snapshot, DisplayPoint::new(0, 2)).unwrap(),
+            prev_word_boundary(&snapshot, DisplayPoint::new(0, 2)),
             DisplayPoint::new(0, 0)
         );
         assert_eq!(
-            prev_word_boundary(&snapshot, DisplayPoint::new(0, 1)).unwrap(),
+            prev_word_boundary(&snapshot, DisplayPoint::new(0, 1)),
             DisplayPoint::new(0, 0)
         );
 
         assert_eq!(
-            next_word_boundary(&snapshot, DisplayPoint::new(0, 0)).unwrap(),
+            next_word_boundary(&snapshot, DisplayPoint::new(0, 0)),
             DisplayPoint::new(0, 1)
         );
         assert_eq!(
-            next_word_boundary(&snapshot, DisplayPoint::new(0, 1)).unwrap(),
+            next_word_boundary(&snapshot, DisplayPoint::new(0, 1)),
             DisplayPoint::new(0, 6)
         );
         assert_eq!(
-            next_word_boundary(&snapshot, DisplayPoint::new(0, 2)).unwrap(),
+            next_word_boundary(&snapshot, DisplayPoint::new(0, 2)),
             DisplayPoint::new(0, 6)
         );
         assert_eq!(
-            next_word_boundary(&snapshot, DisplayPoint::new(0, 6)).unwrap(),
+            next_word_boundary(&snapshot, DisplayPoint::new(0, 6)),
             DisplayPoint::new(0, 12)
         );
         assert_eq!(
-            next_word_boundary(&snapshot, DisplayPoint::new(0, 7)).unwrap(),
+            next_word_boundary(&snapshot, DisplayPoint::new(0, 7)),
             DisplayPoint::new(0, 12)
+        );
+    }
+
+    #[gpui::test]
+    fn test_surrounding_word(cx: &mut gpui::MutableAppContext) {
+        let tab_size = 4;
+        let family_id = cx.font_cache().load_family(&["Helvetica"]).unwrap();
+        let font_id = cx
+            .font_cache()
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+        let buffer = cx.add_model(|cx| Buffer::new(0, "lorem ipsum   dolor\n    sit", cx));
+        let display_map =
+            cx.add_model(|cx| DisplayMap::new(buffer, tab_size, font_id, font_size, None, cx));
+        let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 0)),
+            DisplayPoint::new(0, 0)..DisplayPoint::new(0, 5)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 2)),
+            DisplayPoint::new(0, 0)..DisplayPoint::new(0, 5)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 5)),
+            DisplayPoint::new(0, 0)..DisplayPoint::new(0, 5)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 6)),
+            DisplayPoint::new(0, 6)..DisplayPoint::new(0, 11)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 7)),
+            DisplayPoint::new(0, 6)..DisplayPoint::new(0, 11)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 11)),
+            DisplayPoint::new(0, 6)..DisplayPoint::new(0, 11)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 13)),
+            DisplayPoint::new(0, 11)..DisplayPoint::new(0, 14)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 14)),
+            DisplayPoint::new(0, 14)..DisplayPoint::new(0, 19)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 17)),
+            DisplayPoint::new(0, 14)..DisplayPoint::new(0, 19)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(0, 19)),
+            DisplayPoint::new(0, 14)..DisplayPoint::new(0, 19)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(1, 0)),
+            DisplayPoint::new(1, 0)..DisplayPoint::new(1, 4)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(1, 1)),
+            DisplayPoint::new(1, 0)..DisplayPoint::new(1, 4)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(1, 6)),
+            DisplayPoint::new(1, 4)..DisplayPoint::new(1, 7)
+        );
+        assert_eq!(
+            surrounding_word(&snapshot, DisplayPoint::new(1, 7)),
+            DisplayPoint::new(1, 4)..DisplayPoint::new(1, 7)
         );
     }
 }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -101,18 +101,18 @@ pub fn line_beginning(
     map: &DisplayMapSnapshot,
     point: DisplayPoint,
     toggle_indent: bool,
-) -> Result<DisplayPoint> {
+) -> DisplayPoint {
     let (indent, is_blank) = map.line_indent(point.row());
     if toggle_indent && !is_blank && point.column() != indent {
-        Ok(DisplayPoint::new(point.row(), indent))
+        DisplayPoint::new(point.row(), indent)
     } else {
-        Ok(DisplayPoint::new(point.row(), 0))
+        DisplayPoint::new(point.row(), 0)
     }
 }
 
-pub fn line_end(map: &DisplayMapSnapshot, point: DisplayPoint) -> Result<DisplayPoint> {
+pub fn line_end(map: &DisplayMapSnapshot, point: DisplayPoint) -> DisplayPoint {
     let line_end = DisplayPoint::new(point.row(), map.line_len(point.row()));
-    Ok(map.clip_point(line_end, Bias::Left))
+    map.clip_point(line_end, Bias::Left)
 }
 
 pub fn prev_word_boundary(map: &DisplayMapSnapshot, mut point: DisplayPoint) -> DisplayPoint {

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -181,6 +181,14 @@ pub fn next_word_boundary(map: &DisplayMapSnapshot, mut point: DisplayPoint) -> 
     point
 }
 
+pub fn is_inside_word(map: &DisplayMapSnapshot, point: DisplayPoint) -> bool {
+    let ix = map.clip_point(point, Bias::Left).to_offset(map, Bias::Left);
+    let text = map.buffer_snapshot.text();
+    let next_char_kind = text.chars_at(ix).next().map(char_kind);
+    let prev_char_kind = text.reversed_chars_at(ix).next().map(char_kind);
+    prev_char_kind.zip(next_char_kind) == Some((CharKind::Word, CharKind::Word))
+}
+
 pub fn surrounding_word(map: &DisplayMapSnapshot, point: DisplayPoint) -> Range<DisplayPoint> {
     let mut start = map.clip_point(point, Bias::Left).to_offset(map, Bias::Left);
     let mut end = start;

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -3651,6 +3651,7 @@ mod tests {
             Event::LeftMouseDown {
                 position: Default::default(),
                 cmd: false,
+                click_count: 1,
             },
             cx,
         );

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -3650,6 +3650,7 @@ mod tests {
         presenter.borrow_mut().dispatch_event(
             Event::LeftMouseDown {
                 position: Default::default(),
+                shift: false,
                 cmd: false,
                 click_count: 1,
             },

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -3650,6 +3650,8 @@ mod tests {
         presenter.borrow_mut().dispatch_event(
             Event::LeftMouseDown {
                 position: Default::default(),
+                ctrl: false,
+                alt: false,
                 shift: false,
                 cmd: false,
                 click_count: 1,

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -15,7 +15,7 @@ pub enum Event {
     LeftMouseDown {
         position: Vector2F,
         cmd: bool,
-        count: usize,
+        click_count: usize,
     },
     LeftMouseUp {
         position: Vector2F,

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -15,6 +15,7 @@ pub enum Event {
     LeftMouseDown {
         position: Vector2F,
         cmd: bool,
+        shift: bool,
         click_count: usize,
     },
     LeftMouseUp {

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -15,6 +15,7 @@ pub enum Event {
     LeftMouseDown {
         position: Vector2F,
         cmd: bool,
+        count: usize,
     },
     LeftMouseUp {
         position: Vector2F,

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -14,8 +14,10 @@ pub enum Event {
     },
     LeftMouseDown {
         position: Vector2F,
-        cmd: bool,
+        ctrl: bool,
+        alt: bool,
         shift: bool,
+        cmd: bool,
         click_count: usize,
     },
     LeftMouseUp {

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -94,6 +94,7 @@ impl Event {
                     cmd: native_event
                         .modifierFlags()
                         .contains(NSEventModifierFlags::NSCommandKeyMask),
+                    count: native_event.clickCount() as usize,
                 })
             }
             NSEventType::NSLeftMouseUp => window_height.map(|window_height| Self::LeftMouseUp {

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -86,14 +86,14 @@ impl Event {
                 })
             }
             NSEventType::NSLeftMouseDown => {
+                let modifiers = native_event.modifierFlags();
                 window_height.map(|window_height| Self::LeftMouseDown {
                     position: vec2f(
                         native_event.locationInWindow().x as f32,
                         window_height - native_event.locationInWindow().y as f32,
                     ),
-                    cmd: native_event
-                        .modifierFlags()
-                        .contains(NSEventModifierFlags::NSCommandKeyMask),
+                    shift: modifiers.contains(NSEventModifierFlags::NSShiftKeyMask),
+                    cmd: modifiers.contains(NSEventModifierFlags::NSCommandKeyMask),
                     click_count: native_event.clickCount() as usize,
                 })
             }

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -92,6 +92,8 @@ impl Event {
                         native_event.locationInWindow().x as f32,
                         window_height - native_event.locationInWindow().y as f32,
                     ),
+                    ctrl: modifiers.contains(NSEventModifierFlags::NSControlKeyMask),
+                    alt: modifiers.contains(NSEventModifierFlags::NSAlternateKeyMask),
                     shift: modifiers.contains(NSEventModifierFlags::NSShiftKeyMask),
                     cmd: modifiers.contains(NSEventModifierFlags::NSCommandKeyMask),
                     click_count: native_event.clickCount() as usize,

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -94,7 +94,7 @@ impl Event {
                     cmd: native_event
                         .modifierFlags()
                         .contains(NSEventModifierFlags::NSCommandKeyMask),
-                    count: native_event.clickCount() as usize,
+                    click_count: native_event.clickCount() as usize,
                 })
             }
             NSEventType::NSLeftMouseUp => window_height.map(|window_height| Self::LeftMouseUp {


### PR DESCRIPTION
Closes #237 

* Shift-click to extend the newest selection
* Alt-click to add a new selection
* Double click to select by word
* Triple click to select by line
* Click and drag in the gutter to select lines
* Quad click to select all
