### PR TITLE
Calculate hit-box based on visible bounds in `{Mouse}EventHandler`

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1147,6 +1147,7 @@ impl Element for EditorElement {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         layout: &mut LayoutState,
         paint: &mut PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/examples/text.rs
+++ b/crates/gpui/examples/text.rs
@@ -104,6 +104,7 @@ impl gpui::Element for TextElement {
         &mut self,
         _: &gpui::Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut gpui::EventContext,

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -74,6 +74,7 @@ pub trait Element {
         &mut self,
         event: &Event,
         bounds: RectF,
+        visible_bounds: RectF,
         layout: &mut Self::LayoutState,
         paint: &mut Self::PaintState,
         cx: &mut EventContext,
@@ -169,6 +170,7 @@ pub enum Lifecycle<T: Element> {
         element: T,
         constraint: SizeConstraint,
         bounds: RectF,
+        visible_bounds: RectF,
         layout: T::LayoutState,
         paint: T::PaintState,
     },
@@ -222,6 +224,7 @@ impl<T: Element> AnyElement for Lifecycle<T> {
                     element,
                     constraint,
                     bounds,
+                    visible_bounds,
                     layout,
                     paint,
                 }
@@ -242,6 +245,7 @@ impl<T: Element> AnyElement for Lifecycle<T> {
                     element,
                     constraint,
                     bounds,
+                    visible_bounds,
                     layout,
                     paint,
                 }
@@ -254,12 +258,13 @@ impl<T: Element> AnyElement for Lifecycle<T> {
         if let Lifecycle::PostPaint {
             element,
             bounds,
+            visible_bounds,
             layout,
             paint,
             ..
         } = self
         {
-            element.dispatch_event(event, *bounds, layout, paint, cx)
+            element.dispatch_event(event, *bounds, *visible_bounds, layout, paint, cx)
         } else {
             panic!("invalid element lifecycle state");
         }
@@ -288,6 +293,7 @@ impl<T: Element> AnyElement for Lifecycle<T> {
                 element,
                 constraint,
                 bounds,
+                visible_bounds,
                 layout,
                 paint,
             } => {
@@ -299,6 +305,8 @@ impl<T: Element> AnyElement for Lifecycle<T> {
                         new_map.insert("type".into(), typ);
                     }
                     new_map.insert("constraint".into(), constraint.to_json());
+                    new_map.insert("bounds".into(), bounds.to_json());
+                    new_map.insert("visible_bounds".into(), visible_bounds.to_json());
                     new_map.append(map);
                     json::Value::Object(new_map)
                 } else {

--- a/crates/gpui/src/elements/align.rs
+++ b/crates/gpui/src/elements/align.rs
@@ -85,7 +85,8 @@ impl Element for Align {
     fn dispatch_event(
         &mut self,
         event: &Event,
-        _: pathfinder_geometry::rect::RectF,
+        _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/canvas.rs
+++ b/crates/gpui/src/elements/canvas.rs
@@ -59,6 +59,7 @@ where
         &mut self,
         _: &crate::Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut crate::EventContext,

--- a/crates/gpui/src/elements/constrained_box.rs
+++ b/crates/gpui/src/elements/constrained_box.rs
@@ -81,6 +81,7 @@ impl Element for ConstrainedBox {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/container.rs
+++ b/crates/gpui/src/elements/container.rs
@@ -247,6 +247,7 @@ impl Element for Container {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/empty.rs
+++ b/crates/gpui/src/elements/empty.rs
@@ -52,6 +52,7 @@ impl Element for Empty {
         &mut self,
         _: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut EventContext,

--- a/crates/gpui/src/elements/event_handler.rs
+++ b/crates/gpui/src/elements/event_handler.rs
@@ -85,6 +85,8 @@ impl Element for EventHandler {
         &mut self,
         event: &Event,
         bounds: RectF,
+        _: RectF,
+        visible_bounds: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/event_handler.rs
+++ b/crates/gpui/src/elements/event_handler.rs
@@ -84,7 +84,6 @@ impl Element for EventHandler {
     fn dispatch_event(
         &mut self,
         event: &Event,
-        bounds: RectF,
         _: RectF,
         visible_bounds: RectF,
         _: &mut Self::LayoutState,
@@ -92,7 +91,7 @@ impl Element for EventHandler {
         cx: &mut EventContext,
     ) -> bool {
         if let Some(capture) = self.capture.as_mut() {
-            if capture(event, bounds, cx) {
+            if capture(event, visible_bounds, cx) {
                 return true;
             }
         }
@@ -103,7 +102,7 @@ impl Element for EventHandler {
             match event {
                 Event::LeftMouseDown { position, .. } => {
                     if let Some(callback) = self.mouse_down.as_mut() {
-                        if bounds.contains_point(*position) {
+                        if visible_bounds.contains_point(*position) {
                             return callback(cx);
                         }
                     }
@@ -111,7 +110,7 @@ impl Element for EventHandler {
                 }
                 Event::RightMouseDown { position, .. } => {
                     if let Some(callback) = self.right_mouse_down.as_mut() {
-                        if bounds.contains_point(*position) {
+                        if visible_bounds.contains_point(*position) {
                             return callback(cx);
                         }
                     }
@@ -123,7 +122,7 @@ impl Element for EventHandler {
                     ..
                 } => {
                     if let Some(callback) = self.navigate_mouse_down.as_mut() {
-                        if bounds.contains_point(*position) {
+                        if visible_bounds.contains_point(*position) {
                             return callback(*direction, cx);
                         }
                     }

--- a/crates/gpui/src/elements/expanded.rs
+++ b/crates/gpui/src/elements/expanded.rs
@@ -66,6 +66,7 @@ impl Element for Expanded {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -271,12 +271,6 @@ impl Element for Flex {
         _: &mut Self::PaintState,
         cx: &mut EventContext,
     ) -> bool {
-        if let Some(position) = event.position() {
-            if !bounds.contains_point(position) {
-                return false;
-            }
-        }
-
         let mut handled = false;
         for child in &mut self.children {
             handled = child.dispatch_event(event, cx) || handled;

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -266,6 +266,7 @@ impl Element for Flex {
         &mut self,
         event: &Event,
         bounds: RectF,
+        _: RectF,
         remaining_space: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,
@@ -390,6 +391,7 @@ impl Element for FlexItem {
     fn dispatch_event(
         &mut self,
         event: &Event,
+        _: RectF,
         _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,

--- a/crates/gpui/src/elements/hook.rs
+++ b/crates/gpui/src/elements/hook.rs
@@ -57,6 +57,7 @@ impl Element for Hook {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/image.rs
+++ b/crates/gpui/src/elements/image.rs
@@ -81,6 +81,7 @@ impl Element for Image {
         &mut self,
         _: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut EventContext,

--- a/crates/gpui/src/elements/label.rs
+++ b/crates/gpui/src/elements/label.rs
@@ -166,6 +166,7 @@ impl Element for Label {
         &mut self,
         _: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut EventContext,

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -253,6 +253,7 @@ impl Element for List {
         &mut self,
         event: &Event,
         bounds: RectF,
+        _: RectF,
         scroll_top: &mut ListOffset,
         _: &mut (),
         cx: &mut EventContext,
@@ -871,6 +872,7 @@ mod tests {
         fn dispatch_event(
             &mut self,
             _: &Event,
+            _: RectF,
             _: RectF,
             _: &mut (),
             _: &mut (),

--- a/crates/gpui/src/elements/mouse_event_handler.rs
+++ b/crates/gpui/src/elements/mouse_event_handler.rs
@@ -100,6 +100,7 @@ impl Element for MouseEventHandler {
         &mut self,
         event: &Event,
         bounds: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/mouse_event_handler.rs
+++ b/crates/gpui/src/elements/mouse_event_handler.rs
@@ -99,8 +99,8 @@ impl Element for MouseEventHandler {
     fn dispatch_event(
         &mut self,
         event: &Event,
-        bounds: RectF,
         _: RectF,
+        visible_bounds: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,
@@ -113,8 +113,8 @@ impl Element for MouseEventHandler {
         let handled_in_child = self.child.dispatch_event(event, cx);
 
         let hit_bounds = RectF::from_points(
-            bounds.origin() - vec2f(self.padding.left, self.padding.top),
-            bounds.lower_right() + vec2f(self.padding.right, self.padding.bottom),
+            visible_bounds.origin() - vec2f(self.padding.left, self.padding.top),
+            visible_bounds.lower_right() + vec2f(self.padding.right, self.padding.bottom),
         )
         .round_out();
 

--- a/crates/gpui/src/elements/overlay.rs
+++ b/crates/gpui/src/elements/overlay.rs
@@ -44,6 +44,7 @@ impl Element for Overlay {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/stack.rs
+++ b/crates/gpui/src/elements/stack.rs
@@ -51,6 +51,7 @@ impl Element for Stack {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -76,6 +76,7 @@ impl Element for Svg {
         &mut self,
         _: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut EventContext,

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -172,6 +172,7 @@ impl Element for Text {
         &mut self,
         _: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut EventContext,

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -281,6 +281,7 @@ where
         &mut self,
         event: &Event,
         bounds: RectF,
+        _: RectF,
         layout: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -535,6 +535,7 @@ impl Element for ChildView {
         &mut self,
         event: &Event,
         _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         cx: &mut EventContext,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -16,7 +16,7 @@ use gpui::{
     action,
     color::Color,
     elements::*,
-    geometry::{vector::vec2f, PathBuilder},
+    geometry::{rect::RectF, vector::vec2f, PathBuilder},
     json::{self, to_string_pretty, ToJson},
     keymap::Binding,
     platform::{CursorStyle, WindowOptions},
@@ -2068,7 +2068,8 @@ impl Element for AvatarRibbon {
     fn dispatch_event(
         &mut self,
         _: &gpui::Event,
-        _: gpui::geometry::rect::RectF,
+        _: RectF,
+        _: RectF,
         _: &mut Self::LayoutState,
         _: &mut Self::PaintState,
         _: &mut gpui::EventContext,


### PR DESCRIPTION
This pull request is a refinement over #745, where we attempted to fix #707. On that pull request, we avoided dispatching events to a `Flex`'s children when such events were not contained within the flex element bounds. Unfortunately, that approach was problematic because it didn't give an opportunity to `MouseEventHandler`s to handle mouse move events when they didn't intersect with the element bounds, causing elements to never clear their hover state, cursor style, etc.

With these changes, we are introducing a new `visible_bounds` parameter to the `Element::dispatch_event` trait. This is used in `MouseEventHandler` and `EventHandler` to determine their hit-box so that only clicks targeting the visible portion of the element trigger a mouse down/up callback.

/cc: @nathansobo 