### PR TITLE
Show project browser when opening folder

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -469,7 +469,7 @@ mod tests {
         workspace
             .update(cx, |workspace, cx| {
                 workspace.open_paths(
-                    &[PathBuf::from("/root/dir1"), PathBuf::from("/root/dir2")],
+                    vec![PathBuf::from("/root/dir1"), PathBuf::from("/root/dir2")],
                     cx,
                 )
             })

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -566,6 +566,18 @@ impl AsyncAppContext {
         self.update(|cx| cx.add_view(window_id, build_view))
     }
 
+    pub fn add_window<T, F>(
+        &mut self,
+        window_options: WindowOptions,
+        build_root_view: F,
+    ) -> (usize, ViewHandle<T>)
+    where
+        T: View,
+        F: FnOnce(&mut ViewContext<T>) -> T,
+    {
+        self.update(|cx| cx.add_window(window_options, build_root_view))
+    }
+
     pub fn platform(&self) -> Arc<dyn Platform> {
         self.0.borrow().platform()
     }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -49,7 +49,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
 
             let opened = workspace
                 .update(&mut cx, |workspace, cx| {
-                    workspace.open_paths(&[entry_path], cx)
+                    workspace.open_paths(vec![entry_path], cx)
                 })
                 .await;
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -43,7 +43,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
     cx.spawn(|mut cx| {
         async move {
             let (journal_dir, entry_path) = create_entry.await?;
-            let (workspace, _, _) = cx
+            let (workspace, _) = cx
                 .update(|cx| workspace::open_paths(&[journal_dir], &app_state, cx))
                 .await;
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -43,7 +43,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
     cx.spawn(|mut cx| {
         async move {
             let (journal_dir, entry_path) = create_entry.await?;
-            let (workspace, _) = cx
+            let (workspace, _, _) = cx
                 .update(|cx| workspace::open_paths(&[journal_dir], &app_state, cx))
                 .await;
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2115,6 +2115,7 @@ pub fn open_paths(
 ) -> Task<(
     ViewHandle<Workspace>,
     Vec<Option<Result<Box<dyn ItemHandle>, Arc<anyhow::Error>>>>,
+    bool,
 )> {
     log::info!("open paths {:?}", abs_paths);
 
@@ -2136,6 +2137,7 @@ pub fn open_paths(
         }
     }
 
+    let is_new_workspace = existing.is_none();
     let workspace = existing.unwrap_or_else(|| {
         cx.add_window((app_state.build_window_options)(), |cx| {
             let project = Project::local(
@@ -2153,7 +2155,7 @@ pub fn open_paths(
     let task = workspace.update(cx, |workspace, cx| workspace.open_paths(abs_paths, cx));
     cx.spawn(|_| async move {
         let items = task.await;
-        (workspace, items)
+        (workspace, items, is_new_workspace)
     })
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -360,8 +360,10 @@ mod tests {
             .await;
         assert_eq!(cx.window_ids().len(), 1);
         let workspace_1 = cx.root_view::<Workspace>(cx.window_ids()[0]).unwrap();
-        workspace_1.read_with(cx, |workspace, cx| {
-            assert_eq!(workspace.worktrees(cx).count(), 2)
+        workspace_1.update(cx, |workspace, cx| {
+            assert_eq!(workspace.worktrees(cx).count(), 2);
+            assert!(workspace.left_sidebar_mut().active_item().is_some());
+            assert!(workspace.active_pane().is_focused(cx));
         });
 
         cx.update(|cx| {


### PR DESCRIPTION
Closes #878 

Also, in bba65e120d9c6dcdaecfb24cf2a861ec93e61375 I took care of ensuring we only add one worktree when running `zed /dir /dir/file`.