### PR TITLE
Avoid infinite loop when a language server fails to start

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -378,8 +378,16 @@ impl LanguageServer {
         }
     }
 
-    pub fn capabilities(&self) -> watch::Receiver<Option<ServerCapabilities>> {
-        self.capabilities.clone()
+    pub fn capabilities(&self) -> impl 'static + Future<Output = Option<ServerCapabilities>> {
+        let mut rx = self.capabilities.clone();
+        async move {
+            loop {
+                let value = rx.recv().await?;
+                if value.is_some() {
+                    return value;
+                }
+            }
+        }
     }
 
     pub fn request<T: request::Request>(


### PR DESCRIPTION
Fixes #531

We currently use a `postage::watch` channel to indicate to users of `LanguageServer` that the server has been successfully initialized and reported its capabilities. Because this watch channel contained an *optional* value, there were code paths that repeatedly called `recv()` on the channel until a `Some` value was received. But on all postage streams, `recv()` returns `Poll::Ready(None)` when the stream is *closed* (which in this case happened because the server failed to start). Confusion between an outer None and the inner None lead to an infinite loop.

I've adjusted the `LanguageServer::capabilities` API so that it encapsulates the `watch::Receiver`, and instead just returns a `Future` that resolves with a `Some(capabilities)` if the server starts successfully, and `None` if it fails to start.