### PR TITLE
Fix go to line panic by replacing an unwrap with an and_then

### DIFF
--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -59,7 +59,9 @@ impl GoToLine {
     }
 
     fn toggle(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
-        if let Some(editor) = workspace.active_item(cx).unwrap().downcast::<Editor>() {
+        if let Some(editor) = workspace.active_item(cx)
+            .and_then(|active_item| active_item.downcast::<Editor>())
+        {
             workspace.toggle_modal(cx, |cx, _| {
                 let view = cx.add_view(|cx| GoToLine::new(editor, cx));
                 cx.subscribe(&view, Self::on_event).detach();


### PR DESCRIPTION
Closes #629 