### PR TITLE
Introduce host disconnection in randomized collaboration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,6 @@ dependencies = [
  "gpui",
  "log",
  "parking_lot",
- "postage",
  "prost",
  "prost-build",
  "rand 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ dependencies = [
  "async-tungstenite",
  "base64 0.13.0",
  "clock",
+ "collections",
  "futures",
  "gpui",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6122,7 +6122,6 @@ dependencies = [
  "oauth2",
  "oauth2-surf",
  "parking_lot",
- "postage",
  "project",
  "rand 0.8.3",
  "rpc",

--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, Result};
 use futures::{future::BoxFuture, stream::BoxStream, Future, StreamExt};
 use gpui::{executor, ModelHandle, TestAppContext};
 use parking_lot::Mutex;
-use postage::barrier;
 use rpc::{proto, ConnectionId, Peer, Receipt, TypedEnvelope};
 use std::{fmt, rc::Rc, sync::Arc};
 
@@ -23,7 +22,6 @@ struct FakeServerState {
     connection_id: Option<ConnectionId>,
     forbid_connections: bool,
     auth_count: usize,
-    connection_killer: Option<barrier::Sender>,
     access_token: usize,
 }
 
@@ -76,15 +74,13 @@ impl FakeServer {
                             Err(EstablishConnectionError::Unauthorized)?
                         }
 
-                        let (client_conn, server_conn, kill) =
-                            Connection::in_memory(cx.background());
+                        let (client_conn, server_conn, _) = Connection::in_memory(cx.background());
                         let (connection_id, io, incoming) =
                             peer.add_test_connection(server_conn, cx.background()).await;
                         cx.background().spawn(io).detach();
                         let mut state = state.lock();
                         state.connection_id = Some(connection_id);
                         state.incoming = Some(incoming);
-                        state.connection_killer = Some(kill);
                         Ok(client_conn)
                     })
                 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3850,7 +3850,7 @@ impl Project {
             let buffer = this
                 .opened_buffers
                 .get(&buffer_id)
-                .map(|buffer| buffer.upgrade(cx).unwrap())
+                .and_then(|buffer| buffer.upgrade(cx))
                 .ok_or_else(|| anyhow!("unknown buffer id {}", buffer_id))?;
             Ok::<_, anyhow::Error>((project_id, buffer))
         })?;
@@ -3882,7 +3882,7 @@ impl Project {
                 buffers.insert(
                     this.opened_buffers
                         .get(buffer_id)
-                        .map(|buffer| buffer.upgrade(cx).unwrap())
+                        .and_then(|buffer| buffer.upgrade(cx))
                         .ok_or_else(|| anyhow!("unknown buffer id {}", buffer_id))?,
                 );
             }
@@ -3911,7 +3911,7 @@ impl Project {
                 buffers.insert(
                     this.opened_buffers
                         .get(buffer_id)
-                        .map(|buffer| buffer.upgrade(cx).unwrap())
+                        .and_then(|buffer| buffer.upgrade(cx))
                         .ok_or_else(|| anyhow!("unknown buffer id {}", buffer_id))?,
                 );
             }
