### PR TITLE
Don't merge keymap contexts from containing elements

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1047,6 +1047,11 @@ impl Editor {
             let buffer = self.buffer.read(cx).snapshot(cx);
             let mut oldest_selection = self.oldest_selection::<usize>(&buffer);
             if self.selection_count() == 1 {
+                if oldest_selection.is_empty() {
+                    cx.propagate_action();
+                    return;
+                }
+
                 oldest_selection.start = oldest_selection.head().clone();
                 oldest_selection.end = oldest_selection.head().clone();
             }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1164,8 +1164,7 @@ impl MutableAppContext {
         let mut context = keymap::Context::default();
         for view_id in &responder_chain {
             if let Some(view) = self.cx.views.get(&(window_id, *view_id)) {
-                context.extend(view.keymap_context(self.as_ref()));
-                context_chain.push(context.clone());
+                context_chain.push(view.keymap_context(self.as_ref()));
             } else {
                 return Err(anyhow!(
                     "View {} in responder chain does not exist",
@@ -4094,7 +4093,10 @@ mod tests {
         let mut view_2 = View::new(2);
         let mut view_3 = View::new(3);
         view_1.keymap_context.set.insert("a".into());
+        view_2.keymap_context.set.insert("a".into());
         view_2.keymap_context.set.insert("b".into());
+        view_3.keymap_context.set.insert("a".into());
+        view_3.keymap_context.set.insert("b".into());
         view_3.keymap_context.set.insert("c".into());
 
         let (window_id, view_1) = cx.add_window(Default::default(), |_| view_1);


### PR DESCRIPTION
I was pairing with @hillegass today on adding a find panel inside the editor, and was perplexed by the fact that our `escape` binding to dismiss the panel wasn't working.

Eventually, we figured out that the `escape` binding on `Editor` was getting triggered instead. This is because of the way that we are merging keymap contexts... so that the context for the `FindPanel` inside an `Editor` is actually `FindPanel & Editor`... it contains both identifiers. This makes it impossible for a keybinding to express whether it's being triggered *directly on* an element or simply *inside* an element.

Eventually, I think we'll want to rework our approach to keymap selectors to be more like CSS so that we can express containment. I'd never want to do all of CSS, but a reasonable subset would make sense. For now, however, I'm not sure we really need to express bindings on an element contained by another kind of element (and maybe we never will).

So now, each element's keymap context is completely controlled by only that element, and none of the state from parent contexts is merged in. I honestly think this could get us pretty far. I had to make one fix to our handling of `escape` in the editor in order to make this change. It only worked before due to a lucky registration order for the bindings in question that caused the `escape` binding for the go-to-line and file finder panels to be triggered before that of the editor.