### PR TITLE
Allow pane tabs to be scrolled when they overflow

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1152,10 +1152,7 @@ pub mod tests {
                         *markers[0].column_mut() += 1;
                     }
 
-                    assert_eq!(
-                        unmarked_snapshot.clip_point(dbg!(markers[0]), bias),
-                        markers[1]
-                    )
+                    assert_eq!(unmarked_snapshot.clip_point(markers[0], bias), markers[1])
                 }
             };
         }

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -259,8 +259,6 @@ impl Element for Flex {
                 if *remaining_space < 0. && bounds.contains_point(position) {
                     if let Some(scroll_state) = self.scroll_state.as_ref() {
                         scroll_state.update(cx, |scroll_state, cx| {
-                            dbg!(precise, delta);
-
                             let mut delta = match self.axis {
                                 Axis::Horizontal => {
                                     if delta.x() != 0. {

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -270,6 +270,12 @@ impl Element for Flex {
         _: &mut Self::PaintState,
         cx: &mut EventContext,
     ) -> bool {
+        if let Some(position) = event.position() {
+            if !bounds.contains_point(position) {
+                return false;
+            }
+        }
+
         let mut handled = false;
         for child in &mut self.children {
             handled = child.dispatch_event(event, cx) || handled;

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -8,11 +8,10 @@ use crate::{
     ElementBox,
 };
 use json::ToJson;
-use parking_lot::Mutex;
-use std::{cmp, ops::Range, sync::Arc};
+use std::{cell::RefCell, cmp, ops::Range, rc::Rc};
 
 #[derive(Clone, Default)]
-pub struct UniformListState(Arc<Mutex<StateInner>>);
+pub struct UniformListState(Rc<RefCell<StateInner>>);
 
 #[derive(Debug)]
 pub enum ScrollTarget {
@@ -22,11 +21,11 @@ pub enum ScrollTarget {
 
 impl UniformListState {
     pub fn scroll_to(&self, scroll_to: ScrollTarget) {
-        self.0.lock().scroll_to = Some(scroll_to);
+        self.0.borrow_mut().scroll_to = Some(scroll_to);
     }
 
     pub fn scroll_top(&self) -> f32 {
-        self.0.lock().scroll_top
+        self.0.borrow().scroll_top
     }
 }
 
@@ -96,7 +95,7 @@ where
             delta *= 20.;
         }
 
-        let mut state = self.state.0.lock();
+        let mut state = self.state.0.borrow_mut();
         state.scroll_top = (state.scroll_top - delta.y()).max(0.0).min(scroll_max);
         cx.notify();
 
@@ -104,7 +103,7 @@ where
     }
 
     fn autoscroll(&mut self, scroll_max: f32, list_height: f32, item_height: f32) {
-        let mut state = self.state.0.lock();
+        let mut state = self.state.0.borrow_mut();
 
         if let Some(scroll_to) = state.scroll_to.take() {
             let item_ix;
@@ -141,7 +140,7 @@ where
     }
 
     fn scroll_top(&self) -> f32 {
-        self.state.0.lock().scroll_top
+        self.state.0.borrow().scroll_top
     }
 }
 

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -61,3 +61,20 @@ pub enum Event {
         left_mouse_down: bool,
     },
 }
+
+impl Event {
+    pub fn position(&self) -> Option<Vector2F> {
+        match self {
+            Event::KeyDown { .. } => None,
+            Event::ScrollWheel { position, .. }
+            | Event::LeftMouseDown { position, .. }
+            | Event::LeftMouseUp { position }
+            | Event::LeftMouseDragged { position }
+            | Event::RightMouseDown { position, .. }
+            | Event::RightMouseUp { position }
+            | Event::NavigateMouseDown { position, .. }
+            | Event::NavigateMouseUp { position, .. }
+            | Event::MouseMoved { position, .. } => Some(*position),
+        }
+    }
+}

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -633,7 +633,7 @@ impl Pane {
         enum Tabs {}
         let pane = cx.handle();
         let tabs = MouseEventHandler::new::<Tabs, _, _>(0, cx, |mouse_state, cx| {
-            let mut row = Flex::row();
+            let mut row = Flex::row().scrollable::<Tabs, _>(1, cx);
             for (ix, item) in self.items.iter().enumerate() {
                 let is_active = ix == self.active_item_index;
 


### PR DESCRIPTION
Closes #330 
Closes #707

https://user-images.githubusercontent.com/1789/161881178-074d096a-05c8-4b73-a5c8-c19220ab995c.mp4

- [x] Allow tabs to be scrolled via the mouse
- [x] Autoscroll when active tab changes
- [x] Don't dispatch events on flex children when event is outside of flex bounds