### PR TITLE
Properly clear out registration and sharing state when a host loses their connection

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -711,7 +711,9 @@ impl LocalWorktree {
                 let worktree = this.as_local_mut().unwrap();
                 match response {
                     Ok(_) => {
-                        worktree.registration = Registration::Done { project_id };
+                        if worktree.registration == Registration::Pending {
+                            worktree.registration = Registration::Done { project_id };
+                        }
                         Ok(())
                     }
                     Err(error) => {
@@ -806,6 +808,11 @@ impl LocalWorktree {
                 .await
                 .unwrap_or_else(|| Err(anyhow!("share ended")))
         })
+    }
+
+    pub fn unregister(&mut self) {
+        self.unshare();
+        self.registration = Registration::None;
     }
 
     pub fn unshare(&mut self) {

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -96,7 +96,7 @@ pub struct ConnectionState {
 
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
-const RECEIVE_TIMEOUT: Duration = Duration::from_secs(30);
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl Peer {
     pub fn new() -> Arc<Self> {

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -96,7 +96,7 @@ pub struct ConnectionState {
 
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
-const RECEIVE_TIMEOUT: Duration = Duration::from_secs(5);
+pub const RECEIVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl Peer {
     pub fn new() -> Arc<Self> {

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1310,10 +1310,7 @@ mod tests {
             .unwrap();
 
         // Unshare the project as client A
-        project_a
-            .update(cx_a, |project, cx| project.unshare(cx))
-            .await
-            .unwrap();
+        project_a.update(cx_a, |project, cx| project.unshare(cx));
         project_b
             .condition(cx_b, |project, _| project.is_read_only())
             .await;

--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -1343,6 +1343,107 @@ mod tests {
     }
 
     #[gpui::test(iterations = 10)]
+    async fn test_host_disconnect(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
+        let lang_registry = Arc::new(LanguageRegistry::test());
+        let fs = FakeFs::new(cx_a.background());
+        cx_a.foreground().forbid_parking();
+
+        // Connect to a server as 2 clients.
+        let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
+        let client_a = server.create_client(cx_a, "user_a").await;
+        let client_b = server.create_client(cx_b, "user_b").await;
+
+        // Share a project as client A
+        fs.insert_tree(
+            "/a",
+            json!({
+                ".zed.toml": r#"collaborators = ["user_b"]"#,
+                "a.txt": "a-contents",
+                "b.txt": "b-contents",
+            }),
+        )
+        .await;
+        let project_a = cx_a.update(|cx| {
+            Project::local(
+                client_a.clone(),
+                client_a.user_store.clone(),
+                lang_registry.clone(),
+                fs.clone(),
+                cx,
+            )
+        });
+        let (worktree_a, _) = project_a
+            .update(cx_a, |p, cx| {
+                p.find_or_create_local_worktree("/a", true, cx)
+            })
+            .await
+            .unwrap();
+        worktree_a
+            .read_with(cx_a, |tree, _| tree.as_local().unwrap().scan_complete())
+            .await;
+        let project_id = project_a.update(cx_a, |p, _| p.next_remote_id()).await;
+        let worktree_id = worktree_a.read_with(cx_a, |tree, _| tree.id());
+        project_a.update(cx_a, |p, cx| p.share(cx)).await.unwrap();
+        assert!(worktree_a.read_with(cx_a, |tree, _| tree.as_local().unwrap().is_shared()));
+
+        // Join that project as client B
+        let project_b = Project::remote(
+            project_id,
+            client_b.clone(),
+            client_b.user_store.clone(),
+            lang_registry.clone(),
+            fs.clone(),
+            &mut cx_b.to_async(),
+        )
+        .await
+        .unwrap();
+        project_b
+            .update(cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
+            .await
+            .unwrap();
+
+        // Drop client A's connection. Collaborators should disappear and the project should not be shown as shared.
+        server.disconnect_client(client_a.current_user_id(cx_a));
+        cx_a.foreground().advance_clock(rpc::RECEIVE_TIMEOUT);
+        project_a
+            .condition(cx_a, |project, _| project.collaborators().is_empty())
+            .await;
+        project_a.read_with(cx_a, |project, _| assert!(!project.is_shared()));
+        project_b
+            .condition(cx_b, |project, _| project.is_read_only())
+            .await;
+        assert!(worktree_a.read_with(cx_a, |tree, _| !tree.as_local().unwrap().is_shared()));
+        cx_b.update(|_| {
+            drop(project_b);
+        });
+
+        // Await reconnection
+        let project_id = project_a.update(cx_a, |p, _| p.next_remote_id()).await;
+
+        // Share the project again and ensure guests can still join.
+        project_a
+            .update(cx_a, |project, cx| project.share(cx))
+            .await
+            .unwrap();
+        assert!(worktree_a.read_with(cx_a, |tree, _| tree.as_local().unwrap().is_shared()));
+
+        let project_b2 = Project::remote(
+            project_id,
+            client_b.clone(),
+            client_b.user_store.clone(),
+            lang_registry.clone(),
+            fs.clone(),
+            &mut cx_b.to_async(),
+        )
+        .await
+        .unwrap();
+        project_b2
+            .update(cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
+            .await
+            .unwrap();
+    }
+
+    #[gpui::test(iterations = 10)]
     async fn test_propagate_saves_and_fs_changes(
         cx_a: &mut TestAppContext,
         cx_b: &mut TestAppContext,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1278,7 +1278,7 @@ impl Workspace {
         self.project.update(cx, |project, cx| {
             if project.is_local() {
                 if project.is_shared() {
-                    project.unshare(cx).detach();
+                    project.unshare(cx);
                 } else {
                     project.share(cx).detach();
                 }


### PR DESCRIPTION
Fixes #634
Fixes #507

Previously, our failure to clear out registration and sharing state meant that when we reconnected, we didn't realize that we were in the proper state to re-share (since we thought we were still shared). We also didn't clear out collaborators. Now everything works as expected.

As part of this, we've reduced the `RECEIVE_TIMEOUT` to 5 seconds since the cost of disconnect is lower due to being able to re-share. This is somewhat arbitrary, but 30s felt like a long time to wait to receive feedback when things aren't working due to a lack of connectivity.