### PR TITLE
Allow the zed app to connect to both the old and new rpc endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.14.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8645e929ec7964448a901db9da30cd2ae8c7fecf4d6176af427837531dbbb63b"
+checksum = "5682ea0913e5c20780fe5785abacb85a411e7437bf52a1bedb93ddb3972cb8dd"
 dependencies = [
  "async-tls",
  "futures-io",
@@ -2451,15 +2451,6 @@ name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes 1.0.1",
-]
 
 [[package]]
 name = "instant"
@@ -5186,16 +5177,15 @@ checksum = "85e00391c1f3d171490a3f8bd79999b0002ae38d3da0d6a3a306c754b053d71b"
 
 [[package]]
 name = "tungstenite"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
+checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes 1.0.1",
  "http",
  "httparse",
- "input_buffer",
  "log",
  "rand 0.8.3",
  "sha-1 0.9.6",
@@ -5698,7 +5688,6 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "async-tungstenite",
  "chat_panel",
  "client",
  "clock",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -16,7 +16,7 @@ rpc = { path = "../rpc" }
 sum_tree = { path = "../sum_tree" }
 anyhow = "1.0.38"
 async-recursion = "0.3"
-async-tungstenite = { version = "0.14", features = ["async-tls"] }
+async-tungstenite = { version = "0.16", features = ["async-tls"] }
 futures = "0.3"
 image = "0.23"
 lazy_static = "1.4.0"

--- a/crates/client/src/channel.rs
+++ b/crates/client/src/channel.rs
@@ -599,8 +599,8 @@ mod tests {
     #[gpui::test]
     async fn test_channel_messages(mut cx: TestAppContext) {
         let user_id = 5;
-        let mut client = Client::new();
         let http_client = FakeHttpClient::new(|_| async move { Ok(Response::new(404)) });
+        let mut client = Client::new(http_client.clone());
         let server = FakeServer::for_client(user_id, &mut client, &cx).await;
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -582,7 +582,7 @@ mod tests {
     async fn test_diagnostics(mut cx: TestAppContext) {
         let settings = cx.update(WorkspaceParams::test).settings;
         let http_client = FakeHttpClient::new(|_| async move { Ok(ServerResponse::new(404)) });
-        let client = Client::new();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
         let fs = Arc::new(FakeFs::new());
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -898,7 +898,7 @@ impl Collaborator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use client::{http::ServerResponse, test::FakeHttpClient};
+    use client::test::FakeHttpClient;
     use fs::RealFs;
     use gpui::TestAppContext;
     use language::LanguageRegistry;
@@ -1004,8 +1004,8 @@ mod tests {
     fn build_project(cx: &mut TestAppContext) -> ModelHandle<Project> {
         let languages = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(RealFs);
-        let client = client::Client::new();
-        let http_client = FakeHttpClient::new(|_| async move { Ok(ServerResponse::new(404)) });
+        let http_client = FakeHttpClient::with_404_response();
+        let client = client::Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
         cx.update(|cx| Project::local(client, user_store, languages, fs, cx))
     }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3054,8 +3054,8 @@ mod tests {
         )
         .await;
 
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3092,8 +3092,8 @@ mod tests {
             "file1": "the old contents",
         }));
 
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3127,8 +3127,8 @@ mod tests {
         }));
         let file_path = dir.path().join("file1");
 
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3176,7 +3176,8 @@ mod tests {
         }));
 
         let user_id = 5;
