### PR TITLE
Filter out supporting diagnostics that contain no messages

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -912,7 +912,7 @@ impl Project {
                 });
                 if let Some(infos) = &diagnostic.related_information {
                     for info in infos {
-                        if info.location.uri == params.uri {
+                        if info.location.uri == params.uri && !info.message.is_empty() {
                             let range = range_from_lsp(info.location.range);
                             diagnostics.push(DiagnosticEntry {
                                 range,


### PR DESCRIPTION
Fixes #372 

This is consistent with what VS Code does and we will just avoid displaying that diagnostic so that all downstream code that depends on displaying a message can make assumptions about its presence.