### PR TITLE
Render blocks as arbitrary elements

### DIFF
--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -827,8 +827,8 @@ impl AlignedBlock {
         self.render.lock()(cx)
     }
 
-    pub fn disposition(&self) -> BlockDisposition {
-        self.block.disposition
+    pub fn position(&self) -> &Anchor {
+        &self.block.position
     }
 }
 

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -66,7 +66,6 @@ where
 
 pub struct BlockContext<'a> {
     pub cx: &'a AppContext,
-    pub gutter_width: f32,
     pub anchor_x: f32,
 }
 
@@ -822,6 +821,10 @@ impl AlignedBlock {
     pub fn render(&self, cx: &BlockContext) -> ElementBox {
         self.render.lock()(cx)
     }
+
+    pub fn disposition(&self) -> BlockDisposition {
+        self.block.disposition
+    }
 }
 
 impl Deref for AlignedBlock {
@@ -935,11 +938,7 @@ mod tests {
                     start_row..start_row + block.height(),
                     block.column(),
                     block
-                        .render(&BlockContext {
-                            cx,
-                            gutter_width: 0.,
-                            anchor_x: 0.,
-                        })
+                        .render(&BlockContext { cx, anchor_x: 0. })
                         .name()
                         .unwrap()
                         .to_string(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2883,7 +2883,7 @@ impl Editor {
                     new_styles.insert(*block_id, move |cx: &BlockContext| {
                         let diagnostic = diagnostic.clone();
                         let settings = build_settings.borrow()(cx.cx);
-                        render_diagnostic(diagnostic, &settings.style)
+                        render_diagnostic(diagnostic, &settings.style, is_valid, cx.anchor_x)
                     });
                 }
                 self.display_map
@@ -2931,7 +2931,7 @@ impl Editor {
                             render: Arc::new(move |cx| {
                                 let settings = build_settings.borrow()(cx.cx);
                                 let diagnostic = diagnostic.clone();
-                                render_diagnostic(diagnostic, &settings.style)
+                                render_diagnostic(diagnostic, &settings.style, true, cx.anchor_x)
                             }),
                             disposition: BlockDisposition::Below,
                         }
@@ -3641,10 +3641,18 @@ impl SelectionExt for Selection<Point> {
     }
 }
 
-fn render_diagnostic(diagnostic: Diagnostic, style: &EditorStyle) -> ElementBox {
+fn render_diagnostic(
+    diagnostic: Diagnostic,
+    style: &EditorStyle,
+    valid: bool,
+    anchor_x: f32,
+) -> ElementBox {
     let mut text_style = style.text.clone();
-    text_style.color = diagnostic_style(diagnostic.severity, true, &style).text;
-    Text::new(diagnostic.message, text_style).boxed()
+    text_style.color = diagnostic_style(diagnostic.severity, valid, &style).text;
+    Text::new(diagnostic.message, text_style)
+        .contained()
+        .with_margin_left(anchor_x)
+        .boxed()
 }
 
 pub fn diagnostic_style(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8,11 +8,12 @@ mod test;
 
 use aho_corasick::AhoCorasick;
 use clock::ReplicaId;
+pub use display_map::DisplayPoint;
 use display_map::*;
-pub use display_map::{DisplayPoint, DisplayRow};
 pub use element::*;
 use gpui::{
     action,
+    elements::Text,
     geometry::vector::{vec2f, Vector2F},
     keymap::Binding,
     text_layout, AppContext, ClipboardItem, Element, ElementBox, Entity, ModelHandle,
@@ -28,14 +29,14 @@ use std::{
     cmp,
     collections::HashMap,
     iter, mem,
-    ops::{Range, RangeInclusive},
+    ops::{Deref, Range, RangeInclusive},
     rc::Rc,
     sync::Arc,
     time::Duration,
 };
 use sum_tree::Bias;
 use text::rope::TextDimension;
-use theme::{DiagnosticStyle, EditorStyle, SyntaxTheme};
+use theme::{DiagnosticStyle, EditorStyle};
 use util::post_inc;
 use workspace::{EntryOpener, Workspace};
 
@@ -2877,35 +2878,16 @@ impl Editor {
                 active_diagnostics.is_valid = is_valid;
                 let mut new_styles = HashMap::new();
                 for (block_id, diagnostic) in &active_diagnostics.blocks {
-                    let severity = diagnostic.severity;
-                    let message_len = diagnostic.message.len();
-                    new_styles.insert(
-                        *block_id,
-                        (
-                            Some({
-                                let build_settings = self.build_settings.clone();
-                                move |cx: &AppContext| {
-                                    let settings = build_settings.borrow()(cx);
-                                    vec![(
-                                        message_len,
-                                        diagnostic_style(severity, is_valid, &settings.style)
-                                            .text
-                                            .into(),
-                                    )]
-                                }
-                            }),
-                            Some({
-                                let build_settings = self.build_settings.clone();
-                                move |cx: &AppContext| {
-                                    let settings = build_settings.borrow()(cx);
-                                    diagnostic_style(severity, is_valid, &settings.style).block
-                                }
-                            }),
-                        ),
-                    );
+                    let build_settings = self.build_settings.clone();
+                    let diagnostic = diagnostic.clone();
+                    new_styles.insert(*block_id, move |cx: &BlockContext| {
+                        let diagnostic = diagnostic.clone();
+                        let settings = build_settings.borrow()(cx.cx);
+                        render_diagnostic(diagnostic, &settings.style)
+                    });
                 }
                 self.display_map
-                    .update(cx, |display_map, _| display_map.restyle_blocks(new_styles));
+                    .update(cx, |display_map, _| display_map.replace_blocks(new_styles));
             }
         }
     }
@@ -2940,30 +2922,17 @@ impl Editor {
                 .insert_blocks(
                     diagnostic_group.iter().map(|(range, diagnostic)| {
                         let build_settings = self.build_settings.clone();
-                        let message_len = diagnostic.message.len();
-                        let severity = diagnostic.severity;
+                        let diagnostic = diagnostic.clone();
+                        let message_height = diagnostic.message.lines().count() as u8;
+
                         BlockProperties {
                             position: range.start,
-                            text: diagnostic.message.as_str(),
-                            build_runs: Some(Arc::new({
-                                let build_settings = build_settings.clone();
-                                move |cx| {
-                                    let settings = build_settings.borrow()(cx);
-                                    vec![(
-                                        message_len,
-                                        diagnostic_style(severity, true, &settings.style)
-                                            .text
-                                            .into(),
-                                    )]
-                                }
-                            })),
-                            build_style: Some(Arc::new({
-                                let build_settings = build_settings.clone();
-                                move |cx| {
-                                    let settings = build_settings.borrow()(cx);
-                                    diagnostic_style(severity, true, &settings.style).block
-                                }
-                            })),
+                            height: message_height,
+                            render: Arc::new(move |cx| {
+                                let settings = build_settings.borrow()(cx.cx);
+                                let diagnostic = diagnostic.clone();
+                                render_diagnostic(diagnostic, &settings.style)
+                            }),
                             disposition: BlockDisposition::Below,
                         }
                     }),
@@ -3482,33 +3451,12 @@ impl Editor {
 }
 
 impl Snapshot {
-    pub fn is_empty(&self) -> bool {
-        self.display_snapshot.is_empty()
-    }
-
     pub fn is_focused(&self) -> bool {
         self.is_focused
     }
 
     pub fn placeholder_text(&self) -> Option<&Arc<str>> {
         self.placeholder_text.as_ref()
-    }
-
-    pub fn buffer_row_count(&self) -> u32 {
-        self.display_snapshot.buffer_row_count()
-    }
-
-    pub fn buffer_rows<'a>(&'a self, start_row: u32, cx: &'a AppContext) -> BufferRows<'a> {
-        self.display_snapshot.buffer_rows(start_row, Some(cx))
-    }
-
-    pub fn chunks<'a>(
-        &'a self,
-        display_rows: Range<u32>,
-        theme: Option<&'a SyntaxTheme>,
-        cx: &'a AppContext,
-    ) -> display_map::Chunks<'a> {
-        self.display_snapshot.chunks(display_rows, theme, cx)
     }
 
     pub fn scroll_position(&self) -> Vector2F {
@@ -3518,29 +3466,13 @@ impl Snapshot {
             &self.scroll_top_anchor,
         )
     }
+}
 
-    pub fn max_point(&self) -> DisplayPoint {
-        self.display_snapshot.max_point()
-    }
+impl Deref for Snapshot {
+    type Target = DisplayMapSnapshot;
 
-    pub fn longest_row(&self) -> u32 {
-        self.display_snapshot.longest_row()
-    }
-
-    pub fn line_len(&self, display_row: u32) -> u32 {
-        self.display_snapshot.line_len(display_row)
-    }
-
-    pub fn line(&self, display_row: u32) -> String {
-        self.display_snapshot.line(display_row)
-    }
-
-    pub fn prev_row_boundary(&self, point: DisplayPoint) -> (DisplayPoint, Point) {
-        self.display_snapshot.prev_row_boundary(point)
-    }
-
-    pub fn next_row_boundary(&self, point: DisplayPoint) -> (DisplayPoint, Point) {
-        self.display_snapshot.next_row_boundary(point)
+    fn deref(&self) -> &Self::Target {
+        &self.display_snapshot
     }
 }
 
@@ -3707,6 +3639,12 @@ impl SelectionExt for Selection<Point> {
             display_rows: display_start.row()..display_end.row() + 1,
         }
     }
+}
+
+fn render_diagnostic(diagnostic: Diagnostic, style: &EditorStyle) -> ElementBox {
+    let mut text_style = style.text.clone();
+    text_style.color = diagnostic_style(diagnostic.severity, true, &style).text;
+    Text::new(diagnostic.message, text_style).boxed()
 }
 
 pub fn diagnostic_style(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1,4 +1,4 @@
-use crate::display_map::{BlockContext, BlockDisposition};
+use crate::display_map::{BlockContext, ToDisplayPoint};
 
 use super::{
     DisplayPoint, Editor, EditorMode, EditorSettings, EditorStyle, Input, Scroll, Select,
@@ -19,7 +19,7 @@ use gpui::{
     MutableAppContext, PaintContext, Quad, Scene, SizeConstraint, ViewContext, WeakViewHandle,
 };
 use json::json;
-use language::Chunk;
+use language::{Chunk, ToPoint};
 use smallvec::SmallVec;
 use std::{
     cmp::{self, Ordering},
@@ -633,10 +633,11 @@ impl EditorElement {
         snapshot
             .blocks_in_range(rows.clone())
             .map(|(start_row, block)| {
-                let anchor_row = match block.disposition() {
-                    BlockDisposition::Above => start_row + block.height(),
-                    BlockDisposition::Below => start_row - 1,
-                };
+                let anchor_row = block
+                    .position()
+                    .to_point(&snapshot.buffer_snapshot)
+                    .to_display_point(snapshot)
+                    .row();
 
                 let anchor_x = if rows.contains(&anchor_row) {
                     line_layouts[(anchor_row - rows.start) as usize]

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -301,6 +301,10 @@ impl<T: Element> Default for Lifecycle<T> {
 }
 
 impl ElementBox {
+    pub fn name(&self) -> Option<&str> {
+        self.0.name.as_deref()
+    }
+
     pub fn metadata<T: 'static>(&self) -> Option<&T> {
         let element = unsafe { &*self.0.element.as_ptr() };
         element.metadata().and_then(|m| m.downcast_ref())

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -253,8 +253,6 @@ pub struct EditorStyle {
 #[derive(Copy, Clone, Deserialize, Default)]
 pub struct DiagnosticStyle {
     pub text: Color,
-    #[serde(flatten)]
-    pub block: BlockStyle,
 }
 
 #[derive(Clone, Copy, Default, Deserialize)]
@@ -271,14 +269,6 @@ pub struct InputEditorStyle {
     #[serde(default)]
     pub placeholder_text: Option<TextStyle>,
     pub selection: SelectionStyle,
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
-pub struct BlockStyle {
-    pub background: Option<Color>,
-    pub border: Option<Color>,
-    pub gutter_background: Option<Color>,
-    pub gutter_border: Option<Color>,
 }
 
 impl EditorStyle {


### PR DESCRIPTION
Previously, we attempted to weave the content of block decorations into the editor's text itself. This ended up being pretty complicated and also inflexible. With this PR, you can now pass an arbitrary `render` closure when creating a block that returns an `ElementBox`. You specify the block's `height` as an integer number of lines, and in the text layer we simply punch a hole in the content by inserting empty lines. Then, when laying out and painting the editor element, we query the visible blocks and call their `render` functions to get elements. We then perform layout on each element with a size based on the height of the block in lines. We also provide the `anchor_x` position when rendering the element so that we can align its content.

This will allow us to render arbitrary content in blocks, such as diagnostic messages with a different font size. This is in preparation to attempt to use blocks as our primary primitive for rendering collapsed content regions between excerpts when showing project-wide diagnostics, search results, etc.