### PR TITLE
Improve handling of renames with respect to language servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ dependencies = [
  "text",
  "theme",
  "tree-sitter",
+ "tree-sitter-json",
  "tree-sitter-rust",
  "unindent",
  "util",

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -57,5 +57,6 @@ util = { path = "../util", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"
 rand = "0.8.3"
+tree-sitter-json = "0.19.0"
 tree-sitter-rust = "0.20.0"
 unindent = "0.1.7"

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -486,6 +486,7 @@ impl Buffer {
     }
 
     pub fn set_language(&mut self, language: Option<Arc<Language>>, cx: &mut ModelContext<Self>) {
+        *self.syntax_tree.lock() = None;
         self.language = language;
         self.reparse(cx);
     }


### PR DESCRIPTION
Closes #718 

With this pull request, when detecting that a buffer's underlying file was renamed, Zed will now issue a `DidCloseTextDocument` notification for the old path, followed by a `DidOpenTextDocument` notification for the new path. Note that we are not sending the more specific `DidRenameFiles` notification because that gets ignored by rust-analyzer.

As part of this, we also fixed a panic that would happen when resetting a buffer's language due to re-using a previous syntax tree built for a different language.