### PR TITLE
Eliminate ToFoldPoint trait

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -6,7 +6,7 @@ mod wrap_map;
 use crate::{Anchor, MultiBuffer, MultiBufferSnapshot, ToOffset, ToPoint};
 use block_map::{BlockMap, BlockPoint};
 use collections::{HashMap, HashSet};
-use fold_map::{FoldMap, ToFoldPoint as _};
+use fold_map::FoldMap;
 use gpui::{fonts::FontId, Entity, ModelContext, ModelHandle};
 use language::{Point, Subscription as BufferSubscription};
 use std::ops::Range;
@@ -200,7 +200,7 @@ impl DisplaySnapshot {
 
     pub fn prev_line_boundary(&self, mut point: Point) -> (Point, DisplayPoint) {
         loop {
-            let mut fold_point = point.to_fold_point(&self.folds_snapshot, Bias::Left);
+            let mut fold_point = self.folds_snapshot.to_fold_point(point, Bias::Left);
             *fold_point.column_mut() = 0;
             point = fold_point.to_buffer_point(&self.folds_snapshot);
 
@@ -216,7 +216,7 @@ impl DisplaySnapshot {
 
     pub fn next_line_boundary(&self, mut point: Point) -> (Point, DisplayPoint) {
         loop {
-            let mut fold_point = point.to_fold_point(&self.folds_snapshot, Bias::Right);
+            let mut fold_point = self.folds_snapshot.to_fold_point(point, Bias::Right);
             *fold_point.column_mut() = self.folds_snapshot.line_len(fold_point.row());
             point = fold_point.to_buffer_point(&self.folds_snapshot);
 
@@ -231,7 +231,7 @@ impl DisplaySnapshot {
     }
 
     fn point_to_display_point(&self, point: Point, bias: Bias) -> DisplayPoint {
-        let fold_point = point.to_fold_point(&self.folds_snapshot, bias);
+        let fold_point = self.folds_snapshot.to_fold_point(point, bias);
         let tab_point = self.tabs_snapshot.to_tab_point(fold_point);
         let wrap_point = self.wraps_snapshot.from_tab_point(tab_point);
         let block_point = self.blocks_snapshot.to_block_point(wrap_point);

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -1,4 +1,4 @@
-use super::fold_map::{self, FoldEdit, FoldPoint, FoldSnapshot, ToFoldPoint};
+use super::fold_map::{self, FoldEdit, FoldPoint, FoldSnapshot};
 use crate::MultiBufferSnapshot;
 use language::{rope, Chunk};
 use parking_lot::Mutex;
@@ -201,10 +201,6 @@ impl TabSnapshot {
         TabPoint::new(input.row(), expanded as u32)
     }
 
-    pub fn from_point(&self, point: Point, bias: Bias) -> TabPoint {
-        self.to_tab_point(point.to_fold_point(&self.fold_snapshot, bias))
-    }
-
     pub fn to_fold_point(&self, output: TabPoint, bias: Bias) -> (FoldPoint, usize, usize) {
         let chars = self.fold_snapshot.chars_at(FoldPoint::new(output.row(), 0));
         let expanded = output.column() as usize;
@@ -215,6 +211,10 @@ impl TabSnapshot {
             expanded_char_column,
             to_next_stop,
         )
+    }
+
+    pub fn from_point(&self, point: Point, bias: Bias) -> TabPoint {
+        self.to_tab_point(self.fold_snapshot.to_fold_point(point, bias))
     }
 
     pub fn to_point(&self, point: TabPoint, bias: Bias) -> Point {


### PR DESCRIPTION
This was a drive-by on a branch that I'll probably end up abandoning, so I figured I'd cherry-pick it to `main`. It's super minor, but I think it makes things more consistent.