### PR TITLE
Fix panics when moving lines with block decorations and simplify line boundary detection

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -200,37 +200,27 @@ impl DisplaySnapshot {
         self.buffer_snapshot.max_buffer_row()
     }
 
-    pub fn prev_row_boundary(&self, input_display_point: DisplayPoint) -> (DisplayPoint, Point) {
-        let mut display_point = input_display_point;
+    pub fn prev_row_boundary(&self, mut display_point: DisplayPoint) -> (DisplayPoint, Point) {
         loop {
             *display_point.column_mut() = 0;
             let mut point = display_point.to_point(self);
-            point = self.buffer_snapshot.clip_point(point, Bias::Left);
             point.column = 0;
-            let next_display_point = self.point_to_display_point_with_clipping(point, Bias::Left);
+            let next_display_point = self.point_to_display_point(point, Bias::Left);
             if next_display_point == display_point {
                 return (display_point, point);
-            }
-            if next_display_point > display_point {
-                panic!("invalid display point {:?}", input_display_point);
             }
             display_point = next_display_point;
         }
     }
 
-    pub fn next_row_boundary(&self, input_display_point: DisplayPoint) -> (DisplayPoint, Point) {
-        let mut display_point = input_display_point;
+    pub fn next_row_boundary(&self, mut display_point: DisplayPoint) -> (DisplayPoint, Point) {
         loop {
             *display_point.column_mut() = self.line_len(display_point.row());
-            let mut point = self.display_point_to_point(display_point, Bias::Right);
-            point = self.buffer_snapshot.clip_point(point, Bias::Right);
+            let mut point = display_point.to_point(self);
             point.column = self.buffer_snapshot.line_len(point.row);
             let next_display_point = self.point_to_display_point(point, Bias::Right);
             if next_display_point == display_point {
                 return (display_point, point);
-            }
-            if next_display_point < display_point {
-                panic!("invalid display point {:?}", input_display_point);
             }
             display_point = next_display_point;
         }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -226,6 +226,19 @@ impl DisplaySnapshot {
         }
     }
 
+    pub fn prev_line_boundary(&self, mut point: Point) -> Point {
+        loop {
+            point.column = 0;
+            let mut display_point = self.point_to_display_point(point, Bias::Left);
+            *display_point.column_mut() = 0;
+            let next_point = self.display_point_to_point(display_point, Bias::Left);
+            if next_point == point {
+                return point;
+            }
+            point = next_point;
+        }
+    }
+
     pub fn next_line_boundary(&self, mut point: Point) -> Point {
         loop {
             point.column = self.buffer_snapshot.line_len(point.row);
@@ -243,16 +256,6 @@ impl DisplaySnapshot {
         let fold_point = point.to_fold_point(&self.folds_snapshot, bias);
         let tab_point = self.tabs_snapshot.to_tab_point(fold_point);
         let wrap_point = self.wraps_snapshot.from_tab_point(tab_point);
-        let block_point = self.blocks_snapshot.to_block_point(wrap_point);
-        DisplayPoint(block_point)
-    }
-
-    fn point_to_display_point_with_clipping(&self, point: Point, bias: Bias) -> DisplayPoint {
-        let fold_point = point.to_fold_point(&self.folds_snapshot, bias);
-        let tab_point = self.tabs_snapshot.to_tab_point(fold_point);
-        let wrap_point = self
-            .wraps_snapshot
-            .from_tab_point_with_clipping(tab_point, bias);
         let block_point = self.blocks_snapshot.to_block_point(wrap_point);
         DisplayPoint(block_point)
     }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -226,6 +226,19 @@ impl DisplaySnapshot {
         }
     }
 
+    pub fn next_line_boundary(&self, mut point: Point) -> Point {
+        loop {
+            point.column = self.buffer_snapshot.line_len(point.row);
+            let mut display_point = self.point_to_display_point(point, Bias::Right);
+            *display_point.column_mut() = self.line_len(display_point.row());
+            let next_point = self.display_point_to_point(display_point, Bias::Right);
+            if next_point == point {
+                return point;
+            }
+            point = next_point;
+        }
+    }
+
     fn point_to_display_point(&self, point: Point, bias: Bias) -> DisplayPoint {
         let fold_point = point.to_fold_point(&self.folds_snapshot, bias);
         let tab_point = self.tabs_snapshot.to_tab_point(fold_point);

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -200,53 +200,27 @@ impl DisplaySnapshot {
         self.buffer_snapshot.max_buffer_row()
     }
 
-    pub fn prev_row_boundary(&self, mut display_point: DisplayPoint) -> (DisplayPoint, Point) {
-        loop {
-            *display_point.column_mut() = 0;
-            let mut point = display_point.to_point(self);
-            point.column = 0;
-            let next_display_point = self.point_to_display_point(point, Bias::Left);
-            if next_display_point == display_point {
-                return (display_point, point);
-            }
-            display_point = next_display_point;
-        }
-    }
-
-    pub fn next_row_boundary(&self, mut display_point: DisplayPoint) -> (DisplayPoint, Point) {
-        loop {
-            *display_point.column_mut() = self.line_len(display_point.row());
-            let mut point = display_point.to_point(self);
-            point.column = self.buffer_snapshot.line_len(point.row);
-            let next_display_point = self.point_to_display_point(point, Bias::Right);
-            if next_display_point == display_point {
-                return (display_point, point);
-            }
-            display_point = next_display_point;
-        }
-    }
-
-    pub fn prev_line_boundary(&self, mut point: Point) -> Point {
+    pub fn prev_line_boundary(&self, mut point: Point) -> (Point, DisplayPoint) {
         loop {
             point.column = 0;
             let mut display_point = self.point_to_display_point(point, Bias::Left);
             *display_point.column_mut() = 0;
             let next_point = self.display_point_to_point(display_point, Bias::Left);
             if next_point == point {
-                return point;
+                return (point, display_point);
             }
             point = next_point;
         }
     }
 
-    pub fn next_line_boundary(&self, mut point: Point) -> Point {
+    pub fn next_line_boundary(&self, mut point: Point) -> (Point, DisplayPoint) {
         loop {
             point.column = self.buffer_snapshot.line_len(point.row);
             let mut display_point = self.point_to_display_point(point, Bias::Right);
             *display_point.column_mut() = self.line_len(display_point.row());
             let next_point = self.display_point_to_point(display_point, Bias::Right);
             if next_point == point {
-                return point;
+                return (point, display_point);
             }
             point = next_point;
         }
@@ -631,23 +605,21 @@ mod tests {
             log::info!("display text: {:?}", snapshot.text());
 
             // Line boundaries
+            let buffer = &snapshot.buffer_snapshot;
             for _ in 0..5 {
-                let row = rng.gen_range(0..=snapshot.max_point().row());
-                let column = rng.gen_range(0..=snapshot.line_len(row));
-                let point = snapshot.clip_point(DisplayPoint::new(row, column), Left);
+                let row = rng.gen_range(0..=buffer.max_point().row);
+                let column = rng.gen_range(0..=buffer.line_len(row));
+                let point = buffer.clip_point(Point::new(row, column), Left);
 
-                let (prev_display_bound, prev_buffer_bound) = snapshot.prev_row_boundary(point);
-                let (next_display_bound, next_buffer_bound) = snapshot.next_row_boundary(point);
+                let (prev_buffer_bound, prev_display_bound) = snapshot.prev_line_boundary(point);
+                let (next_buffer_bound, next_display_bound) = snapshot.next_line_boundary(point);
 
-                assert!(prev_display_bound <= point);
-                assert!(next_display_bound >= point);
+                assert!(prev_buffer_bound <= point);
+                assert!(next_buffer_bound >= point);
                 assert_eq!(prev_buffer_bound.column, 0);
                 assert_eq!(prev_display_bound.column(), 0);
-                if next_buffer_bound < snapshot.buffer_snapshot.max_point() {
-                    assert_eq!(
-                        snapshot.buffer_snapshot.chars_at(next_buffer_bound).next(),
-                        Some('\n')
-                    );
+                if next_buffer_bound < buffer.max_point() {
+                    assert_eq!(buffer.chars_at(next_buffer_bound).next(), Some('\n'));
                 }
 
                 assert_eq!(

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -672,15 +672,6 @@ impl WrapSnapshot {
         WrapPoint(cursor.start().1 .0 + (point.0 - cursor.start().0 .0))
     }
 
-    pub fn from_tab_point_with_clipping(&self, point: TabPoint, bias: Bias) -> WrapPoint {
-        let mut cursor = self.transforms.cursor::<(TabPoint, WrapPoint)>();
-        cursor.seek(&point, bias, &());
-        self.clip_point(
-            WrapPoint(cursor.start().1 .0 + (point.0 - cursor.start().0 .0)),
-            bias,
-        )
-    }
-
     pub fn clip_point(&self, mut point: WrapPoint, bias: Bias) -> WrapPoint {
         if bias == Bias::Left {
             let mut cursor = self.transforms.cursor::<WrapPoint>();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1783,8 +1783,104 @@ impl Editor {
     }
 
     pub fn move_line_down(&mut self, _: &MoveLineDown, cx: &mut ViewContext<Self>) {
-        self.start_transaction(cx);
+        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+        let buffer = self.buffer.read(cx).snapshot(cx);
 
+        let mut deletes = Vec::new();
+        let mut inserts = Vec::new();
+        // let mut new_selection_ranges = Vec::new();
+        let mut unfold_ranges = Vec::new();
+        let mut refold_ranges = Vec::new();
+
+        let selections = self.local_selections::<Point>(cx);
+        let mut selections = selections.iter().peekable();
+        let mut contiguous_row_selections = Vec::new();
+        let mut new_selections = Vec::new();
+
+        while let Some(selection) = selections.next() {
+            // Find all the selections that span a contiguous row range
+            contiguous_row_selections.push(selection.clone());
+            let start_row = selection.start.row;
+            let mut end_row = if selection.end.column > 0 || selection.is_empty() {
+                display_map
+                    .next_row_boundary(selection.end.to_display_point(&display_map))
+                    .1
+                    .row
+                    + 1
+            } else {
+                selection.end.row
+            };
+
+            while let Some(next_selection) = selections.peek() {
+                if next_selection.start.row <= end_row {
+                    end_row = if next_selection.end.column > 0 || next_selection.is_empty() {
+                        display_map
+                            .next_row_boundary(next_selection.end.to_display_point(&display_map))
+                            .1
+                            .row
+                            + 1
+                    } else {
+                        next_selection.end.row
+                    };
+                    contiguous_row_selections.push(selections.next().unwrap().clone());
+                } else {
+                    break;
+                }
+            }
+
+            // Move the text spanned by the row range to be after the last line of the row range
+            if end_row <= buffer.max_point().row {
+                let range_to_move = Point::new(start_row, 0)..Point::new(end_row, 0);
+                let insertion_point = Point::new(end_row, buffer.line_len(end_row));
+                let insertion_row = insertion_point.row + 1;
+                let mut text = String::from("\n");
+                text.extend(buffer.text_for_range(range_to_move.clone()));
+                text.pop(); // Drop trailing newline
+                deletes.push(range_to_move.clone());
+                inserts.push((insertion_point, text));
+
+                // Make the selections relative to the insertion row
+                new_selections.extend(contiguous_row_selections.drain(..).map(|mut selection| {
+                    selection.start.row = insertion_row + selection.start.row - start_row;
+                    selection.end.row = insertion_row + selection.end.row - start_row;
+                    selection
+                }));
+
+                // Unfold all the folds spanned by these rows
+                unfold_ranges.push(range_to_move.clone());
+
+                // Refold ranges relative to the insertion row
+                for fold in display_map.folds_in_range(
+                    buffer.anchor_before(range_to_move.start)
+                        ..buffer.anchor_after(range_to_move.end),
+                ) {
+                    let mut start = fold.start.to_point(&buffer);
+                    let mut end = fold.end.to_point(&buffer);
+                    start.row = insertion_row + start.row - start_row;
+                    end.row = insertion_row + end.row - start_row;
+                    refold_ranges.push(start..end);
+                }
+            } else {
+                new_selections.extend(contiguous_row_selections.drain(..));
+            }
+        }
+
+        self.start_transaction(cx);
+        self.unfold_ranges(unfold_ranges, cx);
+        self.buffer.update(cx, |buffer, cx| {
+            for (point, text) in inserts.into_iter().rev() {
+                buffer.edit([point..point], text, cx);
+            }
+        });
+        self.fold_ranges(refold_ranges, cx);
+        self.update_selections(new_selections, Some(Autoscroll::Fit), cx);
+        self.buffer.update(cx, |buffer, cx| {
+            buffer.edit(deletes.into_iter().rev(), "", cx);
+        });
+        self.end_transaction(cx);
+    }
+
+    pub fn move_line_down2(&mut self, _: &MoveLineDown, cx: &mut ViewContext<Self>) {
         let selections = self.local_selections::<Point>(cx);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).snapshot(cx);
@@ -1799,10 +1895,12 @@ impl Editor {
         while let Some(selection) = selections.next() {
             // Accumulate contiguous regions of rows that we want to move.
             contiguous_selections.push(selection.point_range(&buffer));
+
             let SpannedRows {
                 mut buffer_rows,
                 mut display_rows,
             } = selection.spanned_rows(false, &display_map);
+
             while let Some(next_selection) = selections.peek() {
                 let SpannedRows {
                     buffer_rows: next_buffer_rows,
@@ -1818,6 +1916,9 @@ impl Editor {
                 }
             }
 
+            println!("spanned buffer rows {:?}", buffer_rows);
+            println!("spanned display rows {:?}", display_rows);
+
             // Cut the text from the selected rows and paste it at the end of the next line.
             if display_rows.end <= display_map.max_point().row() {
                 let start = Point::new(buffer_rows.start, 0).to_offset(&buffer);
@@ -1829,33 +1930,38 @@ impl Editor {
                 let next_row_buffer_end = display_map.next_row_boundary(next_row_display_end).1;
                 let next_row_buffer_end_offset = next_row_buffer_end.to_offset(&buffer);
 
+                dbg!(next_row_display_end);
+                dbg!(next_row_buffer_end);
+
                 let mut text = String::new();
                 text.push('\n');
                 text.extend(buffer.text_for_range(start..end));
                 edits.push((start..end + 1, String::new()));
                 edits.push((next_row_buffer_end_offset..next_row_buffer_end_offset, text));
 
-                let row_delta = next_row_buffer_end.row - buffer_rows.end + 1;
-
                 // Move selections down.
+                let display_row_delta = next_row_display_end.row() - display_rows.end + 1;
                 for range in &mut contiguous_selections {
-                    range.start.row += row_delta;
-                    range.end.row += row_delta;
+                    range.start.row += display_row_delta;
+                    range.end.row += display_row_delta;
                 }
 
                 // Move folds down.
                 old_folds.push(start..end);
+                let buffer_row_delta = next_row_buffer_end.row - buffer_rows.end + 1;
                 for fold in display_map.folds_in_range(start..end) {
                     let mut start = fold.start.to_point(&buffer);
                     let mut end = fold.end.to_point(&buffer);
-                    start.row += row_delta;
-                    end.row += row_delta;
+                    start.row += buffer_row_delta;
+                    end.row += buffer_row_delta;
                     new_folds.push(start..end);
                 }
             }
 
             new_selection_ranges.extend(contiguous_selections.drain(..));
         }
+
+        self.start_transaction(cx);
 
         self.unfold_ranges(old_folds, cx);
         self.buffer.update(cx, |buffer, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1826,6 +1826,7 @@ impl Editor {
 
                 let next_row_display_end =
                     DisplayPoint::new(display_rows.end, display_map.line_len(display_rows.end));
+
                 let next_row_buffer_end = display_map.next_row_boundary(next_row_display_end).1;
                 let next_row_buffer_end_offset = next_row_buffer_end.to_offset(&buffer);
 
@@ -5165,6 +5166,27 @@ mod tests {
                     DisplayPoint::new(4, 0)..DisplayPoint::new(4, 2)
                 ]
             );
+        });
+    }
+
+    #[gpui::test]
+    fn test_move_line_up_down_with_blocks(cx: &mut gpui::MutableAppContext) {
+        let settings = EditorSettings::test(&cx);
+        let buffer = MultiBuffer::build_simple(&sample_text(10, 5, 'a'), cx);
+        let (_, editor) =
+            cx.add_window(Default::default(), |cx| build_editor(buffer, settings, cx));
+        editor.update(cx, |editor, cx| {
+            editor.insert_blocks(
+                [BlockProperties {
+                    position: Point::new(2, 0),
+                    disposition: BlockDisposition::Below,
+                    height: 1,
+                    render: Arc::new(|_| Empty::new().boxed()),
+                }],
+                cx,
+            );
+            editor.select_ranges([Point::new(2, 0)..Point::new(2, 0)], None, cx);
+            editor.move_line_down(&MoveLineDown, cx);
         });
     }
 

--- a/crates/text/src/rope.rs
+++ b/crates/text/src/rope.rs
@@ -565,6 +565,12 @@ impl Chunk {
 
             if ch == '\n' {
                 point.row += 1;
+                if point.row > target.row {
+                    panic!(
+                        "point {:?} is beyond the end of a line with length {}",
+                        target, point.column
+                    );
+                }
                 point.column = 0;
             } else {
                 point.column += ch.len_utf8() as u32;


### PR DESCRIPTION
This PR was started to fix some panics we were observing when moving lines containing block decorations. These were caused by the interface for `find_{next,prev}_row_boundary` taking display points, which could potentially be inside of blocks. Our point translation from display to buffer coordinates doesn't take a bias, and the default behavior would cause us to translate to the buffer position *before* decorations with a `Below` disposition and *after* above decorations with an `Above` disposition, which could end up moving us in the opposite of the intended direction when seeking for a boundary.

We explored letting these methods take an optional bias, but it ended up feeling simpler to change the interface to these methods to take buffer points instead of display points. This made it impossible to provide an invalid position to begin with, alleviating the need to provide a bias when translating from display to buffer coordinates in the block map.

This PR includes a rewrite of the line movement methods that feels like a simplification and relies more heavily on buffer coordinates instead of display coordinates.

We also added `MultiBuffer::range_contains_excerpt_boundary` to disallow lines from being moved across excerpts. Unfortunately, this wasn't enough to fully avoid strange behavior when performing line-oriented operations in the project diagnostics view. Because it's possible for the same line to appear twice in an excerpt view, we can no longer use naive deltas to update selections, folds, etc when manipulating lines because moving a single line may actually cause multiple lines to move.

This still seems worth merging to fix line movement in the presence of singleton buffers with block decorations, but more work will be needed to address the multi-buffer case.