### PR TITLE
Replace signed out silhouette with a "Sign in" label

### DIFF
--- a/crates/theme/src/lib.rs
+++ b/crates/theme/src/lib.rs
@@ -47,6 +47,8 @@ pub struct Titlebar {
     pub offline_icon: OfflineIcon,
     pub icon_color: Color,
     pub avatar: ImageStyle,
+    pub sign_in_prompt: ContainedText,
+    pub hovered_sign_in_prompt: ContainedText,
     pub outdated_warning: ContainedText,
 }
 

--- a/crates/zed/assets/themes/_base.toml
+++ b/crates/zed/assets/themes/_base.toml
@@ -17,7 +17,7 @@ outdated_warning = { extends = "$text.2", size = 13 }
 extends = "$text.2"
 size = 13
 underline = true
-padding = { right = 12 }
+padding = { right = 8 }
 
 [workspace.titlebar.hovered_sign_in_prompt]
 extends = "$workspace.titlebar.sign_in_prompt"

--- a/crates/zed/assets/themes/_base.toml
+++ b/crates/zed/assets/themes/_base.toml
@@ -13,6 +13,16 @@ icon_color = "$text.2.color"
 avatar = { corner_radius = 10, border = { width = 1, color = "#00000088" } }
 outdated_warning = { extends = "$text.2", size = 13 }
 
+[workspace.titlebar.sign_in_prompt]
+extends = "$text.2"
+size = 13
+underline = true
+padding = { right = 12 }
+
+[workspace.titlebar.hovered_sign_in_prompt]
+extends = "$workspace.titlebar.sign_in_prompt"
+color = "$text.1.color"
+
 [workspace.titlebar.offline_icon]
 padding = { right = 4 }
 width = 16


### PR DESCRIPTION
Closes #251 

<img width="1273" alt="Screenshot 2021-11-25 at 10 37 54" src="https://user-images.githubusercontent.com/482957/143416872-f50274fe-b25d-402f-97ec-a0b39277b96c.png">

