### PR TITLE
Fix `rpc::Client` subscription panics 

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 path = "src/client.rs"
 
 [features]
-test-support = ["rpc/test-support"]
+test-support = ["gpui/test-support", "rpc/test-support"]
 
 [dependencies]
 gpui = { path = "../gpui" }
@@ -29,3 +29,7 @@ surf = "2.2"
 thiserror = "1.0.29"
 time = "0.3"
 tiny_http = "0.8"
+
+[dev-dependencies]
+gpui = { path = "../gpui", features = ["test-support"] }
+rpc = { path = "../rpc", features = ["test-support"] }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -848,14 +848,13 @@ mod tests {
         let server = FakeServer::for_client(user_id, &mut client, &cx).await;
 
         let model = cx.add_model(|_| Model { subscription: None });
-        let (done_tx, mut done_rx) = postage::oneshot::channel();
-        let mut done_tx = Some(done_tx);
+        let (mut done_tx, mut done_rx) = postage::oneshot::channel();
         model.update(&mut cx, |model, cx| {
             model.subscription = Some(client.subscribe(
                 cx,
                 move |model, _: TypedEnvelope<proto::Ping>, _, _| {
                     model.subscription.take();
-                    postage::sink::Sink::try_send(&mut done_tx.take().unwrap(), ()).unwrap();
+                    postage::sink::Sink::try_send(&mut done_tx, ()).unwrap();
                     Ok(())
                 },
             ));


### PR DESCRIPTION
Fixes #290 

I was unable to reproduce the issue above when running the application so this is a _tentative_ fix, but after tracing the possible execution paths through, it seems like the only way for the panic to occur would be if we drop a subscription while handling a message for that same subscription (see how I reproduced this in the `test_dropping_subscription_in_handler` regression test). This seems to match what we observed in the stack trace posted in #290.

This could happen because we don't want to hold the `Client`'s state while invoking a handler because the handler itself could interact with the client. Thus, when receiving a message that matched the subscription, we used to _remove_ the handler from the state, release the lock and then re-insert the handler after re-acquiring the lock and invoking it. If a subscription got dropped as part of the handler code, `Subscription::drop` would panic because there would be no handler in the state.

With this pull request, we will instead wrap handlers inside of `Option`s. Crucially, when we receive a message and we invoke the handler, we will `::take` it as opposed to removing it. When the handler is finally done, we will re-acquire the lock and check for the existence of its key in the map and only re-insert it if it hasn't been dropped.

As part of this, I also discovered an issue where dropping a subscription and re-adding one for the same message type would result in a panic. This had to do with forgetting to clean up some state, specifically removing the entity id extractor for the unregistered message type.