### PR TITLE
Move window to the foreground when opening a path in an existing workspace

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -851,6 +851,12 @@ impl MutableAppContext {
         self.cx.windows.keys().cloned()
     }
 
+    pub fn activate_window(&self, window_id: usize) {
+        if let Some((_, window)) = self.presenters_and_platform_windows.get(&window_id) {
+            window.activate()
+        }
+    }
+
     pub fn root_view<T: View>(&self, window_id: usize) -> Option<ViewHandle<T>> {
         self.cx
             .windows

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -96,6 +96,7 @@ pub trait Window: WindowContext {
         answers: &[&str],
         done_fn: Box<dyn FnOnce(usize)>,
     );
+    fn activate(&self);
 }
 
 pub trait WindowContext {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -347,6 +347,12 @@ impl platform::Window for Window {
             ];
         }
     }
+
+    fn activate(&self) {
+        unsafe {
+            let _: () = msg_send![self.0.borrow().native_window, makeKeyAndOrderFront: nil];
+        }
+    }
 }
 
 impl platform::WindowContext for Window {

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -223,6 +223,8 @@ impl super::Window for Window {
     fn prompt(&self, _: crate::PromptLevel, _: &str, _: &[&str], f: Box<dyn FnOnce(usize)>) {
         self.last_prompt.replace(Some(f));
     }
+
+    fn activate(&self) {}
 }
 
 pub fn platform() -> Platform {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1462,10 +1462,11 @@ pub fn open_paths(
     // Open paths in existing workspace if possible
     let mut existing = None;
     for window_id in cx.window_ids().collect::<Vec<_>>() {
-        if let Some(workspace) = cx.root_view::<Workspace>(window_id) {
-            if workspace.update(cx, |view, cx| {
-                if view.contains_paths(abs_paths, cx.as_ref()) {
-                    existing = Some(workspace.clone());
+        if let Some(workspace_handle) = cx.root_view::<Workspace>(window_id) {
+            if workspace_handle.update(cx, |workspace, cx| {
+                if workspace.contains_paths(abs_paths, cx.as_ref()) {
+                    cx.activate_window(window_id);
+                    existing = Some(workspace_handle.clone());
                     true
                 } else {
                     false


### PR DESCRIPTION
Fixes #348 