### PR TITLE
Ensure there's at least one selection in `Editor::set_selections`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4992,6 +4992,11 @@ impl Editor {
         pending_selection: Option<PendingSelection>,
         cx: &mut ViewContext<Self>,
     ) {
+        assert!(
+            !selections.is_empty() || pending_selection.is_some(),
+            "must have at least one selection"
+        );
+
         let old_cursor_position = self.newest_anchor_selection().head();
 
         self.selections = selections;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4952,6 +4952,9 @@ impl Editor {
         );
         let offsets =
             snapshot.summaries_for_anchors::<usize, _>(anchors_with_status.iter().map(|a| &a.1));
+        assert_eq!(anchors_with_status.len(), 2 * self.selections.len());
+        assert_eq!(offsets.len(), anchors_with_status.len());
+
         let offsets = offsets.chunks(2);
         let statuses = anchors_with_status
             .chunks(2)

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -3664,10 +3664,9 @@ mod tests {
             }
 
             // Anchor resolution
-            for (anchor, resolved_offset) in anchors
-                .iter()
-                .zip(snapshot.summaries_for_anchors::<usize, _>(&anchors))
-            {
+            let summaries = snapshot.summaries_for_anchors::<usize, _>(&anchors);
+            assert_eq!(anchors.len(), summaries.len());
+            for (anchor, resolved_offset) in anchors.iter().zip(summaries) {
                 assert!(resolved_offset <= snapshot.len());
                 assert_eq!(
                     snapshot.summary_for_anchor::<usize>(anchor),

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -3357,7 +3357,7 @@ mod tests {
                 }
                 40..=44 if !anchors.is_empty() => {
                     let multibuffer = multibuffer.read(cx).read(cx);
-
+                    let prev_len = anchors.len();
                     anchors = multibuffer
                         .refresh_anchors(&anchors)
                         .into_iter()
@@ -3366,6 +3366,7 @@ mod tests {
 
                     // Ensure the newly-refreshed anchors point to a valid excerpt and don't
                     // overshoot its boundaries.
+                    assert_eq!(anchors.len(), prev_len);
                     let mut cursor = multibuffer.excerpts.cursor::<Option<&ExcerptId>>();
                     for anchor in &anchors {
                         if anchor.excerpt_id == ExcerptId::min()


### PR DESCRIPTION
Closes #503 

This pull request introduces assertions that will cause Zed to panic as soon as the invariant gets violated. This will be useful to investigate issue #503.