### PR TITLE
Fix divergence bug when peer reconnects reusing a prior replica id

### DIFF
--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -826,6 +826,8 @@ impl Buffer {
                         edit.timestamp,
                     );
                     self.snapshot.version.observe(edit.timestamp.local());
+                    self.local_clock.observe(edit.timestamp.local());
+                    self.lamport_clock.observe(edit.timestamp.lamport());
                     self.resolve_edit(edit.timestamp.local());
                 }
             }
@@ -836,6 +838,7 @@ impl Buffer {
                 if !self.version.observed(undo.id) {
                     self.apply_undo(&undo)?;
                     self.snapshot.version.observe(undo.id);
+                    self.local_clock.observe(undo.id);
                     self.lamport_clock.observe(lamport_timestamp);
                 }
             }
@@ -1033,8 +1036,6 @@ impl Buffer {
         self.snapshot.visible_text = visible_text;
         self.snapshot.deleted_text = deleted_text;
         self.snapshot.insertions.edit(new_insertions, &());
-        self.local_clock.observe(timestamp.local());
-        self.lamport_clock.observe(timestamp.lamport());
         self.subscriptions.publish_mut(&edits);
     }
 


### PR DESCRIPTION
Tentatively closes #780 

As part of investigating #780, I realized we didn't have any code path exercising peer disconnection and reconnection. When adding this scenario to the buffer's randomized test, it caught a divergence bug due to not observing the footprint of the reconnecting replica's prior undos into the local clock. This was causing the replica to generate edits with a version strictly smaller than what other peers may have observed, thus letting those peers think they had already seen those edits and skip them.

I don't remember whether such a reconnection actually happened when @nathansobo, @maxbrunsfeld and I saw that panic during our collaboration session, but I do remember at some point I _did_ reconnect to @nathansobo's session, so it seems plausible this was caused by that bug.