### PR TITLE
Add back key bindings that were removed accidentally

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -205,7 +205,8 @@
         "enter": "editor::ConfirmRename"
     },
     "Editor && showing_completions": {
-        "enter": "editor::ConfirmCompletion"
+        "enter": "editor::ConfirmCompletion",
+        "tab": "editor::ConfirmCompletion"
     },
     "Editor && showing_code_actions": {
         "enter": "editor::ConfirmCodeAction"

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -53,7 +53,21 @@
         "cmd-t": "project_symbols::Toggle",
         "cmd-p": "file_finder::Toggle",
         "alt-shift-D": "diagnostics::Deploy",
-        "ctrl-alt-cmd-j": "journal::NewJournalEntry"
+        "ctrl-alt-cmd-j": "journal::NewJournalEntry",
+        "cmd-1": [
+            "workspace::ToggleSidebarItemFocus",
+            {
+                "side": "Left",
+                "item_index": 0
+            }
+        ],
+        "cmd-shift-!": [
+            "workspace::ToggleSidebarItem",
+            {
+                "side": "Left",
+                "item_index": 0
+            }
+        ]
     },
     "ProjectSearchBar": {
         "enter": "project_search::Search",

--- a/crates/workspace/src/sidebar.rs
+++ b/crates/workspace/src/sidebar.rs
@@ -1,7 +1,6 @@
 use super::Workspace;
-use gpui::{
-    elements::*, impl_internal_actions, platform::CursorStyle, AnyViewHandle, RenderContext,
-};
+use gpui::{elements::*, impl_actions, platform::CursorStyle, AnyViewHandle, RenderContext};
+use serde::Deserialize;
 use std::{cell::RefCell, rc::Rc};
 use theme::Theme;
 
@@ -12,7 +11,7 @@ pub struct Sidebar {
     width: Rc<RefCell<f32>>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Deserialize)]
 pub enum Side {
     Left,
     Right,
@@ -23,15 +22,15 @@ struct Item {
     view: AnyViewHandle,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
 pub struct ToggleSidebarItem(pub SidebarItemId);
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
 pub struct ToggleSidebarItemFocus(pub SidebarItemId);
 
-impl_internal_actions!(workspace, [ToggleSidebarItem, ToggleSidebarItemFocus]);
+impl_actions!(workspace, [ToggleSidebarItem, ToggleSidebarItemFocus]);
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
 pub struct SidebarItemId {
     pub side: Side,
     pub item_index: usize,


### PR DESCRIPTION
Fixes a regression introduced in #786 

* `tab` to confirm a completion
* `cmd-1` to toggle focus between the project browser and the center
* `cmd-shift-1` to show or hide the project browser