### PR TITLE
Don't panic when allocating tiny_skia pixmap

### DIFF
--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -143,7 +143,7 @@ impl SpriteCache {
         }) {
             Entry::Occupied(entry) => Some(entry.get().clone()),
             Entry::Vacant(entry) => {
-                let mut pixmap = tiny_skia::Pixmap::new(size.x() as u32, size.y() as u32).unwrap();
+                let mut pixmap = tiny_skia::Pixmap::new(size.x() as u32, size.y() as u32)?;
                 resvg::render(&svg, usvg::FitTo::Width(size.x() as u32), pixmap.as_mut());
                 let mask = pixmap
                     .pixels()


### PR DESCRIPTION
Missed the fact that tiny_skia::PixMap::new can return none when size is zero. This passes the None on to be handled upstream (where we log it)