### PR TITLE
Allow splitting of project diagnostics

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -586,6 +586,18 @@ impl workspace::ItemView for ProjectDiagnosticsEditor {
             Event::Saved | Event::Dirtied | Event::FileHandleChanged
         )
     }
+
+    fn clone_on_split(&self, cx: &mut ViewContext<Self>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        Some(ProjectDiagnosticsEditor::new(
+            self.model.clone(),
+            self.workspace.clone(),
+            self.settings.clone(),
+            cx,
+        ))
+    }
 }
 
 fn path_header_renderer(buffer: ModelHandle<Buffer>, build_settings: BuildSettings) -> RenderBlock {


### PR DESCRIPTION
Closes #333 

Note how this just trivially splits the project diagnostics editor without maintaining selections or scroll position. We could maintain those but doing so properly would require a bigger refactoring than what seems appropriate for this edge case. In particular, we would need to maintain excerpts and blocks inside a single `ProjectDiagnostics` model that is shared across `ProjectDiagnosticEditor` splits. That is tricky, though, because you can only add blocks to editors at the moment and so that makes having multiple editors but a single `ProjectDiagnostics` harder.

One way of solving that would be to somehow allow sharing blocks across editors but I am not sure it's worth the complexity at the moment. There are other hacky ways of doing this but again I am not sure the effort is worth it at this time.