@@ -3942,7 +3942,7 @@ impl Project {
         let buffer = this.read_with(&cx, |this, cx| {
             this.opened_buffers
                 .get(&envelope.payload.buffer_id)
-                .map(|buffer| buffer.upgrade(cx).unwrap())
+                .and_then(|buffer| buffer.upgrade(cx))
                 .ok_or_else(|| anyhow!("unknown buffer id {}", envelope.payload.buffer_id))
         })?;
         buffer
@@ -3972,7 +3972,7 @@ impl Project {
             let buffer = this
                 .opened_buffers
                 .get(&envelope.payload.buffer_id)
-                .map(|buffer| buffer.upgrade(cx).unwrap())
+                .and_then(|buffer| buffer.upgrade(cx))
                 .ok_or_else(|| anyhow!("unknown buffer id {}", envelope.payload.buffer_id))?;
             let language = buffer.read(cx).language();
             let completion = language::proto::deserialize_completion(
@@ -4014,7 +4014,7 @@ impl Project {
         let buffer = this.update(&mut cx, |this, cx| {
             this.opened_buffers
                 .get(&envelope.payload.buffer_id)
-                .map(|buffer| buffer.upgrade(cx).unwrap())
+                .and_then(|buffer| buffer.upgrade(cx))
                 .ok_or_else(|| anyhow!("unknown buffer id {}", envelope.payload.buffer_id))
         })?;
         buffer
@@ -4055,7 +4055,7 @@ impl Project {
             let buffer = this
                 .opened_buffers
                 .get(&envelope.payload.buffer_id)
-                .map(|buffer| buffer.upgrade(cx).unwrap())
+                .and_then(|buffer| buffer.upgrade(cx))
                 .ok_or_else(|| anyhow!("unknown buffer id {}", envelope.payload.buffer_id))?;
             Ok::<_, anyhow::Error>(this.apply_code_action(buffer, action, false, cx))
         })?;

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1216,7 +1216,7 @@ impl Project {
                 let file = File::from_dyn(buffer.file())?;
                 let abs_path = file.as_local()?.abs_path(cx);
                 let uri = lsp::Url::from_file_path(abs_path).unwrap();
-                let buffer_snapshots = self.buffer_snapshots.entry(buffer.remote_id()).or_default();
+                let buffer_snapshots = self.buffer_snapshots.get_mut(&buffer.remote_id())?;
                 let (version, prev_snapshot) = buffer_snapshots.last()?;
                 let next_snapshot = buffer.text_snapshot();
                 let next_version = version + 1;

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -11,7 +11,10 @@ use client::{proto, Client, TypedEnvelope};
 use clock::ReplicaId;
 use collections::HashMap;
 use futures::{
-    channel::mpsc::{self, UnboundedSender},
+    channel::{
+        mpsc::{self, UnboundedSender},
+        oneshot,
+    },
     Stream, StreamExt,
 };
 use fuzzy::CharBag;
@@ -26,7 +29,6 @@ use language::{
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use postage::{
-    oneshot,
     prelude::{Sink as _, Stream as _},
     watch,
 };
@@ -727,11 +729,11 @@ impl LocalWorktree {
 
     pub fn share(&mut self, project_id: u64, cx: &mut ModelContext<Worktree>) -> Task<Result<()>> {
         let register = self.register(project_id, cx);
-        let (mut share_tx, mut share_rx) = oneshot::channel();
+        let (share_tx, share_rx) = oneshot::channel();
         let (snapshots_to_send_tx, snapshots_to_send_rx) =
             smol::channel::unbounded::<LocalSnapshot>();
         if self.share.is_some() {
-            let _ = share_tx.try_send(Ok(()));
+            let _ = share_tx.send(Ok(()));
         } else {
             let rpc = self.client.clone();
             let worktree_id = cx.model_id() as u64;
@@ -756,15 +758,15 @@ impl LocalWorktree {
                                 })
                                 .await
                             {
-                                let _ = share_tx.try_send(Err(error));
+                                let _ = share_tx.send(Err(error));
                                 return Err(anyhow!("failed to send initial update worktree"));
                             } else {
-                                let _ = share_tx.try_send(Ok(()));
+                                let _ = share_tx.send(Ok(()));
                                 snapshot
                             }
                         }
                         Err(error) => {
-                            let _ = share_tx.try_send(Err(error.into()));
+                            let _ = share_tx.send(Err(error.into()));
                             return Err(anyhow!("failed to send initial update worktree"));
                         }
                     };
@@ -804,9 +806,8 @@ impl LocalWorktree {
                 });
             }
             share_rx
-                .next()
                 .await
-                .unwrap_or_else(|| Err(anyhow!("share ended")))
+                .unwrap_or_else(|_| Err(anyhow!("share ended")))
         })
     }
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -23,7 +23,6 @@ base64 = "0.13"
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.11.1"
-postage = { version = "0.4.1", features = ["futures-traits"] }
 prost = "0.8"
 rand = "0.8"
 rsa = "0.4"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -9,9 +9,13 @@ path = "src/rpc.rs"
 doctest = false
 
 [features]
