### PR TITLE
Buffer all incoming file-system events

### DIFF
--- a/crates/project/src/fs.rs
+++ b/crates/project/src/fs.rs
@@ -115,7 +115,7 @@ impl Fs for RealFs {
         path: &Path,
         latency: Duration,
     ) -> Pin<Box<dyn Send + Stream<Item = Vec<fsevent::Event>>>> {
-        let (mut tx, rx) = postage::mpsc::channel(64);
+        let (tx, rx) = smol::channel::unbounded();
         let (stream, handle) = EventStream::new(&[path], latency);
         std::mem::forget(handle);
         std::thread::spawn(move || {


### PR DESCRIPTION
Fixes #397 

This avoids a problem where the operating system would drop events on the floor and tell us to rescan the entire directory, which in turn would cause a flicker in the project browser.