### PR TITLE
Fix buffer replication bugs that would lead to divergence among replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,6 +4858,7 @@ dependencies = [
  "rand 0.8.3",
  "smallvec",
  "sum_tree",
+ "util",
 ]
 
 [[package]]
@@ -5382,8 +5383,10 @@ name = "util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clock",
  "futures",
  "log",
+ "rand 0.8.3",
  "serde_json",
  "surf",
  "tempdir",

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -327,6 +327,13 @@ impl Buffer {
             );
         }
 
+        let deferred_ops = message
+            .deferred_operations
+            .into_iter()
+            .map(proto::deserialize_operation)
+            .collect::<Result<Vec<_>>>()?;
+        this.apply_ops(deferred_ops, cx)?;
+
         Ok(this)
     }
 
@@ -361,6 +368,16 @@ impl Buffer {
                 .map(|set| {
                     proto::serialize_diagnostic_set(set.provider_name().to_string(), set.iter())
                 })
+                .collect(),
+            deferred_operations: self
+                .deferred_ops
+                .iter()
+                .map(proto::serialize_operation)
+                .chain(
+                    self.text
+                        .deferred_ops()
+                        .map(|op| proto::serialize_operation(&Operation::Buffer(op.clone()))),
+                )
                 .collect(),
         }
     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1342,6 +1342,7 @@ impl Buffer {
             })
             .collect::<Vec<_>>();
         self.text.apply_ops(buffer_ops)?;
