### PR TITLE
Format on save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "async-tungstenite",
  "base64 0.13.0",
  "futures",
+ "gpui",
  "log",
  "parking_lot",
  "postage",

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -661,9 +661,9 @@ impl Client {
         })
     }
 
-    pub async fn disconnect(self: &Arc<Self>, cx: &AsyncAppContext) -> Result<()> {
+    pub fn disconnect(self: &Arc<Self>, cx: &AsyncAppContext) -> Result<()> {
         let conn_id = self.connection_id()?;
-        self.peer.disconnect(conn_id).await;
+        self.peer.disconnect(conn_id);
         self.set_status(Status::SignedOut, cx);
         Ok(())
     }
@@ -764,7 +764,7 @@ mod tests {
         let ping = server.receive::<proto::Ping>().await.unwrap();
         server.respond(ping.receipt(), proto::Ack {}).await;
 
-        client.disconnect(&cx.to_async()).await.unwrap();
+        client.disconnect(&cx.to_async()).unwrap();
         assert!(server.receive::<proto::Ping>().await.is_err());
     }
 
@@ -783,7 +783,7 @@ mod tests {
         assert_eq!(server.auth_count(), 1);
 
         server.forbid_connections();
-        server.disconnect().await;
+        server.disconnect();
         while !matches!(status.recv().await, Some(Status::ReconnectionError { .. })) {}
 
         server.allow_connections();
@@ -792,7 +792,7 @@ mod tests {
         assert_eq!(server.auth_count(), 1); // Client reused the cached credentials when reconnecting
 
         server.forbid_connections();
-        server.disconnect().await;
+        server.disconnect();
         while !matches!(status.recv().await, Some(Status::ReconnectionError { .. })) {}
 
         // Clear cached credentials after authentication fails

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -691,6 +691,14 @@ impl Client {
     ) -> impl Future<Output = Result<()>> {
         self.peer.respond(receipt, response)
     }
+
+    pub fn respond_with_error<T: RequestMessage>(
+        &self,
+        receipt: Receipt<T>,
+        error: proto::Error,
+    ) -> impl Future<Output = Result<()>> {
+        self.peer.respond_with_error(receipt, error)
+    }
 }
 
 fn read_credentials_from_keychain(cx: &AsyncAppContext) -> Option<Credentials> {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -11,11 +11,12 @@ use async_tungstenite::tungstenite::{
     error::Error as WebsocketError,
     http::{Request, StatusCode},
 };
+use futures::StreamExt;
 use gpui::{action, AsyncAppContext, Entity, ModelContext, MutableAppContext, Task};
 use http::HttpClient;
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
-use postage::{prelude::Stream, watch};
+use postage::watch;
 use rand::prelude::*;
 use rpc::proto::{AnyTypedEnvelope, EntityMessage, EnvelopedMessage, RequestMessage};
 use std::{
@@ -436,7 +437,7 @@ impl Client {
                 let mut cx = cx.clone();
                 let this = self.clone();
                 async move {
-                    while let Some(message) = incoming.recv().await {
+                    while let Some(message) = incoming.next().await {
                         let mut state = this.state.write();
                         let payload_type_id = message.payload_type_id();
                         let entity_id = if let Some(extract_entity_id) =
@@ -777,23 +778,23 @@ mod tests {
         let server = FakeServer::for_client(user_id, &mut client, &cx).await;
         let mut status = client.status();
         assert!(matches!(
-            status.recv().await,
+            status.next().await,
             Some(Status::Connected { .. })
         ));
         assert_eq!(server.auth_count(), 1);
 
         server.forbid_connections();
         server.disconnect();
-        while !matches!(status.recv().await, Some(Status::ReconnectionError { .. })) {}
+        while !matches!(status.next().await, Some(Status::ReconnectionError { .. })) {}
 
         server.allow_connections();
         cx.foreground().advance_clock(Duration::from_secs(10));
-        while !matches!(status.recv().await, Some(Status::Connected { .. })) {}
+        while !matches!(status.next().await, Some(Status::Connected { .. })) {}
         assert_eq!(server.auth_count(), 1); // Client reused the cached credentials when reconnecting
 
         server.forbid_connections();
         server.disconnect();
-        while !matches!(status.recv().await, Some(Status::ReconnectionError { .. })) {}
+        while !matches!(status.next().await, Some(Status::ReconnectionError { .. })) {}
 
         // Clear cached credentials after authentication fails
         server.roll_access_token();
@@ -801,7 +802,7 @@ mod tests {
         cx.foreground().advance_clock(Duration::from_secs(10));
         assert_eq!(server.auth_count(), 1);
         cx.foreground().advance_clock(Duration::from_secs(10));
-        while !matches!(status.recv().await, Some(Status::Connected { .. })) {}
+        while !matches!(status.next().await, Some(Status::Connected { .. })) {}
         assert_eq!(server.auth_count(), 2); // Client re-authenticated due to an invalid token
     }
 
@@ -861,8 +862,8 @@ mod tests {
 
         server.send(proto::UnshareProject { project_id: 1 }).await;
         server.send(proto::UnshareProject { project_id: 2 }).await;
-        done_rx1.recv().await.unwrap();
-        done_rx2.recv().await.unwrap();
+        done_rx1.next().await.unwrap();
+        done_rx2.next().await.unwrap();
     }
 
     #[gpui::test]
@@ -890,7 +891,7 @@ mod tests {
             })
         });
         server.send(proto::Ping {}).await;
-        done_rx2.recv().await.unwrap();
+        done_rx2.next().await.unwrap();
     }
 
     #[gpui::test]
@@ -914,7 +915,7 @@ mod tests {
             ));
         });
         server.send(proto::Ping {}).await;
-        done_rx.recv().await.unwrap();
+        done_rx.next().await.unwrap();
     }
 
     struct Model {

--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -72,8 +72,8 @@ impl FakeServer {
         server
     }
 
-    pub async fn disconnect(&self) {
-        self.peer.disconnect(self.connection_id()).await;
+    pub fn disconnect(&self) {
+        self.peer.disconnect(self.connection_id());
         self.connection_id.lock().take();
         self.incoming.lock().take();
     }

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -798,6 +798,20 @@ impl MultiBuffer {
         cx.emit(event.clone());
     }
 
+    pub fn format(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        let mut format_tasks = Vec::new();
+        for BufferState { buffer, .. } in self.buffers.borrow().values() {
+            format_tasks.push(buffer.update(cx, |buffer, cx| buffer.format(cx)));
+        }
+
+        cx.spawn(|_, _| async move {
+            for format in format_tasks {
+                format.await?;
+            }
+            Ok(())
+        })
+    }
+
     pub fn save(&mut self, cx: &mut ModelContext<Self>) -> Result<Task<Result<()>>> {
         let mut save_tasks = Vec::new();
         for BufferState { buffer, .. } in self.buffers.borrow().values() {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1,9 +1,12 @@
-use crate::diagnostic_set::{DiagnosticEntry, DiagnosticGroup};
 pub use crate::{
     diagnostic_set::DiagnosticSet,
     highlight_map::{HighlightId, HighlightMap},
     proto, BracketPair, Grammar, Language, LanguageConfig, LanguageRegistry, LanguageServerConfig,
     PLAIN_TEXT,
+};
+use crate::{
+    diagnostic_set::{DiagnosticEntry, DiagnosticGroup},
+    range_from_lsp, ToPointUtf16,
 };
 use anyhow::{anyhow, Result};
 use clock::ReplicaId;
@@ -179,6 +182,9 @@ pub trait File {
     ) -> Task<Result<(clock::Global, SystemTime)>>;
 
     fn load_local(&self, cx: &AppContext) -> Option<Task<Result<String>>>;
+
+    fn format_remote(&self, buffer_id: u64, cx: &mut MutableAppContext)
+        -> Option<Task<Result<()>>>;
 
     fn buffer_updated(&self, buffer_id: u64, operation: Operation, cx: &mut MutableAppContext);
 
@@ -435,6 +441,65 @@ impl Buffer {
 
     pub fn file(&self) -> Option<&dyn File> {
         self.file.as_deref()
+    }
+
+    pub fn format(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        let file = if let Some(file) = self.file.as_ref() {
+            file
+        } else {
+            return Task::ready(Err(anyhow!("buffer has no file")));
+        };
+
+        if let Some(LanguageServerState { server, .. }) = self.language_server.as_ref() {
+            let server = server.clone();
+            let abs_path = file.abs_path().unwrap();
+            let version = self.version();
+            cx.spawn(|this, mut cx| async move {
+                let edits = server
+                    .request::<lsp::request::Formatting>(lsp::DocumentFormattingParams {
+                        text_document: lsp::TextDocumentIdentifier::new(
+                            lsp::Url::from_file_path(&abs_path).unwrap(),
+                        ),
+                        options: Default::default(),
+                        work_done_progress_params: Default::default(),
+                    })
+                    .await?;
+
+                if let Some(edits) = edits {
+                    this.update(&mut cx, |this, cx| {
+                        if this.version == version {
+                            for edit in &edits {
+                                let range = range_from_lsp(edit.range);
+                                if this.clip_point_utf16(range.start, Bias::Left) != range.start
+                                    || this.clip_point_utf16(range.end, Bias::Left) != range.end
+                                {
+                                    return Err(anyhow!(
+                                        "invalid formatting edits received from language server"
+                                    ));
+                                }
+                            }
+
+                            for edit in edits.into_iter().rev() {
+                                this.edit([range_from_lsp(edit.range)], edit.new_text, cx);
+                            }
+                            Ok(())
+                        } else {
+                            Err(anyhow!("buffer edited since starting to format"))
+                        }
+                    })
+                } else {
+                    Ok(())
+                }
+            })
+        } else {
+            let format = file.format_remote(self.remote_id(), cx.as_mut());
+            cx.spawn(|_, _| async move {
+                if let Some(format) = format {
+                    format.await?;
+                }
+                Ok(())
+            })
+        }
     }
 
     pub fn save(

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -6,7 +6,7 @@ pub use crate::{
 };
 use crate::{
     diagnostic_set::{DiagnosticEntry, DiagnosticGroup},
-    range_from_lsp, ToPointUtf16,
+    range_from_lsp,
 };
 use anyhow::{anyhow, Result};
 use clock::ReplicaId;

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -15,7 +15,7 @@ use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use serde::Deserialize;
-use std::{path::Path, str, sync::Arc};
+use std::{ops::Range, path::Path, str, sync::Arc};
 use theme::SyntaxTheme;
 use tree_sitter::{self, Query};
 pub use tree_sitter::{Parser, Tree};
@@ -31,6 +31,10 @@ lazy_static! {
         },
         None,
     ));
+}
+
+pub trait ToPointUtf16 {
+    fn to_point_utf16(self) -> PointUtf16;
 }
 
 #[derive(Default, Deserialize)]
@@ -243,4 +247,16 @@ impl LanguageServerConfig {
             fake,
         )
     }
+}
+
+impl ToPointUtf16 for lsp::Position {
+    fn to_point_utf16(self) -> PointUtf16 {
+        PointUtf16::new(self.line, self.character)
+    }
+}
+
+pub fn range_from_lsp(range: lsp::Range) -> Range<PointUtf16> {
+    let start = PointUtf16::new(range.start.line, range.start.character);
+    let end = PointUtf16::new(range.end.line, range.end.character);
+    start..end
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -308,6 +308,7 @@ impl Project {
                 client.subscribe_to_entity(remote_id, cx, Self::handle_update_buffer),
                 client.subscribe_to_entity(remote_id, cx, Self::handle_save_buffer),
                 client.subscribe_to_entity(remote_id, cx, Self::handle_buffer_saved),
+                client.subscribe_to_entity(remote_id, cx, Self::handle_format_buffer),
             ]);
         }
     }