-        let mut client = Client::new();
+        let http_client = FakeHttpClient::with_404_response();
+        let mut client = Client::new(http_client.clone());
         let server = FakeServer::for_client(user_id, &mut client, &cx).await;
         let user_store = server.build_user_store(client.clone(), &mut cx).await;
         let tree = Worktree::open_local(
@@ -3221,7 +3222,7 @@ mod tests {
             1,
             1,
             initial_snapshot.to_proto(),
-            Client::new(),
+            Client::new(http_client.clone()),
             user_store,
             Default::default(),
             &mut cx.to_async(),
@@ -3327,8 +3328,8 @@ mod tests {
             }
         }));
 
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3369,7 +3370,8 @@ mod tests {
     #[gpui::test]
     async fn test_buffer_deduping(mut cx: gpui::TestAppContext) {
         let user_id = 100;
-        let mut client = Client::new();
+        let http_client = FakeHttpClient::with_404_response();
+        let mut client = Client::new(http_client);
         let server = FakeServer::for_client(user_id, &mut client, &cx).await;
         let user_store = server.build_user_store(client.clone(), &mut cx).await;
 
@@ -3433,8 +3435,8 @@ mod tests {
             "file2": "def",
             "file3": "ghi",
         }));
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3570,8 +3572,8 @@ mod tests {
 
         let initial_contents = "aaa\nbbbbb\nc\n";
         let dir = temp_tree(json!({ "the-file": initial_contents }));
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3687,8 +3689,8 @@ mod tests {
             "b.rs": "const y: i32 = 1",
         }));
 
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let tree = Worktree::open_local(
@@ -3755,8 +3757,8 @@ mod tests {
     #[gpui::test]
     async fn test_grouped_diagnostics(mut cx: gpui::TestAppContext) {
         let fs = Arc::new(FakeFs::new());
-        let client = Client::new();
         let http_client = FakeHttpClient::with_404_response();
+        let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         fs.insert_tree(

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -13,7 +13,7 @@ test-support = []
 [dependencies]
 anyhow = "1.0"
 async-lock = "2.4"
-async-tungstenite = "0.14"
+async-tungstenite = "0.16"
 base64 = "0.13"
 futures = "0.3"
 log = "0.4"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,7 +19,7 @@ rpc = { path = "../rpc" }
 anyhow = "1.0.40"
 async-std = { version = "1.8.0", features = ["attributes"] }
 async-trait = "0.1.50"
-async-tungstenite = "0.14"
+async-tungstenite = "0.16"
 base64 = "0.13"
 clap = "=3.0.0-beta.2"
 comrak = "0.10"

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -112,6 +112,9 @@ pub fn add_routes(app: &mut Server<Arc<AppState>>) {
     app.at("/sign_in").get(get_sign_in);
     app.at("/sign_out").post(post_sign_out);
     app.at("/auth_callback").get(get_auth_callback);
+    app.at("/native_app_signin").get(get_sign_in);
+    app.at("/native_app_signin_succeeded")
+        .get(get_app_signin_success);
 }
 
 #[derive(Debug, Deserialize)]
@@ -164,6 +167,10 @@ async fn get_sign_in(mut request: Request) -> tide::Result {
         .insert("auth_csrf_token", csrf_token)?;
 
     Ok(tide::Redirect::new(auth_url).into())
+}
+
+async fn get_app_signin_success(_: Request) -> tide::Result {
+    Ok(tide::Redirect::new("/").into())
 }
 
 async fn get_auth_callback(mut request: Request) -> tide::Result {

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -2440,9 +2440,10 @@ mod tests {
         }
 
         async fn create_client(&mut self, cx: &mut TestAppContext, name: &str) -> TestClient {
+            let http = FakeHttpClient::with_404_response();
             let user_id = self.app_state.db.create_user(name, false).await.unwrap();
             let client_name = name.to_string();
-            let mut client = Client::new();
+            let mut client = Client::new(http.clone());
             let server = self.server.clone();
             let connection_killers = self.connection_killers.clone();
             let forbid_connections = self.forbid_connections.clone();
@@ -2489,7 +2490,6 @@ mod tests {
                     })
                 });
 
-            let http = FakeHttpClient::new(|_| async move { Ok(surf::http::Response::new(404)) });
             client
                 .authenticate_and_connect(&cx.to_async())
                 .await

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -368,10 +368,10 @@ impl WorkspaceParams {
     pub fn test(cx: &mut MutableAppContext) -> Self {
         let fs = Arc::new(project::FakeFs::new());
         let languages = Arc::new(LanguageRegistry::new());
-        let client = Client::new();
         let http_client = client::test::FakeHttpClient::new(|_| async move {
             Ok(client::http::ServerResponse::new(404))
         });
+        let client = Client::new(http_client.clone());
         let theme =
             gpui::fonts::with_font_cache(cx.font_cache().clone(), || theme::Theme::default());
         let settings = Settings::new("Courier", cx.font_cache(), Arc::new(theme)).unwrap();

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -55,7 +55,6 @@ workspace = { path = "../workspace" }
 anyhow = "1.0.38"
 async-recursion = "0.3"
 async-trait = "0.1"
-async-tungstenite = { version = "0.14", features = ["async-tls"] }
 crossbeam-channel = "0.5.0"
 ctor = "0.1.20"
 dirs = "3.0"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -48,8 +48,8 @@ fn main() {
     languages.set_theme(&settings.borrow().theme.editor.syntax);
 
     app.run(move |cx| {
-        let client = client::Client::new();
         let http = http::client();
+        let client = client::Client::new(http.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
         let mut entry_openers = Vec::new();
 

--- a/crates/zed/src/test.rs
+++ b/crates/zed/src/test.rs
@@ -1,5 +1,5 @@
 use crate::{assets::Assets, build_window_options, build_workspace, AppState};
-use client::{http::ServerResponse, test::FakeHttpClient, ChannelList, Client, UserStore};
+use client::{test::FakeHttpClient, ChannelList, Client, UserStore};
 use gpui::{AssetSource, MutableAppContext};
 use language::LanguageRegistry;
 use parking_lot::Mutex;
@@ -20,8 +20,8 @@ pub fn test_app_state(cx: &mut MutableAppContext) -> Arc<AppState> {
     editor::init(cx, &mut entry_openers);
     let (settings_tx, settings) = watch::channel_with(build_settings(cx));
     let themes = ThemeRegistry::new(Assets, cx.font_cache().clone());
-    let client = Client::new();
-    let http = FakeHttpClient::new(|_| async move { Ok(ServerResponse::new(404)) });
+    let http = FakeHttpClient::with_404_response();
+    let client = Client::new(http.clone());
     let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http, cx));
     let mut languages = LanguageRegistry::new();
     languages.add(Arc::new(language::Language::new(

--- a/script/zed_with_local_servers
+++ b/script/zed_with_local_servers
@@ -1,1 +1,1 @@
-ZED_SITE_URL=http://localhost:3000 ZED_COLLAB_URL=http://localhost:8080 cargo run $@
+ZED_SERVER_URL=http://localhost:3000 cargo run $@


### PR DESCRIPTION
Related to https://github.com/zed-industries/zed.dev/pull/13

This switches the Zed app back to only knowing about *one* root server URL (`zed.dev` by default), instead of two separate URLs.

To establish a web socket connection, the app will make an HTTP request to `zed.dev/rpc`. Currently, that endpoint is handled directly by the Rust server, and expects a websocket upgrade. But in the future, that endpoint will be part of the new Next.js frontend. The new frontend will authenticate the user and then redirect them to the Rust service (`collaboration.zed.dev` or similar).

I've added some additional routes to the Rust server so that it behaves like the new frontend for auth.