+        self.deferred_ops.insert(deferred_ops);
         self.flush_deferred_ops(cx);
         self.did_edit(&old_version, was_dirty, cx);
         // Notify independently of whether the buffer was edited as the operations could include a

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1814,14 +1814,22 @@ impl BufferSnapshot {
             .iter()
             .filter(|(replica_id, _)| **replica_id != self.text.replica_id())
             .map(move |(replica_id, selections)| {
-                let start_ix = match selections
-                    .binary_search_by(|probe| probe.end.cmp(&range.start, self).unwrap())
-                {
+                let start_ix = match selections.binary_search_by(|probe| {
+                    probe
+                        .end
+                        .cmp(&range.start, self)
+                        .unwrap()
+                        .then(Ordering::Greater)
+                }) {
                     Ok(ix) | Err(ix) => ix,
                 };
-                let end_ix = match selections
-                    .binary_search_by(|probe| probe.start.cmp(&range.end, self).unwrap())
-                {
+                let end_ix = match selections.binary_search_by(|probe| {
+                    probe
+                        .start
+                        .cmp(&range.end, self)
+                        .unwrap()
+                        .then(Ordering::Less)
+                }) {
                     Ok(ix) | Err(ix) => ix,
                 };
 

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -50,13 +50,6 @@ pub fn serialize_operation(operation: &Operation) -> proto::Operation {
                 lamport_timestamp: lamport_timestamp.value,
                 selections: serialize_selections(selections),
             }),
-            Operation::RemoveSelections {
-                replica_id,
-                lamport_timestamp,
-            } => proto::operation::Variant::RemoveSelections(proto::operation::RemoveSelections {
-                replica_id: *replica_id as u32,
-                lamport_timestamp: lamport_timestamp.value,
-            }),
             Operation::UpdateDiagnostics {
                 provider_name,
                 diagnostics,
@@ -246,13 +239,6 @@ pub fn deserialize_operation(message: proto::Operation) -> Result<Operation> {
                     selections: Arc::from(selections),
                 }
             }
-            proto::operation::Variant::RemoveSelections(message) => Operation::RemoveSelections {
-                replica_id: message.replica_id as ReplicaId,
-                lamport_timestamp: clock::Lamport {
-                    replica_id: message.replica_id as ReplicaId,
-                    value: message.lamport_timestamp,
-                },
-            },
             proto::operation::Variant::UpdateDiagnosticSet(message) => {
                 let (provider_name, diagnostics) = deserialize_diagnostic_set(
                     message

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -780,6 +780,21 @@ async fn test_empty_diagnostic_ranges(mut cx: gpui::TestAppContext) {
     });
 }
 
+#[gpui::test]
+fn test_serialization(cx: &mut gpui::MutableAppContext) {
+    let buffer1 = cx.add_model(|cx| {
+        let mut buffer = Buffer::new(0, "abc", cx);
+        buffer.edit([3..3], "DE", cx);
+        buffer.undo(cx);
+        buffer
+    });
+    assert_eq!(buffer1.read(cx).text(), "abc");
+
+    let message = buffer1.read(cx).to_proto();
+    let buffer2 = cx.add_model(|cx| Buffer::from_proto(1, message, None, cx).unwrap());
+    assert_eq!(buffer2.read(cx).text(), "abc");
+}
+
 fn chunks_with_diagnostics<T: ToOffset + ToPoint>(
     buffer: &Buffer,
     range: Range<T>,

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -782,17 +782,30 @@ async fn test_empty_diagnostic_ranges(mut cx: gpui::TestAppContext) {
 
 #[gpui::test]
 fn test_serialization(cx: &mut gpui::MutableAppContext) {
+    let mut now = Instant::now();
+
     let buffer1 = cx.add_model(|cx| {
         let mut buffer = Buffer::new(0, "abc", cx);
-        buffer.edit([3..3], "DE", cx);
+        buffer.edit([3..3], "D", cx);
+
+        now += Duration::from_secs(1);
+        buffer.start_transaction_at(now);
+        buffer.edit([4..4], "E", cx);
+        buffer.end_transaction_at(now, cx);
+        assert_eq!(buffer.text(), "abcDE");
+
         buffer.undo(cx);
+        assert_eq!(buffer.text(), "abcD");
+
+        buffer.edit([4..4], "F", cx);
+        assert_eq!(buffer.text(), "abcDF");
         buffer
     });
-    assert_eq!(buffer1.read(cx).text(), "abc");
+    assert_eq!(buffer1.read(cx).text(), "abcDF");
 
     let message = buffer1.read(cx).to_proto();
     let buffer2 = cx.add_model(|cx| Buffer::from_proto(1, message, None, cx).unwrap());
-    assert_eq!(buffer2.read(cx).text(), "abc");
+    assert_eq!(buffer2.read(cx).text(), "abcDF");
 }
 
 fn chunks_with_diagnostics<T: ToOffset + ToPoint>(

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -262,13 +262,14 @@ message Entry {
 
 message Buffer {
     uint64 id = 1;
-    string content = 2;
-    string deleted_content = 3;
+    string visible_text = 2;
+    string deleted_text = 3;
     repeated BufferFragment fragments = 4;
     repeated UndoMapEntry undo_map = 5;
     repeated VectorClockEntry version = 6;
     repeated SelectionSet selections = 7;
     repeated DiagnosticSet diagnostic_sets = 8;
+    uint32 lamport_timestamp = 9;
 }
 
 message BufferFragment {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -263,9 +263,23 @@ message Entry {
 message Buffer {
     uint64 id = 1;
     string content = 2;
-    repeated Operation.Edit history = 3;
-    repeated SelectionSet selections = 4;
-    repeated DiagnosticSet diagnostic_sets = 5;
+    string deleted_content = 3;
+    repeated BufferFragment fragments = 4;
+    repeated UndoMapEntry undo_map = 5;
+    repeated VectorClockEntry version = 6;
+    repeated SelectionSet selections = 7;
+    repeated DiagnosticSet diagnostic_sets = 8;
+}
+
+message BufferFragment {
+    uint32 replica_id = 1;
+    uint32 local_timestamp = 2;
+    uint32 lamport_timestamp = 3;
+    uint32 insertion_offset = 4;
+    uint32 len = 5;
+    bool visible =  6;
+    repeated VectorClockEntry deletions = 7;
+    repeated VectorClockEntry max_undos = 8;
 }
 
 message SelectionSet {
@@ -350,12 +364,6 @@ message Operation {
         repeated UndoCount counts = 6;
     }
 
-    message UndoCount {
-        uint32 replica_id = 1;
-        uint32 local_timestamp = 2;
-        uint32 count = 3;
-    }
-
     message UpdateSelections {
         uint32 replica_id = 1;
         uint32 lamport_timestamp = 3;
@@ -366,6 +374,18 @@ message Operation {
         uint32 replica_id = 1;
         uint32 lamport_timestamp = 3;
     }
+}
+
+message UndoMapEntry {
+    uint32 replica_id = 1;
+    uint32 local_timestamp = 2;
+    repeated UndoCount counts = 3;
+}
+
+message UndoCount {
+    uint32 replica_id = 1;
+    uint32 local_timestamp = 2;
+    uint32 count = 3;
 }
 
 message VectorClockEntry {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -287,6 +287,7 @@ message BufferFragment {
 message SelectionSet {
     uint32 replica_id = 1;
     repeated Selection selections = 2;
+    uint32 lamport_timestamp = 3;
 }
 
 message Selection {
@@ -344,8 +345,7 @@ message Operation {
         Edit edit = 1;
         Undo undo = 2;
         UpdateSelections update_selections = 3;
-        RemoveSelections remove_selections = 4;
-        UpdateDiagnosticSet update_diagnostic_set = 5;
+        UpdateDiagnosticSet update_diagnostic_set = 4;
     }
 
     message Edit {
@@ -370,11 +370,6 @@ message Operation {
         uint32 replica_id = 1;
         uint32 lamport_timestamp = 3;
         repeated Selection selections = 4;
-    }
-
-    message RemoveSelections {
-        uint32 replica_id = 1;
-        uint32 lamport_timestamp = 3;
     }
 }
 

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -270,6 +270,7 @@ message Buffer {
     repeated SelectionSet selections = 7;
     repeated DiagnosticSet diagnostic_sets = 8;
     uint32 lamport_timestamp = 9;
+    repeated Operation deferred_operations = 10;
 }
 
 message BufferFragment {

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -398,7 +398,7 @@ mod tests {
                 proto::OpenBufferResponse {
                     buffer: Some(proto::Buffer {
                         id: 101,
-                        content: "path/one content".to_string(),
+                        visible_text: "path/one content".to_string(),
                         ..Default::default()
                     }),
                 }
@@ -419,7 +419,7 @@ mod tests {
                 proto::OpenBufferResponse {
                     buffer: Some(proto::Buffer {
                         id: 102,
-                        content: "path/two content".to_string(),
+                        visible_text: "path/two content".to_string(),
                         ..Default::default()
                     }),
                 }
@@ -448,7 +448,7 @@ mod tests {
                                 proto::OpenBufferResponse {
                                     buffer: Some(proto::Buffer {
                                         id: 101,
-                                        content: "path/one content".to_string(),
+                                        visible_text: "path/one content".to_string(),
                                         ..Default::default()
                                     }),
                                 }
@@ -458,7 +458,7 @@ mod tests {
                                 proto::OpenBufferResponse {
                                     buffer: Some(proto::Buffer {
                                         id: 102,
-                                        content: "path/two content".to_string(),
+                                        visible_text: "path/two content".to_string(),
                                         ..Default::default()
                                     }),
                                 }

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -399,9 +399,7 @@ mod tests {
                     buffer: Some(proto::Buffer {
                         id: 101,
                         content: "path/one content".to_string(),
-                        history: vec![],
-                        selections: vec![],
-                        diagnostic_sets: vec![],
+                        ..Default::default()
                     }),
                 }
             );
@@ -422,9 +420,7 @@ mod tests {
                     buffer: Some(proto::Buffer {
                         id: 102,
                         content: "path/two content".to_string(),
-                        history: vec![],
-                        selections: vec![],
-                        diagnostic_sets: vec![],
+                        ..Default::default()
                     }),
                 }
             );
@@ -453,9 +449,7 @@ mod tests {
                                     buffer: Some(proto::Buffer {
                                         id: 101,
                                         content: "path/one content".to_string(),
-                                        history: vec![],
-                                        selections: vec![],
-                                        diagnostic_sets: vec![],
+                                        ..Default::default()
                                     }),
                                 }
                             }
@@ -465,9 +459,7 @@ mod tests {
                                     buffer: Some(proto::Buffer {
                                         id: 102,
                                         content: "path/two content".to_string(),
-                                        history: vec![],
-                                        selections: vec![],
-                                        diagnostic_sets: vec![],
+                                        ..Default::default()
                                     }),
                                 }
                             }

--- a/crates/sum_tree/src/tree_map.rs
+++ b/crates/sum_tree/src/tree_map.rs
@@ -23,10 +23,13 @@ pub struct MapKeyRef<'a, K>(Option<&'a K>);
 impl<K: Clone + Debug + Default + Ord, V: Clone + Debug> TreeMap<K, V> {
     pub fn get<'a>(&self, key: &'a K) -> Option<&V> {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>();
-        let key = MapKeyRef(Some(key));
-        cursor.seek(&key, Bias::Left, &());
-        if key.cmp(cursor.start(), &()) == Ordering::Equal {
-            Some(&cursor.item().unwrap().value)
+        cursor.seek(&MapKeyRef(Some(key)), Bias::Left, &());
+        if let Some(item) = cursor.item() {
+            if *key == item.key().0 {
+                Some(&item.value)
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -129,24 +132,32 @@ mod tests {
         assert_eq!(map.iter().collect::<Vec<_>>(), vec![]);
 
         map.insert(3, "c");
+        assert_eq!(map.get(&3), Some(&"c"));
         assert_eq!(map.iter().collect::<Vec<_>>(), vec![(&3, &"c")]);
 
         map.insert(1, "a");
+        assert_eq!(map.get(&1), Some(&"a"));
         assert_eq!(map.iter().collect::<Vec<_>>(), vec![(&1, &"a"), (&3, &"c")]);
 
         map.insert(2, "b");
+        assert_eq!(map.get(&2), Some(&"b"));
+        assert_eq!(map.get(&1), Some(&"a"));
+        assert_eq!(map.get(&3), Some(&"c"));
         assert_eq!(
             map.iter().collect::<Vec<_>>(),
             vec![(&1, &"a"), (&2, &"b"), (&3, &"c")]
         );
 
         map.remove(&2);
+        assert_eq!(map.get(&2), None);
         assert_eq!(map.iter().collect::<Vec<_>>(), vec![(&1, &"a"), (&3, &"c")]);
 
         map.remove(&3);
+        assert_eq!(map.get(&3), None);
         assert_eq!(map.iter().collect::<Vec<_>>(), vec![(&1, &"a")]);
 
         map.remove(&1);
+        assert_eq!(map.get(&1), None);
         assert_eq!(map.iter().collect::<Vec<_>>(), vec![]);
     }
 }

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = { version = "1.6", features = ["union"] }
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
+util = { path = "../util", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"
 rand = "0.8.3"

--- a/crates/text/src/locator.rs
+++ b/crates/text/src/locator.rs
@@ -19,6 +19,11 @@ impl Locator {
         Self(smallvec![u64::MAX])
     }
 
+    pub fn from_index(ix: usize, count: usize) -> Self {
+        let id = ((ix as u128 * u64::MAX as u128) / count as u128) as u64;
+        Self(smallvec![id])
+    }
+
     pub fn assign(&mut self, other: &Self) {
         self.0.resize(other.0.len(), 0);
         self.0.copy_from_slice(&other.0);

--- a/crates/text/src/operation_queue.rs
+++ b/crates/text/src/operation_queue.rs
@@ -53,7 +53,7 @@ impl<T: Operation> OperationQueue<T> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.0.cursor::<()>().map(|i| &i.0)
+        self.0.iter().map(|i| &i.0)
     }
 }
 

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1101,6 +1101,10 @@ impl Buffer {
         Ok(())
     }
 
+    pub fn deferred_ops(&self) -> impl Iterator<Item = &Operation> {
+        self.deferred_ops.iter()
+    }
+
     fn flush_deferred_ops(&mut self) -> Result<()> {
         self.deferred_replicas.clear();
         let mut deferred_ops = Vec::new();

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1105,7 +1105,6 @@ impl Buffer {
         self.deferred_replicas.clear();
         let mut deferred_ops = Vec::new();
         for op in self.deferred_ops.drain().iter().cloned() {
-            dbg!(&self.version, &op, self.can_apply_op(&op));
             if self.can_apply_op(&op) {
                 self.apply_op(op)?;
             } else {
@@ -1241,7 +1240,15 @@ impl Buffer {
 
 #[cfg(any(test, feature = "test-support"))]
 impl Buffer {
-    fn random_byte_range(&mut self, start_offset: usize, rng: &mut impl rand::Rng) -> Range<usize> {
+    pub fn set_group_interval(&mut self, group_interval: Duration) {
+        self.history.group_interval = group_interval;
+    }
+
+    pub fn random_byte_range(
+        &mut self,
+        start_offset: usize,
+        rng: &mut impl rand::Rng,
+    ) -> Range<usize> {
         let end = self.clip_offset(rng.gen_range(start_offset..=self.len()), Bias::Right);
         let start = self.clip_offset(rng.gen_range(start_offset..=end), Bias::Right);
         start..end

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1248,11 +1248,7 @@ impl Buffer {
         self.history.group_interval = group_interval;
     }
 
-    pub fn random_byte_range(
-        &mut self,
-        start_offset: usize,
-        rng: &mut impl rand::Rng,
-    ) -> Range<usize> {
+    pub fn random_byte_range(&self, start_offset: usize, rng: &mut impl rand::Rng) -> Range<usize> {
         let end = self.clip_offset(rng.gen_range(start_offset..=self.len()), Bias::Right);
         let start = self.clip_offset(rng.gen_range(start_offset..=end), Bias::Right);
         start..end

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -4,12 +4,16 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-test-support = ["serde_json", "tempdir"]
+test-support = ["clock", "rand", "serde_json", "tempdir"]
 
 [dependencies]
+clock = { path = "../clock", optional = true }
 anyhow = "1.0.38"
 futures = "0.3"
 log = "0.4"
+rand = { version = "0.8", optional = true }
 surf = "2.2"
 tempdir = { version = "0.3.7", optional = true }
-serde_json = { version = "1.0.64", features = ["preserve_order"], optional = true }
+serde_json = { version = "1.0.64", features = [
+    "preserve_order"
+], optional = true }

--- a/crates/util/src/test.rs
+++ b/crates/util/src/test.rs
@@ -1,5 +1,89 @@
+use clock::ReplicaId;
 use std::path::{Path, PathBuf};
 use tempdir::TempDir;
+
+#[derive(Clone)]
+struct Envelope<T: Clone> {
+    message: T,
+    sender: ReplicaId,
+}
+
+pub struct Network<T: Clone, R: rand::Rng> {
+    inboxes: std::collections::BTreeMap<ReplicaId, Vec<Envelope<T>>>,
+    all_messages: Vec<T>,
+    rng: R,
+}
+
+impl<T: Clone, R: rand::Rng> Network<T, R> {
+    pub fn new(rng: R) -> Self {
+        Network {
+            inboxes: Default::default(),
+            all_messages: Vec::new(),
+            rng,
+        }
+    }
+
+    pub fn add_peer(&mut self, id: ReplicaId) {
+        self.inboxes.insert(id, Vec::new());
+    }
+
+    pub fn replicate(&mut self, old_replica_id: ReplicaId, new_replica_id: ReplicaId) {
+        self.inboxes
+            .insert(new_replica_id, self.inboxes[&old_replica_id].clone());
+    }
+
+    pub fn is_idle(&self) -> bool {
+        self.inboxes.values().all(|i| i.is_empty())
+    }
+
+    pub fn broadcast(&mut self, sender: ReplicaId, messages: Vec<T>) {
+        for (replica, inbox) in self.inboxes.iter_mut() {
+            if *replica != sender {
+                for message in &messages {
+                    let min_index = inbox
+                        .iter()
+                        .enumerate()
+                        .rev()
+                        .find_map(|(index, envelope)| {
+                            if sender == envelope.sender {
+                                Some(index + 1)
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or(0);
+
+                    // Insert one or more duplicates of this message *after* the previous
+                    // message delivered by this replica.
+                    for _ in 0..self.rng.gen_range(1..4) {
+                        let insertion_index = self.rng.gen_range(min_index..inbox.len() + 1);
+                        inbox.insert(
+                            insertion_index,
+                            Envelope {
+                                message: message.clone(),
+                                sender,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        self.all_messages.extend(messages);
+    }
+
+    pub fn has_unreceived(&self, receiver: ReplicaId) -> bool {
+        !self.inboxes[&receiver].is_empty()
+    }
+
+    pub fn receive(&mut self, receiver: ReplicaId) -> Vec<T> {
+        let inbox = self.inboxes.get_mut(&receiver).unwrap();
+        let count = self.rng.gen_range(0..inbox.len() + 1);
+        inbox
+            .drain(0..count)
+            .map(|envelope| envelope.message)
+            .collect()
+    }
+}
 
 pub fn temp_tree(tree: serde_json::Value) -> TempDir {
     let dir = TempDir::new("").unwrap();


### PR DESCRIPTION
Fixes #305 

The primary change that this pull request introduces is an overhaul of the serialization format of the buffer. Previously, we would rely on serializing operations and applying them on the newly-joined guest's buffer replica. With these changes we are instead serializing the visible and deleted text ropes as well as the fragments tree directly. This makes spinning up a new replica easier to reason about and, despite we haven't benchmarked it, faster as well.

As part of this pull request, we also introduced a randomized test covering replication aspects such as buffer and operation serialization, as well as active selection replication. This uncovered several other bugs that would lead to divergence or rendering bugs:

- Deferred operations weren't being serialized (870fa5f2789a2c292927470e4c0b3ca15eeea1ee)
- Deferred operations weren't being tracked properly (587a9082259e1b7a052e33208d21eca8baf5501b)
- `::remote_selections_in_range` didn't work correctly at the query range's boundaries (f8c262016629b0a66bb97c442857326c187ea2fd)
- `TreeMap::get` would always report `None` (eb65a5d29a1c2837cfee86cf92cf43f06bca5f76)
- Update selection operations that were deferred because some anchors couldn't be resolve might override newer selection operations that the buffer was able to apply because they referred to known fragments (e56609cf0c8b3ee2a35bd211e042fd51ece9bbfe)