### PR TITLE
enable shifting focus between panes, and closing all inactive tabs in a pane

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -28,6 +28,7 @@ action!(CloseActiveItem);
 action!(CloseItem, usize);
 action!(GoBack);
 action!(GoForward);
+action!(ShiftFocus, SplitDirection);
 
 const MAX_NAVIGATION_HISTORY_LEN: usize = 1024;
 
@@ -50,6 +51,9 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(|pane: &mut Pane, action: &Split, cx| {
         pane.split(action.0, cx);
     });
+    cx.add_action(|pane: &mut Pane, action: &ShiftFocus, cx| {
+        pane.shift_focus(action.0, cx);
+    });
     cx.add_action(|workspace: &mut Workspace, _: &GoBack, cx| {
         Pane::go_back(workspace, cx).detach();
     });
@@ -67,6 +71,37 @@ pub fn init(cx: &mut MutableAppContext) {
         Binding::new("cmd-k right", Split(SplitDirection::Right), Some("Pane")),
         Binding::new("ctrl--", GoBack, Some("Pane")),
         Binding::new("shift-ctrl-_", GoForward, Some("Pane")),
+        Binding::new(
+            "cmd-k cmd-left",
+            ShiftFocus(SplitDirection::Left),
+            Some("Pane"),
+        ),
+        Binding::new(
+            "cmd-k cmd-right",
+            ShiftFocus(SplitDirection::Right),
+            Some("Pane"),
+        ),
+        Binding::new("cmd-k cmd-up", ShiftFocus(SplitDirection::Up), Some("Pane")),
+        Binding::new(
+            "cmd-k cmd-down",
+            ShiftFocus(SplitDirection::Down),
+            Some("Pane"),
+        ),
+        Binding::new(
+            "cmd-k cmd-down",
+            ShiftFocus(SplitDirection::Down),
+            Some("Pane"),
+        ),
+        Binding::new(
+            "cmd-k cmd-left",
+            ShiftFocus(SplitDirection::Left),
+            Some("Pane"),
+        ),
+        Binding::new(
+            "cmd-k cmd-right",
+            ShiftFocus(SplitDirection::Right),
+            Some("Pane"),
+        ),
     ]);
 }
 
@@ -74,6 +109,7 @@ pub enum Event {
     Activate,
     Remove,
     Split(SplitDirection),
+    ShiftFocus(SplitDirection),
 }
 
 pub struct Pane {
@@ -397,6 +433,10 @@ impl Pane {
 
     pub fn split(&mut self, direction: SplitDirection, cx: &mut ViewContext<Self>) {
         cx.emit(Event::Split(direction));
+    }
+
+    pub fn shift_focus(&mut self, direction: SplitDirection, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::ShiftFocus(direction))
     }
 
     pub fn show_toolbar<F, V>(&mut self, cx: &mut ViewContext<Self>, build_toolbar: F)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1029,6 +1029,7 @@ impl Workspace {
                 pane::Event::Activate => {
                     self.activate_pane(pane, cx);
                 }
+                pane::Event::ShiftFocus(direction) => self.shift_focus_pane(*direction, cx),
             }
         } else {
             error!("pane {} not found", pane_id);
@@ -1051,6 +1052,12 @@ impl Workspace {
         self.center.split(&pane, &new_pane, direction).unwrap();
         cx.notify();
         new_pane
+    }
+
+    fn shift_focus_pane(&mut self, direction: SplitDirection, cx: &mut ViewContext<Self>) {
+        if let Some(neighbor) = self.center.find_adjacent(self.active_pane(), direction) {
+            self.activate_pane(neighbor, cx);
+        }
     }
 
     fn remove_pane(&mut self, pane: ViewHandle<Pane>, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Enables shifting focus between panes, as requested in: https://github.com/zed-industries/zed/issues/391

Edit: also enables closing all inactive tabs.