### PR TITLE
Clear selection goal column when cutting a full line

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2496,6 +2496,7 @@ impl Editor {
                 if is_entire_line {
                     selection.start = Point::new(selection.start.row, 0);
                     selection.end = cmp::min(max_point, Point::new(selection.end.row + 1, 0));
+                    selection.goal = SelectionGoal::None;
                 }
                 let mut len = 0;
                 for chunk in buffer.text_for_range(selection.start..selection.end) {


### PR DESCRIPTION
Fixes #389 