### PR TITLE
Allow undoing and redoing selections via `cmd-u` and `cmd-shift-u`

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1081,10 +1081,7 @@ pub mod tests {
         );
         language.set_theme(&theme);
 
-        let (text, highlighted_ranges) = marked_text_ranges(
-            r#"const{} <a>: B = "c [d]""#,
-            vec![('{', '}'), ('<', '>'), ('[', ']')],
-        );
+        let (text, highlighted_ranges) = marked_text_ranges(r#"const[] [a]: B = "c [d]""#);
 
         let buffer = cx.add_model(|cx| Buffer::new(0, text, cx).with_language(language, cx));
         buffer.condition(&cx, |buf, _| !buf.is_parsing()).await;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3998,7 +3998,7 @@ impl Editor {
             state.stack.pop();
         }
 
-        self.update_selections(new_selections, Some(Autoscroll::Fit), cx);
+        self.update_selections(new_selections, Some(Autoscroll::Newest), cx);
         if state.stack.len() > 1 {
             self.add_selections_state = Some(state);
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4421,9 +4421,9 @@ impl Editor {
         self.end_selection(cx);
         self.selection_history.mode = SelectionHistoryMode::Undoing;
         if let Some(entry) = self.selection_history.undo_stack.pop_back() {
-            self.set_selections(entry.selections.clone(), None, true, cx);
-            self.select_next_state = entry.select_next_state.clone();
-            self.add_selections_state = entry.add_selections_state.clone();
+            self.set_selections(entry.selections, None, true, cx);
+            self.select_next_state = entry.select_next_state;
+            self.add_selections_state = entry.add_selections_state;
             self.request_autoscroll(Autoscroll::Newest, cx);
         }
         self.selection_history.mode = SelectionHistoryMode::Normal;
@@ -4433,9 +4433,9 @@ impl Editor {
         self.end_selection(cx);
         self.selection_history.mode = SelectionHistoryMode::Redoing;
         if let Some(entry) = self.selection_history.redo_stack.pop_back() {
-            self.set_selections(entry.selections.clone(), None, true, cx);
-            self.select_next_state = entry.select_next_state.clone();
-            self.add_selections_state = entry.add_selections_state.clone();
+            self.set_selections(entry.selections, None, true, cx);
+            self.select_next_state = entry.select_next_state;
+            self.add_selections_state = entry.add_selections_state;
             self.request_autoscroll(Autoscroll::Newest, cx);
         }
         self.selection_history.mode = SelectionHistoryMode::Normal;

--- a/crates/util/src/test.rs
+++ b/crates/util/src/test.rs
@@ -77,22 +77,18 @@ pub fn marked_text(marked_text: &str) -> (String, Vec<usize>) {
     (unmarked_text, markers.remove(&'|').unwrap_or_else(Vec::new))
 }
 
-pub fn marked_text_ranges(
-    marked_text: &str,
-    range_markers: Vec<(char, char)>,
-) -> (String, Vec<Range<usize>>) {
-    let mut marker_chars = Vec::new();
-    for (start, end) in range_markers.iter() {
-        marker_chars.push(*start);
-        marker_chars.push(*end);
-    }
-    let (unmarked_text, markers) = marked_text_by(marked_text, marker_chars);
-    let ranges = range_markers
-        .iter()
-        .map(|(start_marker, end_marker)| {
-            let start = markers.get(start_marker).unwrap()[0];
-            let end = markers.get(end_marker).unwrap()[0];
-            start..end
+pub fn marked_text_ranges(marked_text: &str) -> (String, Vec<Range<usize>>) {
+    let (unmarked_text, mut markers) = marked_text_by(marked_text, vec!['[', ']']);
+    let opens = markers.remove(&'[').unwrap_or_default();
+    let closes = markers.remove(&']').unwrap_or_default();
+    assert_eq!(opens.len(), closes.len(), "marked ranges are unbalanced");
+
+    let ranges = opens
+        .into_iter()
+        .zip(closes)
+        .map(|(open, close)| {
+            assert!(close >= open, "marked ranges must be disjoint");
+            open..close
         })
         .collect();
     (unmarked_text, ranges)


### PR DESCRIPTION
Closes #609 
Closes #570 