### PR TITLE
Fix focus bugs in `ProjectSearchView`

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -5872,7 +5872,7 @@ mod tests {
                 let observed_events = observed_events.clone();
                 move |this, view, cx| {
                     observed_events.lock().push(format!(
-                        "{} observed {} focus",
+                        "{} observed {}'s focus",
                         this.name,
                         view.read(cx).name
                     ))

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -170,7 +170,11 @@ impl View for ProjectSearchView {
                 .insert(self.model.read(cx).project.downgrade(), handle)
         });
 
-        self.focus_query_editor(cx);
+        if self.model.read(cx).match_ranges.is_empty() {
+            cx.focus(&self.query_editor);
+        } else {
+            self.focus_results_editor(cx);
+        }
     }
 }
 
@@ -394,7 +398,6 @@ impl ProjectSearchView {
 
         if let Some(existing) = existing {
             workspace.activate_item(&existing, cx);
-            existing.update(cx, |existing, cx| existing.focus_query_editor(cx));
         } else {
             let model = cx.add_model(|cx| ProjectSearch::new(workspace.project().clone(), cx));
             workspace.add_item(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -398,6 +398,9 @@ impl ProjectSearchView {
 
         if let Some(existing) = existing {
             workspace.activate_item(&existing, cx);
+            existing.update(cx, |existing, cx| {
+                existing.focus_query_editor(cx);
+            });
         } else {
             let model = cx.add_model(|cx| ProjectSearch::new(workspace.project().clone(), cx));
             workspace.add_item(


### PR DESCRIPTION
Supersedes https://github.com/zed-industries/zed/pull/821
Fixes https://github.com/zed-industries/zed/issues/819

This pull request fixes the above bug which was caused by a weird interplay of focus events (see 27057fdb1b25af3efd4b5e29d6b168f10a76a82b for more details). Moreover, with these changes we are also persisting the focus state in the project search: this fixes a bug that caused Zed to always focus the results editor when the tab was re-activated, independently of what was focused before.

@Kethku @nathansobo: given the finicky nature of this bug, I'd appreciate if you guys could try this out before we merge this pull request. 