### PR TITLE
Snap icon sprites to pixel grid

### DIFF
--- a/crates/gpui/src/platform/mac/renderer.rs
+++ b/crates/gpui/src/platform/mac/renderer.rs
@@ -561,9 +561,10 @@ impl Renderer {
         }
 
         for icon in icons {
-            let origin = icon.bounds.origin() * scale_factor;
-            let target_size = icon.bounds.size() * scale_factor;
-            let source_size = (target_size * 2.).ceil().to_i32();
+            // Snap sprite to pixel grid.
+            let origin = (icon.bounds.origin() * scale_factor).floor();
+            let target_size = (icon.bounds.size() * scale_factor).ceil();
+            let source_size = (target_size * 2.).to_i32();
 
             let sprite =
                 self.sprite_cache


### PR DESCRIPTION
Closes #643 

This should resolve some rendering artifacts potentially caused by floating point errors when sampling the texture. It should also lead to crisper images when icons are rendered midway through a pixel.

Note that we snap all other scene elements (glyphs, paths, quads, etc.) to the pixel grid and we've never seen rendering artifacts for those, so it feels reasonable to assume this was a sampling error even though I could not reproduce the problem locally.