### PR TITLE
Avoid panic that we don't understand in handle_get_code_actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayref"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -29,7 +29,7 @@ settings = { path = "../settings" }
 sum_tree = { path = "../sum_tree" }
 util = { path = "../util" }
 aho-corasick = "0.7"
-anyhow = "1.0.38"
+anyhow = "1.0.56"
 async-trait = "0.1"
 futures = "0.3"
 ignore = "0.4"


### PR DESCRIPTION
Closes #780

This is a temporary solution where we hopefully detect the state that would cause a panic and return an error to the guest instead. In the future, we can consult our logs to get more information about why this error is happening.