### PR TITLE
Fully disable vim mode on start unless it's enabled

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -13,7 +13,7 @@ pub fn init(cx: &mut MutableAppContext) {
 fn editor_created(EditorCreated(editor): &EditorCreated, cx: &mut MutableAppContext) {
     cx.update_default_global(|vim_state: &mut VimState, cx| {
         vim_state.editors.insert(editor.id(), editor.downgrade());
-        VimState::sync_editor_options(cx);
+        vim_state.sync_editor_options(cx);
     })
 }
 
@@ -24,21 +24,21 @@ fn editor_focused(EditorFocused(editor): &EditorFocused, cx: &mut MutableAppCont
         Mode::Normal
     };
 
-    cx.update_default_global(|vim_state: &mut VimState, _| {
-        vim_state.active_editor = Some(editor.downgrade());
+    VimState::update_global(cx, |state, cx| {
+        state.active_editor = Some(editor.downgrade());
+        state.switch_mode(&SwitchMode(mode), cx);
     });
-    VimState::switch_mode(&SwitchMode(mode), cx);
 }
 
 fn editor_blurred(EditorBlurred(editor): &EditorBlurred, cx: &mut MutableAppContext) {
-    cx.update_default_global(|vim_state: &mut VimState, _| {
-        if let Some(previous_editor) = vim_state.active_editor.clone() {
+    VimState::update_global(cx, |state, cx| {
+        if let Some(previous_editor) = state.active_editor.clone() {
             if previous_editor == editor.clone() {
-                vim_state.active_editor = None;
+                state.active_editor = None;
             }
         }
-    });
-    VimState::sync_editor_options(cx);
+        state.sync_editor_options(cx);
+    })
 }
 
 fn editor_released(EditorReleased(editor): &EditorReleased, cx: &mut MutableAppContext) {

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -18,11 +18,13 @@ pub fn init(cx: &mut MutableAppContext) {
 }
 
 fn normal_before(_: &mut Workspace, _: &NormalBefore, cx: &mut ViewContext<Workspace>) {
-    VimState::update_active_editor(cx, |editor, cx| {
-        editor.move_cursors(cx, |map, mut cursor, _| {
-            *cursor.column_mut() = cursor.column().saturating_sub(1);
-            (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
+    VimState::update_global(cx, |state, cx| {
+        state.update_active_editor(cx, |editor, cx| {
+            editor.move_cursors(cx, |map, mut cursor, _| {
+                *cursor.column_mut() = cursor.column().saturating_sub(1);
+                (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
+            });
         });
-    });
-    VimState::switch_mode(&SwitchMode(Mode::Normal), cx);
+        state.switch_mode(&SwitchMode(Mode::Normal), cx);
+    })
 }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -28,31 +28,39 @@ pub fn init(cx: &mut MutableAppContext) {
 }
 
 fn move_left(_: &mut Workspace, _: &MoveLeft, cx: &mut ViewContext<Workspace>) {
-    VimState::update_active_editor(cx, |editor, cx| {
-        editor.move_cursors(cx, |map, mut cursor, _| {
-            *cursor.column_mut() = cursor.column().saturating_sub(1);
-            (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
+    VimState::update_global(cx, |state, cx| {
+        state.update_active_editor(cx, |editor, cx| {
+            editor.move_cursors(cx, |map, mut cursor, _| {
+                *cursor.column_mut() = cursor.column().saturating_sub(1);
+                (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
+            });
+        });
+    })
+}
+
+fn move_down(_: &mut Workspace, _: &MoveDown, cx: &mut ViewContext<Workspace>) {
+    VimState::update_global(cx, |state, cx| {
+        state.update_active_editor(cx, |editor, cx| {
+            editor.move_cursors(cx, movement::down);
         });
     });
 }
 
-fn move_down(_: &mut Workspace, _: &MoveDown, cx: &mut ViewContext<Workspace>) {
-    VimState::update_active_editor(cx, |editor, cx| {
-        editor.move_cursors(cx, movement::down);
-    });
-}
-
 fn move_up(_: &mut Workspace, _: &MoveUp, cx: &mut ViewContext<Workspace>) {
-    VimState::update_active_editor(cx, |editor, cx| {
-        editor.move_cursors(cx, movement::up);
+    VimState::update_global(cx, |state, cx| {
+        state.update_active_editor(cx, |editor, cx| {
+            editor.move_cursors(cx, movement::up);
+        });
     });
 }
 
 fn move_right(_: &mut Workspace, _: &MoveRight, cx: &mut ViewContext<Workspace>) {
-    VimState::update_active_editor(cx, |editor, cx| {
-        editor.move_cursors(cx, |map, mut cursor, _| {
-            *cursor.column_mut() += 1;
-            (map.clip_point(cursor, Bias::Right), SelectionGoal::None)
+    VimState::update_global(cx, |state, cx| {
+        state.update_active_editor(cx, |editor, cx| {
+            editor.move_cursors(cx, |map, mut cursor, _| {
+                *cursor.column_mut() += 1;
+                (map.clip_point(cursor, Bias::Right), SelectionGoal::None)
+            });
         });
     });
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -65,6 +65,9 @@ impl VimState {
     fn set_enabled(&mut self, enabled: bool, cx: &mut MutableAppContext) {
         if self.enabled != enabled {
             self.enabled = enabled;
+            if enabled {
+                self.mode = Mode::Normal;
+            }
             self.sync_editor_options(cx);
         }
     }


### PR DESCRIPTION
Fixes #685 

* Completely ignore `VimState::mode` when we're disabled.
* I made some structural adjustments to remove the need for defer. Instead of accessing the global in associated VimState functions, we now have a single `VimState::update_global` method that allows us to call its mutable instance methods.
* I adjusted `observe_global` to take a reference to the global being observed.

/cc @Kethku 