### PR TITLE
Go to definition

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -17,7 +17,7 @@ use postage::watch;
 use project::{Project, ProjectPath, WorktreeId};
 use std::{cmp::Ordering, mem, ops::Range, rc::Rc, sync::Arc};
 use util::TryFutureExt;
-use workspace::{Navigation, Workspace};
+use workspace::{NavHistory, Workspace};
 
 action!(Deploy);
 action!(OpenExcerpts);
@@ -522,7 +522,7 @@ impl workspace::Item for ProjectDiagnostics {
     fn build_view(
         handle: ModelHandle<Self>,
         workspace: &Workspace,
-        _: Rc<Navigation>,
+        _: Rc<NavHistory>,
         cx: &mut ViewContext<Self::View>,
     ) -> Self::View {
         ProjectDiagnosticsEditor::new(handle, workspace.weak_handle(), workspace.settings(), cx)

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -9,13 +9,13 @@ use editor::{
     Autoscroll, BuildSettings, Editor, ExcerptId, ExcerptProperties, MultiBuffer, ToOffset,
 };
 use gpui::{
-    action, elements::*, keymap::Binding, AppContext, Entity, ModelHandle, MutableAppContext,
-    RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
+    action, elements::*, keymap::Binding, AnyViewHandle, AppContext, Entity, ModelHandle,
+    MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use language::{Bias, Buffer, Diagnostic, DiagnosticEntry, Point, Selection, SelectionGoal};
 use postage::watch;
 use project::{Project, ProjectPath};
-use std::{cmp::Ordering, mem, ops::Range, path::PathBuf, rc::Rc, sync::Arc};
+use std::{any::TypeId, cmp::Ordering, mem, ops::Range, path::PathBuf, rc::Rc, sync::Arc};
 use util::TryFutureExt;
 use workspace::{NavHistory, Workspace};
 
@@ -194,7 +194,6 @@ impl ProjectDiagnosticsEditor {
                     }
                     let editor = workspace
                         .open_item(buffer, cx)
-                        .to_any()
                         .downcast::<Editor>()
                         .unwrap();
                     editor.update(cx, |editor, cx| {
@@ -594,6 +593,21 @@ impl workspace::ItemView for ProjectDiagnosticsEditor {
             self.settings.clone(),
             cx,
         ))
+    }
+
+    fn act_as_type(
+        &self,
+        type_id: TypeId,
+        self_handle: &ViewHandle<Self>,
+        _: &AppContext,
+    ) -> Option<AnyViewHandle> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self_handle.into())
+        } else if type_id == TypeId::of::<Editor>() {
+            Some((&self.editor).into())
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -15,9 +15,9 @@ use gpui::{
 use language::{Bias, Buffer, Diagnostic, DiagnosticEntry, Point, Selection, SelectionGoal};
 use postage::watch;
 use project::{Project, ProjectPath};
-use std::{any::TypeId, cmp::Ordering, mem, ops::Range, path::PathBuf, rc::Rc, sync::Arc};
+use std::{any::TypeId, cmp::Ordering, mem, ops::Range, path::PathBuf, sync::Arc};
 use util::TryFutureExt;
-use workspace::{NavHistory, Workspace};
+use workspace::{ItemNavHistory, Workspace};
 
 action!(Deploy);
 action!(OpenExcerpts);
@@ -517,7 +517,7 @@ impl workspace::Item for ProjectDiagnostics {
     fn build_view(
         handle: ModelHandle<Self>,
         workspace: &Workspace,
-        _: Rc<NavHistory>,
+        _: ItemNavHistory,
         cx: &mut ViewContext<Self::View>,
     ) -> Self::View {
         ProjectDiagnosticsEditor::new(handle, workspace.weak_handle(), workspace.settings(), cx)

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -731,6 +731,8 @@ mod tests {
         // Create some diagnostics
         worktree.update(&mut cx, |worktree, cx| {
             worktree
+                .as_local_mut()
+                .unwrap()
                 .update_diagnostic_entries(
                     Arc::from("/test/main.rs".as_ref()),
                     None,
@@ -882,6 +884,8 @@ mod tests {
         // Diagnostics are added for another earlier path.
         worktree.update(&mut cx, |worktree, cx| {
             worktree
+                .as_local_mut()
+                .unwrap()
                 .update_diagnostic_entries(
                     Arc::from("/test/consts.rs".as_ref()),
                     None,
@@ -980,6 +984,8 @@ mod tests {
         // Diagnostics are added to the first path
         worktree.update(&mut cx, |worktree, cx| {
             worktree
+                .as_local_mut()
+                .unwrap()
                 .update_diagnostic_entries(
                     Arc::from("/test/consts.rs".as_ref()),
                     None,

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -560,7 +560,7 @@ impl workspace::ItemView for ProjectDiagnosticsEditor {
         true
     }
 
-    fn save(&mut self, cx: &mut ViewContext<Self>) -> Result<Task<Result<()>>> {
+    fn save(&mut self, cx: &mut ViewContext<Self>) -> Task<Result<()>> {
         self.excerpts.update(cx, |excerpts, cx| excerpts.save(cx))
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -15,7 +15,7 @@ use gpui::{
 use language::{Bias, Buffer, Diagnostic, DiagnosticEntry, Point, Selection, SelectionGoal};
 use postage::watch;
 use project::{Project, ProjectPath, WorktreeId};
-use std::{cmp::Ordering, mem, ops::Range, rc::Rc, sync::Arc};
+use std::{cmp::Ordering, mem, ops::Range, path::PathBuf, rc::Rc, sync::Arc};
 use util::TryFutureExt;
 use workspace::{NavHistory, Workspace};
 
@@ -570,8 +570,8 @@ impl workspace::ItemView for ProjectDiagnosticsEditor {
 
     fn save_as(
         &mut self,
-        _: ModelHandle<project::Worktree>,
-        _: &std::path::Path,
+        _: ModelHandle<Project>,
+        _: PathBuf,
         _: &mut ViewContext<Self>,
     ) -> Task<Result<()>> {
         unreachable!()

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -539,7 +539,7 @@ impl workspace::Item for ProjectDiagnostics {
         diagnostics
     }
 
-    fn project_entry(&self) -> Option<project::ProjectEntry> {
+    fn project_path(&self) -> Option<project::ProjectPath> {
         None
     }
 }
@@ -555,7 +555,7 @@ impl workspace::ItemView for ProjectDiagnosticsEditor {
         "Project Diagnostics".to_string()
     }
 
-    fn project_entry(&self, _: &AppContext) -> Option<project::ProjectEntry> {
+    fn project_path(&self, _: &AppContext) -> Option<project::ProjectPath> {
         None
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -764,9 +764,9 @@ mod tests {
             )
             .await;
 
-        let worktree = project
+        let (worktree, _) = project
             .update(&mut cx, |project, cx| {
-                project.add_local_worktree("/test", cx)
+                project.find_or_create_worktree_for_abs_path("/test", false, cx)
             })
             .await
             .unwrap();

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -680,7 +680,6 @@ mod tests {
     use editor::{display_map::BlockContext, DisplayPoint, EditorSnapshot};
     use gpui::TestAppContext;
     use language::{Diagnostic, DiagnosticEntry, DiagnosticSeverity, PointUtf16};
-    use project::worktree;
     use serde_json::json;
     use std::sync::Arc;
     use unindent::Unindent as _;
@@ -727,6 +726,7 @@ mod tests {
             })
             .await
             .unwrap();
+        let worktree_id = worktree.read_with(&cx, |tree, _| tree.id());
 
         // Create some diagnostics
         worktree.update(&mut cx, |worktree, cx| {
@@ -903,7 +903,13 @@ mod tests {
                     cx,
                 )
                 .unwrap();
-            cx.emit(worktree::Event::DiskBasedDiagnosticsUpdated);
+        });
+        project.update(&mut cx, |_, cx| {
+            cx.emit(project::Event::DiagnosticsUpdated(ProjectPath {
+                worktree_id,
+                path: Arc::from("/test/consts.rs".as_ref()),
+            }));
+            cx.emit(project::Event::DiskBasedDiagnosticsUpdated { worktree_id });
         });
 
         view.next_notification(&cx).await;
@@ -1017,7 +1023,13 @@ mod tests {
                     cx,
                 )
                 .unwrap();
-            cx.emit(worktree::Event::DiskBasedDiagnosticsUpdated);
+        });
+        project.update(&mut cx, |_, cx| {
+            cx.emit(project::Event::DiagnosticsUpdated(ProjectPath {
+                worktree_id,
+                path: Arc::from("/test/consts.rs".as_ref()),
+            }));
+            cx.emit(project::Event::DiskBasedDiagnosticsUpdated { worktree_id });
         });
 
         view.next_notification(&cx).await;

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -528,7 +528,7 @@ impl workspace::Item for ProjectDiagnostics {
         ProjectDiagnosticsEditor::new(handle, workspace.weak_handle(), workspace.settings(), cx)
     }
 
-    fn project_path(&self) -> Option<project::ProjectPath> {
+    fn project_entry(&self) -> Option<project::ProjectEntry> {
         None
     }
 }
@@ -544,7 +544,7 @@ impl workspace::ItemView for ProjectDiagnosticsEditor {
         "Project Diagnostics".to_string()
     }
 
-    fn project_path(&self, _: &AppContext) -> Option<project::ProjectPath> {
+    fn project_entry(&self, _: &AppContext) -> Option<project::ProjectEntry> {
         None
     }
 

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -19,7 +19,7 @@ impl DiagnosticSummary {
         cx: &mut ViewContext<Self>,
     ) -> Self {
         cx.subscribe(project, |this, project, event, cx| match event {
-            project::Event::DiskBasedDiagnosticsUpdated { .. } => {
+            project::Event::DiskBasedDiagnosticsUpdated => {
                 this.summary = project.read(cx).diagnostic_summary(cx);
                 cx.notify();
             }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -840,7 +840,7 @@ mod tests {
             ("mod.body".to_string(), Color::red().into()),
             ("fn.name".to_string(), Color::blue().into()),
         ]);
-        let lang = Arc::new(
+        let language = Arc::new(
             Language::new(
                 LanguageConfig {
                     name: "Test".to_string(),
@@ -857,10 +857,9 @@ mod tests {
             )
             .unwrap(),
         );
-        lang.set_theme(&theme);
+        language.set_theme(&theme);
 
-        let buffer =
-            cx.add_model(|cx| Buffer::new(0, text, cx).with_language(Some(lang), None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         buffer.condition(&cx, |buf, _| !buf.is_parsing()).await;
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
 
@@ -928,7 +927,7 @@ mod tests {
             ("mod.body".to_string(), Color::red().into()),
             ("fn.name".to_string(), Color::blue().into()),
         ]);
-        let lang = Arc::new(
+        let language = Arc::new(
             Language::new(
                 LanguageConfig {
                     name: "Test".to_string(),
@@ -945,10 +944,9 @@ mod tests {
             )
             .unwrap(),
         );
-        lang.set_theme(&theme);
+        language.set_theme(&theme);
 
-        let buffer =
-            cx.add_model(|cx| Buffer::new(0, text, cx).with_language(Some(lang), None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         buffer.condition(&cx, |buf, _| !buf.is_parsing()).await;
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -533,9 +533,8 @@ impl Editor {
         _: &workspace::OpenNew,
         cx: &mut ViewContext<Workspace>,
     ) {
-        let buffer = cx.add_model(|cx| {
-            Buffer::new(0, "", cx).with_language(Some(language::PLAIN_TEXT.clone()), None, cx)
-        });
+        let buffer = cx
+            .add_model(|cx| Buffer::new(0, "", cx).with_language(language::PLAIN_TEXT.clone(), cx));
         workspace.open_item(BufferItemHandle(buffer), cx);
     }
 
@@ -5746,10 +5745,10 @@ mod tests {
     #[gpui::test]
     async fn test_select_larger_smaller_syntax_node(mut cx: gpui::TestAppContext) {
         let settings = cx.read(EditorSettings::test);
-        let language = Some(Arc::new(Language::new(
+        let language = Arc::new(Language::new(
             LanguageConfig::default(),
             Some(tree_sitter_rust::language()),
-        )));
+        ));
 
         let text = r#"
             use mod1::mod2::{mod3, mod4};
@@ -5760,7 +5759,7 @@ mod tests {
         "#
         .unindent();
 
-        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
         let (_, view) = cx.add_window(|cx| build_editor(buffer, settings, cx));
         view.condition(&cx, |view, cx| !view.buffer.read(cx).is_parsing(cx))
@@ -5887,7 +5886,7 @@ mod tests {
     #[gpui::test]
     async fn test_autoindent_selections(mut cx: gpui::TestAppContext) {
         let settings = cx.read(EditorSettings::test);
-        let language = Some(Arc::new(
+        let language = Arc::new(
             Language::new(
                 LanguageConfig {
                     brackets: vec![
@@ -5915,11 +5914,11 @@ mod tests {
                 "#,
             )
             .unwrap(),
-        ));
+        );
 
         let text = "fn a() {}";
 
-        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
         let (_, editor) = cx.add_window(|cx| build_editor(buffer, settings, cx));
         editor
@@ -5944,7 +5943,7 @@ mod tests {
     #[gpui::test]
     async fn test_autoclose_pairs(mut cx: gpui::TestAppContext) {
         let settings = cx.read(EditorSettings::test);
-        let language = Some(Arc::new(Language::new(
+        let language = Arc::new(Language::new(
             LanguageConfig {
                 brackets: vec![
                     BracketPair {
@@ -5963,7 +5962,7 @@ mod tests {
                 ..Default::default()
             },
             Some(tree_sitter_rust::language()),
-        )));
+        ));
 
         let text = r#"
             a
@@ -5973,7 +5972,7 @@ mod tests {
         "#
         .unindent();
 
-        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
         let (_, view) = cx.add_window(|cx| build_editor(buffer, settings, cx));
         view.condition(&cx, |view, cx| !view.buffer.read(cx).is_parsing(cx))
@@ -6055,13 +6054,13 @@ mod tests {
     #[gpui::test]
     async fn test_toggle_comment(mut cx: gpui::TestAppContext) {
         let settings = cx.read(EditorSettings::test);
-        let language = Some(Arc::new(Language::new(
+        let language = Arc::new(Language::new(
             LanguageConfig {
                 line_comment: Some("// ".to_string()),
                 ..Default::default()
             },
             Some(tree_sitter_rust::language()),
-        )));
+        ));
 
         let text = "
             fn a() {
@@ -6072,7 +6071,7 @@ mod tests {
         "
         .unindent();
 
-        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
         let (_, view) = cx.add_window(|cx| build_editor(buffer, settings, cx));
 
@@ -6323,7 +6322,7 @@ mod tests {
     #[gpui::test]
     async fn test_extra_newline_insertion(mut cx: gpui::TestAppContext) {
         let settings = cx.read(EditorSettings::test);
-        let language = Some(Arc::new(Language::new(
+        let language = Arc::new(Language::new(
             LanguageConfig {
                 brackets: vec![
                     BracketPair {
@@ -6342,7 +6341,7 @@ mod tests {
                 ..Default::default()
             },
             Some(tree_sitter_rust::language()),
-        )));
+        ));
 
         let text = concat!(
             "{   }\n",     // Suppress rustfmt
@@ -6352,7 +6351,7 @@ mod tests {
             "{{} }\n",     //
         );
 
-        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, None, cx));
+        let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
         let (_, view) = cx.add_window(|cx| build_editor(buffer, settings, cx));
         view.condition(&cx, |view, cx| !view.buffer.read(cx).is_parsing(cx))

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3021,7 +3021,7 @@ impl Editor {
                         .downcast::<Self>()
                         .unwrap();
                     target_editor.update(cx, |target_editor, cx| {
-                        target_editor.select_ranges([range], Some(Autoscroll::Fit), cx);
+                        target_editor.select_ranges([range], Some(Autoscroll::Center), cx);
                     });
                 }
             });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -470,7 +470,7 @@ impl Editor {
         clone.nav_history = self
             .nav_history
             .as_ref()
-            .map(|nav_history| nav_history.clone(&cx.handle()));
+            .map(|nav_history| ItemNavHistory::new(nav_history.history(), &cx.handle()));
         clone
     }
 
@@ -2457,6 +2457,14 @@ impl Editor {
             goal: SelectionGoal::None,
         };
         self.update_selections(vec![selection], Some(Autoscroll::Fit), cx);
+    }
+
+    pub fn set_nav_history(&mut self, nav_history: Option<ItemNavHistory>) {
+        self.nav_history = nav_history;
+    }
+
+    pub fn nav_history(&self) -> Option<&ItemNavHistory> {
+        self.nav_history.as_ref()
     }
 
     fn push_to_nav_history(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -215,7 +215,7 @@ pub fn init(cx: &mut MutableAppContext, path_openers: &mut Vec<Box<dyn PathOpene
         Binding::new("alt-down", SelectSmallerSyntaxNode, Some("Editor")),
         Binding::new("ctrl-shift-W", SelectSmallerSyntaxNode, Some("Editor")),
         Binding::new("f8", ShowNextDiagnostic, Some("Editor")),
-        Binding::new("alt-enter", GoToDefinition, Some("Editor")),
+        Binding::new("f12", GoToDefinition, Some("Editor")),
         Binding::new("ctrl-m", MoveToEnclosingBracket, Some("Editor")),
         Binding::new("pageup", PageUp, Some("Editor")),
         Binding::new("pagedown", PageDown, Some("Editor")),

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -34,7 +34,7 @@ impl PathOpener for BufferOpener {
     ) -> Option<Task<Result<Box<dyn ItemHandle>>>> {
         let buffer = worktree.open_buffer(project_path.path, cx);
         let task = cx.spawn(|_, _| async move {
-            let buffer = buffer.await?;
+            let buffer = buffer.await?.0;
             Ok(Box::new(BufferItemHandle(buffer)) as Box<dyn ItemHandle>)
         });
         Some(task)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -7,7 +7,7 @@ use gpui::{
 use language::{Bias, Buffer, Diagnostic};
 use postage::watch;
 use project::worktree::File;
-use project::{Project, ProjectEntry, ProjectPath, Worktree};
+use project::{Project, ProjectEntry, ProjectPath};
 use std::rc::Rc;
 use std::{fmt::Write, path::PathBuf};
 use text::{Point, Selection};
@@ -28,13 +28,13 @@ struct WeakBufferItemHandle(WeakModelHandle<Buffer>);
 impl PathOpener for BufferOpener {
     fn open(
         &self,
-        worktree: &mut Worktree,
+        project: &mut Project,
         project_path: ProjectPath,
-        cx: &mut ModelContext<Worktree>,
+        cx: &mut ModelContext<Project>,
     ) -> Option<Task<Result<Box<dyn ItemHandle>>>> {
-        let buffer = worktree.open_buffer(project_path.path, cx);
+        let buffer = project.open_buffer(project_path, cx);
         let task = cx.spawn(|_, _| async move {
-            let buffer = buffer.await?.0;
+            let buffer = buffer.await?;
             Ok(Box::new(BufferItemHandle(buffer)) as Box<dyn ItemHandle>)
         });
         Some(task)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -160,20 +160,18 @@ impl ItemView for Editor {
         self.project_entry(cx).is_some()
     }
 
-    fn save(&mut self, cx: &mut ViewContext<Self>) -> Result<Task<Result<()>>> {
+    fn save(&mut self, cx: &mut ViewContext<Self>) -> Task<Result<()>> {
         let buffer = self.buffer().clone();
-        Ok(cx.spawn(|editor, mut cx| async move {
+        cx.spawn(|editor, mut cx| async move {
             buffer
                 .update(&mut cx, |buffer, cx| buffer.format(cx).log_err())
                 .await;
             editor.update(&mut cx, |editor, cx| {
                 editor.request_autoscroll(Autoscroll::Fit, cx)
             });
-            buffer
-                .update(&mut cx, |buffer, cx| buffer.save(cx))?
-                .await?;
+            buffer.update(&mut cx, |buffer, cx| buffer.save(cx)).await?;
             Ok(())
-        }))
+        })
     }
 
     fn can_save_as(&self, _: &AppContext) -> bool {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -279,7 +279,7 @@ impl StatusItemView for CursorPosition {
         active_pane_item: Option<&dyn ItemViewHandle>,
         cx: &mut ViewContext<Self>,
     ) {
-        if let Some(editor) = active_pane_item.and_then(|item| item.to_any().downcast::<Editor>()) {
+        if let Some(editor) = active_pane_item.and_then(|item| item.downcast::<Editor>()) {
             self._observe_active_editor = Some(cx.observe(&editor, Self::update_position));
             self.update_position(editor, cx);
         } else {
@@ -365,7 +365,7 @@ impl StatusItemView for DiagnosticMessage {
         active_pane_item: Option<&dyn ItemViewHandle>,
         cx: &mut ViewContext<Self>,
     ) {
-        if let Some(editor) = active_pane_item.and_then(|item| item.to_any().downcast::<Editor>()) {
+        if let Some(editor) = active_pane_item.and_then(|item| item.downcast::<Editor>()) {
             self._observe_active_editor = Some(cx.observe(&editor, Self::update));
             self.update(editor, cx);
         } else {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -194,7 +194,7 @@ impl ItemView for Editor {
             .clone();
 
         project.update(cx, |project, cx| {
-            project.save_buffer_as(buffer, &abs_path, cx)
+            project.save_buffer_as(buffer, abs_path, cx)
         })
     }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -8,13 +8,14 @@ use language::{Bias, Buffer, Diagnostic};
 use postage::watch;
 use project::worktree::File;
 use project::{Project, ProjectEntry, ProjectPath};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::{fmt::Write, path::PathBuf};
 use text::{Point, Selection};
 use util::TryFutureExt;
 use workspace::{
-    ItemHandle, ItemView, ItemViewHandle, NavHistory, PathOpener, Settings, StatusItemView,
-    WeakItemHandle, Workspace,
+    ItemHandle, ItemNavHistory, ItemView, ItemViewHandle, NavHistory, PathOpener, Settings,
+    StatusItemView, WeakItemHandle, Workspace,
 };
 
 pub struct BufferOpener;
@@ -46,7 +47,7 @@ impl ItemHandle for BufferItemHandle {
         &self,
         window_id: usize,
         workspace: &Workspace,
-        nav_history: Rc<NavHistory>,
+        nav_history: Rc<RefCell<NavHistory>>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(self.0.clone(), cx));
@@ -57,7 +58,7 @@ impl ItemHandle for BufferItemHandle {
                 crate::settings_builder(weak_buffer, workspace.settings()),
                 cx,
             );
-            editor.nav_history = Some(nav_history);
+            editor.nav_history = Some(ItemNavHistory::new(nav_history, &cx.handle()));
             editor
         }))
     }

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -812,18 +812,18 @@ impl MultiBuffer {
         })
     }
 
-    pub fn save(&mut self, cx: &mut ModelContext<Self>) -> Result<Task<Result<()>>> {
+    pub fn save(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         let mut save_tasks = Vec::new();
         for BufferState { buffer, .. } in self.buffers.borrow().values() {
-            save_tasks.push(buffer.update(cx, |buffer, cx| buffer.save(cx))?);
+            save_tasks.push(buffer.update(cx, |buffer, cx| buffer.save(cx)));
         }
 
-        Ok(cx.spawn(|_, _| async move {
+        cx.spawn(|_, _| async move {
             for save in save_tasks {
                 save.await?;
             }
             Ok(())
-        }))
+        })
     }
 
     pub fn language<'a>(&self, cx: &'a AppContext) -> Option<&'a Arc<Language>> {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -789,6 +789,19 @@ impl MultiBuffer {
         cx.notify();
     }
 
+    pub fn text_anchor_for_position<'a, T: ToOffset>(
+        &'a self,
+        position: T,
+        cx: &AppContext,
+    ) -> (ModelHandle<Buffer>, language::Anchor) {
+        let snapshot = self.read(cx);
+        let anchor = snapshot.anchor_before(position);
+        (
+            self.buffers.borrow()[&anchor.buffer_id].buffer.clone(),
+            anchor.text_anchor,
+        )
+    }
+
     fn on_buffer_event(
         &mut self,
         _: ModelHandle<Buffer>,

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -454,9 +454,10 @@ mod tests {
             .await;
 
         let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/root"), false, cx)
             })
             .await
             .unwrap();
@@ -514,9 +515,10 @@ mod tests {
         .await;
 
         let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree("/dir".as_ref(), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/dir"), false, cx)
             })
             .await
             .unwrap();
@@ -579,9 +581,14 @@ mod tests {
             .await;
 
         let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root/the-parent-dir/the-file"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(
+                    Path::new("/root/the-parent-dir/the-file"),
+                    false,
+                    cx,
+                )
             })
             .await
             .unwrap();

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -80,17 +80,13 @@ impl GoToLine {
     }
 
     fn toggle(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
-        workspace.toggle_modal(cx, |cx, workspace| {
-            let editor = workspace
-                .active_item(cx)
-                .unwrap()
-                .to_any()
-                .downcast::<Editor>()
-                .unwrap();
-            let view = cx.add_view(|cx| GoToLine::new(editor, workspace.settings.clone(), cx));
-            cx.subscribe(&view, Self::on_event).detach();
-            view
-        });
+        if let Some(editor) = workspace.active_item(cx).unwrap().downcast::<Editor>() {
+            workspace.toggle_modal(cx, |cx, workspace| {
+                let view = cx.add_view(|cx| GoToLine::new(editor, workspace.settings.clone(), cx));
+                cx.subscribe(&view, Self::on_event).detach();
+                view
+            });
+        }
     }
 
     fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -660,6 +660,7 @@ type GlobalActionCallback = dyn FnMut(&dyn AnyAction, &mut MutableAppContext);
 
 type SubscriptionCallback = Box<dyn FnMut(&dyn Any, &mut MutableAppContext) -> bool>;
 type ObservationCallback = Box<dyn FnMut(&mut MutableAppContext) -> bool>;
+type ReleaseObservationCallback = Box<dyn FnMut(&mut MutableAppContext)>;
 
 pub struct MutableAppContext {
     weak_self: Option<rc::Weak<RefCell<Self>>>,
@@ -674,6 +675,7 @@ pub struct MutableAppContext {
     next_subscription_id: usize,
     subscriptions: Arc<Mutex<HashMap<usize, BTreeMap<usize, SubscriptionCallback>>>>,
     observations: Arc<Mutex<HashMap<usize, BTreeMap<usize, ObservationCallback>>>>,
+    release_observations: Arc<Mutex<HashMap<usize, BTreeMap<usize, ReleaseObservationCallback>>>>,
     presenters_and_platform_windows:
         HashMap<usize, (Rc<RefCell<Presenter>>, Box<dyn platform::Window>)>,
     debug_elements_callbacks: HashMap<usize, Box<dyn Fn(&AppContext) -> crate::json::Value>>,
@@ -717,6 +719,7 @@ impl MutableAppContext {
             next_subscription_id: 0,
             subscriptions: Default::default(),
             observations: Default::default(),
+            release_observations: Default::default(),
             presenters_and_platform_windows: HashMap::new(),
             debug_elements_callbacks: HashMap::new(),
             foreground,
@@ -1030,6 +1033,27 @@ impl MutableAppContext {
             observations: Some(Arc::downgrade(&self.observations)),
         }
     }
+
+    pub fn observe_release<E, H, F>(&mut self, handle: &H, mut callback: F) -> Subscription
+    where
+        E: Entity,
+        E::Event: 'static,
+        H: Handle<E>,
+        F: 'static + FnMut(&mut Self),
+    {
+        let id = post_inc(&mut self.next_subscription_id);
+        self.release_observations
+            .lock()
+            .entry(handle.id())
+            .or_default()
+            .insert(id, Box::new(move |cx| callback(cx)));
+        Subscription::ReleaseObservation {
+            id,
+            entity_id: handle.id(),
+            observations: Some(Arc::downgrade(&self.release_observations)),
+        }
+    }
+
     pub(crate) fn notify_model(&mut self, model_id: usize) {
         if self.pending_notifications.insert(model_id) {
             self.pending_effects
@@ -1208,6 +1232,7 @@ impl MutableAppContext {
         self.cx.windows.remove(&window_id);
         self.presenters_and_platform_windows.remove(&window_id);
         self.remove_dropped_entities();
+        self.flush_effects();
     }
 
     fn open_platform_window(&mut self, window_id: usize, window_options: WindowOptions) {
@@ -1358,6 +1383,9 @@ impl MutableAppContext {
                 self.observations.lock().remove(&model_id);
                 let mut model = self.cx.models.remove(&model_id).unwrap();
                 model.release(self);
+                self.pending_effects.push_back(Effect::Release {
+                    entity_id: model_id,
+                });
             }
 
             for (window_id, view_id) in dropped_views {
@@ -1381,6 +1409,9 @@ impl MutableAppContext {
                 if let Some(view_id) = change_focus_to {
                     self.focus(window_id, view_id);
                 }
+
+                self.pending_effects
+                    .push_back(Effect::Release { entity_id: view_id });
             }
 
             for key in dropped_element_states {
@@ -1406,6 +1437,7 @@ impl MutableAppContext {
                         Effect::ViewNotification { window_id, view_id } => {
                             self.notify_view_observers(window_id, view_id)
                         }
+                        Effect::Release { entity_id } => self.notify_release_observers(entity_id),
                         Effect::Focus { window_id, view_id } => {
                             self.focus(window_id, view_id);
                         }
@@ -1564,6 +1596,15 @@ impl MutableAppContext {
                             .insert(id, callback);
                     }
                 }
+            }
+        }
+    }
+
+    fn notify_release_observers(&mut self, entity_id: usize) {
+        let callbacks = self.release_observations.lock().remove(&entity_id);
+        if let Some(callbacks) = callbacks {
+            for (_, mut callback) in callbacks {
+                callback(self);
             }
         }
     }
@@ -1824,6 +1865,9 @@ pub enum Effect {
         window_id: usize,
         view_id: usize,
     },
+    Release {
+        entity_id: usize,
+    },
     Focus {
         window_id: usize,
         view_id: usize,
@@ -1849,6 +1893,10 @@ impl Debug for Effect {
                 .debug_struct("Effect::ViewNotification")
                 .field("window_id", window_id)
                 .field("view_id", view_id)
+                .finish(),
+            Effect::Release { entity_id } => f
+                .debug_struct("Effect::Release")
+                .field("entity_id", entity_id)
                 .finish(),
             Effect::Focus { window_id, view_id } => f
                 .debug_struct("Effect::Focus")
@@ -2068,6 +2116,25 @@ impl<'a, T: Entity> ModelContext<'a, T> {
                 true
             } else {
                 false
+            }
+        })
+    }
+
+    pub fn observe_release<S, F>(
+        &mut self,
+        handle: &ModelHandle<S>,
+        mut callback: F,
+    ) -> Subscription
+    where
+        S: Entity,
+        F: 'static + FnMut(&mut T, &mut ModelContext<T>),
+    {
+        let observer = self.weak_handle();
+        self.app.observe_release(handle, move |cx| {
+            if let Some(observer) = observer.upgrade(cx) {
+                observer.update(cx, |observer, cx| {
+                    callback(observer, cx);
+                });
             }
         })
     }
@@ -2301,6 +2368,22 @@ impl<'a, T: View> ViewContext<'a, T> {
                 true
             } else {
                 false
+            }
+        })
+    }
+
+    pub fn observe_release<E, F, H>(&mut self, handle: &H, mut callback: F) -> Subscription
+    where
+        E: Entity,
+        H: Handle<E>,
+        F: 'static + FnMut(&mut T, &mut ViewContext<T>),
+    {
+        let observer = self.weak_handle();
+        self.app.observe_release(handle, move |cx| {
+            if let Some(observer) = observer.upgrade(cx) {
+                observer.update(cx, |observer, cx| {
+                    callback(observer, cx);
+                });
             }
         })
     }
@@ -3263,6 +3346,12 @@ pub enum Subscription {
         entity_id: usize,
         observations: Option<Weak<Mutex<HashMap<usize, BTreeMap<usize, ObservationCallback>>>>>,
     },
+    ReleaseObservation {
+        id: usize,
+        entity_id: usize,
+        observations:
+            Option<Weak<Mutex<HashMap<usize, BTreeMap<usize, ReleaseObservationCallback>>>>>,
+    },
 }
 
 impl Subscription {
@@ -3274,6 +3363,9 @@ impl Subscription {
             Subscription::Observation { observations, .. } => {
                 observations.take();
             }
+            Subscription::ReleaseObservation { observations, .. } => {
+                observations.take();
+            }
         }
     }
 }
@@ -3282,6 +3374,17 @@ impl Drop for Subscription {
     fn drop(&mut self) {
         match self {
             Subscription::Observation {
+                id,
+                entity_id,
+                observations,
+            } => {
+                if let Some(observations) = observations.as_ref().and_then(Weak::upgrade) {
+                    if let Some(observations) = observations.lock().get_mut(entity_id) {
+                        observations.remove(id);
+                    }
+                }
+            }
+            Subscription::ReleaseObservation {
                 id,
                 entity_id,
                 observations,
@@ -3401,7 +3504,10 @@ mod tests {
     use super::*;
     use crate::elements::*;
     use smol::future::poll_once;
-    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::{
+        cell::Cell,
+        sync::atomic::{AtomicUsize, Ordering::SeqCst},
+    };
 
     #[crate::test(self)]
     fn test_model_handles(cx: &mut MutableAppContext) {
@@ -3652,18 +3758,18 @@ mod tests {
     #[crate::test(self)]
     fn test_entity_release_hooks(cx: &mut MutableAppContext) {
         struct Model {
-            released: Arc<Mutex<bool>>,
+            released: Rc<Cell<bool>>,
         }
 
         struct View {
-            released: Arc<Mutex<bool>>,
+            released: Rc<Cell<bool>>,
         }
 
         impl Entity for Model {
             type Event = ();
 
             fn release(&mut self, _: &mut MutableAppContext) {
-                *self.released.lock() = true;
+                self.released.set(true);
             }
         }
 
@@ -3671,7 +3777,7 @@ mod tests {
             type Event = ();
 
             fn release(&mut self, _: &mut MutableAppContext) {
-                *self.released.lock() = true;
+                self.released.set(true);
             }
         }
 
@@ -3685,27 +3791,41 @@ mod tests {
             }
         }
 
-        let model_released = Arc::new(Mutex::new(false));
-        let view_released = Arc::new(Mutex::new(false));
+        let model_released = Rc::new(Cell::new(false));
+        let model_release_observed = Rc::new(Cell::new(false));
+        let view_released = Rc::new(Cell::new(false));
+        let view_release_observed = Rc::new(Cell::new(false));
 
         let model = cx.add_model(|_| Model {
             released: model_released.clone(),
         });
-
-        let (window_id, _) = cx.add_window(Default::default(), |_| View {
+        let (window_id, view) = cx.add_window(Default::default(), |_| View {
             released: view_released.clone(),
         });
+        assert!(!model_released.get());
+        assert!(!view_released.get());
 
-        assert!(!*model_released.lock());
-        assert!(!*view_released.lock());
+        cx.observe_release(&model, {
+            let model_release_observed = model_release_observed.clone();
+            move |_| model_release_observed.set(true)
+        })
+        .detach();
+        cx.observe_release(&view, {
+            let view_release_observed = view_release_observed.clone();
+            move |_| view_release_observed.set(true)
+        })
+        .detach();
 
         cx.update(move |_| {
             drop(model);
         });
-        assert!(*model_released.lock());
+        assert!(model_released.get());
+        assert!(model_release_observed.get());
 
-        drop(cx.remove_window(window_id));
-        assert!(*view_released.lock());
+        drop(view);
+        cx.remove_window(window_id);
+        assert!(view_released.get());
+        assert!(view_release_observed.get());
     }
 
     #[crate::test(self)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -20,6 +20,7 @@ use crate::{
 use anyhow::Result;
 use async_task::Runnable;
 pub use event::Event;
+use postage::oneshot;
 use std::{
     any::Any,
     path::{Path, PathBuf},
@@ -70,13 +71,8 @@ pub(crate) trait ForegroundPlatform {
     fn prompt_for_paths(
         &self,
         options: PathPromptOptions,
-        done_fn: Box<dyn FnOnce(Option<Vec<std::path::PathBuf>>)>,
-    );
-    fn prompt_for_new_path(
-        &self,
-        directory: &Path,
-        done_fn: Box<dyn FnOnce(Option<std::path::PathBuf>)>,
-    );
+    ) -> oneshot::Receiver<Option<Vec<PathBuf>>>;
+    fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>>;
 }
 
 pub trait Dispatcher: Send + Sync {
@@ -89,13 +85,7 @@ pub trait Window: WindowContext {
     fn on_event(&mut self, callback: Box<dyn FnMut(Event)>);
     fn on_resize(&mut self, callback: Box<dyn FnMut()>);
     fn on_close(&mut self, callback: Box<dyn FnOnce()>);
-    fn prompt(
-        &self,
-        level: PromptLevel,
-        msg: &str,
-        answers: &[&str],
-        done_fn: Box<dyn FnOnce(usize)>,
-    );
+    fn prompt(&self, level: PromptLevel, msg: &str, answers: &[&str]) -> oneshot::Receiver<usize>;
 }
 
 pub trait WindowContext {

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -55,7 +55,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                 .await;
 
             if let Some(Some(Ok(item))) = opened.first() {
-                if let Some(editor) = item.to_any().downcast::<Editor>() {
+                if let Some(editor) = item.downcast::<Editor>() {
                     editor.update(&mut cx, |editor, cx| {
                         let len = editor.buffer().read(cx).read(cx).len();
                         editor.select_ranges([len..len], Some(Autoscroll::Center), cx);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -385,13 +385,17 @@ impl Buffer {
         }
     }
 
-    pub fn with_language(
+    pub fn with_language(mut self, language: Arc<Language>, cx: &mut ModelContext<Self>) -> Self {
+        self.set_language(Some(language), cx);
+        self
+    }
+
+    pub fn with_language_server(
         mut self,
-        language: Option<Arc<Language>>,
-        language_server: Option<Arc<LanguageServer>>,
+        server: Arc<LanguageServer>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        self.set_language(language, language_server, cx);
+        self.set_language_server(Some(server), cx);
         self
     }
 
@@ -523,13 +527,16 @@ impl Buffer {
         }))
     }
 
-    pub fn set_language(
+    pub fn set_language(&mut self, language: Option<Arc<Language>>, cx: &mut ModelContext<Self>) {
+        self.language = language;
+        self.reparse(cx);
+    }
+
+    pub fn set_language_server(
         &mut self,
-        language: Option<Arc<Language>>,
         language_server: Option<Arc<lsp::LanguageServer>>,
         cx: &mut ModelContext<Self>,
     ) {
-        self.language = language;
         self.language_server = if let Some(server) = language_server {
             let (latest_snapshot_tx, mut latest_snapshot_rx) = watch::channel();
             Some(LanguageServerState {
@@ -611,7 +618,6 @@ impl Buffer {
             None
         };
 
-        self.reparse(cx);
         self.update_language_server();
     }
 

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -145,9 +145,8 @@ async fn test_apply_diff(mut cx: gpui::TestAppContext) {
 #[gpui::test]
 async fn test_reparse(mut cx: gpui::TestAppContext) {
     let text = "fn a() {}";
-    let buffer = cx.add_model(|cx| {
-        Buffer::new(0, text, cx).with_language(Some(Arc::new(rust_lang())), None, cx)
-    });
+    let buffer =
+        cx.add_model(|cx| Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx));
 
     // Wait for the initial text to parse
     buffer
@@ -280,7 +279,7 @@ async fn test_reparse(mut cx: gpui::TestAppContext) {
 
 #[gpui::test]
 async fn test_outline(mut cx: gpui::TestAppContext) {
-    let language = Some(Arc::new(
+    let language = Arc::new(
         rust_lang()
             .with_outline_query(
                 r#"
@@ -308,7 +307,7 @@ async fn test_outline(mut cx: gpui::TestAppContext) {
                 "#,
             )
             .unwrap(),
-    ));
+    );
 
     let text = r#"
         struct Person {
@@ -337,7 +336,7 @@ async fn test_outline(mut cx: gpui::TestAppContext) {
     "#
     .unindent();
 
-    let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, None, cx));
+    let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
     let outline = buffer
         .read_with(&cx, |buffer, _| buffer.snapshot().outline(None))
         .unwrap();
@@ -422,7 +421,7 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
             }
         "
         .unindent();
-        Buffer::new(0, text, cx).with_language(Some(Arc::new(rust_lang())), None, cx)
+        Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx)
     });
     let buffer = buffer.read(cx);
     assert_eq!(
@@ -452,8 +451,7 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
 fn test_edit_with_autoindent(cx: &mut MutableAppContext) {
     cx.add_model(|cx| {
         let text = "fn a() {}";
-        let mut buffer =
-            Buffer::new(0, text, cx).with_language(Some(Arc::new(rust_lang())), None, cx);
+        let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
         buffer.edit_with_autoindent([8..8], "\n\n", cx);
         assert_eq!(buffer.text(), "fn a() {\n    \n}");
@@ -479,8 +477,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
         "
         .unindent();
 
-        let mut buffer =
-            Buffer::new(0, text, cx).with_language(Some(Arc::new(rust_lang())), None, cx);
+        let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
         // Lines 2 and 3 don't match the indentation suggestion. When editing these lines,
         // their indentation is not adjusted.
@@ -529,8 +526,7 @@ fn test_autoindent_adjusts_lines_when_only_text_changes(cx: &mut MutableAppConte
         "
         .unindent();
 
-        let mut buffer =
-            Buffer::new(0, text, cx).with_language(Some(Arc::new(rust_lang())), None, cx);
+        let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
         buffer.edit_with_autoindent([5..5], "\nb", cx);
         assert_eq!(
@@ -575,7 +571,9 @@ async fn test_diagnostics(mut cx: gpui::TestAppContext) {
     .unindent();
 
     let buffer = cx.add_model(|cx| {
-        Buffer::new(0, text, cx).with_language(Some(Arc::new(rust_lang)), Some(language_server), cx)
+        Buffer::new(0, text, cx)
+            .with_language(Arc::new(rust_lang), cx)
+            .with_language_server(language_server, cx)
     });
 
     let open_notification = fake
@@ -849,7 +847,7 @@ async fn test_empty_diagnostic_ranges(mut cx: gpui::TestAppContext) {
         );
 
         let mut buffer = Buffer::new(0, text, cx);
-        buffer.set_language(Some(Arc::new(rust_lang())), None, cx);
+        buffer.set_language(Some(Arc::new(rust_lang())), cx);
         buffer
             .update_diagnostics(
                 None,

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -144,7 +144,7 @@ impl OutlineView {
     fn toggle(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
         if let Some(editor) = workspace
             .active_item(cx)
-            .and_then(|item| item.to_any().downcast::<Editor>())
+            .and_then(|item| item.downcast::<Editor>())
         {
             let settings = workspace.settings();
             let buffer = editor

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -959,14 +959,6 @@ impl Project {
         }
     }
 
-    pub fn path_for_entry(&self, entry: ProjectEntry, cx: &AppContext) -> Option<ProjectPath> {
-        let worktree = self.worktree_for_id(entry.worktree_id, cx)?.read(cx);
-        Some(ProjectPath {
-            worktree_id: entry.worktree_id,
-            path: worktree.entry_for_id(entry.entry_id)?.path.clone(),
-        })
-    }
-
     pub fn is_running_disk_based_diagnostics(&self) -> bool {
         self.language_servers_with_diagnostics_running > 0
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -819,7 +819,8 @@ impl Project {
                 Ok(definitions)
             })
         } else {
-            todo!()
+            log::info!("go to definition is not yet implemented for guests");
+            Task::ready(Ok(Default::default()))
         }
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -567,6 +567,14 @@ impl Project {
         }
     }
 
+    pub fn path_for_entry(&self, entry: ProjectEntry, cx: &AppContext) -> Option<ProjectPath> {
+        let worktree = self.worktree_for_id(entry.worktree_id, cx)?.read(cx);
+        Some(ProjectPath {
+            worktree_id: entry.worktree_id,
+            path: worktree.entry_for_id(entry.entry_id)?.path.clone(),
+        })
+    }
+
     pub fn is_running_disk_based_diagnostics(&self) -> bool {
         self.pending_disk_based_diagnostics > 0
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1324,9 +1324,13 @@ impl Project {
         cancel_flag: &'a AtomicBool,
         cx: &AppContext,
     ) -> impl 'a + Future<Output = Vec<PathMatch>> {
-        let include_root_name = self.worktrees.len() > 1;
-        let candidate_sets = self
+        let worktrees = self
             .worktrees(cx)
+            .filter(|worktree| !worktree.read(cx).is_weak())
+            .collect::<Vec<_>>();
+        let include_root_name = worktrees.len() > 1;
+        let candidate_sets = worktrees
+            .into_iter()
             .map(|worktree| CandidateSet {
                 snapshot: worktree.read(cx).snapshot(),
                 include_ignored,

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1,7 +1,7 @@
 use super::{
     fs::{self, Fs},
     ignore::IgnoreStack,
-    DiagnosticSummary, ProjectEntry,
+    DiagnosticSummary,
 };
 use ::ignore::gitignore::{Gitignore, GitignoreBuilder};
 use anyhow::{anyhow, Result};
@@ -2201,13 +2201,6 @@ impl File {
 
     pub fn worktree_id(&self, cx: &AppContext) -> WorktreeId {
         self.worktree.read(cx).id()
-    }
-
-    pub fn project_entry(&self, cx: &AppContext) -> Option<ProjectEntry> {
-        self.entry_id.map(|entry_id| ProjectEntry {
-            worktree_id: self.worktree_id(cx),
-            entry_id,
-        })
     }
 }
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1947,7 +1947,7 @@ impl fmt::Debug for Snapshot {
 #[derive(Clone, PartialEq)]
 pub struct File {
     entry_id: Option<usize>,
-    worktree: ModelHandle<Worktree>,
+    pub worktree: ModelHandle<Worktree>,
     worktree_path: Arc<Path>,
     pub path: Arc<Path>,
     pub mtime: SystemTime,

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1002,7 +1002,6 @@ pub struct LocalWorktree {
     client: Arc<Client>,
     user_store: ModelHandle<UserStore>,
     fs: Arc<dyn Fs>,
-    languages: Vec<Arc<Language>>,
     language_servers: HashMap<String, Arc<LanguageServer>>,
 }
 
@@ -1110,7 +1109,6 @@ impl LocalWorktree {
                 client,
                 user_store,
                 fs,
-                languages: Default::default(),
                 language_servers: Default::default(),
             };
 
@@ -1155,19 +1153,11 @@ impl LocalWorktree {
         &self.language_registry
     }
 
-    pub fn languages(&self) -> &[Arc<Language>] {
-        &self.languages
-    }
-
     pub fn register_language(
         &mut self,
         language: &Arc<Language>,
         cx: &mut ModelContext<Worktree>,
     ) -> Option<Arc<LanguageServer>> {
-        if !self.languages.iter().any(|l| Arc::ptr_eq(l, language)) {
-            self.languages.push(language.clone());
-        }
-
         if let Some(server) = self.language_servers.get(language.name()) {
             return Some(server.clone());
         }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1,7 +1,7 @@
 use super::{
     fs::{self, Fs},
     ignore::IgnoreStack,
-    DiagnosticSummary,
+    DiagnosticSummary, ProjectEntry,
 };
 use ::ignore::gitignore::{Gitignore, GitignoreBuilder};
 use anyhow::{anyhow, Context, Result};
@@ -2371,6 +2371,13 @@ impl File {
 
     pub fn worktree_id(&self, cx: &AppContext) -> WorktreeId {
         self.worktree.read(cx).id()
+    }
+
+    pub fn project_entry(&self, cx: &AppContext) -> Option<ProjectEntry> {
+        self.entry_id.map(|entry_id| ProjectEntry {
+            worktree_id: self.worktree_id(cx),
+            entry_id,
+        })
     }
 }
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -455,7 +455,7 @@ impl Worktree {
         let worktree_id = envelope.payload.worktree_id;
         let buffer_id = envelope.payload.buffer_id;
         let save = cx.spawn(|_, mut cx| async move {
-            buffer.update(&mut cx, |buffer, cx| buffer.save(cx))?.await
+            buffer.update(&mut cx, |buffer, cx| buffer.save(cx)).await
         });
 
         cx.background()
@@ -3094,7 +3094,7 @@ mod tests {
             .unwrap();
         let save = buffer.update(&mut cx, |buffer, cx| {
             buffer.edit(Some(0..0), "a line of text.\n".repeat(10 * 1024), cx);
-            buffer.save(cx).unwrap()
+            buffer.save(cx)
         });
         save.await.unwrap();
 
@@ -3132,7 +3132,7 @@ mod tests {
             .unwrap();
         let save = buffer.update(&mut cx, |buffer, cx| {
             buffer.edit(Some(0..0), "a line of text.\n".repeat(10 * 1024), cx);
-            buffer.save(cx).unwrap()
+            buffer.save(cx)
         });
         save.await.unwrap();
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -267,6 +267,10 @@ impl Worktree {
         }
     }
 
+    pub fn is_local(&self) -> bool {
+        matches!(self, Worktree::Local(_))
+    }
+
     pub fn snapshot(&self) -> Snapshot {
         match self {
             Worktree::Local(worktree) => worktree.snapshot(),

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -191,12 +191,10 @@ message DiagnosticSummary {
 
 message DiskBasedDiagnosticsUpdating {
     uint64 project_id = 1;
-    uint64 worktree_id = 2;
 }
 
 message DiskBasedDiagnosticsUpdated {
     uint64 project_id = 1;
-    uint64 worktree_id = 2;
 }
 
 message GetChannels {}

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -272,6 +272,7 @@ message Worktree {
     string root_name = 2;
     repeated Entry entries = 3;
     repeated DiagnosticSummary diagnostic_summaries = 4;
+    bool weak = 5;
 }
 
 message Entry {

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1906,8 +1906,14 @@ mod tests {
         // Cause the language server to start.
         let _ = cx_a
             .background()
-            .spawn(worktree_a.update(&mut cx_a, |worktree, cx| {
-                worktree.open_buffer("other.rs", cx)
+            .spawn(project_a.update(&mut cx_a, |project, cx| {
+                project.open_buffer(
+                    ProjectPath {
+                        worktree_id,
+                        path: Path::new("other.rs").into(),
+                    },
+                    cx,
+                )
             }))
             .await
             .unwrap();

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -309,6 +309,7 @@ impl Server {
                                 .values()
                                 .cloned()
                                 .collect(),
+                            weak: worktree.weak,
                         })
                     })
                     .collect();
@@ -421,6 +422,7 @@ impl Server {
                 authorized_user_ids: contact_user_ids.clone(),
                 root_name: request.payload.root_name,
                 share: None,
+                weak: false,
             },
         );
 
@@ -1158,8 +1160,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1184,7 +1188,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let worktree_b = project_b.update(&mut cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
 
         let replica_id_b = project_b.read_with(&cx_b, |project, _| {
             assert_eq!(
@@ -1293,8 +1297,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1321,7 +1327,7 @@ mod tests {
         .await
         .unwrap();
 
-        let worktree_b = project_b.read_with(&cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.read_with(&cx_b, |p, cx| p.worktrees(cx).next().unwrap());
         worktree_b
             .update(&mut cx_b, |tree, cx| tree.open_buffer("a.txt", cx))
             .await
@@ -1353,7 +1359,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let worktree_c = project_c.read_with(&cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_c = project_c.read_with(&cx_b, |p, cx| p.worktrees(cx).next().unwrap());
         worktree_c
             .update(&mut cx_b, |tree, cx| tree.open_buffer("a.txt", cx))
             .await
@@ -1395,8 +1401,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1433,8 +1441,8 @@ mod tests {
         .unwrap();
 
         // Open and edit a buffer as both guests B and C.
-        let worktree_b = project_b.read_with(&cx_b, |p, _| p.worktrees()[0].clone());
-        let worktree_c = project_c.read_with(&cx_c, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.read_with(&cx_b, |p, cx| p.worktrees(cx).next().unwrap());
+        let worktree_c = project_c.read_with(&cx_c, |p, cx| p.worktrees(cx).next().unwrap());
         let buffer_b = worktree_b
             .update(&mut cx_b, |tree, cx| tree.open_buffer("file1", cx))
             .await
@@ -1547,8 +1555,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/dir", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/dir", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1573,7 +1583,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let worktree_b = project_b.update(&mut cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
 
         // Open a buffer as client B
         let buffer_b = worktree_b
@@ -1642,8 +1652,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/dir", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/dir", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1668,7 +1680,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let worktree_b = project_b.update(&mut cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
 
         // Open a buffer as client A
         let buffer_a = worktree_a
@@ -1723,8 +1735,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/dir", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/dir", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1749,7 +1763,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let worktree_b = project_b.update(&mut cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
 
         // See that a guest has joined as client A.
         project_a
@@ -1799,8 +1813,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -1886,8 +1902,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -2023,7 +2041,7 @@ mod tests {
             .await;
 
         // Open the file with the errors on client B. They should be present.
-        let worktree_b = project_b.update(&mut cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
         let buffer_b = cx_b
             .background()
             .spawn(worktree_b.update(&mut cx_b, |worktree, cx| worktree.open_buffer("a.rs", cx)))
@@ -2108,8 +2126,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a
@@ -2136,7 +2156,7 @@ mod tests {
         .unwrap();
 
         // Open the file to be formatted on client B.
-        let worktree_b = project_b.update(&mut cx_b, |p, _| p.worktrees()[0].clone());
+        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
         let buffer_b = cx_b
             .background()
             .spawn(worktree_b.update(&mut cx_b, |worktree, cx| worktree.open_buffer("a.rs", cx)))
@@ -2616,8 +2636,10 @@ mod tests {
                 cx,
             )
         });
-        let worktree_a = project_a
-            .update(&mut cx_a, |p, cx| p.add_local_worktree("/a", cx))
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_worktree_for_abs_path("/a", false, cx)
+            })
             .await
             .unwrap();
         worktree_a

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1474,7 +1474,7 @@ mod tests {
             .await;
 
         // Edit the buffer as the host and concurrently save as guest B.
-        let save_b = buffer_b.update(&mut cx_b, |buf, cx| buf.save(cx).unwrap());
+        let save_b = buffer_b.update(&mut cx_b, |buf, cx| buf.save(cx));
         buffer_a.update(&mut cx_a, |buf, cx| buf.edit([0..0], "hi-a, ", cx));
         save_b.await.unwrap();
         assert_eq!(
@@ -1591,7 +1591,6 @@ mod tests {
 
         buffer_b
             .update(&mut cx_b, |buf, cx| buf.save(cx))
-            .unwrap()
             .await
             .unwrap();
         worktree_b

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1213,7 +1213,8 @@ mod tests {
         let buffer_b = worktree_b
             .update(&mut cx_b, |worktree, cx| worktree.open_buffer("b.txt", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let buffer_b = cx_b.add_model(|cx| MultiBuffer::singleton(buffer_b, cx));
         buffer_b.read_with(&cx_b, |buf, cx| {
             assert_eq!(buf.read(cx).text(), "b-contents")
@@ -1222,7 +1223,8 @@ mod tests {
         let buffer_a = worktree_a
             .update(&mut cx_a, |tree, cx| tree.open_buffer("b.txt", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         let editor_b = cx_b.add_view(window_b, |cx| {
             Editor::for_buffer(buffer_b, Arc::new(|cx| EditorSettings::test(cx)), cx)
@@ -1436,11 +1438,13 @@ mod tests {
         let buffer_b = worktree_b
             .update(&mut cx_b, |tree, cx| tree.open_buffer("file1", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let buffer_c = worktree_c
             .update(&mut cx_c, |tree, cx| tree.open_buffer("file1", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         buffer_b.update(&mut cx_b, |buf, cx| buf.edit([0..0], "i-am-b, ", cx));
         buffer_c.update(&mut cx_c, |buf, cx| buf.edit([0..0], "i-am-c, ", cx));
 
@@ -1448,7 +1452,8 @@ mod tests {
         let buffer_a = worktree_a
             .update(&mut cx_a, |tree, cx| tree.open_buffer("file1", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         buffer_a
             .condition(&mut cx_a, |buf, _| buf.text() == "i-am-c, i-am-b, ")
@@ -1574,7 +1579,8 @@ mod tests {
         let buffer_b = worktree_b
             .update(&mut cx_b, |worktree, cx| worktree.open_buffer("a.txt", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let mtime = buffer_b.read_with(&cx_b, |buf, _| buf.file().unwrap().mtime());
 
         buffer_b.update(&mut cx_b, |buf, cx| buf.edit([0..0], "world ", cx));
@@ -1669,7 +1675,8 @@ mod tests {
         let buffer_a = worktree_a
             .update(&mut cx_a, |tree, cx| tree.open_buffer("a.txt", cx))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         // Start opening the same buffer as client B
         let buffer_b = cx_b
@@ -1681,7 +1688,7 @@ mod tests {
         buffer_a.update(&mut cx_a, |buf, cx| buf.edit([0..0], "z", cx));
 
         let text = buffer_a.read_with(&cx_a, |buf, _| buf.text());
-        let buffer_b = buffer_b.await.unwrap();
+        let buffer_b = buffer_b.await.unwrap().0;
         buffer_b.condition(&cx_b, |buf, _| buf.text() == text).await;
     }
 
@@ -2016,7 +2023,8 @@ mod tests {
             .background()
             .spawn(worktree_b.update(&mut cx_b, |worktree, cx| worktree.open_buffer("a.rs", cx)))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         buffer_b.read_with(&cx_b, |buffer, _| {
             assert_eq!(
@@ -2128,7 +2136,8 @@ mod tests {
             .background()
             .spawn(worktree_b.update(&mut cx_b, |worktree, cx| worktree.open_buffer("a.rs", cx)))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         let format = buffer_b.update(&mut cx_b, |buffer, cx| buffer.format(cx));
         let (request_id, _) = fake_language_server

--- a/crates/server/src/rpc/store.rs
+++ b/crates/server/src/rpc/store.rs
@@ -31,6 +31,7 @@ pub struct Worktree {
     pub authorized_user_ids: Vec<UserId>,
     pub root_name: String,
     pub share: Option<WorktreeShare>,
+    pub weak: bool,
 }
 
 #[derive(Default)]
@@ -202,6 +203,7 @@ impl Store {
                 let mut worktree_root_names = project
                     .worktrees
                     .values()
+                    .filter(|worktree| !worktree.weak)
                     .map(|worktree| worktree.root_name.clone())
                     .collect::<Vec<_>>();
                 worktree_root_names.sort_unstable();

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -551,11 +551,8 @@ impl ItemNavHistory {
         }
     }
 
-    pub fn clone<T: ItemView>(&self, item_view: &ViewHandle<T>) -> Self {
-        Self {
-            history: self.history.clone(),
-            item_view: Rc::new(item_view.downgrade()),
-        }
+    pub fn history(&self) -> Rc<RefCell<NavHistory>> {
+        self.history.clone()
     }
 
     pub fn push<D: 'static + Any>(&self, data: Option<D>) {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -351,7 +351,7 @@ impl Pane {
 
     fn focus_active_item(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(active_item) = self.active_item() {
-            cx.focus(active_item.to_any());
+            cx.focus(active_item);
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -137,7 +137,7 @@ pub trait Item: Entity + Sized {
     fn build_view(
         handle: ModelHandle<Self>,
         workspace: &Workspace,
-        navigation: Rc<Navigation>,
+        nav_history: Rc<NavHistory>,
         cx: &mut ViewContext<Self::View>,
     ) -> Self::View;
 
@@ -190,7 +190,7 @@ pub trait ItemHandle: Send + Sync {
         &self,
         window_id: usize,
         workspace: &Workspace,
-        navigation: Rc<Navigation>,
+        nav_history: Rc<NavHistory>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle>;
     fn boxed_clone(&self) -> Box<dyn ItemHandle>;
@@ -242,11 +242,11 @@ impl<T: Item> ItemHandle for ModelHandle<T> {
         &self,
         window_id: usize,
         workspace: &Workspace,
-        navigation: Rc<Navigation>,
+        nav_history: Rc<NavHistory>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
         Box::new(cx.add_view(window_id, |cx| {
-            T::build_view(self.clone(), workspace, navigation, cx)
+            T::build_view(self.clone(), workspace, nav_history, cx)
         }))
     }
 
@@ -276,10 +276,10 @@ impl ItemHandle for Box<dyn ItemHandle> {
         &self,
         window_id: usize,
         workspace: &Workspace,
-        navigation: Rc<Navigation>,
+        nav_history: Rc<NavHistory>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
-        ItemHandle::add_view(self.as_ref(), window_id, workspace, navigation, cx)
+        ItemHandle::add_view(self.as_ref(), window_id, workspace, nav_history, cx)
     }
 
     fn boxed_clone(&self) -> Box<dyn ItemHandle> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -684,7 +684,7 @@ impl Workspace {
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<ProjectPath>> {
         let entry = self.project().update(cx, |project, cx| {
-            project.worktree_for_abs_path(abs_path, cx)
+            project.find_or_create_worktree_for_abs_path(abs_path, cx)
         });
         cx.spawn(|_, cx| async move {
             let (worktree, path) = entry.await?;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -205,7 +205,6 @@ mod tests {
             workspace
                 .active_item(cx)
                 .unwrap()
-                .to_any()
                 .downcast::<editor::Editor>()
                 .unwrap()
         });
@@ -451,7 +450,7 @@ mod tests {
         let editor = cx.read(|cx| {
             let pane = workspace.read(cx).active_pane().read(cx);
             let item = pane.active_item().unwrap();
-            item.to_any().downcast::<Editor>().unwrap()
+            item.downcast::<Editor>().unwrap()
         });
 
         cx.update(|cx| {
@@ -504,7 +503,6 @@ mod tests {
             workspace
                 .active_item(cx)
                 .unwrap()
-                .to_any()
                 .downcast::<Editor>()
                 .unwrap()
         });
@@ -573,7 +571,6 @@ mod tests {
             workspace
                 .active_item(cx)
                 .unwrap()
-                .to_any()
                 .downcast::<Editor>()
                 .unwrap()
         });
@@ -598,7 +595,6 @@ mod tests {
             workspace
                 .active_item(cx)
                 .unwrap()
-                .to_any()
                 .downcast::<Editor>()
                 .unwrap()
         });
@@ -738,7 +734,6 @@ mod tests {
             .update(&mut cx, |w, cx| w.open_path(file1.clone(), cx))
             .await
             .unwrap()
-            .to_any()
             .downcast::<Editor>()
             .unwrap();
         editor1.update(&mut cx, |editor, cx| {
@@ -748,14 +743,12 @@ mod tests {
             .update(&mut cx, |w, cx| w.open_path(file2.clone(), cx))
             .await
             .unwrap()
-            .to_any()
             .downcast::<Editor>()
             .unwrap();
         let editor3 = workspace
             .update(&mut cx, |w, cx| w.open_path(file3.clone(), cx))
             .await
             .unwrap()
-            .to_any()
             .downcast::<Editor>()
             .unwrap();
         editor3.update(&mut cx, |editor, cx| {
@@ -871,7 +864,7 @@ mod tests {
         ) -> (ProjectPath, DisplayPoint) {
             workspace.update(cx, |workspace, cx| {
                 let item = workspace.active_item(cx).unwrap();
-                let editor = item.to_any().downcast::<Editor>().unwrap();
+                let editor = item.downcast::<Editor>().unwrap();
                 let selections = editor.update(cx, |editor, cx| editor.selected_display_ranges(cx));
                 let path = workspace
                     .project()

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(cx.window_ids().len(), 1);
         let workspace_1 = cx.root_view::<Workspace>(cx.window_ids()[0]).unwrap();
         workspace_1.read_with(&cx, |workspace, cx| {
-            assert_eq!(workspace.worktrees(cx).len(), 2)
+            assert_eq!(workspace.worktrees(cx).count(), 2)
         });
 
         cx.update(|cx| {
@@ -242,9 +242,10 @@ mod tests {
             .await;
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
         let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/root"), false, cx)
             })
             .await
             .unwrap();
@@ -366,9 +367,10 @@ mod tests {
 
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
         let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree("/dir1".as_ref(), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/dir1"), false, cx)
             })
             .await
             .unwrap();
@@ -402,7 +404,6 @@ mod tests {
             let worktree_roots = workspace
                 .read(cx)
                 .worktrees(cx)
-                .iter()
                 .map(|w| w.read(cx).as_local().unwrap().abs_path().as_ref())
                 .collect::<HashSet<_>>();
             assert_eq!(
@@ -433,9 +434,10 @@ mod tests {
 
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
         let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/root"), false, cx)
             })
             .await
             .unwrap();
@@ -481,21 +483,14 @@ mod tests {
         app_state.fs.as_fake().insert_dir("/root").await.unwrap();
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
         let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/root"), false, cx)
             })
             .await
             .unwrap();
-        let worktree = cx.read(|cx| {
-            workspace
-                .read(cx)
-                .worktrees(cx)
-                .iter()
-                .next()
-                .unwrap()
-                .clone()
-        });
+        let worktree = cx.read(|cx| workspace.read(cx).worktrees(cx).next().unwrap());
 
         // Create a new untitled buffer
         cx.dispatch_action(window_id, vec![workspace.id()], OpenNew(app_state.clone()));
@@ -640,9 +635,10 @@ mod tests {
 
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
         let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/root"), false, cx)
             })
             .await
             .unwrap();
@@ -717,9 +713,10 @@ mod tests {
             .await;
         let params = cx.update(|cx| WorkspaceParams::local(&app_state, cx));
         let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        workspace
-            .update(&mut cx, |workspace, cx| {
-                workspace.add_worktree(Path::new("/root"), cx)
+        params
+            .project
+            .update(&mut cx, |project, cx| {
+                project.find_or_create_worktree_for_abs_path(Path::new("/root"), false, cx)
             })
             .await
             .unwrap();


### PR DESCRIPTION
Refs #343 

Remaining tasks:

- [x] Make "go to definition" work in project diagnostics
- [x] Center selection when jumping to definition
- [x] Record navigation history entry in project diagnostics
- [x] Don't store a navigation history entry at offset 0 when initially opening a file
- [x] Don't show "weak" worktrees in project panel
- [x] Remove "weak" worktrees that have no open buffer in them
- [ ] ~~Implement `Project::definition` when the project is remote~~
