### PR TITLE
Implement select next (cmd-d) and replace selection with next (cmd-k cmd-d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
 name = "editor"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "buffer",
  "clock",

--- a/crates/buffer/src/anchor.rs
+++ b/crates/buffer/src/anchor.rs
@@ -142,8 +142,12 @@ impl<T> AnchorMap<T> {
     {
         let content = content.into();
         content
-            .summaries_for_anchors(self)
-            .map(move |(sum, value)| (sum, value))
+            .summaries_for_anchors(
+                self.version.clone(),
+                self.bias,
+                self.entries.iter().map(|e| &e.0),
+            )
+            .zip(self.entries.iter().map(|e| &e.1))
     }
 }
 
@@ -196,7 +200,14 @@ impl<T> AnchorRangeMap<T> {
         D: 'a + TextDimension<'a>,
     {
         let content = content.into();
-        content.summaries_for_anchor_ranges(self)
+        content
+            .summaries_for_anchor_ranges(
+                self.version.clone(),
+                self.start_bias,
+                self.end_bias,
+                self.entries.iter().map(|e| &e.0),
+            )
+            .zip(self.entries.iter().map(|e| &e.1))
     }
 
     pub fn full_offset_ranges(&self) -> impl Iterator<Item = &(Range<FullOffset>, T)> {

--- a/crates/buffer/src/selection.rs
+++ b/crates/buffer/src/selection.rs
@@ -1,3 +1,5 @@
+use sum_tree::Bias;
+
 use crate::rope::TextDimension;
 
 use super::{AnchorRangeMap, Buffer, Content, Point, ToOffset, ToPoint};
@@ -108,6 +110,27 @@ impl SelectionSet {
     {
         self.selections
             .ranges(content)
+            .map(|(range, state)| Selection {
+                id: state.id,
+                start: range.start,
+                end: range.end,
+                reversed: state.reversed,
+                goal: state.goal,
+            })
+    }
+
+    pub fn intersecting_selections<'a, D, I, C>(
+        &'a self,
+        range: Range<(I, Bias)>,
+        content: C,
+    ) -> impl 'a + Iterator<Item = Selection<D>>
+    where
+        D: 'a + TextDimension<'a>,
+        I: 'a + ToOffset,
+        C: 'a + Into<Content<'a>>,
+    {
+        self.selections
+            .intersecting_ranges(range, content)
             .map(|(range, state)| Selection {
                 id: state.id,
                 start: range.start,

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -20,6 +20,7 @@ sum_tree = { path = "../sum_tree" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
+aho-corasick = "0.7"
 anyhow = "1.0"
 lazy_static = "1.4"
 log = "0.4"

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -418,6 +418,12 @@ impl DisplayPoint {
     }
 }
 
+impl ToDisplayPoint for usize {
+    fn to_display_point(&self, map: &DisplayMapSnapshot) -> DisplayPoint {
+        map.point_to_display_point(self.to_point(&map.buffer_snapshot), Bias::Left)
+    }
+}
+
 impl ToDisplayPoint for Point {
     fn to_display_point(&self, map: &DisplayMapSnapshot) -> DisplayPoint {
         map.point_to_display_point(*self, Bias::Left)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -748,11 +748,13 @@ impl Element for EditorElement {
         self.update_view(cx.app, |view, cx| {
             highlighted_row = view.highlighted_row();
             for selection_set_id in view.active_selection_sets(cx).collect::<Vec<_>>() {
-                let replica_selections = view.selections_in_range(
-                    selection_set_id,
-                    DisplayPoint::new(start_row, 0)..DisplayPoint::new(end_row, 0),
-                    cx,
-                );
+                let replica_selections = view
+                    .intersecting_selections(
+                        selection_set_id,
+                        DisplayPoint::new(start_row, 0)..DisplayPoint::new(end_row, 0),
+                        cx,
+                    )
+                    .collect::<Vec<_>>();
                 for selection in &replica_selections {
                     if selection_set_id == view.selection_set_id {
                         let is_empty = selection.start == selection.end;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -380,13 +380,12 @@ impl EditorElement {
 
             for selection in selections {
                 if selection.start != selection.end {
-                    let range_start = cmp::min(selection.start, selection.end);
-                    let range_end = cmp::max(selection.start, selection.end);
-                    let row_range = if range_end.column() == 0 {
-                        cmp::max(range_start.row(), start_row)..cmp::min(range_end.row(), end_row)
+                    let row_range = if selection.end.column() == 0 {
+                        cmp::max(selection.start.row(), start_row)
+                            ..cmp::min(selection.end.row(), end_row)
                     } else {
-                        cmp::max(range_start.row(), start_row)
-                            ..cmp::min(range_end.row() + 1, end_row)
+                        cmp::max(selection.start.row(), start_row)
+                            ..cmp::min(selection.end.row() + 1, end_row)
                     };
 
                     let selection = Selection {
@@ -399,16 +398,18 @@ impl EditorElement {
                             .map(|row| {
                                 let line_layout = &layout.line_layouts[(row - start_row) as usize];
                                 SelectionLine {
-                                    start_x: if row == range_start.row() {
+                                    start_x: if row == selection.start.row() {
                                         content_origin.x()
-                                            + line_layout.x_for_index(range_start.column() as usize)
+                                            + line_layout
+                                                .x_for_index(selection.start.column() as usize)
                                             - scroll_left
                                     } else {
                                         content_origin.x() - scroll_left
                                     },
-                                    end_x: if row == range_end.row() {
+                                    end_x: if row == selection.end.row() {
                                         content_origin.x()
-                                            + line_layout.x_for_index(range_end.column() as usize)
+                                            + line_layout
+                                                .x_for_index(selection.end.column() as usize)
                                             - scroll_left
                                     } else {
                                         content_origin.x()
@@ -425,13 +426,13 @@ impl EditorElement {
                 }
 
                 if view.show_local_cursors() || *replica_id != local_replica_id {
-                    let cursor_position = selection.end;
+                    let cursor_position = selection.head();
                     if (start_row..end_row).contains(&cursor_position.row()) {
                         let cursor_row_layout =
-                            &layout.line_layouts[(selection.end.row() - start_row) as usize];
-                        let x = cursor_row_layout.x_for_index(selection.end.column() as usize)
+                            &layout.line_layouts[(cursor_position.row() - start_row) as usize];
+                        let x = cursor_row_layout.x_for_index(cursor_position.column() as usize)
                             - scroll_left;
-                        let y = selection.end.row() as f32 * layout.line_height - scroll_top;
+                        let y = cursor_position.row() as f32 * layout.line_height - scroll_top;
                         cursors.push(Cursor {
                             color: style.cursor,
                             origin: content_origin + vec2f(x, y),
@@ -747,26 +748,16 @@ impl Element for EditorElement {
         self.update_view(cx.app, |view, cx| {
             highlighted_row = view.highlighted_row();
             for selection_set_id in view.active_selection_sets(cx).collect::<Vec<_>>() {
-                let mut set = Vec::new();
-                for selection in view.selections_in_range(
+                let replica_selections = view.selections_in_range(
                     selection_set_id,
                     DisplayPoint::new(start_row, 0)..DisplayPoint::new(end_row, 0),
                     cx,
-                ) {
-                    set.push(selection.clone());
+                );
+                for selection in &replica_selections {
                     if selection_set_id == view.selection_set_id {
                         let is_empty = selection.start == selection.end;
-                        let mut selection_start;
-                        let mut selection_end;
-                        if selection.start < selection.end {
-                            selection_start = selection.start;
-                            selection_end = selection.end;
-                        } else {
-                            selection_start = selection.end;
-                            selection_end = selection.start;
-                        };
-                        selection_start = snapshot.prev_row_boundary(selection_start).0;
-                        selection_end = snapshot.next_row_boundary(selection_end).0;
+                        let selection_start = snapshot.prev_row_boundary(selection.start).0;
+                        let selection_end = snapshot.next_row_boundary(selection.end).0;
                         for row in cmp::max(selection_start.row(), start_row)
                             ..=cmp::min(selection_end.row(), end_row)
                         {
@@ -777,7 +768,7 @@ impl Element for EditorElement {
                     }
                 }
 
-                selections.insert(selection_set_id.replica_id, set);
+                selections.insert(selection_set_id.replica_id, replica_selections);
             }
         });
 
@@ -939,7 +930,7 @@ pub struct LayoutState {
     line_height: f32,
     em_width: f32,
     em_advance: f32,
-    selections: HashMap<ReplicaId, Vec<Range<DisplayPoint>>>,
+    selections: HashMap<ReplicaId, Vec<buffer::Selection<DisplayPoint>>>,
     overscroll: Vector2F,
     text_offset: Vector2F,
     max_visible_line_width: f32,

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -194,8 +194,8 @@ pub fn deserialize_operation(message: proto::Operation) -> Result<Operation> {
                     .selections
                     .iter()
                     .map(|selection| {
-                        let range = (FullOffset(selection.start as usize), Bias::Left)
-                            ..(FullOffset(selection.end as usize), Bias::Right);
+                        let range = FullOffset(selection.start as usize)
+                            ..FullOffset(selection.end as usize);
                         let state = SelectionState {
                             id: selection.id as usize,
                             reversed: selection.reversed,
@@ -204,7 +204,12 @@ pub fn deserialize_operation(message: proto::Operation) -> Result<Operation> {
                         (range, state)
                     })
                     .collect();
-                let selections = AnchorRangeMap::from_full_offset_ranges(version, entries);
+                let selections = AnchorRangeMap::from_full_offset_ranges(
+                    version,
+                    Bias::Left,
+                    Bias::Left,
+                    entries,
+                );
 
                 Operation::Buffer(buffer::Operation::UpdateSelections {
                     set_id: clock::Lamport {
@@ -276,11 +281,13 @@ pub fn deserialize_selection_set(set: proto::SelectionSet) -> SelectionSet {
         active: set.is_active,
         selections: Arc::new(AnchorRangeMap::from_full_offset_ranges(
             set.version.into(),
+            Bias::Left,
+            Bias::Left,
             set.selections
                 .into_iter()
                 .map(|selection| {
-                    let range = (FullOffset(selection.start as usize), Bias::Left)
-                        ..(FullOffset(selection.end as usize), Bias::Left);
+                    let range =
+                        FullOffset(selection.start as usize)..FullOffset(selection.end as usize);
                     let state = SelectionState {
                         id: selection.id as usize,
                         reversed: selection.reversed,


### PR DESCRIPTION
Closes #253 

This PR also renames `selections_in_range` to `intersecting_selections` and changes it interface to return `Selection<DisplayPoint>` instead of `Range<DisplayPoint>`. It also optimizes the intersecting selections query to avoid resolving selections that don't intersect the specified range.

I usually think of `cmd-u` as a related binding to `cmd-d`, but it's actually the more general facility of "cursor undo", so I think we should implement it as part of a separate effort.