### PR TITLE
Don't starve UI thread when rapidly receiving LSP messages

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -201,6 +201,9 @@ impl LanguageServer {
                             std::str::from_utf8(&buffer)?
                         ));
                     }
+
+                    // Don't starve the main thread when receiving lots of messages at once.
+                    smol::future::yield_now().await;
                 }
             }
             .log_err()


### PR DESCRIPTION
Fixes #749
Supplants #752

After talking with @as-cii, it looks like we accidentally dropped this code in #702.

In an ideal world, we'd only every compute a single frame per display refresh. However, in order to do so, we'd need a very accurate estimate of how long that frame would take to compute so we could wait until the last possible moment to draw a new frame. This would allow multiple events to request redraw and all coalesce into a single update. However, this would be complex to implement. Is it even possible to accurately estimate how long a frame would take to compute?

By yielding, we still potentially compute updates that we eventually discard, but make space for other events such as cursor movements to be handled.

🍐'd w/ @as-cii 