### PR TITLE
Last touches on project diagnostics for now

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -103,7 +103,7 @@ impl View for ProjectDiagnosticsEditor {
         if self.path_states.is_empty() {
             let theme = &self.settings.borrow().theme.project_diagnostics;
             Label::new(
-                "No problems detected in the project".to_string(),
+                "No problems in workspace".to_string(),
                 theme.empty_message.clone(),
             )
             .aligned()
@@ -770,48 +770,52 @@ pub(crate) fn render_summary(
     text_style: &TextStyle,
     theme: &theme::ProjectDiagnostics,
 ) -> ElementBox {
-    let icon_width = theme.tab_icon_width;
-    let icon_spacing = theme.tab_icon_spacing;
-    let summary_spacing = theme.tab_summary_spacing;
-    Flex::row()
-        .with_children([
-            Svg::new("icons/diagnostic-summary-error.svg")
-                .with_color(text_style.color)
-                .constrained()
-                .with_width(icon_width)
+    if summary.error_count == 0 && summary.warning_count == 0 {
+        Label::new("No problems".to_string(), text_style.clone()).boxed()
+    } else {
+        let icon_width = theme.tab_icon_width;
+        let icon_spacing = theme.tab_icon_spacing;
+        let summary_spacing = theme.tab_summary_spacing;
+        Flex::row()
+            .with_children([
+                Svg::new("icons/diagnostic-summary-error.svg")
+                    .with_color(text_style.color)
+                    .constrained()
+                    .with_width(icon_width)
+                    .aligned()
+                    .contained()
+                    .with_margin_right(icon_spacing)
+                    .named("no-icon"),
+                Label::new(
+                    summary.error_count.to_string(),
+                    LabelStyle {
+                        text: text_style.clone(),
+                        highlight_text: None,
+                    },
+                )
                 .aligned()
-                .contained()
-                .with_margin_right(icon_spacing)
-                .named("no-icon"),
-            Label::new(
-                summary.error_count.to_string(),
-                LabelStyle {
-                    text: text_style.clone(),
-                    highlight_text: None,
-                },
-            )
-            .aligned()
-            .boxed(),
-            Svg::new("icons/diagnostic-summary-warning.svg")
-                .with_color(text_style.color)
-                .constrained()
-                .with_width(icon_width)
+                .boxed(),
+                Svg::new("icons/diagnostic-summary-warning.svg")
+                    .with_color(text_style.color)
+                    .constrained()
+                    .with_width(icon_width)
+                    .aligned()
+                    .contained()
+                    .with_margin_left(summary_spacing)
+                    .with_margin_right(icon_spacing)
+                    .named("warn-icon"),
+                Label::new(
+                    summary.warning_count.to_string(),
+                    LabelStyle {
+                        text: text_style.clone(),
+                        highlight_text: None,
+                    },
+                )
                 .aligned()
-                .contained()
-                .with_margin_left(summary_spacing)
-                .with_margin_right(icon_spacing)
-                .named("warn-icon"),
-            Label::new(
-                summary.warning_count.to_string(),
-                LabelStyle {
-                    text: text_style.clone(),
-                    highlight_text: None,
-                },
-            )
-            .aligned()
-            .boxed(),
-        ])
-        .boxed()
+                .boxed(),
+            ])
+            .boxed()
+    }
 }
 
 fn compare_diagnostics<L: language::ToOffset, R: language::ToOffset>(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3493,9 +3493,11 @@ impl Editor {
 
     fn set_selections(&mut self, selections: Arc<[Selection<Anchor>]>, cx: &mut ViewContext<Self>) {
         self.selections = selections;
-        self.buffer.update(cx, |buffer, cx| {
-            buffer.set_active_selections(&self.selections, cx)
-        });
+        if self.focused {
+            self.buffer.update(cx, |buffer, cx| {
+                buffer.set_active_selections(&self.selections, cx)
+            });
+        }
     }
 
     pub fn request_autoscroll(&mut self, autoscroll: Autoscroll, cx: &mut ViewContext<Self>) {
@@ -3721,6 +3723,10 @@ impl Editor {
     }
 
     fn pause_cursor_blinking(&mut self, cx: &mut ViewContext<Self>) {
+        if !self.focused {
+            return;
+        }
+
         self.show_local_cursors = true;
         cx.notify();
 

--- a/crates/zed/assets/themes/_base.toml
+++ b/crates/zed/assets/themes/_base.toml
@@ -185,7 +185,7 @@ corner_radius = 6
 
 [project_panel]
 extends = "$panel"
-padding.top = 6    # ($workspace.tab.height - $project_panel.entry.height) / 2
+padding.top = 6 # ($workspace.tab.height - $project_panel.entry.height) / 2
 
 [project_panel.entry]
 text = "$text.1"
@@ -313,7 +313,7 @@ message.highlight_text.color = "$text.3.color"
 
 [project_diagnostics]
 background = "$surface.1"
-empty_message = "$text.0"
+empty_message = { extends = "$text.0", size = 18 }
 status_bar_item = { extends = "$text.2", margin.right = 10 }
 tab_icon_width = 13
 tab_icon_spacing = 4


### PR DESCRIPTION
Refs #361 

- Implement the new empty state
- Show non-disk-based diagnostics 
- Fix spurious cursor appearing when the project diagnostics were visible but not focused