### PR TITLE
Command palette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6175,7 +6175,6 @@ dependencies = [
  "collections",
  "command_palette",
  "contacts_panel",
- "crossbeam-channel",
  "ctor",
  "diagnostics",
  "dirs 3.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,6 +5310,7 @@ dependencies = [
  "gpui",
  "log",
  "parking_lot",
+ "picker",
  "postage",
  "settings",
  "smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "env_logger 0.8.3",
  "fuzzy",
  "gpui",
+ "picker",
  "postage",
  "project",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3374,6 +3374,7 @@ dependencies = [
  "gpui",
  "language",
  "ordered-float",
+ "picker",
  "postage",
  "settings",
  "smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,6 +3794,7 @@ dependencies = [
  "fuzzy",
  "gpui",
  "ordered-float",
+ "picker",
  "postage",
  "project",
  "settings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "command_palette"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "editor",
+ "env_logger 0.8.3",
+ "fuzzy",
+ "gpui",
+ "serde_json",
+ "settings",
+ "theme",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "comrak"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6138,6 +6154,7 @@ dependencies = [
  "client",
  "clock",
  "collections",
+ "command_palette",
  "contacts_panel",
  "crossbeam-channel",
  "ctor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "env_logger 0.8.3",
  "fuzzy",
  "gpui",
+ "picker",
  "serde_json",
  "settings",
  "theme",
@@ -3543,6 +3544,21 @@ checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "picker"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "editor",
+ "env_logger 0.8.3",
+ "gpui",
+ "serde_json",
+ "settings",
+ "theme",
+ "util",
+ "workspace",
 ]
 
 [[package]]

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -16,7 +16,8 @@
         "ctrl-n": "menu::SelectNext",
         "cmd-up": "menu::SelectFirst",
         "cmd-down": "menu::SelectLast",
-        "enter": "menu::Confirm"
+        "enter": "menu::Confirm",
+        "escape": "menu::Cancel"
     },
     "Pane": {
         "shift-cmd-{": "pane::ActivatePrevItem",
@@ -52,6 +53,7 @@
         "cmd-k t": "theme_selector::Reload",
         "cmd-t": "project_symbols::Toggle",
         "cmd-p": "file_finder::Toggle",
+        "cmd-shift-P": "command_palette::Toggle",
         "alt-shift-D": "diagnostics::Deploy",
         "ctrl-alt-cmd-j": "journal::NewJournalEntry",
         "cmd-1": [

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -250,21 +250,9 @@
             "\n"
         ]
     },
-    "OutlineView": {
-        "escape": "outline::Toggle"
-    },
-    "ProjectSymbolsView": {
-        "escape": "project_symbols::Toggle"
-    },
-    "ThemeSelector": {
-        "escape": "theme_selector::Toggle"
-    },
     "GoToLine": {
         "escape": "go_to_line::Toggle",
         "enter": "go_to_line::Confirm"
-    },
-    "FileFinder": {
-        "escape": "file_finder::Toggle"
     },
     "ChatPanel": {
         "enter": "chat_panel::Send"

--- a/assets/themes/dark.json
+++ b/assets/themes/dark.json
@@ -708,6 +708,29 @@
       }
     }
   },
