### PR TITLE
Add sub-word movement and helper functions for finding word boundaries

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -12,7 +12,7 @@ use gpui::{
     Entity, ModelContext, ModelHandle,
 };
 use language::{Point, Subscription as BufferSubscription};
-use std::{any::TypeId, ops::Range, sync::Arc};
+use std::{any::TypeId, fmt::Debug, ops::Range, sync::Arc};
 use sum_tree::{Bias, TreeMap};
 use tab_map::TabMap;
 use wrap_map::WrapMap;
@@ -414,8 +414,18 @@ impl DisplaySnapshot {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, Ord, PartialOrd, PartialEq)]
 pub struct DisplayPoint(BlockPoint);
+
+impl Debug for DisplayPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "DisplayPoint({}, {})",
+            self.row(),
+            self.column()
+        ))
+    }
+}
 
 impl DisplayPoint {
     pub fn new(row: u32, column: u32) -> Self {
@@ -426,7 +436,6 @@ impl DisplayPoint {
         Self::new(0, 0)
     }
 
-    #[cfg(test)]
     pub fn is_zero(&self) -> bool {
         self.0.is_zero()
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3480,7 +3480,7 @@ impl Editor {
         let mut selections = self.local_selections::<Point>(cx);
         for selection in &mut selections {
             let head = selection.head().to_display_point(&display_map);
-            let cursor = movement::prev_word_boundary(&display_map, head).to_point(&display_map);
+            let cursor = movement::previous_word_start(&display_map, head).to_point(&display_map);
             selection.start = cursor.clone();
             selection.end = cursor;
             selection.reversed = false;
@@ -3498,7 +3498,7 @@ impl Editor {
         let mut selections = self.local_selections::<Point>(cx);
         for selection in &mut selections {
             let head = selection.head().to_display_point(&display_map);
-            let cursor = movement::prev_word_boundary(&display_map, head).to_point(&display_map);
+            let cursor = movement::previous_word_start(&display_map, head).to_point(&display_map);
             selection.set_head(cursor);
             selection.goal = SelectionGoal::None;
         }
@@ -3517,7 +3517,7 @@ impl Editor {
             if selection.is_empty() {
                 let head = selection.head().to_display_point(&display_map);
                 let cursor =
-                    movement::prev_word_boundary(&display_map, head).to_point(&display_map);
+                    movement::previous_word_start(&display_map, head).to_point(&display_map);
                 selection.set_head(cursor);
                 selection.goal = SelectionGoal::None;
             }
@@ -3536,7 +3536,7 @@ impl Editor {
         let mut selections = self.local_selections::<Point>(cx);
         for selection in &mut selections {
             let head = selection.head().to_display_point(&display_map);
-            let cursor = movement::next_word_boundary(&display_map, head).to_point(&display_map);
+            let cursor = movement::next_word_end(&display_map, head).to_point(&display_map);
             selection.start = cursor;
             selection.end = cursor;
             selection.reversed = false;
@@ -3554,7 +3554,7 @@ impl Editor {
         let mut selections = self.local_selections::<Point>(cx);
         for selection in &mut selections {
             let head = selection.head().to_display_point(&display_map);
-            let cursor = movement::next_word_boundary(&display_map, head).to_point(&display_map);
+            let cursor = movement::next_word_end(&display_map, head).to_point(&display_map);
             selection.set_head(cursor);
             selection.goal = SelectionGoal::None;
         }
@@ -3572,8 +3572,7 @@ impl Editor {
         for selection in &mut selections {
             if selection.is_empty() {
                 let head = selection.head().to_display_point(&display_map);
-                let cursor =
-                    movement::next_word_boundary(&display_map, head).to_point(&display_map);
+                let cursor = movement::next_word_end(&display_map, head).to_point(&display_map);
                 selection.set_head(cursor);
                 selection.goal = SelectionGoal::None;
             }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -133,101 +133,111 @@ pub fn line_end(
 }
 
 pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
-    find_boundary_reversed(map, point, |left, right| {
-        char_kind(left) != char_kind(right) && !right.is_whitespace()
+    find_preceding_boundary(map, point, |left, right| {
+        (char_kind(left) != char_kind(right) && !right.is_whitespace()) || left == '\n'
     })
 }
 
 pub fn previous_subword_start(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
-    find_boundary_reversed(map, point, |left, right| {
-        (char_kind(left) != char_kind(right)
-            || left == '_' && right != '_'
-            || left.is_lowercase() && right.is_uppercase())
-            && !right.is_whitespace()
+    find_preceding_boundary(map, point, |left, right| {
+        let is_word_start = char_kind(left) != char_kind(right) && !right.is_whitespace();
+        let is_subword_start =
+            left == '_' && right != '_' || left.is_lowercase() && right.is_uppercase();
+        is_word_start || is_subword_start || left == '\n'
     })
 }
 
 pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
     find_boundary(map, point, |left, right| {
-        char_kind(left) != char_kind(right) && !left.is_whitespace()
+        (char_kind(left) != char_kind(right) && !left.is_whitespace()) || right == '\n'
     })
 }
 
 pub fn next_subword_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
     find_boundary(map, point, |left, right| {
-        (char_kind(left) != char_kind(right)
-            || left != '_' && right == '_'
-            || left.is_lowercase() && right.is_uppercase())
-            && !left.is_whitespace()
+        let is_word_end = (char_kind(left) != char_kind(right)) && !left.is_whitespace();
+        let is_subword_end =
+            left != '_' && right == '_' || left.is_lowercase() && right.is_uppercase();
+        is_word_end || is_subword_end || right == '\n'
     })
 }
 
-pub fn find_boundary_reversed(
+/// Scans for a boundary from the start of each line preceding the given end point until a boundary
+/// is found, indicated by the given predicate returning true. The predicate is called with the
+/// character to the left and right of the candidate boundary location, and will be called with `\n`
+/// characters indicating the start or end of a line. If the predicate returns true multiple times
+/// on a line, the *rightmost* boundary is returned.
+pub fn find_preceding_boundary(
     map: &DisplaySnapshot,
-    mut start: DisplayPoint,
-    is_boundary: impl Fn(char, char) -> bool,
+    end: DisplayPoint,
+    mut is_boundary: impl FnMut(char, char) -> bool,
 ) -> DisplayPoint {
-    let mut line_start = 0;
-    if start.row() > 0 {
-        if let Some(indent) = map.soft_wrap_indent(start.row() - 1) {
-            line_start = indent;
-        }
-    }
-
-    if start.column() == line_start {
-        if start.row() == 0 {
-            return DisplayPoint::new(0, 0);
-        } else {
-            let row = start.row() - 1;
-            start = map.clip_point(DisplayPoint::new(row, map.line_len(row)), Bias::Left);
-        }
-    }
-
-    let mut boundary = DisplayPoint::new(start.row(), 0);
-    let mut column = 0;
-    let mut prev_ch = None;
-    for ch in map.chars_at(DisplayPoint::new(start.row(), 0)) {
-        if column >= start.column() {
-            break;
-        }
-
-        if let Some(prev_ch) = prev_ch {
-            if is_boundary(prev_ch, ch) {
-                *boundary.column_mut() = column;
+    let mut point = end;
+    loop {
+        *point.column_mut() = 0;
+        if point.row() > 0 {
+            if let Some(indent) = map.soft_wrap_indent(point.row() - 1) {
+                *point.column_mut() = indent;
             }
         }
 
-        prev_ch = Some(ch);
-        column += ch.len_utf8() as u32;
-    }
-    boundary
-}
+        let mut boundary = None;
+        let mut prev_ch = if point.is_zero() { None } else { Some('\n') };
+        for ch in map.chars_at(point) {
+            if point >= end {
+                break;
+            }
 
-pub fn find_boundary(
-    map: &DisplaySnapshot,
-    mut start: DisplayPoint,
-    is_boundary: impl Fn(char, char) -> bool,
-) -> DisplayPoint {
-    let mut prev_ch = None;
-    for ch in map.chars_at(start) {
-        if let Some(prev_ch) = prev_ch {
+            if let Some(prev_ch) = prev_ch {
+                if is_boundary(prev_ch, ch) {
+                    boundary = Some(point);
+                }
+            }
+
             if ch == '\n' {
                 break;
             }
+
+            prev_ch = Some(ch);
+            *point.column_mut() += ch.len_utf8() as u32;
+        }
+
+        if let Some(boundary) = boundary {
+            return boundary;
+        } else if point.row() == 0 {
+            return DisplayPoint::zero();
+        } else {
+            *point.row_mut() -= 1;
+        }
+    }
+}
+
+/// Scans for a boundary following the given start point until a boundary is found, indicated by the
+/// given predicate returning true. The predicate is called with the character to the left and right
+/// of the candidate boundary location, and will be called with `\n` characters indicating the start
+/// or end of a line.
+pub fn find_boundary(
+    map: &DisplaySnapshot,
+    mut point: DisplayPoint,
+    mut is_boundary: impl FnMut(char, char) -> bool,
+) -> DisplayPoint {
+    let mut prev_ch = None;
+    for ch in map.chars_at(point) {
+        if let Some(prev_ch) = prev_ch {
             if is_boundary(prev_ch, ch) {
                 break;
             }
         }
 
         if ch == '\n' {
-            *start.row_mut() += 1;
-            *start.column_mut() = 0;
+            *point.row_mut() += 1;
+            *point.column_mut() = 0;
         } else {
-            *start.column_mut() += ch.len_utf8() as u32;
+            *point.column_mut() += ch.len_utf8() as u32;
         }
         prev_ch = Some(ch);
     }
-    map.clip_point(start, Bias::Right)
+    map.clip_point(point, Bias::Right)
 }
 
 pub fn is_inside_word(map: &DisplaySnapshot, point: DisplayPoint) -> bool {
@@ -271,7 +281,9 @@ mod tests {
         }
 
         assert("\n|   |lorem", cx);
+        assert("|\n|   lorem", cx);
         assert("    |lorem|", cx);
+        assert("|    |lorem", cx);
         assert("    |lor|em", cx);
         assert("\nlorem\n|   |ipsum", cx);
         assert("\n\n|\n|", cx);
@@ -315,6 +327,37 @@ mod tests {
         assert(" bc|Δ|", cx);
         assert(" |bcδ|", cx);
         assert(" ab|——|cd", cx);
+    }
+
+    #[gpui::test]
+    fn test_find_preceding_boundary(cx: &mut gpui::MutableAppContext) {
+        fn assert(
+            marked_text: &str,
+            cx: &mut gpui::MutableAppContext,
+            is_boundary: impl FnMut(char, char) -> bool,
+        ) {
+            let (snapshot, display_points) = marked_snapshot(marked_text, cx);
+            assert_eq!(
+                find_preceding_boundary(&snapshot, display_points[1], is_boundary),
+                display_points[0]
+            );
+        }
+
+        assert("abc|def\ngh\nij|k", cx, |left, right| {
+            left == 'c' && right == 'd'
+        });
+        assert("abcdef\n|gh\nij|k", cx, |left, right| {
+            left == '\n' && right == 'g'
+        });
+        let mut line_count = 0;
+        assert("abcdef\n|gh\nij|k", cx, |left, _| {
+            if left == '\n' {
+                line_count += 1;
+                line_count == 2
+            } else {
+                false
+            }
+        });
     }
 
     #[gpui::test]
@@ -370,6 +413,37 @@ mod tests {
         assert("lorem|_ipsum|", cx);
         assert(" |bc|Δ", cx);
         assert(" ab|——|cd", cx);
+    }
+
+    #[gpui::test]
+    fn test_find_boundary(cx: &mut gpui::MutableAppContext) {
+        fn assert(
+            marked_text: &str,
+            cx: &mut gpui::MutableAppContext,
+            is_boundary: impl FnMut(char, char) -> bool,
+        ) {
+            let (snapshot, display_points) = marked_snapshot(marked_text, cx);
+            assert_eq!(
+                find_boundary(&snapshot, display_points[0], is_boundary),
+                display_points[1]
+            );
+        }
+
+        assert("abc|def\ngh\nij|k", cx, |left, right| {
+            left == 'j' && right == 'k'
+        });
+        assert("ab|cdef\ngh\n|ijk", cx, |left, right| {
+            left == '\n' && right == 'i'
+        });
+        let mut line_count = 0;
+        assert("abc|def\ngh\n|ijk", cx, |left, _| {
+            if left == '\n' {
+                line_count += 1;
+                line_count == 2
+            } else {
+                false
+            }
+        });
     }
 
     #[gpui::test]

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1407,7 +1407,7 @@ impl MultiBufferSnapshot {
         );
 
         for ch in prev_chars {
-            if Some(char_kind(ch)) == word_kind {
+            if Some(char_kind(ch)) == word_kind && ch != '\n' {
                 start -= ch.len_utf8();
             } else {
                 break;
@@ -1415,7 +1415,7 @@ impl MultiBufferSnapshot {
         }
 
         for ch in next_chars {
-            if Some(char_kind(ch)) == word_kind {
+            if Some(char_kind(ch)) == word_kind && ch != '\n' {
                 end += ch.len_utf8();
             } else {
                 break;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -271,7 +271,6 @@ pub(crate) struct DiagnosticEndpoint {
 
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub enum CharKind {
-    Newline,
     Punctuation,
     Whitespace,
     Word,
@@ -2259,9 +2258,7 @@ pub fn contiguous_ranges(
 }
 
 pub fn char_kind(c: char) -> CharKind {
-    if c == '\n' {
-        CharKind::Newline
-    } else if c.is_whitespace() {
+    if c.is_whitespace() {
         CharKind::Whitespace
     } else if c.is_alphanumeric() || c == '_' {
         CharKind::Word


### PR DESCRIPTION
This PR refines our approach to word-based movement and improves test coverage.

It also adds `movement::find_boundary` and `movement::find_preceding_boundary`, which can be used to search the buffer for boundaries between two characters that satisfy a given predicate. We're thinking that @Kethku's Vim emulation can lean on these methods to create word-based movement commands that wrap across newlines to match Vim's behavior.

Tasks

- [x] Implement sub-word movement methods
- [x] Implement boundary-finding methods
- [ ] Add editor bindings for sub-word movement