### PR TITLE
Compute line-height as a multiple of font size

### DIFF
--- a/crates/gpui/src/elements/label.rs
+++ b/crates/gpui/src/elements/label.rs
@@ -146,8 +146,7 @@ impl Element for Label {
                 .ceil()
                 .max(constraint.min.x())
                 .min(constraint.max.x()),
-            cx.font_cache
-                .line_height(self.style.text.font_id, self.style.text.font_size),
+            cx.font_cache.line_height(self.style.text.font_size),
         );
 
         (size, line)

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -114,7 +114,7 @@ impl Element for Text {
             max_line_width = max_line_width.max(shaped_line.width());
         }
 
-        let line_height = cx.font_cache.line_height(font_id, self.style.font_size);
+        let line_height = cx.font_cache.line_height(self.style.font_size);
         let size = vec2f(
             max_line_width
                 .ceil()

--- a/crates/gpui/src/font_cache.rs
+++ b/crates/gpui/src/font_cache.rs
@@ -168,9 +168,8 @@ impl FontCache {
         advance.x() * self.em_scale(font_id, font_size)
     }
 
-    pub fn line_height(&self, font_id: FontId, font_size: f32) -> f32 {
-        let height = self.metric(font_id, |m| m.bounding_box.height());
-        (height * self.em_scale(font_id, font_size)).ceil()
+    pub fn line_height(&self, font_size: f32) -> f32 {
+        (font_size * 1.618).round()
     }
 
     pub fn cap_height(&self, font_id: FontId, font_size: f32) -> f32 {
@@ -194,7 +193,7 @@ impl FontCache {
     }
 
     pub fn baseline_offset(&self, font_id: FontId, font_size: f32) -> f32 {
-        let line_height = self.line_height(font_id, font_size);
+        let line_height = self.line_height(font_size);
         let ascent = self.ascent(font_id, font_size);
         let descent = self.descent(font_id, font_size);
         let padding_top = (line_height - ascent - descent) / 2.;

--- a/crates/gpui/src/fonts.rs
+++ b/crates/gpui/src/fonts.rs
@@ -188,7 +188,7 @@ impl TextStyle {
     }
 
     pub fn line_height(&self, font_cache: &FontCache) -> f32 {
-        font_cache.line_height(self.font_id, self.font_size)
+        font_cache.line_height(self.font_size)
     }
 
     pub fn cap_height(&self, font_cache: &FontCache) -> f32 {


### PR DESCRIPTION
...instead of using the bounding box. This makes `PragmataPro` and other fonts render more cleanly.

<img width="1257" alt="Screen Shot 2022-03-15 at 16 37 54" src="https://user-images.githubusercontent.com/482957/158414757-911f500e-16b0-4dcc-8474-fb48d6758ba9.png">

