### PR TITLE
Open settings file in new window if current window isn't local

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3699,7 +3699,7 @@ impl Project {
         let buffer_handle = this.read_with(&cx, |this, _| {
             this.opened_buffers
                 .get(&buffer_id)
-                .map(|buffer| buffer.upgrade(&cx).unwrap())
+                .and_then(|buffer| buffer.upgrade(&cx))
                 .ok_or_else(|| anyhow!("unknown buffer id {}", buffer_id))
         })?;
         let request = T::from_proto(


### PR DESCRIPTION
This fixes a crash that I observed when using the latest `main` version of Zed, and attempting to open the settings as a guest. We need to avoid opening the settings in the same window, because it breaks the invariant that all buffers in a project are either local or remote.