### PR TITLE
Always run multiple iterations of all integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5850,6 +5850,7 @@ dependencies = [
  "tide-compress",
  "time 0.2.25",
  "toml",
+ "util",
  "zed",
 ]
 

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    // std::env::set_var("RUST_LOG", "info");
-    env_logger::init();
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    }
 }

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -18,9 +18,9 @@ use crate::{
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    env_logger::builder()
-        .filter_level(log::LevelFilter::Info)
-        .init();
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    }
 }
 
 pub fn run_test(

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -17,8 +17,9 @@ use util::test::Network;
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    // std::env::set_var("RUST_LOG", "info");
-    env_logger::init();
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    }
 }
 
 #[test]

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -547,7 +547,7 @@ impl FakeLanguageServer {
                     request.params,
                 );
             } else {
-                println!(
+                log::info!(
                     "skipping message in fake language server {:?}",
                     std::str::from_utf8(&self.buffer)
                 );

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -61,6 +61,7 @@ gpui = { path = "../gpui" }
 zed = { path = "../zed", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"
+util = { path = "../util" }
 
 lazy_static = "1.4"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }

--- a/crates/server/src/db.rs
+++ b/crates/server/src/db.rs
@@ -526,54 +526,88 @@ pub struct ChannelMessage {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use lazy_static::lazy_static;
+    use parking_lot::Mutex;
     use rand::prelude::*;
     use sqlx::{
         migrate::{MigrateDatabase, Migrator},
         Postgres,
     };
-    use std::path::Path;
+    use std::{mem, path::Path};
 
     pub struct TestDb {
-        pub db: Db,
+        pub db: Option<Db>,
         pub name: String,
         pub url: String,
     }
 
-    impl TestDb {
-        pub fn new() -> Self {
-            // Enable tests to run in parallel by serializing the creation of each test database.
-            lazy_static::lazy_static! {
-                static ref DB_CREATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
-            }
+    lazy_static! {
+        static ref POOL: Mutex<Vec<TestDb>> = Default::default();
+    }
 
-            let mut rng = StdRng::from_entropy();
-            let name = format!("zed-test-{}", rng.gen::<u128>());
-            let url = format!("postgres://postgres@localhost/{}", name);
-            let migrations_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"));
-            let db = block_on(async {
-                {
-                    let _lock = DB_CREATION.lock();
-                    Postgres::create_database(&url)
-                        .await
-                        .expect("failed to create test db");
-                }
-                let mut db = Db::new(&url, 5).await.unwrap();
-                db.test_mode = true;
-                let migrator = Migrator::new(migrations_path).await.unwrap();
-                migrator.run(&db.pool).await.unwrap();
-                db
-            });
-
-            Self { db, name, url }
-        }
-
-        pub fn db(&self) -> &Db {
-            &self.db
+    #[ctor::dtor]
+    fn clear_pool() {
+        for db in POOL.lock().drain(..) {
+            db.teardown();
         }
     }
 
-    impl Drop for TestDb {
-        fn drop(&mut self) {
+    impl TestDb {
+        pub fn new() -> Self {
+            let mut pool = POOL.lock();
+            if let Some(db) = pool.pop() {
+                db.truncate();
+                db
+            } else {
+                let mut rng = StdRng::from_entropy();
+                let name = format!("zed-test-{}", rng.gen::<u128>());
+                let url = format!("postgres://postgres@localhost/{}", name);
+                let migrations_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"));
+                let db = block_on(async {
+                    Postgres::create_database(&url)
+                        .await
+                        .expect("failed to create test db");
+                    let mut db = Db::new(&url, 5).await.unwrap();
+                    db.test_mode = true;
+                    let migrator = Migrator::new(migrations_path).await.unwrap();
+                    migrator.run(&db.pool).await.unwrap();
+                    db
+                });
+
+                Self {
+                    db: Some(db),
+                    name,
+                    url,
+                }
+            }
+        }
+
+        pub fn db(&self) -> &Db {
+            self.db.as_ref().unwrap()
+        }
+
+        fn truncate(&self) {
+            block_on(async {
+                let query = "
+                    SELECT tablename FROM pg_tables
+                    WHERE schemaname = 'public';
+                ";
+                let table_names = sqlx::query_scalar::<_, String>(query)
+                    .fetch_all(&self.db().pool)
+                    .await
+                    .unwrap();
+                sqlx::query(&format!(
+                    "TRUNCATE TABLE {} RESTART IDENTITY",
+                    table_names.join(", ")
+                ))
+                .execute(&self.db().pool)
+                .await
+                .unwrap();
+            })
+        }
+
+        fn teardown(mut self) {
+            let db = self.db.take().unwrap();
             block_on(async {
                 let query = "
                     SELECT pg_terminate_backend(pg_stat_activity.pid)
@@ -582,12 +616,24 @@ pub mod tests {
                 ";
                 sqlx::query(query)
                     .bind(&self.name)
-                    .execute(&self.db.pool)
+                    .execute(&db.pool)
                     .await
                     .unwrap();
-                self.db.pool.close().await;
+                db.pool.close().await;
                 Postgres::drop_database(&self.url).await.unwrap();
             });
+        }
+    }
+
+    impl Drop for TestDb {
+        fn drop(&mut self) {
+            if let Some(db) = self.db.take() {
+                POOL.lock().push(TestDb {
+                    db: Some(db),
+                    name: mem::take(&mut self.name),
+                    url: mem::take(&mut self.url),
+                });
+            }
         }
     }
 

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1196,8 +1196,9 @@ mod tests {
     #[cfg(test)]
     #[ctor::ctor]
     fn init_logger() {
-        // std::env::set_var("RUST_LOG", "info");
-        env_logger::init();
+        if std::env::var("RUST_LOG").is_ok() {
+            env_logger::init();
+        }
     }
 
     #[gpui::test]

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1201,7 +1201,7 @@ mod tests {
         }
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_share_project(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         let (window_b, _) = cx_b.add_window(|_| EmptyView);
         let lang_registry = Arc::new(LanguageRegistry::new());
@@ -1340,7 +1340,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_unshare_project(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
@@ -1437,7 +1437,7 @@ mod tests {
             .unwrap();
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_propagate_saves_and_fs_changes(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
@@ -1623,7 +1623,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_buffer_conflict_after_save(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
@@ -1716,7 +1716,7 @@ mod tests {
         });
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_buffer_reloading(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
@@ -1878,7 +1878,7 @@ mod tests {
         buffer_b.condition(&cx_b, |buf, _| buf.text() == text).await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_leaving_worktree_while_opening_buffer(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
@@ -1956,7 +1956,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_peer_disconnection(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
@@ -2027,7 +2027,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_collaborating_with_diagnostics(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
@@ -2251,7 +2251,7 @@ mod tests {
         });
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_collaborating_with_completion(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
@@ -2476,7 +2476,7 @@ mod tests {
         );
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_formatting_buffer(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2580,7 +2580,7 @@ mod tests {
         );
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_definition(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2737,7 +2737,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_open_buffer_while_getting_definition_pointing_to_it(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
@@ -2851,7 +2851,7 @@ mod tests {
         assert_eq!(definitions[0].target_buffer, buffer_b2);
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_basic_chat(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
 
@@ -2991,7 +2991,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_chat_message_validation(mut cx_a: TestAppContext) {
         cx_a.foreground().forbid_parking();
 
@@ -3051,7 +3051,7 @@ mod tests {
         );
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_chat_reconnection(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
 
@@ -3263,7 +3263,7 @@ mod tests {
             .await;
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 10)]
     async fn test_contacts(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -12,8 +12,9 @@ use util::test::Network;
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    // std::env::set_var("RUST_LOG", "info");
-    env_logger::init();
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    }
 }
 
 #[test]

--- a/crates/zed/src/test.rs
+++ b/crates/zed/src/test.rs
@@ -12,7 +12,9 @@ use workspace::Settings;
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    env_logger::init();
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    }
 }
 
 pub fn test_app_state(cx: &mut MutableAppContext) -> Arc<AppState> {


### PR DESCRIPTION
This PR speeds up the integration tests by maintaining a pool of databases for a given test run.

The challenge is when to clear the pool of databases. We tried using `ctor::dtor` and `atexit`, but neither worked on CI. We think this may have to do with the fact that we need to use x86 emulation on CI because the GitHub actions runner doesn't support the new apple architecture.

To avoid these crashes, I switched to clearing the DB pool when the number of in-use DBs goes to zero. This results in us repeatedly clearing it in the case of the final test that's running, which isn't ideal, but still gets us a big speedup during the part of the run where multiple tests are running.

To improve this further, maybe we could add something to our `#[gpui::test]` macro which allows us to detect when we are on the final iteration of a randomized test. Then we could only clear the DB pool in that case, which would let us get proper utilization of the pool even at the end of the test run, for the final test. Alternatively, if we use the same number of iterations for all integration tests, then we'll mostly avoid clearing the pool prematurely, since for most of the time, there will be multiple tests running.