### PR TITLE
Fix bad diagnostic state when restarting a language server w/ a running diagnostic task

### DIFF
--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -3,8 +3,8 @@ use gpui::{
     elements::*, platform::CursorStyle, Entity, ModelHandle, RenderContext, View, ViewContext,
 };
 use project::Project;
-use workspace::{StatusItemView};
 use settings::Settings;
+use workspace::StatusItemView;
 
 pub struct DiagnosticSummary {
     summary: project::DiagnosticSummary,


### PR DESCRIPTION
Previously, if you restarted a language server while it was in the process of updating diagnostics, the project would permanently get into a "Checking..." diagnostic state. I found this in the course of investigating #700, but I don't think it was the cause of the problem we experienced there.