### PR TITLE
Make theme selector eagerly display the selected theme

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -76,7 +76,7 @@ impl View for FileFinder {
                 Container::new(
                     Flex::new(Axis::Vertical)
                         .with_child(
-                            Container::new(ChildView::new(&self.query_editor).boxed())
+                            ChildView::new(&self.query_editor).contained()
                                 .with_style(settings.theme.selector.input_editor.container)
                                 .boxed(),
                         )

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -76,7 +76,8 @@ impl View for FileFinder {
                 Container::new(
                     Flex::new(Axis::Vertical)
                         .with_child(
-                            ChildView::new(&self.query_editor).contained()
+                            ChildView::new(&self.query_editor)
+                                .contained()
                                 .with_style(settings.theme.selector.input_editor.container)
                                 .boxed(),
                         )

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -144,7 +144,7 @@ impl OutlineView {
                     let view = cx.add_view(|cx| OutlineView::new(outline, editor, settings, cx));
                     cx.subscribe(&view, Self::on_event).detach();
                     view
-                })
+                });
             }
         }
     }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -340,7 +340,11 @@ impl View for ThemeSelector {
             ConstrainedBox::new(
                 Container::new(
                     Flex::new(Axis::Vertical)
-                        .with_child(ChildView::new(&self.query_editor).boxed())
+                        .with_child(
+                            ChildView::new(&self.query_editor).contained()
+                                .with_style(settings.theme.selector.input_editor.container)
+                                .boxed(),
+                        )
                         .with_child(Flexible::new(1.0, false, self.render_matches(cx)).boxed())
                         .boxed(),
                 )

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -218,7 +218,8 @@ impl ThemeSelector {
             ))
         };
 
-        self.selected_index = self.selected_index
+        self.selected_index = self
+            .selected_index
             .min(self.matches.len().saturating_sub(1));
 
         cx.notify();
@@ -341,7 +342,8 @@ impl View for ThemeSelector {
                 Container::new(
                     Flex::new(Axis::Vertical)
                         .with_child(
-                            ChildView::new(&self.query_editor).contained()
+                            ChildView::new(&self.query_editor)
+                                .contained()
                                 .with_style(settings.theme.selector.input_editor.container)
                                 .boxed(),
                         )

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -754,20 +754,26 @@ impl Workspace {
         })
     }
 
-    pub fn toggle_modal<V, F>(&mut self, cx: &mut ViewContext<Self>, add_view: F)
+    // Returns the model that was toggled closed if it was open
+    pub fn toggle_modal<V, F>(&mut self, cx: &mut ViewContext<Self>, add_view: F) -> Option<ViewHandle<V>>
     where
         V: 'static + View,
         F: FnOnce(&mut ViewContext<Self>, &mut Self) -> ViewHandle<V>,
     {
-        if self.modal.as_ref().map_or(false, |modal| modal.is::<V>()) {
-            self.modal.take();
+        cx.notify();
+        // Whatever modal was visible is getting clobbered. If its the same type as V, then return
+        // it. Otherwise, create a new modal and set it as active.
+        let already_open_modal = self.modal.take()
+            .and_then(|modal| modal.downcast::<V>());
+        if let Some(already_open_modal) = already_open_modal {
             cx.focus_self();
+            Some(already_open_modal)
         } else {
             let modal = add_view(cx, self);
             cx.focus(&modal);
             self.modal = Some(modal.into());
+            None
         }
-        cx.notify();
     }
 
     pub fn modal(&self) -> Option<&AnyViewHandle> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -755,7 +755,11 @@ impl Workspace {
     }
 
     // Returns the model that was toggled closed if it was open
-    pub fn toggle_modal<V, F>(&mut self, cx: &mut ViewContext<Self>, add_view: F) -> Option<ViewHandle<V>>
+    pub fn toggle_modal<V, F>(
+        &mut self,
+        cx: &mut ViewContext<Self>,
+        add_view: F,
+    ) -> Option<ViewHandle<V>>
     where
         V: 'static + View,
         F: FnOnce(&mut ViewContext<Self>, &mut Self) -> ViewHandle<V>,
@@ -763,8 +767,7 @@ impl Workspace {
         cx.notify();
         // Whatever modal was visible is getting clobbered. If its the same type as V, then return
         // it. Otherwise, create a new modal and set it as active.
-        let already_open_modal = self.modal.take()
-            .and_then(|modal| modal.downcast::<V>());
+        let already_open_modal = self.modal.take().and_then(|modal| modal.downcast::<V>());
         if let Some(already_open_modal) = already_open_modal {
             cx.focus_self();
             Some(already_open_modal)


### PR DESCRIPTION
Addresses https://github.com/zed-industries/zed/issues/547

![Kapture 2022-03-08 at 18 47 18](https://user-images.githubusercontent.com/3323631/157363038-1d3fc200-05ff-455e-bec7-af68360fd6bd.gif)

To get this right, I had to make some changes to toggle_modal in the workspace. It now returns the closed modal in order to do some cleanup if necessary on close.

The selector also now better preserves the selected item when the matches change so that the theme doesn't flash unnecessarily.