### PR TITLE
Don't activate the next pane when opening excerpts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5956,8 +5956,6 @@ impl Editor {
         // and activating a new item causes the pane to call a method on us reentrantly,
         // which panics if we're on the stack.
         cx.defer(move |workspace, cx| {
-            workspace.activate_next_pane(cx);
-
             for (buffer, ranges) in new_selections_by_buffer.into_iter() {
                 let editor = workspace.open_project_item::<Self>(buffer, cx);
                 editor.update(cx, |editor, cx| {


### PR DESCRIPTION
When opening an excerpt from a multi-buffer (`alt-enter`), we originally thought that it would be useful to open it in the opposite pane when you had a split. Now that we've introduced following, this has become annoying, because it sometimes causes you to unintentionally break a follow in another pane.

In general, for now, I think we're converging on *not* having any editor commands change your focus to a different pane as a side effect.