### PR TITLE
autoscroll to first find upon query edit

### DIFF
--- a/crates/find/src/find.rs
+++ b/crates/find/src/find.rs
@@ -415,6 +415,7 @@ impl FindBar {
                 self.clear_matches(cx);
                 self.update_matches(cx);
                 cx.notify();
+                self.go_to_match(&GoToMatch(Direction::Next), cx);
             }
             _ => {}
         }


### PR DESCRIPTION
Addresses: https://github.com/zed-industries/zed/issues/429

![gif](https://user-images.githubusercontent.com/4350451/152669009-0dbcf624-94fc-44f2-a98b-0590c35d017c.gif)


(It looks simple, I couldn't resist! Hopefully I've done it right?)