### PR TITLE
Add support for rendering the cursor as a Block and Underscore

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1023,10 +1023,7 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn set_cursor_shape(
-        &mut self,
-        cursor_shape: CursorShape
-    ) {
+    pub fn set_cursor_shape(&mut self, cursor_shape: CursorShape) {
         self.cursor_shape = cursor_shape;
         // TODO: Do we need to notify?
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -450,6 +450,7 @@ pub struct Editor {
     document_highlights_task: Option<Task<()>>,
     pending_rename: Option<RenameState>,
     searchable: bool,
+    cursor_shape: CursorShape,
 }
 
 pub struct EditorSnapshot {
@@ -930,6 +931,7 @@ impl Editor {
             document_highlights_task: Default::default(),
             pending_rename: Default::default(),
             searchable: true,
+            cursor_shape: Default::default(),
         };
         this.end_selection(cx);
         this
@@ -1019,6 +1021,14 @@ impl Editor {
         }
 
         cx.notify();
+    }
+
+    pub fn set_cursor_shape(
+        &mut self,
+        cursor_shape: CursorShape
+    ) {
+        self.cursor_shape = cursor_shape;
+        // TODO: Do we need to notify?
     }
 
     pub fn scroll_position(&self, cx: &mut ViewContext<Self>) -> Vector2F {
@@ -5569,7 +5579,7 @@ impl View for Editor {
         self.display_map.update(cx, |map, cx| {
             map.set_font(style.text.font_id, style.text.font_size, cx)
         });
-        EditorElement::new(self.handle.clone(), style.clone()).boxed()
+        EditorElement::new(self.handle.clone(), style.clone(), self.cursor_shape).boxed()
     }
 
     fn ui_name() -> &'static str {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1023,9 +1023,9 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn set_cursor_shape(&mut self, cursor_shape: CursorShape) {
+    pub fn set_cursor_shape(&mut self, cursor_shape: CursorShape, cx: &mut ViewContext<Self>) {
         self.cursor_shape = cursor_shape;
-        // TODO: Do we need to notify?
+        cx.notify();
     }
 
     pub fn scroll_position(&self, cx: &mut ViewContext<Self>) -> Vector2F {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -36,8 +36,16 @@ pub struct EditorElement {
 }
 
 impl EditorElement {
-    pub fn new(view: WeakViewHandle<Editor>, style: EditorStyle, cursor_shape: CursorShape) -> Self {
-        Self { view, style, cursor_shape }
+    pub fn new(
+        view: WeakViewHandle<Editor>,
+        style: EditorStyle,
+        cursor_shape: CursorShape,
+    ) -> Self {
+        Self {
+            view,
+            style,
+            cursor_shape,
+        }
     }
 
     fn view<'a>(&self, cx: &'a AppContext) -> &'a Editor {
@@ -365,7 +373,8 @@ impl EditorElement {
                             &layout.line_layouts[(cursor_position.row() - start_row) as usize];
                         let cursor_column = cursor_position.column() as usize;
                         let cursor_character_x = cursor_row_layout.x_for_index(cursor_column);
-                        let mut character_width = cursor_row_layout.x_for_index(cursor_column + 1) - cursor_character_x;
+                        let mut character_width =
+                            cursor_row_layout.x_for_index(cursor_column + 1) - cursor_character_x;
                         // TODO: Is there a better option here for the character size
                         // at the end of the line?
                         // Default to 1/3 the line height
@@ -1228,7 +1237,7 @@ impl PaintState {
 pub enum CursorShape {
     Bar,
     Block,
-    Underscore
+    Underscore,
 }
 
 impl Default for CursorShape {
@@ -1242,17 +1251,20 @@ struct Cursor {
     character_width: f32,
     line_height: f32,
     color: Color,
-    shape: CursorShape
+    shape: CursorShape,
 }
 
 impl Cursor {
     fn paint(&self, cx: &mut PaintContext) {
         let bounds = match self.shape {
             CursorShape::Bar => RectF::new(self.origin, vec2f(2.0, self.line_height)),
-            CursorShape::Block => RectF::new(self.origin, vec2f(self.character_width, self.line_height)),
+            CursorShape::Block => {
+                RectF::new(self.origin, vec2f(self.character_width, self.line_height))
+            }
             CursorShape::Underscore => RectF::new(
                 self.origin + Vector2F::new(0.0, self.line_height - 2.0),
-                vec2f(self.character_width, 2.0)),
+                vec2f(self.character_width, 2.0),
+            ),
         };
 
         cx.scene.push_quad(Quad {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1268,7 +1268,7 @@ pub enum CursorShape {
 
 impl Default for CursorShape {
     fn default() -> Self {
-        CursorShape::Block
+        CursorShape::Bar
     }
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1467,7 +1467,7 @@ mod tests {
         let (window_id, editor) = cx.add_window(Default::default(), |cx| {
             Editor::new(EditorMode::Full, buffer, None, settings.1, None, cx)
         });
-        let element = EditorElement::new(editor.downgrade(), editor.read(cx).style(cx));
+        let element = EditorElement::new(editor.downgrade(), editor.read(cx).style(cx), CursorShape::Bar);
 
         let layouts = editor.update(cx, |editor, cx| {
             let snapshot = editor.snapshot(cx);

--- a/crates/gpui/src/text_layout.rs
+++ b/crates/gpui/src/text_layout.rs
@@ -186,7 +186,7 @@ pub struct Run {
     pub glyphs: Vec<Glyph>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Glyph {
     pub id: GlyphId,
     pub position: Vector2F,
@@ -210,15 +210,31 @@ impl Line {
         self.layout.width
     }
 
+    pub fn font_size(&self) -> f32 {
+        self.layout.font_size
+    }
+
     pub fn x_for_index(&self, index: usize) -> f32 {
         for run in &self.layout.runs {
             for glyph in &run.glyphs {
-                if glyph.index == index {
+                if glyph.index >= index {
                     return glyph.position.x();
                 }
             }
         }
         self.layout.width
+    }
+
+    pub fn font_for_index(&self, index: usize) -> Option<FontId> {
+        for run in &self.layout.runs {
+            for glyph in &run.glyphs {
+                if glyph.index >= index {
+                    return Some(run.font_id);
+                }
+            }
+        }
+
+        None
     }
 
     pub fn index_for_x(&self, x: f32) -> Option<usize> {


### PR DESCRIPTION
This doesn't make a functional change, but adds a function to the Editor which lets you specify how cursors should be rendered. This is a necessary change to indicate to the user which mode they are in when using vim bindings.