### PR TITLE
Avoid re-using excerpt IDs in `MultiBuffer`

### DIFF
--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -241,6 +241,14 @@ impl FoldMap {
                 self.buffer.lock().len(),
                 "transform tree does not match buffer's length"
             );
+
+            let mut folds = self.folds.iter().peekable();
+            while let Some(fold) = folds.next() {
+                if let Some(next_fold) = folds.peek() {
+                    let comparison = fold.0.cmp(&next_fold.0, &self.buffer.lock()).unwrap();
+                    assert!(comparison.is_le());
+                }
+            }
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4517,25 +4517,32 @@ impl Editor {
         self.remove_blocks([rename.block_id].into_iter().collect(), cx);
         self.clear_highlighted_ranges::<Rename>(cx);
 
-        let editor = rename.editor.read(cx);
-        let snapshot = self.buffer.read(cx).snapshot(cx);
-        let selection = editor.newest_selection_with_snapshot::<usize>(&snapshot);
+        let selection_in_rename_editor = rename.editor.read(cx).newest_selection::<usize>(cx);
 
         // Update the selection to match the position of the selection inside
         // the rename editor.
+        let snapshot = self.buffer.read(cx).read(cx);
         let rename_range = rename.range.to_offset(&snapshot);
         let start = snapshot
-            .clip_offset(rename_range.start + selection.start, Bias::Left)
+            .clip_offset(
+                rename_range.start + selection_in_rename_editor.start,
+                Bias::Left,
+            )
             .min(rename_range.end);
         let end = snapshot
-            .clip_offset(rename_range.start + selection.end, Bias::Left)
+            .clip_offset(
+                rename_range.start + selection_in_rename_editor.end,
+                Bias::Left,
+            )
             .min(rename_range.end);
+        drop(snapshot);
+
         self.update_selections(
             vec![Selection {
                 id: self.newest_anchor_selection().id,
                 start,
                 end,
-                reversed: selection.reversed,
+                reversed: selection_in_rename_editor.reversed,
                 goal: SelectionGoal::None,
             }],
             None,

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1998,10 +1998,9 @@ impl MultiBufferSnapshot {
     pub fn can_resolve(&self, anchor: &Anchor) -> bool {
         if anchor.excerpt_id == ExcerptId::min() || anchor.excerpt_id == ExcerptId::max() {
             true
-        } else if let Some((buffer_id, buffer_snapshot)) =
-            self.buffer_snapshot_for_excerpt(&anchor.excerpt_id)
-        {
-            anchor.buffer_id == Some(buffer_id) && buffer_snapshot.can_resolve(&anchor.text_anchor)
+        } else if let Some(excerpt) = self.excerpt(&anchor.excerpt_id) {
+            anchor.buffer_id == Some(excerpt.buffer_id)
+                && excerpt.buffer.can_resolve(&anchor.text_anchor)
         } else {
             false
         }
@@ -2231,15 +2230,12 @@ impl MultiBufferSnapshot {
         ))
     }
 
-    fn buffer_snapshot_for_excerpt<'a>(
-        &'a self,
-        excerpt_id: &'a ExcerptId,
-    ) -> Option<(usize, &'a BufferSnapshot)> {
+    fn excerpt<'a>(&'a self, excerpt_id: &'a ExcerptId) -> Option<&'a Excerpt> {
         let mut cursor = self.excerpts.cursor::<Option<&ExcerptId>>();
         cursor.seek(&Some(excerpt_id), Bias::Left, &());
         if let Some(excerpt) = cursor.item() {
             if excerpt.id == *excerpt_id {
-                return Some((excerpt.buffer_id, &excerpt.buffer));
+                return Some(excerpt);
             }
         }
         None

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -36,7 +36,7 @@ pub type ExcerptId = Locator;
 pub struct MultiBuffer {
     snapshot: RefCell<MultiBufferSnapshot>,
     buffers: RefCell<HashMap<usize, BufferState>>,
-    used_excerpt_ids: SumTree<Locator>,
+    used_excerpt_ids: SumTree<ExcerptId>,
     subscriptions: Topic,
     singleton: bool,
     replica_id: ReplicaId,

--- a/crates/editor/src/multi_buffer/anchor.rs
+++ b/crates/editor/src/multi_buffer/anchor.rs
@@ -41,22 +41,7 @@ impl Anchor {
             if self.excerpt_id == ExcerptId::min() || self.excerpt_id == ExcerptId::max() {
                 Ok(Ordering::Equal)
             } else if let Some(excerpt) = snapshot.excerpt(&self.excerpt_id) {
-                // Even though the anchor refers to a valid excerpt the underlying buffer might have
-                // changed. In that case, treat the anchor as if it were at the start of that
-                // excerpt.
-                if self.buffer_id == Some(excerpt.buffer_id)
-                    && other.buffer_id == Some(excerpt.buffer_id)
-                {
-                    let self_anchor = excerpt.clip_anchor(self.text_anchor.clone());
-                    let other_anchor = excerpt.clip_anchor(other.text_anchor.clone());
-                    self_anchor.cmp(&other_anchor, &excerpt.buffer)
-                } else if self.buffer_id == Some(excerpt.buffer_id) {
-                    Ok(Ordering::Greater)
-                } else if other.buffer_id == Some(excerpt.buffer_id) {
-                    Ok(Ordering::Less)
-                } else {
-                    Ok(Ordering::Equal)
-                }
+                self.text_anchor.cmp(&other.text_anchor, &excerpt.buffer)
             } else {
                 Ok(Ordering::Equal)
             }
@@ -68,13 +53,11 @@ impl Anchor {
     pub fn bias_left(&self, snapshot: &MultiBufferSnapshot) -> Anchor {
         if self.text_anchor.bias != Bias::Left {
             if let Some(excerpt) = snapshot.excerpt(&self.excerpt_id) {
-                if self.buffer_id == Some(excerpt.buffer_id) {
-                    return Self {
-                        buffer_id: self.buffer_id,
-                        excerpt_id: self.excerpt_id.clone(),
-                        text_anchor: self.text_anchor.bias_left(&excerpt.buffer),
-                    };
-                }
+                return Self {
+                    buffer_id: self.buffer_id,
+                    excerpt_id: self.excerpt_id.clone(),
+                    text_anchor: self.text_anchor.bias_left(&excerpt.buffer),
+                };
             }
         }
         self.clone()
@@ -83,13 +66,11 @@ impl Anchor {
     pub fn bias_right(&self, snapshot: &MultiBufferSnapshot) -> Anchor {
         if self.text_anchor.bias != Bias::Right {
             if let Some(excerpt) = snapshot.excerpt(&self.excerpt_id) {
-                if self.buffer_id == Some(excerpt.buffer_id) {
-                    return Self {
-                        buffer_id: self.buffer_id,
-                        excerpt_id: self.excerpt_id.clone(),
-                        text_anchor: self.text_anchor.bias_right(&excerpt.buffer),
-                    };
-                }
+                return Self {
+                    buffer_id: self.buffer_id,
+                    excerpt_id: self.excerpt_id.clone(),
+                    text_anchor: self.text_anchor.bias_right(&excerpt.buffer),
+                };
             }
         }
         self.clone()

--- a/crates/editor/src/multi_buffer/anchor.rs
+++ b/crates/editor/src/multi_buffer/anchor.rs
@@ -40,17 +40,19 @@ impl Anchor {
         if excerpt_id_cmp.is_eq() {
             if self.excerpt_id == ExcerptId::min() || self.excerpt_id == ExcerptId::max() {
                 Ok(Ordering::Equal)
-            } else if let Some((buffer_id, buffer_snapshot)) =
-                snapshot.buffer_snapshot_for_excerpt(&self.excerpt_id)
-            {
+            } else if let Some(excerpt) = snapshot.excerpt(&self.excerpt_id) {
                 // Even though the anchor refers to a valid excerpt the underlying buffer might have
                 // changed. In that case, treat the anchor as if it were at the start of that
                 // excerpt.
-                if self.buffer_id == Some(buffer_id) && other.buffer_id == Some(buffer_id) {
-                    self.text_anchor.cmp(&other.text_anchor, buffer_snapshot)
-                } else if self.buffer_id == Some(buffer_id) {
+                if self.buffer_id == Some(excerpt.buffer_id)
+                    && other.buffer_id == Some(excerpt.buffer_id)
+                {
+                    let self_anchor = excerpt.clip_anchor(self.text_anchor.clone());
+                    let other_anchor = excerpt.clip_anchor(other.text_anchor.clone());
+                    self_anchor.cmp(&other_anchor, &excerpt.buffer)
+                } else if self.buffer_id == Some(excerpt.buffer_id) {
                     Ok(Ordering::Greater)
-                } else if other.buffer_id == Some(buffer_id) {
+                } else if other.buffer_id == Some(excerpt.buffer_id) {
                     Ok(Ordering::Less)
                 } else {
                     Ok(Ordering::Equal)
@@ -65,14 +67,12 @@ impl Anchor {
 
     pub fn bias_left(&self, snapshot: &MultiBufferSnapshot) -> Anchor {
         if self.text_anchor.bias != Bias::Left {
-            if let Some((buffer_id, buffer_snapshot)) =
-                snapshot.buffer_snapshot_for_excerpt(&self.excerpt_id)
-            {
-                if self.buffer_id == Some(buffer_id) {
+            if let Some(excerpt) = snapshot.excerpt(&self.excerpt_id) {
+                if self.buffer_id == Some(excerpt.buffer_id) {
                     return Self {
                         buffer_id: self.buffer_id,
                         excerpt_id: self.excerpt_id.clone(),
-                        text_anchor: self.text_anchor.bias_left(buffer_snapshot),
+                        text_anchor: self.text_anchor.bias_left(&excerpt.buffer),
                     };
                 }
             }
@@ -82,14 +82,12 @@ impl Anchor {
 
     pub fn bias_right(&self, snapshot: &MultiBufferSnapshot) -> Anchor {
         if self.text_anchor.bias != Bias::Right {
-            if let Some((buffer_id, buffer_snapshot)) =
-                snapshot.buffer_snapshot_for_excerpt(&self.excerpt_id)
-            {
-                if self.buffer_id == Some(buffer_id) {
+            if let Some(excerpt) = snapshot.excerpt(&self.excerpt_id) {
+                if self.buffer_id == Some(excerpt.buffer_id) {
                     return Self {
                         buffer_id: self.buffer_id,
                         excerpt_id: self.excerpt_id.clone(),
-                        text_anchor: self.text_anchor.bias_right(buffer_snapshot),
+                        text_anchor: self.text_anchor.bias_right(&excerpt.buffer),
                     };
                 }
             }

--- a/crates/text/src/locator.rs
+++ b/crates/text/src/locator.rs
@@ -19,11 +19,6 @@ impl Locator {
         Self(smallvec![u64::MAX])
     }
 
-    pub fn from_index(ix: usize, count: usize) -> Self {
-        let id = (1 + ix as u64) * (u64::MAX / (count as u64 + 2));
-        Self(smallvec![id])
-    }
-
     pub fn assign(&mut self, other: &Self) {
         self.0.resize(other.0.len(), 0);
         self.0.copy_from_slice(&other.0);

--- a/crates/text/src/locator.rs
+++ b/crates/text/src/locator.rs
@@ -49,6 +49,30 @@ impl Default for Locator {
     }
 }
 
+impl sum_tree::Item for Locator {
+    type Summary = Locator;
+
+    fn summary(&self) -> Self::Summary {
+        self.clone()
+    }
+}
+
+impl sum_tree::KeyedItem for Locator {
+    type Key = Locator;
+
+    fn key(&self) -> Self::Key {
+        self.clone()
+    }
+}
+
+impl sum_tree::Summary for Locator {
+    type Context = ();
+
+    fn add_summary(&mut self, summary: &Self, _: &()) {
+        self.assign(summary);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
With these changes we introduce a new `used_excerpt_ids` field in `MultiBuffer` that prevents assigning the same excerpt ID more than once when inserting a new excerpt, preventing anchors from jumping around when excerpts are removed. This is necessary for data structures like the `FoldMap` where we index folds sorted by their range: if an anchor is allowed to move non-monotonically, it is possible to invalidate the order in which folds are stored and that was causing our randomized tests to fail.

This pull request also simplifies a lot of the code paths that were resolving or comparing anchors because now, if we find an excerpt that has the same ID as the anchor, we can assume that it shares the same buffer and that the anchor is located within the bounds of the excerpt.