### PR TITLE
Fix duplicate nav entries

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -454,9 +454,9 @@ impl workspace::Item for ProjectDiagnosticsEditor {
         None
     }
 
-    fn navigate(&mut self, data: Box<dyn Any>, cx: &mut ViewContext<Self>) {
+    fn navigate(&mut self, data: Box<dyn Any>, cx: &mut ViewContext<Self>) -> bool {
         self.editor
-            .update(cx, |editor, cx| editor.navigate(data, cx));
+            .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
     fn is_dirty(&self, cx: &AppContext) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1393,8 +1393,6 @@ impl Editor {
             }
         }
 
-        self.push_to_nav_history(newest_selection.head(), Some(end.to_point(&buffer)), cx);
-
         let selection = Selection {
             id: post_inc(&mut self.next_selection_id),
             start,
@@ -6279,6 +6277,7 @@ mod tests {
                 editor.selected_display_ranges(cx),
                 &[DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0)]
             );
+            assert!(nav_history.borrow_mut().pop_backward().is_none());
 
             // Move the cursor a small distance via the mouse.
             // Nothing is added to the navigation history.
@@ -6305,6 +6304,7 @@ mod tests {
                 editor.selected_display_ranges(cx),
                 &[DisplayPoint::new(5, 0)..DisplayPoint::new(5, 0)]
             );
+            assert!(nav_history.borrow_mut().pop_backward().is_none());
 
             editor
         });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5060,7 +5060,7 @@ impl Editor {
         cx.notify();
     }
 
-    fn transact(
+    pub fn transact(
         &mut self,
         cx: &mut ViewContext<Self>,
         update: impl FnOnce(&mut Self, &mut ViewContext<Self>),

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -302,9 +302,9 @@ impl Item for ProjectSearchView {
         });
     }
 
-    fn navigate(&mut self, data: Box<dyn Any>, cx: &mut ViewContext<Self>) {
+    fn navigate(&mut self, data: Box<dyn Any>, cx: &mut ViewContext<Self>) -> bool {
         self.results_editor
-            .update(cx, |editor, cx| editor.navigate(data, cx));
+            .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
     fn should_update_tab_on_event(event: &ViewEvent) -> bool {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -203,7 +203,9 @@ pub struct JoinProjectParams {
 
 pub trait Item: View {
     fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
-    fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) {}
+    fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) -> bool {
+        false
+    }
     fn tab_content(&self, style: &theme::Tab, cx: &AppContext) -> ElementBox;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
     fn project_entry_id(&self, cx: &AppContext) -> Option<ProjectEntryId>;
@@ -362,7 +364,7 @@ pub trait ItemHandle: 'static + fmt::Debug {
         cx: &mut ViewContext<Workspace>,
     );
     fn deactivated(&self, cx: &mut MutableAppContext);
-    fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext);
+    fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext) -> bool;
     fn id(&self) -> usize;
     fn to_any(&self) -> AnyViewHandle;
     fn is_dirty(&self, cx: &AppContext) -> bool;
@@ -510,8 +512,8 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
         self.update(cx, |this, cx| this.deactivated(cx));
     }
 
-    fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext) {
-        self.update(cx, |this, cx| this.navigate(data, cx));
+    fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext) -> bool {
+        self.update(cx, |this, cx| this.navigate(data, cx))
     }
 
     fn save(&self, project: ModelHandle<Project>, cx: &mut MutableAppContext) -> Task<Result<()>> {


### PR DESCRIPTION
Reduces a duplicate entry when beginning a selection.
Also modifies the contract in Item navigate to return a bool indicating whether the navigation actually moved the selection and then continue popping until the navigation did something.