### PR TITLE
Unfold when selecting next match

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -114,6 +114,7 @@ impl DisplayMap {
     pub fn unfold<T: ToOffset>(
         &mut self,
         ranges: impl IntoIterator<Item = Range<T>>,
+        inclusive: bool,
         cx: &mut ModelContext<Self>,
     ) {
         let snapshot = self.buffer.read(cx).snapshot(cx);
@@ -124,7 +125,7 @@ impl DisplayMap {
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
         self.block_map.read(snapshot, edits);
-        let (snapshot, edits) = fold_map.unfold(ranges);
+        let (snapshot, edits) = fold_map.unfold(ranges, inclusive);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits);
         let (snapshot, edits) = self
             .wrap_map
@@ -629,7 +630,7 @@ mod tests {
                     if rng.gen() && fold_count > 0 {
                         log::info!("unfolding ranges: {:?}", ranges);
                         map.update(cx, |map, cx| {
-                            map.unfold(ranges, cx);
+                            map.unfold(ranges, true, cx);
                         });
                     } else {
                         log::info!("folding ranges: {:?}", ranges);

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1283,9 +1283,14 @@ mod tests {
         assert_eq!(snapshot4.text(), "123a…c123456eee");
 
         let (mut writer, _, _) = map.write(buffer_snapshot.clone(), vec![]);
-        writer.unfold(Some(Point::new(0, 4)..Point::new(0, 5)), true);
+        writer.unfold(Some(Point::new(0, 4)..Point::new(0, 4)), false);
         let (snapshot5, _) = map.read(buffer_snapshot.clone(), vec![]);
-        assert_eq!(snapshot5.text(), "123aaaaa\nbbbbbb\nccc123456eee");
+        assert_eq!(snapshot5.text(), "123a…c123456eee");
+
+        let (mut writer, _, _) = map.write(buffer_snapshot.clone(), vec![]);
+        writer.unfold(Some(Point::new(0, 4)..Point::new(0, 4)), true);
+        let (snapshot6, _) = map.read(buffer_snapshot.clone(), vec![]);
+        assert_eq!(snapshot6.text(), "123aaaaa\nbbbbbb\nccc123456eee");
     }
 
     #[gpui::test]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3907,6 +3907,7 @@ impl Editor {
                         reversed: false,
                         goal: SelectionGoal::None,
                     });
+                    self.unfold_ranges([next_selected_range], false, cx);
                     self.update_selections(selections, Some(Autoscroll::Newest), cx);
                 } else {
                     select_next_state.done = true;
@@ -3934,6 +3935,7 @@ impl Editor {
                     wordwise: true,
                     done: false,
                 };
+                self.unfold_ranges([selection.start..selection.end], false, cx);
                 self.update_selections(selections, Some(Autoscroll::Newest), cx);
                 self.select_next_state = Some(select_state);
             } else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -122,7 +122,7 @@ action!(ConfirmRename);
 action!(PageUp);
 action!(PageDown);
 action!(Fold);
-action!(Unfold);
+action!(UnfoldLines);
 action!(FoldSelectedRanges);
 action!(Scroll, Vector2F);
 action!(Select, SelectPhase);
@@ -263,7 +263,7 @@ pub fn init(cx: &mut MutableAppContext) {
         Binding::new("pageup", PageUp, Some("Editor")),
         Binding::new("pagedown", PageDown, Some("Editor")),
         Binding::new("alt-cmd-[", Fold, Some("Editor")),
-        Binding::new("alt-cmd-]", Unfold, Some("Editor")),
+        Binding::new("alt-cmd-]", UnfoldLines, Some("Editor")),
         Binding::new("alt-cmd-f", FoldSelectedRanges, Some("Editor")),
         Binding::new("ctrl-space", ShowCompletions, Some("Editor")),
         Binding::new("cmd-.", ToggleCodeActions(false), Some("Editor")),
@@ -329,7 +329,7 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::page_up);
     cx.add_action(Editor::page_down);
     cx.add_action(Editor::fold);
-    cx.add_action(Editor::unfold);
+    cx.add_action(Editor::unfold_lines);
     cx.add_action(Editor::fold_selected_ranges);
     cx.add_action(Editor::show_completions);
     cx.add_action(Editor::toggle_code_actions);
@@ -5187,7 +5187,7 @@ impl Editor {
         self.fold_ranges(fold_ranges, cx);
     }
 
-    pub fn unfold(&mut self, _: &Unfold, cx: &mut ViewContext<Self>) {
+    pub fn unfold_lines(&mut self, _: &UnfoldLines, cx: &mut ViewContext<Self>) {
         let selections = self.local_selections::<Point>(cx);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = &display_map.buffer_snapshot;
@@ -6467,7 +6467,7 @@ mod tests {
                 .unindent(),
             );
 
-            view.unfold(&Unfold, cx);
+            view.unfold_lines(&UnfoldLines, cx);
             assert_eq!(
                 view.display_text(cx),
                 "
@@ -6488,7 +6488,7 @@ mod tests {
                 .unindent(),
             );
 
-            view.unfold(&Unfold, cx);
+            view.unfold_lines(&UnfoldLines, cx);
             assert_eq!(view.display_text(cx), buffer.read(cx).read(cx).text());
         });
     }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -336,11 +336,9 @@ impl SearchBar {
                             direction,
                             &editor.buffer().read(cx).read(cx),
                         );
-                        editor.select_ranges(
-                            [ranges[new_index].clone()],
-                            Some(Autoscroll::Fit),
-                            cx,
-                        );
+                        let range_to_select = ranges[new_index].clone();
+                        editor.unfold_ranges([range_to_select.clone()], false, cx);
+                        editor.select_ranges([range_to_select], Some(Autoscroll::Fit), cx);
                     }
                 });
             }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -489,6 +489,7 @@ impl ProjectSearchView {
             );
             let range_to_select = model.match_ranges[new_index].clone();
             self.results_editor.update(cx, |editor, cx| {
+                editor.unfold_ranges([range_to_select.clone()], false, cx);
                 editor.select_ranges([range_to_select], Some(Autoscroll::Fit), cx);
             });
         }


### PR DESCRIPTION
Closes #593 

Unfolding takes place when selecting the next match in project search, buffer search as well as when hitting `cmd-d`.