### PR TITLE
Ensure `active_item_index` doesn't go off the end when closing items

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -406,11 +406,13 @@ impl Pane {
         });
 
         if self.item_views.is_empty() {
-            self.update_active_toolbar(cx);
             cx.emit(Event::Remove);
         } else {
-            self.activate_item(new_active_item_index, cx);
+            self.active_item_index = cmp::min(new_active_item_index, self.item_views.len() - 1);
+            self.focus_active_item(cx);
+            self.activate(cx);
         }
+        self.update_active_toolbar(cx);
 
         cx.notify();
     }


### PR DESCRIPTION
This fixes a bug introduced in #538, where closing the current tab would hide all the other tabs, if the current tab was the last one.

Also, this pull request manually sets the active item index instead of calling `Pane::activate_item`: even though this introduces a little bit of duplication, it prevents us from mistakenly calling `deactivate` on the wrong item. This would
happen because `activate_item` looks at `self.active_item_index` to determine which item to deactivate before setting the new one. However, that index is potentially invalid because `::close_items` manipulates the `item_views` vector,
so `activate_item` could end up calling `deactivate` on an item view that was not active in the first place.