### PR TITLE
Add basic JSON support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,6 +5327,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-json"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b04c4e1a92139535eb9fca4ec8fa9666cc96b618005d3ae35f3c957fa92f92"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-markdown"
 version = "0.0.1"
 source = "git+https://github.com/MDeiml/tree-sitter-markdown?rev=330ecab87a3e3a7211ac69bbadc19eabecdb1cca#330ecab87a3e3a7211ac69bbadc19eabecdb1cca"
@@ -5935,6 +5945,7 @@ dependencies = [
  "toml",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-json",
  "tree-sitter-markdown",
  "tree-sitter-rust",
  "unindent",

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -574,7 +574,7 @@ impl LanguageServerConfig {
             Self {
                 fake_config: Some(FakeLanguageServerConfig {
                     servers_tx,
-                    capabilities: Default::default(),
+                    capabilities: lsp::LanguageServer::full_capabilities(),
                     initializer: None,
                 }),
                 disk_based_diagnostics_progress_token: Some("fakeServer/check".to_string()),

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -102,10 +102,13 @@ struct Error {
 impl LanguageServer {
     pub fn new(
         binary_path: &Path,
+        args: &[&str],
         root_path: &Path,
         background: Arc<executor::Background>,
     ) -> Result<Arc<Self>> {
         let mut server = Command::new(binary_path)
+            .current_dir(root_path)
+            .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -512,8 +512,16 @@ type FakeLanguageServerHandlers = Arc<
 
 #[cfg(any(test, feature = "test-support"))]
 impl LanguageServer {
+    pub fn full_capabilities() -> ServerCapabilities {
+        ServerCapabilities {
+            document_highlight_provider: Some(OneOf::Left(true)),
+            code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+            ..Default::default()
+        }
+    }
+
     pub fn fake(cx: &mut gpui::MutableAppContext) -> (Arc<Self>, FakeLanguageServer) {
-        Self::fake_with_capabilities(Default::default(), cx)
+        Self::fake_with_capabilities(Self::full_capabilities(), cx)
     }
 
     pub fn fake_with_capabilities(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -8,7 +8,7 @@ use language::{
     proto::{deserialize_anchor, serialize_anchor},
     range_from_lsp, Anchor, Bias, Buffer, PointUtf16, ToLspPosition, ToPointUtf16,
 };
-use lsp::DocumentHighlightKind;
+use lsp::{DocumentHighlightKind, ServerCapabilities};
 use std::{cmp::Reverse, ops::Range, path::Path};
 
 #[async_trait(?Send)]
@@ -16,6 +16,10 @@ pub(crate) trait LspCommand: 'static + Sized {
     type Response: 'static + Default + Send;
     type LspRequest: 'static + Send + lsp::request::Request;
     type ProtoRequest: 'static + Send + proto::RequestMessage;
+
+    fn check_capabilities(&self, _: &lsp::ServerCapabilities) -> bool {
+        true
+    }
 
     fn to_lsp(
         &self,
@@ -609,6 +613,10 @@ impl LspCommand for GetDocumentHighlights {
     type Response = Vec<DocumentHighlight>;
     type LspRequest = lsp::request::DocumentHighlightRequest;
     type ProtoRequest = proto::GetDocumentHighlights;
+
+    fn check_capabilities(&self, capabilities: &ServerCapabilities) -> bool {
+        capabilities.document_highlight_provider.is_some()
+    }
 
     fn to_lsp(&self, path: &Path, _: &AppContext) -> lsp::DocumentHighlightParams {
         lsp::DocumentHighlightParams {

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -92,6 +92,7 @@ tiny_http = "0.8"
 toml = "0.5"
 tree-sitter = "0.20.4"
 tree-sitter-c = "0.20.1"
+tree-sitter-json = "0.19.0"
 tree-sitter-rust = "0.20.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 url = "2.2"

--- a/crates/zed/languages/c/brackets.scm
+++ b/crates/zed/languages/c/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/languages/json/brackets.scm
+++ b/crates/zed/languages/json/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/languages/json/config.toml
+++ b/crates/zed/languages/json/config.toml
@@ -5,3 +5,6 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false },
 ]
+
+[language_server]
+disk_based_diagnostic_sources = []

--- a/crates/zed/languages/json/config.toml
+++ b/crates/zed/languages/json/config.toml
@@ -1,0 +1,7 @@
+name = "JSON"
+path_suffixes = ["json"]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false },
+]

--- a/crates/zed/languages/json/highlights.scm
+++ b/crates/zed/languages/json/highlights.scm
@@ -1,0 +1,12 @@
+(string) @string
+
+(pair
+  key: (string) @property)
+
+(number) @number
+
+[
+  (true)
+  (false)
+  (null)
+] @constant

--- a/crates/zed/languages/json/indents.scm
+++ b/crates/zed/languages/json/indents.scm
@@ -1,0 +1,2 @@
+(array "]" @end) @indent
+(object "}" @end) @indent

--- a/crates/zed/languages/json/outline.scm
+++ b/crates/zed/languages/json/outline.scm
@@ -1,0 +1,2 @@
+(pair
+  key: (string (string_content) @name)) @item

--- a/crates/zed/src/language.rs
+++ b/crates/zed/src/language.rs
@@ -7,6 +7,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use rust_embed::RustEmbed;
 use serde::Deserialize;
+use serde_json::json;
 use smol::fs::{self, File};
 use std::{borrow::Cow, env::consts, path::PathBuf, str, sync::Arc};
 use util::{ResultExt, TryFutureExt};
@@ -522,6 +523,12 @@ impl LspAdapter for JsonLspAdapter {
     }
 
     fn process_diagnostics(&self, _: &mut lsp::PublishDiagnosticsParams) {}
+
+    fn initialization_options(&self) -> Option<serde_json::Value> {
+        Some(json!({
+            "provideFormatter": true
+        }))
+    }
 }
 
 pub fn build_language_registry() -> LanguageRegistry {

--- a/crates/zed/src/language.rs
+++ b/crates/zed/src/language.rs
@@ -429,6 +429,7 @@ pub fn build_language_registry() -> LanguageRegistry {
             .join(".zed"),
     );
     languages.add(Arc::new(c()));
+    languages.add(Arc::new(json()));
     languages.add(Arc::new(rust()));
     languages.add(Arc::new(markdown()));
     languages
@@ -455,11 +456,27 @@ fn c() -> Language {
     Language::new(config, Some(grammar))
         .with_highlights_query(load_query("c/highlights.scm").as_ref())
         .unwrap()
+        .with_brackets_query(load_query("c/brackets.scm").as_ref())
+        .unwrap()
         .with_indents_query(load_query("c/indents.scm").as_ref())
         .unwrap()
         .with_outline_query(load_query("c/outline.scm").as_ref())
         .unwrap()
         .with_lsp_ext(CLsp)
+}
+
+fn json() -> Language {
+    let grammar = tree_sitter_json::language();
+    let config = toml::from_slice(&LanguageDir::get("json/config.toml").unwrap().data).unwrap();
+    Language::new(config, Some(grammar))
+        .with_highlights_query(load_query("json/highlights.scm").as_ref())
+        .unwrap()
+        .with_brackets_query(load_query("json/brackets.scm").as_ref())
+        .unwrap()
+        .with_indents_query(load_query("json/indents.scm").as_ref())
+        .unwrap()
+        .with_outline_query(load_query("json/outline.scm").as_ref())
+        .unwrap()
 }
 
 fn markdown() -> Language {


### PR DESCRIPTION
Closes #511

This PR enables syntax highlighting, auto-indent, and the outline view in JSON files. It also adds some code intelligence features via VSCode's [`json-languageserver`](https://www.npmjs.com/package/vscode-json-languageserver).

Right now, format-on-save does not work, because `json-languageserver` expects a different type of formatting request (`rangeFormatting`), which we don't yet do. It'll be easy to add support for this, but we're holding off on it for now, because it would create some conflicts with another outstanding PR.