### PR TITLE
Safer Atlas Allocation

### DIFF
--- a/crates/gpui/src/platform/mac/image_cache.rs
+++ b/crates/gpui/src/platform/mac/image_cache.rs
@@ -33,7 +33,7 @@ impl ImageCache {
             .remove(&image.id)
             .or_else(|| self.curr_frame.get(&image.id).copied())
             .or_else(|| self.atlases.upload(image.size(), image.as_bytes()))
-            .ok_or_else(|| anyhow!("Could not upload image of size {:?}", image.size()))
+            .ok_or_else(|| anyhow!("could not upload image of size {:?}", image.size()))
             .unwrap();
         self.curr_frame.insert(image.id, (alloc_id, atlas_bounds));
         (alloc_id, atlas_bounds)

--- a/crates/gpui/src/platform/mac/image_cache.rs
+++ b/crates/gpui/src/platform/mac/image_cache.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use metal::{MTLPixelFormat, TextureDescriptor, TextureRef};
 
 use super::atlas::{AllocId, AtlasAllocator};
@@ -31,7 +32,9 @@ impl ImageCache {
             .prev_frame
             .remove(&image.id)
             .or_else(|| self.curr_frame.get(&image.id).copied())
-            .unwrap_or_else(|| self.atlases.upload(image.size(), image.as_bytes()));
+            .or_else(|| self.atlases.upload(image.size(), image.as_bytes()))
+            .ok_or_else(|| anyhow!("Could not upload image of size {:?}", image.size()))
+            .unwrap();
         self.curr_frame.insert(image.id, (alloc_id, atlas_bounds));
         (alloc_id, atlas_bounds)
     }

--- a/crates/gpui/src/platform/mac/renderer.rs
+++ b/crates/gpui/src/platform/mac/renderer.rs
@@ -172,7 +172,13 @@ impl Renderer {
             for path in layer.paths() {
                 let origin = path.bounds.origin() * scene.scale_factor();
                 let size = (path.bounds.size() * scene.scale_factor()).ceil();
-                let (alloc_id, atlas_origin) = self.path_atlases.allocate(size.to_i32());
+
+                let path_allocation = self.path_atlases.allocate(size.to_i32());
+                if path_allocation.is_none() {
+                    // Path size was likely zero.
+                    continue;
+                }
+                let (alloc_id, atlas_origin) = path_allocation.unwrap();
                 let atlas_origin = atlas_origin.to_f32();
                 sprites.push(PathSprite {
                     layer_id,
@@ -569,6 +575,10 @@ impl Renderer {
             let sprite =
                 self.sprite_cache
                     .render_icon(source_size, icon.path.clone(), icon.svg.clone());
+            if sprite.is_none() {
+                continue;
+            }
+            let sprite = sprite.unwrap();
 
             sprites_by_atlas
                 .entry(sprite.atlas_id)

--- a/crates/gpui/src/platform/mac/renderer.rs
+++ b/crates/gpui/src/platform/mac/renderer.rs
@@ -9,6 +9,7 @@ use crate::{
     scene::{Glyph, Icon, Image, Layer, Quad, Scene, Shadow, Underline},
 };
 use cocoa::foundation::NSUInteger;
+use log::warn;
 use metal::{MTLPixelFormat, MTLResourceOptions, NSRange};
 use shaders::ToFloat2 as _;
 use std::{collections::HashMap, ffi::c_void, iter::Peekable, mem, sync::Arc, vec};
@@ -176,6 +177,7 @@ impl Renderer {
                 let path_allocation = self.path_atlases.allocate(size.to_i32());
                 if path_allocation.is_none() {
                     // Path size was likely zero.
+                    warn!("could not allocate path texture of size {:?}", size);
                     continue;
                 }
                 let (alloc_id, atlas_origin) = path_allocation.unwrap();

--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -117,7 +117,7 @@ impl SpriteCache {
 
                 let (alloc_id, atlas_bounds) = atlases
                     .upload(glyph_bounds.size(), &mask)
-                    .expect("Could not upload glyph");
+                    .expect("could not upload glyph");
                 Some(GlyphSprite {
                     atlas_id: alloc_id.atlas_id,
                     atlas_origin: atlas_bounds.origin(),

--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -4,6 +4,7 @@ use crate::{
     geometry::vector::{vec2f, Vector2F, Vector2I},
     platform,
 };
+use collections::hash_map::Entry;
 use metal::{MTLPixelFormat, TextureDescriptor};
 use ordered_float::OrderedFloat;
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
@@ -114,7 +115,9 @@ impl SpriteCache {
                     scale_factor,
                 )?;
 
-                let (alloc_id, atlas_bounds) = atlases.upload(glyph_bounds.size(), &mask);
+                let (alloc_id, atlas_bounds) = atlases
+                    .upload(glyph_bounds.size(), &mask)
+                    .expect("Could not upload glyph");
                 Some(GlyphSprite {
                     atlas_id: alloc_id.atlas_id,
                     atlas_origin: atlas_bounds.origin(),
@@ -130,15 +133,15 @@ impl SpriteCache {
         size: Vector2I,
         path: Cow<'static, str>,
         svg: usvg::Tree,
-    ) -> IconSprite {
+    ) -> Option<IconSprite> {
         let atlases = &mut self.atlases;
-        self.icons
-            .entry(IconDescriptor {
-                path,
-                width: size.x(),
-                height: size.y(),
-            })
-            .or_insert_with(|| {
+        match self.icons.entry(IconDescriptor {
+            path,
+            width: size.x(),
+            height: size.y(),
+        }) {
+            Entry::Occupied(entry) => Some(entry.get().clone()),
+            Entry::Vacant(entry) => {
                 let mut pixmap = tiny_skia::Pixmap::new(size.x() as u32, size.y() as u32).unwrap();
                 resvg::render(&svg, usvg::FitTo::Width(size.x() as u32), pixmap.as_mut());
                 let mask = pixmap
@@ -146,15 +149,15 @@ impl SpriteCache {
                     .iter()
                     .map(|a| a.alpha())
                     .collect::<Vec<_>>();
-
-                let (alloc_id, atlas_bounds) = atlases.upload(size, &mask);
-                IconSprite {
+                let (alloc_id, atlas_bounds) = atlases.upload(size, &mask)?;
+                let icon_sprite = IconSprite {
                     atlas_id: alloc_id.atlas_id,
                     atlas_origin: atlas_bounds.origin(),
                     size,
-                }
-            })
-            .clone()
+                };
+                Some(entry.insert(icon_sprite).clone())
+            }
+        }
     }
 
     pub fn atlas_texture(&self, atlas_id: usize) -> Option<&metal::TextureRef> {


### PR DESCRIPTION
This is an attempt at fixing a panic I get occasionally when waking my mac from sleep.

The panic is in the atlas allocator and I believe it happens when we try to allocate a zero size texture to an atlas. So rather than just unwrapping the value, I changed the upload and allocate functions to return options and then decide whether unwrap makes sense in each case.

For glyphs and images, I decided to unwrap because they can't be zero size.
For icons and paths, I just skip adding the texture to the atlas and adding it to the gpu buffer.

I did some investigation as to why we allocate zero size textures, and believe it is due to a zero size view rectangle returned from appkit, but honestly I don't really understand that code, and I think this will work as well.