### PR TITLE
Restore underline for warnings about unused code

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4211,7 +4211,7 @@ impl Editor {
             };
             let group = diagnostics.find_map(|entry| {
                 if entry.diagnostic.is_primary
-                    && !entry.diagnostic.is_unnecessary
+                    && entry.diagnostic.severity <= DiagnosticSeverity::WARNING
                     && !entry.range.is_empty()
                     && Some(entry.range.end) != active_primary_range.as_ref().map(|r| *r.end())
                 {


### PR DESCRIPTION
This tweaks the logic introduced in https://github.com/zed-industries/zed/pull/626 for presenting unused code.

If cargo issues a warning for an unused variable, we will now still display it with the yellow squiggly underline that indicates a warning. We only suppress the squiggly underline for 'unused' diagnostics with a severity of `HINT` or `WARNING`.

Similarly, when jumping to the next or previous diagnostics, we will include warnings about unused code. For those commands too, I think we should filter out diagnostics based on their severity, rather than basing it on whether the code in question is marked as 'unnecessary'.