### PR TITLE
Open untitled buffers via the `Project`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -940,9 +940,15 @@ impl Editor {
         _: &workspace::OpenNew,
         cx: &mut ViewContext<Workspace>,
     ) {
-        let buffer = cx
-            .add_model(|cx| Buffer::new(0, "", cx).with_language(language::PLAIN_TEXT.clone(), cx));
-        workspace.open_item(BufferItemHandle(buffer), cx);
+        let project = workspace.project();
+        if project.read(cx).is_remote() {
+            cx.propagate_action();
+        } else if let Some(buffer) = project
+            .update(cx, |project, cx| project.create_buffer(cx))
+            .log_err()
+        {
+            workspace.open_item(BufferItemHandle(buffer), cx);
+        }
     }
 
     pub fn replica_id(&self, cx: &AppContext) -> ReplicaId {


### PR DESCRIPTION
This allows the registration of such buffers in the project, which is necessary to correctly support `::save_buffer_as` and opens the door to sharing untitled buffers with guests in the future.

Note that, for now, this disallows guests to create untitled buffers in the current window and will create a new window instead. This is because we don't yet have a global way of allocating a buffer's remote id (nor a way of saving such buffers in the host's worktree) and we instead rely on the local model ID, which could clash with the host's buffer IDs.

I think we should revisit this once guests can share their untitled buffers with the host and other remote peers, as well as once we start keying operations by entry id.