-test-support = ["gpui/test-support"]
+test-support = ["collections/test-support", "gpui/test-support"]
 
 [dependencies]
+clock = { path = "../clock" }
+collections = { path = "../collections" }
+gpui = { path = "../gpui", optional = true }
+util = { path = "../util" }
 anyhow = "1.0"
 async-lock = "2.4"
 async-tungstenite = "0.16"
@@ -26,14 +30,12 @@ rsa = "0.4"
 serde = { version = "1", features = ["derive"] }
 smol-timeout = "0.6"
 zstd = "0.9"
-clock = { path = "../clock" }
-gpui = { path = "../gpui", optional = true }
-util = { path = "../util" }
 
 [build-dependencies]
 prost-build = "0.8"
 
 [dev-dependencies]
+collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 smol = "1.2.5"
 tempdir = "0.3.7"

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -1,6 +1,9 @@
-use super::proto::{self, AnyTypedEnvelope, EnvelopedMessage, MessageStream, RequestMessage};
-use super::Connection;
+use super::{
+    proto::{self, AnyTypedEnvelope, EnvelopedMessage, MessageStream, RequestMessage},
+    Connection,
+};
 use anyhow::{anyhow, Context, Result};
+use collections::HashMap;
 use futures::{channel::oneshot, stream::BoxStream, FutureExt as _, StreamExt};
 use parking_lot::{Mutex, RwLock};
 use postage::{
@@ -10,7 +13,6 @@ use postage::{
 use smol_timeout::TimeoutExt as _;
 use std::sync::atomic::Ordering::SeqCst;
 use std::{
-    collections::HashMap,
     fmt,
     future::Future,
     marker::PhantomData,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,7 +14,6 @@ required-features = ["seed-support"]
 
 [dependencies]
 collections = { path = "../collections" }
-settings = { path = "../settings" }
 rpc = { path = "../rpc" }
 anyhow = "1.0.40"
 async-io = "1.3"
@@ -65,6 +64,7 @@ editor = { path = "../editor", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
 project = { path = "../project", features = ["test-support"] }
+settings = { path = "../settings", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -33,7 +33,6 @@ lipsum = { version = "0.8", optional = true }
 oauth2 = { version = "4.0.0", default_features = false }
 oauth2-surf = "0.1.1"
 parking_lot = "0.11.1"
-postage = { version = "0.4.1", features = ["futures-traits"] }
 rand = "0.8"
 rust-embed = { version = "6.3", features = ["include-exclude"] }
 scrypt = "0.7"

--- a/crates/server/src/rpc/store.rs
+++ b/crates/server/src/rpc/store.rs
@@ -244,6 +244,9 @@ impl Store {
                 language_servers: Default::default(),
             },
         );
+        if let Some(connection) = self.connections.get_mut(&host_connection_id) {
+            connection.projects.insert(project_id);
+        }
         self.next_project_id += 1;
         project_id
     }
@@ -266,9 +269,7 @@ impl Store {
                     .or_default()
                     .insert(project_id);
             }
-            if let Some(connection) = self.connections.get_mut(&project.host_connection_id) {
-                connection.projects.insert(project_id);
-            }
+
             project.worktrees.insert(worktree_id, worktree);
             if let Ok(share) = project.share_mut() {
                 share.worktrees.insert(worktree_id, Default::default());


### PR DESCRIPTION
This is a collection of miscellaneous improvements resulting from our investigation on #744. We still don't know what's going on unfortunately, but these are improvements nonetheless:

- Added a step in the randomized test that disconnects the host. This uncovered a few bugs and panics on the client that got fixed as part of this pull request (see 3daaef02ca5e81999481cecfdb733e7c5b57946a, 663beab1b9276991ef7c1ea70ba5a1ffc511b695 and 32fd4eb3ac4796cdb1aae45647459c0d78b0105f).
- Replaced `postage` with `futures` on the server. We've had issues with postage reliability in the past and we worry there could be some bug in their implementation that causes some future to never wake up and stall the server's event loop.
- Added a timeout in `Peer`'s event loop when putting an incoming message on the queue. This speculatively prevents cases where the server gets stuck on a message handler.