### PR TITLE
Fix "proc macro not expanded" errors

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -13,6 +13,7 @@ use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use serde::Deserialize;
+use serde_json::Value;
 use std::{cell::RefCell, ops::Range, path::Path, str, sync::Arc};
 use theme::SyntaxTheme;
 use tree_sitter::{self, Query};
@@ -80,6 +81,7 @@ pub struct LanguageServerConfig {
     pub binary: String,
     pub disk_based_diagnostic_sources: HashSet<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
+    pub initialization_options: Option<Value>,
     #[cfg(any(test, feature = "test-support"))]
     #[serde(skip)]
     fake_config: Option<FakeLanguageServerConfig>,
@@ -265,7 +267,13 @@ impl Language {
             } else {
                 Path::new(&config.binary).to_path_buf()
             };
-            lsp::LanguageServer::new(&binary_path, root_path, cx.background().clone()).map(Some)
+            lsp::LanguageServer::new(
+                &binary_path,
+                config.initialization_options.clone(),
+                root_path,
+                cx.background().clone(),
+            )
+            .map(Some)
         } else {
             Ok(None)
         }

--- a/crates/zed/languages/rust/config.toml
+++ b/crates/zed/languages/rust/config.toml
@@ -14,4 +14,7 @@ brackets = [
 binary = "rust-analyzer"
 disk_based_diagnostic_sources = ["rustc"]
 disk_based_diagnostics_progress_token = "rustAnalyzer/cargo check"
-initialization_options = { procMacro = { enable = true } }
+
+[language_server.initialization_options]
+procMacro = { enable = true }
+cargo = { loadOutDirsFromCheck = true }

--- a/crates/zed/languages/rust/config.toml
+++ b/crates/zed/languages/rust/config.toml
@@ -14,3 +14,4 @@ brackets = [
 binary = "rust-analyzer"
 disk_based_diagnostic_sources = ["rustc"]
 disk_based_diagnostics_progress_token = "rustAnalyzer/cargo check"
+initialization_options = { procMacro = { enable = true } }

--- a/script/download-rust-analyzer
+++ b/script/download-rust-analyzer
@@ -2,7 +2,7 @@
 
 set -e
 
-export RUST_ANALYZER_URL="https://github.com/rust-analyzer/rust-analyzer/releases/download/2022-01-24/"
+export RUST_ANALYZER_URL="https://github.com/rust-analyzer/rust-analyzer/releases/download/2022-02-14/"
 
 function download {
     local filename="rust-analyzer-$1"


### PR DESCRIPTION
Fixes #428 

Based on [this conversation](https://users.rust-lang.org/t/how-to-disable-rust-analyzer-proc-macro-warnings-in-neovim/53150/2), it seems like we may need to explicitly enable procedural macro support when initializing `rust-analyzer`. Although it's strange because there's also [this PR which claims to enable support by default](https://github.com/rust-analyzer/rust-analyzer/issues/7328).

It also seems like we need to configure rust-analyzer with `cargo.loadOutDirsFromCheck: true`. When I make *both* of these configuration changes, I *think* I'm no longer seeing these warnings. But I'm still not totally confident because I thought it was working before I made the out dirs change and then I ended up seeing the errors again.