### PR TITLE
De-emphasize unnecessary code diagnostics

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -218,7 +218,14 @@ impl ProjectDiagnosticsEditor {
         let mut first_excerpt_id = None;
         let excerpts_snapshot = self.excerpts.update(cx, |excerpts, excerpts_cx| {
             let mut old_groups = path_state.diagnostic_groups.iter().enumerate().peekable();
-            let mut new_groups = snapshot.diagnostic_groups().into_iter().peekable();
+            let mut new_groups = snapshot
+                .diagnostic_groups()
+                .into_iter()
+                .filter(|group| {
+                    group.entries[group.primary_ix].diagnostic.severity
+                        <= DiagnosticSeverity::WARNING
+                })
+                .peekable();
             loop {
                 let mut to_insert = None;
                 let mut to_remove = None;

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -819,7 +819,8 @@ impl<'a> Iterator for BlockChunks<'a> {
                 text: unsafe { std::str::from_utf8_unchecked(&NEWLINES[..line_count as usize]) },
                 syntax_highlight_id: None,
                 highlight_style: None,
-                diagnostic: None,
+                diagnostic_severity: None,
+                is_unnecessary: false,
             });
         }
 

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1078,7 +1078,8 @@ impl<'a> Iterator for FoldChunks<'a> {
                 text: output_text,
                 syntax_highlight_id: None,
                 highlight_style: None,
-                diagnostic: None,
+                diagnostic_severity: None,
+                is_unnecessary: false,
             });
         }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4211,6 +4211,7 @@ impl Editor {
             };
             let group = diagnostics.find_map(|entry| {
                 if entry.diagnostic.is_primary
+                    && !entry.diagnostic.is_unnecessary
                     && !entry.range.is_empty()
                     && Some(entry.range.end) != active_primary_range.as_ref().map(|r| *r.end())
                 {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -665,22 +665,25 @@ impl EditorElement {
                     }
                 }
 
-                if let Some(severity) = chunk.diagnostic {
-                    let diagnostic_style = super::diagnostic_style(severity, true, style);
-                    let diagnostic_highlight = HighlightStyle {
-                        underline: Some(Underline {
-                            color: Some(diagnostic_style.message.text.color),
-                            thickness: 1.0.into(),
-                            squiggly: true,
-                        }),
-                        ..Default::default()
-                    };
+                let mut diagnostic_highlight = HighlightStyle {
+                    ..Default::default()
+                };
 
-                    if let Some(highlight_style) = highlight_style.as_mut() {
-                        highlight_style.highlight(diagnostic_highlight);
-                    } else {
-                        highlight_style = Some(diagnostic_highlight);
-                    }
+                if chunk.is_unnecessary {
+                    diagnostic_highlight.fade_out = Some(style.unnecessary_code_fade);
+                } else if let Some(severity) = chunk.diagnostic_severity {
+                    let diagnostic_style = super::diagnostic_style(severity, true, style);
+                    diagnostic_highlight.underline = Some(Underline {
+                        color: Some(diagnostic_style.message.text.color),
+                        thickness: 1.0.into(),
+                        squiggly: true,
+                    });
+                }
+
+                if let Some(highlight_style) = highlight_style.as_mut() {
+                    highlight_style.highlight(diagnostic_highlight);
+                } else {
+                    highlight_style = Some(diagnostic_highlight);
                 }
 
                 (chunk.text, highlight_style)

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -132,6 +132,7 @@ pub fn serialize_diagnostics<'a>(
             is_valid: entry.diagnostic.is_valid,
             code: entry.diagnostic.code.clone(),
             is_disk_based: entry.diagnostic.is_disk_based,
+            is_unnecessary: entry.diagnostic.is_unnecessary,
         })
         .collect()
 }
@@ -308,6 +309,7 @@ pub fn deserialize_diagnostics(
                     is_valid: diagnostic.is_valid,
                     is_primary: diagnostic.is_primary,
                     is_disk_based: diagnostic.is_disk_based,
+                    is_unnecessary: diagnostic.is_unnecessary,
                 },
             })
         })

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -630,6 +630,7 @@ message Diagnostic {
     bool is_primary = 7;
     bool is_valid = 8;
     bool is_disk_based = 9;
+    bool is_unnecessary = 10;
 
     enum Severity {
         None = 0;

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -5,4 +5,4 @@ pub mod proto;
 pub use conn::Connection;
 pub use peer::*;
 
-pub const PROTOCOL_VERSION: u32 = 10;
+pub const PROTOCOL_VERSION: u32 = 11;

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -303,6 +303,7 @@ pub struct Editor {
     pub invalid_hint_diagnostic: DiagnosticStyle,
     pub autocomplete: AutocompleteStyle,
     pub code_actions_indicator: Color,
+    pub unnecessary_code_fade: f32,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/crates/zed/assets/themes/_base.toml
+++ b/crates/zed/assets/themes/_base.toml
@@ -250,6 +250,7 @@ gutter_padding_factor = 2.5
 active_line_background = "$state.active_line"
 highlighted_line_background = "$state.highlighted_line"
 rename_fade = 0.6
+unnecessary_code_fade = 0.5
 document_highlight_read_background = "#99999920"
 document_highlight_write_background = "#99999916"
 diff_background_deleted = "$state.deleted_line"


### PR DESCRIPTION
Closes #579 

- Only show errors and warnings in project diagnostics multi-buffer
- Fade out unnecessary code instead of underling it
- Skip over unnecessary code diagnostics when hitting `f8`

<img width="1324" alt="Screen Shot 2022-03-15 at 15 58 48" src="https://user-images.githubusercontent.com/482957/158406655-0e04724d-13c4-4f4a-b5a8-14edc61e50c4.png">

