### PR TITLE
Automatically include current view id in element state ids

### DIFF
--- a/crates/chat_panel/src/chat_panel.rs
+++ b/crates/chat_panel/src/chat_panel.rs
@@ -325,21 +325,17 @@ impl ChatPanel {
         enum SignInPromptLabel {}
 
         Align::new(
-            MouseEventHandler::new::<SignInPromptLabel, _, _, _>(
-                cx.view_id(),
-                cx,
-                |mouse_state, _| {
-                    Label::new(
-                        "Sign in to use chat".to_string(),
-                        if mouse_state.hovered {
-                            theme.chat_panel.hovered_sign_in_prompt.clone()
-                        } else {
-                            theme.chat_panel.sign_in_prompt.clone()
-                        },
-                    )
-                    .boxed()
-                },
-            )
+            MouseEventHandler::new::<SignInPromptLabel, _, _>(0, cx, |mouse_state, _| {
+                Label::new(
+                    "Sign in to use chat".to_string(),
+                    if mouse_state.hovered {
+                        theme.chat_panel.hovered_sign_in_prompt.clone()
+                    } else {
+                        theme.chat_panel.sign_in_prompt.clone()
+                    },
+                )
+                .boxed()
+            })
             .with_cursor_style(CursorStyle::PointingHand)
             .on_click(move |cx| {
                 let rpc = rpc.clone();

--- a/crates/contacts_panel/src/contacts_panel.rs
+++ b/crates/contacts_panel/src/contacts_panel.rs
@@ -27,7 +27,6 @@ impl ContactsPanel {
                 1000.,
                 {
                     let app_state = app_state.clone();
-                    let view_id = cx.view_id();
                     move |ix, cx| {
                         let user_store = app_state.user_store.read(cx);
                         let contacts = user_store.contacts().clone();
@@ -36,7 +35,6 @@ impl ContactsPanel {
                             &contacts[ix],
                             current_user_id,
                             app_state.clone(),
-                            view_id,
                             cx,
                         )
                     }
@@ -58,7 +56,6 @@ impl ContactsPanel {
         collaborator: &Contact,
         current_user_id: Option<u64>,
         app_state: Arc<AppState>,
-        view_id: usize,
         cx: &mut LayoutContext,
     ) -> ElementBox {
         let theme = &app_state.settings.borrow().theme.contacts_panel;
@@ -159,8 +156,8 @@ impl ContactsPanel {
                                 let is_shared = project.is_shared;
                                 let app_state = app_state.clone();
 
-                                MouseEventHandler::new::<ContactsPanel, _, _, _>(
-                                    (view_id, project_id as usize),
+                                MouseEventHandler::new::<ContactsPanel, _, _>(
+                                    project_id as usize,
                                     cx,
                                     |mouse_state, _| {
                                         let style = match (project.is_shared, mouse_state.hovered) {

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -57,7 +57,7 @@ impl View for DiagnosticSummary {
         let theme = &self.settings.borrow().theme.project_diagnostics;
 
         let in_progress = self.in_progress;
-        MouseEventHandler::new::<Tag, _, _, _>(cx.view_id(), cx, |_, _| {
+        MouseEventHandler::new::<Tag, _, _>(0, cx, |_, _| {
             if in_progress {
                 Label::new(
                     "Checking... ".to_string(),

--- a/crates/find/src/find.rs
+++ b/crates/find/src/find.rs
@@ -227,7 +227,7 @@ impl FindBar {
     ) -> ElementBox {
         let theme = &self.settings.borrow().theme.find;
         let is_active = self.is_mode_enabled(mode);
-        MouseEventHandler::new::<Self, _, _, _>((cx.view_id(), mode as usize), cx, |state, _| {
+        MouseEventHandler::new::<Self, _, _>(mode as usize, cx, |state, _| {
             let style = match (is_active, state.hovered) {
                 (false, false) => &theme.mode_button,
                 (false, true) => &theme.hovered_mode_button,
@@ -251,21 +251,18 @@ impl FindBar {
         cx: &mut RenderContext<Self>,
     ) -> ElementBox {
         let theme = &self.settings.borrow().theme.find;
-        MouseEventHandler::new::<Self, _, _, _>(
-            (cx.view_id(), 10 + direction as usize),
-            cx,
-            |state, _| {
-                let style = if state.hovered {
-                    &theme.hovered_mode_button
-                } else {
-                    &theme.mode_button
-                };
-                Label::new(icon.to_string(), style.text.clone())
-                    .contained()
-                    .with_style(style.container)
-                    .boxed()
-            },
-        )
+        enum NavButton {}
+        MouseEventHandler::new::<NavButton, _, _>(direction as usize, cx, |state, _| {
+            let style = if state.hovered {
+                &theme.hovered_mode_button
+            } else {
+                &theme.mode_button
+            };
+            Label::new(icon.to_string(), style.text.clone())
+                .contained()
+                .with_style(style.container)
+                .boxed()
+        })
         .on_click(move |cx| cx.dispatch_action(GoToMatch(direction)))
         .with_cursor_style(CursorStyle::PointingHand)
         .boxed()

--- a/crates/gpui/src/elements/mouse_event_handler.rs
+++ b/crates/gpui/src/elements/mouse_event_handler.rs
@@ -5,11 +5,10 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     platform::CursorStyle,
-    CursorStyleHandle, DebugContext, Element, ElementBox, ElementStateHandle, ElementStateId,
-    Event, EventContext, LayoutContext, MutableAppContext, PaintContext, SizeConstraint,
+    CursorStyleHandle, DebugContext, Element, ElementBox, ElementStateContext, ElementStateHandle,
+    Event, EventContext, LayoutContext, PaintContext, SizeConstraint,
 };
 use serde_json::json;
-use std::ops::DerefMut;
 
 pub struct MouseEventHandler {
     state: ElementStateHandle<MouseState>,
@@ -30,14 +29,13 @@ pub struct MouseState {
 }
 
 impl MouseEventHandler {
-    pub fn new<Tag, F, C, Id>(id: Id, cx: &mut C, render_child: F) -> Self
+    pub fn new<Tag, C, F>(id: usize, cx: &mut C, render_child: F) -> Self
     where
         Tag: 'static,
+        C: ElementStateContext,
         F: FnOnce(&MouseState, &mut C) -> ElementBox,
-        C: DerefMut<Target = MutableAppContext>,
-        Id: Into<ElementStateId>,
     {
-        let state_handle = cx.element_state::<Tag, _>(id.into());
+        let state_handle = cx.element_state::<Tag, _>(id);
         let child = state_handle.update(cx, |state, cx| render_child(state, cx));
         Self {
             state: state_handle,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -7,8 +7,8 @@ use crate::{
     platform::Event,
     text_layout::TextLayoutCache,
     Action, AnyAction, AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AssetCache, ElementBox,
-    Entity, FontSystem, ModelHandle, ReadModel, ReadView, Scene, UpgradeModelHandle,
-    UpgradeViewHandle, View, ViewHandle, WeakModelHandle, WeakViewHandle,
+    ElementStateContext, Entity, FontSystem, ModelHandle, ReadModel, ReadView, Scene,
+    UpgradeModelHandle, UpgradeViewHandle, View, ViewHandle, WeakModelHandle, WeakViewHandle,
 };
 use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
@@ -289,6 +289,12 @@ impl<'a> UpgradeModelHandle for LayoutContext<'a> {
 impl<'a> UpgradeViewHandle for LayoutContext<'a> {
     fn upgrade_view_handle<T: View>(&self, handle: &WeakViewHandle<T>) -> Option<ViewHandle<T>> {
         self.app.upgrade_view_handle(handle)
+    }
+}
+
+impl<'a> ElementStateContext for LayoutContext<'a> {
+    fn current_view_id(&self) -> usize {
+        *self.view_stack.last().unwrap()
     }
 }
 

--- a/crates/gpui/src/views/select.rs
+++ b/crates/gpui/src/views/select.rs
@@ -104,7 +104,7 @@ impl View for Select {
             Default::default()
         };
         let mut result = Flex::column().with_child(
-            MouseEventHandler::new::<Header, _, _, _>(self.handle.id(), cx, |mouse_state, cx| {
+            MouseEventHandler::new::<Header, _, _>(self.handle.id(), cx, |mouse_state, cx| {
                 Container::new((self.render_item)(
                     self.selected_item_ix,
                     ItemType::Header,
@@ -132,8 +132,8 @@ impl View for Select {
                                     let selected_item_ix = this.selected_item_ix;
                                     range.end = range.end.min(this.item_count);
                                     items.extend(range.map(|ix| {
-                                        MouseEventHandler::new::<Item, _, _, _>(
-                                            (handle.id(), ix),
+                                        MouseEventHandler::new::<Item, _, _>(
+                                            ix,
                                             cx,
                                             |mouse_state, cx| {
                                                 (handle.read(cx).render_item)(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -476,7 +476,7 @@ impl ProjectPanel {
         cx: &mut ViewContext<Self>,
     ) -> ElementBox {
         let is_dir = details.is_dir;
-        MouseEventHandler::new::<Self, _, _, _>((cx.view_id(), entry.entry_id), cx, |state, _| {
+        MouseEventHandler::new::<Self, _, _>(entry.entry_id, cx, |state, _| {
             let style = match (details.is_selected, state.hovered) {
                 (false, false) => &theme.entry,
                 (false, true) => &theme.hovered_entry,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -466,7 +466,7 @@ impl Pane {
         let theme = &settings.theme;
 
         enum Tabs {}
-        let tabs = MouseEventHandler::new::<Tabs, _, _, _>(cx.view_id(), cx, |mouse_state, cx| {
+        let tabs = MouseEventHandler::new::<Tabs, _, _>(0, cx, |mouse_state, cx| {
             let mut row = Flex::row();
             for (ix, (_, item_view)) in self.item_views.iter().enumerate() {
                 let is_active = ix == self.active_item_index;
@@ -543,7 +543,7 @@ impl Pane {
                                             let item_id = item_view.id();
                                             enum TabCloseButton {}
                                             let icon = Svg::new("icons/x.svg");
-                                            MouseEventHandler::new::<TabCloseButton, _, _, _>(
+                                            MouseEventHandler::new::<TabCloseButton, _, _>(
                                                 item_id,
                                                 cx,
                                                 |mouse_state, _| {

--- a/crates/workspace/src/sidebar.rs
+++ b/crates/workspace/src/sidebar.rs
@@ -83,26 +83,22 @@ impl Sidebar {
                             &theme.item
                         };
                         enum SidebarButton {}
-                        MouseEventHandler::new::<SidebarButton, _, _, _>(
-                            item.view.id(),
-                            cx,
-                            |_, _| {
-                                ConstrainedBox::new(
-                                    Align::new(
-                                        ConstrainedBox::new(
-                                            Svg::new(item.icon_path)
-                                                .with_color(theme.icon_color)
-                                                .boxed(),
-                                        )
-                                        .with_height(theme.icon_size)
-                                        .boxed(),
+                        MouseEventHandler::new::<SidebarButton, _, _>(item.view.id(), cx, |_, _| {
+                            ConstrainedBox::new(
+                                Align::new(
+                                    ConstrainedBox::new(
+                                        Svg::new(item.icon_path)
+                                            .with_color(theme.icon_color)
+                                            .boxed(),
                                     )
+                                    .with_height(theme.icon_size)
                                     .boxed(),
                                 )
-                                .with_height(theme.height)
-                                .boxed()
-                            },
-                        )
+                                .boxed(),
+                            )
+                            .with_height(theme.height)
+                            .boxed()
+                        })
                         .with_cursor_style(CursorStyle::PointingHand)
                         .on_mouse_down(move |cx| {
                             cx.dispatch_action(ToggleSidebarItem(SidebarItemId {
@@ -161,7 +157,7 @@ impl Sidebar {
     ) -> ElementBox {
         let width = self.width.clone();
         let side = self.side;
-        MouseEventHandler::new::<Self, _, _, _>((cx.view_id(), self.side.id()), cx, |_, _| {
+        MouseEventHandler::new::<Self, _, _>(side as usize, cx, |_, _| {
             Container::new(Empty::new().boxed())
                 .with_style(self.theme(settings).resize_handle)
                 .boxed()
@@ -182,14 +178,5 @@ impl Sidebar {
             cx.notify();
         })
         .boxed()
-    }
-}
-
-impl Side {
-    fn id(self) -> usize {
-        match self {
-            Side::Left => 0,
-            Side::Right => 1,
-        }
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1191,7 +1191,7 @@ impl Workspace {
         if let Some(avatar) = user.and_then(|user| user.avatar.clone()) {
             self.render_avatar(avatar, replica_id, theme)
         } else {
-            MouseEventHandler::new::<Authenticate, _, _, _>(cx.view_id(), cx, |state, _| {
+            MouseEventHandler::new::<Authenticate, _, _>(0, cx, |state, _| {
                 let style = if state.hovered {
                     &theme.workspace.titlebar.hovered_sign_in_prompt
                 } else {
@@ -1252,7 +1252,7 @@ impl Workspace {
                 theme.workspace.titlebar.share_icon_color
             };
             Some(
-                MouseEventHandler::new::<Share, _, _, _>(cx.view_id(), cx, |_, _| {
+                MouseEventHandler::new::<Share, _, _>(0, cx, |_, _| {
                     Align::new(
                         ConstrainedBox::new(
                             Svg::new("icons/broadcast-24.svg").with_color(color).boxed(),


### PR DESCRIPTION
Several times, we've accidentally used the same element state id for multiple elements that are both on screen. This used to cause *infinite loops* when event handlers tried to mutate the state. More recently, we've changed it so that it crashes the application as soon the element state is incorrectly reused. But element states are still dangerously error prone.

This PR eliminates one type or problem that can occur when using element states: two different *views* creating element states with the same tag and id.

I have removed the `element_state` method from `MutableAppContext`. That method is now only available on certain "Context" types that are tied to a particular view (e.g. `ViewContext`, `RenderContext`, and `LayoutContext`), and which implement a new trait called `ElementStateContext` (feedback on the name welcome). When you call `element_state` on one of these context types, they will automatically include the current view id into the key used to lookup the element state.

This does impose a limitation that it's *impossible* to ever use the same element state for two different views, but I think that so far, we would never want to do that.