### PR TITLE
Update breadcrumbs when multibuffers' excerpts change

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -16,6 +16,7 @@ use language::{
     Bias, Buffer, Diagnostic, DiagnosticEntry, DiagnosticSeverity, Point, Selection, SelectionGoal,
 };
 use project::{DiagnosticSummary, Project, ProjectPath};
+use settings::Settings;
 use std::{
     any::{Any, TypeId},
     cmp::Ordering,
@@ -26,7 +27,6 @@ use std::{
 };
 use util::TryFutureExt;
 use workspace::{ItemHandle as _, ItemNavHistory, Workspace};
-use settings::Settings;
 
 action!(Deploy);
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/741

Previously, there was no Editor event that captured a change to a multibuffer's *excerpts*. This PR changes the meaning of the editor's `BufferEdited` event so that it also includes those changes (in addition to edits to the underlying buffer). I think that for most code paths that are interested in watching for changes to an editor, it is good to also trigger them when excerpts are added or removed.