### PR TITLE
Relax ordering constraints for low-priority messages

### DIFF
--- a/crates/chat_panel/src/chat_panel.rs
+++ b/crates/chat_panel/src/chat_panel.rs
@@ -325,17 +325,21 @@ impl ChatPanel {
         enum SignInPromptLabel {}
 
         Align::new(
-            MouseEventHandler::new::<SignInPromptLabel, _, _, _>(0, cx, |mouse_state, _| {
-                Label::new(
-                    "Sign in to use chat".to_string(),
-                    if mouse_state.hovered {
-                        theme.chat_panel.hovered_sign_in_prompt.clone()
-                    } else {
-                        theme.chat_panel.sign_in_prompt.clone()
-                    },
-                )
-                .boxed()
-            })
+            MouseEventHandler::new::<SignInPromptLabel, _, _, _>(
+                cx.view_id(),
+                cx,
+                |mouse_state, _| {
+                    Label::new(
+                        "Sign in to use chat".to_string(),
+                        if mouse_state.hovered {
+                            theme.chat_panel.hovered_sign_in_prompt.clone()
+                        } else {
+                            theme.chat_panel.sign_in_prompt.clone()
+                        },
+                    )
+                    .boxed()
+                },
+            )
             .with_cursor_style(CursorStyle::PointingHand)
             .on_click(move |cx| {
                 let rpc = rpc.clone();

--- a/crates/client/src/channel.rs
+++ b/crates/client/src/channel.rs
@@ -190,7 +190,7 @@ impl Channel {
         rpc: Arc<Client>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        let _subscription = rpc.add_model_for_remote_entity(cx.handle(), details.id);
+        let _subscription = rpc.add_model_for_remote_entity(details.id, cx);
 
         {
             let user_store = user_store.clone();

--- a/crates/client/src/channel.rs
+++ b/crates/client/src/channel.rs
@@ -180,14 +180,17 @@ impl Entity for Channel {
 }
 
 impl Channel {
+    pub fn init(rpc: &Arc<Client>) {
+        rpc.add_entity_message_handler(Self::handle_message_sent);
+    }
+
     pub fn new(
         details: ChannelDetails,
         user_store: ModelHandle<UserStore>,
         rpc: Arc<Client>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        let _subscription =
-            rpc.add_entity_message_handler(details.id, cx, Self::handle_message_sent);
+        let _subscription = rpc.add_model_for_remote_entity(cx.handle(), details.id);
 
         {
             let user_store = user_store.clone();

--- a/crates/client/src/channel.rs
+++ b/crates/client/src/channel.rs
@@ -598,10 +598,14 @@ mod tests {
 
     #[gpui::test]
     async fn test_channel_messages(mut cx: TestAppContext) {
+        cx.foreground().forbid_parking();
+
         let user_id = 5;
         let http_client = FakeHttpClient::new(|_| async move { Ok(Response::new(404)) });
         let mut client = Client::new(http_client.clone());
         let server = FakeServer::for_client(user_id, &mut client, &cx).await;
+
+        Channel::init(&client);
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
 
         let channel_list = cx.add_model(|cx| ChannelList::new(user_store, client.clone(), cx));

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -220,6 +220,10 @@ impl Client {
         })
     }
 
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     pub fn override_authenticate<F>(&mut self, authenticate: F) -> &mut Self
     where

--- a/crates/clock/src/clock.rs
+++ b/crates/clock/src/clock.rs
@@ -216,6 +216,16 @@ impl Global {
     }
 }
 
+impl FromIterator<Local> for Global {
+    fn from_iter<T: IntoIterator<Item = Local>>(locals: T) -> Self {
+        let mut result = Self::new();
+        for local in locals {
+            result.observe(local);
+        }
+        result
+    }
+}
+
 impl Ord for Lamport {
     fn cmp(&self, other: &Self) -> Ordering {
         // Use the replica id to break ties between concurrent events.

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -57,7 +57,7 @@ impl View for DiagnosticSummary {
         let theme = &self.settings.borrow().theme.project_diagnostics;
 
         let in_progress = self.in_progress;
-        MouseEventHandler::new::<Tag, _, _, _>(0, cx, |_, _| {
+        MouseEventHandler::new::<Tag, _, _, _>(cx.view_id(), cx, |_, _| {
             if in_progress {
                 Label::new(
                     "Checking... ".to_string(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2264,7 +2264,7 @@ impl Editor {
             enum Tag {}
             let style = (self.build_settings)(cx).style;
             Some(
-                MouseEventHandler::new::<Tag, _, _, _>(0, cx, |_, _| {
+                MouseEventHandler::new::<Tag, _, _, _>(cx.view_id(), cx, |_, _| {
                     Svg::new("icons/zap.svg")
                         .with_color(style.code_actions_indicator)
                         .boxed()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7737,9 +7737,8 @@ mod tests {
                 }),
                 ..Default::default()
             },
-            &cx,
-        )
-        .await;
+            cx.background(),
+        );
 
         let text = "
             one

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7791,7 +7791,9 @@ mod tests {
             ],
         )
         .await;
-        editor.next_notification(&cx).await;
+        editor
+            .condition(&cx, |editor, _| editor.context_menu_visible())
+            .await;
 
         let apply_additional_edits = editor.update(&mut cx, |editor, cx| {
             editor.move_down(&MoveDown, cx);
@@ -7855,7 +7857,7 @@ mod tests {
         )
         .await;
         editor
-            .condition(&cx, |editor, _| editor.context_menu.is_some())
+            .condition(&cx, |editor, _| editor.context_menu_visible())
             .await;
 
         editor.update(&mut cx, |editor, cx| {
@@ -7873,7 +7875,9 @@ mod tests {
             ],
         )
         .await;
-        editor.next_notification(&cx).await;
+        editor
+            .condition(&cx, |editor, _| editor.context_menu_visible())
+            .await;
 
         let apply_additional_edits = editor.update(&mut cx, |editor, cx| {
             let apply_additional_edits = editor

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5447,8 +5447,8 @@ mod tests {
     use super::*;
     use language::LanguageConfig;
     use lsp::FakeLanguageServer;
-    use postage::prelude::Stream;
     use project::{FakeFs, ProjectPath};
+    use smol::stream::StreamExt;
     use std::{cell::RefCell, rc::Rc, time::Instant};
     use text::Point;
     use unindent::Unindent;
@@ -7911,7 +7911,7 @@ mod tests {
                 );
                 Some(lsp::CompletionResponse::Array(
                     completions
-                        .into_iter()
+                        .iter()
                         .map(|(range, new_text)| lsp::CompletionItem {
                             label: new_text.to_string(),
                             text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
@@ -7926,7 +7926,7 @@ mod tests {
                         .collect(),
                 ))
             })
-            .recv()
+            .next()
             .await;
         }
 
@@ -7936,7 +7936,7 @@ mod tests {
         ) {
             fake.handle_request::<lsp::request::ResolveCompletionItem, _>(move |_| {
                 lsp::CompletionItem {
-                    additional_text_edits: edit.map(|(range, new_text)| {
+                    additional_text_edits: edit.clone().map(|(range, new_text)| {
                         vec![lsp::TextEdit::new(
                             lsp::Range::new(
                                 lsp::Position::new(range.start.row, range.start.column),
@@ -7948,7 +7948,7 @@ mod tests {
                     ..Default::default()
                 }
             })
-            .recv()
+            .next()
             .await;
         }
     }

--- a/crates/fuzzy/src/char_bag.rs
+++ b/crates/fuzzy/src/char_bag.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct CharBag(u64);
 
 impl CharBag {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -492,6 +492,15 @@ impl TestAppContext {
         self.cx.borrow().background().clone()
     }
 
+    pub fn spawn<F, Fut, T>(&self, f: F) -> Task<T>
+    where
+        F: FnOnce(AsyncAppContext) -> Fut,
+        Fut: 'static + Future<Output = T>,
+        T: 'static,
+    {
+        self.cx.borrow_mut().spawn(f)
+    }
+
     pub fn simulate_new_path_selection(&self, result: impl FnOnce(PathBuf) -> Option<PathBuf>) {
         self.foreground_platform.simulate_new_path_selection(result);
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -474,6 +474,10 @@ impl TestAppContext {
         self.cx.borrow().cx.font_cache.clone()
     }
 
+    pub fn foreground_platform(&self) -> Rc<platform::test::ForegroundPlatform> {
+        self.foreground_platform.clone()
+    }
+
     pub fn platform(&self) -> Arc<dyn platform::Platform> {
         self.cx.borrow().cx.platform.clone()
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -685,6 +685,7 @@ pub struct MutableAppContext {
     next_entity_id: usize,
     next_window_id: usize,
     next_subscription_id: usize,
+    frame_count: usize,
     subscriptions: Arc<Mutex<HashMap<usize, BTreeMap<usize, SubscriptionCallback>>>>,
     observations: Arc<Mutex<HashMap<usize, BTreeMap<usize, ObservationCallback>>>>,
     release_observations: Arc<Mutex<HashMap<usize, BTreeMap<usize, ReleaseObservationCallback>>>>,
@@ -729,6 +730,7 @@ impl MutableAppContext {
             next_entity_id: 0,
             next_window_id: 0,
             next_subscription_id: 0,
+            frame_count: 0,
             subscriptions: Default::default(),
             observations: Default::default(),
             release_observations: Default::default(),
@@ -920,6 +922,7 @@ impl MutableAppContext {
         window_id: usize,
         titlebar_height: f32,
     ) -> HashMap<usize, ElementBox> {
+        self.start_frame();
         let view_ids = self
             .views
             .keys()
@@ -941,6 +944,10 @@ impl MutableAppContext {
                 )
             })
             .collect()
+    }
+
+    pub(crate) fn start_frame(&mut self) {
+        self.frame_count += 1;
     }
 
     pub fn update<T, F: FnOnce(&mut Self) -> T>(&mut self, callback: F) -> T {
@@ -1397,7 +1404,12 @@ impl MutableAppContext {
             .element_states
             .entry(key)
             .or_insert_with(|| Box::new(T::default()));
-        ElementStateHandle::new(TypeId::of::<Tag>(), id, &self.cx.ref_counts)
+        ElementStateHandle::new(
+            TypeId::of::<Tag>(),
+            id,
+            self.frame_count,
+            &self.cx.ref_counts,
+        )
     }
 
     fn remove_dropped_entities(&mut self) {
@@ -3368,8 +3380,15 @@ pub struct ElementStateHandle<T> {
 }
 
 impl<T: 'static> ElementStateHandle<T> {
-    fn new(tag_type_id: TypeId, id: ElementStateId, ref_counts: &Arc<Mutex<RefCounts>>) -> Self {
-        ref_counts.lock().inc_element_state(tag_type_id, id);
+    fn new(
+        tag_type_id: TypeId,
+        id: ElementStateId,
+        frame_id: usize,
+        ref_counts: &Arc<Mutex<RefCounts>>,
+    ) -> Self {
+        ref_counts
+            .lock()
+            .inc_element_state(tag_type_id, id, frame_id);
         Self {
             value_type: PhantomData,
             tag_type_id,
@@ -3508,10 +3527,15 @@ impl Drop for Subscription {
 #[derive(Default)]
 struct RefCounts {
     entity_counts: HashMap<usize, usize>,
-    element_state_counts: HashMap<(TypeId, ElementStateId), usize>,
+    element_state_counts: HashMap<(TypeId, ElementStateId), ElementStateRefCount>,
     dropped_models: HashSet<usize>,
     dropped_views: HashSet<(usize, usize)>,
     dropped_element_states: HashSet<(TypeId, ElementStateId)>,
+}
+
+struct ElementStateRefCount {
+    ref_count: usize,
+    frame_id: usize,
 }
 
 impl RefCounts {
@@ -3537,11 +3561,21 @@ impl RefCounts {
         }
     }
 
-    fn inc_element_state(&mut self, tag_type_id: TypeId, id: ElementStateId) {
+    fn inc_element_state(&mut self, tag_type_id: TypeId, id: ElementStateId, frame_id: usize) {
         match self.element_state_counts.entry((tag_type_id, id)) {
-            Entry::Occupied(mut entry) => *entry.get_mut() += 1,
+            Entry::Occupied(mut entry) => {
+                let entry = entry.get_mut();
+                if entry.frame_id == frame_id || entry.ref_count >= 2 {
+                    panic!("used the same element state more than once in the same frame");
+                }
+                entry.ref_count += 1;
+                entry.frame_id = frame_id;
+            }
             Entry::Vacant(entry) => {
-                entry.insert(1);
+                entry.insert(ElementStateRefCount {
+                    ref_count: 1,
+                    frame_id,
+                });
                 self.dropped_element_states.remove(&(tag_type_id, id));
             }
         }
@@ -3567,9 +3601,9 @@ impl RefCounts {
 
     fn dec_element_state(&mut self, tag_type_id: TypeId, id: ElementStateId) {
         let key = (tag_type_id, id);
-        let count = self.element_state_counts.get_mut(&key).unwrap();
-        *count -= 1;
-        if *count == 0 {
+        let entry = self.element_state_counts.get_mut(&key).unwrap();
+        entry.ref_count -= 1;
+        if entry.ref_count == 0 {
             self.element_state_counts.remove(&key);
             self.dropped_element_states.insert(key);
         }

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -370,6 +370,13 @@ impl Foreground {
         *any_value.downcast().unwrap()
     }
 
+    pub fn run_until_parked(&self) {
+        match self {
+            Self::Deterministic { executor, .. } => executor.run_until_parked(),
+            _ => panic!("this method can only be called on a deterministic executor"),
+        }
+    }
+
     pub fn parking_forbidden(&self) -> bool {
         match self {
             Self::Deterministic { executor, .. } => executor.state.lock().forbid_parking,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -6,9 +6,9 @@ use crate::{
     json::{self, ToJson},
     platform::Event,
     text_layout::TextLayoutCache,
-    Action, AnyAction, AnyViewHandle, AssetCache, ElementBox, Entity, FontSystem, ModelHandle,
-    ReadModel, ReadView, Scene, UpgradeModelHandle, UpgradeViewHandle, View, ViewHandle,
-    WeakModelHandle, WeakViewHandle,
+    Action, AnyAction, AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AssetCache, ElementBox,
+    Entity, FontSystem, ModelHandle, ReadModel, ReadView, Scene, UpgradeModelHandle,
+    UpgradeViewHandle, View, ViewHandle, WeakModelHandle, WeakViewHandle,
 };
 use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
@@ -279,6 +279,10 @@ impl<'a> UpgradeModelHandle for LayoutContext<'a> {
         handle: &WeakModelHandle<T>,
     ) -> Option<ModelHandle<T>> {
         self.app.upgrade_model_handle(handle)
+    }
+
+    fn upgrade_any_model_handle(&self, handle: &AnyWeakModelHandle) -> Option<AnyModelHandle> {
+        self.app.upgrade_any_model_handle(handle)
     }
 }
 

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -62,6 +62,7 @@ impl Presenter {
     }
 
     pub fn invalidate(&mut self, mut invalidation: WindowInvalidation, cx: &mut MutableAppContext) {
+        cx.start_frame();
         for view_id in invalidation.removed {
             invalidation.updated.remove(&view_id);
             self.rendered_views.remove(&view_id);
@@ -81,6 +82,7 @@ impl Presenter {
         invalidation: Option<WindowInvalidation>,
         cx: &mut MutableAppContext,
     ) {
+        cx.start_frame();
         if let Some(invalidation) = invalidation {
             for view_id in invalidation.removed {
                 self.rendered_views.remove(&view_id);

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -99,7 +99,7 @@ pub fn run_test(
                     println!("retrying: attempt {}", retries);
                 } else {
                     if is_randomized {
-                        eprintln!("failing seed: {}", atomic_seed.load(SeqCst));
+                        eprintln!("failing seed: {}", atomic_seed.load(SeqCst) - 1);
                     }
                     panic::resume_unwind(error);
                 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1283,6 +1283,10 @@ impl Buffer {
         self.text.wait_for_edits(edit_ids)
     }
 
+    pub fn wait_for_version(&mut self, version: clock::Global) -> impl Future<Output = ()> {
+        self.text.wait_for_version(version)
+    }
+
     pub fn set_active_selections(
         &mut self,
         selections: Arc<[Selection<Anchor>]>,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1283,10 +1283,6 @@ impl Buffer {
         self.text.wait_for_edits(edit_ids)
     }
 
-    pub fn wait_for_version(&mut self, version: clock::Global) -> impl Future<Output = ()> {
-        self.text.wait_for_version(version)
-    }
-
     pub fn set_active_selections(
         &mut self,
         selections: Arc<[Selection<Anchor>]>,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -11,9 +11,7 @@ use collections::HashSet;
 use gpui::AppContext;
 use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
-use lsp::FakeLanguageServer;
 use parking_lot::Mutex;
-use postage::prelude::Stream;
 use serde::Deserialize;
 use std::{cell::RefCell, ops::Range, path::Path, str, sync::Arc};
 use theme::SyntaxTheme;
@@ -237,6 +235,8 @@ impl Language {
         if let Some(config) = &self.config.language_server {
             #[cfg(any(test, feature = "test-support"))]
             if let Some(fake_config) = &config.fake_config {
+                use postage::prelude::Stream;
+
                 let (server, mut fake_server) = lsp::LanguageServer::fake_with_capabilities(
                     fake_config.capabilities.clone(),
                     cx.background().clone(),
@@ -408,7 +408,7 @@ impl LanguageServerConfig {
 
     pub fn set_fake_initializer(
         &mut self,
-        initializer: impl 'static + Send + Sync + Fn(&mut FakeLanguageServer),
+        initializer: impl 'static + Send + Sync + Fn(&mut lsp::FakeLanguageServer),
     ) {
         self.fake_config.as_mut().unwrap().initializer = Some(Box::new(initializer));
     }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -12,10 +12,14 @@ use gpui::AppContext;
 use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use postage::prelude::Stream;
 use serde::Deserialize;
 use std::{cell::RefCell, ops::Range, path::Path, str, sync::Arc};
 use theme::SyntaxTheme;
 use tree_sitter::{self, Query};
+
+#[cfg(any(test, feature = "test-support"))]
+use futures::channel::mpsc;
 
 pub use buffer::Operation;
 pub use buffer::*;
@@ -79,7 +83,13 @@ pub struct LanguageServerConfig {
     pub disk_based_diagnostics_progress_token: Option<String>,
     #[cfg(any(test, feature = "test-support"))]
     #[serde(skip)]
-    pub fake_server: Option<(Arc<lsp::LanguageServer>, Arc<std::sync::atomic::AtomicBool>)>,
+    fake_config: Option<FakeLanguageServerConfig>,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+struct FakeLanguageServerConfig {
+    servers_tx: mpsc::UnboundedSender<lsp::FakeLanguageServer>,
+    capabilities: lsp::ServerCapabilities,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -224,8 +234,21 @@ impl Language {
     ) -> Result<Option<Arc<lsp::LanguageServer>>> {
         if let Some(config) = &self.config.language_server {
             #[cfg(any(test, feature = "test-support"))]
-            if let Some((server, started)) = &config.fake_server {
-                started.store(true, std::sync::atomic::Ordering::SeqCst);
+            if let Some(fake_config) = &config.fake_config {
+                let (server, fake_server) = lsp::LanguageServer::fake_with_capabilities(
+                    fake_config.capabilities.clone(),
+                    cx.background().clone(),
+                );
+
+                let servers_tx = fake_config.servers_tx.clone();
+                let mut initialized = server.capabilities();
+                cx.background()
+                    .spawn(async move {
+                        while initialized.recv().await.is_none() {}
+                        servers_tx.unbounded_send(fake_server).ok();
+                    })
+                    .detach();
+
                 return Ok(Some(server.clone()));
             }
 
@@ -357,25 +380,24 @@ impl CompletionLabel {
 
 #[cfg(any(test, feature = "test-support"))]
 impl LanguageServerConfig {
-    pub async fn fake(cx: &gpui::TestAppContext) -> (Self, lsp::FakeLanguageServer) {
-        Self::fake_with_capabilities(Default::default(), cx).await
+    pub fn fake() -> (Self, mpsc::UnboundedReceiver<lsp::FakeLanguageServer>) {
+        Self::fake_with_capabilities(Default::default())
     }
 
-    pub async fn fake_with_capabilities(
-        capabilites: lsp::ServerCapabilities,
-        cx: &gpui::TestAppContext,
-    ) -> (Self, lsp::FakeLanguageServer) {
-        let (server, fake) = lsp::LanguageServer::fake_with_capabilities(capabilites, cx).await;
-        fake.started
-            .store(false, std::sync::atomic::Ordering::SeqCst);
-        let started = fake.started.clone();
+    pub fn fake_with_capabilities(
+        capabilities: lsp::ServerCapabilities,
+    ) -> (Self, mpsc::UnboundedReceiver<lsp::FakeLanguageServer>) {
+        let (servers_tx, servers_rx) = mpsc::unbounded();
         (
             Self {
-                fake_server: Some((server, started)),
+                fake_config: Some(FakeLanguageServerConfig {
+                    servers_tx,
+                    capabilities,
+                }),
                 disk_based_diagnostics_progress_token: Some("fakeServer/check".to_string()),
                 ..Default::default()
             },
-            fake,
+            servers_rx,
         )
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -11,6 +11,7 @@ use collections::HashSet;
 use gpui::AppContext;
 use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
+use lsp::FakeLanguageServer;
 use parking_lot::Mutex;
 use postage::prelude::Stream;
 use serde::Deserialize;
@@ -90,6 +91,7 @@ pub struct LanguageServerConfig {
 struct FakeLanguageServerConfig {
     servers_tx: mpsc::UnboundedSender<lsp::FakeLanguageServer>,
     capabilities: lsp::ServerCapabilities,
+    initializer: Option<Box<dyn 'static + Send + Sync + Fn(&mut lsp::FakeLanguageServer)>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -235,10 +237,14 @@ impl Language {
         if let Some(config) = &self.config.language_server {
             #[cfg(any(test, feature = "test-support"))]
             if let Some(fake_config) = &config.fake_config {
-                let (server, fake_server) = lsp::LanguageServer::fake_with_capabilities(
+                let (server, mut fake_server) = lsp::LanguageServer::fake_with_capabilities(
                     fake_config.capabilities.clone(),
                     cx.background().clone(),
                 );
+
+                if let Some(initalizer) = &fake_config.initializer {
+                    initalizer(&mut fake_server);
+                }
 
                 let servers_tx = fake_config.servers_tx.clone();
                 let mut initialized = server.capabilities();
@@ -381,24 +387,30 @@ impl CompletionLabel {
 #[cfg(any(test, feature = "test-support"))]
 impl LanguageServerConfig {
     pub fn fake() -> (Self, mpsc::UnboundedReceiver<lsp::FakeLanguageServer>) {
-        Self::fake_with_capabilities(Default::default())
-    }
-
-    pub fn fake_with_capabilities(
-        capabilities: lsp::ServerCapabilities,
-    ) -> (Self, mpsc::UnboundedReceiver<lsp::FakeLanguageServer>) {
         let (servers_tx, servers_rx) = mpsc::unbounded();
         (
             Self {
                 fake_config: Some(FakeLanguageServerConfig {
                     servers_tx,
-                    capabilities,
+                    capabilities: Default::default(),
+                    initializer: None,
                 }),
                 disk_based_diagnostics_progress_token: Some("fakeServer/check".to_string()),
                 ..Default::default()
             },
             servers_rx,
         )
+    }
+
+    pub fn set_fake_capabilities(&mut self, capabilities: lsp::ServerCapabilities) {
+        self.fake_config.as_mut().unwrap().capabilities = capabilities;
+    }
+
+    pub fn set_fake_initializer(
+        &mut self,
+        initializer: impl 'static + Send + Sync + Fn(&mut FakeLanguageServer),
+    ) {
+        self.fake_config.as_mut().unwrap().initializer = Some(Box::new(initializer));
     }
 }
 

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -557,7 +557,7 @@ fn test_autoindent_adjusts_lines_when_only_text_changes(cx: &mut MutableAppConte
 
 #[gpui::test]
 async fn test_diagnostics(mut cx: gpui::TestAppContext) {
-    let (language_server, mut fake) = lsp::LanguageServer::fake(&cx).await;
+    let (language_server, mut fake) = lsp::LanguageServer::fake(cx.background());
     let mut rust_lang = rust_lang();
     rust_lang.config.language_server = Some(LanguageServerConfig {
         disk_based_diagnostic_sources: HashSet::from_iter(["disk".to_string()]),
@@ -840,7 +840,7 @@ async fn test_diagnostics(mut cx: gpui::TestAppContext) {
 
 #[gpui::test]
 async fn test_edits_from_lsp_with_past_version(mut cx: gpui::TestAppContext) {
-    let (language_server, mut fake) = lsp::LanguageServer::fake(&cx).await;
+    let (language_server, mut fake) = lsp::LanguageServer::fake(cx.background());
 
     let text = "
         fn a() {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -420,7 +420,9 @@ impl LanguageServer {
                 anyhow!("tried to send a request to a language server that has been shut down")
             })
             .and_then(|outbound_tx| {
-                outbound_tx.try_send(message)?;
+                outbound_tx
+                    .try_send(message)
+                    .context("failed to write to language server's stdin")?;
                 Ok(())
             });
         async move {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -312,7 +312,7 @@ impl Project {
                 languages,
                 user_store,
                 fs,
-                subscriptions: vec![client.add_model_for_remote_entity(cx.handle(), remote_id)],
+                subscriptions: vec![client.add_model_for_remote_entity(remote_id, cx)],
                 client,
                 client_state: ProjectClientState::Remote {
                     sharing_has_stopped: false,
@@ -349,10 +349,8 @@ impl Project {
 
         self.subscriptions.clear();
         if let Some(remote_id) = remote_id {
-            self.subscriptions.push(
-                self.client
-                    .add_model_for_remote_entity(cx.handle(), remote_id),
-            );
+            self.subscriptions
+                .push(self.client.add_model_for_remote_entity(remote_id, cx));
         }
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -161,6 +161,31 @@ pub struct ProjectEntry {
 }
 
 impl Project {
+    pub fn init(client: &Arc<Client>) {
+        client.add_entity_message_handler(Self::handle_add_collaborator);
+        client.add_entity_message_handler(Self::handle_buffer_reloaded);
+        client.add_entity_message_handler(Self::handle_buffer_saved);
+        client.add_entity_message_handler(Self::handle_close_buffer);
+        client.add_entity_message_handler(Self::handle_disk_based_diagnostics_updated);
+        client.add_entity_message_handler(Self::handle_disk_based_diagnostics_updating);
+        client.add_entity_message_handler(Self::handle_remove_collaborator);
+        client.add_entity_message_handler(Self::handle_share_worktree);
+        client.add_entity_message_handler(Self::handle_unregister_worktree);
+        client.add_entity_message_handler(Self::handle_unshare_project);
+        client.add_entity_message_handler(Self::handle_update_buffer_file);
+        client.add_entity_message_handler(Self::handle_update_buffer);
+        client.add_entity_message_handler(Self::handle_update_diagnostic_summary);
+        client.add_entity_message_handler(Self::handle_update_worktree);
+        client.add_entity_request_handler(Self::handle_apply_additional_edits_for_completion);
+        client.add_entity_request_handler(Self::handle_apply_code_action);
+        client.add_entity_request_handler(Self::handle_format_buffers);
+        client.add_entity_request_handler(Self::handle_get_code_actions);
+        client.add_entity_request_handler(Self::handle_get_completions);
+        client.add_entity_request_handler(Self::handle_get_definition);
+        client.add_entity_request_handler(Self::handle_open_buffer);
+        client.add_entity_request_handler(Self::handle_save_buffer);
+    }
+
     pub fn local(
         client: Arc<Client>,
         user_store: ModelHandle<UserStore>,
@@ -287,45 +312,7 @@ impl Project {
                 languages,
                 user_store,
                 fs,
-                subscriptions: vec![
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_unshare_project),
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_add_collaborator),
-                    client.add_entity_message_handler(
-                        remote_id,
-                        cx,
-                        Self::handle_remove_collaborator,
-                    ),
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_share_worktree),
-                    client.add_entity_message_handler(
-                        remote_id,
-                        cx,
-                        Self::handle_unregister_worktree,
-                    ),
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_update_worktree),
-                    client.add_entity_message_handler(
-                        remote_id,
-                        cx,
-                        Self::handle_update_diagnostic_summary,
-                    ),
-                    client.add_entity_message_handler(
-                        remote_id,
-                        cx,
-                        Self::handle_disk_based_diagnostics_updating,
-                    ),
-                    client.add_entity_message_handler(
-                        remote_id,
-                        cx,
-                        Self::handle_disk_based_diagnostics_updated,
-                    ),
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_update_buffer),
-                    client.add_entity_message_handler(
-                        remote_id,
-                        cx,
-                        Self::handle_update_buffer_file,
-                    ),
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_buffer_reloaded),
-                    client.add_entity_message_handler(remote_id, cx, Self::handle_buffer_saved),
-                ],
+                subscriptions: vec![client.add_model_for_remote_entity(cx.handle(), remote_id)],
                 client,
                 client_state: ProjectClientState::Remote {
                     sharing_has_stopped: false,
@@ -362,27 +349,10 @@ impl Project {
 
         self.subscriptions.clear();
         if let Some(remote_id) = remote_id {
-            let client = &self.client;
-            self.subscriptions.extend([
-                client.add_entity_request_handler(remote_id, cx, Self::handle_open_buffer),
-                client.add_entity_message_handler(remote_id, cx, Self::handle_close_buffer),
-                client.add_entity_message_handler(remote_id, cx, Self::handle_add_collaborator),
-                client.add_entity_message_handler(remote_id, cx, Self::handle_remove_collaborator),
-                client.add_entity_message_handler(remote_id, cx, Self::handle_update_worktree),
-                client.add_entity_message_handler(remote_id, cx, Self::handle_update_buffer),
-                client.add_entity_request_handler(remote_id, cx, Self::handle_save_buffer),
-                client.add_entity_message_handler(remote_id, cx, Self::handle_buffer_saved),
-                client.add_entity_request_handler(remote_id, cx, Self::handle_format_buffers),
-                client.add_entity_request_handler(remote_id, cx, Self::handle_get_completions),
-                client.add_entity_request_handler(
-                    remote_id,
-                    cx,
-                    Self::handle_apply_additional_edits_for_completion,
-                ),
-                client.add_entity_request_handler(remote_id, cx, Self::handle_get_code_actions),
-                client.add_entity_request_handler(remote_id, cx, Self::handle_apply_code_action),
-                client.add_entity_request_handler(remote_id, cx, Self::handle_get_definition),
-            ]);
+            self.subscriptions.push(
+                self.client
+                    .add_model_for_remote_entity(cx.handle(), remote_id),
+            );
         }
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -351,6 +351,10 @@ impl Project {
         cx.update(|cx| Project::local(client, user_store, languages, fs, cx))
     }
 
+    pub fn fs(&self) -> &Arc<dyn Fs> {
+        &self.fs
+    }
+
     fn set_remote_id(&mut self, remote_id: Option<u64>, cx: &mut ModelContext<Self>) {
         if let ProjectClientState::Local { remote_id_tx, .. } = &mut self.client_state {
             *remote_id_tx.borrow_mut() = remote_id;

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1580,6 +1580,7 @@ impl Project {
         } else if let Some(project_id) = self.remote_id() {
             let rpc = self.client.clone();
             cx.foreground().spawn(async move {
+                let _buffer = buffer_handle.clone();
                 let response = rpc
                     .request(proto::GetCodeActions {
                         project_id,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -344,6 +344,11 @@ impl Project {
         cx.update(|cx| Project::local(client, user_store, languages, fs, cx))
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn shared_buffer(&self, peer_id: PeerId, remote_id: u64) -> Option<ModelHandle<Buffer>> {
+        Some(self.shared_buffers.get(&peer_id)?.get(&remote_id)?.clone())
+    }
+
     pub fn fs(&self) -> &Arc<dyn Fs> {
         &self.fs
     }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1404,6 +1404,7 @@ impl language::File for File {
                         .request(proto::SaveBuffer {
                             project_id,
                             buffer_id,
+                            version: (&version).into(),
                         })
                         .await?;
                     let version = response.version.try_into()?;

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1354,7 +1354,9 @@ impl language::File for File {
     fn full_path(&self, cx: &AppContext) -> PathBuf {
         let mut full_path = PathBuf::new();
         full_path.push(self.worktree.read(cx).root_name());
-        full_path.push(&self.path);
+        if self.path.components().next().is_some() {
+            full_path.push(&self.path);
+        }
         full_path
     }
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -869,6 +869,10 @@ impl RemoteWorktree {
         Ok(())
     }
 
+    pub fn has_pending_updates(&self) -> bool {
+        !self.pending_updates.is_empty()
+    }
+
     pub fn update_diagnostic_summary(
         &mut self,
         path: Arc<Path>,

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -88,7 +88,7 @@ pub struct RemoteWorktree {
     pending_updates: VecDeque<proto::UpdateWorktree>,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct Snapshot {
     id: WorktreeId,
     root_name: String,
@@ -1668,7 +1668,7 @@ impl sum_tree::Summary for EntrySummary {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 struct PathEntry {
     id: usize,
     path: Arc<Path>,

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -9,62 +9,63 @@ message Envelope {
         Ack ack = 4;
         Error error = 5;
         Ping ping = 6;
+        Test test = 7;
 
-        RegisterProject register_project = 7;
-        RegisterProjectResponse register_project_response = 8;
-        UnregisterProject unregister_project = 9;
-        ShareProject share_project = 10;
-        UnshareProject unshare_project = 11;
-        JoinProject join_project = 12;
-        JoinProjectResponse join_project_response = 13;
-        LeaveProject leave_project = 14;
-        AddProjectCollaborator add_project_collaborator = 15;
-        RemoveProjectCollaborator remove_project_collaborator = 16;
-        GetDefinition get_definition = 17;
-        GetDefinitionResponse get_definition_response = 18;
+        RegisterProject register_project = 8;
+        RegisterProjectResponse register_project_response = 9;
+        UnregisterProject unregister_project = 10;
+        ShareProject share_project = 11;
+        UnshareProject unshare_project = 12;
+        JoinProject join_project = 13;
+        JoinProjectResponse join_project_response = 14;
+        LeaveProject leave_project = 15;
+        AddProjectCollaborator add_project_collaborator = 16;
+        RemoveProjectCollaborator remove_project_collaborator = 17;
+        GetDefinition get_definition = 18;
+        GetDefinitionResponse get_definition_response = 19;
 
-        RegisterWorktree register_worktree = 19;
-        UnregisterWorktree unregister_worktree = 20;
-        ShareWorktree share_worktree = 21;
-        UpdateWorktree update_worktree = 22;
-        UpdateDiagnosticSummary update_diagnostic_summary = 23;
-        DiskBasedDiagnosticsUpdating disk_based_diagnostics_updating = 24;
-        DiskBasedDiagnosticsUpdated disk_based_diagnostics_updated = 25;
+        RegisterWorktree register_worktree = 20;
+        UnregisterWorktree unregister_worktree = 21;
+        ShareWorktree share_worktree = 22;
+        UpdateWorktree update_worktree = 23;
+        UpdateDiagnosticSummary update_diagnostic_summary = 24;
+        DiskBasedDiagnosticsUpdating disk_based_diagnostics_updating = 25;
+        DiskBasedDiagnosticsUpdated disk_based_diagnostics_updated = 26;
 
-        OpenBuffer open_buffer = 26;
-        OpenBufferResponse open_buffer_response = 27;
-        CloseBuffer close_buffer = 28;
-        UpdateBuffer update_buffer = 29;
-        UpdateBufferFile update_buffer_file = 30;
-        SaveBuffer save_buffer = 31;
-        BufferSaved buffer_saved = 32;
-        BufferReloaded buffer_reloaded = 33;
-        FormatBuffers format_buffers = 34;
-        FormatBuffersResponse format_buffers_response = 35;
-        GetCompletions get_completions = 36;
-        GetCompletionsResponse get_completions_response = 37;
-        ApplyCompletionAdditionalEdits apply_completion_additional_edits = 38;
-        ApplyCompletionAdditionalEditsResponse apply_completion_additional_edits_response = 39;
-        GetCodeActions get_code_actions = 40;
-        GetCodeActionsResponse get_code_actions_response = 41;
-        ApplyCodeAction apply_code_action = 42;
-        ApplyCodeActionResponse apply_code_action_response = 43;
+        OpenBuffer open_buffer = 27;
+        OpenBufferResponse open_buffer_response = 28;
+        CloseBuffer close_buffer = 29;
+        UpdateBuffer update_buffer = 30;
+        UpdateBufferFile update_buffer_file = 31;
+        SaveBuffer save_buffer = 32;
+        BufferSaved buffer_saved = 33;
+        BufferReloaded buffer_reloaded = 34;
+        FormatBuffers format_buffers = 35;
+        FormatBuffersResponse format_buffers_response = 36;
+        GetCompletions get_completions = 37;
+        GetCompletionsResponse get_completions_response = 38;
+        ApplyCompletionAdditionalEdits apply_completion_additional_edits = 39;
+        ApplyCompletionAdditionalEditsResponse apply_completion_additional_edits_response = 40;
+        GetCodeActions get_code_actions = 41;
+        GetCodeActionsResponse get_code_actions_response = 42;
+        ApplyCodeAction apply_code_action = 43;
+        ApplyCodeActionResponse apply_code_action_response = 44;
 
-        GetChannels get_channels = 44;
-        GetChannelsResponse get_channels_response = 45;
-        JoinChannel join_channel = 46;
-        JoinChannelResponse join_channel_response = 47;
-        LeaveChannel leave_channel = 48;
-        SendChannelMessage send_channel_message = 49;
-        SendChannelMessageResponse send_channel_message_response = 50;
-        ChannelMessageSent channel_message_sent = 51;
-        GetChannelMessages get_channel_messages = 52;
-        GetChannelMessagesResponse get_channel_messages_response = 53;
+        GetChannels get_channels = 45;
+        GetChannelsResponse get_channels_response = 46;
+        JoinChannel join_channel = 47;
+        JoinChannelResponse join_channel_response = 48;
+        LeaveChannel leave_channel = 49;
+        SendChannelMessage send_channel_message = 50;
+        SendChannelMessageResponse send_channel_message_response = 51;
+        ChannelMessageSent channel_message_sent = 52;
+        GetChannelMessages get_channel_messages = 53;
+        GetChannelMessagesResponse get_channel_messages_response = 54;
 
-        UpdateContacts update_contacts = 54;
+        UpdateContacts update_contacts = 55;
 
-        GetUsers get_users = 55;
-        GetUsersResponse get_users_response = 56;
+        GetUsers get_users = 56;
+        GetUsersResponse get_users_response = 57;
     }
 }
 
@@ -76,6 +77,10 @@ message Ack {}
 
 message Error {
     string message = 1;
+}
+
+message Test {
+    uint64 id = 1;
 }
 
 message RegisterProject {}

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -261,6 +261,7 @@ message GetCodeActions {
 
 message GetCodeActionsResponse {
     repeated CodeAction actions = 1;
+    repeated VectorClockEntry version = 2;
 }
 
 message ApplyCodeAction {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -222,10 +222,12 @@ message GetCompletions {
     uint64 project_id = 1;
     uint64 buffer_id = 2;
     Anchor position = 3;
+    repeated VectorClockEntry version = 4;
 }
 
 message GetCompletionsResponse {
     repeated Completion completions = 1;
+    repeated VectorClockEntry version = 2;
 }
 
 message ApplyCompletionAdditionalEdits {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -192,6 +192,7 @@ message UpdateBufferFile {
 message SaveBuffer {
     uint64 project_id = 1;
     uint64 buffer_id = 2;
+    repeated VectorClockEntry version = 3;
 }
 
 message BufferSaved {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -128,11 +128,12 @@ message ShareWorktree {
 }
 
 message UpdateWorktree {
-    uint64 project_id = 1;
-    uint64 worktree_id = 2;
-    string root_name = 3;
-    repeated Entry updated_entries = 4;
-    repeated uint64 removed_entries = 5;
+    uint64 id = 1;
+    uint64 project_id = 2;
+    uint64 worktree_id = 3;
+    string root_name = 4;
+    repeated Entry updated_entries = 5;
+    repeated uint64 removed_entries = 6;
 }
 
 message AddProjectCollaborator {
@@ -386,6 +387,7 @@ message Worktree {
     repeated Entry entries = 3;
     repeated DiagnosticSummary diagnostic_summaries = 4;
     bool weak = 5;
+    uint64 next_update_id = 6;
 }
 
 message File {

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -5,7 +5,7 @@ use futures::stream::BoxStream;
 use futures::{FutureExt as _, StreamExt};
 use parking_lot::{Mutex, RwLock};
 use postage::{
-    mpsc,
+    barrier, mpsc,
     prelude::{Sink as _, Stream as _},
 };
 use smol_timeout::TimeoutExt as _;
@@ -91,7 +91,8 @@ pub struct Peer {
 pub struct ConnectionState {
     outgoing_tx: futures::channel::mpsc::UnboundedSender<proto::Envelope>,
     next_message_id: Arc<AtomicU32>,
-    response_channels: Arc<Mutex<Option<HashMap<u32, mpsc::Sender<proto::Envelope>>>>>,
+    response_channels:
+        Arc<Mutex<Option<HashMap<u32, mpsc::Sender<(proto::Envelope, barrier::Sender)>>>>>,
 }
 
 const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -177,12 +178,18 @@ impl Peer {
                 if let Some(responding_to) = incoming.responding_to {
                     let channel = response_channels.lock().as_mut()?.remove(&responding_to);
                     if let Some(mut tx) = channel {
-                        if let Err(error) = tx.send(incoming).await {
+                        let mut requester_resumed = barrier::channel();
+                        if let Err(error) = tx.send((incoming, requester_resumed.0)).await {
                             log::debug!(
                                 "received RPC but request future was dropped {:?}",
-                                error.0
+                                error.0 .0
                             );
                         }
+                        // Drop response channel before awaiting on the barrier. This allows the
+                        // barrier to get dropped even if the request's future is dropped before it
+                        // has a chance to observe the response.
+                        drop(tx);
+                        requester_resumed.1.recv().await;
                     } else {
                         log::warn!("received RPC response to unknown request {}", responding_to);
                     }
@@ -253,7 +260,7 @@ impl Peer {
         });
         async move {
             send?;
-            let response = rx
+            let (response, _barrier) = rx
                 .recv()
                 .await
                 .ok_or_else(|| anyhow!("connection was closed"))?;

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -265,7 +265,7 @@ impl Peer {
                 .await
                 .ok_or_else(|| anyhow!("connection was closed"))?;
             if let Some(proto::envelope::Payload::Error(error)) = &response.payload {
-                Err(anyhow!("request failed").context(error.message.clone()))
+                Err(anyhow!("RPC request failed - {}", error.message))
             } else {
                 T::Response::from_envelope(response)
                     .ok_or_else(|| anyhow!("received response of the wrong type"))

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -199,6 +199,7 @@ request_messages!(
     (ShareProject, Ack),
     (ShareWorktree, Ack),
     (UpdateBuffer, Ack),
+    (UpdateWorktree, Ack),
 );
 
 entity_messages!(

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -165,6 +165,7 @@ messages!(
     SendChannelMessageResponse,
     ShareProject,
     ShareWorktree,
+    Test,
     UnregisterProject,
     UnregisterWorktree,
     UnshareProject,
@@ -198,6 +199,7 @@ request_messages!(
     (SendChannelMessage, SendChannelMessageResponse),
     (ShareProject, Ack),
     (ShareWorktree, Ack),
+    (Test, Test),
     (UpdateBuffer, Ack),
     (UpdateWorktree, Ack),
 );

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -15,7 +15,6 @@ required-features = ["seed-support"]
 [dependencies]
 collections = { path = "../collections" }
 rpc = { path = "../rpc" }
-
 anyhow = "1.0.40"
 async-std = { version = "1.8.0", features = ["attributes"] }
 async-trait = "0.1.50"
@@ -57,12 +56,12 @@ features = ["runtime-async-std-rustls", "postgres", "time", "uuid"]
 
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
-gpui = { path = "../gpui" }
+gpui = { path = "../gpui", features = ["test-support"] }
+rpc = { path = "../rpc", features = ["test-support"] }
 zed = { path = "../zed", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"
 util = { path = "../util" }
-
 lazy_static = "1.4"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -111,7 +111,7 @@ async fn create_access_token(request: Request) -> tide::Result {
         .get_user_by_github_login(request.param("github_login")?)
         .await?
         .ok_or_else(|| surf::Error::from_str(StatusCode::NotFound, "user not found"))?;
-    let access_token = auth::create_access_token(request.db(), user.id).await?;
+    let access_token = auth::create_access_token(request.db().as_ref(), user.id).await?;
 
     #[derive(Deserialize)]
     struct QueryParams {

--- a/crates/server/src/db.rs
+++ b/crates/server/src/db.rs
@@ -1,11 +1,12 @@
 use anyhow::Context;
-use async_std::task::{block_on, yield_now};
-use serde::Serialize;
-use sqlx::{types::Uuid, FromRow, Result};
-use time::OffsetDateTime;
-
+use anyhow::Result;
 pub use async_sqlx_session::PostgresSessionStore as SessionStore;
+use async_std::task::{block_on, yield_now};
+use async_trait::async_trait;
+use serde::Serialize;
 pub use sqlx::postgres::PgPoolOptions as DbOptions;
+use sqlx::{types::Uuid, FromRow};
+use time::OffsetDateTime;
 
 macro_rules! test_support {
     ($self:ident, { $($token:tt)* }) => {{
@@ -21,13 +22,77 @@ macro_rules! test_support {
     }};
 }
 
-#[derive(Clone)]
-pub struct Db {
+#[async_trait]
+pub trait Db: Send + Sync {
+    async fn create_signup(
+        &self,
+        github_login: &str,
+        email_address: &str,
+        about: &str,
+        wants_releases: bool,
+        wants_updates: bool,
+        wants_community: bool,
+    ) -> Result<SignupId>;
+    async fn get_all_signups(&self) -> Result<Vec<Signup>>;
+    async fn destroy_signup(&self, id: SignupId) -> Result<()>;
+    async fn create_user(&self, github_login: &str, admin: bool) -> Result<UserId>;
+    async fn get_all_users(&self) -> Result<Vec<User>>;
+    async fn get_user_by_id(&self, id: UserId) -> Result<Option<User>>;
+    async fn get_users_by_ids(&self, ids: Vec<UserId>) -> Result<Vec<User>>;
+    async fn get_user_by_github_login(&self, github_login: &str) -> Result<Option<User>>;
+    async fn set_user_is_admin(&self, id: UserId, is_admin: bool) -> Result<()>;
+    async fn destroy_user(&self, id: UserId) -> Result<()>;
+    async fn create_access_token_hash(
+        &self,
+        user_id: UserId,
+        access_token_hash: &str,
+        max_access_token_count: usize,
+    ) -> Result<()>;
+    async fn get_access_token_hashes(&self, user_id: UserId) -> Result<Vec<String>>;
+    #[cfg(any(test, feature = "seed-support"))]
+    async fn find_org_by_slug(&self, slug: &str) -> Result<Option<Org>>;
+    #[cfg(any(test, feature = "seed-support"))]
+    async fn create_org(&self, name: &str, slug: &str) -> Result<OrgId>;
+    #[cfg(any(test, feature = "seed-support"))]
+    async fn add_org_member(&self, org_id: OrgId, user_id: UserId, is_admin: bool) -> Result<()>;
+    #[cfg(any(test, feature = "seed-support"))]
+    async fn create_org_channel(&self, org_id: OrgId, name: &str) -> Result<ChannelId>;
+    #[cfg(any(test, feature = "seed-support"))]
+    async fn get_org_channels(&self, org_id: OrgId) -> Result<Vec<Channel>>;
+    async fn get_accessible_channels(&self, user_id: UserId) -> Result<Vec<Channel>>;
+    async fn can_user_access_channel(&self, user_id: UserId, channel_id: ChannelId)
+        -> Result<bool>;
+    #[cfg(any(test, feature = "seed-support"))]
+    async fn add_channel_member(
+        &self,
+        channel_id: ChannelId,
+        user_id: UserId,
+        is_admin: bool,
+    ) -> Result<()>;
+    async fn create_channel_message(
+        &self,
+        channel_id: ChannelId,
+        sender_id: UserId,
+        body: &str,
+        timestamp: OffsetDateTime,
+        nonce: u128,
+    ) -> Result<MessageId>;
+    async fn get_channel_messages(
+        &self,
+        channel_id: ChannelId,
+        count: usize,
+        before_id: Option<MessageId>,
+    ) -> Result<Vec<ChannelMessage>>;
+    #[cfg(test)]
+    async fn teardown(&self, name: &str, url: &str);
+}
+
+pub struct PostgresDb {
     pool: sqlx::PgPool,
     test_mode: bool,
 }
 
-impl Db {
+impl PostgresDb {
     pub async fn new(url: &str, max_connections: u32) -> tide::Result<Self> {
         let pool = DbOptions::new()
             .max_connections(max_connections)
@@ -39,10 +104,12 @@ impl Db {
             test_mode: false,
         })
     }
+}
 
+#[async_trait]
+impl Db for PostgresDb {
     // signups
-
-    pub async fn create_signup(
+    async fn create_signup(
         &self,
         github_login: &str,
         email_address: &str,
@@ -64,7 +131,7 @@ impl Db {
                 VALUES ($1, $2, $3, $4, $5, $6)
                 RETURNING id
             ";
-            sqlx::query_scalar(query)
+            Ok(sqlx::query_scalar(query)
                 .bind(github_login)
                 .bind(email_address)
                 .bind(about)
@@ -73,31 +140,31 @@ impl Db {
                 .bind(wants_community)
                 .fetch_one(&self.pool)
                 .await
-                .map(SignupId)
+                .map(SignupId)?)
         })
     }
 
-    pub async fn get_all_signups(&self) -> Result<Vec<Signup>> {
+    async fn get_all_signups(&self) -> Result<Vec<Signup>> {
         test_support!(self, {
             let query = "SELECT * FROM signups ORDER BY github_login ASC";
-            sqlx::query_as(query).fetch_all(&self.pool).await
+            Ok(sqlx::query_as(query).fetch_all(&self.pool).await?)
         })
     }
 
-    pub async fn destroy_signup(&self, id: SignupId) -> Result<()> {
+    async fn destroy_signup(&self, id: SignupId) -> Result<()> {
         test_support!(self, {
             let query = "DELETE FROM signups WHERE id = $1";
-            sqlx::query(query)
+            Ok(sqlx::query(query)
                 .bind(id.0)
                 .execute(&self.pool)
                 .await
-                .map(drop)
+                .map(drop)?)
         })
     }
 
     // users
 
-    pub async fn create_user(&self, github_login: &str, admin: bool) -> Result<UserId> {
+    async fn create_user(&self, github_login: &str, admin: bool) -> Result<UserId> {
         test_support!(self, {
             let query = "
                 INSERT INTO users (github_login, admin)
@@ -105,31 +172,28 @@ impl Db {
                 ON CONFLICT (github_login) DO UPDATE SET github_login = excluded.github_login
                 RETURNING id
             ";
-            sqlx::query_scalar(query)
+            Ok(sqlx::query_scalar(query)
                 .bind(github_login)
                 .bind(admin)
                 .fetch_one(&self.pool)
                 .await
-                .map(UserId)
+                .map(UserId)?)
         })
     }
 
-    pub async fn get_all_users(&self) -> Result<Vec<User>> {
+    async fn get_all_users(&self) -> Result<Vec<User>> {
         test_support!(self, {
             let query = "SELECT * FROM users ORDER BY github_login ASC";
-            sqlx::query_as(query).fetch_all(&self.pool).await
+            Ok(sqlx::query_as(query).fetch_all(&self.pool).await?)
         })
     }
 
-    pub async fn get_user_by_id(&self, id: UserId) -> Result<Option<User>> {
-        let users = self.get_users_by_ids([id]).await?;
+    async fn get_user_by_id(&self, id: UserId) -> Result<Option<User>> {
+        let users = self.get_users_by_ids(vec![id]).await?;
         Ok(users.into_iter().next())
     }
 
-    pub async fn get_users_by_ids(
-        &self,
-        ids: impl IntoIterator<Item = UserId>,
-    ) -> Result<Vec<User>> {
+    async fn get_users_by_ids(&self, ids: Vec<UserId>) -> Result<Vec<User>> {
         let ids = ids.into_iter().map(|id| id.0).collect::<Vec<_>>();
         test_support!(self, {
             let query = "
@@ -138,33 +202,36 @@ impl Db {
                 WHERE users.id = ANY ($1)
             ";
 
-            sqlx::query_as(query).bind(&ids).fetch_all(&self.pool).await
+            Ok(sqlx::query_as(query)
+                .bind(&ids)
+                .fetch_all(&self.pool)
+                .await?)
         })
     }
 
-    pub async fn get_user_by_github_login(&self, github_login: &str) -> Result<Option<User>> {
+    async fn get_user_by_github_login(&self, github_login: &str) -> Result<Option<User>> {
         test_support!(self, {
             let query = "SELECT * FROM users WHERE github_login = $1 LIMIT 1";
-            sqlx::query_as(query)
+            Ok(sqlx::query_as(query)
                 .bind(github_login)
                 .fetch_optional(&self.pool)
-                .await
+                .await?)
         })
     }
 
-    pub async fn set_user_is_admin(&self, id: UserId, is_admin: bool) -> Result<()> {
+    async fn set_user_is_admin(&self, id: UserId, is_admin: bool) -> Result<()> {
         test_support!(self, {
             let query = "UPDATE users SET admin = $1 WHERE id = $2";
-            sqlx::query(query)
+            Ok(sqlx::query(query)
                 .bind(is_admin)
                 .bind(id.0)
                 .execute(&self.pool)
                 .await
-                .map(drop)
+                .map(drop)?)
         })
     }
 
-    pub async fn destroy_user(&self, id: UserId) -> Result<()> {
+    async fn destroy_user(&self, id: UserId) -> Result<()> {
         test_support!(self, {
             let query = "DELETE FROM access_tokens WHERE user_id = $1;";
             sqlx::query(query)
@@ -173,17 +240,17 @@ impl Db {
                 .await
                 .map(drop)?;
             let query = "DELETE FROM users WHERE id = $1;";
-            sqlx::query(query)
+            Ok(sqlx::query(query)
                 .bind(id.0)
                 .execute(&self.pool)
                 .await
-                .map(drop)
+                .map(drop)?)
         })
     }
 
     // access tokens
 
-    pub async fn create_access_token_hash(
+    async fn create_access_token_hash(
         &self,
         user_id: UserId,
         access_token_hash: &str,
@@ -216,11 +283,11 @@ impl Db {
                 .bind(max_access_token_count as u32)
                 .execute(&mut tx)
                 .await?;
-            tx.commit().await
+            Ok(tx.commit().await?)
         })
     }
 
-    pub async fn get_access_token_hashes(&self, user_id: UserId) -> Result<Vec<String>> {
+    async fn get_access_token_hashes(&self, user_id: UserId) -> Result<Vec<String>> {
         test_support!(self, {
             let query = "
                 SELECT hash
@@ -228,10 +295,10 @@ impl Db {
                 WHERE user_id = $1
                 ORDER BY id DESC
             ";
-            sqlx::query_scalar(query)
+            Ok(sqlx::query_scalar(query)
                 .bind(user_id.0)
                 .fetch_all(&self.pool)
-                .await
+                .await?)
         })
     }
 
@@ -239,82 +306,77 @@ impl Db {
 
     #[allow(unused)] // Help rust-analyzer
     #[cfg(any(test, feature = "seed-support"))]
-    pub async fn find_org_by_slug(&self, slug: &str) -> Result<Option<Org>> {
+    async fn find_org_by_slug(&self, slug: &str) -> Result<Option<Org>> {
         test_support!(self, {
             let query = "
                 SELECT *
                 FROM orgs
                 WHERE slug = $1
             ";
-            sqlx::query_as(query)
+            Ok(sqlx::query_as(query)
                 .bind(slug)
                 .fetch_optional(&self.pool)
-                .await
+                .await?)
         })
     }
 
     #[cfg(any(test, feature = "seed-support"))]
-    pub async fn create_org(&self, name: &str, slug: &str) -> Result<OrgId> {
+    async fn create_org(&self, name: &str, slug: &str) -> Result<OrgId> {
         test_support!(self, {
             let query = "
                 INSERT INTO orgs (name, slug)
                 VALUES ($1, $2)
                 RETURNING id
             ";
-            sqlx::query_scalar(query)
+            Ok(sqlx::query_scalar(query)
                 .bind(name)
                 .bind(slug)
                 .fetch_one(&self.pool)
                 .await
-                .map(OrgId)
+                .map(OrgId)?)
         })
     }
 
     #[cfg(any(test, feature = "seed-support"))]
-    pub async fn add_org_member(
-        &self,
-        org_id: OrgId,
-        user_id: UserId,
-        is_admin: bool,
-    ) -> Result<()> {
+    async fn add_org_member(&self, org_id: OrgId, user_id: UserId, is_admin: bool) -> Result<()> {
         test_support!(self, {
             let query = "
                 INSERT INTO org_memberships (org_id, user_id, admin)
                 VALUES ($1, $2, $3)
                 ON CONFLICT DO NOTHING
             ";
-            sqlx::query(query)
+            Ok(sqlx::query(query)
                 .bind(org_id.0)
                 .bind(user_id.0)
                 .bind(is_admin)
                 .execute(&self.pool)
                 .await
-                .map(drop)
+                .map(drop)?)
         })
     }
 
     // channels
 
     #[cfg(any(test, feature = "seed-support"))]
-    pub async fn create_org_channel(&self, org_id: OrgId, name: &str) -> Result<ChannelId> {
+    async fn create_org_channel(&self, org_id: OrgId, name: &str) -> Result<ChannelId> {
         test_support!(self, {
             let query = "
                 INSERT INTO channels (owner_id, owner_is_user, name)
                 VALUES ($1, false, $2)
                 RETURNING id
             ";
-            sqlx::query_scalar(query)
+            Ok(sqlx::query_scalar(query)
                 .bind(org_id.0)
                 .bind(name)
                 .fetch_one(&self.pool)
                 .await
-                .map(ChannelId)
+                .map(ChannelId)?)
         })
     }
 
     #[allow(unused)] // Help rust-analyzer
     #[cfg(any(test, feature = "seed-support"))]
-    pub async fn get_org_channels(&self, org_id: OrgId) -> Result<Vec<Channel>> {
+    async fn get_org_channels(&self, org_id: OrgId) -> Result<Vec<Channel>> {
         test_support!(self, {
             let query = "
                 SELECT *
@@ -323,32 +385,32 @@ impl Db {
                     channels.owner_is_user = false AND
                     channels.owner_id = $1
             ";
-            sqlx::query_as(query)
+            Ok(sqlx::query_as(query)
                 .bind(org_id.0)
                 .fetch_all(&self.pool)
-                .await
+                .await?)
         })
     }
 
-    pub async fn get_accessible_channels(&self, user_id: UserId) -> Result<Vec<Channel>> {
+    async fn get_accessible_channels(&self, user_id: UserId) -> Result<Vec<Channel>> {
         test_support!(self, {
             let query = "
                 SELECT
-                    channels.id, channels.name
+                    channels.*
                 FROM
                     channel_memberships, channels
                 WHERE
                     channel_memberships.user_id = $1 AND
                     channel_memberships.channel_id = channels.id
             ";
-            sqlx::query_as(query)
+            Ok(sqlx::query_as(query)
                 .bind(user_id.0)
                 .fetch_all(&self.pool)
-                .await
+                .await?)
         })
     }
 
-    pub async fn can_user_access_channel(
+    async fn can_user_access_channel(
         &self,
         user_id: UserId,
         channel_id: ChannelId,
@@ -360,17 +422,17 @@ impl Db {
                 WHERE user_id = $1 AND channel_id = $2
                 LIMIT 1
             ";
-            sqlx::query_scalar::<_, i32>(query)
+            Ok(sqlx::query_scalar::<_, i32>(query)
                 .bind(user_id.0)
                 .bind(channel_id.0)
                 .fetch_optional(&self.pool)
                 .await
-                .map(|e| e.is_some())
+                .map(|e| e.is_some())?)
         })
     }
 
     #[cfg(any(test, feature = "seed-support"))]
-    pub async fn add_channel_member(
+    async fn add_channel_member(
         &self,
         channel_id: ChannelId,
         user_id: UserId,
@@ -382,19 +444,19 @@ impl Db {
                 VALUES ($1, $2, $3)
                 ON CONFLICT DO NOTHING
             ";
-            sqlx::query(query)
+            Ok(sqlx::query(query)
                 .bind(channel_id.0)
                 .bind(user_id.0)
                 .bind(is_admin)
                 .execute(&self.pool)
                 .await
-                .map(drop)
+                .map(drop)?)
         })
     }
 
     // messages
 
-    pub async fn create_channel_message(
+    async fn create_channel_message(
         &self,
         channel_id: ChannelId,
         sender_id: UserId,
@@ -409,7 +471,7 @@ impl Db {
                 ON CONFLICT (nonce) DO UPDATE SET nonce = excluded.nonce
                 RETURNING id
             ";
-            sqlx::query_scalar(query)
+            Ok(sqlx::query_scalar(query)
                 .bind(channel_id.0)
                 .bind(sender_id.0)
                 .bind(body)
@@ -417,11 +479,11 @@ impl Db {
                 .bind(Uuid::from_u128(nonce))
                 .fetch_one(&self.pool)
                 .await
-                .map(MessageId)
+                .map(MessageId)?)
         })
     }
 
-    pub async fn get_channel_messages(
+    async fn get_channel_messages(
         &self,
         channel_id: ChannelId,
         count: usize,
@@ -431,7 +493,7 @@ impl Db {
             let query = r#"
                 SELECT * FROM (
                     SELECT
-                        id, sender_id, body, sent_at AT TIME ZONE 'UTC' as sent_at, nonce
+                        id, channel_id, sender_id, body, sent_at AT TIME ZONE 'UTC' as sent_at, nonce
                     FROM
                         channel_messages
                     WHERE
@@ -442,12 +504,34 @@ impl Db {
                 ) as recent_messages
                 ORDER BY id ASC
             "#;
-            sqlx::query_as(query)
+            Ok(sqlx::query_as(query)
                 .bind(channel_id.0)
                 .bind(before_id.unwrap_or(MessageId::MAX))
                 .bind(count as i64)
                 .fetch_all(&self.pool)
+                .await?)
+        })
+    }
+
+    #[cfg(test)]
+    async fn teardown(&self, name: &str, url: &str) {
+        use util::ResultExt;
+
+        test_support!(self, {
+            let query = "
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE pg_stat_activity.datname = '{}' AND pid <> pg_backend_pid();
+            ";
+            sqlx::query(query)
+                .bind(name)
+                .execute(&self.pool)
                 .await
+                .log_err();
+            self.pool.close().await;
+            <sqlx::Postgres as sqlx::migrate::MigrateDatabase>::drop_database(url)
+                .await
+                .log_err();
         })
     }
 }
@@ -479,7 +563,7 @@ macro_rules! id_type {
 }
 
 id_type!(UserId);
-#[derive(Debug, FromRow, Serialize, PartialEq)]
+#[derive(Clone, Debug, FromRow, Serialize, PartialEq)]
 pub struct User {
     pub id: UserId,
     pub github_login: String,
@@ -507,16 +591,19 @@ pub struct Signup {
 }
 
 id_type!(ChannelId);
-#[derive(Debug, FromRow, Serialize)]
+#[derive(Clone, Debug, FromRow, Serialize)]
 pub struct Channel {
     pub id: ChannelId,
     pub name: String,
+    pub owner_id: i32,
+    pub owner_is_user: bool,
 }
 
 id_type!(MessageId);
-#[derive(Debug, FromRow)]
+#[derive(Clone, Debug, FromRow)]
 pub struct ChannelMessage {
     pub id: MessageId,
+    pub channel_id: ChannelId,
     pub sender_id: UserId,
     pub body: String,
     pub sent_at: OffsetDateTime,
@@ -526,6 +613,9 @@ pub struct ChannelMessage {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use anyhow::anyhow;
+    use collections::BTreeMap;
+    use gpui::{executor::Background, TestAppContext};
     use lazy_static::lazy_static;
     use parking_lot::Mutex;
     use rand::prelude::*;
@@ -533,227 +623,119 @@ pub mod tests {
         migrate::{MigrateDatabase, Migrator},
         Postgres,
     };
-    use std::{
-        mem,
-        path::Path,
-        sync::atomic::{AtomicUsize, Ordering::SeqCst},
-        thread,
-    };
-    use util::ResultExt as _;
+    use std::{path::Path, sync::Arc};
+    use util::post_inc;
 
-    pub struct TestDb {
-        pub db: Option<Db>,
-        pub name: String,
-        pub url: String,
-        clean_pool_on_drop: bool,
-    }
+    #[gpui::test]
+    async fn test_get_users_by_ids(cx: TestAppContext) {
+        for test_db in [TestDb::postgres(), TestDb::fake(cx.background())] {
+            let db = test_db.db();
 
-    lazy_static! {
-        static ref DB_POOL: Mutex<Vec<TestDb>> = Default::default();
-        static ref DB_COUNT: AtomicUsize = Default::default();
-    }
+            let user = db.create_user("user", false).await.unwrap();
+            let friend1 = db.create_user("friend-1", false).await.unwrap();
+            let friend2 = db.create_user("friend-2", false).await.unwrap();
+            let friend3 = db.create_user("friend-3", false).await.unwrap();
 
-    impl TestDb {
-        pub fn new() -> Self {
-            DB_COUNT.fetch_add(1, SeqCst);
-            let mut pool = DB_POOL.lock();
-            if let Some(db) = pool.pop() {
-                db.truncate();
-                db
-            } else {
-                let mut rng = StdRng::from_entropy();
-                let name = format!("zed-test-{}", rng.gen::<u128>());
-                let url = format!("postgres://postgres@localhost/{}", name);
-                let migrations_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"));
-                let db = block_on(async {
-                    Postgres::create_database(&url)
-                        .await
-                        .expect("failed to create test db");
-                    let mut db = Db::new(&url, 5).await.unwrap();
-                    db.test_mode = true;
-                    let migrator = Migrator::new(migrations_path).await.unwrap();
-                    migrator.run(&db.pool).await.unwrap();
-                    db
-                });
-
-                Self {
-                    db: Some(db),
-                    name,
-                    url,
-                    clean_pool_on_drop: false,
-                }
-            }
-        }
-
-        pub fn set_clean_pool_on_drop(&mut self, delete_on_drop: bool) {
-            self.clean_pool_on_drop = delete_on_drop;
-        }
-
-        pub fn db(&self) -> &Db {
-            self.db.as_ref().unwrap()
-        }
-
-        fn truncate(&self) {
-            block_on(async {
-                let query = "
-                    SELECT tablename FROM pg_tables
-                    WHERE schemaname = 'public';
-                ";
-                let table_names = sqlx::query_scalar::<_, String>(query)
-                    .fetch_all(&self.db().pool)
+            assert_eq!(
+                db.get_users_by_ids(vec![user, friend1, friend2, friend3])
                     .await
-                    .unwrap();
-                sqlx::query(&format!(
-                    "TRUNCATE TABLE {} RESTART IDENTITY",
-                    table_names.join(", ")
-                ))
-                .execute(&self.db().pool)
-                .await
-                .unwrap();
-            })
-        }
-
-        async fn teardown(mut self) -> Result<()> {
-            let db = self.db.take().unwrap();
-            let query = "
-                SELECT pg_terminate_backend(pg_stat_activity.pid)
-                FROM pg_stat_activity
-                WHERE pg_stat_activity.datname = '{}' AND pid <> pg_backend_pid();
-            ";
-            sqlx::query(query)
-                .bind(&self.name)
-                .execute(&db.pool)
-                .await?;
-            db.pool.close().await;
-            Postgres::drop_database(&self.url).await?;
-            Ok(())
+                    .unwrap(),
+                vec![
+                    User {
+                        id: user,
+                        github_login: "user".to_string(),
+                        admin: false,
+                    },
+                    User {
+                        id: friend1,
+                        github_login: "friend-1".to_string(),
+                        admin: false,
+                    },
+                    User {
+                        id: friend2,
+                        github_login: "friend-2".to_string(),
+                        admin: false,
+                    },
+                    User {
+                        id: friend3,
+                        github_login: "friend-3".to_string(),
+                        admin: false,
+                    }
+                ]
+            );
         }
     }
 
-    impl Drop for TestDb {
-        fn drop(&mut self) {
-            if let Some(db) = self.db.take() {
-                DB_POOL.lock().push(TestDb {
-                    db: Some(db),
-                    name: mem::take(&mut self.name),
-                    url: mem::take(&mut self.url),
-                    clean_pool_on_drop: true,
-                });
-                if DB_COUNT.fetch_sub(1, SeqCst) == 1
-                    && (self.clean_pool_on_drop || thread::panicking())
-                {
-                    block_on(async move {
-                        let mut pool = DB_POOL.lock();
-                        for db in pool.drain(..) {
-                            db.teardown().await.log_err();
-                        }
-                    });
-                }
+    #[gpui::test]
+    async fn test_recent_channel_messages(cx: TestAppContext) {
+        for test_db in [TestDb::postgres(), TestDb::fake(cx.background())] {
+            let db = test_db.db();
+            let user = db.create_user("user", false).await.unwrap();
+            let org = db.create_org("org", "org").await.unwrap();
+            let channel = db.create_org_channel(org, "channel").await.unwrap();
+            for i in 0..10 {
+                db.create_channel_message(
+                    channel,
+                    user,
+                    &i.to_string(),
+                    OffsetDateTime::now_utc(),
+                    i,
+                )
+                .await
+                .unwrap();
             }
-        }
-    }
 
-    #[gpui::test]
-    async fn test_get_users_by_ids() {
-        let test_db = TestDb::new();
-        let db = test_db.db();
+            let messages = db.get_channel_messages(channel, 5, None).await.unwrap();
+            assert_eq!(
+                messages.iter().map(|m| &m.body).collect::<Vec<_>>(),
+                ["5", "6", "7", "8", "9"]
+            );
 
-        let user = db.create_user("user", false).await.unwrap();
-        let friend1 = db.create_user("friend-1", false).await.unwrap();
-        let friend2 = db.create_user("friend-2", false).await.unwrap();
-        let friend3 = db.create_user("friend-3", false).await.unwrap();
-
-        assert_eq!(
-            db.get_users_by_ids([user, friend1, friend2, friend3])
-                .await
-                .unwrap(),
-            vec![
-                User {
-                    id: user,
-                    github_login: "user".to_string(),
-                    admin: false,
-                },
-                User {
-                    id: friend1,
-                    github_login: "friend-1".to_string(),
-                    admin: false,
-                },
-                User {
-                    id: friend2,
-                    github_login: "friend-2".to_string(),
-                    admin: false,
-                },
-                User {
-                    id: friend3,
-                    github_login: "friend-3".to_string(),
-                    admin: false,
-                }
-            ]
-        );
-    }
-
-    #[gpui::test]
-    async fn test_recent_channel_messages() {
-        let test_db = TestDb::new();
-        let db = test_db.db();
-        let user = db.create_user("user", false).await.unwrap();
-        let org = db.create_org("org", "org").await.unwrap();
-        let channel = db.create_org_channel(org, "channel").await.unwrap();
-        for i in 0..10 {
-            db.create_channel_message(channel, user, &i.to_string(), OffsetDateTime::now_utc(), i)
+            let prev_messages = db
+                .get_channel_messages(channel, 4, Some(messages[0].id))
                 .await
                 .unwrap();
+            assert_eq!(
+                prev_messages.iter().map(|m| &m.body).collect::<Vec<_>>(),
+                ["1", "2", "3", "4"]
+            );
         }
-
-        let messages = db.get_channel_messages(channel, 5, None).await.unwrap();
-        assert_eq!(
-            messages.iter().map(|m| &m.body).collect::<Vec<_>>(),
-            ["5", "6", "7", "8", "9"]
-        );
-
-        let prev_messages = db
-            .get_channel_messages(channel, 4, Some(messages[0].id))
-            .await
-            .unwrap();
-        assert_eq!(
-            prev_messages.iter().map(|m| &m.body).collect::<Vec<_>>(),
-            ["1", "2", "3", "4"]
-        );
     }
 
     #[gpui::test]
-    async fn test_channel_message_nonces() {
-        let test_db = TestDb::new();
-        let db = test_db.db();
-        let user = db.create_user("user", false).await.unwrap();
-        let org = db.create_org("org", "org").await.unwrap();
-        let channel = db.create_org_channel(org, "channel").await.unwrap();
+    async fn test_channel_message_nonces(cx: TestAppContext) {
+        for test_db in [TestDb::postgres(), TestDb::fake(cx.background())] {
+            let db = test_db.db();
+            let user = db.create_user("user", false).await.unwrap();
+            let org = db.create_org("org", "org").await.unwrap();
+            let channel = db.create_org_channel(org, "channel").await.unwrap();
 
-        let msg1_id = db
-            .create_channel_message(channel, user, "1", OffsetDateTime::now_utc(), 1)
-            .await
-            .unwrap();
-        let msg2_id = db
-            .create_channel_message(channel, user, "2", OffsetDateTime::now_utc(), 2)
-            .await
-            .unwrap();
-        let msg3_id = db
-            .create_channel_message(channel, user, "3", OffsetDateTime::now_utc(), 1)
-            .await
-            .unwrap();
-        let msg4_id = db
-            .create_channel_message(channel, user, "4", OffsetDateTime::now_utc(), 2)
-            .await
-            .unwrap();
+            let msg1_id = db
+                .create_channel_message(channel, user, "1", OffsetDateTime::now_utc(), 1)
+                .await
+                .unwrap();
+            let msg2_id = db
+                .create_channel_message(channel, user, "2", OffsetDateTime::now_utc(), 2)
+                .await
+                .unwrap();
+            let msg3_id = db
+                .create_channel_message(channel, user, "3", OffsetDateTime::now_utc(), 1)
+                .await
+                .unwrap();
+            let msg4_id = db
+                .create_channel_message(channel, user, "4", OffsetDateTime::now_utc(), 2)
+                .await
+                .unwrap();
 
-        assert_ne!(msg1_id, msg2_id);
-        assert_eq!(msg1_id, msg3_id);
-        assert_eq!(msg2_id, msg4_id);
+            assert_ne!(msg1_id, msg2_id);
+            assert_eq!(msg1_id, msg3_id);
+            assert_eq!(msg2_id, msg4_id);
+        }
     }
 
     #[gpui::test]
     async fn test_create_access_tokens() {
-        let test_db = TestDb::new();
+        let test_db = TestDb::postgres();
         let db = test_db.db();
         let user = db.create_user("the-user", false).await.unwrap();
 
@@ -781,5 +763,360 @@ pub mod tests {
             db.get_access_token_hashes(user).await.unwrap(),
             &["h5".to_string(), "h4".to_string(), "h3".to_string()]
         );
+    }
+
+    pub struct TestDb {
+        pub db: Option<Arc<dyn Db>>,
+        pub name: String,
+        pub url: String,
+    }
+
+    impl TestDb {
+        pub fn postgres() -> Self {
+            lazy_static! {
+                static ref LOCK: Mutex<()> = Mutex::new(());
+            }
+
+            let _guard = LOCK.lock();
+            let mut rng = StdRng::from_entropy();
+            let name = format!("zed-test-{}", rng.gen::<u128>());
+            let url = format!("postgres://postgres@localhost/{}", name);
+            let migrations_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations"));
+            let db = block_on(async {
+                Postgres::create_database(&url)
+                    .await
+                    .expect("failed to create test db");
+                let mut db = PostgresDb::new(&url, 5).await.unwrap();
+                db.test_mode = true;
+                let migrator = Migrator::new(migrations_path).await.unwrap();
+                migrator.run(&db.pool).await.unwrap();
+                db
+            });
+            Self {
+                db: Some(Arc::new(db)),
+                name,
+                url,
+            }
+        }
+
+        pub fn fake(background: Arc<Background>) -> Self {
+            Self {
+                db: Some(Arc::new(FakeDb::new(background))),
+                name: "fake".to_string(),
+                url: "fake".to_string(),
+            }
+        }
+
+        pub fn db(&self) -> &Arc<dyn Db> {
+            self.db.as_ref().unwrap()
+        }
+    }
+
+    impl Drop for TestDb {
+        fn drop(&mut self) {
+            if let Some(db) = self.db.take() {
+                block_on(db.teardown(&self.name, &self.url));
+            }
+        }
+    }
+
+    pub struct FakeDb {
+        background: Arc<Background>,
+        users: Mutex<BTreeMap<UserId, User>>,
+        next_user_id: Mutex<i32>,
+        orgs: Mutex<BTreeMap<OrgId, Org>>,
+        next_org_id: Mutex<i32>,
+        org_memberships: Mutex<BTreeMap<(OrgId, UserId), bool>>,
+        channels: Mutex<BTreeMap<ChannelId, Channel>>,
+        next_channel_id: Mutex<i32>,
+        channel_memberships: Mutex<BTreeMap<(ChannelId, UserId), bool>>,
+        channel_messages: Mutex<BTreeMap<MessageId, ChannelMessage>>,
+        next_channel_message_id: Mutex<i32>,
+    }
+
+    impl FakeDb {
+        pub fn new(background: Arc<Background>) -> Self {
+            Self {
+                background,
+                users: Default::default(),
+                next_user_id: Mutex::new(1),
+                orgs: Default::default(),
+                next_org_id: Mutex::new(1),
+                org_memberships: Default::default(),
+                channels: Default::default(),
+                next_channel_id: Mutex::new(1),
+                channel_memberships: Default::default(),
+                channel_messages: Default::default(),
+                next_channel_message_id: Mutex::new(1),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Db for FakeDb {
+        async fn create_signup(
+            &self,
+            _github_login: &str,
+            _email_address: &str,
+            _about: &str,
+            _wants_releases: bool,
+            _wants_updates: bool,
+            _wants_community: bool,
+        ) -> Result<SignupId> {
+            unimplemented!()
+        }
+
+        async fn get_all_signups(&self) -> Result<Vec<Signup>> {
+            unimplemented!()
+        }
+
+        async fn destroy_signup(&self, _id: SignupId) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn create_user(&self, github_login: &str, admin: bool) -> Result<UserId> {
+            self.background.simulate_random_delay().await;
+
+            let mut users = self.users.lock();
+            if let Some(user) = users
+                .values()
+                .find(|user| user.github_login == github_login)
+            {
+                Ok(user.id)
+            } else {
+                let user_id = UserId(post_inc(&mut *self.next_user_id.lock()));
+                users.insert(
+                    user_id,
+                    User {
+                        id: user_id,
+                        github_login: github_login.to_string(),
+                        admin,
+                    },
+                );
+                Ok(user_id)
+            }
+        }
+
+        async fn get_all_users(&self) -> Result<Vec<User>> {
+            unimplemented!()
+        }
+
+        async fn get_user_by_id(&self, id: UserId) -> Result<Option<User>> {
+            Ok(self.get_users_by_ids(vec![id]).await?.into_iter().next())
+        }
+
+        async fn get_users_by_ids(&self, ids: Vec<UserId>) -> Result<Vec<User>> {
+            self.background.simulate_random_delay().await;
+            let users = self.users.lock();
+            Ok(ids.iter().filter_map(|id| users.get(id).cloned()).collect())
+        }
+
+        async fn get_user_by_github_login(&self, _github_login: &str) -> Result<Option<User>> {
+            unimplemented!()
+        }
+
+        async fn set_user_is_admin(&self, _id: UserId, _is_admin: bool) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn destroy_user(&self, _id: UserId) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn create_access_token_hash(
+            &self,
+            _user_id: UserId,
+            _access_token_hash: &str,
+            _max_access_token_count: usize,
+        ) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn get_access_token_hashes(&self, _user_id: UserId) -> Result<Vec<String>> {
+            unimplemented!()
+        }
+
+        async fn find_org_by_slug(&self, _slug: &str) -> Result<Option<Org>> {
+            unimplemented!()
+        }
+
+        async fn create_org(&self, name: &str, slug: &str) -> Result<OrgId> {
+            self.background.simulate_random_delay().await;
+            let mut orgs = self.orgs.lock();
+            if orgs.values().any(|org| org.slug == slug) {
+                Err(anyhow!("org already exists"))
+            } else {
+                let org_id = OrgId(post_inc(&mut *self.next_org_id.lock()));
+                orgs.insert(
+                    org_id,
+                    Org {
+                        id: org_id,
+                        name: name.to_string(),
+                        slug: slug.to_string(),
+                    },
+                );
+                Ok(org_id)
+            }
+        }
+
+        async fn add_org_member(
+            &self,
+            org_id: OrgId,
+            user_id: UserId,
+            is_admin: bool,
+        ) -> Result<()> {
+            self.background.simulate_random_delay().await;
+            if !self.orgs.lock().contains_key(&org_id) {
+                return Err(anyhow!("org does not exist"));
+            }
+            if !self.users.lock().contains_key(&user_id) {
+                return Err(anyhow!("user does not exist"));
+            }
+
+            self.org_memberships
+                .lock()
+                .entry((org_id, user_id))
+                .or_insert(is_admin);
+            Ok(())
+        }
+
+        async fn create_org_channel(&self, org_id: OrgId, name: &str) -> Result<ChannelId> {
+            self.background.simulate_random_delay().await;
+            if !self.orgs.lock().contains_key(&org_id) {
+                return Err(anyhow!("org does not exist"));
+            }
+
+            let mut channels = self.channels.lock();
+            let channel_id = ChannelId(post_inc(&mut *self.next_channel_id.lock()));
+            channels.insert(
+                channel_id,
+                Channel {
+                    id: channel_id,
+                    name: name.to_string(),
+                    owner_id: org_id.0,
+                    owner_is_user: false,
+                },
+            );
+            Ok(channel_id)
+        }
+
+        async fn get_org_channels(&self, org_id: OrgId) -> Result<Vec<Channel>> {
+            self.background.simulate_random_delay().await;
+            Ok(self
+                .channels
+                .lock()
+                .values()
+                .filter(|channel| !channel.owner_is_user && channel.owner_id == org_id.0)
+                .cloned()
+                .collect())
+        }
+
+        async fn get_accessible_channels(&self, user_id: UserId) -> Result<Vec<Channel>> {
+            self.background.simulate_random_delay().await;
+            let channels = self.channels.lock();
+            let memberships = self.channel_memberships.lock();
+            Ok(channels
+                .values()
+                .filter(|channel| memberships.contains_key(&(channel.id, user_id)))
+                .cloned()
+                .collect())
+        }
+
+        async fn can_user_access_channel(
+            &self,
+            user_id: UserId,
+            channel_id: ChannelId,
+        ) -> Result<bool> {
+            self.background.simulate_random_delay().await;
+            Ok(self
+                .channel_memberships
+                .lock()
+                .contains_key(&(channel_id, user_id)))
+        }
+
+        async fn add_channel_member(
+            &self,
+            channel_id: ChannelId,
+            user_id: UserId,
+            is_admin: bool,
+        ) -> Result<()> {
+            self.background.simulate_random_delay().await;
+            if !self.channels.lock().contains_key(&channel_id) {
+                return Err(anyhow!("channel does not exist"));
+            }
+            if !self.users.lock().contains_key(&user_id) {
+                return Err(anyhow!("user does not exist"));
+            }
+
+            self.channel_memberships
+                .lock()
+                .entry((channel_id, user_id))
+                .or_insert(is_admin);
+            Ok(())
+        }
+
+        async fn create_channel_message(
+            &self,
+            channel_id: ChannelId,
+            sender_id: UserId,
+            body: &str,
+            timestamp: OffsetDateTime,
+            nonce: u128,
+        ) -> Result<MessageId> {
+            self.background.simulate_random_delay().await;
+            if !self.channels.lock().contains_key(&channel_id) {
+                return Err(anyhow!("channel does not exist"));
+            }
+            if !self.users.lock().contains_key(&sender_id) {
+                return Err(anyhow!("user does not exist"));
+            }
+
+            let mut messages = self.channel_messages.lock();
+            if let Some(message) = messages
+                .values()
+                .find(|message| message.nonce.as_u128() == nonce)
+            {
+                Ok(message.id)
+            } else {
+                let message_id = MessageId(post_inc(&mut *self.next_channel_message_id.lock()));
+                messages.insert(
+                    message_id,
+                    ChannelMessage {
+                        id: message_id,
+                        channel_id,
+                        sender_id,
+                        body: body.to_string(),
+                        sent_at: timestamp,
+                        nonce: Uuid::from_u128(nonce),
+                    },
+                );
+                Ok(message_id)
+            }
+        }
+
+        async fn get_channel_messages(
+            &self,
+            channel_id: ChannelId,
+            count: usize,
+            before_id: Option<MessageId>,
+        ) -> Result<Vec<ChannelMessage>> {
+            let mut messages = self
+                .channel_messages
+                .lock()
+                .values()
+                .rev()
+                .filter(|message| {
+                    message.channel_id == channel_id
+                        && message.id < before_id.unwrap_or(MessageId::MAX)
+                })
+                .take(count)
+                .cloned()
+                .collect::<Vec<_>>();
+            dbg!(count, before_id, &messages);
+            messages.sort_unstable_by_key(|message| message.id);
+            Ok(messages)
+        }
+
+        async fn teardown(&self, _name: &str, _url: &str) {}
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use async_std::net::TcpListener;
 use async_trait::async_trait;
 use auth::RequestExt as _;
-use db::Db;
+use db::{Db, PostgresDb};
 use handlebars::{Handlebars, TemplateRenderError};
 use parking_lot::RwLock;
 use rust_embed::RustEmbed;
@@ -49,7 +49,7 @@ pub struct Config {
 }
 
 pub struct AppState {
-    db: Db,
+    db: Arc<dyn Db>,
     handlebars: RwLock<Handlebars<'static>>,
     auth_client: auth::Client,
     github_client: Arc<github::AppClient>,
@@ -59,7 +59,7 @@ pub struct AppState {
 
 impl AppState {
     async fn new(config: Config) -> tide::Result<Arc<Self>> {
-        let db = Db::new(&config.database_url, 5).await?;
+        let db = PostgresDb::new(&config.database_url, 5).await?;
         let github_client =
             github::AppClient::new(config.github_app_id, config.github_private_key.clone());
         let repo_client = github_client
@@ -68,7 +68,7 @@ impl AppState {
             .context("failed to initialize github client")?;
 
         let this = Self {
-            db,
+            db: Arc::new(db),
             handlebars: Default::default(),
             auth_client: auth::build_client(&config.github_client_id, &config.github_client_secret),
             github_client,
@@ -112,7 +112,7 @@ impl AppState {
 #[async_trait]
 trait RequestExt {
     async fn layout_data(&mut self) -> tide::Result<Arc<LayoutData>>;
-    fn db(&self) -> &Db;
+    fn db(&self) -> &Arc<dyn Db>;
 }
 
 #[async_trait]
@@ -126,7 +126,7 @@ impl RequestExt for Request {
         Ok(self.ext::<Arc<LayoutData>>().unwrap().clone())
     }
 
-    fn db(&self) -> &Db {
+    fn db(&self) -> &Arc<dyn Db> {
         &self.state().db
     }
 }

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1604,14 +1604,12 @@ mod tests {
         )
         .await
         .unwrap();
-        let worktree_b = project_b.update(&mut cx_b, |p, cx| p.worktrees(cx).next().unwrap());
 
         // Open a buffer as client B
         let buffer_b = project_b
             .update(&mut cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
             .await
             .unwrap();
-        let mtime = buffer_b.read_with(&cx_b, |buf, _| buf.file().unwrap().mtime());
 
         buffer_b.update(&mut cx_b, |buf, cx| buf.edit([0..0], "world ", cx));
         buffer_b.read_with(&cx_b, |buf, _| {
@@ -1623,13 +1621,10 @@ mod tests {
             .update(&mut cx_b, |buf, cx| buf.save(cx))
             .await
             .unwrap();
-        worktree_b
-            .condition(&cx_b, |_, cx| {
-                buffer_b.read(cx).file().unwrap().mtime() != mtime
-            })
+        buffer_b
+            .condition(&cx_b, |buffer_b, _| !buffer_b.is_dirty())
             .await;
         buffer_b.read_with(&cx_b, |buf, _| {
-            assert!(!buf.is_dirty());
             assert!(!buf.has_conflict());
         });
 

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -3682,11 +3682,21 @@ mod tests {
                 "guest {} has different worktrees than the host",
                 ix
             );
-            for (id, snapshot) in &host_worktree_snapshots {
+            for (id, host_snapshot) in &host_worktree_snapshots {
+                let guest_snapshot = &worktree_snapshots[id];
                 assert_eq!(
-                    worktree_snapshots[id], *snapshot,
+                    guest_snapshot.root_name(),
+                    host_snapshot.root_name(),
+                    "guest {} has different root name than the host for worktree {}",
+                    ix,
+                    id
+                );
+                assert_eq!(
+                    guest_snapshot.entries(false).collect::<Vec<_>>(),
+                    host_snapshot.entries(false).collect::<Vec<_>>(),
                     "guest {} has different snapshot than the host for worktree {}",
-                    ix, id
+                    ix,
+                    id
                 );
             }
 

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -75,7 +75,7 @@ impl Server {
             .add_request_handler(Server::register_worktree)
             .add_message_handler(Server::unregister_worktree)
             .add_request_handler(Server::share_worktree)
-            .add_message_handler(Server::update_worktree)
+            .add_request_handler(Server::update_worktree)
             .add_message_handler(Server::update_diagnostic_summary)
             .add_message_handler(Server::disk_based_diagnostics_updating)
             .add_message_handler(Server::disk_based_diagnostics_updated)
@@ -497,11 +497,12 @@ impl Server {
     async fn update_worktree(
         mut self: Arc<Server>,
         request: TypedEnvelope<proto::UpdateWorktree>,
-    ) -> tide::Result<()> {
+    ) -> tide::Result<proto::Ack> {
         let connection_ids = self.state_mut().update_worktree(
             request.sender_id,
             request.payload.project_id,
             request.payload.worktree_id,
+            request.payload.id,
             &request.payload.removed_entries,
             &request.payload.updated_entries,
         )?;
@@ -511,7 +512,7 @@ impl Server {
                 .forward_send(request.sender_id, connection_id, request.payload.clone())
         })?;
 
-        Ok(())
+        Ok(proto::Ack {})
     }
 
     async fn update_diagnostic_summary(

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -4007,13 +4007,24 @@ mod tests {
                                 .clone()
                         };
 
-                        buffer.update(&mut cx, |buffer, cx| {
-                            log::info!(
-                                "Host: updating buffer {:?}",
-                                buffer.file().unwrap().full_path(cx)
-                            );
-                            buffer.randomly_edit(&mut *rng.borrow_mut(), 5, cx)
-                        });
+                        if rng.borrow_mut().gen_bool(0.1) {
+                            cx.update(|cx| {
+                                log::info!(
+                                    "Host: dropping buffer {:?}",
+                                    buffer.read(cx).file().unwrap().full_path(cx)
+                                );
+                                self.buffers.remove(&buffer);
+                                drop(buffer);
+                            });
+                        } else {
+                            buffer.update(&mut cx, |buffer, cx| {
+                                log::info!(
+                                    "Host: updating buffer {:?}",
+                                    buffer.file().unwrap().full_path(cx)
+                                );
+                                buffer.randomly_edit(&mut *rng.borrow_mut(), 5, cx)
+                            });
+                        }
                     }
                     _ => loop {
                         let path_component_count = rng.borrow_mut().gen_range(1..=5);
@@ -4093,14 +4104,26 @@ mod tests {
                         .clone()
                 };
 
-                buffer.update(&mut cx, |buffer, cx| {
-                    log::info!(
-                        "Guest {}: updating buffer {:?}",
-                        guest_id,
-                        buffer.file().unwrap().full_path(cx)
-                    );
-                    buffer.randomly_edit(&mut *rng.borrow_mut(), 5, cx)
-                });
+                if rng.borrow_mut().gen_bool(0.1) {
+                    cx.update(|cx| {
+                        log::info!(
+                            "Guest {}: dropping buffer {:?}",
+                            guest_id,
+                            buffer.read(cx).file().unwrap().full_path(cx)
+                        );
+                        self.buffers.remove(&buffer);
+                        drop(buffer);
+                    });
+                } else {
+                    buffer.update(&mut cx, |buffer, cx| {
+                        log::info!(
+                            "Guest {}: updating buffer {:?}",
+                            guest_id,
+                            buffer.file().unwrap().full_path(cx)
+                        );
+                        buffer.randomly_edit(&mut *rng.borrow_mut(), 5, cx)
+                    });
+                }
 
                 cx.background().simulate_random_delay().await;
             }

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1082,7 +1082,6 @@ mod tests {
         github, AppState, Config,
     };
     use ::rpc::Peer;
-    use async_std::task;
     use gpui::{executor, ModelHandle, TestAppContext};
     use parking_lot::Mutex;
     use postage::{mpsc, watch};

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -2660,6 +2660,7 @@ mod tests {
         // Set up a fake language server.
         let (language_server_config, mut fake_language_server) =
             LanguageServerConfig::fake(&cx_a).await;
+
         Arc::get_mut(&mut lang_registry)
             .unwrap()
             .add(Arc::new(Language::new(
@@ -2687,6 +2688,7 @@ mod tests {
                 cx,
             )
         });
+
         let (worktree_a, _) = project_a
             .update(&mut cx_a, |p, cx| {
                 p.find_or_create_local_worktree("/root", false, cx)

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -3794,6 +3794,9 @@ mod tests {
                 .await
                 .unwrap();
 
+            Channel::init(&client);
+            Project::init(&client);
+
             let peer_id = PeerId(connection_id_rx.next().await.unwrap().0);
             let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http, cx));
             let mut authed_user =

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -2336,9 +2336,10 @@ mod tests {
             .await;
 
         // Confirm a completion on the guest.
-        editor_b.next_notification(&cx_b).await;
+        editor_b
+            .condition(&cx_b, |editor, _| editor.context_menu_visible())
+            .await;
         editor_b.update(&mut cx_b, |editor, cx| {
-            assert!(editor.context_menu_visible());
             editor.confirm_completion(&ConfirmCompletion(Some(0)), cx);
             assert_eq!(editor.text(cx), "fn main() { a.first_method() }");
         });
@@ -2363,22 +2364,17 @@ mod tests {
             }
         });
 
+        // The additional edit is applied.
         buffer_a
             .condition(&cx_a, |buffer, _| {
-                buffer.text() == "fn main() { a.first_method() }"
+                buffer.text() == "use d::SomeTrait;\nfn main() { a.first_method() }"
             })
             .await;
-
-        // The additional edit is applied.
         buffer_b
             .condition(&cx_b, |buffer, _| {
                 buffer.text() == "use d::SomeTrait;\nfn main() { a.first_method() }"
             })
             .await;
-        assert_eq!(
-            buffer_a.read_with(&cx_a, |buffer, _| buffer.text()),
-            buffer_b.read_with(&cx_b, |buffer, _| buffer.text()),
-        );
     }
 
     #[gpui::test(iterations = 10)]

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -785,7 +785,12 @@ impl Server {
         self: Arc<Server>,
         request: TypedEnvelope<proto::GetUsers>,
     ) -> tide::Result<proto::GetUsersResponse> {
-        let user_ids = request.payload.user_ids.into_iter().map(UserId::from_proto);
+        let user_ids = request
+            .payload
+            .user_ids
+            .into_iter()
+            .map(UserId::from_proto)
+            .collect();
         let users = self
             .app_state
             .db
@@ -1139,18 +1144,14 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_share_project(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_share_project(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         let (window_b, _) = cx_b.add_window(|_| EmptyView);
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1282,17 +1283,13 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_unshare_project(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_unshare_project(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1387,14 +1384,13 @@ mod tests {
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
         mut cx_c: TestAppContext,
-        last_iteration: bool,
     ) {
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 3 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
         let client_c = server.create_client(&mut cx_c, "user_c").await;
@@ -1566,17 +1562,13 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_buffer_conflict_after_save(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_buffer_conflict_after_save(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1658,17 +1650,13 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_buffer_reloading(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_buffer_reloading(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1747,14 +1735,13 @@ mod tests {
     async fn test_editing_while_guest_opens_buffer(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1830,14 +1817,13 @@ mod tests {
     async fn test_leaving_worktree_while_opening_buffer(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1906,17 +1892,13 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_peer_disconnection(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_peer_disconnection(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1984,7 +1966,6 @@ mod tests {
     async fn test_collaborating_with_diagnostics(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2005,7 +1986,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2209,7 +2190,6 @@ mod tests {
     async fn test_collaborating_with_completion(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2237,7 +2217,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2419,11 +2399,7 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_formatting_buffer(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_formatting_buffer(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
@@ -2443,7 +2419,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2525,11 +2501,7 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_definition(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_definition(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
@@ -2564,7 +2536,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2682,7 +2654,6 @@ mod tests {
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
         mut rng: StdRng,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2713,7 +2684,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2792,7 +2763,6 @@ mod tests {
     async fn test_collaborating_with_code_actions(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2815,7 +2785,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -3032,15 +3002,11 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_basic_chat(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_basic_chat(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -3176,10 +3142,10 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_chat_message_validation(mut cx_a: TestAppContext, last_iteration: bool) {
+    async fn test_chat_message_validation(mut cx_a: TestAppContext) {
         cx_a.foreground().forbid_parking();
 
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
 
         let db = &server.app_state.db;
@@ -3236,15 +3202,11 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_chat_reconnection(
-        mut cx_a: TestAppContext,
-        mut cx_b: TestAppContext,
-        last_iteration: bool,
-    ) {
+    async fn test_chat_reconnection(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
         let mut status_b = client_b.status();
@@ -3456,14 +3418,13 @@ mod tests {
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
         mut cx_c: TestAppContext,
-        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 3 clients.
-        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
         let client_c = server.create_client(&mut cx_c, "user_c").await;
@@ -3595,7 +3556,7 @@ mod tests {
     }
 
     #[gpui::test(iterations = 100)]
-    async fn test_random_collaboration(cx: TestAppContext, rng: StdRng, last_iteration: bool) {
+    async fn test_random_collaboration(cx: TestAppContext, rng: StdRng) {
         cx.foreground().forbid_parking();
         let max_peers = env::var("MAX_PEERS")
             .map(|i| i.parse().expect("invalid `MAX_PEERS` variable"))
@@ -3654,7 +3615,7 @@ mod tests {
         .await;
 
         let operations = Rc::new(Cell::new(0));
-        let mut server = TestServer::start(cx.foreground(), last_iteration).await;
+        let mut server = TestServer::start(cx.foreground(), cx.background()).await;
         let mut clients = Vec::new();
 
         let mut next_entity_id = 100000;
@@ -3849,9 +3810,11 @@ mod tests {
     }
 
     impl TestServer {
-        async fn start(foreground: Rc<executor::Foreground>, clean_db_pool_on_drop: bool) -> Self {
-            let mut test_db = TestDb::new();
-            test_db.set_clean_pool_on_drop(clean_db_pool_on_drop);
+        async fn start(
+            foreground: Rc<executor::Foreground>,
+            background: Arc<executor::Background>,
+        ) -> Self {
+            let test_db = TestDb::fake(background);
             let app_state = Self::build_app_state(&test_db).await;
             let peer = Peer::new();
             let notifications = mpsc::unbounded();

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -3641,7 +3641,7 @@ mod tests {
                     language_server: Some(language_server_config),
                     ..Default::default()
                 },
-                Some(tree_sitter_rust::language()),
+                None,
             )));
 
         let fs = Arc::new(FakeFs::new(cx.background()));

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1134,14 +1134,18 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_share_project(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_share_project(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         let (window_b, _) = cx_b.add_window(|_| EmptyView);
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1273,13 +1277,17 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_unshare_project(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_unshare_project(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1374,13 +1382,14 @@ mod tests {
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
         mut cx_c: TestAppContext,
+        last_iteration: bool,
     ) {
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 3 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
         let client_c = server.create_client(&mut cx_c, "user_c").await;
@@ -1552,13 +1561,17 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_buffer_conflict_after_save(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_buffer_conflict_after_save(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1640,13 +1653,17 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_buffer_reloading(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_buffer_reloading(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1725,13 +1742,14 @@ mod tests {
     async fn test_editing_while_guest_opens_buffer(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1807,13 +1825,14 @@ mod tests {
     async fn test_leaving_worktree_while_opening_buffer(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1882,13 +1901,17 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_peer_disconnection(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_peer_disconnection(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -1956,6 +1979,7 @@ mod tests {
     async fn test_collaborating_with_diagnostics(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -1977,7 +2001,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2180,6 +2204,7 @@ mod tests {
     async fn test_collaborating_with_completion(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2211,7 +2236,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2382,7 +2407,11 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_formatting_buffer(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_formatting_buffer(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
@@ -2403,7 +2432,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2484,7 +2513,11 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_definition(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_definition(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
@@ -2520,7 +2553,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2636,6 +2669,7 @@ mod tests {
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
         mut rng: StdRng,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2667,7 +2701,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2745,6 +2779,7 @@ mod tests {
     async fn test_collaborating_with_code_actions(
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let mut lang_registry = Arc::new(LanguageRegistry::new());
@@ -2774,7 +2809,7 @@ mod tests {
             )));
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -2983,11 +3018,15 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_basic_chat(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_basic_chat(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
 
@@ -3123,10 +3162,10 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_chat_message_validation(mut cx_a: TestAppContext) {
+    async fn test_chat_message_validation(mut cx_a: TestAppContext, last_iteration: bool) {
         cx_a.foreground().forbid_parking();
 
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
 
         let db = &server.app_state.db;
@@ -3183,11 +3222,15 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
-    async fn test_chat_reconnection(mut cx_a: TestAppContext, mut cx_b: TestAppContext) {
+    async fn test_chat_reconnection(
+        mut cx_a: TestAppContext,
+        mut cx_b: TestAppContext,
+        last_iteration: bool,
+    ) {
         cx_a.foreground().forbid_parking();
 
         // Connect to a server as 2 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
         let mut status_b = client_b.status();
@@ -3399,13 +3442,14 @@ mod tests {
         mut cx_a: TestAppContext,
         mut cx_b: TestAppContext,
         mut cx_c: TestAppContext,
+        last_iteration: bool,
     ) {
         cx_a.foreground().forbid_parking();
         let lang_registry = Arc::new(LanguageRegistry::new());
         let fs = Arc::new(FakeFs::new(cx_a.background()));
 
         // Connect to a server as 3 clients.
-        let mut server = TestServer::start(cx_a.foreground()).await;
+        let mut server = TestServer::start(cx_a.foreground(), last_iteration).await;
         let client_a = server.create_client(&mut cx_a, "user_a").await;
         let client_b = server.create_client(&mut cx_b, "user_b").await;
         let client_c = server.create_client(&mut cx_c, "user_c").await;
@@ -3536,8 +3580,8 @@ mod tests {
         }
     }
 
-    #[gpui::test(iterations = 10)]
-    async fn test_random_collaboration(cx: TestAppContext, rng: StdRng) {
+    #[gpui::test(iterations = 100)]
+    async fn test_random_collaboration(cx: TestAppContext, rng: StdRng, last_iteration: bool) {
         cx.foreground().forbid_parking();
         let max_peers = env::var("MAX_PEERS")
             .map(|i| i.parse().expect("invalid `MAX_PEERS` variable"))
@@ -3558,7 +3602,7 @@ mod tests {
         .await;
 
         let operations = Rc::new(Cell::new(0));
-        let mut server = TestServer::start(cx.foreground()).await;
+        let mut server = TestServer::start(cx.foreground(), last_iteration).await;
         let mut clients = Vec::new();
 
         let mut next_entity_id = 100000;
@@ -3729,8 +3773,9 @@ mod tests {
     }
 
     impl TestServer {
-        async fn start(foreground: Rc<executor::Foreground>) -> Self {
-            let test_db = TestDb::new();
+        async fn start(foreground: Rc<executor::Foreground>, clean_db_pool_on_drop: bool) -> Self {
+            let mut test_db = TestDb::new();
+            test_db.set_clean_pool_on_drop(clean_db_pool_on_drop);
             let app_state = Self::build_app_state(&test_db).await;
             let peer = Peer::new();
             let notifications = mpsc::channel(128);

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -3622,6 +3622,15 @@ mod tests {
                     ..Default::default()
                 }]))
             });
+
+            fake_server.handle_request::<lsp::request::CodeActionRequest, _>(|_| {
+                Some(vec![lsp::CodeActionOrCommand::CodeAction(
+                    lsp::CodeAction {
+                        title: "the-code-action".to_string(),
+                        ..Default::default()
+                    },
+                )])
+            });
         });
 
         Arc::get_mut(&mut host_lang_registry)
@@ -4180,7 +4189,7 @@ mod tests {
                             drop(buffer);
                         });
                     }
-                    10..=19 => {
+                    10..=14 => {
                         project
                             .update(&mut cx, |project, cx| {
                                 log::info!(
@@ -4189,6 +4198,19 @@ mod tests {
                                     buffer.read(cx).file().unwrap().full_path(cx)
                                 );
                                 project.completions(&buffer, 0, cx)
+                            })
+                            .await
+                            .expect("completion request failed");
+                    }
+                    15..=19 => {
+                        project
+                            .update(&mut cx, |project, cx| {
+                                log::info!(
+                                    "Guest {}: requesting code actions for buffer {:?}",
+                                    guest_id,
+                                    buffer.read(cx).file().unwrap().full_path(cx)
+                                );
+                                project.code_actions(&buffer, 0..0, cx)
                             })
                             .await
                             .expect("completion request failed");

--- a/crates/server/src/rpc/store.rs
+++ b/crates/server/src/rpc/store.rs
@@ -537,6 +537,7 @@ impl Store {
         connection_id: ConnectionId,
         project_id: u64,
         worktree_id: u64,
+        update_id: u64,
         removed_entries: &[u64],
         updated_entries: &[proto::Entry],
     ) -> tide::Result<Vec<ConnectionId>> {
@@ -548,6 +549,11 @@ impl Store {
             .share
             .as_mut()
             .ok_or_else(|| anyhow!("worktree is not shared"))?;
+        if share.next_update_id != update_id {
+            return Err(anyhow!("received worktree updates out-of-order"))?;
+        }
+
+        share.next_update_id = update_id + 1;
         for entry_id in removed_entries {
             share.entries.remove(&entry_id);
         }

--- a/crates/server/src/rpc/store.rs
+++ b/crates/server/src/rpc/store.rs
@@ -43,6 +43,7 @@ pub struct ProjectShare {
 pub struct WorktreeShare {
     pub entries: HashMap<u64, proto::Entry>,
     pub diagnostic_summaries: BTreeMap<PathBuf, proto::DiagnosticSummary>,
+    pub next_update_id: u64,
 }
 
 #[derive(Default)]
@@ -403,6 +404,7 @@ impl Store {
         connection_id: ConnectionId,
         entries: HashMap<u64, proto::Entry>,
         diagnostic_summaries: BTreeMap<PathBuf, proto::DiagnosticSummary>,
+        next_update_id: u64,
     ) -> tide::Result<SharedWorktree> {
         let project = self
             .projects
@@ -416,6 +418,7 @@ impl Store {
             worktree.share = Some(WorktreeShare {
                 entries,
                 diagnostic_summaries,
+                next_update_id,
             });
             Ok(SharedWorktree {
                 authorized_user_ids: project.authorized_user_ids(),

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -478,6 +478,14 @@ impl<T: Item> SumTree<T> {
     }
 }
 
+impl<T: Item + PartialEq> PartialEq for SumTree<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().eq(other.iter())
+    }
+}
+
+impl<T: Item + Eq> Eq for SumTree<T> {}
+
 impl<T: KeyedItem> SumTree<T> {
     pub fn insert_or_replace(&mut self, item: T, cx: &<T::Summary as Summary>::Context) -> bool {
         let mut replaced = false;

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -21,7 +21,7 @@ use operation_queue::OperationQueue;
 pub use patch::Patch;
 pub use point::*;
 pub use point_utf16::*;
-use postage::{barrier, oneshot, prelude::*};
+use postage::{oneshot, prelude::*};
 #[cfg(any(test, feature = "test-support"))]
 pub use random_char_iter::*;
 use rope::TextDimension;
@@ -53,7 +53,6 @@ pub struct Buffer {
     pub lamport_clock: clock::Lamport,
     subscriptions: Topic,
     edit_id_resolvers: HashMap<clock::Local, Vec<oneshot::Sender<()>>>,
-    version_barriers: Vec<(clock::Global, barrier::Sender)>,
 }
 
 #[derive(Clone, Debug)]
@@ -575,7 +574,6 @@ impl Buffer {
             lamport_clock,
             subscriptions: Default::default(),
             edit_id_resolvers: Default::default(),
-            version_barriers: Default::default(),
         }
     }
 
@@ -837,8 +835,6 @@ impl Buffer {
                 }
             }
         }
-        self.version_barriers
-            .retain(|(version, _)| !self.snapshot.version().observed_all(version));
         Ok(())
     }
 
@@ -1306,16 +1302,6 @@ impl Buffer {
             for mut future in futures {
                 future.recv().await;
             }
-        }
-    }
-
-    pub fn wait_for_version(&mut self, version: clock::Global) -> impl Future<Output = ()> {
-        let (tx, mut rx) = barrier::channel();
-        if !self.snapshot.version.observed_all(&version) {
-            self.version_barriers.push((version, tx));
-        }
-        async move {
-            rx.recv().await;
         }
     }
 

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -4,13 +4,14 @@ pub mod test;
 use futures::Future;
 use std::{
     cmp::Ordering,
+    ops::AddAssign,
     pin::Pin,
     task::{Context, Poll},
 };
 
-pub fn post_inc(value: &mut usize) -> usize {
+pub fn post_inc<T: From<u8> + AddAssign<T> + Copy>(value: &mut T) -> T {
     let prev = *value;
-    *value += 1;
+    *value += T::from(1);
     prev
 }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -53,6 +53,8 @@ fn main() {
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
         let mut path_openers = Vec::new();
 
+        project::Project::init(&client);
+        client::Channel::init(&client);
         client::init(client.clone(), cx);
         workspace::init(cx);
         editor::init(cx, &mut path_openers);


### PR DESCRIPTION
With this pull request we will now distinguish between _foreground_ and _background_ messages. We do this because we don't want messages/requests that don't mutate essential state to stall subsequent messages/requests that do. The example that triggered this change was code actions. We issue a code action query on every selection update, which on a large codebase can take up to 100-200ms: if we wait for the query result before sending any further message to the host, essential state like selections won't be relayed before those 100-200ms. Note how performing e.g. 10 code action queries means that host will observe the newest selection update after 1-2s.

We tried relaxing the ordering constraint on all messages but it became really hard to reason about all the permutations in which requests could arrive in and that was causing us to introduce way too much complexity into the codebase.

As a bonus, this pull request adds a randomized test that exercises collaboration amongst peer in an end-to-end way and we're feeling pretty confident that the current implementation is resilient to race conditions thanks to that.