### PR TITLE
Set default tsx tabsize

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -62,6 +62,13 @@ fn main() {
                 tab_size: Some(2),
                 ..Default::default()
             },
+        )
+        .with_overrides(
+            "TSX",
+            settings::LanguageOverride {
+                tab_size: Some(2),
+                ..Default::default()
+            },
         );
     let settings_file = load_settings_file(&app, fs.clone());
 


### PR DESCRIPTION
Also removes js from the config.toml for tsx. Not sure why it was there, I can revert that change if it was intentional.