+  "command_palette": {
+    "keystroke_spacing": 8,
+    "key": {
+      "text": {
+        "family": "Zed Mono",
+        "color": "#9c9c9c",
+        "size": 12
+      },
+      "corner_radius": 3,
+      "background": "#2472f2",
+      "border": {
+        "color": "#2472f2",
+        "width": 1
+      },
+      "padding": {
+        "left": 3,
+        "right": 3
+      },
+      "margin": {
+        "left": 3
+      }
+    }
+  },
   "project_panel": {
     "padding": {
       "top": 6,

--- a/assets/themes/dark.json
+++ b/assets/themes/dark.json
@@ -713,7 +713,7 @@
     "key": {
       "text": {
         "family": "Zed Mono",
-        "color": "#9c9c9c",
+        "color": "#f1f1f1",
         "size": 12
       },
       "corner_radius": 3,

--- a/assets/themes/light.json
+++ b/assets/themes/light.json
@@ -713,7 +713,7 @@
     "key": {
       "text": {
         "family": "Zed Mono",
-        "color": "#474747",
+        "color": "#2b2b2b",
         "size": 12
       },
       "corner_radius": 3,

--- a/assets/themes/light.json
+++ b/assets/themes/light.json
@@ -708,6 +708,29 @@
       }
     }
   },
+  "command_palette": {
+    "keystroke_spacing": 8,
+    "key": {
+      "text": {
+        "family": "Zed Mono",
+        "color": "#474747",
+        "size": 12
+      },
+      "corner_radius": 3,
+      "background": "#c5dafc",
+      "border": {
+        "color": "#9ec1fa",
+        "width": 1
+      },
+      "padding": {
+        "left": 3,
+        "right": 3
+      },
+      "margin": {
+        "left": 3
+      }
+    }
+  },
   "project_panel": {
     "padding": {
       "top": 6,

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "command_palette"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/command_palette.rs"
+doctest = false
+
+[dependencies]
+editor = { path = "../editor" }
+fuzzy = { path = "../fuzzy" }
+gpui = { path = "../gpui" }
+settings = { path = "../settings" }
+util = { path = "../util" }
+theme = { path = "../theme" }
+workspace = { path = "../workspace" }
+
+[dev-dependencies]
+gpui = { path = "../gpui", features = ["test-support"] }
+serde_json = { version = "1.0.64", features = ["preserve_order"] }
+workspace = { path = "../workspace", features = ["test-support"] }
+ctor = "0.1"
+env_logger = "0.8"

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -19,6 +19,7 @@ workspace = { path = "../workspace" }
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
+editor = { path = "../editor", features = ["test-support"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 workspace = { path = "../workspace", features = ["test-support"] }
 ctor = "0.1"

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -18,7 +18,7 @@ pub fn init(cx: &mut MutableAppContext) {
 actions!(command_palette, [Toggle]);
 
 pub struct CommandPalette {
-    selector: ViewHandle<Picker<Self>>,
+    picker: ViewHandle<Picker<Self>>,
     actions: Vec<Command>,
     matches: Vec<StringMatch>,
     selected_ix: usize,
@@ -48,9 +48,9 @@ impl CommandPalette {
                     .map_or(Vec::new(), |binding| binding.keystrokes().to_vec()),
             })
             .collect();
-        let selector = cx.add_view(|cx| Picker::new(this, cx));
+        let picker = cx.add_view(|cx| Picker::new(this, cx));
         Self {
-            selector,
+            picker,
             actions,
             matches: vec![],
             selected_ix: 0,
@@ -98,11 +98,11 @@ impl View for CommandPalette {
     }
 
     fn render(&mut self, _: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
-        ChildView::new(self.selector.clone()).boxed()
+        ChildView::new(self.picker.clone()).boxed()
     }
 
     fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.selector);
+        cx.focus(&self.picker);
     }
 }
 
@@ -115,7 +115,7 @@ impl PickerDelegate for CommandPalette {
         self.selected_ix
     }
 
-    fn set_selected_index(&mut self, ix: usize) {
+    fn set_selected_index(&mut self, ix: usize, _: &mut ViewContext<Self>) {
         self.selected_ix = ix;
     }
 

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -5,22 +5,20 @@ use gpui::{
     keymap::Keystroke,
     Action, Element, Entity, MutableAppContext, View, ViewContext, ViewHandle,
 };
-use selector::{SelectorModal, SelectorModalDelegate};
+use picker::{Picker, PickerDelegate};
 use settings::Settings;
 use std::cmp;
 use workspace::Workspace;
 
-mod selector;
-
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(CommandPalette::toggle);
-    selector::init::<CommandPalette>(cx);
+    Picker::<CommandPalette>::init(cx);
 }
 
 actions!(command_palette, [Toggle]);
 
 pub struct CommandPalette {
-    selector: ViewHandle<SelectorModal<Self>>,
+    selector: ViewHandle<Picker<Self>>,
     actions: Vec<Command>,
     matches: Vec<StringMatch>,
     selected_ix: usize,
@@ -50,7 +48,7 @@ impl CommandPalette {
                     .map_or(Vec::new(), |binding| binding.keystrokes().to_vec()),
             })
             .collect();
-        let selector = cx.add_view(|cx| SelectorModal::new(this, cx));
+        let selector = cx.add_view(|cx| Picker::new(this, cx));
         Self {
             selector,
             actions,
@@ -108,7 +106,7 @@ impl View for CommandPalette {
     }
 }
 
-impl SelectorModalDelegate for CommandPalette {
+impl PickerDelegate for CommandPalette {
     fn match_count(&self) -> usize {
         self.matches.len()
     }

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -35,7 +35,7 @@ pub enum Event {
 }
 
 struct Command {
-    name: &'static str,
+    name: String,
     action: Box<dyn Action>,
     keystrokes: Vec<Keystroke>,
 }
@@ -46,7 +46,7 @@ impl CommandPalette {
         let actions = cx
             .available_actions(cx.window_id(), focused_view_id)
             .map(|(name, action, bindings)| Command {
-                name,
+                name: humanize(name),
                 action,
                 keystrokes: bindings
                     .last()
@@ -259,6 +259,30 @@ impl PickerDelegate for CommandPalette {
     }
 }
 
+fn humanize(name: &str) -> String {
+    let capacity = name.len() + name.chars().filter(|c| c.is_uppercase()).count();
+    let mut result = String::with_capacity(capacity);
+    let mut prev_char = '\0';
+    for char in name.chars() {
+        if char == ':' {
+            if prev_char == ':' {
+                result.push(' ');
+            } else {
+                result.push(':');
+            }
+        } else if char.is_uppercase() {
+            if prev_char.is_lowercase() {
+                result.push(' ');
+            }
+            result.push(char);
+        } else {
+            result.push(char);
+        }
+        prev_char = char;
+    }
+    result
+}
+
 impl std::fmt::Debug for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Command")
@@ -267,3 +291,5 @@ impl std::fmt::Debug for Command {
             .finish()
     }
 }
+
+// #[cfg(test)]

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -1,0 +1,179 @@
+use std::cmp;
+
+use fuzzy::{StringMatch, StringMatchCandidate};
+use gpui::{
+    actions,
+    elements::{ChildView, Label},
+    Action, Element, Entity, MutableAppContext, View, ViewContext, ViewHandle,
+};
+use selector::{SelectorModal, SelectorModalDelegate};
+use settings::Settings;
+use workspace::Workspace;
+
+mod selector;
+
+pub fn init(cx: &mut MutableAppContext) {
+    cx.add_action(CommandPalette::toggle);
+    selector::init::<CommandPalette>(cx);
+}
+
+actions!(command_palette, [Toggle]);
+
+pub struct CommandPalette {
+    selector: ViewHandle<SelectorModal<Self>>,
+    actions: Vec<(&'static str, Box<dyn Action>)>,
+    matches: Vec<StringMatch>,
+    selected_ix: usize,
+    focused_view_id: usize,
+}
+
+pub enum Event {
+    Dismissed,
+}
+
+impl CommandPalette {
+    pub fn new(
+        focused_view_id: usize,
+        actions: Vec<(&'static str, Box<dyn Action>)>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
+        let this = cx.weak_handle();
+        let selector = cx.add_view(|cx| SelectorModal::new(this, cx));
+        Self {
+            selector,
+            actions,
+            matches: vec![],
+            selected_ix: 0,
+            focused_view_id,
+        }
+    }
+
+    fn toggle(_: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
+        let workspace = cx.handle();
+        let window_id = cx.window_id();
+        let focused_view_id = cx.focused_view_id(window_id).unwrap_or(workspace.id());
+
+        cx.as_mut().defer(move |cx| {
+            let actions = cx.available_actions(window_id, focused_view_id);
+            workspace.update(cx, |workspace, cx| {
+                workspace.toggle_modal(cx, |cx, _| {
+                    let selector = cx.add_view(|cx| Self::new(focused_view_id, actions, cx));
+                    cx.subscribe(&selector, Self::on_event).detach();
+                    selector
+                });
+            });
+        });
+    }
+
+    fn on_event(
+        workspace: &mut Workspace,
+        _: ViewHandle<Self>,
+        event: &Event,
+        cx: &mut ViewContext<Workspace>,
+    ) {
+        match event {
+            Event::Dismissed => {
+                workspace.dismiss_modal(cx);
+            }
+        }
+    }
+}
+
+impl Entity for CommandPalette {
+    type Event = Event;
+}
+
+impl View for CommandPalette {
+    fn ui_name() -> &'static str {
+        "CommandPalette"
+    }
+
+    fn render(&mut self, _: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
+        ChildView::new(self.selector.clone()).boxed()
+    }
+
+    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+        cx.focus(&self.selector);
+    }
+}
+
+impl SelectorModalDelegate for CommandPalette {
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_ix
+    }
+
+    fn set_selected_index(&mut self, ix: usize) {
+        self.selected_ix = ix;
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        cx: &mut gpui::ViewContext<Self>,
+    ) -> gpui::Task<()> {
+        let candidates = self
+            .actions
+            .iter()
+            .enumerate()
+            .map(|(ix, (name, _))| StringMatchCandidate {
+                id: ix,
+                string: name.to_string(),
+                char_bag: name.chars().collect(),
+            })
+            .collect::<Vec<_>>();
+        cx.spawn(move |this, mut cx| async move {
+            let matches = fuzzy::match_strings(
+                &candidates,
+                &query,
+                true,
+                10000,
+                &Default::default(),
+                cx.background(),
+            )
+            .await;
+            this.update(&mut cx, |this, _| {
+                this.matches = matches;
+                if this.matches.is_empty() {
+                    this.selected_ix = 0;
+                } else {
+                    this.selected_ix = cmp::min(this.selected_ix, this.matches.len() - 1);
+                }
+            });
+        })
+    }
+
+    fn dismiss(&mut self, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::Dismissed);
+    }
+
+    fn confirm(&mut self, cx: &mut ViewContext<Self>) {
+        if !self.matches.is_empty() {
+            let window_id = cx.window_id();
+            let action_ix = self.matches[self.selected_ix].candidate_id;
+            cx.dispatch_action_at(
+                window_id,
+                self.focused_view_id,
+                self.actions[action_ix].1.as_ref(),
+            )
+        }
+        cx.emit(Event::Dismissed);
+    }
+
+    fn render_match(&self, ix: usize, selected: bool, cx: &gpui::AppContext) -> gpui::ElementBox {
+        let settings = cx.global::<Settings>();
+        let theme = &settings.theme.selector;
+        let style = if selected {
+            &theme.active_item
+        } else {
+            &theme.item
+        };
+        Label::new(self.matches[ix].string.clone(), style.label.clone())
+            .contained()
+            .with_style(style.container)
+            .boxed()
+    }
+}

--- a/crates/command_palette/src/selector.rs
+++ b/crates/command_palette/src/selector.rs
@@ -1,0 +1,222 @@
+use editor::Editor;
+use gpui::{
+    elements::{
+        ChildView, Flex, FlexItem, Label, ParentElement, ScrollTarget, UniformList,
+        UniformListState,
+    },
+    keymap, AppContext, Axis, Element, ElementBox, Entity, MutableAppContext, RenderContext, Task,
+    View, ViewContext, ViewHandle, WeakViewHandle,
+};
+use settings::Settings;
+use std::cmp;
+use workspace::menu::{Cancel, Confirm, SelectFirst, SelectLast, SelectNext, SelectPrev};
+
+pub fn init<D: SelectorModalDelegate>(cx: &mut MutableAppContext) {
+    cx.add_action(SelectorModal::<D>::select_first);
+    cx.add_action(SelectorModal::<D>::select_last);
+    cx.add_action(SelectorModal::<D>::select_next);
+    cx.add_action(SelectorModal::<D>::select_prev);
+    cx.add_action(SelectorModal::<D>::confirm);
+    cx.add_action(SelectorModal::<D>::cancel);
+}
+
+pub struct SelectorModal<D: SelectorModalDelegate> {
+    delegate: WeakViewHandle<D>,
+    query_editor: ViewHandle<Editor>,
+    list_state: UniformListState,
+}
+
+pub trait SelectorModalDelegate: View {
+    fn match_count(&self) -> usize;
+    fn selected_index(&self) -> usize;
+    fn set_selected_index(&mut self, ix: usize);
+    fn update_matches(&mut self, query: String, cx: &mut ViewContext<Self>) -> Task<()>;
+    fn confirm(&mut self, cx: &mut ViewContext<Self>);
+    fn dismiss(&mut self, cx: &mut ViewContext<Self>);
+    fn render_match(&self, ix: usize, selected: bool, cx: &AppContext) -> ElementBox;
+}
+
+impl<D: SelectorModalDelegate> Entity for SelectorModal<D> {
+    type Event = ();
+}
+
+impl<D: SelectorModalDelegate> View for SelectorModal<D> {
+    fn ui_name() -> &'static str {
+        "SelectorModal"
+    }
+
+    fn render(&mut self, cx: &mut RenderContext<Self>) -> gpui::ElementBox {
+        let settings = cx.global::<Settings>();
+        Flex::new(Axis::Vertical)
+            .with_child(
+                ChildView::new(&self.query_editor)
+                    .contained()
+                    .with_style(settings.theme.selector.input_editor.container)
+                    .boxed(),
+            )
+            .with_child(
+                FlexItem::new(self.render_matches(cx))
+                    .flex(1., false)
+                    .boxed(),
+            )
+            .contained()
+            .with_style(settings.theme.selector.container)
+            .constrained()
+            .with_max_width(500.0)
+            .with_max_height(420.0)
+            .aligned()
+            .top()
+            .named("selector")
+    }
+
+    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
+        let mut cx = Self::default_keymap_context();
+        cx.set.insert("menu".into());
+        cx
+    }
+
+    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+        cx.focus(&self.query_editor);
+    }
+}
+
+impl<D: SelectorModalDelegate> SelectorModal<D> {
+    pub fn new(delegate: WeakViewHandle<D>, cx: &mut ViewContext<Self>) -> Self {
+        let query_editor = cx.add_view(|cx| {
+            Editor::single_line(Some(|theme| theme.selector.input_editor.clone()), cx)
+        });
+        cx.subscribe(&query_editor, Self::on_query_editor_event)
+            .detach();
+
+        Self {
+            delegate,
+            query_editor,
+            list_state: Default::default(),
+        }
+    }
+
+    fn render_matches(&self, cx: &AppContext) -> ElementBox {
+        let delegate = self.delegate.clone();
+        let match_count = if let Some(delegate) = delegate.upgrade(cx) {
+            delegate.read(cx).match_count()
+        } else {
+            0
+        };
+
+        if match_count == 0 {
+            let settings = cx.global::<Settings>();
+            return Label::new(
+                "No matches".into(),
+                settings.theme.selector.empty.label.clone(),
+            )
+            .contained()
+            .with_style(settings.theme.selector.empty.container)
+            .named("empty matches");
+        }
+
+        UniformList::new(
+            self.list_state.clone(),
+            match_count,
+            move |mut range, items, cx| {
+                let cx = cx.as_ref();
+                let delegate = delegate.upgrade(cx).unwrap();
+                let delegate = delegate.read(cx);
+                let selected_ix = delegate.selected_index();
+                range.end = cmp::min(range.end, delegate.match_count());
+                items.extend(range.map(move |ix| delegate.render_match(ix, ix == selected_ix, cx)));
+            },
+        )
+        .contained()
+        .with_margin_top(6.0)
+        .named("matches")
+    }
+
+    fn on_query_editor_event(
+        &mut self,
+        _: ViewHandle<Editor>,
+        event: &editor::Event,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            match event {
+                editor::Event::BufferEdited { .. } => {
+                    let query = self.query_editor.read(cx).text(cx);
+                    let update = delegate.update(cx, |d, cx| d.update_matches(query, cx));
+                    cx.spawn(|this, mut cx| async move {
+                        update.await;
+                        this.update(&mut cx, |_, cx| cx.notify());
+                    })
+                    .detach();
+                }
+                editor::Event::Blurred => delegate.update(cx, |delegate, cx| {
+                    delegate.dismiss(cx);
+                }),
+                _ => {}
+            }
+        }
+    }
+
+    fn select_first(&mut self, _: &SelectFirst, cx: &mut ViewContext<Self>) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            let index = 0;
+            delegate.update(cx, |delegate, _| delegate.set_selected_index(0));
+            self.list_state.scroll_to(ScrollTarget::Show(index));
+            cx.notify();
+        }
+    }
+
+    fn select_last(&mut self, _: &SelectLast, cx: &mut ViewContext<Self>) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            let index = delegate.update(cx, |delegate, _| {
+                let match_count = delegate.match_count();
+                let index = if match_count > 0 { match_count - 1 } else { 0 };
+                delegate.set_selected_index(index);
+                index
+            });
+            self.list_state.scroll_to(ScrollTarget::Show(index));
+            cx.notify();
+        }
+    }
+
+    fn select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            let index = delegate.update(cx, |delegate, _| {
+                let mut selected_index = delegate.selected_index();
+                if selected_index + 1 < delegate.match_count() {
+                    selected_index += 1;
+                    delegate.set_selected_index(selected_index);
+                }
+                selected_index
+            });
+            self.list_state.scroll_to(ScrollTarget::Show(index));
+            cx.notify();
+        }
+    }
+
+    fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            let index = delegate.update(cx, |delegate, _| {
+                let mut selected_index = delegate.selected_index();
+                if selected_index > 0 {
+                    selected_index -= 1;
+                    delegate.set_selected_index(selected_index);
+                }
+                selected_index
+            });
+            self.list_state.scroll_to(ScrollTarget::Show(index));
+            cx.notify();
+        }
+    }
+
+    fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            delegate.update(cx, |delegate, cx| delegate.confirm(cx));
+        }
+    }
+
+    fn cancel(&mut self, _: &Cancel, cx: &mut ViewContext<Self>) {
+        if let Some(delegate) = self.delegate.upgrade(cx) {
+            delegate.update(cx, |delegate, cx| delegate.dismiss(cx));
+        }
+    }
+}

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 editor = { path = "../editor" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
+picker = { path = "../picker" }
 project = { path = "../project" }
 settings = { path = "../settings" }
 util = { path = "../util" }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -113,14 +113,11 @@ impl FileFinder {
     }
 
     pub fn new(project: ModelHandle<Project>, cx: &mut ViewContext<Self>) -> Self {
-        cx.observe(&project, Self::project_updated).detach();
-
         let handle = cx.weak_handle();
-        let picker = cx.add_view(|cx| Picker::new(handle, cx));
-
+        cx.observe(&project, Self::project_updated).detach();
         Self {
             project,
-            picker,
+            picker: cx.add_view(|cx| Picker::new(handle, cx)),
             search_count: 0,
             latest_search_id: 0,
             latest_search_did_cancel: false,

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1,7 +1,7 @@
 use fuzzy::PathMatch;
 use gpui::{
-    actions, elements::*, impl_internal_actions, AppContext, Entity, ModelHandle,
-    MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle,
+    actions, elements::*, AppContext, Entity, ModelHandle, MutableAppContext, RenderContext, Task,
+    View, ViewContext, ViewHandle,
 };
 use picker::{Picker, PickerDelegate};
 use project::{Project, ProjectPath, WorktreeId};
@@ -28,11 +28,7 @@ pub struct FileFinder {
     cancel_flag: Arc<AtomicBool>,
 }
 
-#[derive(Clone)]
-pub struct Select(pub ProjectPath);
-
 actions!(file_finder, [Toggle]);
-impl_internal_actions!(file_finder, [Select]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(FileFinder::toggle);
@@ -240,33 +236,21 @@ impl PickerDelegate for FileFinder {
         };
         let (file_name, file_name_positions, full_path, full_path_positions) =
             self.labels_for_match(path_match);
-        let action = Select(ProjectPath {
-            worktree_id: WorktreeId::from_usize(path_match.worktree_id),
-            path: path_match.path.clone(),
-        });
-
-        EventHandler::new(
-            Flex::column()
-                .with_child(
-                    Label::new(file_name.to_string(), style.label.clone())
-                        .with_highlights(file_name_positions)
-                        .boxed(),
-                )
-                .with_child(
-                    Label::new(full_path, style.label.clone())
-                        .with_highlights(full_path_positions)
-                        .boxed(),
-                )
-                .flex(1., false)
-                .contained()
-                .with_style(style.container)
-                .boxed(),
-        )
-        .on_mouse_down(move |cx| {
-            cx.dispatch_action(action.clone());
-            true
-        })
-        .named("match")
+        Flex::column()
+            .with_child(
+                Label::new(file_name.to_string(), style.label.clone())
+                    .with_highlights(file_name_positions)
+                    .boxed(),
+            )
+            .with_child(
+                Label::new(full_path, style.label.clone())
+                    .with_highlights(full_path_positions)
+                    .boxed(),
+            )
+            .flex(1., false)
+            .contained()
+            .with_style(style.container)
+            .named("match")
     }
 }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1340,6 +1340,17 @@ impl MutableAppContext {
             .collect()
     }
 
+    pub fn dispatch_action_at(&mut self, window_id: usize, view_id: usize, action: &dyn Action) {
+        let presenter = self
+            .presenters_and_platform_windows
+            .get(&window_id)
+            .unwrap()
+            .0
+            .clone();
+        let dispatch_path = presenter.borrow().dispatch_path_from(view_id);
+        self.dispatch_action_any(window_id, &dispatch_path, action);
+    }
+
     pub fn dispatch_action<A: Action>(
         &mut self,
         window_id: usize,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -51,15 +51,21 @@ impl Presenter {
     }
 
     pub fn dispatch_path(&self, app: &AppContext) -> Vec<usize> {
-        let mut path = Vec::new();
-        if let Some(mut view_id) = app.focused_view_id(self.window_id) {
-            path.push(view_id);
-            while let Some(parent_id) = self.parents.get(&view_id).copied() {
-                path.push(parent_id);
-                view_id = parent_id;
-            }
-            path.reverse();
+        if let Some(view_id) = app.focused_view_id(self.window_id) {
+            self.dispatch_path_from(view_id)
+        } else {
+            Vec::new()
         }
+    }
+
+    pub(crate) fn dispatch_path_from(&self, mut view_id: usize) -> Vec<usize> {
+        let mut path = Vec::new();
+        path.push(view_id);
+        while let Some(parent_id) = self.parents.get(&view_id).copied() {
+            path.push(parent_id);
+            view_id = parent_id;
+        }
+        path.reverse();
         path
     }
 

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -12,6 +12,7 @@ editor = { path = "../editor" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
 language = { path = "../language" }
+picker = { path = "../picker" }
 settings = { path = "../settings" }
 text = { path = "../text" }
 workspace = { path = "../workspace" }

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -4,38 +4,31 @@ use editor::{
 };
 use fuzzy::StringMatch;
 use gpui::{
-    actions, elements::*, geometry::vector::Vector2F, keymap, AppContext, Axis, Entity,
-    MutableAppContext, RenderContext, View, ViewContext, ViewHandle, WeakViewHandle,
+    actions, elements::*, geometry::vector::Vector2F, AppContext, Entity, MutableAppContext,
+    RenderContext, Task, View, ViewContext, ViewHandle,
 };
 use language::Outline;
 use ordered_float::OrderedFloat;
+use picker::{Picker, PickerDelegate};
 use settings::Settings;
 use std::cmp::{self, Reverse};
-use workspace::{
-    menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrev},
-    Workspace,
-};
+use workspace::Workspace;
 
 actions!(outline, [Toggle]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(OutlineView::toggle);
-    cx.add_action(OutlineView::confirm);
-    cx.add_action(OutlineView::select_prev);
-    cx.add_action(OutlineView::select_next);
-    cx.add_action(OutlineView::select_first);
-    cx.add_action(OutlineView::select_last);
+    Picker::<OutlineView>::init(cx);
 }
 
 struct OutlineView {
-    handle: WeakViewHandle<Self>,
+    picker: ViewHandle<Picker<Self>>,
     active_editor: ViewHandle<Editor>,
     outline: Outline<Anchor>,
     selected_match_index: usize,
     prev_scroll_position: Option<Vector2F>,
     matches: Vec<StringMatch>,
-    query_editor: ViewHandle<Editor>,
-    list_state: UniformListState,
+    last_query: String,
 }
 
 pub enum Event {
@@ -55,38 +48,12 @@ impl View for OutlineView {
         "OutlineView"
     }
 
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
-        cx
-    }
-
-    fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {
-        let settings = cx.global::<Settings>();
-
-        Flex::new(Axis::Vertical)
-            .with_child(
-                Container::new(ChildView::new(&self.query_editor).boxed())
-                    .with_style(settings.theme.selector.input_editor.container)
-                    .boxed(),
-            )
-            .with_child(
-                FlexItem::new(self.render_matches(cx))
-                    .flex(1.0, false)
-                    .boxed(),
-            )
-            .contained()
-            .with_style(settings.theme.selector.container)
-            .constrained()
-            .with_max_width(800.0)
-            .with_max_height(1200.0)
-            .aligned()
-            .top()
-            .named("outline view")
+    fn render(&mut self, _: &mut RenderContext<Self>) -> ElementBox {
+        ChildView::new(self.picker.clone()).boxed()
     }
 
     fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.query_editor);
+        cx.focus(&self.picker);
     }
 }
 
@@ -96,24 +63,16 @@ impl OutlineView {
         editor: ViewHandle<Editor>,
         cx: &mut ViewContext<Self>,
     ) -> Self {
-        let query_editor = cx.add_view(|cx| {
-            Editor::single_line(Some(|theme| theme.selector.input_editor.clone()), cx)
-        });
-        cx.subscribe(&query_editor, Self::on_query_editor_event)
-            .detach();
-
-        let mut this = Self {
-            handle: cx.weak_handle(),
+        let handle = cx.weak_handle();
+        Self {
+            picker: cx.add_view(|cx| Picker::new(handle, cx).with_max_size(800., 1200.)),
+            last_query: Default::default(),
             matches: Default::default(),
             selected_match_index: 0,
             prev_scroll_position: Some(editor.update(cx, |editor, cx| editor.scroll_position(cx))),
             active_editor: editor,
             outline,
-            query_editor,
-            list_state: Default::default(),
-        };
-        this.update_matches(cx);
-        this
+        }
     }
 
     fn toggle(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
@@ -137,34 +96,18 @@ impl OutlineView {
         }
     }
 
-    fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
-        if self.selected_match_index > 0 {
-            self.select(self.selected_match_index - 1, true, false, cx);
-        }
+    fn restore_active_editor(&mut self, cx: &mut MutableAppContext) {
+        self.active_editor.update(cx, |editor, cx| {
+            editor.highlight_rows(None);
+            if let Some(scroll_position) = self.prev_scroll_position {
+                editor.set_scroll_position(scroll_position, cx);
+            }
+        })
     }
 
-    fn select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
-        if self.selected_match_index + 1 < self.matches.len() {
-            self.select(self.selected_match_index + 1, true, false, cx);
-        }
-    }
-
-    fn select_first(&mut self, _: &SelectFirst, cx: &mut ViewContext<Self>) {
-        self.select(0, true, false, cx);
-    }
-
-    fn select_last(&mut self, _: &SelectLast, cx: &mut ViewContext<Self>) {
-        self.select(self.matches.len().saturating_sub(1), true, false, cx);
-    }
-
-    fn select(&mut self, index: usize, navigate: bool, center: bool, cx: &mut ViewContext<Self>) {
-        self.selected_match_index = index;
-        self.list_state.scroll_to(if center {
-            ScrollTarget::Center(index)
-        } else {
-            ScrollTarget::Show(index)
-        });
-        if navigate {
+    fn set_selected_index(&mut self, ix: usize, navigate: bool, cx: &mut ViewContext<Self>) {
+        self.selected_match_index = ix;
+        if navigate && !self.matches.is_empty() {
             let selected_match = &self.matches[self.selected_match_index];
             let outline_item = &self.outline.items[selected_match.candidate_id];
             self.active_editor.update(cx, |active_editor, cx| {
@@ -181,27 +124,6 @@ impl OutlineView {
         cx.notify();
     }
 
-    fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
-        self.prev_scroll_position.take();
-        self.active_editor.update(cx, |active_editor, cx| {
-            if let Some(rows) = active_editor.highlighted_rows() {
-                let snapshot = active_editor.snapshot(cx).display_snapshot;
-                let position = DisplayPoint::new(rows.start, 0).to_point(&snapshot);
-                active_editor.select_ranges([position..position], Some(Autoscroll::Center), cx);
-            }
-        });
-        cx.emit(Event::Dismissed);
-    }
-
-    fn restore_active_editor(&mut self, cx: &mut MutableAppContext) {
-        self.active_editor.update(cx, |editor, cx| {
-            editor.highlight_rows(None);
-            if let Some(scroll_position) = self.prev_scroll_position {
-                editor.set_scroll_position(scroll_position, cx);
-            }
-        })
-    }
-
     fn on_event(
         workspace: &mut Workspace,
         _: ViewHandle<Self>,
@@ -212,24 +134,27 @@ impl OutlineView {
             Event::Dismissed => workspace.dismiss_modal(cx),
         }
     }
+}
 
-    fn on_query_editor_event(
-        &mut self,
-        _: ViewHandle<Editor>,
-        event: &editor::Event,
-        cx: &mut ViewContext<Self>,
-    ) {
-        match event {
-            editor::Event::Blurred => cx.emit(Event::Dismissed),
-            editor::Event::BufferEdited { .. } => self.update_matches(cx),
-            _ => {}
-        }
+impl PickerDelegate for OutlineView {
+    fn match_count(&self) -> usize {
+        self.matches.len()
     }
 
-    fn update_matches(&mut self, cx: &mut ViewContext<Self>) {
+    fn selected_index(&self) -> usize {
+        self.selected_match_index
+    }
+
+    fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Self>) {
+        self.set_selected_index(ix, true, cx);
+    }
+
+    fn center_selection_after_match_updates(&self) -> bool {
+        true
+    }
+
+    fn update_matches(&mut self, query: String, cx: &mut ViewContext<Self>) -> Task<()> {
         let selected_index;
-        let navigate_to_selected_index;
-        let query = self.query_editor.update(cx, |buffer, cx| buffer.text(cx));
         if query.is_empty() {
             self.restore_active_editor(cx);
             self.matches = self
@@ -271,7 +196,6 @@ impl OutlineView {
                 .max_by_key(|(_, depth, distance)| (*depth, Reverse(*distance)))
                 .map(|(ix, _, _)| ix)
                 .unwrap_or(0);
-            navigate_to_selected_index = false;
         } else {
             self.matches = smol::block_on(self.outline.search(&query, cx.background().clone()));
             selected_index = self
@@ -281,57 +205,33 @@ impl OutlineView {
                 .max_by_key(|(_, m)| OrderedFloat(m.score))
                 .map(|(ix, _)| ix)
                 .unwrap_or(0);
-            navigate_to_selected_index = !self.matches.is_empty();
         }
-        self.select(selected_index, navigate_to_selected_index, true, cx);
+        self.last_query = query;
+        self.set_selected_index(selected_index, false, cx);
+        Task::ready(())
     }
 
-    fn render_matches(&self, cx: &AppContext) -> ElementBox {
-        if self.matches.is_empty() {
-            let settings = cx.global::<Settings>();
-            return Container::new(
-                Label::new(
-                    "No matches".into(),
-                    settings.theme.selector.empty.label.clone(),
-                )
-                .boxed(),
-            )
-            .with_style(settings.theme.selector.empty.container)
-            .named("empty matches");
-        }
-
-        let handle = self.handle.clone();
-        let list = UniformList::new(
-            self.list_state.clone(),
-            self.matches.len(),
-            move |mut range, items, cx| {
-                let cx = cx.as_ref();
-                let view = handle.upgrade(cx).unwrap();
-                let view = view.read(cx);
-                let start = range.start;
-                range.end = cmp::min(range.end, view.matches.len());
-                items.extend(
-                    view.matches[range]
-                        .iter()
-                        .enumerate()
-                        .map(move |(ix, m)| view.render_match(m, start + ix, cx)),
-                );
-            },
-        );
-
-        Container::new(list.boxed())
-            .with_margin_top(6.0)
-            .named("matches")
+    fn confirm(&mut self, cx: &mut ViewContext<Self>) {
+        self.prev_scroll_position.take();
+        self.active_editor.update(cx, |active_editor, cx| {
+            if let Some(rows) = active_editor.highlighted_rows() {
+                let snapshot = active_editor.snapshot(cx).display_snapshot;
+                let position = DisplayPoint::new(rows.start, 0).to_point(&snapshot);
+                active_editor.select_ranges([position..position], Some(Autoscroll::Center), cx);
+            }
+        });
+        cx.emit(Event::Dismissed);
     }
 
-    fn render_match(
-        &self,
-        string_match: &StringMatch,
-        index: usize,
-        cx: &AppContext,
-    ) -> ElementBox {
+    fn dismiss(&mut self, cx: &mut ViewContext<Self>) {
+        self.restore_active_editor(cx);
+        cx.emit(Event::Dismissed);
+    }
+
+    fn render_match(&self, ix: usize, selected: bool, cx: &AppContext) -> ElementBox {
         let settings = cx.global::<Settings>();
-        let style = if index == self.selected_match_index {
+        let string_match = &self.matches[ix];
+        let style = if selected {
             &settings.theme.selector.active_item
         } else {
             &settings.theme.selector.item

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
-name = "command_palette"
+name = "picker"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-path = "src/command_palette.rs"
+path = "src/picker.rs"
 doctest = false
 
 [dependencies]
 editor = { path = "../editor" }
-fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
-picker = { path = "../picker" }
 settings = { path = "../settings" }
 util = { path = "../util" }
 theme = { path = "../theme" }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -20,7 +20,7 @@ pub struct Picker<D: PickerDelegate> {
 pub trait PickerDelegate: View {
     fn match_count(&self) -> usize;
     fn selected_index(&self) -> usize;
-    fn set_selected_index(&mut self, ix: usize);
+    fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Self>);
     fn update_matches(&mut self, query: String, cx: &mut ViewContext<Self>) -> Task<()>;
     fn confirm(&mut self, cx: &mut ViewContext<Self>);
     fn dismiss(&mut self, cx: &mut ViewContext<Self>);
@@ -159,7 +159,7 @@ impl<D: PickerDelegate> Picker<D> {
     fn select_first(&mut self, _: &SelectFirst, cx: &mut ViewContext<Self>) {
         if let Some(delegate) = self.delegate.upgrade(cx) {
             let index = 0;
-            delegate.update(cx, |delegate, _| delegate.set_selected_index(0));
+            delegate.update(cx, |delegate, cx| delegate.set_selected_index(0, cx));
             self.list_state.scroll_to(ScrollTarget::Show(index));
             cx.notify();
         }
@@ -167,10 +167,10 @@ impl<D: PickerDelegate> Picker<D> {
 
     fn select_last(&mut self, _: &SelectLast, cx: &mut ViewContext<Self>) {
         if let Some(delegate) = self.delegate.upgrade(cx) {
-            let index = delegate.update(cx, |delegate, _| {
+            let index = delegate.update(cx, |delegate, cx| {
                 let match_count = delegate.match_count();
                 let index = if match_count > 0 { match_count - 1 } else { 0 };
-                delegate.set_selected_index(index);
+                delegate.set_selected_index(index, cx);
                 index
             });
             self.list_state.scroll_to(ScrollTarget::Show(index));
@@ -180,11 +180,11 @@ impl<D: PickerDelegate> Picker<D> {
 
     fn select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
         if let Some(delegate) = self.delegate.upgrade(cx) {
-            let index = delegate.update(cx, |delegate, _| {
+            let index = delegate.update(cx, |delegate, cx| {
                 let mut selected_index = delegate.selected_index();
                 if selected_index + 1 < delegate.match_count() {
                     selected_index += 1;
-                    delegate.set_selected_index(selected_index);
+                    delegate.set_selected_index(selected_index, cx);
                 }
                 selected_index
             });
@@ -195,11 +195,11 @@ impl<D: PickerDelegate> Picker<D> {
 
     fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
         if let Some(delegate) = self.delegate.upgrade(cx) {
-            let index = delegate.update(cx, |delegate, _| {
+            let index = delegate.update(cx, |delegate, cx| {
                 let mut selected_index = delegate.selected_index();
                 if selected_index > 0 {
                     selected_index -= 1;
-                    delegate.set_selected_index(selected_index);
+                    delegate.set_selected_index(selected_index, cx);
                 }
                 selected_index
             });

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 editor = { path = "../editor" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
+picker = { path = "../picker" }
 project = { path = "../project" }
 text = { path = "../text" }
 settings = { path = "../settings" }

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -3,43 +3,32 @@ use editor::{
 };
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, elements::*, keymap, AppContext, Axis, Entity, ModelHandle, MutableAppContext,
-    RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
+    actions, elements::*, AppContext, Entity, ModelHandle, MutableAppContext, RenderContext, Task,
+    View, ViewContext, ViewHandle,
 };
 use ordered_float::OrderedFloat;
+use picker::{Picker, PickerDelegate};
 use project::{Project, Symbol};
 use settings::Settings;
-use std::{
-    borrow::Cow,
-    cmp::{self, Reverse},
-};
+use std::{borrow::Cow, cmp::Reverse};
 use util::ResultExt;
-use workspace::{
-    menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrev},
-    Workspace,
-};
+use workspace::Workspace;
 
 actions!(project_symbols, [Toggle]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(ProjectSymbolsView::toggle);
-    cx.add_action(ProjectSymbolsView::confirm);
-    cx.add_action(ProjectSymbolsView::select_prev);
-    cx.add_action(ProjectSymbolsView::select_next);
-    cx.add_action(ProjectSymbolsView::select_first);
-    cx.add_action(ProjectSymbolsView::select_last);
+    Picker::<ProjectSymbolsView>::init(cx);
 }
 
 pub struct ProjectSymbolsView {
-    handle: WeakViewHandle<Self>,
+    picker: ViewHandle<Picker<Self>>,
     project: ModelHandle<Project>,
     selected_match_index: usize,
-    list_state: UniformListState,
     symbols: Vec<Symbol>,
     match_candidates: Vec<StringMatchCandidate>,
+    show_worktree_root_name: bool,
     matches: Vec<StringMatch>,
-    pending_symbols_task: Task<Option<()>>,
-    query_editor: ViewHandle<Editor>,
 }
 
 pub enum Event {
@@ -56,59 +45,29 @@ impl View for ProjectSymbolsView {
         "ProjectSymbolsView"
     }
 
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
-        cx
-    }
-
-    fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {
-        let settings = cx.global::<Settings>();
-        Flex::new(Axis::Vertical)
-            .with_child(
-                Container::new(ChildView::new(&self.query_editor).boxed())
-                    .with_style(settings.theme.selector.input_editor.container)
-                    .boxed(),
-            )
-            .with_child(
-                FlexItem::new(self.render_matches(cx))
-                    .flex(1., false)
-                    .boxed(),
-            )
-            .contained()
-            .with_style(settings.theme.selector.container)
-            .constrained()
-            .with_max_width(500.0)
-            .with_max_height(420.0)
-            .aligned()
-            .top()
-            .named("project symbols view")
+    fn render(&mut self, _: &mut RenderContext<Self>) -> ElementBox {
+        ChildView::new(self.picker.clone()).boxed()
     }
 
     fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.query_editor);
+        cx.focus(&self.picker);
     }
 }
 
 impl ProjectSymbolsView {
     fn new(project: ModelHandle<Project>, cx: &mut ViewContext<Self>) -> Self {
-        let query_editor = cx.add_view(|cx| {
-            Editor::single_line(Some(|theme| theme.selector.input_editor.clone()), cx)
-        });
-        cx.subscribe(&query_editor, Self::on_query_editor_event)
-            .detach();
+        let handle = cx.weak_handle();
+        let picker = cx.add_view(|cx| Picker::new(handle, cx));
         let mut this = Self {
-            handle: cx.weak_handle(),
+            picker,
             project,
             selected_match_index: 0,
-            list_state: Default::default(),
             symbols: Default::default(),
             match_candidates: Default::default(),
             matches: Default::default(),
-            pending_symbols_task: Task::ready(None),
-            query_editor,
+            show_worktree_root_name: false,
         };
-        this.update_matches(cx);
+        this.update_matches(String::new(), cx).detach();
         this
     }
 
@@ -121,72 +80,7 @@ impl ProjectSymbolsView {
         });
     }
 
-    fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
-        if self.selected_match_index > 0 {
-            self.select(self.selected_match_index - 1, cx);
-        }
-    }
-
-    fn select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
-        if self.selected_match_index + 1 < self.matches.len() {
-            self.select(self.selected_match_index + 1, cx);
-        }
-    }
-
-    fn select_first(&mut self, _: &SelectFirst, cx: &mut ViewContext<Self>) {
-        self.select(0, cx);
-    }
-
-    fn select_last(&mut self, _: &SelectLast, cx: &mut ViewContext<Self>) {
-        self.select(self.matches.len().saturating_sub(1), cx);
-    }
-
-    fn select(&mut self, index: usize, cx: &mut ViewContext<Self>) {
-        self.selected_match_index = index;
-        self.list_state.scroll_to(ScrollTarget::Show(index));
-        cx.notify();
-    }
-
-    fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
-        if let Some(symbol) = self
-            .matches
-            .get(self.selected_match_index)
-            .map(|mat| self.symbols[mat.candidate_id].clone())
-        {
-            cx.emit(Event::Selected(symbol));
-        }
-    }
-
-    fn update_matches(&mut self, cx: &mut ViewContext<Self>) {
-        self.filter(cx);
-        let query = self.query_editor.read(cx).text(cx);
-        let symbols = self
-            .project
-            .update(cx, |project, cx| project.symbols(&query, cx));
-        self.pending_symbols_task = cx.spawn_weak(|this, mut cx| async move {
-            let symbols = symbols.await.log_err()?;
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, cx| {
-                    this.match_candidates = symbols
-                        .iter()
-                        .enumerate()
-                        .map(|(id, symbol)| {
-                            StringMatchCandidate::new(
-                                id,
-                                symbol.label.text[symbol.label.filter_range.clone()].to_string(),
-                            )
-                        })
-                        .collect();
-                    this.symbols = symbols;
-                    this.filter(cx);
-                });
-            }
-            None
-        });
-    }
-
-    fn filter(&mut self, cx: &mut ViewContext<Self>) {
-        let query = self.query_editor.read(cx).text(cx);
+    fn filter(&mut self, query: &str, cx: &mut ViewContext<Self>) {
         let mut matches = if query.is_empty() {
             self.match_candidates
                 .iter()
@@ -201,7 +95,7 @@ impl ProjectSymbolsView {
         } else {
             smol::block_on(fuzzy::match_strings(
                 &self.match_candidates,
-                &query,
+                query,
                 false,
                 100,
                 &Default::default(),
@@ -225,110 +119,8 @@ impl ProjectSymbolsView {
         }
 
         self.matches = matches;
-        self.select_first(&SelectFirst, cx);
+        self.set_selected_index(0, cx);
         cx.notify();
-    }
-
-    fn render_matches(&self, cx: &AppContext) -> ElementBox {
-        if self.matches.is_empty() {
-            let settings = cx.global::<Settings>();
-            return Container::new(
-                Label::new(
-                    "No matches".into(),
-                    settings.theme.selector.empty.label.clone(),
-                )
-                .boxed(),
-            )
-            .with_style(settings.theme.selector.empty.container)
-            .named("empty matches");
-        }
-
-        let handle = self.handle.clone();
-        let list = UniformList::new(
-            self.list_state.clone(),
-            self.matches.len(),
-            move |mut range, items, cx| {
-                let cx = cx.as_ref();
-                let view = handle.upgrade(cx).unwrap();
-                let view = view.read(cx);
-                let start = range.start;
-                range.end = cmp::min(range.end, view.matches.len());
-
-                let show_worktree_root_name =
-                    view.project.read(cx).visible_worktrees(cx).count() > 1;
-                items.extend(view.matches[range].iter().enumerate().map(move |(ix, m)| {
-                    view.render_match(m, start + ix, show_worktree_root_name, cx)
-                }));
-            },
-        );
-
-        Container::new(list.boxed())
-            .with_margin_top(6.0)
-            .named("matches")
-    }
-
-    fn render_match(
-        &self,
-        string_match: &StringMatch,
-        index: usize,
-        show_worktree_root_name: bool,
-        cx: &AppContext,
-    ) -> ElementBox {
-        let settings = cx.global::<Settings>();
-        let style = if index == self.selected_match_index {
-            &settings.theme.selector.active_item
-        } else {
-            &settings.theme.selector.item
-        };
-        let symbol = &self.symbols[string_match.candidate_id];
-        let syntax_runs = styled_runs_for_code_label(&symbol.label, &settings.theme.editor.syntax);
-
-        let mut path = symbol.path.to_string_lossy();
-        if show_worktree_root_name {
-            let project = self.project.read(cx);
-            if let Some(worktree) = project.worktree_for_id(symbol.worktree_id, cx) {
-                path = Cow::Owned(format!(
-                    "{}{}{}",
-                    worktree.read(cx).root_name(),
-                    std::path::MAIN_SEPARATOR,
-                    path.as_ref()
-                ));
-            }
-        }
-
-        Flex::column()
-            .with_child(
-                Text::new(symbol.label.text.clone(), style.label.text.clone())
-                    .with_soft_wrap(false)
-                    .with_highlights(combine_syntax_and_fuzzy_match_highlights(
-                        &symbol.label.text,
-                        style.label.text.clone().into(),
-                        syntax_runs,
-                        &string_match.positions,
-                    ))
-                    .boxed(),
-            )
-            .with_child(
-                // Avoid styling the path differently when it is selected, since
-                // the symbol's syntax highlighting doesn't change when selected.
-                Label::new(path.to_string(), settings.theme.selector.item.label.clone()).boxed(),
-            )
-            .contained()
-            .with_style(style.container)
-            .boxed()
-    }
-
-    fn on_query_editor_event(
-        &mut self,
-        _: ViewHandle<Editor>,
-        event: &editor::Event,
-        cx: &mut ViewContext<Self>,
-    ) {
-        match event {
-            editor::Event::Blurred => cx.emit(Event::Dismissed),
-            editor::Event::BufferEdited { .. } => self.update_matches(cx),
-            _ => {}
-        }
     }
 
     fn on_event(
@@ -367,5 +159,110 @@ impl ProjectSymbolsView {
                 workspace.dismiss_modal(cx);
             }
         }
+    }
+}
+
+impl PickerDelegate for ProjectSymbolsView {
+    fn confirm(&mut self, cx: &mut ViewContext<Self>) {
+        if let Some(symbol) = self
+            .matches
+            .get(self.selected_match_index)
+            .map(|mat| self.symbols[mat.candidate_id].clone())
+        {
+            cx.emit(Event::Selected(symbol));
+        }
+    }
+
+    fn dismiss(&mut self, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::Dismissed);
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_match_index
+    }
+
+    fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Self>) {
+        self.selected_match_index = ix;
+        cx.notify();
+    }
+
+    fn update_matches(&mut self, query: String, cx: &mut ViewContext<Self>) -> Task<()> {
+        self.filter(&query, cx);
+        self.show_worktree_root_name = self.project.read(cx).visible_worktrees(cx).count() > 1;
+        let symbols = self
+            .project
+            .update(cx, |project, cx| project.symbols(&query, cx));
+        cx.spawn_weak(|this, mut cx| async move {
+            let symbols = symbols.await.log_err();
+            if let Some(this) = this.upgrade(&cx) {
+                if let Some(symbols) = symbols {
+                    this.update(&mut cx, |this, cx| {
+                        this.match_candidates = symbols
+                            .iter()
+                            .enumerate()
+                            .map(|(id, symbol)| {
+                                StringMatchCandidate::new(
+                                    id,
+                                    symbol.label.text[symbol.label.filter_range.clone()]
+                                        .to_string(),
+                                )
+                            })
+                            .collect();
+                        this.symbols = symbols;
+                        this.filter(&query, cx);
+                    });
+                }
+            }
+        })
+    }
+
+    fn render_match(&self, ix: usize, selected: bool, cx: &AppContext) -> ElementBox {
+        let string_match = &self.matches[ix];
+        let settings = cx.global::<Settings>();
+        let style = if selected {
+            &settings.theme.selector.active_item
+        } else {
+            &settings.theme.selector.item
+        };
+        let symbol = &self.symbols[string_match.candidate_id];
+        let syntax_runs = styled_runs_for_code_label(&symbol.label, &settings.theme.editor.syntax);
+
+        let mut path = symbol.path.to_string_lossy();
+        if self.show_worktree_root_name {
+            let project = self.project.read(cx);
+            if let Some(worktree) = project.worktree_for_id(symbol.worktree_id, cx) {
+                path = Cow::Owned(format!(
+                    "{}{}{}",
+                    worktree.read(cx).root_name(),
+                    std::path::MAIN_SEPARATOR,
+                    path.as_ref()
+                ));
+            }
+        }
+
+        Flex::column()
+            .with_child(
+                Text::new(symbol.label.text.clone(), style.label.text.clone())
+                    .with_soft_wrap(false)
+                    .with_highlights(combine_syntax_and_fuzzy_match_highlights(
+                        &symbol.label.text,
+                        style.label.text.clone().into(),
+                        syntax_runs,
+                        &string_match.positions,
+                    ))
+                    .boxed(),
+            )
+            .with_child(
+                // Avoid styling the path differently when it is selected, since
+                // the symbol's syntax highlighting doesn't change when selected.
+                Label::new(path.to_string(), settings.theme.selector.item.label.clone()).boxed(),
+            )
+            .contained()
+            .with_style(style.container)
+            .boxed()
     }
 }

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -57,18 +57,15 @@ impl View for ProjectSymbolsView {
 impl ProjectSymbolsView {
     fn new(project: ModelHandle<Project>, cx: &mut ViewContext<Self>) -> Self {
         let handle = cx.weak_handle();
-        let picker = cx.add_view(|cx| Picker::new(handle, cx));
-        let mut this = Self {
-            picker,
+        Self {
             project,
+            picker: cx.add_view(|cx| Picker::new(handle, cx)),
             selected_match_index: 0,
             symbols: Default::default(),
             match_candidates: Default::default(),
             matches: Default::default(),
             show_worktree_root_name: false,
-        };
-        this.update_matches(String::new(), cx).detach();
-        this
+        }
     }
 
     fn toggle(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -21,6 +21,7 @@ pub struct Theme {
     pub chat_panel: ChatPanel,
     pub contacts_panel: ContactsPanel,
     pub project_panel: ProjectPanel,
+    pub command_palette: CommandPalette,
     pub selector: Selector,
     pub editor: Editor,
     pub search: Search,
@@ -187,6 +188,12 @@ pub struct ProjectPanelEntry {
     pub icon_spacing: f32,
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub struct CommandPalette {
+    pub key: ContainedLabel,
+    pub keystroke_spacing: f32,
+}
+
 #[derive(Deserialize, Default)]
 pub struct ContactsPanel {
     #[serde(flatten)]
@@ -259,7 +266,7 @@ pub struct ContainedText {
     pub text: TextStyle,
 }
 
-#[derive(Clone, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize, Default)]
 pub struct ContainedLabel {
     #[serde(flatten)]
     pub container: ContainerStyle,

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 editor = { path = "../editor" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
+picker = { path = "../picker" }
 theme = { path = "../theme" }
 settings = { path = "../settings" }
 workspace = { path = "../workspace" }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -1,35 +1,30 @@
-use editor::Editor;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, elements::*, keymap, AppContext, Axis, Element, ElementBox, Entity, MutableAppContext,
+    actions, elements::*, AppContext, Element, ElementBox, Entity, MutableAppContext,
     RenderContext, View, ViewContext, ViewHandle,
 };
+use picker::{Picker, PickerDelegate};
 use settings::Settings;
-use std::{cmp, sync::Arc};
+use std::sync::Arc;
 use theme::{Theme, ThemeRegistry};
-use workspace::{
-    menu::{Confirm, SelectNext, SelectPrev},
-    Workspace,
-};
+use workspace::Workspace;
 
 pub struct ThemeSelector {
-    themes: Arc<ThemeRegistry>,
+    registry: Arc<ThemeRegistry>,
+    theme_names: Vec<String>,
     matches: Vec<StringMatch>,
-    query_editor: ViewHandle<Editor>,
-    list_state: UniformListState,
-    selected_index: usize,
     original_theme: Arc<Theme>,
+    picker: ViewHandle<Picker<Self>>,
     selection_completed: bool,
+    selected_index: usize,
 }
 
 actions!(theme_selector, [Toggle, Reload]);
 
 pub fn init(cx: &mut MutableAppContext) {
-    cx.add_action(ThemeSelector::confirm);
-    cx.add_action(ThemeSelector::select_prev);
-    cx.add_action(ThemeSelector::select_next);
     cx.add_action(ThemeSelector::toggle);
     cx.add_action(ThemeSelector::reload);
+    Picker::<ThemeSelector>::init(cx);
 }
 
 pub enum Event {
@@ -38,38 +33,38 @@ pub enum Event {
 
 impl ThemeSelector {
     fn new(registry: Arc<ThemeRegistry>, cx: &mut ViewContext<Self>) -> Self {
-        let query_editor = cx.add_view(|cx| {
-            Editor::single_line(Some(|theme| theme.selector.input_editor.clone()), cx)
-        });
-
-        cx.subscribe(&query_editor, Self::on_query_editor_event)
-            .detach();
-
+        let handle = cx.weak_handle();
+        let picker = cx.add_view(|cx| Picker::new(handle, cx));
         let original_theme = cx.global::<Settings>().theme.clone();
-
+        let theme_names = registry.list().collect::<Vec<_>>();
+        let matches = theme_names
+            .iter()
+            .map(|name| StringMatch {
+                candidate_id: 0,
+                score: 0.0,
+                positions: Default::default(),
+                string: name.clone(),
+            })
+            .collect();
         let mut this = Self {
-            themes: registry,
-            query_editor,
-            matches: Vec::new(),
-            list_state: Default::default(),
-            selected_index: 0, // Default index for now
+            registry,
+            theme_names,
+            matches,
+            picker,
             original_theme: original_theme.clone(),
+            selected_index: 0,
             selection_completed: false,
         };
-        this.update_matches(cx);
-
-        // Set selected index to current theme
         this.select_if_matching(&original_theme.name);
-
         this
     }
 
     fn toggle(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
         let themes = workspace.themes();
         workspace.toggle_modal(cx, |cx, _| {
-            let selector = cx.add_view(|cx| Self::new(themes, cx));
-            cx.subscribe(&selector, Self::on_event).detach();
-            selector
+            let this = cx.add_view(|cx| Self::new(themes, cx));
+            cx.subscribe(&this, Self::on_event).detach();
+            this
         });
     }
 
@@ -88,36 +83,9 @@ impl ThemeSelector {
         }
     }
 
-    fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
-        self.selection_completed = true;
-        cx.emit(Event::Dismissed);
-    }
-
-    fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
-        if self.selected_index > 0 {
-            self.selected_index -= 1;
-        }
-        self.list_state
-            .scroll_to(ScrollTarget::Show(self.selected_index));
-
-        self.show_selected_theme(cx);
-        cx.notify();
-    }
-
-    fn select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
-        if self.selected_index + 1 < self.matches.len() {
-            self.selected_index += 1;
-        }
-        self.list_state
-            .scroll_to(ScrollTarget::Show(self.selected_index));
-
-        self.show_selected_theme(cx);
-        cx.notify();
-    }
-
     fn show_selected_theme(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(mat) = self.matches.get(self.selected_index) {
-            match self.themes.get(&mat.string) {
+            match self.registry.get(&mat.string) {
                 Ok(theme) => Self::set_theme(theme, cx),
                 Err(error) => {
                     log::error!("error loading theme {}: {}", mat.string, error)
@@ -134,49 +102,6 @@ impl ThemeSelector {
             .unwrap_or(self.selected_index);
     }
 
-    fn update_matches(&mut self, cx: &mut ViewContext<Self>) {
-        let background = cx.background().clone();
-        let candidates = self
-            .themes
-            .list()
-            .enumerate()
-            .map(|(id, name)| StringMatchCandidate {
-                id,
-                char_bag: name.as_str().into(),
-                string: name,
-            })
-            .collect::<Vec<_>>();
-        let query = self.query_editor.update(cx, |buffer, cx| buffer.text(cx));
-
-        self.matches = if query.is_empty() {
-            candidates
-                .into_iter()
-                .enumerate()
-                .map(|(index, candidate)| StringMatch {
-                    candidate_id: index,
-                    string: candidate.string,
-                    positions: Vec::new(),
-                    score: 0.0,
-                })
-                .collect()
-        } else {
-            smol::block_on(match_strings(
-                &candidates,
-                &query,
-                false,
-                100,
-                &Default::default(),
-                background,
-            ))
-        };
-
-        self.selected_index = self
-            .selected_index
-            .min(self.matches.len().saturating_sub(1));
-
-        cx.notify();
-    }
-
     fn on_event(
         workspace: &mut Workspace,
         _: ViewHandle<ThemeSelector>,
@@ -190,89 +115,104 @@ impl ThemeSelector {
         }
     }
 
-    fn on_query_editor_event(
-        &mut self,
-        _: ViewHandle<Editor>,
-        event: &editor::Event,
-        cx: &mut ViewContext<Self>,
-    ) {
-        match event {
-            editor::Event::BufferEdited { .. } => {
-                self.update_matches(cx);
-                self.select_if_matching(&cx.global::<Settings>().theme.name);
-                self.show_selected_theme(cx);
-            }
-            editor::Event::Blurred => cx.emit(Event::Dismissed),
-            _ => {}
-        }
-    }
-
-    fn render_matches(&self, cx: &mut RenderContext<Self>) -> ElementBox {
-        if self.matches.is_empty() {
-            let settings = cx.global::<Settings>();
-            return Container::new(
-                Label::new(
-                    "No matches".into(),
-                    settings.theme.selector.empty.label.clone(),
-                )
-                .boxed(),
-            )
-            .with_style(settings.theme.selector.empty.container)
-            .named("empty matches");
-        }
-
-        let handle = cx.handle();
-        let list =
-            UniformList::new(
-                self.list_state.clone(),
-                self.matches.len(),
-                move |mut range, items, cx| {
-                    let cx = cx.as_ref();
-                    let selector = handle.upgrade(cx).unwrap();
-                    let selector = selector.read(cx);
-                    let start = range.start;
-                    range.end = cmp::min(range.end, selector.matches.len());
-                    items.extend(selector.matches[range].iter().enumerate().map(
-                        move |(i, path_match)| selector.render_match(path_match, start + i, cx),
-                    ));
-                },
-            );
-
-        Container::new(list.boxed())
-            .with_margin_top(6.0)
-            .named("matches")
-    }
-
-    fn render_match(&self, theme_match: &StringMatch, index: usize, cx: &AppContext) -> ElementBox {
-        let settings = cx.global::<Settings>();
-        let theme = &settings.theme;
-
-        let container = Container::new(
-            Label::new(
-                theme_match.string.clone(),
-                if index == self.selected_index {
-                    theme.selector.active_item.label.clone()
-                } else {
-                    theme.selector.item.label.clone()
-                },
-            )
-            .with_highlights(theme_match.positions.clone())
-            .boxed(),
-        )
-        .with_style(if index == self.selected_index {
-            theme.selector.active_item.container
-        } else {
-            theme.selector.item.container
-        });
-
-        container.boxed()
-    }
-
     fn set_theme(theme: Arc<Theme>, cx: &mut MutableAppContext) {
         cx.update_global::<Settings, _, _>(|settings, cx| {
             settings.theme = theme;
             cx.refresh_windows();
         });
+    }
+}
+
+impl PickerDelegate for ThemeSelector {
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn confirm(&mut self, cx: &mut ViewContext<Self>) {
+        self.selection_completed = true;
+        cx.emit(Event::Dismissed);
+    }
+
+    fn dismiss(&mut self, cx: &mut ViewContext<Self>) {
+        if !self.selection_completed {
+            Self::set_theme(self.original_theme.clone(), cx);
+            self.selection_completed = true;
+        }
+        cx.emit(Event::Dismissed);
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Self>) {
+        self.selected_index = ix;
+        self.show_selected_theme(cx);
+    }
+
+    fn update_matches(&mut self, query: String, cx: &mut ViewContext<Self>) -> gpui::Task<()> {
+        let background = cx.background().clone();
+        let candidates = self
+            .theme_names
+            .iter()
+            .enumerate()
+            .map(|(id, name)| StringMatchCandidate {
+                id,
+                char_bag: name.as_str().into(),
+                string: name.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(|this, mut cx| async move {
+            let matches = if query.is_empty() {
+                candidates
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, candidate)| StringMatch {
+                        candidate_id: index,
+                        string: candidate.string,
+                        positions: Vec::new(),
+                        score: 0.0,
+                    })
+                    .collect()
+            } else {
+                match_strings(
+                    &candidates,
+                    &query,
+                    false,
+                    100,
+                    &Default::default(),
+                    background,
+                )
+                .await
+            };
+
+            this.update(&mut cx, |this, cx| {
+                this.matches = matches;
+                this.selected_index = this
+                    .selected_index
+                    .min(this.matches.len().saturating_sub(1));
+                this.show_selected_theme(cx);
+                cx.notify();
+            });
+        })
+    }
+
+    fn render_match(&self, ix: usize, selected: bool, cx: &AppContext) -> ElementBox {
+        let settings = cx.global::<Settings>();
+        let theme = &settings.theme;
+        let theme_match = &self.matches[ix];
+        let style = if selected {
+            &theme.selector.active_item
+        } else {
+            &theme.selector.item
+        };
+
+        Label::new(theme_match.string.clone(), style.label.clone())
+            .with_highlights(theme_match.positions.clone())
+            .contained()
+            .with_style(style.container)
+            .boxed()
     }
 }
 
@@ -291,43 +231,11 @@ impl View for ThemeSelector {
         "ThemeSelector"
     }
 
-    fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {
-        let theme = cx.global::<Settings>().theme.clone();
-        Align::new(
-            ConstrainedBox::new(
-                Container::new(
-                    Flex::new(Axis::Vertical)
-                        .with_child(
-                            ChildView::new(&self.query_editor)
-                                .contained()
-                                .with_style(theme.selector.input_editor.container)
-                                .boxed(),
-                        )
-                        .with_child(
-                            FlexItem::new(self.render_matches(cx))
-                                .flex(1., false)
-                                .boxed(),
-                        )
-                        .boxed(),
-                )
-                .with_style(theme.selector.container)
-                .boxed(),
-            )
-            .with_max_width(600.0)
-            .with_max_height(400.0)
-            .boxed(),
-        )
-        .top()
-        .named("theme selector")
+    fn render(&mut self, _: &mut RenderContext<Self>) -> ElementBox {
+        ChildView::new(self.picker.clone()).boxed()
     }
 
     fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.query_editor);
-    }
-
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
-        cx
+        cx.focus(&self.picker);
     }
 }

--- a/crates/workspace/src/menu.rs
+++ b/crates/workspace/src/menu.rs
@@ -1,4 +1,11 @@
 gpui::actions!(
     menu,
-    [Confirm, SelectPrev, SelectNext, SelectFirst, SelectLast]
+    [
+        Cancel,
+        Confirm,
+        SelectPrev,
+        SelectNext,
+        SelectFirst,
+        SelectLast
+    ]
 );

--- a/crates/workspace/src/menu.rs
+++ b/crates/workspace/src/menu.rs
@@ -1,3 +1,6 @@
+#[derive(Clone)]
+pub struct SelectIndex(pub usize);
+
 gpui::actions!(
     menu,
     [
@@ -9,3 +12,5 @@ gpui::actions!(
         SelectLast
     ]
 );
+
+gpui::impl_internal_actions!(menu, [SelectIndex]);

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -33,6 +33,7 @@ assets = { path = "../assets" }
 breadcrumbs = { path = "../breadcrumbs" }
 chat_panel = { path = "../chat_panel" }
 collections = { path = "../collections" }
+command_palette = { path = "../command_palette" }
 client = { path = "../client" }
 clock = { path = "../clock" }
 contacts_panel = { path = "../contacts_panel" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -65,7 +65,6 @@ anyhow = "1.0.38"
 async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
 async-recursion = "0.3"
 async-trait = "0.1"
-crossbeam-channel = "0.5.0"
 ctor = "0.1.20"
 dirs = "3.0"
 easy-parallel = "3.1.0"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -98,6 +98,7 @@ fn main() {
         project::Project::init(&client);
         client::Channel::init(&client);
         client::init(client.clone(), cx);
+        command_palette::init(cx);
         workspace::init(&client, cx);
         editor::init(cx);
         go_to_line::init(cx);

--- a/styles/src/styleTree/app.ts
+++ b/styles/src/styleTree/app.ts
@@ -2,6 +2,7 @@ import Theme from "../themes/theme";
 import chatPanel from "./chatPanel";
 import { text } from "./components";
 import contactsPanel from "./contactsPanel";
+import commandPalette from "./commandPalette";
 import editor from "./editor";
 import projectPanel from "./projectPanel";
 import search from "./search";
@@ -29,6 +30,7 @@ export default function app(theme: Theme): Object {
         },
       },
     },
+    commandPalette: commandPalette(theme),
     projectPanel: projectPanel(theme),
     chatPanel: chatPanel(theme),
     contactsPanel: contactsPanel(theme),

--- a/styles/src/styleTree/commandPalette.ts
+++ b/styles/src/styleTree/commandPalette.ts
@@ -5,7 +5,7 @@ export default function commandPalette(theme: Theme) {
   return {
     keystrokeSpacing: 8,
     key: {
-      text: text(theme, "mono", "secondary", { size: "xs" }),
+      text: text(theme, "mono", "primary", { size: "xs" }),
       cornerRadius: 3,
       background: backgroundColor(theme, "info", "base"),
       border: border(theme, "info"),

--- a/styles/src/styleTree/commandPalette.ts
+++ b/styles/src/styleTree/commandPalette.ts
@@ -1,0 +1,21 @@
+import Theme from "../themes/theme";
+import { text, backgroundColor, border } from "./components";
+
+export default function commandPalette(theme: Theme) {
+  return {
+    keystrokeSpacing: 8,
+    key: {
+      text: text(theme, "mono", "secondary", { size: "xs" }),
+      cornerRadius: 3,
+      background: backgroundColor(theme, "info", "base"),
+      border: border(theme, "info"),
+      padding: {
+        left: 3,
+        right: 3,
+      },
+      margin: {
+        left: 3
+      },
+    }
+  }
+}

--- a/styles/src/styleTree/selectorModal.ts
+++ b/styles/src/styleTree/selectorModal.ts
@@ -38,7 +38,7 @@ export default function selectorModal(theme: Theme): Object {
     },
     inputEditor: {
       background: backgroundColor(theme, 500),
-      corner_radius: 6,
+      cornerRadius: 6,
       placeholderText: text(theme, "sans", "placeholder"),
       selection: player(theme, 1).selection,
       text: text(theme, "mono", "primary"),


### PR DESCRIPTION
Closes #711
Fixes #562

<img width="1057" alt="Screen Shot 2022-04-18 at 6 18 59 PM" src="https://user-images.githubusercontent.com/326587/163901133-892ca5df-ce14-41d9-b4ab-5035ddfd6369.png">

This PR adds a "command palette" modal, bound to `cmd-shift-p`. It also makes some small improvements to all of the fuzzy-matching modals in the app, as they're now all reusing the same code. They all let you click on items with the mouse now.

There are some weaknesses of the command palette that we decided to address in a later pass.
* Some actions that take arguments like `pane::Split(SplitDirection)` cannot yet be invoked from the command palette. To solve this, we may add explicit configuration for the command palette, where you can specify an *action*, an argument, and a human-readable name.
* Some actions are semantically associated with a given view (e.g. `Editor`, but are bound on an ancestor view like `Workspace`. Currently, those actions will appear in the command palette even if the main view that they operate on is not present. To solve this, we may add a notion of context selectors to actions, similar to how key bindings.

We decided to go ahead and merge this even with those limitations, because it's not clear how their importance compares to other priorities that we have, and the current command palette is still fairly useful even with these limitations.

* [x] Populate command palette with available commands and key bindings for the focused view
* [x] Style the key bindings
* [x] Use the new `Picker` helper type for other selector modals
  * [x] file finder
  * [x] project symbols
  * [x] theme selector
  * [x] outline view
* [x] Highlight matched characters in command names
* [x] Ensure that you can deploy other modals via the command palette
* [x] Display nice, readable names for actions instead of internal names