### PR TITLE
Provide editor styling information separately from editor settings

### DIFF
--- a/crates/chat_panel/src/chat_panel.rs
+++ b/crates/chat_panel/src/chat_panel.rs
@@ -2,7 +2,7 @@ use client::{
     channel::{Channel, ChannelEvent, ChannelList, ChannelMessage},
     Client,
 };
-use editor::{Editor, EditorSettings};
+use editor::Editor;
 use gpui::{
     action,
     elements::*,
@@ -16,7 +16,7 @@ use postage::{prelude::Stream, watch};
 use std::sync::Arc;
 use time::{OffsetDateTime, UtcOffset};
 use util::{ResultExt, TryFutureExt};
-use workspace::Settings;
+use workspace::{settings::SoftWrap, Settings};
 
 const MESSAGE_LOADING_THRESHOLD: usize = 50;
 
@@ -52,21 +52,14 @@ impl ChatPanel {
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let input_editor = cx.add_view(|cx| {
-            Editor::auto_height(
+            let mut editor = Editor::auto_height(
                 4,
-                {
-                    let settings = settings.clone();
-                    Arc::new(move |_| {
-                        let settings = settings.borrow();
-                        EditorSettings {
-                            tab_size: settings.tab_size,
-                            style: settings.theme.chat_panel.input_editor.as_editor(),
-                            soft_wrap: editor::SoftWrap::EditorWidth,
-                        }
-                    })
-                },
+                settings.clone(),
+                Some(|theme| theme.chat_panel.input_editor.clone()),
                 cx,
-            )
+            );
+            editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+            editor
         });
         let channel_select = cx.add_view(|cx| {
             let channel_list = channel_list.clone();

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -14,6 +14,7 @@ test-support = [
     "gpui/test-support",
     "project/test-support",
     "util/test-support",
+    "workspace/test-support",
 ]
 
 [dependencies]
@@ -50,6 +51,7 @@ lsp = { path = "../lsp", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 project = { path = "../project", features = ["test-support"] }
+workspace = { path = "../workspace", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"
 rand = "0.8"

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -56,12 +56,11 @@ impl ItemHandle for BufferItemHandle {
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
         let buffer = cx.add_model(|cx| MultiBuffer::singleton(self.0.clone(), cx));
-        let weak_buffer = buffer.downgrade();
         Box::new(cx.add_view(window_id, |cx| {
             let mut editor = Editor::for_buffer(
                 buffer,
-                crate::settings_builder(weak_buffer, workspace.settings()),
                 Some(workspace.project().clone()),
+                workspace.settings(),
                 cx,
             );
             editor.nav_history = Some(ItemNavHistory::new(nav_history, &cx.handle()));
@@ -101,12 +100,11 @@ impl ItemHandle for MultiBufferItemHandle {
         nav_history: Rc<RefCell<NavHistory>>,
         cx: &mut MutableAppContext,
     ) -> Box<dyn ItemViewHandle> {
-        let weak_buffer = self.0.downgrade();
         Box::new(cx.add_view(window_id, |cx| {
             let mut editor = Editor::for_buffer(
                 self.0.clone(),
-                crate::settings_builder(weak_buffer, workspace.settings()),
                 Some(workspace.project().clone()),
+                workspace.settings(),
                 cx,
             );
             editor.nav_history = Some(ItemNavHistory::new(nav_history, &cx.handle()));

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1,4 +1,4 @@
-use editor::{Editor, EditorSettings};
+use editor::Editor;
 use fuzzy::PathMatch;
 use gpui::{
     action,
@@ -266,17 +266,8 @@ impl FileFinder {
 
         let query_editor = cx.add_view(|cx| {
             Editor::single_line(
-                {
-                    let settings = settings.clone();
-                    Arc::new(move |_| {
-                        let settings = settings.borrow();
-                        EditorSettings {
-                            style: settings.theme.selector.input_editor.as_editor(),
-                            tab_size: settings.tab_size,
-                            soft_wrap: editor::SoftWrap::None,
-                        }
-                    })
-                },
+                settings.clone(),
+                Some(|theme| theme.selector.input_editor.clone()),
                 cx,
             )
         });

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -1,10 +1,9 @@
-use editor::{display_map::ToDisplayPoint, Autoscroll, DisplayPoint, Editor, EditorSettings};
+use editor::{display_map::ToDisplayPoint, Autoscroll, DisplayPoint, Editor};
 use gpui::{
     action, elements::*, geometry::vector::Vector2F, keymap::Binding, Axis, Entity,
     MutableAppContext, RenderContext, View, ViewContext, ViewHandle,
 };
 use postage::watch;
-use std::sync::Arc;
 use text::{Bias, Point};
 use workspace::{Settings, Workspace};
 
@@ -42,17 +41,8 @@ impl GoToLine {
     ) -> Self {
         let line_editor = cx.add_view(|cx| {
             Editor::single_line(
-                {
-                    let settings = settings.clone();
-                    Arc::new(move |_| {
-                        let settings = settings.borrow();
-                        EditorSettings {
-                            tab_size: settings.tab_size,
-                            style: settings.theme.selector.input_editor.as_editor(),
-                            soft_wrap: editor::SoftWrap::None,
-                        }
-                    })
-                },
+                settings.clone(),
+                Some(|theme| theme.selector.input_editor.clone()),
                 cx,
             )
         });

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -1,6 +1,6 @@
 use editor::{
     combine_syntax_and_fuzzy_match_highlights, display_map::ToDisplayPoint, Anchor, AnchorRangeExt,
-    Autoscroll, DisplayPoint, Editor, EditorSettings, ToPoint,
+    Autoscroll, DisplayPoint, Editor, ToPoint,
 };
 use fuzzy::StringMatch;
 use gpui::{
@@ -14,10 +14,7 @@ use gpui::{
 use language::Outline;
 use ordered_float::OrderedFloat;
 use postage::watch;
-use std::{
-    cmp::{self, Reverse},
-    sync::Arc,
-};
+use std::cmp::{self, Reverse};
 use workspace::{
     menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrev},
     Settings, Workspace,
@@ -107,17 +104,8 @@ impl OutlineView {
     ) -> Self {
         let query_editor = cx.add_view(|cx| {
             Editor::single_line(
-                {
-                    let settings = settings.clone();
-                    Arc::new(move |_| {
-                        let settings = settings.borrow();
-                        EditorSettings {
-                            style: settings.theme.selector.input_editor.as_editor(),
-                            tab_size: settings.tab_size,
-                            soft_wrap: editor::SoftWrap::None,
-                        }
-                    })
-                },
+                settings.clone(),
+                Some(|theme| theme.selector.input_editor.clone()),
                 cx,
             )
         });

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -1,6 +1,6 @@
 use editor::{
     combine_syntax_and_fuzzy_match_highlights, items::BufferItemHandle, styled_runs_for_code_label,
-    Autoscroll, Bias, Editor, EditorSettings,
+    Autoscroll, Bias, Editor,
 };
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
@@ -16,7 +16,6 @@ use project::{Project, Symbol};
 use std::{
     borrow::Cow,
     cmp::{self, Reverse},
-    sync::Arc,
 };
 use util::ResultExt;
 use workspace::{
@@ -105,17 +104,8 @@ impl ProjectSymbolsView {
     ) -> Self {
         let query_editor = cx.add_view(|cx| {
             Editor::single_line(
-                {
-                    let settings = settings.clone();
-                    Arc::new(move |_| {
-                        let settings = settings.borrow();
-                        EditorSettings {
-                            style: settings.theme.selector.input_editor.as_editor(),
-                            tab_size: settings.tab_size,
-                            soft_wrap: editor::SoftWrap::None,
-                        }
-                    })
-                },
+                settings.clone(),
+                Some(|theme| theme.selector.input_editor.clone()),
                 cx,
             )
         });

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1177,8 +1177,8 @@ mod tests {
             EstablishConnectionError, UserStore,
         },
         editor::{
-            self, ConfirmCodeAction, ConfirmCompletion, ConfirmRename, Editor, EditorSettings,
-            Input, MultiBuffer, Redo, Rename, ToOffset, ToggleCodeActions, Undo,
+            self, ConfirmCodeAction, ConfirmCompletion, ConfirmRename, Editor, Input, MultiBuffer,
+            Redo, Rename, ToOffset, ToggleCodeActions, Undo,
         },
         fs::{FakeFs, Fs as _},
         language::{
@@ -1187,7 +1187,7 @@ mod tests {
         },
         lsp,
         project::{DiagnosticSummary, Project, ProjectPath},
-        workspace::{Workspace, WorkspaceParams},
+        workspace::{Settings, Workspace, WorkspaceParams},
     };
 
     #[cfg(test)]
@@ -1298,7 +1298,12 @@ mod tests {
             .unwrap();
 
         let editor_b = cx_b.add_view(window_b, |cx| {
-            Editor::for_buffer(buffer_b, Arc::new(|cx| EditorSettings::test(cx)), None, cx)
+            Editor::for_buffer(
+                buffer_b,
+                None,
+                watch::channel_with(Settings::test(cx)).1,
+                cx,
+            )
         });
 
         // TODO
@@ -2330,8 +2335,8 @@ mod tests {
         let editor_b = cx_b.add_view(window_b, |cx| {
             Editor::for_buffer(
                 cx.add_model(|cx| MultiBuffer::singleton(buffer_b.clone(), cx)),
-                Arc::new(|cx| EditorSettings::test(cx)),
                 Some(project_b.clone()),
+                watch::channel_with(Settings::test(cx)).1,
                 cx,
             )
         });

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -23,7 +23,7 @@ pub struct Theme {
     pub contacts_panel: ContactsPanel,
     pub project_panel: ProjectPanel,
     pub selector: Selector,
-    pub editor: EditorStyle,
+    pub editor: Editor,
     pub find: Find,
     pub project_diagnostics: ProjectDiagnostics,
 }
@@ -112,7 +112,7 @@ pub struct Find {
 #[derive(Clone, Deserialize, Default)]
 pub struct FindEditor {
     #[serde(flatten)]
-    pub input: InputEditorStyle,
+    pub input: FieldEditor,
     pub max_width: f32,
 }
 
@@ -151,7 +151,7 @@ pub struct ChatPanel {
     pub message: ChatMessage,
     pub pending_message: ChatMessage,
     pub channel_select: ChannelSelect,
-    pub input_editor: InputEditorStyle,
+    pub input_editor: FieldEditor,
     pub sign_in_prompt: TextStyle,
     pub hovered_sign_in_prompt: TextStyle,
 }
@@ -236,7 +236,7 @@ pub struct Selector {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub empty: ContainedLabel,
-    pub input_editor: InputEditorStyle,
+    pub input_editor: FieldEditor,
     pub item: ContainedLabel,
     pub active_item: ContainedLabel,
 }
@@ -269,10 +269,9 @@ pub struct ProjectDiagnostics {
 }
 
 #[derive(Clone, Deserialize, Default)]
-pub struct EditorStyle {
-    pub text: TextStyle,
+pub struct Editor {
+    pub text_color: Color,
     #[serde(default)]
-    pub placeholder_text: Option<TextStyle>,
     pub background: Color,
     pub selection: SelectionStyle,
     pub gutter_background: Color,
@@ -345,7 +344,7 @@ pub struct SelectionStyle {
 }
 
 #[derive(Clone, Deserialize, Default)]
-pub struct InputEditorStyle {
+pub struct FieldEditor {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub text: TextStyle,
@@ -354,83 +353,13 @@ pub struct InputEditorStyle {
     pub selection: SelectionStyle,
 }
 
-impl EditorStyle {
-    pub fn placeholder_text(&self) -> &TextStyle {
-        self.placeholder_text.as_ref().unwrap_or(&self.text)
-    }
-
+impl Editor {
     pub fn replica_selection_style(&self, replica_id: u16) -> &SelectionStyle {
         let style_ix = replica_id as usize % (self.guest_selections.len() + 1);
         if style_ix == 0 {
             &self.selection
         } else {
             &self.guest_selections[style_ix - 1]
-        }
-    }
-}
-
-impl InputEditorStyle {
-    pub fn as_editor(&self) -> EditorStyle {
-        let default_diagnostic_style = DiagnosticStyle {
-            message: self.text.clone().into(),
-            header: Default::default(),
-            text_scale_factor: 1.,
-        };
-        EditorStyle {
-            text: self.text.clone(),
-            placeholder_text: self.placeholder_text.clone(),
-            background: self
-                .container
-                .background_color
-                .unwrap_or(Color::transparent_black()),
-            selection: self.selection,
-            gutter_background: Default::default(),
-            gutter_padding_factor: Default::default(),
-            active_line_background: Default::default(),
-            highlighted_line_background: Default::default(),
-            document_highlight_read_background: Default::default(),
-            document_highlight_write_background: Default::default(),
-            diff_background_deleted: Default::default(),
-            diff_background_inserted: Default::default(),
-            line_number: Default::default(),
-            line_number_active: Default::default(),
-            guest_selections: Default::default(),
-            syntax: Default::default(),
-            diagnostic_path_header: DiagnosticPathHeader {
-                container: Default::default(),
-                filename: ContainedText {
-                    container: Default::default(),
-                    text: self.text.clone(),
-                },
-                path: ContainedText {
-                    container: Default::default(),
-                    text: self.text.clone(),
-                },
-                text_scale_factor: 1.,
-            },
-            diagnostic_header: DiagnosticHeader {
-                container: Default::default(),
-                message: ContainedLabel {
-                    container: Default::default(),
-                    label: self.text.clone().into(),
-                },
-                code: ContainedText {
-                    container: Default::default(),
-                    text: self.text.clone(),
-                },
-                icon_width_factor: Default::default(),
-                text_scale_factor: 1.,
-            },
-            error_diagnostic: default_diagnostic_style.clone(),
-            invalid_error_diagnostic: default_diagnostic_style.clone(),
-            warning_diagnostic: default_diagnostic_style.clone(),
-            invalid_warning_diagnostic: default_diagnostic_style.clone(),
-            information_diagnostic: default_diagnostic_style.clone(),
-            invalid_information_diagnostic: default_diagnostic_style.clone(),
-            hint_diagnostic: default_diagnostic_style.clone(),
-            invalid_hint_diagnostic: default_diagnostic_style.clone(),
-            autocomplete: Default::default(),
-            code_actions_indicator: Default::default(),
         }
     }
 }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -1,4 +1,4 @@
-use editor::{Editor, EditorSettings};
+use editor::Editor;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
     action,
@@ -63,17 +63,8 @@ impl ThemeSelector {
     ) -> Self {
         let query_editor = cx.add_view(|cx| {
             Editor::single_line(
-                {
-                    let settings = settings.clone();
-                    Arc::new(move |_| {
-                        let settings = settings.borrow();
-                        EditorSettings {
-                            tab_size: settings.tab_size,
-                            style: settings.theme.selector.input_editor.as_editor(),
-                            soft_wrap: editor::SoftWrap::None,
-                        }
-                    })
-                },
+                settings.clone(),
+                Some(|theme| theme.selector.input_editor.clone()),
                 cx,
             )
         });

--- a/crates/workspace/src/settings.rs
+++ b/crates/workspace/src/settings.rs
@@ -72,4 +72,17 @@ impl Settings {
             .and_then(|settings| settings.preferred_line_length)
             .unwrap_or(self.preferred_line_length)
     }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn test(cx: &gpui::AppContext) -> Settings {
+        Settings {
+            buffer_font_family: cx.font_cache().load_family(&["Monaco"]).unwrap(),
+            buffer_font_size: 14.,
+            tab_size: 4,
+            soft_wrap: SoftWrap::None,
+            preferred_line_length: 80,
+            overrides: Default::default(),
+            theme: gpui::fonts::with_font_cache(cx.font_cache().clone(), || Default::default()),
+        }
+    }
 }

--- a/crates/zed/assets/themes/_base.toml
+++ b/crates/zed/assets/themes/_base.toml
@@ -243,7 +243,7 @@ background = "$state.hover"
 text = "$text.0"
 
 [editor]
-text = "$text.1"
+text_color = "$text.1.color"
 background = "$surface.1"
 gutter_background = "$surface.1"
 gutter_padding_factor = 2.5
@@ -282,8 +282,8 @@ header.border = { width = 1, top = true, color = "$border.0" }
 text_scale_factor = 0.857
 
 [editor.error_diagnostic.message]
-text = { extends = "$editor.text", size = 14, color = "$status.bad" }
-highlight_text = { extends = "$editor.text", size = 14, color = "$status.bad", weight = "bold" }
+text = { extends = "$text.1", size = 14, color = "$status.bad" }
+highlight_text = { extends = "$text.1", size = 14, color = "$status.bad", weight = "bold" }
 
 [editor.warning_diagnostic]
 extends = "$editor.error_diagnostic"


### PR DESCRIPTION
This is just a refactor, but I pulled it out into its own branch since it entailed a big shred.

* Since regular editors' font sizes and families are controlled by the settings and not the theme, don't store a dummy text style in the theme. Instead, only store a font color, and synthesize the text style for regular editors using both the theme and the settings.
* Style single-line and auto-height editors (now called "field editors") using a single function that takes the entire theme and selects a relevant sub-object.
