### PR TITLE
Speed up `WrapSnapshot::line_len` using the indexed transforms

### DIFF
--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -96,6 +96,22 @@ impl TabSnapshot {
         self.fold_snapshot.buffer_snapshot()
     }
 
+    pub fn line_len(&self, row: u32) -> u32 {
+        let max_point = self.max_point();
+        if row < max_point.row() {
+            self.chunks(
+                TabPoint::new(row, 0)..TabPoint::new(row + 1, 0),
+                false,
+                None,
+            )
+            .map(|chunk| chunk.text.len() as u32)
+            .sum::<u32>()
+                - 1
+        } else {
+            max_point.column()
+        }
+    }
+
     pub fn text_summary(&self) -> TextSummary {
         self.text_summary_for_range(TabPoint::zero()..self.max_point())
     }
@@ -517,8 +533,11 @@ mod tests {
                 actual_summary.longest_row = expected_summary.longest_row;
                 actual_summary.longest_row_chars = expected_summary.longest_row_chars;
             }
+            assert_eq!(actual_summary, expected_summary);
+        }
 
-            assert_eq!(actual_summary, expected_summary,);
+        for row in 0..=text.max_point().row {
+            assert_eq!(tabs_snapshot.line_len(row), text.line_len(row));
         }
     }
 }

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -559,11 +559,6 @@ impl WrapSnapshot {
         Patch::new(wrap_edits)
     }
 
-    pub fn text_chunks(&self, wrap_row: u32) -> impl Iterator<Item = &str> {
-        self.chunks(wrap_row..self.max_point().row() + 1, false, None)
-            .map(|h| h.text)
-    }
-
     pub fn chunks<'a>(
         &'a self,
         rows: Range<u32>,
@@ -1284,6 +1279,11 @@ mod tests {
     impl WrapSnapshot {
         pub fn text(&self) -> String {
             self.text_chunks(0).collect()
+        }
+
+        pub fn text_chunks(&self, wrap_row: u32) -> impl Iterator<Item = &str> {
+            self.chunks(wrap_row..self.max_point().row() + 1, false, None)
+                .map(|h| h.text)
         }
 
         fn verify_chunks(&mut self, rng: &mut impl Rng) {


### PR DESCRIPTION
Closes #810 

There is still a lot of room for improvement if we index more information about tabs and avoid retrieving chunks for point translation.