### PR TITLE
Keymap improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_comments"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ee439ee368ba4a77ac70d04f14015415af8600d6c894dc1f11bd79758c57d5"
+
+[[package]]
 name = "json_env_logger"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,7 +2649,7 @@ dependencies = [
  "text",
  "theme",
  "tree-sitter",
- "tree-sitter-json",
+ "tree-sitter-json 0.19.0",
  "tree-sitter-rust",
  "unindent",
  "util",
@@ -4304,6 +4310,7 @@ dependencies = [
  "assets",
  "collections",
  "gpui",
+ "json_comments",
  "schemars",
  "serde",
  "serde_json",
@@ -5194,6 +5201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-json"
+version = "0.20.0"
+source = "git+https://github.com/tree-sitter/tree-sitter-json?rev=137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8#137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-markdown"
 version = "0.0.1"
 source = "git+https://github.com/MDeiml/tree-sitter-markdown?rev=330ecab87a3e3a7211ac69bbadc19eabecdb1cca#330ecab87a3e3a7211ac69bbadc19eabecdb1cca"
@@ -5837,7 +5853,7 @@ dependencies = [
  "toml",
  "tree-sitter",
  "tree-sitter-c",
- "tree-sitter-json",
+ "tree-sitter-json 0.20.0",
  "tree-sitter-markdown",
  "tree-sitter-rust",
  "tree-sitter-typescript",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -1,17 +1,5 @@
 [
-    {
-        "bindings": {
-            "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
-            "cmd-s": "workspace::Save",
-            "cmd-alt-i": "zed::DebugElements",
-            "cmd-k cmd-left": "workspace::ActivatePreviousPane",
-            "cmd-k cmd-right": "workspace::ActivateNextPane",
-            "cmd-=": "zed::IncreaseBufferFontSize",
-            "cmd--": "zed::DecreaseBufferFontSize",
-            "cmd-,": "zed::OpenSettings",
-            "alt-cmd-,": "zed::OpenKeymap"
-        }
-    },
+    // Standard macOS bindings
     {
         "context": "menu",
         "bindings": {
@@ -27,77 +15,15 @@
         }
     },
     {
-        "context": "Pane",
         "bindings": {
             "shift-cmd-{": "pane::ActivatePrevItem",
             "shift-cmd-}": "pane::ActivateNextItem",
             "cmd-w": "pane::CloseActiveItem",
             "alt-cmd-w": "pane::CloseInactiveItems",
-            "ctrl--": "pane::GoBack",
-            "shift-ctrl-_": "pane::GoForward",
-            "cmd-k up": [
-                "pane::Split",
-                "Up"
-            ],
-            "cmd-k down": [
-                "pane::Split",
-                "Down"
-            ],
-            "cmd-k left": [
-                "pane::Split",
-                "Left"
-            ],
-            "cmd-k right": [
-                "pane::Split",
-                "Right"
-            ],
-            "cmd-shift-F": "project_search::ToggleFocus",
-            "cmd-f": "project_search::ToggleFocus",
-            "cmd-g": "search::SelectNextMatch",
-            "cmd-shift-G": "search::SelectPrevMatch"
-        }
-    },
-    {
-        "context": "Workspace",
-        "bindings": {
-            "cmd-shift-F": "project_search::Deploy",
-            "cmd-k cmd-t": "theme_selector::Toggle",
-            "cmd-k t": "theme_selector::Reload",
-            "cmd-t": "project_symbols::Toggle",
-            "cmd-p": "file_finder::Toggle",
-            "cmd-shift-P": "command_palette::Toggle",
-            "alt-shift-D": "diagnostics::Deploy",
-            "ctrl-alt-cmd-j": "journal::NewJournalEntry",
-            "cmd-1": [
-                "workspace::ToggleSidebarItemFocus",
-                {
-                    "side": "Left",
-                    "item_index": 0
-                }
-            ],
-            "cmd-shift-!": [
-                "workspace::ToggleSidebarItem",
-                {
-                    "side": "Left",
-                    "item_index": 0
-                }
-            ]
-        }
-    },
-    {
-        "context": "ProjectSearchBar",
-        "bindings": {
-            "enter": "project_search::Search",
-            "cmd-enter": "project_search::SearchInNew"
-        }
-    },
-    {
-        "context": "BufferSearchBar",
-        "bindings": {
-            "escape": "buffer_search::Dismiss",
-            "cmd-f": "buffer_search::FocusEditor",
-            "enter": "search::SelectNextMatch",
-            "shift-enter": "search::SelectPrevMatch"
+            "cmd-s": "workspace::Save",
+            "cmd-=": "zed::IncreaseBufferFontSize",
+            "cmd--": "zed::DecreaseBufferFontSize",
+            "cmd-,": "zed::OpenSettings"
         }
     },
     {
@@ -110,23 +36,13 @@
             "ctrl-d": "editor::Delete",
             "tab": "editor::Tab",
             "shift-tab": "editor::TabPrev",
-            "cmd-[": "editor::Outdent",
-            "cmd-]": "editor::Indent",
-            "ctrl-shift-K": "editor::DeleteLine",
-            "alt-backspace": "editor::DeleteToPreviousWordStart",
-            "alt-h": "editor::DeleteToPreviousWordStart",
-            "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
-            "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
-            "alt-delete": "editor::DeleteToNextWordEnd",
-            "alt-d": "editor::DeleteToNextWordEnd",
-            "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
-            "ctrl-alt-d": "editor::DeleteToNextSubwordEnd",
+            "ctrl-k": "editor::CutToEndOfLine",
             "cmd-backspace": "editor::DeleteToBeginningOfLine",
             "cmd-delete": "editor::DeleteToEndOfLine",
-            "ctrl-k": "editor::CutToEndOfLine",
-            "cmd-shift-D": "editor::DuplicateLine",
-            "ctrl-cmd-up": "editor::MoveLineUp",
-            "ctrl-cmd-down": "editor::MoveLineDown",
+            "alt-backspace": "editor::DeleteToPreviousWordStart",
+            "alt-delete": "editor::DeleteToNextWordEnd",
+            "alt-h": "editor::DeleteToPreviousWordStart",
+            "alt-d": "editor::DeleteToNextWordEnd",
             "cmd-x": "editor::Cut",
             "cmd-c": "editor::Copy",
             "cmd-v": "editor::Paste",
@@ -142,12 +58,8 @@
             "ctrl-f": "editor::MoveRight",
             "alt-left": "editor::MoveToPreviousWordStart",
             "alt-b": "editor::MoveToPreviousWordStart",
-            "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
-            "ctrl-alt-b": "editor::MoveToPreviousSubwordStart",
             "alt-right": "editor::MoveToNextWordEnd",
             "alt-f": "editor::MoveToNextWordEnd",
-            "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
-            "ctrl-alt-f": "editor::MoveToNextSubwordEnd",
             "cmd-left": "editor::MoveToBeginningOfLine",
             "ctrl-a": "editor::MoveToBeginningOfLine",
             "cmd-right": "editor::MoveToEndOfLine",
@@ -164,21 +76,12 @@
             "ctrl-shift-F": "editor::SelectRight",
             "alt-shift-left": "editor::SelectToPreviousWordStart",
             "alt-shift-B": "editor::SelectToPreviousWordStart",
-            "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
-            "ctrl-alt-shift-B": "editor::SelectToPreviousSubwordStart",
             "alt-shift-right": "editor::SelectToNextWordEnd",
             "alt-shift-F": "editor::SelectToNextWordEnd",
-            "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
             "cmd-shift-up": "editor::SelectToBeginning",
             "cmd-shift-down": "editor::SelectToEnd",
             "cmd-a": "editor::SelectAll",
             "cmd-l": "editor::SelectLine",
-            "cmd-shift-L": "editor::SplitSelectionIntoLines",
-            "cmd-alt-up": "editor::AddSelectionAbove",
-            "cmd-ctrl-p": "editor::AddSelectionAbove",
-            "cmd-alt-down": "editor::AddSelectionBelow",
-            "cmd-ctrl-n": "editor::AddSelectionBelow",
-            "ctrl-alt-shift-F": "editor::SelectToNextSubwordEnd",
             "cmd-shift-left": [
                 "editor::SelectToBeginningOfLine",
                 {
@@ -203,40 +106,8 @@
                     "stop_at_soft_wraps": true
                 }
             ],
-            "cmd-d": [
-                "editor::SelectNext",
-                {
-                    "replace_newest": false
-                }
-            ],
-            "cmd-k cmd-d": [
-                "editor::SelectNext",
-                {
-                    "replace_newest": true
-                }
-            ],
-            "cmd-/": "editor::ToggleComments",
-            "alt-up": "editor::SelectLargerSyntaxNode",
-            "ctrl-w": "editor::SelectLargerSyntaxNode",
-            "alt-down": "editor::SelectSmallerSyntaxNode",
-            "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
-            "cmd-u": "editor::UndoSelection",
-            "cmd-shift-U": "editor::RedoSelection",
-            "f8": "editor::GoToNextDiagnostic",
-            "shift-f8": "editor::GoToPrevDiagnostic",
-            "f2": "editor::Rename",
-            "f12": "editor::GoToDefinition",
-            "alt-shift-f12": "editor::FindAllReferences",
-            "ctrl-m": "editor::MoveToEnclosingBracket",
             "pageup": "editor::PageUp",
-            "pagedown": "editor::PageDown",
-            "alt-cmd-[": "editor::Fold",
-            "alt-cmd-]": "editor::UnfoldLines",
-            "alt-cmd-f": "editor::FoldSelectedRanges",
-            "ctrl-space": "editor::ShowCompletions",
-            "cmd-.": "editor::ToggleCodeActions",
-            "alt-enter": "editor::OpenExcerpts",
-            "cmd-f10": "editor::RestartLanguageServer"
+            "pagedown": "editor::PageDown"
         }
     },
     {
@@ -254,9 +125,203 @@
                 {
                     "focus": false
                 }
+            ]
+        }
+    },
+    {
+        "context": "Editor && mode == auto_height",
+        "bindings": {
+            "alt-enter": [
+                "editor::Input",
+                "\n"
+            ]
+        }
+    },
+    {
+        "context": "Pane",
+        "bindings": {
+            "cmd-f": "project_search::ToggleFocus",
+            "cmd-g": "search::SelectNextMatch",
+            "cmd-shift-G": "search::SelectPrevMatch"
+        }
+    },
+    {
+        "context": "BufferSearchBar",
+        "bindings": {
+            "escape": "buffer_search::Dismiss",
+            "cmd-f": "buffer_search::FocusEditor",
+            "enter": "search::SelectNextMatch",
+            "shift-enter": "search::SelectPrevMatch"
+        }
+    },
+    // Bindings from VS Code
+    {
+        "context": "Editor",
+        "bindings": {
+            "cmd-[": "editor::Outdent",
+            "cmd-]": "editor::Indent",
+            "cmd-alt-up": "editor::AddSelectionAbove",
+            "cmd-ctrl-p": "editor::AddSelectionAbove",
+            "cmd-alt-down": "editor::AddSelectionBelow",
+            "cmd-ctrl-n": "editor::AddSelectionBelow",
+            "cmd-d": [
+                "editor::SelectNext",
+                {
+                    "replace_newest": false
+                }
             ],
+            "cmd-k cmd-d": [
+                "editor::SelectNext",
+                {
+                    "replace_newest": true
+                }
+            ],
+            "cmd-/": "editor::ToggleComments",
+            "alt-up": "editor::SelectLargerSyntaxNode",
+            "alt-down": "editor::SelectSmallerSyntaxNode",
+            "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
+            "cmd-u": "editor::UndoSelection",
+            "cmd-shift-U": "editor::RedoSelection",
+            "f8": "editor::GoToNextDiagnostic",
+            "shift-f8": "editor::GoToPrevDiagnostic",
+            "f2": "editor::Rename",
+            "f12": "editor::GoToDefinition",
+            "alt-shift-f12": "editor::FindAllReferences",
+            "ctrl-m": "editor::MoveToEnclosingBracket",
+            "alt-cmd-[": "editor::Fold",
+            "alt-cmd-]": "editor::UnfoldLines",
+            "ctrl-space": "editor::ShowCompletions",
+            "cmd-.": "editor::ToggleCodeActions"
+        }
+    },
+    {
+        "context": "Editor && mode == full",
+        "bindings": {
             "cmd-shift-O": "outline::Toggle",
             "ctrl-g": "go_to_line::Toggle"
+        }
+    },
+    {
+        "context": "Pane",
+        "bindings": {
+            "ctrl--": "pane::GoBack",
+            "shift-ctrl-_": "pane::GoForward",
+            "cmd-shift-F": "project_search::ToggleFocus"
+        }
+    },
+    {
+        "context": "Workspace",
+        "bindings": {
+            "cmd-shift-F": "project_search::Deploy",
+            "cmd-k cmd-t": "theme_selector::Toggle",
+            "cmd-k t": "theme_selector::Reload",
+            "cmd-t": "project_symbols::Toggle",
+            "cmd-p": "file_finder::Toggle",
+            "cmd-shift-P": "command_palette::Toggle"
+        }
+    },
+    // Bindings from Sublime Text
+    {
+        "context": "Editor",
+        "bindings": {
+            "ctrl-shift-K": "editor::DeleteLine",
+            "cmd-shift-D": "editor::DuplicateLine",
+            "cmd-shift-L": "editor::SplitSelectionIntoLines",
+            "ctrl-cmd-up": "editor::MoveLineUp",
+            "ctrl-cmd-down": "editor::MoveLineDown",
+            "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
+            "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
+            "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
+            "ctrl-alt-d": "editor::DeleteToNextSubwordEnd",
+            "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
+            "ctrl-alt-b": "editor::MoveToPreviousSubwordStart",
+            "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
+            "ctrl-alt-f": "editor::MoveToNextSubwordEnd",
+            "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
+            "ctrl-alt-shift-B": "editor::SelectToPreviousSubwordStart",
+            "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
+            "ctrl-alt-shift-F": "editor::SelectToNextSubwordEnd"
+        }
+    },
+    {
+        "bindings": {
+            "cmd-k cmd-left": "workspace::ActivatePreviousPane",
+            "cmd-k cmd-right": "workspace::ActivateNextPane"
+        }
+    },
+    {
+        "context": "Pane",
+        "bindings": {
+            "cmd-k up": [
+                "pane::Split",
+                "Up"
+            ],
+            "cmd-k down": [
+                "pane::Split",
+                "Down"
+            ],
+            "cmd-k left": [
+                "pane::Split",
+                "Left"
+            ],
+            "cmd-k right": [
+                "pane::Split",
+                "Right"
+            ]
+        }
+    },
+    // Custom bindings
+    {
+        "bindings": {
+            "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
+            "cmd-alt-i": "zed::DebugElements",
+            "alt-cmd-,": "zed::OpenKeymap"
+        }
+    },
+    {
+        "context": "Editor",
+        "bindings": {
+            "ctrl-w": "editor::SelectLargerSyntaxNode",
+            "alt-cmd-f": "editor::FoldSelectedRanges",
+            "alt-enter": "editor::OpenExcerpts",
+            "cmd-f10": "editor::RestartLanguageServer"
+        }
+    },
+    {
+        "context": "Workspace",
+        "bindings": {
+            "alt-shift-D": "diagnostics::Deploy",
+            "ctrl-alt-cmd-j": "journal::NewJournalEntry",
+            "cmd-1": [
+                "workspace::ToggleSidebarItemFocus",
+                {
+                    "side": "Left",
+                    "item_index": 0
+                }
+            ],
+            "cmd-shift-!": [
+                "workspace::ToggleSidebarItem",
+                {
+                    "side": "Left",
+                    "item_index": 0
+                }
+            ]
+        }
+    },
+    {
+        "context": "ProjectPanel",
+        "bindings": {
+            "left": "project_panel::CollapseSelectedEntry",
+            "right": "project_panel::ExpandSelectedEntry"
+        }
+    },
+    // Bindings that should be unified with other bindings
+    // for more general actions
+    {
+        "context": "ProjectSearchBar",
+        "bindings": {
+            "enter": "project_search::Search",
+            "cmd-enter": "project_search::SearchInNew"
         }
     },
     {
@@ -279,15 +344,6 @@
         }
     },
     {
-        "context": "Editor && mode == auto_height",
-        "bindings": {
-            "alt-enter": [
-                "editor::Input",
-                "\n"
-            ]
-        }
-    },
-    {
         "context": "GoToLine",
         "bindings": {
             "escape": "go_to_line::Toggle",
@@ -298,13 +354,6 @@
         "context": "ChatPanel",
         "bindings": {
             "enter": "chat_panel::Send"
-        }
-    },
-    {
-        "context": "ProjectPanel",
-        "bindings": {
-            "left": "project_panel::CollapseSelectedEntry",
-            "right": "project_panel::ExpandSelectedEntry"
         }
     }
 ]

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -1,7 +1,6 @@
 [
     // Standard macOS bindings
     {
-        "context": "menu",
         "bindings": {
             "up": "menu::SelectPrev",
             "ctrl-p": "menu::SelectPrev",
@@ -11,11 +10,7 @@
             "cmd-down": "menu::SelectLast",
             "enter": "menu::Confirm",
             "escape": "menu::Cancel",
-            "ctrl-c": "menu::Cancel"
-        }
-    },
-    {
-        "bindings": {
+            "ctrl-c": "menu::Cancel",
             "shift-cmd-{": "pane::ActivatePrevItem",
             "shift-cmd-}": "pane::ActivateNextItem",
             "cmd-w": "pane::CloseActiveItem",
@@ -288,6 +283,12 @@
         }
     },
     {
+        "context": "ProjectSearchBar",
+        "bindings": {
+            "cmd-enter": "project_search::SearchInNew"
+        }
+    },
+    {
         "context": "Workspace",
         "bindings": {
             "alt-shift-D": "diagnostics::Deploy",
@@ -318,13 +319,6 @@
     // Bindings that should be unified with other bindings
     // for more general actions
     {
-        "context": "ProjectSearchBar",
-        "bindings": {
-            "enter": "project_search::Search",
-            "cmd-enter": "project_search::SearchInNew"
-        }
-    },
-    {
         "context": "Editor && renaming",
         "bindings": {
             "enter": "editor::ConfirmRename"
@@ -341,19 +335,6 @@
         "context": "Editor && showing_code_actions",
         "bindings": {
             "enter": "editor::ConfirmCodeAction"
-        }
-    },
-    {
-        "context": "GoToLine",
-        "bindings": {
-            "escape": "go_to_line::Toggle",
-            "enter": "go_to_line::Confirm"
-        }
-    },
-    {
-        "context": "ChatPanel",
-        "bindings": {
-            "enter": "chat_panel::Send"
         }
     }
 ]

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -174,7 +174,6 @@
             "cmd-/": "editor::ToggleComments",
             "alt-up": "editor::SelectLargerSyntaxNode",
             "alt-down": "editor::SelectSmallerSyntaxNode",
-            "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
             "cmd-u": "editor::UndoSelection",
             "cmd-shift-U": "editor::RedoSelection",
             "f8": "editor::GoToNextDiagnostic",
@@ -265,6 +264,26 @@
             ]
         }
     },
