### PR TITLE
Improve remote file handling

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -126,7 +126,7 @@ impl ItemView for Editor {
             .buffer()
             .read(cx)
             .file(cx)
-            .and_then(|file| file.file_name());
+            .and_then(|file| file.file_name(cx));
         if let Some(name) = filename {
             name.to_string_lossy().into()
         } else {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -122,13 +122,9 @@ impl ItemView for Editor {
     }
 
     fn title(&self, cx: &AppContext) -> String {
-        let filename = self
-            .buffer()
-            .read(cx)
-            .file(cx)
-            .and_then(|file| file.file_name(cx));
-        if let Some(name) = filename {
-            name.to_string_lossy().into()
+        let file = self.buffer().read(cx).file(cx);
+        if let Some(file) = file {
+            file.file_name(cx).to_string_lossy().into()
         } else {
             "untitled".into()
         }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -189,6 +189,8 @@ pub trait File {
     fn buffer_removed(&self, buffer_id: u64, cx: &mut MutableAppContext);
 
     fn as_any(&self) -> &dyn Any;
+
+    fn to_proto(&self) -> rpc::proto::File;
 }
 
 pub trait LocalFile: File {
@@ -352,6 +354,7 @@ impl Buffer {
     pub fn to_proto(&self) -> proto::Buffer {
         proto::Buffer {
             id: self.remote_id(),
+            file: self.file.as_ref().map(|f| f.to_proto()),
             visible_text: self.text.text(),
             deleted_text: self.text.deleted_text(),
             undo_map: self

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -170,7 +170,7 @@ pub trait File {
 
     /// Returns the last component of this handle's absolute path. If this handle refers to the root
     /// of its worktree, then this method will return the name of the worktree itself.
-    fn file_name(&self, cx: &AppContext) -> Option<OsString>;
+    fn file_name(&self, cx: &AppContext) -> OsString;
 
     fn is_deleted(&self) -> bool;
 

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "project"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/project.rs"

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2428,7 +2428,7 @@ mod tests {
                 .as_remote_mut()
                 .unwrap()
                 .snapshot
-                .apply_update(update_message)
+                .apply_remote_update(update_message)
                 .unwrap();
 
             assert_eq!(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -938,7 +938,7 @@ impl Project {
         let buffer_abs_path;
         if let Some(file) = File::from_dyn(buffer.file()) {
             worktree = file.worktree.clone();
-            buffer_abs_path = file.abs_path(cx);
+            buffer_abs_path = file.as_local().map(|f| f.abs_path(cx));
         } else {
             return Task::ready(Err(anyhow!("buffer does not belong to any worktree")));
         };
@@ -2181,8 +2181,8 @@ mod tests {
         cx.update(|cx| {
             let target_buffer = definition.target_buffer.read(cx);
             assert_eq!(
-                target_buffer.file().unwrap().abs_path(cx),
-                Some(dir.path().join("a.rs"))
+                target_buffer.file().unwrap().as_local().unwrap().abs_path(cx),
+                dir.path().join("a.rs")
             );
             assert_eq!(definition.target_range.to_offset(target_buffer), 9..10);
             assert_eq!(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -624,7 +624,7 @@ impl Project {
     ) -> Option<()> {
         let (path, full_path) = {
             let file = buffer.read(cx).file()?;
-            (file.path().clone(), file.full_path())
+            (file.path().clone(), file.full_path(cx))
         };
 
         // If the buffer has a language, set it and start/assign the language server
@@ -938,7 +938,7 @@ impl Project {
         let buffer_abs_path;
         if let Some(file) = File::from_dyn(buffer.file()) {
             worktree = file.worktree.clone();
-            buffer_abs_path = file.abs_path();
+            buffer_abs_path = file.abs_path(cx);
         } else {
             return Task::ready(Err(anyhow!("buffer does not belong to any worktree")));
         };
@@ -1168,7 +1168,6 @@ impl Project {
     ) {
         let local = worktree_handle.read(cx).is_local();
         let snapshot = worktree_handle.read(cx).snapshot();
-        let worktree_path = snapshot.abs_path();
         let mut buffers_to_delete = Vec::new();
         for (buffer_id, buffer) in &self.open_buffers {
             if let OpenBuffer::Loaded(buffer) = buffer {
@@ -1185,7 +1184,6 @@ impl Project {
                             {
                                 File {
                                     is_local: local,
-                                    worktree_path: worktree_path.clone(),
                                     entry_id: Some(entry.id),
                                     mtime: entry.mtime,
                                     path: entry.path.clone(),
@@ -1196,7 +1194,6 @@ impl Project {
                             {
                                 File {
                                     is_local: local,
-                                    worktree_path: worktree_path.clone(),
                                     entry_id: Some(entry.id),
                                     mtime: entry.mtime,
                                     path: entry.path.clone(),
@@ -1205,7 +1202,6 @@ impl Project {
                             } else {
                                 File {
                                     is_local: local,
-                                    worktree_path: worktree_path.clone(),
                                     entry_id: None,
                                     path: old_file.path().clone(),
                                     mtime: old_file.mtime(),
@@ -2185,7 +2181,7 @@ mod tests {
         cx.update(|cx| {
             let target_buffer = definition.target_buffer.read(cx);
             assert_eq!(
-                target_buffer.file().unwrap().abs_path(),
+                target_buffer.file().unwrap().abs_path(cx),
                 Some(dir.path().join("a.rs"))
             );
             assert_eq!(definition.target_range.to_offset(target_buffer), 9..10);

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -265,7 +265,7 @@ impl Worktree {
                     .spawn(async move {
                         while let Some(update) = updates_rx.recv().await {
                             let mut snapshot = snapshot_tx.borrow().clone();
-                            if let Err(error) = snapshot.apply_update(update) {
+                            if let Err(error) = snapshot.apply_remote_update(update) {
                                 log::error!("error applying worktree update: {}", error);
                             }
                             *snapshot_tx.borrow_mut() = snapshot;
@@ -1000,7 +1000,7 @@ impl Snapshot {
         }
     }
 
-    pub(crate) fn apply_update(&mut self, update: proto::UpdateWorktree) -> Result<()> {
+    pub(crate) fn apply_remote_update(&mut self, update: proto::UpdateWorktree) -> Result<()> {
         let mut entries_by_path_edits = Vec::new();
         let mut entries_by_id_edits = Vec::new();
         for entry_id in update.removed_entries {
@@ -2618,7 +2618,7 @@ mod tests {
             let update = scanner
                 .snapshot()
                 .build_update(&prev_snapshot, 0, 0, include_ignored);
-            prev_snapshot.apply_update(update).unwrap();
+            prev_snapshot.apply_remote_update(update).unwrap();
             assert_eq!(
                 prev_snapshot.to_vec(true),
                 scanner.snapshot().to_vec(include_ignored)

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -36,23 +36,24 @@ message Envelope {
         UpdateBufferFile update_buffer_file = 28;
         SaveBuffer save_buffer = 29;
         BufferSaved buffer_saved = 30;
-        FormatBuffer format_buffer = 31;
+        BufferReloaded buffer_reloaded = 31;
+        FormatBuffer format_buffer = 32;
 
-        GetChannels get_channels = 32;
-        GetChannelsResponse get_channels_response = 33;
-        JoinChannel join_channel = 34;
-        JoinChannelResponse join_channel_response = 35;
-        LeaveChannel leave_channel = 36;
-        SendChannelMessage send_channel_message = 37;
-        SendChannelMessageResponse send_channel_message_response = 38;
-        ChannelMessageSent channel_message_sent = 39;
-        GetChannelMessages get_channel_messages = 40;
-        GetChannelMessagesResponse get_channel_messages_response = 41;
+        GetChannels get_channels = 33;
+        GetChannelsResponse get_channels_response = 34;
+        JoinChannel join_channel = 35;
+        JoinChannelResponse join_channel_response = 36;
+        LeaveChannel leave_channel = 37;
+        SendChannelMessage send_channel_message = 38;
+        SendChannelMessageResponse send_channel_message_response = 39;
+        ChannelMessageSent channel_message_sent = 40;
+        GetChannelMessages get_channel_messages = 41;
+        GetChannelMessagesResponse get_channel_messages_response = 42;
 
-        UpdateContacts update_contacts = 42;
+        UpdateContacts update_contacts = 43;
 
-        GetUsers get_users = 43;
-        GetUsersResponse get_users_response = 44;
+        GetUsers get_users = 44;
+        GetUsersResponse get_users_response = 45;
     }
 }
 
@@ -166,6 +167,13 @@ message SaveBuffer {
 }
 
 message BufferSaved {
+    uint64 project_id = 1;
+    uint64 buffer_id = 2;
+    repeated VectorClockEntry version = 3;
+    Timestamp mtime = 4;
+}
+
+message BufferReloaded {
     uint64 project_id = 1;
     uint64 buffer_id = 2;
     repeated VectorClockEntry version = 3;

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -33,25 +33,26 @@ message Envelope {
         OpenBufferResponse open_buffer_response = 25;
         CloseBuffer close_buffer = 26;
         UpdateBuffer update_buffer = 27;
-        SaveBuffer save_buffer = 28;
-        BufferSaved buffer_saved = 29;
-        FormatBuffer format_buffer = 30;
+        UpdateBufferFile update_buffer_file = 28;
+        SaveBuffer save_buffer = 29;
+        BufferSaved buffer_saved = 30;
+        FormatBuffer format_buffer = 31;
 
-        GetChannels get_channels = 31;
-        GetChannelsResponse get_channels_response = 32;
-        JoinChannel join_channel = 33;
-        JoinChannelResponse join_channel_response = 34;
-        LeaveChannel leave_channel = 35;
-        SendChannelMessage send_channel_message = 36;
-        SendChannelMessageResponse send_channel_message_response = 37;
-        ChannelMessageSent channel_message_sent = 38;
-        GetChannelMessages get_channel_messages = 39;
-        GetChannelMessagesResponse get_channel_messages_response = 40;
+        GetChannels get_channels = 32;
+        GetChannelsResponse get_channels_response = 33;
+        JoinChannel join_channel = 34;
+        JoinChannelResponse join_channel_response = 35;
+        LeaveChannel leave_channel = 36;
+        SendChannelMessage send_channel_message = 37;
+        SendChannelMessageResponse send_channel_message_response = 38;
+        ChannelMessageSent channel_message_sent = 39;
+        GetChannelMessages get_channel_messages = 40;
+        GetChannelMessagesResponse get_channel_messages_response = 41;
 
-        UpdateContacts update_contacts = 41;
+        UpdateContacts update_contacts = 42;
 
-        GetUsers get_users = 42;
-        GetUsersResponse get_users_response = 43;
+        GetUsers get_users = 43;
+        GetUsersResponse get_users_response = 44;
     }
 }
 
@@ -88,9 +89,9 @@ message JoinProject {
 }
 
 message JoinProjectResponse {
-    uint32 replica_id = 2;
-    repeated Worktree worktrees = 3;
-    repeated Collaborator collaborators = 4;
+    uint32 replica_id = 1;
+    repeated Worktree worktrees = 2;
+    repeated Collaborator collaborators = 3;
 }
 
 message LeaveProject {
@@ -150,7 +151,13 @@ message CloseBuffer {
 message UpdateBuffer {
     uint64 project_id = 1;
     uint64 buffer_id = 2;
-    repeated Operation operations = 4;
+    repeated Operation operations = 3;
+}
+
+message UpdateBufferFile {
+    uint64 project_id = 1;
+    uint64 buffer_id = 2;
+    File file = 3;
 }
 
 message SaveBuffer {
@@ -177,11 +184,11 @@ message UpdateDiagnosticSummary {
 }
 
 message DiagnosticSummary {
-    string path = 3;
-    uint32 error_count = 4;
-    uint32 warning_count = 5;
-    uint32 info_count = 6;
-    uint32 hint_count = 7;
+    string path = 1;
+    uint32 error_count = 2;
+    uint32 warning_count = 3;
+    uint32 info_count = 4;
+    uint32 hint_count = 5;
 }
 
 message DiskBasedDiagnosticsUpdating {
@@ -272,7 +279,7 @@ message Worktree {
 
 message File {
     uint64 worktree_id = 1;
-    uint64 entry_id = 2;
+    optional uint64 entry_id = 2;
     string path = 3;
     Timestamp mtime = 4;
 }
@@ -289,15 +296,16 @@ message Entry {
 
 message Buffer {
     uint64 id = 1;
-    string visible_text = 2;
-    string deleted_text = 3;
-    repeated BufferFragment fragments = 4;
-    repeated UndoMapEntry undo_map = 5;
-    repeated VectorClockEntry version = 6;
-    repeated SelectionSet selections = 7;
-    repeated Diagnostic diagnostics = 8;
-    uint32 lamport_timestamp = 9;
-    repeated Operation deferred_operations = 10;
+    optional File file = 2;
+    string visible_text = 3;
+    string deleted_text = 4;
+    repeated BufferFragment fragments = 5;
+    repeated UndoMapEntry undo_map = 6;
+    repeated VectorClockEntry version = 7;
+    repeated SelectionSet selections = 8;
+    repeated Diagnostic diagnostics = 9;
+    uint32 lamport_timestamp = 10;
+    repeated Operation deferred_operations = 11;
 }
 
 message BufferFragment {
@@ -306,7 +314,7 @@ message BufferFragment {
     uint32 lamport_timestamp = 3;
     uint32 insertion_offset = 4;
     uint32 len = 5;
-    bool visible =  6;
+    bool visible = 6;
     repeated VectorClockEntry deletions = 7;
     repeated VectorClockEntry max_undos = 8;
 }
@@ -390,8 +398,8 @@ message Operation {
 
     message UpdateSelections {
         uint32 replica_id = 1;
-        uint32 lamport_timestamp = 3;
-        repeated Selection selections = 4;
+        uint32 lamport_timestamp = 2;
+        repeated Selection selections = 3;
     }
 }
 

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -270,6 +270,13 @@ message Worktree {
     bool weak = 5;
 }
 
+message File {
+    uint64 worktree_id = 1;
+    uint64 entry_id = 2;
+    string path = 3;
+    Timestamp mtime = 4;
+}
+
 message Entry {
     uint64 id = 1;
     bool is_dir = 2;

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -198,6 +198,7 @@ entity_messages!(
     UnregisterWorktree,
     UnshareProject,
     UpdateBuffer,
+    UpdateBufferFile,
     UpdateDiagnosticSummary,
     UpdateWorktree,
 );

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -157,6 +157,7 @@ messages!(
     UnregisterWorktree,
     UnshareProject,
     UpdateBuffer,
+    UpdateBufferFile,
     UpdateContacts,
     UpdateDiagnosticSummary,
     UpdateWorktree,

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -122,6 +122,7 @@ macro_rules! entity_messages {
 messages!(
     Ack,
     AddProjectCollaborator,
+    BufferReloaded,
     BufferSaved,
     ChannelMessageSent,
     CloseBuffer,
@@ -184,6 +185,7 @@ request_messages!(
 entity_messages!(
     project_id,
     AddProjectCollaborator,
+    BufferReloaded,
     BufferSaved,
     CloseBuffer,
     DiskBasedDiagnosticsUpdated,

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -78,6 +78,7 @@ impl Server {
             .add_handler(Server::close_buffer)
             .add_handler(Server::update_buffer)
             .add_handler(Server::update_buffer_file)
+            .add_handler(Server::buffer_reloaded)
             .add_handler(Server::buffer_saved)
             .add_handler(Server::save_buffer)
             .add_handler(Server::format_buffer)
@@ -708,6 +709,22 @@ impl Server {
     async fn update_buffer_file(
         self: Arc<Server>,
         request: TypedEnvelope<proto::UpdateBufferFile>,
+    ) -> tide::Result<()> {
+        let receiver_ids = self
+            .state()
+            .project_connection_ids(request.payload.project_id, request.sender_id)
+            .ok_or_else(|| anyhow!(NO_SUCH_PROJECT))?;
+        broadcast(request.sender_id, receiver_ids, |connection_id| {
+            self.peer
+                .forward_send(request.sender_id, connection_id, request.payload.clone())
+        })
+        .await?;
+        Ok(())
+    }
+
+    async fn buffer_reloaded(
+        self: Arc<Server>,
+        request: TypedEnvelope<proto::BufferReloaded>,
     ) -> tide::Result<()> {
         let receiver_ids = self
             .state()
@@ -1657,6 +1674,88 @@ mod tests {
         buffer_b.update(&mut cx_b, |buf, cx| buf.edit([0..0], "hello ", cx));
         buffer_b.read_with(&cx_b, |buf, _| {
             assert!(buf.is_dirty());
+            assert!(!buf.has_conflict());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_buffer_reloading(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+        cx_a.foreground().forbid_parking();
+        let lang_registry = Arc::new(LanguageRegistry::new());
+        let fs = Arc::new(FakeFs::new());
+
+        // Connect to a server as 2 clients.
+        let mut server = TestServer::start(cx_a.foreground()).await;
+        let client_a = server.create_client(&mut cx_a, "user_a").await;
+        let client_b = server.create_client(&mut cx_b, "user_b").await;
+
+        // Share a project as client A
+        fs.insert_tree(
+            "/dir",
+            json!({
+                ".zed.toml": r#"collaborators = ["user_b", "user_c"]"#,
+                "a.txt": "a-contents",
+            }),
+        )
+        .await;
+
+        let project_a = cx_a.update(|cx| {
+            Project::local(
+                client_a.clone(),
+                client_a.user_store.clone(),
+                lang_registry.clone(),
+                fs.clone(),
+                cx,
+            )
+        });
+        let (worktree_a, _) = project_a
+            .update(&mut cx_a, |p, cx| {
+                p.find_or_create_local_worktree("/dir", false, cx)
+            })
+            .await
+            .unwrap();
+        worktree_a
+            .read_with(&cx_a, |tree, _| tree.as_local().unwrap().scan_complete())
+            .await;
+        let project_id = project_a.update(&mut cx_a, |p, _| p.next_remote_id()).await;
+        let worktree_id = worktree_a.read_with(&cx_a, |tree, _| tree.id());
+        project_a
+            .update(&mut cx_a, |p, cx| p.share(cx))
+            .await
+            .unwrap();
+
+        // Join that project as client B
+        let project_b = Project::remote(
+            project_id,
+            client_b.clone(),
+            client_b.user_store.clone(),
+            lang_registry.clone(),
+            fs.clone(),
+            &mut cx_b.to_async(),
+        )
+        .await
+        .unwrap();
+        let _worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
+
+        // Open a buffer as client B
+        let buffer_b = project_b
+            .update(&mut cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
+            .await
+            .unwrap();
+        buffer_b.read_with(&cx_b, |buf, _| {
+            assert!(!buf.is_dirty());
+            assert!(!buf.has_conflict());
+        });
+
+        fs.save(Path::new("/dir/a.txt"), &"new contents".into())
+            .await
+            .unwrap();
+        buffer_b
+            .condition(&cx_b, |buf, _| {
+                buf.text() == "new contents" && !buf.is_dirty()
+            })
+            .await;
+        buffer_b.read_with(&cx_b, |buf, _| {
             assert!(!buf.has_conflict());
         });
     }

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -77,6 +77,7 @@ impl Server {
             .add_handler(Server::open_buffer)
             .add_handler(Server::close_buffer)
             .add_handler(Server::update_buffer)
+            .add_handler(Server::update_buffer_file)
             .add_handler(Server::buffer_saved)
             .add_handler(Server::save_buffer)
             .add_handler(Server::format_buffer)
@@ -701,6 +702,22 @@ impl Server {
         })
         .await?;
         self.peer.respond(request.receipt(), proto::Ack {}).await?;
+        Ok(())
+    }
+
+    async fn update_buffer_file(
+        self: Arc<Server>,
+        request: TypedEnvelope<proto::UpdateBufferFile>,
+    ) -> tide::Result<()> {
+        let receiver_ids = self
+            .state()
+            .project_connection_ids(request.payload.project_id, request.sender_id)
+            .ok_or_else(|| anyhow!(NO_SUCH_PROJECT))?;
+        broadcast(request.sender_id, receiver_ids, |connection_id| {
+            self.peer
+                .forward_send(request.sender_id, connection_id, request.payload.clone())
+        })
+        .await?;
         Ok(())
     }
 
@@ -1470,9 +1487,7 @@ mod tests {
             .condition(&mut cx_a, |buf, _| buf.text() == "i-am-c, i-am-b, i-am-a")
             .await;
         buffer_b
-            .condition(&mut cx_b, |buf, _| {
-                dbg!(buf.text()) == "i-am-c, i-am-b, i-am-a"
-            })
+            .condition(&mut cx_b, |buf, _| buf.text() == "i-am-c, i-am-b, i-am-a")
             .await;
         buffer_c
             .condition(&mut cx_c, |buf, _| buf.text() == "i-am-c, i-am-b, i-am-a")
@@ -1490,7 +1505,10 @@ mod tests {
         buffer_b.read_with(&cx_b, |buf, _| assert!(!buf.is_dirty()));
         buffer_c.condition(&cx_c, |buf, _| !buf.is_dirty()).await;
 
-        // Make changes on host's file system, see those changes on the guests.
+        // Make changes on host's file system, see those changes on guest worktrees.
+        fs.rename("/a/file1".as_ref(), "/a/file1-renamed".as_ref())
+            .await
+            .unwrap();
         fs.rename("/a/file2".as_ref(), "/a/file3".as_ref())
             .await
             .unwrap();
@@ -1498,18 +1516,29 @@ mod tests {
             .await
             .unwrap();
 
+        worktree_a
+            .condition(&cx_a, |tree, _| tree.file_count() == 4)
+            .await;
         worktree_b
             .condition(&cx_b, |tree, _| tree.file_count() == 4)
             .await;
         worktree_c
             .condition(&cx_c, |tree, _| tree.file_count() == 4)
             .await;
+        worktree_a.read_with(&cx_a, |tree, _| {
+            assert_eq!(
+                tree.paths()
+                    .map(|p| p.to_string_lossy())
+                    .collect::<Vec<_>>(),
+                &[".zed.toml", "file1-renamed", "file3", "file4"]
+            )
+        });
         worktree_b.read_with(&cx_b, |tree, _| {
             assert_eq!(
                 tree.paths()
                     .map(|p| p.to_string_lossy())
                     .collect::<Vec<_>>(),
-                &[".zed.toml", "file1", "file3", "file4"]
+                &[".zed.toml", "file1-renamed", "file3", "file4"]
             )
         });
         worktree_c.read_with(&cx_c, |tree, _| {
@@ -1517,9 +1546,26 @@ mod tests {
                 tree.paths()
                     .map(|p| p.to_string_lossy())
                     .collect::<Vec<_>>(),
-                &[".zed.toml", "file1", "file3", "file4"]
+                &[".zed.toml", "file1-renamed", "file3", "file4"]
             )
         });
+
+        // Ensure buffer files are updated as well.
+        buffer_a
+            .condition(&cx_a, |buf, _| {
+                buf.file().unwrap().path().to_str() == Some("file1-renamed")
+            })
+            .await;
+        buffer_b
+            .condition(&cx_b, |buf, _| {
+                buf.file().unwrap().path().to_str() == Some("file1-renamed")
+            })
+            .await;
+        buffer_c
+            .condition(&cx_c, |buf, _| {
+                buf.file().unwrap().path().to_str() == Some("file1-renamed")
+            })
+            .await;
     }
 
     #[gpui::test]


### PR DESCRIPTION
* [x] Clearly distinguish the capabilities of local and remote files via `File` and `LocalFile` traits.
* [x] Eliminate absolute paths and scan-related state in from remote worktrees. Introduce `worktree::LocalSnapshot` that has the path.
* [x] Send `File` protobuf when opening a remote buffer.
* [x] Construct the `File` at the guest based on the proto instead of the local entry.
* [x] Manage guest `File` state with `UpdateBufferFile` messages broadcasted from host to guests.

This should pave the way to open buffers via a `get_definition` request where we don't yet have an entry.