### PR TITLE
Drop borrow to window state before calling beginSheetModalForWindow

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -361,9 +361,10 @@ impl platform::Window for Window {
                 }
             });
             let block = block.copy();
+            let native_window = self.0.borrow().native_window;
             let _: () = msg_send![
                 alert,
-                beginSheetModalForWindow: self.0.borrow().native_window
+                beginSheetModalForWindow: native_window
                 completionHandler: block
             ];
             done_rx


### PR DESCRIPTION
Fixes #733
Fixes #730 

The modal dialog attempts to re-render the window, which needs to borrow the window state mutably. By not holding a borrow to the window state *during* this call, we avoid a double borrow error on the `RefCell` holding the window state.

🍐d with @Kethku 