### PR TITLE
Add syntax highlighting for TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-toml"
+version = "0.5.1"
+source = "git+https://github.com/tree-sitter/tree-sitter-toml?rev=342d9be207c2dba869b9967124c679b5e6fd0ebe#342d9be207c2dba869b9967124c679b5e6fd0ebe"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-typescript"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5856,6 +5865,7 @@ dependencies = [
  "tree-sitter-json 0.20.0",
  "tree-sitter-markdown",
  "tree-sitter-rust",
+ "tree-sitter-toml",
  "tree-sitter-typescript",
  "unindent",
  "url",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -89,6 +89,7 @@ tree-sitter-c = "0.20.1"
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
 tree-sitter-rust = "0.20.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
+tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
 tree-sitter-typescript = "0.20.1"
 url = "2.2"
 

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -38,6 +38,11 @@ pub fn build_language_registry(login_shell_env_loaded: Task<()>) -> LanguageRegi
             Some(Arc::new(rust::RustLspAdapter)),
         ),
         (
+            "toml",
+            tree_sitter_toml::language(),
+            None, //
+        ),
+        (
             "tsx",
             tree_sitter_typescript::language_tsx(),
             Some(Arc::new(typescript::TypeScriptLspAdapter)),

--- a/crates/zed/src/languages/toml/brackets.scm
+++ b/crates/zed/src/languages/toml/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/src/languages/toml/config.toml
+++ b/crates/zed/src/languages/toml/config.toml
@@ -1,0 +1,9 @@
+name = "TOML"
+path_suffixes = ["toml"]
+line_comment = "# "
+autoclose_before = ",]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false },
+]

--- a/crates/zed/src/languages/toml/highlights.scm
+++ b/crates/zed/src/languages/toml/highlights.scm
@@ -1,0 +1,33 @@
+; Properties
+;-----------
+
+(bare_key) @property
+(quoted_key) @property
+
+; Literals
+;---------
+
+(boolean) @constant
+(comment) @comment
+(string) @string
+(integer) @number
+(float) @number
+(offset_date_time) @string.special
+(local_date_time) @string.special
+(local_date) @string.special
+(local_time) @string.special
+
+; Punctuation
+;------------
+
+"." @punctuation.delimiter
+"," @punctuation.delimiter
+
+"=" @operator
+
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"[[" @punctuation.bracket
+"]]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket

--- a/crates/zed/src/languages/toml/outline.scm
+++ b/crates/zed/src/languages/toml/outline.scm
@@ -1,0 +1,15 @@
+(table
+  .
+  "["
+  .
+  (_) @name) @item
+
+(table_array_element
+  .
+  "[["
+  .
+  (_) @name) @item
+
+(pair
+  .
+  (_) @name) @item


### PR DESCRIPTION
Fixes #836

This PR adds syntax highlighting, bracket matching, and outline support for TOML.

<img width="1838" alt="Screen Shot 2022-04-21 at 4 41 24 PM" src="https://user-images.githubusercontent.com/326587/164568310-02d1a728-7662-4186-ac49-bca1c17edadf.png">
