### PR TITLE
Make all `HighlightStyle` properties optional

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1174,7 +1174,7 @@ mod tests {
         for chunk in snapshot.chunks(rows, true) {
             let color = chunk
                 .syntax_highlight_id
-                .and_then(|id| id.style(theme).map(|s| s.color));
+                .and_then(|id| id.style(theme)?.color);
             if let Some((last_chunk, last_color)) = chunks.last_mut() {
                 if color == *last_color {
                     last_chunk.push_str(chunk.text);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -397,7 +397,7 @@ impl EditorElement {
                                                 RunStyle {
                                                     font_id,
                                                     color: style.background,
-                                                    underline: None,
+                                                    underline: Default::default(),
                                                 },
                                             )],
                                         ))
@@ -555,7 +555,7 @@ impl EditorElement {
                     RunStyle {
                         font_id: style.text.font_id,
                         color: Color::black(),
-                        underline: None,
+                        underline: Default::default(),
                     },
                 )],
             )
@@ -596,7 +596,7 @@ impl EditorElement {
                             RunStyle {
                                 font_id: style.text.font_id,
                                 color,
-                                underline: None,
+                                underline: Default::default(),
                             },
                         )],
                     )));
@@ -644,7 +644,7 @@ impl EditorElement {
                             RunStyle {
                                 font_id: placeholder_style.font_id,
                                 color: placeholder_style.color,
-                                underline: None,
+                                underline: Default::default(),
                             },
                         )],
                     )
@@ -669,7 +669,7 @@ impl EditorElement {
                     let diagnostic_style = super::diagnostic_style(severity, true, style);
                     let diagnostic_highlight = HighlightStyle {
                         underline: Some(Underline {
-                            color: diagnostic_style.message.text.color,
+                            color: Some(diagnostic_style.message.text.color),
                             thickness: 1.0.into(),
                             squiggly: true,
                         }),
@@ -1237,7 +1237,7 @@ fn layout_line(
             RunStyle {
                 font_id: style.text.font_id,
                 color: Color::black(),
-                underline: None,
+                underline: Default::default(),
             },
         )],
     )

--- a/crates/gpui/examples/text.rs
+++ b/crates/gpui/examples/text.rs
@@ -62,7 +62,7 @@ impl gpui::Element for TextElement {
                 .select_font(family, &Default::default())
                 .unwrap(),
             color: Color::default(),
-            underline: None,
+            underline: Default::default(),
         };
         let bold = RunStyle {
             font_id: cx
@@ -76,7 +76,7 @@ impl gpui::Element for TextElement {
                 )
                 .unwrap(),
             color: Color::default(),
-            underline: None,
+            underline: Default::default(),
         };
 
         let text = "Hello world!";

--- a/crates/gpui/src/elements/label.rs
+++ b/crates/gpui/src/elements/label.rs
@@ -214,7 +214,7 @@ mod tests {
             "Menlo",
             12.,
             Default::default(),
-            None,
+            Default::default(),
             Color::black(),
             cx.font_cache(),
         )
@@ -223,7 +223,7 @@ mod tests {
             "Menlo",
             12.,
             *FontProperties::new().weight(Weight::BOLD),
-            None,
+            Default::default(),
             Color::new(255, 0, 0, 255),
             cx.font_cache(),
         )

--- a/crates/gpui/src/platform/mac/fonts.rs
+++ b/crates/gpui/src/platform/mac/fonts.rs
@@ -425,21 +425,21 @@ mod tests {
         let menlo_regular = RunStyle {
             font_id: fonts.select_font(&menlo, &Properties::new()).unwrap(),
             color: Default::default(),
-            underline: None,
+            underline: Default::default(),
         };
         let menlo_italic = RunStyle {
             font_id: fonts
                 .select_font(&menlo, &Properties::new().style(Style::Italic))
                 .unwrap(),
             color: Default::default(),
-            underline: None,
+            underline: Default::default(),
         };
         let menlo_bold = RunStyle {
             font_id: fonts
                 .select_font(&menlo, &Properties::new().weight(Weight::BOLD))
                 .unwrap(),
             color: Default::default(),
-            underline: None,
+            underline: Default::default(),
         };
         assert_ne!(menlo_regular, menlo_italic);
         assert_ne!(menlo_regular, menlo_bold);
@@ -466,13 +466,13 @@ mod tests {
         let zapfino_regular = RunStyle {
             font_id: fonts.select_font(&zapfino, &Properties::new())?,
             color: Default::default(),
-            underline: None,
+            underline: Default::default(),
         };
         let menlo = fonts.load_family("Menlo")?;
         let menlo_regular = RunStyle {
             font_id: fonts.select_font(&menlo, &Properties::new())?,
             color: Default::default(),
-            underline: None,
+            underline: Default::default(),
         };
 
         let text = "This is, m𐍈re 𐍈r less, Zapfino!𐍈";
@@ -551,7 +551,7 @@ mod tests {
         let style = RunStyle {
             font_id: fonts.select_font(&font_ids, &Default::default()).unwrap(),
             color: Default::default(),
-            underline: None,
+            underline: Default::default(),
         };
 
         let line = "\u{feff}";

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -284,11 +284,7 @@ impl ProjectSymbolsView {
             &settings.theme.selector.item
         };
         let symbol = &self.symbols[string_match.candidate_id];
-        let syntax_runs = styled_runs_for_code_label(
-            &symbol.label,
-            style.label.text.color,
-            &settings.theme.editor.syntax,
-        );
+        let syntax_runs = styled_runs_for_code_label(&symbol.label, &settings.theme.editor.syntax);
 
         let mut path = symbol.path.to_string_lossy();
         if show_worktree_root_name {


### PR DESCRIPTION
Fixes #623 

Previously, some of those properties such the font weight, style and color would be mandatory: when the theme didn't specify them, Zed would use a default value during deserialization. This meant that those default properties would unconditionally override the base text style, causing a rendering bug when combining syntax highlights with diagnostic styles.

This pull request fixes that by making `HighlightStyle`s more additive: each property can be set independently and only the properties that theme specifies get overridden in the base text style.

/cc: @nathansobo 