### PR TITLE
Add a navigation history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5677,6 +5677,7 @@ dependencies = [
  "project",
  "serde_json",
  "theme",
+ "util",
 ]
 
 [[package]]

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -15,9 +15,9 @@ use gpui::{
 use language::{Bias, Buffer, Diagnostic, DiagnosticEntry, Point, Selection, SelectionGoal};
 use postage::watch;
 use project::{Project, ProjectPath, WorktreeId};
-use std::{cmp::Ordering, mem, ops::Range, sync::Arc};
+use std::{cmp::Ordering, mem, ops::Range, rc::Rc, sync::Arc};
 use util::TryFutureExt;
-use workspace::Workspace;
+use workspace::{Navigation, Workspace};
 
 action!(Deploy);
 action!(OpenExcerpts);
@@ -522,6 +522,7 @@ impl workspace::Item for ProjectDiagnostics {
     fn build_view(
         handle: ModelHandle<Self>,
         workspace: &Workspace,
+        _: Rc<Navigation>,
         cx: &mut ViewContext<Self::View>,
     ) -> Self::View {
         ProjectDiagnosticsEditor::new(handle, workspace.weak_handle(), workspace.settings(), cx)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3297,6 +3297,17 @@ impl Editor {
         }
         self.pause_cursor_blinking(cx);
 
+        let prev_newest_selection = self.selections.iter().max_by_key(|s| s.id);
+        let curr_newest_selection = selections.iter().max_by_key(|s| s.id);
+        if let Some((prev_selection, curr_selection)) =
+            prev_newest_selection.zip(curr_newest_selection)
+        {
+            if prev_selection.head().to_offset(&buffer) != curr_selection.head().to_offset(&buffer)
+            {
+                self.push_to_navigation_history(cx);
+            }
+        }
+
         self.set_selections(
             Arc::from_iter(selections.into_iter().map(|selection| {
                 let end_bias = if selection.end > selection.start {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -41,6 +41,7 @@ use std::{
     iter::{self, FromIterator},
     mem,
     ops::{Deref, Range, RangeInclusive, Sub},
+    rc::Rc,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -48,7 +49,7 @@ use sum_tree::Bias;
 use text::rope::TextDimension;
 use theme::{DiagnosticStyle, EditorStyle};
 use util::post_inc;
-use workspace::{PathOpener, Workspace};
+use workspace::{Navigation, PathOpener, Workspace};
 
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_LINE_LEN: usize = 1024;
@@ -377,6 +378,7 @@ pub struct Editor {
     mode: EditorMode,
     placeholder_text: Option<Arc<str>>,
     highlighted_rows: Option<Range<u32>>,
+    navigation: Option<Rc<Navigation>>,
 }
 
 pub struct EditorSnapshot {
@@ -457,6 +459,7 @@ impl Editor {
         let mut clone = Self::new(self.buffer.clone(), self.build_settings.clone(), cx);
         clone.scroll_position = self.scroll_position;
         clone.scroll_top_anchor = self.scroll_top_anchor.clone();
+        clone.navigation = self.navigation.clone();
         clone
     }
 
@@ -506,6 +509,7 @@ impl Editor {
             mode: EditorMode::Full,
             placeholder_text: None,
             highlighted_rows: None,
+            navigation: None,
         };
         let selection = Selection {
             id: post_inc(&mut this.next_selection_id),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1138,8 +1138,8 @@ impl Editor {
         self.update_selections(selections, autoscroll, cx);
     }
 
-    #[cfg(test)]
-    fn select_display_ranges<'a, T>(&mut self, ranges: T, cx: &mut ViewContext<Self>)
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn select_display_ranges<'a, T>(&mut self, ranges: T, cx: &mut ViewContext<Self>)
     where
         T: IntoIterator<Item = &'a Range<DisplayPoint>>,
     {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -426,6 +426,11 @@ struct ClipboardSelection {
     is_entire_line: bool,
 }
 
+pub struct NavigationData {
+    anchor: Anchor,
+    offset: usize,
+}
+
 impl Editor {
     pub fn single_line(build_settings: BuildSettings, cx: &mut ViewContext<Self>) -> Self {
         let buffer = cx.add_model(|cx| Buffer::new(0, String::new(), cx));
@@ -2438,9 +2443,12 @@ impl Editor {
 
     fn push_to_navigation_history(&self, cx: &mut ViewContext<Self>) {
         if let Some(navigation) = &self.navigation {
+            let buffer = self.buffer.read(cx).read(cx);
             if let Some(last_selection) = self.selections.iter().max_by_key(|s| s.id) {
-                let cursor = last_selection.head();
-                navigation.push(Some(cursor), cx);
+                let anchor = last_selection.head();
+                let offset = anchor.to_offset(&buffer);
+                drop(buffer);
+                navigation.push(Some(NavigationData { anchor, offset }), cx);
             }
         }
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2399,6 +2399,8 @@ impl Editor {
             return;
         }
 
+        self.push_to_navigation_history(cx);
+
         let selection = Selection {
             id: post_inc(&mut self.next_selection_id),
             start: 0,
@@ -2421,6 +2423,8 @@ impl Editor {
             return;
         }
 
+        self.push_to_navigation_history(cx);
+
         let cursor = self.buffer.read(cx).read(cx).len();
         let selection = Selection {
             id: post_inc(&mut self.next_selection_id),
@@ -2430,6 +2434,15 @@ impl Editor {
             goal: SelectionGoal::None,
         };
         self.update_selections(vec![selection], Some(Autoscroll::Fit), cx);
+    }
+
+    fn push_to_navigation_history(&self, cx: &mut ViewContext<Self>) {
+        if let Some(navigation) = &self.navigation {
+            if let Some(last_selection) = self.selections.iter().max_by_key(|s| s.id) {
+                let cursor = last_selection.head();
+                navigation.push(Some(cursor), cx);
+            }
+        }
     }
 
     pub fn select_to_end(&mut self, _: &SelectToEnd, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -149,7 +149,9 @@ impl ItemView for Editor {
     }
 
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
-        self.push_to_navigation_history(cx);
+        if let Some(selection) = self.newest_selection_internal() {
+            self.push_to_navigation_history(selection.head(), None, cx);
+        }
     }
 
     fn is_dirty(&self, cx: &AppContext) -> bool {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -115,7 +115,9 @@ impl ItemView for Editor {
             };
 
             drop(buffer);
+            let navigation = self.navigation.take();
             self.select_ranges([offset..offset], Some(Autoscroll::Fit), cx);
+            self.navigation = navigation;
         }
     }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -133,7 +133,7 @@ impl ItemView for Editor {
         Some(self.clone(cx))
     }
 
-    fn activated(&mut self, cx: &mut ViewContext<Self>) {
+    fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(navigation) = self.navigation.as_ref() {
             navigation.push::<(), _>(None, cx);
         }

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1545,6 +1545,18 @@ impl MultiBufferSnapshot {
         panic!("excerpt not found");
     }
 
+    pub fn can_resolve(&self, anchor: &Anchor) -> bool {
+        if anchor.excerpt_id == ExcerptId::min() || anchor.excerpt_id == ExcerptId::max() {
+            true
+        } else if let Some((buffer_id, buffer_snapshot)) =
+            self.buffer_snapshot_for_excerpt(&anchor.excerpt_id)
+        {
+            anchor.buffer_id == buffer_id && buffer_snapshot.can_resolve(&anchor.text_anchor)
+        } else {
+            false
+        }
+    }
+
     pub fn range_contains_excerpt_boundary<T: ToOffset>(&self, range: Range<T>) -> bool {
         let start = range.start.to_offset(self);
         let end = range.end.to_offset(self);

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1131,12 +1131,6 @@ impl Buffer {
         }
     }
 
-    pub fn can_resolve(&self, anchor: &Anchor) -> bool {
-        *anchor == Anchor::min()
-            || *anchor == Anchor::max()
-            || self.version.observed(anchor.timestamp)
-    }
-
     pub fn peek_undo_stack(&self) -> Option<&Transaction> {
         self.history.undo_stack.last()
     }
@@ -1646,6 +1640,12 @@ impl BufferSnapshot {
                 bias,
             }
         }
+    }
+
+    pub fn can_resolve(&self, anchor: &Anchor) -> bool {
+        *anchor == Anchor::min()
+            || *anchor == Anchor::max()
+            || self.version.observed(anchor.timestamp)
     }
 
     pub fn clip_offset(&self, offset: usize, bias: Bias) -> usize {

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -17,6 +17,7 @@ gpui = { path = "../gpui" }
 language = { path = "../language" }
 project = { path = "../project" }
 theme = { path = "../theme" }
+util = { path = "../util" }
 anyhow = "1.0.38"
 log = "0.4"
 parking_lot = "0.11.1"

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "workspace"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/workspace.rs"

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -57,17 +57,6 @@ pub enum Event {
 
 const MAX_TAB_TITLE_LEN: usize = 24;
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct State {
-    pub tabs: Vec<TabState>,
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct TabState {
-    pub title: String,
-    pub active: bool,
-}
-
 pub struct Pane {
     item_views: Vec<(usize, Box<dyn ItemViewHandle>)>,
     active_item: usize,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1,5 +1,6 @@
 use super::{ItemViewHandle, SplitDirection};
-use crate::{ItemHandle, Settings, Workspace};
+use crate::{ItemHandle, ItemView, Settings, WeakItemViewHandle, Workspace};
+use collections::HashMap;
 use gpui::{
     action,
     elements::*,
@@ -9,7 +10,8 @@ use gpui::{
     Entity, MutableAppContext, Quad, RenderContext, View, ViewContext,
 };
 use postage::watch;
-use std::cmp;
+use project::ProjectPath;
+use std::{any::Any, cell::RefCell, cmp, rc::Rc};
 
 action!(Split, SplitDirection);
 action!(ActivateItem, usize);
@@ -17,6 +19,8 @@ action!(ActivatePrevItem);
 action!(ActivateNextItem);
 action!(CloseActiveItem);
 action!(CloseItem, usize);
+action!(GoBack);
+action!(GoForward);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(|pane: &mut Pane, action: &ActivateItem, cx| {
@@ -37,6 +41,8 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(|pane: &mut Pane, action: &Split, cx| {
         pane.split(action.0, cx);
     });
+    cx.add_action(Pane::go_back);
+    cx.add_action(Pane::go_forward);
 
     cx.add_bindings(vec![
         Binding::new("shift-cmd-{", ActivatePrevItem, Some("Pane")),
@@ -46,6 +52,8 @@ pub fn init(cx: &mut MutableAppContext) {
         Binding::new("cmd-k down", Split(SplitDirection::Down), Some("Pane")),
         Binding::new("cmd-k left", Split(SplitDirection::Left), Some("Pane")),
         Binding::new("cmd-k right", Split(SplitDirection::Right), Some("Pane")),
+        Binding::new("ctrl-", GoBack, Some("Pane")),
+        Binding::new("ctrl-shift-_", GoForward, Some("Pane")),
     ]);
 }
 
@@ -61,6 +69,22 @@ pub struct Pane {
     item_views: Vec<(usize, Box<dyn ItemViewHandle>)>,
     active_item: usize,
     settings: watch::Receiver<Settings>,
+    navigation: Rc<Navigation>,
+}
+
+#[derive(Default)]
+pub struct Navigation(RefCell<NavigationHistory>);
+
+#[derive(Default)]
+struct NavigationHistory {
+    backward_stack: Vec<NavigationEntry>,
+    forward_stack: Vec<NavigationEntry>,
+    paths_by_item: HashMap<usize, ProjectPath>,
+}
+
+struct NavigationEntry {
+    item_view: Box<dyn WeakItemViewHandle>,
+    data: Option<Box<dyn Any>>,
 }
 
 impl Pane {
@@ -69,11 +93,22 @@ impl Pane {
             item_views: Vec::new(),
             active_item: 0,
             settings,
+            navigation: Default::default(),
         }
     }
 
     pub fn activate(&self, cx: &mut ViewContext<Self>) {
         cx.emit(Event::Activate);
+    }
+
+    pub fn go_back(&mut self, _: &GoBack, cx: &mut ViewContext<Self>) {
+        let mut navigation = self.navigation.0.borrow_mut();
+        if let Some(entry) = navigation.go_back() {}
+    }
+
+    pub fn go_forward(&mut self, _: &GoForward, cx: &mut ViewContext<Self>) {
+        let mut navigation = self.navigation.0.borrow_mut();
+        if let Some(entry) = navigation.go_forward() {}
     }
 
     pub fn open_item<T>(
@@ -93,14 +128,15 @@ impl Pane {
             }
         }
 
-        let item_view = item_handle.add_view(cx.window_id(), workspace, cx);
+        let item_view =
+            item_handle.add_view(cx.window_id(), workspace, self.navigation.clone(), cx);
         self.add_item_view(item_view.boxed_clone(), cx);
         item_view
     }
 
     pub fn add_item_view(
         &mut self,
-        item_view: Box<dyn ItemViewHandle>,
+        mut item_view: Box<dyn ItemViewHandle>,
         cx: &mut ViewContext<Self>,
     ) {
         item_view.added_to_pane(cx);
@@ -142,6 +178,7 @@ impl Pane {
         if index < self.item_views.len() {
             self.active_item = index;
             self.focus_active_item(cx);
+            self.item_views[index].1.activated(cx);
             cx.notify();
         }
     }
@@ -172,8 +209,21 @@ impl Pane {
         }
     }
 
-    pub fn close_item(&mut self, item_id: usize, cx: &mut ViewContext<Self>) {
-        self.item_views.retain(|(_, item)| item.id() != item_id);
+    pub fn close_item(&mut self, item_view_id: usize, cx: &mut ViewContext<Self>) {
+        self.item_views.retain(|(item_id, item)| {
+            if item.id() == item_view_id {
+                let mut navigation = self.navigation.0.borrow_mut();
+                if let Some(path) = item.project_path(cx) {
+                    navigation.paths_by_item.insert(*item_id, path);
+                } else {
+                    navigation.paths_by_item.remove(item_id);
+                }
+
+                false
+            } else {
+                true
+            }
+        });
         self.active_item = cmp::min(self.active_item, self.item_views.len().saturating_sub(1));
         if self.item_views.is_empty() {
             cx.emit(Event::Remove);
@@ -367,5 +417,35 @@ impl View for Pane {
 
     fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
         self.focus_active_item(cx);
+    }
+}
+
+impl Navigation {
+    pub fn push<D: 'static + Any, T: ItemView>(&self, data: Option<D>, cx: &mut ViewContext<T>) {
+        let mut state = self.0.borrow_mut();
+        state.backward_stack.push(NavigationEntry {
+            item_view: Box::new(cx.weak_handle()),
+            data: data.map(|data| Box::new(data) as Box<dyn Any>),
+        });
+    }
+}
+
+impl NavigationHistory {
+    fn go_back(&mut self) -> Option<&NavigationEntry> {
+        if let Some(backward) = self.backward_stack.pop() {
+            self.forward_stack.push(backward);
+            self.forward_stack.last()
+        } else {
+            None
+        }
+    }
+
+    fn go_forward(&mut self) -> Option<&NavigationEntry> {
+        if let Some(forward) = self.forward_stack.pop() {
+            self.backward_stack.push(forward);
+            self.backward_stack.last()
+        } else {
+            None
+        }
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -280,9 +280,9 @@ impl Pane {
             let prev_active_item_ix = mem::replace(&mut self.active_item_index, index);
             if prev_active_item_ix != self.active_item_index {
                 self.item_views[prev_active_item_ix].1.deactivated(cx);
-                self.focus_active_item(cx);
-                cx.notify();
             }
+            self.focus_active_item(cx);
+            cx.notify();
         }
     }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -316,6 +316,10 @@ impl Pane {
         let mut item_ix = 0;
         self.item_views.retain(|(_, item_view)| {
             if item_view.id() == item_view_id {
+                if item_ix == self.active_item_index {
+                    item_view.deactivated(cx);
+                }
+
                 let mut navigation = self.navigation.0.borrow_mut();
                 if let Some(path) = item_view.project_path(cx) {
                     navigation.paths_by_item.insert(item_view.id(), path);
@@ -323,9 +327,6 @@ impl Pane {
                     navigation.paths_by_item.remove(&item_view.id());
                 }
 
-                if item_ix == self.active_item_index {
-                    item_view.deactivated(cx);
-                }
                 item_ix += 1;
                 false
             } else {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -11,7 +11,13 @@ use gpui::{
 };
 use postage::watch;
 use project::ProjectPath;
-use std::{any::Any, cell::RefCell, cmp, mem, rc::Rc};
+use std::{
+    any::Any,
+    cell::RefCell,
+    cmp, mem,
+    rc::Rc,
+    time::{Duration, Instant},
+};
 use util::ResultExt;
 
 action!(Split, SplitDirection);
@@ -104,6 +110,7 @@ impl Default for NavigationMode {
 struct NavigationEntry {
     item_view: Box<dyn WeakItemViewHandle>,
     data: Option<Box<dyn Any>>,
+    insertion_time: Option<Instant>,
 }
 
 impl Pane {
@@ -551,9 +558,20 @@ impl Navigation {
         let mut state = self.0.borrow_mut();
         match state.mode {
             NavigationMode::Normal => {
+                let mut insertion_time = Instant::now();
+                if let Some(prev_insertion_time) =
+                    state.backward_stack.last().and_then(|e| e.insertion_time)
+                {
+                    if insertion_time.duration_since(prev_insertion_time) <= Duration::from_secs(2)
+                    {
+                        state.backward_stack.pop();
+                        insertion_time = prev_insertion_time;
+                    }
+                }
                 state.backward_stack.push(NavigationEntry {
                     item_view: Box::new(cx.weak_handle()),
                     data: data.map(|data| Box::new(data) as Box<dyn Any>),
+                    insertion_time: Some(insertion_time),
                 });
                 state.forward_stack.clear();
             }
@@ -561,12 +579,14 @@ impl Navigation {
                 state.forward_stack.push(NavigationEntry {
                     item_view: Box::new(cx.weak_handle()),
                     data: data.map(|data| Box::new(data) as Box<dyn Any>),
+                    insertion_time: None,
                 });
             }
             NavigationMode::GoingForward => {
                 state.backward_stack.push(NavigationEntry {
                     item_view: Box::new(cx.weak_handle()),
                     data: data.map(|data| Box::new(data) as Box<dyn Any>),
+                    insertion_time: None,
                 });
             }
         }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -101,9 +101,9 @@ impl Default for NavigationMode {
     }
 }
 
-struct NavigationEntry {
-    item_view: Box<dyn WeakItemViewHandle>,
-    data: Option<Box<dyn Any>>,
+pub struct NavigationEntry {
+    pub item_view: Box<dyn WeakItemViewHandle>,
+    pub data: Option<Box<dyn Any>>,
 }
 
 impl Pane {
@@ -535,11 +535,19 @@ impl View for Pane {
 }
 
 impl Navigation {
+    pub fn pop_backward(&self) -> Option<NavigationEntry> {
+        self.0.borrow_mut().backward_stack.pop()
+    }
+
+    pub fn pop_forward(&self) -> Option<NavigationEntry> {
+        self.0.borrow_mut().forward_stack.pop()
+    }
+
     fn pop(&self, mode: NavigationMode) -> Option<NavigationEntry> {
         match mode {
             NavigationMode::Normal => None,
-            NavigationMode::GoingBack => self.0.borrow_mut().backward_stack.pop(),
-            NavigationMode::GoingForward => self.0.borrow_mut().forward_stack.pop(),
+            NavigationMode::GoingBack => self.pop_backward(),
+            NavigationMode::GoingForward => self.pop_forward(),
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -33,6 +33,7 @@ use sidebar::{Side, Sidebar, SidebarItemId, ToggleSidebarItem, ToggleSidebarItem
 use status_bar::StatusBar;
 pub use status_bar::StatusItemView;
 use std::{
+    any::Any,
     future::Future,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
@@ -148,6 +149,7 @@ pub trait ItemView: View {
 
     fn added_to_pane(&mut self, _: Rc<Navigation>, _: &mut ViewContext<Self>) {}
     fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
+    fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) {}
     fn item_handle(&self, cx: &AppContext) -> Self::ItemHandle;
     fn title(&self, cx: &AppContext) -> String;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
@@ -211,6 +213,7 @@ pub trait ItemViewHandle {
     fn clone_on_split(&self, cx: &mut MutableAppContext) -> Option<Box<dyn ItemViewHandle>>;
     fn added_to_pane(&mut self, cx: &mut ViewContext<Pane>);
     fn deactivated(&self, cx: &mut MutableAppContext);
+    fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext);
     fn id(&self) -> usize;
     fn to_any(&self) -> AnyViewHandle;
     fn is_dirty(&self, cx: &AppContext) -> bool;
@@ -366,6 +369,10 @@ impl<T: ItemView> ItemViewHandle for ViewHandle<T> {
 
     fn deactivated(&self, cx: &mut MutableAppContext) {
         self.update(cx, |this, cx| this.deactivated(cx));
+    }
+
+    fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext) {
+        self.update(cx, |this, cx| this.navigate(data, cx));
     }
 
     fn save(&self, cx: &mut MutableAppContext) -> Result<Task<Result<()>>> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -36,6 +36,7 @@ use std::{
     future::Future,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
+    rc::Rc,
     sync::Arc,
 };
 use theme::{Theme, ThemeRegistry};
@@ -135,6 +136,7 @@ pub trait Item: Entity + Sized {
     fn build_view(
         handle: ModelHandle<Self>,
         workspace: &Workspace,
+        navigation: Rc<Navigation>,
         cx: &mut ViewContext<Self::View>,
     ) -> Self::View;
 
@@ -144,6 +146,8 @@ pub trait Item: Entity + Sized {
 pub trait ItemView: View {
     type ItemHandle: ItemHandle;
 
+    fn added_to_pane(&mut self, _: Rc<Navigation>, _: &mut ViewContext<Self>) {}
+    fn activated(&mut self, _: &mut ViewContext<Self>) {}
     fn item_handle(&self, cx: &AppContext) -> Self::ItemHandle;
     fn title(&self, cx: &AppContext) -> String;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
@@ -185,6 +189,7 @@ pub trait ItemHandle: Send + Sync {
         &self,
         window_id: usize,
         workspace: &Workspace,
+        navigation: Rc<Navigation>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle>;
     fn boxed_clone(&self) -> Box<dyn ItemHandle>;
@@ -204,7 +209,8 @@ pub trait ItemViewHandle {
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
     fn boxed_clone(&self) -> Box<dyn ItemViewHandle>;
     fn clone_on_split(&self, cx: &mut MutableAppContext) -> Option<Box<dyn ItemViewHandle>>;
-    fn added_to_pane(&self, cx: &mut ViewContext<Pane>);
+    fn added_to_pane(&mut self, cx: &mut ViewContext<Pane>);
+    fn activated(&mut self, cx: &mut MutableAppContext);
     fn id(&self) -> usize;
     fn to_any(&self) -> AnyViewHandle;
     fn is_dirty(&self, cx: &AppContext) -> bool;
@@ -220,6 +226,10 @@ pub trait ItemViewHandle {
     ) -> Task<anyhow::Result<()>>;
 }
 
+pub trait WeakItemViewHandle {
+    fn upgrade(&self, cx: &AppContext) -> Option<Box<dyn ItemViewHandle>>;
+}
+
 impl<T: Item> ItemHandle for ModelHandle<T> {
     fn id(&self) -> usize {
         self.id()
@@ -229,9 +239,12 @@ impl<T: Item> ItemHandle for ModelHandle<T> {
         &self,
         window_id: usize,
         workspace: &Workspace,
+        navigation: Rc<Navigation>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
-        Box::new(cx.add_view(window_id, |cx| T::build_view(self.clone(), workspace, cx)))
+        Box::new(cx.add_view(window_id, |cx| {
+            T::build_view(self.clone(), workspace, navigation, cx)
+        }))
     }
 
     fn boxed_clone(&self) -> Box<dyn ItemHandle> {
@@ -260,9 +273,10 @@ impl ItemHandle for Box<dyn ItemHandle> {
         &self,
         window_id: usize,
         workspace: &Workspace,
+        navigation: Rc<Navigation>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
-        ItemHandle::add_view(self.as_ref(), window_id, workspace, cx)
+        ItemHandle::add_view(self.as_ref(), window_id, workspace, navigation, cx)
     }
 
     fn boxed_clone(&self) -> Box<dyn ItemHandle> {
@@ -330,7 +344,7 @@ impl<T: ItemView> ItemViewHandle for ViewHandle<T> {
         .map(|handle| Box::new(handle) as Box<dyn ItemViewHandle>)
     }
 
-    fn added_to_pane(&self, cx: &mut ViewContext<Pane>) {
+    fn added_to_pane(&mut self, cx: &mut ViewContext<Pane>) {
         cx.subscribe(self, |pane, item, event, cx| {
             if T::should_close_item_on_event(event) {
                 pane.close_item(item.id(), cx);
@@ -347,6 +361,10 @@ impl<T: ItemView> ItemViewHandle for ViewHandle<T> {
             }
         })
         .detach();
+    }
+
+    fn activated(&mut self, cx: &mut MutableAppContext) {
+        self.update(cx, |this, cx| this.activated(cx));
     }
 
     fn save(&self, cx: &mut MutableAppContext) -> Result<Task<Result<()>>> {
@@ -396,6 +414,13 @@ impl Clone for Box<dyn ItemViewHandle> {
 impl Clone for Box<dyn ItemHandle> {
     fn clone(&self) -> Box<dyn ItemHandle> {
         self.boxed_clone()
+    }
+}
+
+impl<T: ItemView> WeakItemViewHandle for WeakViewHandle<T> {
+    fn upgrade(&self, cx: &AppContext) -> Option<Box<dyn ItemViewHandle>> {
+        self.upgrade(cx)
+            .map(|v| Box::new(v) as Box<dyn ItemViewHandle>)
     }
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -147,7 +147,6 @@ pub trait Item: Entity + Sized {
 pub trait ItemView: View {
     type ItemHandle: ItemHandle;
 
-    fn added_to_pane(&mut self, _: Rc<Navigation>, _: &mut ViewContext<Self>) {}
     fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
     fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) {}
     fn item_handle(&self, cx: &AppContext) -> Self::ItemHandle;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -147,7 +147,7 @@ pub trait ItemView: View {
     type ItemHandle: ItemHandle;
 
     fn added_to_pane(&mut self, _: Rc<Navigation>, _: &mut ViewContext<Self>) {}
-    fn activated(&mut self, _: &mut ViewContext<Self>) {}
+    fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
     fn item_handle(&self, cx: &AppContext) -> Self::ItemHandle;
     fn title(&self, cx: &AppContext) -> String;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
@@ -210,7 +210,7 @@ pub trait ItemViewHandle {
     fn boxed_clone(&self) -> Box<dyn ItemViewHandle>;
     fn clone_on_split(&self, cx: &mut MutableAppContext) -> Option<Box<dyn ItemViewHandle>>;
     fn added_to_pane(&mut self, cx: &mut ViewContext<Pane>);
-    fn activated(&mut self, cx: &mut MutableAppContext);
+    fn deactivated(&self, cx: &mut MutableAppContext);
     fn id(&self) -> usize;
     fn to_any(&self) -> AnyViewHandle;
     fn is_dirty(&self, cx: &AppContext) -> bool;
@@ -363,8 +363,8 @@ impl<T: ItemView> ItemViewHandle for ViewHandle<T> {
         .detach();
     }
 
-    fn activated(&mut self, cx: &mut MutableAppContext) {
-        self.update(cx, |this, cx| this.activated(cx));
+    fn deactivated(&self, cx: &mut MutableAppContext) {
+        self.update(cx, |this, cx| this.deactivated(cx));
     }
 
     fn save(&self, cx: &mut MutableAppContext) -> Result<Task<Result<()>>> {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -701,9 +701,9 @@ mod tests {
                 "/root",
                 json!({
                     "a": {
-                        "file1": "contents 1",
-                        "file2": "contents 2",
-                        "file3": "contents 3",
+                        "file1": "contents 1\n".repeat(20),
+                        "file2": "contents 2\n".repeat(20),
+                        "file3": "contents 3\n".repeat(20),
                     },
                 }),
             )
@@ -731,7 +731,7 @@ mod tests {
             .downcast::<Editor>()
             .unwrap();
         editor1.update(&mut cx, |editor, cx| {
-            editor.select_display_ranges(&[DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1)], cx);
+            editor.select_display_ranges(&[DisplayPoint::new(10, 0)..DisplayPoint::new(10, 0)], cx);
         });
         let editor2 = workspace
             .update(&mut cx, |w, cx| w.open_path(file2.clone(), cx))
@@ -748,11 +748,11 @@ mod tests {
             .downcast::<Editor>()
             .unwrap();
         editor3.update(&mut cx, |editor, cx| {
-            editor.select_display_ranges(&[DisplayPoint::new(0, 2)..DisplayPoint::new(0, 2)], cx);
+            editor.select_display_ranges(&[DisplayPoint::new(15, 0)..DisplayPoint::new(15, 0)], cx);
         });
         assert_eq!(
             active_location(&workspace, &mut cx),
-            (file3.clone(), DisplayPoint::new(0, 2))
+            (file3.clone(), DisplayPoint::new(15, 0))
         );
 
         workspace
@@ -776,7 +776,7 @@ mod tests {
             .await;
         assert_eq!(
             active_location(&workspace, &mut cx),
-            (file1.clone(), DisplayPoint::new(0, 1))
+            (file1.clone(), DisplayPoint::new(10, 0))
         );
 
         workspace
@@ -801,7 +801,7 @@ mod tests {
             .await;
         assert_eq!(
             active_location(&workspace, &mut cx),
-            (file1.clone(), DisplayPoint::new(0, 1))
+            (file1.clone(), DisplayPoint::new(10, 0))
         );
 
         workspace
@@ -844,7 +844,7 @@ mod tests {
             .await;
         assert_eq!(
             active_location(&workspace, &mut cx),
-            (file1.clone(), DisplayPoint::new(0, 1))
+            (file1.clone(), DisplayPoint::new(10, 0))
         );
         workspace
             .update(&mut cx, |w, cx| Pane::go_forward(w, cx))

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -760,6 +760,14 @@ mod tests {
             .await;
         assert_eq!(
             active_location(&workspace, &mut cx),
+            (file3.clone(), DisplayPoint::new(0, 0))
+        );
+
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
             (file2.clone(), DisplayPoint::new(0, 0))
         );
 
@@ -771,9 +779,25 @@ mod tests {
             (file1.clone(), DisplayPoint::new(0, 1))
         );
 
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file1.clone(), DisplayPoint::new(0, 0))
+        );
+
         // Go back one more time and ensure we don't navigate past the first item in the history.
         workspace
             .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file1.clone(), DisplayPoint::new(0, 0))
+        );
+
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_forward(w, cx))
             .await;
         assert_eq!(
             active_location(&workspace, &mut cx),
@@ -801,7 +825,7 @@ mod tests {
             .await;
         assert_eq!(
             active_location(&workspace, &mut cx),
-            (file3.clone(), DisplayPoint::new(0, 2))
+            (file3.clone(), DisplayPoint::new(0, 0))
         );
 
         // Go back to an item that has been closed and removed from disk, ensuring it gets skipped.
@@ -821,6 +845,13 @@ mod tests {
         assert_eq!(
             active_location(&workspace, &mut cx),
             (file1.clone(), DisplayPoint::new(0, 1))
+        );
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_forward(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file3.clone(), DisplayPoint::new(0, 0))
         );
 
         fn active_location(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -124,8 +124,8 @@ fn quit(_: &Quit, cx: &mut gpui::MutableAppContext) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor::Editor;
-    use gpui::MutableAppContext;
+    use editor::{DisplayPoint, Editor};
+    use gpui::{MutableAppContext, TestAppContext, ViewHandle};
     use project::ProjectPath;
     use serde_json::json;
     use std::{
@@ -136,11 +136,11 @@ mod tests {
     use theme::DEFAULT_THEME_NAME;
     use util::test::temp_tree;
     use workspace::{
-        open_paths, pane, ItemView, ItemViewHandle, OpenNew, SplitDirection, WorkspaceHandle,
+        open_paths, pane, ItemView, ItemViewHandle, OpenNew, Pane, SplitDirection, WorkspaceHandle,
     };
 
     #[gpui::test]
-    async fn test_open_paths_action(mut cx: gpui::TestAppContext) {
+    async fn test_open_paths_action(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         let dir = temp_tree(json!({
             "a": {
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_new_empty_workspace(mut cx: gpui::TestAppContext) {
+    async fn test_new_empty_workspace(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         cx.update(|cx| {
             workspace::init(cx);
@@ -230,7 +230,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_open_entry(mut cx: gpui::TestAppContext) {
+    async fn test_open_entry(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         app_state
             .fs
@@ -350,7 +350,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_open_paths(mut cx: gpui::TestAppContext) {
+    async fn test_open_paths(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         let fs = app_state.fs.as_fake();
         fs.insert_dir("/dir1").await.unwrap();
@@ -420,7 +420,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_save_conflicting_item(mut cx: gpui::TestAppContext) {
+    async fn test_save_conflicting_item(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         let fs = app_state.fs.as_fake();
         fs.insert_tree("/root", json!({ "a.txt": "" })).await;
@@ -469,7 +469,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_open_and_save_new_file(mut cx: gpui::TestAppContext) {
+    async fn test_open_and_save_new_file(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         app_state.fs.as_fake().insert_dir("/root").await.unwrap();
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
@@ -585,9 +585,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_setting_language_when_saving_as_single_file_worktree(
-        mut cx: gpui::TestAppContext,
-    ) {
+    async fn test_setting_language_when_saving_as_single_file_worktree(mut cx: TestAppContext) {
         let app_state = cx.update(test_app_state);
         app_state.fs.as_fake().insert_dir("/root").await.unwrap();
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
@@ -630,7 +628,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_pane_actions(mut cx: gpui::TestAppContext) {
+    async fn test_pane_actions(mut cx: TestAppContext) {
         cx.update(|cx| pane::init(cx));
         let app_state = cx.update(test_app_state);
         app_state
@@ -691,6 +689,151 @@ mod tests {
             assert_eq!(workspace.panes().len(), 1);
             assert_eq!(workspace.active_pane(), &pane_1);
         });
+    }
+
+    #[gpui::test]
+    async fn test_navigation(mut cx: TestAppContext) {
+        let app_state = cx.update(test_app_state);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                "/root",
+                json!({
+                    "a": {
+                        "file1": "contents 1",
+                        "file2": "contents 2",
+                        "file3": "contents 3",
+                    },
+                }),
+            )
+            .await;
+        let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
+        let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
+        workspace
+            .update(&mut cx, |workspace, cx| {
+                workspace.add_worktree(Path::new("/root"), cx)
+            })
+            .await
+            .unwrap();
+        cx.read(|cx| workspace.read(cx).worktree_scans_complete(cx))
+            .await;
+        let entries = cx.read(|cx| workspace.file_project_paths(cx));
+        let file1 = entries[0].clone();
+        let file2 = entries[1].clone();
+        let file3 = entries[2].clone();
+
+        let editor1 = workspace
+            .update(&mut cx, |w, cx| w.open_path(file1.clone(), cx))
+            .await
+            .unwrap()
+            .to_any()
+            .downcast::<Editor>()
+            .unwrap();
+        editor1.update(&mut cx, |editor, cx| {
+            editor.select_display_ranges(&[DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1)], cx);
+        });
+        let editor2 = workspace
+            .update(&mut cx, |w, cx| w.open_path(file2.clone(), cx))
+            .await
+            .unwrap()
+            .to_any()
+            .downcast::<Editor>()
+            .unwrap();
+        let editor3 = workspace
+            .update(&mut cx, |w, cx| w.open_path(file3.clone(), cx))
+            .await
+            .unwrap()
+            .to_any()
+            .downcast::<Editor>()
+            .unwrap();
+        editor3.update(&mut cx, |editor, cx| {
+            editor.select_display_ranges(&[DisplayPoint::new(0, 2)..DisplayPoint::new(0, 2)], cx);
+        });
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file3.clone(), DisplayPoint::new(0, 2))
+        );
+
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file2.clone(), DisplayPoint::new(0, 0))
+        );
+
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file1.clone(), DisplayPoint::new(0, 1))
+        );
+
+        // Go back one more time and ensure we don't navigate past the first item in the history.
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file1.clone(), DisplayPoint::new(0, 1))
+        );
+
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_forward(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file2.clone(), DisplayPoint::new(0, 0))
+        );
+
+        // Go forward to an item that has been closed, ensuring it gets re-opened at the same
+        // location.
+        workspace.update(&mut cx, |workspace, cx| {
+            workspace
+                .active_pane()
+                .update(cx, |pane, cx| pane.close_item(editor3.id(), cx));
+            drop(editor3);
+        });
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_forward(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file3.clone(), DisplayPoint::new(0, 2))
+        );
+
+        // Go back to an item that has been closed and removed from disk, ensuring it gets skipped.
+        workspace
+            .update(&mut cx, |workspace, cx| {
+                workspace
+                    .active_pane()
+                    .update(cx, |pane, cx| pane.close_item(editor2.id(), cx));
+                drop(editor2);
+                app_state.fs.as_fake().remove(Path::new("/root/a/file2"))
+            })
+            .await
+            .unwrap();
+        workspace
+            .update(&mut cx, |w, cx| Pane::go_back(w, cx))
+            .await;
+        assert_eq!(
+            active_location(&workspace, &mut cx),
+            (file1.clone(), DisplayPoint::new(0, 1))
+        );
+
+        fn active_location(
+            workspace: &ViewHandle<Workspace>,
+            cx: &mut TestAppContext,
+        ) -> (ProjectPath, DisplayPoint) {
+            workspace.update(cx, |workspace, cx| {
+                let item = workspace.active_item(cx).unwrap();
+                let editor = item.to_any().downcast::<Editor>().unwrap();
+                let selections = editor.update(cx, |editor, cx| editor.selected_display_ranges(cx));
+                (item.project_path(cx).unwrap(), selections[0].start)
+            })
+        }
     }
 
     #[gpui::test]


### PR DESCRIPTION
Refs #343

* [x] Add a system for panes to track a history of active items and positions within those items
* [x] Push to this navigation history when navigating to a different buffer
* [x] Allow reopening at the same location in a best-effort way when the anchor can't be resolved
* [x] Add unit tests for the navigation history
* [x] Skip past entries that can't be reopened 
* [x] Push to this navigation history whenever moving the cursor in a "non-local" way
    * How should this generalize?
      * ~Ideally, I think we should push to the history whenever a single command moves the cursor  such that the *previous* cursor position is no longer visible.~
      * Push to the history whenever you  move the cursor by >= 10 lines
* [x] Should we impose some *limit* on the amount of data that's stored in the navigation history?
* [x] Avoid pushing to the navigation stack when typing/selecting in the `outline` and `go_to_line` modals