+    // Bindings that should be unified with bindings for more general actions
+    {
+        "context": "Editor && renaming",
+        "bindings": {
+            "enter": "editor::ConfirmRename"
+        }
+    },
+    {
+        "context": "Editor && showing_completions",
+        "bindings": {
+            "enter": "editor::ConfirmCompletion",
+            "tab": "editor::ConfirmCompletion"
+        }
+    },
+    {
+        "context": "Editor && showing_code_actions",
+        "bindings": {
+            "enter": "editor::ConfirmCodeAction"
+        }
+    },
     // Custom bindings
     {
         "bindings": {
@@ -277,6 +296,7 @@
         "context": "Editor",
         "bindings": {
             "ctrl-w": "editor::SelectLargerSyntaxNode",
+            "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
             "alt-cmd-f": "editor::FoldSelectedRanges",
             "alt-enter": "editor::OpenExcerpts",
             "cmd-f10": "editor::RestartLanguageServer"
@@ -314,27 +334,6 @@
         "bindings": {
             "left": "project_panel::CollapseSelectedEntry",
             "right": "project_panel::ExpandSelectedEntry"
-        }
-    },
-    // Bindings that should be unified with other bindings
-    // for more general actions
-    {
-        "context": "Editor && renaming",
-        "bindings": {
-            "enter": "editor::ConfirmRename"
-        }
-    },
-    {
-        "context": "Editor && showing_completions",
-        "bindings": {
-            "enter": "editor::ConfirmCompletion",
-            "tab": "editor::ConfirmCompletion"
-        }
-    },
-    {
-        "context": "Editor && showing_code_actions",
-        "bindings": {
-            "enter": "editor::ConfirmCodeAction"
         }
     }
 ]

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -1,264 +1,310 @@
-{
-    "*": {
-        "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
-        "cmd-s": "workspace::Save",
-        "cmd-alt-i": "zed::DebugElements",
-        "cmd-k cmd-left": "workspace::ActivatePreviousPane",
-        "cmd-k cmd-right": "workspace::ActivateNextPane",
-        "cmd-=": "zed::IncreaseBufferFontSize",
-        "cmd--": "zed::DecreaseBufferFontSize",
-        "cmd-,": "zed::OpenSettings"
+[
+    {
+        "bindings": {
+            "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
+            "cmd-s": "workspace::Save",
+            "cmd-alt-i": "zed::DebugElements",
+            "cmd-k cmd-left": "workspace::ActivatePreviousPane",
+            "cmd-k cmd-right": "workspace::ActivateNextPane",
+            "cmd-=": "zed::IncreaseBufferFontSize",
+            "cmd--": "zed::DecreaseBufferFontSize",
+            "cmd-,": "zed::OpenSettings",
+            "alt-cmd-,": "zed::OpenKeymap"
+        }
     },
-    "menu": {
-        "up": "menu::SelectPrev",
-        "ctrl-p": "menu::SelectPrev",
-        "down": "menu::SelectNext",
-        "ctrl-n": "menu::SelectNext",
-        "cmd-up": "menu::SelectFirst",
-        "cmd-down": "menu::SelectLast",
-        "enter": "menu::Confirm",
-        "escape": "menu::Cancel"
+    {
+        "context": "menu",
+        "bindings": {
+            "up": "menu::SelectPrev",
+            "ctrl-p": "menu::SelectPrev",
+            "down": "menu::SelectNext",
+            "ctrl-n": "menu::SelectNext",
+            "cmd-up": "menu::SelectFirst",
+            "cmd-down": "menu::SelectLast",
+            "enter": "menu::Confirm",
+            "escape": "menu::Cancel",
+            "ctrl-c": "menu::Cancel"
+        }
     },
-    "Pane": {
-        "shift-cmd-{": "pane::ActivatePrevItem",
-        "shift-cmd-}": "pane::ActivateNextItem",
-        "cmd-w": "pane::CloseActiveItem",
-        "alt-cmd-w": "pane::CloseInactiveItems",
-        "ctrl--": "pane::GoBack",
-        "shift-ctrl-_": "pane::GoForward",
-        "cmd-k up": [
-            "pane::Split",
-            "Up"
-        ],
-        "cmd-k down": [
-            "pane::Split",
-            "Down"
-        ],
-        "cmd-k left": [
-            "pane::Split",
-            "Left"
-        ],
-        "cmd-k right": [
-            "pane::Split",
-            "Right"
-        ],
-        "cmd-shift-F": "project_search::ToggleFocus",
-        "cmd-f": "project_search::ToggleFocus",
-        "cmd-g": "search::SelectNextMatch",
-        "cmd-shift-G": "search::SelectPrevMatch"
+    {
+        "context": "Pane",
+        "bindings": {
+            "shift-cmd-{": "pane::ActivatePrevItem",
+            "shift-cmd-}": "pane::ActivateNextItem",
+            "cmd-w": "pane::CloseActiveItem",
+            "alt-cmd-w": "pane::CloseInactiveItems",
+            "ctrl--": "pane::GoBack",
+            "shift-ctrl-_": "pane::GoForward",
+            "cmd-k up": [
+                "pane::Split",
+                "Up"
+            ],
+            "cmd-k down": [
+                "pane::Split",
+                "Down"
+            ],
+            "cmd-k left": [
+                "pane::Split",
+                "Left"
+            ],
+            "cmd-k right": [
+                "pane::Split",
+                "Right"
+            ],
+            "cmd-shift-F": "project_search::ToggleFocus",
+            "cmd-f": "project_search::ToggleFocus",
+            "cmd-g": "search::SelectNextMatch",
+            "cmd-shift-G": "search::SelectPrevMatch"
+        }
     },
-    "Workspace": {
-        "cmd-shift-F": "project_search::Deploy",
-        "cmd-k cmd-t": "theme_selector::Toggle",
-        "cmd-k t": "theme_selector::Reload",
-        "cmd-t": "project_symbols::Toggle",
-        "cmd-p": "file_finder::Toggle",
-        "cmd-shift-P": "command_palette::Toggle",
-        "alt-shift-D": "diagnostics::Deploy",
-        "ctrl-alt-cmd-j": "journal::NewJournalEntry",
-        "cmd-1": [
-            "workspace::ToggleSidebarItemFocus",
-            {
-                "side": "Left",
-                "item_index": 0
-            }
-        ],
-        "cmd-shift-!": [
-            "workspace::ToggleSidebarItem",
-            {
-                "side": "Left",
-                "item_index": 0
-            }
-        ]
+    {
+        "context": "Workspace",
+        "bindings": {
+            "cmd-shift-F": "project_search::Deploy",
+            "cmd-k cmd-t": "theme_selector::Toggle",
+            "cmd-k t": "theme_selector::Reload",
+            "cmd-t": "project_symbols::Toggle",
+            "cmd-p": "file_finder::Toggle",
+            "cmd-shift-P": "command_palette::Toggle",
+            "alt-shift-D": "diagnostics::Deploy",
+            "ctrl-alt-cmd-j": "journal::NewJournalEntry",
+            "cmd-1": [
+                "workspace::ToggleSidebarItemFocus",
+                {
+                    "side": "Left",
+                    "item_index": 0
+                }
+            ],
+            "cmd-shift-!": [
+                "workspace::ToggleSidebarItem",
+                {
+                    "side": "Left",
+                    "item_index": 0
+                }
+            ]
+        }
     },
-    "ProjectSearchBar": {
-        "enter": "project_search::Search",
-        "cmd-enter": "project_search::SearchInNew"
+    {
+        "context": "ProjectSearchBar",
+        "bindings": {
+            "enter": "project_search::Search",
+            "cmd-enter": "project_search::SearchInNew"
+        }
     },
-    "BufferSearchBar": {
-        "escape": "buffer_search::Dismiss",
-        "cmd-f": "buffer_search::FocusEditor",
-        "enter": "search::SelectNextMatch",
-        "shift-enter": "search::SelectPrevMatch"
+    {
+        "context": "BufferSearchBar",
+        "bindings": {
+            "escape": "buffer_search::Dismiss",
+            "cmd-f": "buffer_search::FocusEditor",
+            "enter": "search::SelectNextMatch",
+            "shift-enter": "search::SelectPrevMatch"
+        }
     },
-    "Editor": {
-        "escape": "editor::Cancel",
-        "backspace": "editor::Backspace",
-        "ctrl-h": "editor::Backspace",
-        "delete": "editor::Delete",
-        "ctrl-d": "editor::Delete",
-        "tab": "editor::Tab",
-        "shift-tab": "editor::TabPrev",
-        "cmd-[": "editor::Outdent",
-        "cmd-]": "editor::Indent",
-        "ctrl-shift-K": "editor::DeleteLine",
-        "alt-backspace": "editor::DeleteToPreviousWordStart",
-        "alt-h": "editor::DeleteToPreviousWordStart",
-        "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
-        "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
-        "alt-delete": "editor::DeleteToNextWordEnd",
-        "alt-d": "editor::DeleteToNextWordEnd",
-        "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
-        "ctrl-alt-d": "editor::DeleteToNextSubwordEnd",
-        "cmd-backspace": "editor::DeleteToBeginningOfLine",
-        "cmd-delete": "editor::DeleteToEndOfLine",
-        "ctrl-k": "editor::CutToEndOfLine",
-        "cmd-shift-D": "editor::DuplicateLine",
-        "ctrl-cmd-up": "editor::MoveLineUp",
-        "ctrl-cmd-down": "editor::MoveLineDown",
-        "cmd-x": "editor::Cut",
-        "cmd-c": "editor::Copy",
-        "cmd-v": "editor::Paste",
-        "cmd-z": "editor::Undo",
-        "cmd-shift-Z": "editor::Redo",
-        "up": "editor::MoveUp",
-        "down": "editor::MoveDown",
-        "left": "editor::MoveLeft",
-        "right": "editor::MoveRight",
-        "ctrl-p": "editor::MoveUp",
-        "ctrl-n": "editor::MoveDown",
-        "ctrl-b": "editor::MoveLeft",
-        "ctrl-f": "editor::MoveRight",
-        "alt-left": "editor::MoveToPreviousWordStart",
-        "alt-b": "editor::MoveToPreviousWordStart",
-        "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
-        "ctrl-alt-b": "editor::MoveToPreviousSubwordStart",
-        "alt-right": "editor::MoveToNextWordEnd",
-        "alt-f": "editor::MoveToNextWordEnd",
-        "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
-        "ctrl-alt-f": "editor::MoveToNextSubwordEnd",
-        "cmd-left": "editor::MoveToBeginningOfLine",
-        "ctrl-a": "editor::MoveToBeginningOfLine",
-        "cmd-right": "editor::MoveToEndOfLine",
-        "ctrl-e": "editor::MoveToEndOfLine",
-        "cmd-up": "editor::MoveToBeginning",
-        "cmd-down": "editor::MoveToEnd",
-        "shift-up": "editor::SelectUp",
-        "ctrl-shift-P": "editor::SelectUp",
-        "shift-down": "editor::SelectDown",
-        "ctrl-shift-N": "editor::SelectDown",
-        "shift-left": "editor::SelectLeft",
-        "ctrl-shift-B": "editor::SelectLeft",
-        "shift-right": "editor::SelectRight",
-        "ctrl-shift-F": "editor::SelectRight",
-        "alt-shift-left": "editor::SelectToPreviousWordStart",
-        "alt-shift-B": "editor::SelectToPreviousWordStart",
-        "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
-        "ctrl-alt-shift-B": "editor::SelectToPreviousSubwordStart",
-        "alt-shift-right": "editor::SelectToNextWordEnd",
-        "alt-shift-F": "editor::SelectToNextWordEnd",
-        "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
-        "cmd-shift-up": "editor::SelectToBeginning",
-        "cmd-shift-down": "editor::SelectToEnd",
-        "cmd-a": "editor::SelectAll",
-        "cmd-l": "editor::SelectLine",
-        "cmd-shift-L": "editor::SplitSelectionIntoLines",
-        "cmd-alt-up": "editor::AddSelectionAbove",
-        "cmd-ctrl-p": "editor::AddSelectionAbove",
-        "cmd-alt-down": "editor::AddSelectionBelow",
-        "cmd-ctrl-n": "editor::AddSelectionBelow",
-        "ctrl-alt-shift-F": "editor::SelectToNextSubwordEnd",
-        "cmd-shift-left": [
-            "editor::SelectToBeginningOfLine",
-            {
-                "stop_at_soft_wraps": true
-            }
-        ],
-        "ctrl-shift-A": [
-            "editor::SelectToBeginningOfLine",
-            {
-                "stop_at_soft_wraps": true
-            }
-        ],
-        "cmd-shift-right": [
-            "editor::SelectToEndOfLine",
-            {
-                "stop_at_soft_wraps": true
-            }
-        ],
-        "ctrl-shift-E": [
-            "editor::SelectToEndOfLine",
-            {
-                "stop_at_soft_wraps": true
-            }
-        ],
-        "cmd-d": [
-            "editor::SelectNext",
-            {
-                "replace_newest": false
-            }
-        ],
-        "cmd-k cmd-d": [
-            "editor::SelectNext",
-            {
-                "replace_newest": true
-            }
-        ],
-        "cmd-/": "editor::ToggleComments",
-        "alt-up": "editor::SelectLargerSyntaxNode",
-        "ctrl-w": "editor::SelectLargerSyntaxNode",
-        "alt-down": "editor::SelectSmallerSyntaxNode",
-        "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
-        "cmd-u": "editor::UndoSelection",
-        "cmd-shift-U": "editor::RedoSelection",
-        "f8": "editor::GoToNextDiagnostic",
-        "shift-f8": "editor::GoToPrevDiagnostic",
-        "f2": "editor::Rename",
-        "f12": "editor::GoToDefinition",
-        "alt-shift-f12": "editor::FindAllReferences",
-        "ctrl-m": "editor::MoveToEnclosingBracket",
-        "pageup": "editor::PageUp",
-        "pagedown": "editor::PageDown",
-        "alt-cmd-[": "editor::Fold",
-        "alt-cmd-]": "editor::UnfoldLines",
-        "alt-cmd-f": "editor::FoldSelectedRanges",
-        "ctrl-space": "editor::ShowCompletions",
-        "cmd-.": "editor::ToggleCodeActions",
-        "alt-enter": "editor::OpenExcerpts",
-        "cmd-f10": "editor::RestartLanguageServer"
+    {
+        "context": "Editor",
+        "bindings": {
+            "escape": "editor::Cancel",
+            "backspace": "editor::Backspace",
+            "ctrl-h": "editor::Backspace",
+            "delete": "editor::Delete",
+            "ctrl-d": "editor::Delete",
+            "tab": "editor::Tab",
+            "shift-tab": "editor::TabPrev",
+            "cmd-[": "editor::Outdent",
+            "cmd-]": "editor::Indent",
+            "ctrl-shift-K": "editor::DeleteLine",
+            "alt-backspace": "editor::DeleteToPreviousWordStart",
+            "alt-h": "editor::DeleteToPreviousWordStart",
+            "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
+            "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
+            "alt-delete": "editor::DeleteToNextWordEnd",
+            "alt-d": "editor::DeleteToNextWordEnd",
+            "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
+            "ctrl-alt-d": "editor::DeleteToNextSubwordEnd",
+            "cmd-backspace": "editor::DeleteToBeginningOfLine",
+            "cmd-delete": "editor::DeleteToEndOfLine",
+            "ctrl-k": "editor::CutToEndOfLine",
+            "cmd-shift-D": "editor::DuplicateLine",
+            "ctrl-cmd-up": "editor::MoveLineUp",
+            "ctrl-cmd-down": "editor::MoveLineDown",
+            "cmd-x": "editor::Cut",
+            "cmd-c": "editor::Copy",
+            "cmd-v": "editor::Paste",
+            "cmd-z": "editor::Undo",
+            "cmd-shift-Z": "editor::Redo",
+            "up": "editor::MoveUp",
+            "down": "editor::MoveDown",
+            "left": "editor::MoveLeft",
+            "right": "editor::MoveRight",
+            "ctrl-p": "editor::MoveUp",
+            "ctrl-n": "editor::MoveDown",
+            "ctrl-b": "editor::MoveLeft",
+            "ctrl-f": "editor::MoveRight",
+            "alt-left": "editor::MoveToPreviousWordStart",
+            "alt-b": "editor::MoveToPreviousWordStart",
+            "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
+            "ctrl-alt-b": "editor::MoveToPreviousSubwordStart",
+            "alt-right": "editor::MoveToNextWordEnd",
+            "alt-f": "editor::MoveToNextWordEnd",
+            "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
+            "ctrl-alt-f": "editor::MoveToNextSubwordEnd",
+            "cmd-left": "editor::MoveToBeginningOfLine",
+            "ctrl-a": "editor::MoveToBeginningOfLine",
+            "cmd-right": "editor::MoveToEndOfLine",
+            "ctrl-e": "editor::MoveToEndOfLine",
+            "cmd-up": "editor::MoveToBeginning",
+            "cmd-down": "editor::MoveToEnd",
+            "shift-up": "editor::SelectUp",
+            "ctrl-shift-P": "editor::SelectUp",
+            "shift-down": "editor::SelectDown",
+            "ctrl-shift-N": "editor::SelectDown",
+            "shift-left": "editor::SelectLeft",
+            "ctrl-shift-B": "editor::SelectLeft",
+            "shift-right": "editor::SelectRight",
+            "ctrl-shift-F": "editor::SelectRight",
+            "alt-shift-left": "editor::SelectToPreviousWordStart",
+            "alt-shift-B": "editor::SelectToPreviousWordStart",
+            "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
+            "ctrl-alt-shift-B": "editor::SelectToPreviousSubwordStart",
+            "alt-shift-right": "editor::SelectToNextWordEnd",
+            "alt-shift-F": "editor::SelectToNextWordEnd",
+            "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
+            "cmd-shift-up": "editor::SelectToBeginning",
+            "cmd-shift-down": "editor::SelectToEnd",
+            "cmd-a": "editor::SelectAll",
+            "cmd-l": "editor::SelectLine",
+            "cmd-shift-L": "editor::SplitSelectionIntoLines",
+            "cmd-alt-up": "editor::AddSelectionAbove",
+            "cmd-ctrl-p": "editor::AddSelectionAbove",
+            "cmd-alt-down": "editor::AddSelectionBelow",
+            "cmd-ctrl-n": "editor::AddSelectionBelow",
+            "ctrl-alt-shift-F": "editor::SelectToNextSubwordEnd",
+            "cmd-shift-left": [
+                "editor::SelectToBeginningOfLine",
+                {
+                    "stop_at_soft_wraps": true
+                }
+            ],
+            "ctrl-shift-A": [
+                "editor::SelectToBeginningOfLine",
+                {
+                    "stop_at_soft_wraps": true
+                }
+            ],
+            "cmd-shift-right": [
+                "editor::SelectToEndOfLine",
+                {
+                    "stop_at_soft_wraps": true
+                }
+            ],
+            "ctrl-shift-E": [
+                "editor::SelectToEndOfLine",
+                {
+                    "stop_at_soft_wraps": true
+                }
+            ],
+            "cmd-d": [
+                "editor::SelectNext",
+                {
+                    "replace_newest": false
+                }
+            ],
+            "cmd-k cmd-d": [
+                "editor::SelectNext",
+                {
+                    "replace_newest": true
+                }
+            ],
+            "cmd-/": "editor::ToggleComments",
+            "alt-up": "editor::SelectLargerSyntaxNode",
+            "ctrl-w": "editor::SelectLargerSyntaxNode",
+            "alt-down": "editor::SelectSmallerSyntaxNode",
+            "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
+            "cmd-u": "editor::UndoSelection",
+            "cmd-shift-U": "editor::RedoSelection",
+            "f8": "editor::GoToNextDiagnostic",
+            "shift-f8": "editor::GoToPrevDiagnostic",
+            "f2": "editor::Rename",
+            "f12": "editor::GoToDefinition",
+            "alt-shift-f12": "editor::FindAllReferences",
+            "ctrl-m": "editor::MoveToEnclosingBracket",
+            "pageup": "editor::PageUp",
+            "pagedown": "editor::PageDown",
+            "alt-cmd-[": "editor::Fold",
+            "alt-cmd-]": "editor::UnfoldLines",
+            "alt-cmd-f": "editor::FoldSelectedRanges",
+            "ctrl-space": "editor::ShowCompletions",
+            "cmd-.": "editor::ToggleCodeActions",
+            "alt-enter": "editor::OpenExcerpts",
+            "cmd-f10": "editor::RestartLanguageServer"
+        }
     },
-    "Editor && renaming": {
-        "enter": "editor::ConfirmRename"
+    {
+        "context": "Editor && mode == full",
+        "bindings": {
+            "enter": "editor::Newline",
+            "cmd-f": [
+                "buffer_search::Deploy",
+                {
+                    "focus": true
+                }
+            ],
+            "cmd-e": [
+                "buffer_search::Deploy",
+                {
+                    "focus": false
+                }
+            ],
+            "cmd-shift-O": "outline::Toggle",
+            "ctrl-g": "go_to_line::Toggle"
+        }
     },
-    "Editor && showing_completions": {
-        "enter": "editor::ConfirmCompletion",
-        "tab": "editor::ConfirmCompletion"
+    {
+        "context": "Editor && renaming",
+        "bindings": {
+            "enter": "editor::ConfirmRename"
+        }
     },
-    "Editor && showing_code_actions": {
-        "enter": "editor::ConfirmCodeAction"
+    {
+        "context": "Editor && showing_completions",
+        "bindings": {
+            "enter": "editor::ConfirmCompletion",
+            "tab": "editor::ConfirmCompletion"
+        }
     },
-    "Editor && mode == full": {
-        "enter": "editor::Newline",
-        "cmd-f": [
-            "buffer_search::Deploy",
-            {
-                "focus": true
-            }
-        ],
-        "cmd-e": [
-            "buffer_search::Deploy",
-            {
-                "focus": false
-            }
-        ],
-        "cmd-shift-O": "outline::Toggle",
-        "ctrl-g": "go_to_line::Toggle"
+    {
+        "context": "Editor && showing_code_actions",
+        "bindings": {
+            "enter": "editor::ConfirmCodeAction"
+        }
     },
-    "Editor && mode == auto_height": {
-        "alt-enter": [
-            "editor::Input",
-            "\n"
-        ]
+    {
+        "context": "Editor && mode == auto_height",
+        "bindings": {
+            "alt-enter": [
+                "editor::Input",
+                "\n"
+            ]
+        }
     },
-    "GoToLine": {
-        "escape": "go_to_line::Toggle",
-        "enter": "go_to_line::Confirm"
+    {
+        "context": "GoToLine",
+        "bindings": {
+            "escape": "go_to_line::Toggle",
+            "enter": "go_to_line::Confirm"
+        }
     },
-    "ChatPanel": {
-        "enter": "chat_panel::Send"
+    {
+        "context": "ChatPanel",
+        "bindings": {
+            "enter": "chat_panel::Send"
+        }
     },
-    "ProjectPanel": {
-        "left": "project_panel::CollapseSelectedEntry",
-        "right": "project_panel::ExpandSelectedEntry"
+    {
+        "context": "ProjectPanel",
+        "bindings": {
+            "left": "project_panel::CollapseSelectedEntry",
+            "right": "project_panel::ExpandSelectedEntry"
+        }
     }
-}
+]

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,93 +1,111 @@
-{
-    "Editor && VimControl": {
-        "i": [
-            "vim::SwitchMode",
-            "Insert"
-        ],
-        "g": [
-            "vim::PushOperator",
-            {
-                "Namespace": "G"
-            }
-        ],
-        "h": "vim::Left",
-        "j": "vim::Down",
-        "k": "vim::Up",
-        "l": "vim::Right",
-        "0": "vim::StartOfLine",
-        "shift-$": "vim::EndOfLine",
-        "shift-G": "vim::EndOfDocument",
-        "w": "vim::NextWordStart",
-        "shift-W": [
-            "vim::NextWordStart",
-            {
-                "ignorePunctuation": true
-            }
-        ],
-        "e": "vim::NextWordEnd",
-        "shift-E": [
-            "vim::NextWordEnd",
-            {
-                "ignorePunctuation": true
-            }
-        ],
-        "b": "vim::PreviousWordStart",
-        "shift-B": [
-            "vim::PreviousWordStart",
-            {
-                "ignorePunctuation": true
-            }
-        ],
-        "escape": [
-            "vim::SwitchMode",
-            "Normal"
-        ]
+[
+    {
+        "context": "Editor && VimControl",
+        "bindings": {
+            "i": [
+                "vim::SwitchMode",
+                "Insert"
+            ],
+            "g": [
+                "vim::PushOperator",
+                {
+                    "Namespace": "G"
+                }
+            ],
+            "h": "vim::Left",
+            "j": "vim::Down",
+            "k": "vim::Up",
+            "l": "vim::Right",
+            "0": "vim::StartOfLine",
+            "shift-$": "vim::EndOfLine",
+            "shift-G": "vim::EndOfDocument",
+            "w": "vim::NextWordStart",
+            "shift-W": [
+                "vim::NextWordStart",
+                {
+                    "ignorePunctuation": true
+                }
+            ],
+            "e": "vim::NextWordEnd",
+            "shift-E": [
+                "vim::NextWordEnd",
+                {
+                    "ignorePunctuation": true
+                }
+            ],
+            "b": "vim::PreviousWordStart",
+            "shift-B": [
+                "vim::PreviousWordStart",
+                {
+                    "ignorePunctuation": true
+                }
+            ],
+            "escape": [
+                "vim::SwitchMode",
+                "Normal"
+            ]
+        }
     },
-    "Editor && vim_operator == g": {
-        "g": "vim::StartOfDocument"
+    {
+        "context": "Editor && vim_operator == g",
+        "bindings": {
+            "g": "vim::StartOfDocument"
+        }
     },
-    "Editor && vim_mode == insert": {
-        "escape": "vim::NormalBefore",
-        "ctrl-c": "vim::NormalBefore"
+    {
+        "context": "Editor && vim_mode == insert",
+        "bindings": {
+            "escape": "vim::NormalBefore",
+            "ctrl-c": "vim::NormalBefore"
+        }
     },
-    "Editor && vim_mode == normal": {
-        "c": [
-            "vim::PushOperator",
-            "Change"
-        ],
-        "d": [
-            "vim::PushOperator",
-            "Delete"
-        ]
+    {
+        "context": "Editor && vim_mode == normal",
+        "bindings": {
+            "c": [
+                "vim::PushOperator",
+                "Change"
+            ],
+            "d": [
+                "vim::PushOperator",
+                "Delete"
+            ]
+        }
     },
-    "Editor && vim_operator == c": {
-        "w": [
-            "vim::NextWordEnd",
-            {
-                "ignorePunctuation": false
-            }
-        ],
-        "shift-W": [
-            "vim::NextWordEnd",
-            {
-                "ignorePunctuation": true
-            }
-        ]
+    {
+        "context": "Editor && vim_operator == c",
+        "bindings": {
+            "w": [
+                "vim::NextWordEnd",
+                {
+                    "ignorePunctuation": false
+                }
+            ],
+            "shift-W": [
+                "vim::NextWordEnd",
+                {
+                    "ignorePunctuation": true
+                }
+            ]
+        }
     },
-    "Editor && vim_operator == d": {
-        "w": [
-            "vim::NextWordStart",
-            {
-                "ignorePunctuation": false,
-                "stopAtNewline": true
-            }
-        ],
-        "shift-W": [
-            "vim::NextWordStart",
-            {
-                "ignorePunctuation": true,
-                "stopAtNewline": true
-            }
-        ]
+    {
+        "context": "Editor && vim_operator == d",
+        "bindings": {
+            "w": [
+                "vim::NextWordStart",
+                {
+                    "ignorePunctuation": false,
+                    "stopAtNewline": true
+                }
+            ],
+            "shift-W": [
+                "vim::NextWordStart",
+                {
+                    "ignorePunctuation": true,
+                    "stopAtNewline": true
+                }
+            ]
+        }
     }
-}
+]

--- a/crates/chat_panel/src/chat_panel.rs
+++ b/crates/chat_panel/src/chat_panel.rs
@@ -16,6 +16,7 @@ use settings::{Settings, SoftWrap};
 use std::sync::Arc;
 use time::{OffsetDateTime, UtcOffset};
 use util::{ResultExt, TryFutureExt};
+use workspace::menu::Confirm;
 
 const MESSAGE_LOADING_THRESHOLD: usize = 50;
 
@@ -32,7 +33,7 @@ pub struct ChatPanel {
 
 pub enum Event {}
 
-actions!(chat_panel, [Send, LoadMoreMessages]);
+actions!(chat_panel, [LoadMoreMessages]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(ChatPanel::send);
@@ -345,7 +346,7 @@ impl ChatPanel {
         .boxed()
     }
 
-    fn send(&mut self, _: &Send, cx: &mut ViewContext<Self>) {
+    fn send(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
         if let Some((channel, _)) = self.active_channel.as_ref() {
             let body = self.input_editor.update(cx, |editor, cx| {
                 let body = editor.text(cx);

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -5,13 +5,17 @@ use gpui::{
 };
 use settings::Settings;
 use text::{Bias, Point};
-use workspace::Workspace;
+use workspace::{
+    menu::{Cancel, Confirm},
+    Workspace,
+};
 
-actions!(go_to_line, [Toggle, Confirm]);
+actions!(go_to_line, [Toggle]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(GoToLine::toggle);
     cx.add_action(GoToLine::confirm);
+    cx.add_action(GoToLine::cancel);
 }
 
 pub struct GoToLine {
@@ -64,6 +68,10 @@ impl GoToLine {
                 view
             });
         }
+    }
+
+    fn cancel(&mut self, _: &Cancel, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::Dismissed);
     }
 
     fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1306,6 +1306,10 @@ impl MutableAppContext {
         }
     }
 
+    pub fn all_action_names<'a>(&'a self) -> impl Iterator<Item = &'static str> + 'a {
+        self.action_deserializers.keys().copied()
+    }
+
     pub fn available_actions(
         &self,
         window_id: usize,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -102,6 +102,10 @@ pub trait LspAdapter: 'static + Send + Sync {
     fn disk_based_diagnostics_progress_token(&self) -> Option<&'static str> {
         None
     }
+
+    fn id_for_language(&self, _name: &str) -> Option<String> {
+        None
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -17,9 +17,11 @@ use std::{
     path::PathBuf,
 };
 use util::ResultExt as _;
-use workspace::{Item, ItemNavHistory, Pane, ToolbarItemLocation, ToolbarItemView, Workspace};
+use workspace::{
+    menu::Confirm, Item, ItemNavHistory, Pane, ToolbarItemLocation, ToolbarItemView, Workspace,
+};
 
-actions!(project_search, [Deploy, Search, SearchInNew, ToggleFocus]);
+actions!(project_search, [Deploy, SearchInNew, ToggleFocus]);
 
 const MAX_TAB_TITLE_LEN: usize = 24;
 
@@ -530,7 +532,7 @@ impl ProjectSearchBar {
         }
     }
 
-    fn search(&mut self, _: &Search, cx: &mut ViewContext<Self>) {
+    fn search(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
         if let Some(search_view) = self.active_project_search.as_ref() {
             search_view.update(cx, |search_view, cx| search_view.search(cx));
         }

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -17,6 +17,7 @@ gpui = { path = "../gpui" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 anyhow = "1.0.38"
+json_comments = "0.2"
 schemars = "0.8"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -9,13 +9,13 @@ use schemars::{
     },
     JsonSchema,
 };
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use theme::{Theme, ThemeRegistry};
 use util::ResultExt as _;
 
-pub use keymap_file::KeymapFile;
+pub use keymap_file::KeymapFileContent;
 
 #[derive(Clone)]
 pub struct Settings {
@@ -259,4 +259,10 @@ fn merge_option<T: Copy>(target: &mut Option<T>, value: Option<T>) {
     if value.is_some() {
         *target = value;
     }
+}
+
+pub fn parse_json_with_comments<T: DeserializeOwned>(content: &str) -> Result<T> {
+    Ok(serde_json::from_reader(
+        json_comments::CommentSettings::c_style().strip_comments(content.as_bytes()),
+    )?)
 }

--- a/crates/vim/src/vim_test_context.rs
+++ b/crates/vim/src/vim_test_context.rs
@@ -24,7 +24,7 @@ impl<'a> VimTestContext<'a> {
             editor::init(cx);
             crate::init(cx);
 
-            settings::KeymapFile::load("keymaps/vim.json", cx).unwrap();
+            settings::KeymapFileContent::load("keymaps/vim.json", cx).unwrap();
         });
 
         let params = cx.update(WorkspaceParams::test);

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -86,7 +86,7 @@ tiny_http = "0.8"
 toml = "0.5"
 tree-sitter = "0.20.4"
 tree-sitter-c = "0.20.1"
-tree-sitter-json = "0.19.0"
+tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
 tree-sitter-rust = "0.20.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 tree-sitter-typescript = "0.20.1"

--- a/crates/zed/src/languages/json.rs
+++ b/crates/zed/src/languages/json.rs
@@ -127,4 +127,12 @@ impl LspAdapter for JsonLspAdapter {
             "provideFormatter": true
         }))
     }
+
+    fn id_for_language(&self, name: &str) -> Option<String> {
+        if name == "JSON" {
+            Some("jsonc".into())
+        } else {
+            None
+        }
+    }
 }

--- a/crates/zed/src/languages/json/config.toml
+++ b/crates/zed/src/languages/json/config.toml
@@ -1,5 +1,6 @@
 name = "JSON"
 path_suffixes = ["json"]
+line_comment = "// "
 autoclose_before = ",]}"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/zed/src/languages/json/highlights.scm
+++ b/crates/zed/src/languages/json/highlights.scm
@@ -1,3 +1,5 @@
+(comment) @comment
+
 (string) @string
 
 (pair

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -17,7 +17,7 @@ use gpui::{App, AssetSource, AsyncAppContext, Task};
 use log::LevelFilter;
 use parking_lot::Mutex;
 use project::Fs;
-use settings::{self, KeymapFile, Settings, SettingsFileContent};
+use settings::{self, KeymapFileContent, Settings, SettingsFileContent};
 use smol::process::Command;
 use std::{env, fs, path::PathBuf, sync::Arc, thread, time::Duration};
 use theme::{ThemeRegistry, DEFAULT_THEME_NAME};
@@ -309,7 +309,7 @@ fn load_config_files(
     fs: Arc<dyn Fs>,
 ) -> oneshot::Receiver<(
     WatchedJsonFile<SettingsFileContent>,
-    WatchedJsonFile<KeymapFile>,
+    WatchedJsonFile<KeymapFileContent>,
 )> {
     let executor = app.background();
     let (tx, rx) = oneshot::channel();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -138,7 +138,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
 
     workspace::lsp_status::init(cx);
 
-    settings::KeymapFile::load_defaults(cx);
+    settings::KeymapFileContent::load_defaults(cx);
 }
 
 pub fn build_workspace(


### PR DESCRIPTION
Refs #714

This PR makes some improvements to Zed's key-binding system:

* Changes Zed's JSON support so that it allows JavaScript-style comments, similar to VS Code's config files. The comments are supported in the Tree-sitter JSON grammar, the JSON language server, and when Zed loads config files internally.
* Adds a new command `zed::OpenKeymap`, bound to `cmd-alt-,` by default, to create and open the `keymap.json` file.
* Provides a JSON schema for `keymap.json` that validates the structure and provides autocompletion for action names.
* Changes the format of `keymap.json` so that the user can completely control the order of the bindings, and can break them up into sections.
* Re-structures the default key-binding file, to break it into the following sections:
  * standard macOS bindings 
  * bindings from VS  Code
  * bindings from Sublime Text
  * bindings that we made up 👈 these we should think about carefully before we ship the alpha