### PR TITLE
Revert "Focus Project Search query editor always when deployed"

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -170,7 +170,11 @@ impl View for ProjectSearchView {
                 .insert(self.model.read(cx).project.downgrade(), handle)
         });
 
-        self.focus_query_editor(cx);
+        if self.model.read(cx).match_ranges.is_empty() {
+            cx.focus(&self.query_editor);
+        } else {
+            self.focus_results_editor(cx);
+        }
     }
 }
 
@@ -394,7 +398,6 @@ impl ProjectSearchView {
 
         if let Some(existing) = existing {
             workspace.activate_item(&existing, cx);
-            existing.update(cx, |existing, cx| existing.focus_query_editor(cx));
         } else {
             let model = cx.add_model(|cx| ProjectSearch::new(workspace.project().clone(), cx));
             workspace.add_item(


### PR DESCRIPTION
Fixes #819
Reopens #771

Reverts zed-industries/zed#797