### PR TITLE
Add a simple journaling feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,9 +2501,9 @@ dependencies = [
 name = "journal"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "dirs 4.0.0",
+ "editor",
  "gpui",
  "log",
  "util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,17 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake3"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,12 +1447,12 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
- "redox_users 0.3.5",
+ "redox_users",
  "winapi",
 ]
 
@@ -1465,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.0",
+ "redox_users",
  "winapi",
 ]
 
@@ -2500,6 +2498,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "journal"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dirs 4.0.0",
+ "gpui",
+ "log",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,7 +3141,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
@@ -3699,12 +3710,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
@@ -3714,23 +3719,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
-]
-
-[[package]]
-name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.5",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3856,18 +3850,6 @@ dependencies = [
  "simple_asn1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -4522,7 +4504,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
- "dirs",
+ "dirs 3.0.1",
  "either",
  "futures-channel",
  "futures-core",
@@ -4827,7 +4809,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -5649,6 +5631,7 @@ dependencies = [
  "gpui",
  "language",
  "log",
+ "parking_lot",
  "postage",
  "project",
  "serde_json",
@@ -5693,7 +5676,7 @@ dependencies = [
  "contacts_panel",
  "crossbeam-channel",
  "ctor",
- "dirs",
+ "dirs 3.0.1",
  "easy-parallel",
  "editor",
  "env_logger",
@@ -5707,6 +5690,7 @@ dependencies = [
  "ignore",
  "image",
  "indexmap",
+ "journal",
  "language",
  "lazy_static",
  "libc",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1251,7 +1251,7 @@ impl Editor {
         }
     }
 
-    fn insert(&mut self, text: &str, cx: &mut ViewContext<Self>) {
+    pub fn insert(&mut self, text: &str, cx: &mut ViewContext<Self>) {
         self.start_transaction(cx);
         let old_selections = self.selections::<usize>(cx).collect::<SmallVec<[_; 32]>>();
         let mut new_selections = Vec::new();

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -667,7 +667,7 @@ pub struct MutableAppContext {
     assets: Arc<AssetCache>,
     cx: AppContext,
     actions: HashMap<TypeId, HashMap<TypeId, Vec<Box<ActionCallback>>>>,
-    global_actions: HashMap<TypeId, Vec<Box<GlobalActionCallback>>>,
+    global_actions: HashMap<TypeId, Box<GlobalActionCallback>>,
     keystroke_matcher: keymap::Matcher,
     next_entity_id: usize,
     next_window_id: usize,
@@ -838,10 +838,13 @@ impl MutableAppContext {
             handler(action, cx);
         });
 
-        self.global_actions
-            .entry(TypeId::of::<A>())
-            .or_default()
-            .push(handler);
+        if self
+            .global_actions
+            .insert(TypeId::of::<A>(), handler)
+            .is_some()
+        {
+            panic!("registered multiple global handlers for the same action type");
+        }
     }
 
     pub fn window_ids(&self) -> impl Iterator<Item = usize> + '_ {
@@ -1125,7 +1128,7 @@ impl MutableAppContext {
             }
 
             if !halted_dispatch {
-                this.dispatch_global_action_any(action);
+                halted_dispatch = this.dispatch_global_action_any(action);
             }
             halted_dispatch
         })
@@ -1135,13 +1138,14 @@ impl MutableAppContext {
         self.dispatch_global_action_any(&action);
     }
 
-    fn dispatch_global_action_any(&mut self, action: &dyn AnyAction) {
+    fn dispatch_global_action_any(&mut self, action: &dyn AnyAction) -> bool {
         self.update(|this| {
-            if let Some((name, mut handlers)) = this.global_actions.remove_entry(&action.id()) {
-                for handler in handlers.iter_mut().rev() {
-                    handler(action, this);
-                }
-                this.global_actions.insert(name, handlers);
+            if let Some((name, mut handler)) = this.global_actions.remove_entry(&action.id()) {
+                handler(action, this);
+                this.global_actions.insert(name, handler);
+                true
+            } else {
+                false
             }
         })
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -3992,12 +3992,7 @@ mod tests {
 
         let actions_clone = actions.clone();
         cx.add_global_action(move |_: &Action, _: &mut MutableAppContext| {
-            actions_clone.borrow_mut().push("global a".to_string());
-        });
-
-        let actions_clone = actions.clone();
-        cx.add_global_action(move |_: &Action, _: &mut MutableAppContext| {
-            actions_clone.borrow_mut().push("global b".to_string());
+            actions_clone.borrow_mut().push("global".to_string());
         });
 
         let actions_clone = actions.clone();
@@ -4053,7 +4048,7 @@ mod tests {
 
         assert_eq!(
             *actions.borrow(),
-            vec!["4 d", "4 c", "3 b", "3 a", "2 d", "2 c", "global b", "global a"]
+            vec!["4 d", "4 c", "3 b", "3 a", "2 d", "2 c", "global"]
         );
     }
 

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "journal"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/journal.rs"
+
+[dependencies]
+gpui = { path = "../gpui" }
+util = { path = "../util" }
+workspace = { path = "../workspace" }
+anyhow = "1.0"
+chrono = "0.4"
+dirs = "4.0"
+log = "0.4"

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 path = "src/journal.rs"
 
 [dependencies]
+editor = { path = "../editor" }
 gpui = { path = "../gpui" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-anyhow = "1.0"
 chrono = "0.4"
 dirs = "4.0"
 log = "0.4"

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -1,8 +1,7 @@
-use std::{fs::OpenOptions, sync::Arc};
-
-use anyhow::anyhow;
-use chrono::{Datelike, Local};
+use chrono::{Datelike, Local, Timelike};
+use editor::{Autoscroll, Editor};
 use gpui::{action, keymap::Binding, MutableAppContext};
+use std::{fs::OpenOptions, sync::Arc};
 use util::TryFutureExt as _;
 use workspace::AppState;
 
@@ -14,27 +13,37 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
 }
 
 pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
-    let paths = cx.background().spawn(async move {
-        let now = Local::now();
-        let home_dir = dirs::home_dir().ok_or_else(|| anyhow!("can't determine home directory"))?;
-        let journal_dir = home_dir.join("journal");
-        let month_dir = journal_dir
-            .join(now.year().to_string())
-            .join(now.month().to_string());
-        let entry_path = month_dir.join(format!("{}.md", now.day()));
+    let now = Local::now();
+    let home_dir = match dirs::home_dir() {
+        Some(home_dir) => home_dir,
+        None => {
+            log::error!("can't determine home directory");
+            return;
+        }
+    };
 
-        std::fs::create_dir_all(dbg!(month_dir))?;
+    let journal_dir = home_dir.join("journal");
+    let month_dir = journal_dir
+        .join(now.year().to_string())
+        .join(now.month().to_string());
+    let entry_path = month_dir.join(format!("{}.md", now.day()));
+    let now = now.time();
+    let (pm, hour) = now.hour12();
+    let am_or_pm = if pm { "PM" } else { "AM" };
+    let entry_heading = format!("# {}:{} {}\n\n", hour, now.minute(), am_or_pm);
+
+    let create_entry = cx.background().spawn(async move {
+        std::fs::create_dir_all(month_dir)?;
         OpenOptions::new()
             .create(true)
             .write(true)
-            .open(dbg!(&entry_path))?;
-
-        Ok::<_, anyhow::Error>((journal_dir, entry_path))
+            .open(&entry_path)?;
+        Ok::<_, std::io::Error>((journal_dir, entry_path))
     });
 
     cx.spawn(|mut cx| {
         async move {
-            let (journal_dir, entry_path) = paths.await?;
+            let (journal_dir, entry_path) = create_entry.await?;
             let workspace = cx
                 .update(|cx| workspace::open_paths(&[journal_dir], &app_state, cx))
                 .await;
@@ -46,7 +55,16 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                 .await;
 
             if let Some(Some(Ok(item))) = opened.first() {
-                log::info!("opened an item!");
+                if let Some(editor) = item.to_any().downcast::<Editor>() {
+                    editor.update(&mut cx, |editor, cx| {
+                        let len = editor.buffer().read(cx).len();
+                        editor.select_ranges([len..len], Some(Autoscroll::Center), cx);
+                        if len > 0 {
+                            editor.insert("\n\n", cx);
+                        }
+                        editor.insert(&entry_heading, cx);
+                    });
+                }
             }
 
             Ok(())

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -1,0 +1,65 @@
+use std::{fs::OpenOptions, sync::Arc};
+
+use anyhow::anyhow;
+use chrono::{Datelike, Local};
+use gpui::{action, keymap::Binding, MutableAppContext};
+use util::TryFutureExt as _;
+use workspace::AppState;
+
+action!(NewJournalEntry);
+
+pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
+    log::info!("JOURNAL INIT");
+    cx.add_bindings(vec![Binding::new("ctrl-alt-cmd-j", NewJournalEntry, None)]);
+
+    let mut counter = 0;
+    cx.add_global_action(move |_: &NewJournalEntry, cx| {
+        log::info!("NEW JOURNAL ENTRY ACTION");
+        counter += 1;
+        if counter == 2 {
+            log::info!("called twice?");
+        }
+        new_journal_entry(app_state.clone(), cx)
+    });
+}
+
+pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
+    log::info!("NEW JOURNAL ENTRY");
+    let paths = cx.background().spawn(async move {
+        let now = Local::now();
+        let home_dir = dirs::home_dir().ok_or_else(|| anyhow!("can't determine home directory"))?;
+        let journal_dir = home_dir.join("journal");
+        let month_dir = journal_dir
+            .join(now.year().to_string())
+            .join(now.month().to_string());
+        let entry_path = month_dir.join(format!("{}.md", now.day()));
+
+        std::fs::create_dir_all(dbg!(month_dir))?;
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(dbg!(&entry_path))?;
+
+        Ok::<_, anyhow::Error>((journal_dir, entry_path))
+    });
+
+    cx.spawn(|mut cx| {
+        async move {
+            let (journal_dir, entry_path) = paths.await?;
+            let workspace = cx
+                .update(|cx| workspace::open_paths(&[journal_dir], &app_state, cx))
+                .await;
+
+            workspace
+                .update(&mut cx, |workspace, cx| {
+                    workspace.open_paths(&[entry_path], cx)
+                })
+                .await;
+
+            dbg!(workspace);
+            Ok(())
+        }
+        .log_err()
+    })
+    .detach();
+}

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -24,13 +24,13 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
 
     let journal_dir = home_dir.join("journal");
     let month_dir = journal_dir
-        .join(now.year().to_string())
-        .join(now.month().to_string());
-    let entry_path = month_dir.join(format!("{}.md", now.day()));
+        .join(format!("{:2}", now.year()))
+        .join(format!("{:2}", now.month()));
+    let entry_path = month_dir.join(format!("{:2}.md", now.day()));
     let now = now.time();
     let (pm, hour) = now.hour12();
     let am_or_pm = if pm { "PM" } else { "AM" };
-    let entry_heading = format!("# {}:{} {}\n\n", hour, now.minute(), am_or_pm);
+    let entry_heading = format!("# {}:{:2} {}\n\n", hour, now.minute(), am_or_pm);
 
     let create_entry = cx.background().spawn(async move {
         std::fs::create_dir_all(month_dir)?;

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1153,7 +1153,8 @@ mod tests {
                 )
             })
             .unwrap()
-            .await;
+            .await
+            .unwrap();
         workspace_b.read_with(&cx_b, |workspace, cx| {
             let active_pane = workspace.active_pane().read(cx);
             assert!(active_pane.active_item().is_some());

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -11,7 +11,7 @@ use parking_lot::Mutex;
 use postage::watch;
 use std::{cmp, sync::Arc};
 use theme::ThemeRegistry;
-use workspace::{Settings, Workspace};
+use workspace::{Settings, Workspace, AppState};
 
 #[derive(Clone)]
 pub struct ThemeSelectorParams {
@@ -315,5 +315,15 @@ impl View for ThemeSelector {
         let mut cx = Self::default_keymap_context();
         cx.set.insert("menu".into());
         cx
+    }
+}
+
+impl<'a> From<&'a AppState> for ThemeSelectorParams {
+    fn from(state: &'a AppState) -> Self {
+        Self {
+            settings_tx: state.settings_tx.clone(),
+            settings: state.settings.clone(),
+            themes: state.themes.clone(),
+        }
     }
 }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -43,7 +43,10 @@ pub trait ResultExt {
     fn warn_on_err(self) -> Option<Self::Ok>;
 }
 
-impl<T> ResultExt for anyhow::Result<T> {
+impl<T, E> ResultExt for Result<T, E>
+where
+    E: std::fmt::Debug,
+{
     type Ok = T;
 
     fn log_err(self) -> Option<T> {

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -17,6 +17,7 @@ project = { path = "../project" }
 theme = { path = "../theme" }
 anyhow = "1.0.38"
 log = "0.4"
+parking_lot = "0.11.1"
 postage = { version = "0.4.1", features = ["futures-traits"] }
 
 [dev-dependencies]

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -107,15 +107,15 @@ impl Pane {
         &mut self,
         project_path: ProjectPath,
         cx: &mut ViewContext<Self>,
-    ) -> bool {
+    ) -> Option<Box<dyn ItemViewHandle>> {
         if let Some(index) = self.items.iter().position(|item| {
             item.project_path(cx.as_ref())
                 .map_or(false, |item_path| item_path == project_path)
         }) {
             self.activate_item(index, cx);
-            true
+            self.items.get(index).map(|handle| handle.boxed_clone())
         } else {
-            false
+            None
         }
     }
 

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -28,23 +28,24 @@ test-support = [
 ]
 
 [dependencies]
-text = { path = "../text" }
 chat_panel = { path = "../chat_panel" }
 client = { path = "../client" }
 clock = { path = "../clock" }
-fsevent = { path = "../fsevent" }
-fuzzy = { path = "../fuzzy" }
+contacts_panel = { path = "../contacts_panel" }
 editor = { path = "../editor" }
 file_finder = { path = "../file_finder" }
+fsevent = { path = "../fsevent" }
+fuzzy = { path = "../fuzzy" }
 go_to_line = { path = "../go_to_line" }
 gpui = { path = "../gpui" }
+journal = { path = "../journal" }
 language = { path = "../language" }
 lsp = { path = "../lsp" }
-contacts_panel = { path = "../contacts_panel" }
 project = { path = "../project" }
 project_panel = { path = "../project_panel" }
 rpc = { path = "../rpc" }
 sum_tree = { path = "../sum_tree" }
+text = { path = "../text" }
 theme = { path = "../theme" }
 theme_selector = { path = "../theme_selector" }
 util = { path = "../util" }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -9,8 +9,10 @@ use parking_lot::Mutex;
 use simplelog::SimpleLogger;
 use std::{fs, path::PathBuf, sync::Arc};
 use theme::{ThemeRegistry, DEFAULT_THEME_NAME};
-use workspace::{self, settings, OpenNew, Settings};
-use zed::{self, assets::Assets, fs::RealFs, language, menus, AppState, OpenParams, OpenPaths};
+use workspace::{self, settings, AppState, OpenNew, OpenParams, OpenPaths, Settings};
+use zed::{
+    self, assets::Assets, build_window_options, build_workspace, fs::RealFs, language, menus,
+};
 
 fn main() {
     init_logger();
@@ -71,7 +73,10 @@ fn main() {
             user_store,
             fs: Arc::new(RealFs),
             entry_openers: Arc::from(entry_openers),
+            build_window_options: &build_window_options,
+            build_workspace: &build_workspace,
         });
+        journal::init(app_state.clone(), cx);
         zed::init(&app_state, cx);
         theme_selector::init(app_state.as_ref().into(), cx);
 
@@ -83,7 +88,7 @@ fn main() {
 
         let paths = collect_path_args();
         if paths.is_empty() {
-            cx.dispatch_global_action(OpenNew(app_state.as_ref().into()));
+            cx.dispatch_global_action(OpenNew(app_state.clone()));
         } else {
             cx.dispatch_global_action(OpenPaths(OpenParams { paths, app_state }));
         }

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -1,19 +1,9 @@
-use crate::{AppState, WorkspaceParams};
+use crate::AppState;
 use gpui::{Menu, MenuItem};
 use std::sync::Arc;
 
 #[cfg(target_os = "macos")]
 pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
-    let workspace_params = WorkspaceParams {
-        client: state.client.clone(),
-        fs: state.fs.clone(),
-        languages: state.languages.clone(),
-        settings: state.settings.clone(),
-        user_store: state.user_store.clone(),
-        channel_list: state.channel_list.clone(),
-        entry_openers: state.entry_openers.clone(),
-    };
-
     vec![
         Menu {
             name: "Zed",
@@ -37,13 +27,13 @@ pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
                 MenuItem::Action {
                     name: "New",
                     keystroke: Some("cmd-n"),
-                    action: Box::new(workspace::OpenNew(workspace_params)),
+                    action: Box::new(workspace::OpenNew(state.clone())),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Open…",
                     keystroke: Some("cmd-o"),
-                    action: Box::new(crate::Open(state.clone())),
+                    action: Box::new(workspace::Open(state.clone())),
                 },
             ],
         },

--- a/crates/zed/src/test.rs
+++ b/crates/zed/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{assets::Assets, build_window_options, AppState, build_workspace};
+use crate::{assets::Assets, build_window_options, build_workspace, AppState};
 use client::{http::ServerResponse, test::FakeHttpClient, ChannelList, Client, UserStore};
 use gpui::{AssetSource, MutableAppContext};
 use language::LanguageRegistry;

--- a/crates/zed/src/test.rs
+++ b/crates/zed/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{assets::Assets, AppState};
+use crate::{assets::Assets, build_window_options, AppState, build_workspace};
 use client::{http::ServerResponse, test::FakeHttpClient, ChannelList, Client, UserStore};
 use gpui::{AssetSource, MutableAppContext};
 use language::LanguageRegistry;
@@ -42,6 +42,8 @@ pub fn test_app_state(cx: &mut MutableAppContext) -> Arc<AppState> {
         user_store,
         fs: Arc::new(FakeFs::new()),
         entry_openers: Arc::from(entry_openers),
+        build_window_options: &build_window_options,
+        build_workspace: &build_workspace,
     })
 }
 


### PR DESCRIPTION
I frequently use Zed for journaling. I used to maintain a simple package for Atom that would streamline creating a new journal entry. It was useful, so I decided to add it as a feature of Zed. When you hit `ctrl-alt-cmd-j`, Zed will now automatically create and open a new file in `~/journal/$year/$month/$day.md` and insert a heading with the current time at the end of the file.

This is kind of a random feature, but I think it's useful and we don't yet have a package system. Maybe other people will find it useful as well. We can allow the journal location to be customized in the future.

This change prompted some reworking around how we open workspace entries so that I could open stuff from the `journal` crate. Previously, this only was possible via an action triggered in `zed/src/main.rs`.