### PR TITLE
Use `&'a Snapshot` directly instead of `impl Into<Content<'a>>`

### DIFF
--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -359,7 +359,8 @@ impl FoldMap {
                 }
 
                 if fold.start > sum.input.bytes {
-                    let text_summary = buffer.text_summary_for_range(sum.input.bytes..fold.start);
+                    let text_summary = buffer
+                        .text_summary_for_range::<TextSummary, _>(sum.input.bytes..fold.start);
                     new_transforms.push(
                         Transform {
                             summary: TransformSummary {
@@ -400,7 +401,8 @@ impl FoldMap {
 
             let sum = new_transforms.summary();
             if sum.input.bytes < edit.new.end {
-                let text_summary = buffer.text_summary_for_range(sum.input.bytes..edit.new.end);
+                let text_summary =
+                    buffer.text_summary_for_range::<TextSummary, _>(sum.input.bytes..edit.new.end);
                 new_transforms.push(
                     Transform {
                         summary: TransformSummary {
@@ -539,7 +541,7 @@ impl Snapshot {
                     let buffer_end = cursor.start().1 + end_in_transform;
                     summary += self
                         .buffer_snapshot
-                        .text_summary_for_range(buffer_start..buffer_end);
+                        .text_summary_for_range::<TextSummary, _>(buffer_start..buffer_end);
                 }
             }
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1358,7 +1358,7 @@ impl Editor {
         let buffer = self.buffer.read(cx);
         if old_selections
             .iter()
-            .zip(autoclose_pair_state.ranges.ranges::<usize, _>(buffer))
+            .zip(autoclose_pair_state.ranges.ranges::<usize>(buffer))
             .all(|(selection, autoclose_range)| {
                 let autoclose_range_end = autoclose_range.end.to_offset(buffer);
                 selection.is_empty() && selection.start == autoclose_range_end
@@ -3072,7 +3072,7 @@ impl Editor {
             .read(cx)
             .selection_set(set_id)
             .unwrap()
-            .intersecting_selections::<Point, _, _>(range, buffer);
+            .intersecting_selections::<Point, _>(range, buffer);
 
         selections
             .map(move |s| Selection {
@@ -3090,7 +3090,7 @@ impl Editor {
         D: 'a + TextDimension<'a> + Ord,
     {
         let buffer = self.buffer.read(cx);
-        let mut selections = self.selection_set(cx).selections::<D, _>(buffer).peekable();
+        let mut selections = self.selection_set(cx).selections::<D>(buffer).peekable();
         let mut pending_selection = self.pending_selection(cx);
         iter::from_fn(move || {
             if let Some(pending) = pending_selection.as_mut() {
@@ -3124,8 +3124,8 @@ impl Editor {
         let buffer = self.buffer.read(cx);
         self.pending_selection.as_ref().map(|pending| Selection {
             id: pending.selection.id,
-            start: pending.selection.start.summary::<D, _>(buffer),
-            end: pending.selection.end.summary::<D, _>(buffer),
+            start: pending.selection.start.summary::<D>(buffer),
+            end: pending.selection.end.summary::<D>(buffer),
             reversed: pending.selection.reversed,
             goal: pending.selection.goal,
         })
@@ -3201,7 +3201,7 @@ impl Editor {
                 if selections.len() == autoclose_pair_state.ranges.len() {
                     selections
                         .iter()
-                        .zip(autoclose_pair_state.ranges.ranges::<Point, _>(buffer))
+                        .zip(autoclose_pair_state.ranges.ranges::<Point>(buffer))
                         .all(|(selection, autoclose_range)| {
                             let head = selection.head().to_point(&*buffer);
                             autoclose_range.start <= head && autoclose_range.end >= head

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -183,7 +183,7 @@ pub fn next_word_boundary(map: &DisplayMapSnapshot, mut point: DisplayPoint) -> 
 
 pub fn is_inside_word(map: &DisplayMapSnapshot, point: DisplayPoint) -> bool {
     let ix = map.clip_point(point, Bias::Left).to_offset(map, Bias::Left);
-    let text = map.buffer_snapshot.text();
+    let text = &map.buffer_snapshot;
     let next_char_kind = text.chars_at(ix).next().map(char_kind);
     let prev_char_kind = text.reversed_chars_at(ix).next().map(char_kind);
     prev_char_kind.zip(next_char_kind) == Some((CharKind::Word, CharKind::Word))
@@ -193,7 +193,7 @@ pub fn surrounding_word(map: &DisplayMapSnapshot, point: DisplayPoint) -> Range<
     let mut start = map.clip_point(point, Bias::Left).to_offset(map, Bias::Left);
     let mut end = start;
 
-    let text = map.buffer_snapshot.text();
+    let text = &map.buffer_snapshot;
     let mut next_chars = text.chars_at(start).peekable();
     let mut prev_chars = text.reversed_chars_at(start).peekable();
     let word_kind = cmp::max(

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -1,6 +1,15 @@
 use super::*;
 use gpui::{ModelHandle, MutableAppContext, Task};
-use std::{any::Any, cell::RefCell, ffi::OsString, iter::FromIterator, ops::Range, path::PathBuf, rc::Rc, time::{Duration, Instant, SystemTime}};
+use std::{
+    any::Any,
+    cell::RefCell,
+    ffi::OsString,
+    iter::FromIterator,
+    ops::Range,
+    path::PathBuf,
+    rc::Rc,
+    time::{Duration, Instant, SystemTime},
+};
 use unindent::Unindent as _;
 
 #[test]
@@ -359,7 +368,7 @@ fn test_autoindent_moves_selections(cx: &mut MutableAppContext) {
         let selection_ranges = buffer
             .selection_set(selection_set_id)
             .unwrap()
-            .selections::<Point, _>(&buffer)
+            .selections::<Point>(&buffer)
             .map(|selection| selection.point_range(&buffer))
             .collect::<Vec<_>>();
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3630,7 +3630,7 @@ mod tests {
             let cursor_positions = buffer
                 .selection_set(selection_set_id)
                 .unwrap()
-                .selections::<Point, _>(&*buffer)
+                .selections::<Point>(&*buffer)
                 .map(|selection| {
                     assert_eq!(selection.start, selection.end);
                     selection.start

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -1,8 +1,8 @@
 use sum_tree::Bias;
 
-use crate::rope::TextDimension;
+use crate::{rope::TextDimension, Snapshot};
 
-use super::{AnchorRangeMap, Buffer, Content, Point, ToOffset, ToPoint};
+use super::{AnchorRangeMap, Buffer, Point, ToOffset, ToPoint};
 use std::{cmp::Ordering, ops::Range, sync::Arc};
 
 pub type SelectionSetId = clock::Lamport;
@@ -103,10 +103,12 @@ impl SelectionSet {
         self.selections.len()
     }
 
-    pub fn selections<'a, D, C>(&'a self, content: C) -> impl 'a + Iterator<Item = Selection<D>>
+    pub fn selections<'a, D>(
+        &'a self,
+        content: &'a Snapshot,
+    ) -> impl 'a + Iterator<Item = Selection<D>>
     where
         D: 'a + TextDimension<'a>,
-        C: 'a + Into<Content<'a>>,
     {
         self.selections
             .ranges(content)
@@ -119,15 +121,14 @@ impl SelectionSet {
             })
     }
 
-    pub fn intersecting_selections<'a, D, I, C>(
+    pub fn intersecting_selections<'a, D, I>(
         &'a self,
         range: Range<(I, Bias)>,
-        content: C,
+        content: &'a Snapshot,
     ) -> impl 'a + Iterator<Item = Selection<D>>
     where
         D: 'a + TextDimension<'a>,
         I: 'a + ToOffset,
-        C: 'a + Into<Content<'a>>,
     {
         self.selections
             .intersecting_ranges(range, content)
@@ -140,10 +141,9 @@ impl SelectionSet {
             })
     }
 
-    pub fn oldest_selection<'a, D, C>(&'a self, content: C) -> Option<Selection<D>>
+    pub fn oldest_selection<'a, D>(&'a self, content: &'a Snapshot) -> Option<Selection<D>>
     where
         D: 'a + TextDimension<'a>,
-        C: 'a + Into<Content<'a>>,
     {
         self.selections
             .min_by_key(content, |selection| selection.id)
@@ -156,10 +156,9 @@ impl SelectionSet {
             })
     }
 
-    pub fn newest_selection<'a, D, C>(&'a self, content: C) -> Option<Selection<D>>
+    pub fn newest_selection<'a, D>(&'a self, content: &'a Snapshot) -> Option<Selection<D>>
     where
         D: 'a + TextDimension<'a>,
-        C: 'a + Into<Content<'a>>,
     {
         self.selections
             .max_by_key(content, |selection| selection.id)

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -67,7 +67,7 @@ fn test_random_edits(mut rng: StdRng) {
 
         let range = buffer.random_byte_range(0, &mut rng);
         assert_eq!(
-            buffer.text_summary_for_range(range.clone()),
+            buffer.text_summary_for_range::<TextSummary, _>(range.clone()),
             TextSummary::from(&reference_string[range])
         );
 
@@ -119,7 +119,7 @@ fn test_line_len() {
 fn test_text_summary_for_range() {
     let buffer = Buffer::new(0, 0, History::new("ab\nefg\nhklm\nnopqrs\ntuvwxyz".into()));
     assert_eq!(
-        buffer.text_summary_for_range(1..3),
+        buffer.text_summary_for_range::<TextSummary, _>(1..3),
         TextSummary {
             bytes: 2,
             lines: Point::new(1, 0),
@@ -131,7 +131,7 @@ fn test_text_summary_for_range() {
         }
     );
     assert_eq!(
-        buffer.text_summary_for_range(1..12),
+        buffer.text_summary_for_range::<TextSummary, _>(1..12),
         TextSummary {
             bytes: 11,
             lines: Point::new(3, 0),
@@ -143,7 +143,7 @@ fn test_text_summary_for_range() {
         }
     );
     assert_eq!(
-        buffer.text_summary_for_range(0..20),
+        buffer.text_summary_for_range::<TextSummary, _>(0..20),
         TextSummary {
             bytes: 20,
             lines: Point::new(4, 1),
@@ -155,7 +155,7 @@ fn test_text_summary_for_range() {
         }
     );
     assert_eq!(
-        buffer.text_summary_for_range(0..22),
+        buffer.text_summary_for_range::<TextSummary, _>(0..22),
         TextSummary {
             bytes: 22,
             lines: Point::new(4, 3),
@@ -167,7 +167,7 @@ fn test_text_summary_for_range() {
         }
     );
     assert_eq!(
-        buffer.text_summary_for_range(7..22),
+        buffer.text_summary_for_range::<TextSummary, _>(7..22),
         TextSummary {
             bytes: 15,
             lines: Point::new(2, 3),


### PR DESCRIPTION
This is minor simplification of the text buffer and associated traits like `ToOffset` and `ToPoint`, removing some generic-ness.