### PR TITLE
Update followers when navigating back and forth

### DIFF
--- a/crates/server/src/rpc.rs
+++ b/crates/server/src/rpc.rs
@@ -4561,6 +4561,29 @@ mod tests {
             })
             .await;
 
+        // When client A navigates back and forth, client B does so as well.
+        workspace_a
+            .update(cx_a, |workspace, cx| {
+                workspace::Pane::go_back(workspace, None, cx)
+            })
+            .await;
+        workspace_b
+            .condition(cx_b, |workspace, cx| {
+                workspace.active_item(cx).unwrap().id() == editor_b2.id()
+            })
+            .await;
+
+        workspace_a
+            .update(cx_a, |workspace, cx| {
+                workspace::Pane::go_forward(workspace, None, cx)
+            })
+            .await;
+        workspace_b
+            .condition(cx_b, |workspace, cx| {
+                workspace.active_item(cx).unwrap().id() == editor_b1.id()
+            })
+            .await;
+
         // Changes to client A's editor are reflected on client B.
         editor_a1.update(cx_a, |editor, cx| {
             editor.select_ranges([1..1, 2..2], None, cx);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -206,10 +206,6 @@ impl Pane {
                     }
 
                     let prev_active_index = mem::replace(&mut pane.active_item_index, index);
-                    pane.focus_active_item(cx);
-                    pane.update_toolbar(cx);
-                    cx.emit(Event::ActivateItem { local: true });
-                    cx.notify();
 
                     let mut navigated = prev_active_index != pane.active_item_index;
                     if let Some(data) = entry.data {
@@ -217,6 +213,11 @@ impl Pane {
                     }
 
                     if navigated {
+                        pane.focus_active_item(cx);
+                        pane.update_toolbar(cx);
+                        pane.activate(cx);
+                        cx.emit(Event::ActivateItem { local: true });
+                        cx.notify();
                         break None;
                     }
                 }


### PR DESCRIPTION
Closes #698 

This pull request fixes an issue where followers wouldn't be updated if navigating back/forward would activate a different tab. I thought I had fixed it in #719, but that pull request only implemented auto-unfollowing when the _follower_ navigated back and forth. With these changes we are also introducing an integration test specifically for the interaction between following and navigation to prove this behavior now works correctly.

More specifically, we needed to emit an `Activate` event from the `Pane` in order for `Workspace` to send a follower update message.