### PR TITLE
Allow dumping the project diagnostic view's state as JSON

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -2,7 +2,7 @@
     "*": {
         "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
         "cmd-s": "workspace::Save",
-        "cmd-alt-i": "workspace::DebugElements",
+        "cmd-alt-i": "zed::DebugElements",
         "cmd-k cmd-left": "workspace::ActivatePreviousPane",
         "cmd-k cmd-right": "workspace::ActivateNextPane",
         "cmd-=": "zed::IncreaseBufferFontSize",

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -1,6 +1,7 @@
 use crate::render_summary;
 use gpui::{
-    elements::*, platform::CursorStyle, Entity, ModelHandle, RenderContext, View, ViewContext,
+    elements::*, platform::CursorStyle, serde_json, Entity, ModelHandle, RenderContext, View,
+    ViewContext,
 };
 use project::Project;
 use settings::Settings;
@@ -66,6 +67,10 @@ impl View for DiagnosticSummary {
         .with_cursor_style(CursorStyle::PointingHand)
         .on_click(|cx| cx.dispatch_action(crate::Deploy))
         .boxed()
+    }
+
+    fn debug_json(&self, _: &gpui::AppContext) -> serde_json::Value {
+        serde_json::json!({ "summary": self.summary })
     }
 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1008,7 +1008,7 @@ impl Editor {
         if project.read(cx).is_remote() {
             cx.propagate_action();
         } else if let Some(buffer) = project
-            .update(cx, |project, cx| project.create_buffer(cx))
+            .update(cx, |project, cx| project.create_buffer("", None, cx))
             .log_err()
         {
             workspace.add_item(

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -209,15 +209,18 @@ impl Presenter {
     }
 
     pub fn debug_elements(&self, cx: &AppContext) -> Option<json::Value> {
-        cx.root_view_id(self.window_id)
-            .and_then(|root_view_id| self.rendered_views.get(&root_view_id))
-            .map(|root_element| {
-                root_element.debug(&DebugContext {
-                    rendered_views: &self.rendered_views,
-                    font_cache: &self.font_cache,
-                    app: cx,
+        let view = cx.root_view(self.window_id)?;
+        Some(json!({
+            "root_view": view.debug_json(cx),
+            "root_element": self.rendered_views.get(&view.id())
+                .map(|root_element| {
+                    root_element.debug(&DebugContext {
+                        rendered_views: &self.rendered_views,
+                        font_cache: &self.font_cache,
+                        app: cx,
+                    })
                 })
-            })
+        }))
     }
 }
 
@@ -554,6 +557,7 @@ impl Element for ChildView {
             "type": "ChildView",
             "view_id": self.view.id(),
             "bounds": bounds.to_json(),
+            "view": self.view.debug_json(cx.app),
             "child": if let Some(view) = cx.rendered_views.get(&self.view.id()) {
                 view.debug(cx)
             } else {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -18,11 +18,11 @@ use gpui::{
     elements::*,
     geometry::{rect::RectF, vector::vec2f, PathBuilder},
     impl_internal_actions,
-    json::{self, to_string_pretty, ToJson},
+    json::{self, ToJson},
     platform::{CursorStyle, WindowOptions},
-    AnyModelHandle, AnyViewHandle, AppContext, AsyncAppContext, Border, ClipboardItem, Entity,
-    ImageData, ModelHandle, MutableAppContext, PathPromptOptions, PromptLevel, RenderContext, Task,
-    View, ViewContext, ViewHandle, WeakViewHandle,
+    AnyModelHandle, AnyViewHandle, AppContext, AsyncAppContext, Border, Entity, ImageData,
+    ModelHandle, MutableAppContext, PathPromptOptions, PromptLevel, RenderContext, Task, View,
+    ViewContext, ViewHandle, WeakViewHandle,
 };
 use language::LanguageRegistry;
 use log::error;
@@ -75,7 +75,6 @@ actions!(
         ToggleShare,
         Unfollow,
         Save,
-        DebugElements,
         ActivatePreviousPane,
         ActivateNextPane,
         FollowNextCollaborator,
@@ -133,7 +132,6 @@ pub fn init(client: &Arc<Client>, cx: &mut MutableAppContext) {
             workspace.save_active_item(cx).detach_and_log_err(cx);
         },
     );
-    cx.add_action(Workspace::debug_elements);
     cx.add_action(Workspace::toggle_sidebar_item);
     cx.add_action(Workspace::toggle_sidebar_item_focus);
     cx.add_action(|workspace: &mut Workspace, _: &ActivatePreviousPane, cx| {
@@ -1051,22 +1049,6 @@ impl Workspace {
             }
         }
         cx.notify();
-    }
-
-    pub fn debug_elements(&mut self, _: &DebugElements, cx: &mut ViewContext<Self>) {
-        match to_string_pretty(&cx.debug_elements()) {
-            Ok(json) => {
-                let kib = json.len() as f32 / 1024.;
-                cx.as_mut().write_to_clipboard(ClipboardItem::new(json));
-                log::info!(
-                    "copied {:.1} KiB of element debug JSON to the clipboard",
-                    kib
-                );
-            }
-            Err(error) => {
-                log::error!("error debugging elements: {}", error);
-            }
-        };
     }
 
     fn add_pane(&mut self, cx: &mut ViewContext<Self>) -> ViewHandle<Pane> {


### PR DESCRIPTION
Refs https://github.com/zed-industries/zed/issues/700

In order to help us to get insight into ☝️ this bug when it occurs, this PR enhances the `DebugElements` command in a couple of ways:
* The JSON can now include arbitrary view-specific information, via optional method on `gpui::View` called `debug_json`. I've implemented `debug_json` for the project diagnostics view so that we'll get many details about its state.
* The command now opens the JSON in a tab, rather than just copying it the clipboard.