### PR TITLE
Fix panic in ProjectDiagnosticsEditor::open_excerpts by introducing new defer feature to GPUI

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -193,7 +193,10 @@ impl ProjectDiagnosticsEditor {
                 }
             }
 
-            workspace.update(cx, |workspace, cx| {
+            // We defer the pane interaction because we ourselves are a workspace item
+            // and activating a new item causes the pane to call a method on us reentrantly,
+            // which panics if we're on the stack.
+            workspace.defer(cx, |workspace, cx| {
                 for (buffer, ranges) in new_selections_by_buffer {
                     let buffer = BufferItemHandle(buffer);
                     if !workspace.activate_pane_for_item(&buffer, cx) {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2938,6 +2938,17 @@ impl<T: View> ViewHandle<T> {
         })
     }
 
+    pub fn defer<C, F>(&self, cx: &mut C, update: F)
+    where
+        C: AsMut<MutableAppContext>,
+        F: 'static + FnOnce(&mut T, &mut ViewContext<T>),
+    {
+        let this = self.clone();
+        cx.as_mut().defer(Box::new(move |cx| {
+            this.update(cx, |view, cx| update(view, cx));
+        }));
+    }
+
     pub fn is_focused(&self, cx: &AppContext) -> bool {
         cx.focused_view_id(self.window_id)
             .map_or(false, |focused_id| focused_id == self.view_id)


### PR DESCRIPTION
When we introduced the navigation history, we started calling `deactivate` on the previous active pane item whenever we changed the active pane item. When opening an excerpt from the diagnostics editor, the diagnostics editor is the active pane item, so we were panicking with a circular entity reference when activating a new pane  for the excerpted buffer caused the current item to be deactivated.

To solve this, I added a new feature to GPUI called `defer`. For now it's only on `ViewContext` and `ViewHandle`, but we could obviously add it to models pretty easily. It takes a closure that takes a mutable reference to the view and a view context and enqueues the running of that closure as an effect. This means the code will be run synchronously as part of the current event loop tick (no messing with futures), but we can be sure that there are no entities on the stack when it runs.

This is a bit of an escape hatch that could let us get away with poor ownership structure, but there are situations in which I think it will be warranted. This is one of those situations.