@@ -803,6 +804,21 @@ impl Project {
         if let Some(worktree) = self.worktree_for_id(worktree_id, cx) {
             worktree.update(cx, |worktree, cx| {
                 worktree.handle_save_buffer(envelope, rpc, cx)
+            })?;
+        }
+        Ok(())
+    }
+
+    pub fn handle_format_buffer(
+        &mut self,
+        envelope: TypedEnvelope<proto::FormatBuffer>,
+        rpc: Arc<Client>,
+        cx: &mut ModelContext<Self>,
+    ) -> Result<()> {
+        let worktree_id = WorktreeId::from_proto(envelope.payload.worktree_id);
+        if let Some(worktree) = self.worktree_for_id(worktree_id, cx) {
+            worktree.update(cx, |worktree, cx| {
+                worktree.handle_format_buffer(envelope, rpc, cx)
             })?;
         }
         Ok(())

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -600,7 +600,6 @@ impl Worktree {
             // We spawn here in order to enqueue the sending of `Ack` *after* transmission of edits
             // associated with formatting.
             cx.spawn(|_| async move {
-                dbg!("responding");
                 match format {
                     Ok(()) => rpc.respond(receipt, proto::Ack {}).await?,
                     Err(error) => {
@@ -923,7 +922,6 @@ impl Worktree {
             )),
         } {
             cx.spawn(|worktree, mut cx| async move {
-                dbg!(&operation);
                 if let Err(error) = rpc
                     .request(proto::UpdateBuffer {
                         project_id,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -30,5 +30,6 @@ zstd = "0.9"
 prost-build = "0.8"
 
 [dev-dependencies]
+gpui = { path = "../gpui", features = ["test-support"] }
 smol = "1.2.5"
 tempdir = "0.3.7"

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -35,22 +35,23 @@ message Envelope {
         UpdateBuffer update_buffer = 27;
         SaveBuffer save_buffer = 28;
         BufferSaved buffer_saved = 29;
+        FormatBuffer format_buffer = 30;
 
-        GetChannels get_channels = 30;
-        GetChannelsResponse get_channels_response = 31;
-        JoinChannel join_channel = 32;
-        JoinChannelResponse join_channel_response = 33;
-        LeaveChannel leave_channel = 34;
-        SendChannelMessage send_channel_message = 35;
-        SendChannelMessageResponse send_channel_message_response = 36;
-        ChannelMessageSent channel_message_sent = 37;
-        GetChannelMessages get_channel_messages = 38;
-        GetChannelMessagesResponse get_channel_messages_response = 39;
+        GetChannels get_channels = 31;
+        GetChannelsResponse get_channels_response = 32;
+        JoinChannel join_channel = 33;
+        JoinChannelResponse join_channel_response = 34;
+        LeaveChannel leave_channel = 35;
+        SendChannelMessage send_channel_message = 36;
+        SendChannelMessageResponse send_channel_message_response = 37;
+        ChannelMessageSent channel_message_sent = 38;
+        GetChannelMessages get_channel_messages = 39;
+        GetChannelMessagesResponse get_channel_messages_response = 40;
 
-        UpdateContacts update_contacts = 40;
+        UpdateContacts update_contacts = 41;
 
-        GetUsers get_users = 41;
-        GetUsersResponse get_users_response = 42;
+        GetUsers get_users = 42;
+        GetUsersResponse get_users_response = 43;
     }
 }
 
@@ -166,6 +167,12 @@ message BufferSaved {
     uint64 buffer_id = 3;
     repeated VectorClockEntry version = 4;
     Timestamp mtime = 5;
+}
+
+message FormatBuffer {
+    uint64 project_id = 1;
+    uint64 worktree_id = 2;
+    uint64 buffer_id = 3;
 }
 
 message UpdateDiagnosticSummary {

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -398,7 +398,7 @@ mod tests {
                 proto::OpenBufferResponse {
                     buffer: Some(proto::Buffer {
                         id: 101,
-                        visible_text: "path/one content".to_string(),
+                        content: "path/one content".to_string(),
                         ..Default::default()
                     }),
                 }
@@ -419,7 +419,7 @@ mod tests {
                 proto::OpenBufferResponse {
                     buffer: Some(proto::Buffer {
                         id: 102,
-                        visible_text: "path/two content".to_string(),
+                        content: "path/two content".to_string(),
                         ..Default::default()
                     }),
                 }
@@ -448,7 +448,7 @@ mod tests {
                                 proto::OpenBufferResponse {
                                     buffer: Some(proto::Buffer {
                                         id: 101,
-                                        visible_text: "path/one content".to_string(),
+                                        content: "path/one content".to_string(),
                                         ..Default::default()
                                     }),
                                 }
@@ -458,7 +458,7 @@ mod tests {
                                 proto::OpenBufferResponse {
                                     buffer: Some(proto::Buffer {
                                         id: 102,
-                                        visible_text: "path/two content".to_string(),
+                                        content: "path/two content".to_string(),
                                         ..Default::default()
                                     }),
                                 }

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -128,6 +128,7 @@ messages!(
     DiskBasedDiagnosticsUpdated,
     DiskBasedDiagnosticsUpdating,
     Error,
+    FormatBuffer,
     GetChannelMessages,
     GetChannelMessagesResponse,
     GetChannels,
@@ -162,6 +163,7 @@ messages!(
 );
 
 request_messages!(
+    (FormatBuffer, Ack),
     (GetChannelMessages, GetChannelMessagesResponse),
     (GetChannels, GetChannelsResponse),
     (GetUsers, GetUsersResponse),
@@ -185,6 +187,7 @@ entity_messages!(
     CloseBuffer,
     DiskBasedDiagnosticsUpdated,
     DiskBasedDiagnosticsUpdating,
+    FormatBuffer,
     JoinProject,
     LeaveProject,
     OpenBuffer,

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -174,7 +174,7 @@ impl Server {
     }
 
     async fn sign_out(self: &mut Arc<Self>, connection_id: ConnectionId) -> tide::Result<()> {
-        self.peer.disconnect(connection_id).await;
+        self.peer.disconnect(connection_id);
         let removed_connection = self.state_mut().remove_connection(connection_id)?;
 
         for (project_id, project) in removed_connection.hosted_projects {
@@ -1801,7 +1801,7 @@ mod tests {
             .await;
 
         // Drop client B's connection and ensure client A observes client B leaving the worktree.
-        client_b.disconnect(&cx_b.to_async()).await.unwrap();
+        client_b.disconnect(&cx_b.to_async()).unwrap();
         project_a
             .condition(&cx_a, |p, _| p.collaborators().len() == 0)
             .await;
@@ -2833,7 +2833,7 @@ mod tests {
 
     impl Drop for TestServer {
         fn drop(&mut self) {
-            task::block_on(self.peer.reset());
+            self.peer.reset();
         }
     }
 

--- a/crates/text/src/rope.rs
+++ b/crates/text/src/rope.rs
@@ -593,6 +593,12 @@ impl Chunk {
 
             if ch == '\n' {
                 point.row += 1;
+                if point.row > target.row {
+                    panic!(
+                        "point {:?} is beyond the end of a line with length {}",
+                        target, point.column
+                    );
+                }
                 point.column = 0;
             } else {
                 point.column += ch.len_utf16() as u32;


### PR DESCRIPTION
Closes #318 

This works collaboratively but isn't configurable. Currently, we will always format on save whenever the language server supports this. For now, that's just for Rust.