### PR TITLE
Apply cursor styles during paint and make editor's cursor an I-Beam

### DIFF
--- a/assets/themes/dark.json
+++ b/assets/themes/dark.json
@@ -89,10 +89,6 @@
         "top": 7
       }
     },
-    "margin": {
-      "bottom": 52,
-      "top": 52
-    },
     "shadow": {
       "blur": 16,
       "color": "#00000052",
@@ -157,6 +153,13 @@
         "left": 8,
         "right": 8
       }
+    },
+    "modal": {
+      "margin": {
+        "bottom": 52,
+        "top": 52
+      },
+      "cursor": "Arrow"
     },
     "left_sidebar": {
       "width": 30,

--- a/assets/themes/light.json
+++ b/assets/themes/light.json
@@ -89,10 +89,6 @@
         "top": 7
       }
     },
-    "margin": {
-      "bottom": 52,
-      "top": 52
-    },
     "shadow": {
       "blur": 16,
       "color": "#0000001f",
@@ -157,6 +153,13 @@
         "left": 8,
         "right": 8
       }
+    },
+    "modal": {
+      "margin": {
+        "bottom": 52,
+        "top": 52
+      },
+      "cursor": "Arrow"
     },
     "left_sidebar": {
       "width": 30,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -16,6 +16,7 @@ use gpui::{
         PathBuilder,
     },
     json::{self, ToJson},
+    platform::CursorStyle,
     text_layout::{self, Line, RunStyle, TextLayoutCache},
     AppContext, Axis, Border, Element, ElementBox, Event, EventContext, LayoutContext,
     MutableAppContext, PaintContext, Quad, Scene, SizeConstraint, ViewContext, WeakViewHandle,
@@ -329,6 +330,7 @@ impl EditorElement {
         let content_origin = bounds.origin() + vec2f(layout.gutter_margin, 0.);
 
         cx.scene.push_layer(Some(bounds));
+        cx.scene.push_cursor_style(bounds, CursorStyle::IBeam);
 
         for (range, color) in &layout.highlighted_ranges {
             self.paint_highlighted_range(

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -161,29 +161,25 @@ impl View for GoToLine {
             self.max_point.row + 1
         );
 
-        Align::new(
-            ConstrainedBox::new(
-                Container::new(
-                    Flex::new(Axis::Vertical)
-                        .with_child(
-                            Container::new(ChildView::new(&self.line_editor).boxed())
-                                .with_style(theme.input_editor.container)
-                                .boxed(),
-                        )
-                        .with_child(
-                            Container::new(Label::new(label, theme.empty.label.clone()).boxed())
-                                .with_style(theme.empty.container)
-                                .boxed(),
-                        )
-                        .boxed(),
-                )
-                .with_style(theme.container)
-                .boxed(),
+        ConstrainedBox::new(
+            Container::new(
+                Flex::new(Axis::Vertical)
+                    .with_child(
+                        Container::new(ChildView::new(&self.line_editor).boxed())
+                            .with_style(theme.input_editor.container)
+                            .boxed(),
+                    )
+                    .with_child(
+                        Container::new(Label::new(label, theme.empty.label.clone()).boxed())
+                            .with_style(theme.empty.container)
+                            .boxed(),
+                    )
+                    .boxed(),
             )
-            .with_max_width(500.0)
+            .with_style(theme.container)
             .boxed(),
         )
-        .top()
+        .with_max_width(500.0)
         .named("go to line")
     }
 

--- a/crates/gpui/src/elements/container.rs
+++ b/crates/gpui/src/elements/container.rs
@@ -1,17 +1,17 @@
-use pathfinder_geometry::rect::RectF;
-use serde::Deserialize;
-use serde_json::json;
-
 use crate::{
     color::Color,
     geometry::{
         deserialize_vec2f,
+        rect::RectF,
         vector::{vec2f, Vector2F},
     },
     json::ToJson,
+    platform::CursorStyle,
     scene::{self, Border, Quad},
     Element, ElementBox, Event, EventContext, LayoutContext, PaintContext, SizeConstraint,
 };
+use serde::Deserialize;
+use serde_json::json;
 
 #[derive(Clone, Copy, Debug, Default, Deserialize)]
 pub struct ContainerStyle {
@@ -27,6 +27,8 @@ pub struct ContainerStyle {
     pub corner_radius: f32,
     #[serde(default)]
     pub shadow: Option<Shadow>,
+    #[serde(default)]
+    pub cursor: Option<CursorStyle>,
 }
 
 pub struct Container {
@@ -128,6 +130,11 @@ impl Container {
         self
     }
 
+    pub fn with_cursor(mut self, style: CursorStyle) -> Self {
+        self.style.cursor = Some(style);
+        self
+    }
+
     fn margin_size(&self) -> Vector2F {
         vec2f(
             self.style.margin.left + self.style.margin.right,
@@ -203,6 +210,10 @@ impl Element for Container {
                 sigma: shadow.blur,
                 color: shadow.color,
             });
+        }
+
+        if let Some(style) = self.style.cursor {
+            cx.scene.push_cursor_style(quad_bounds, style);
         }
 
         let child_origin =

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -21,6 +21,7 @@ use anyhow::{anyhow, Result};
 use async_task::Runnable;
 pub use event::{Event, NavigationDirection};
 use postage::oneshot;
+use serde::Deserialize;
 use std::{
     any::Any,
     path::{Path, PathBuf},
@@ -125,11 +126,12 @@ pub enum PromptLevel {
     Critical,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub enum CursorStyle {
     Arrow,
     ResizeLeftRight,
     PointingHand,
+    IBeam,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -583,6 +583,7 @@ impl platform::Platform for MacPlatform {
                 CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],
                 CursorStyle::ResizeLeftRight => msg_send![class!(NSCursor), resizeLeftRightCursor],
                 CursorStyle::PointingHand => msg_send![class!(NSCursor), pointingHandCursor],
+                CursorStyle::IBeam => msg_send![class!(NSCursor), IBeamCursor],
             };
             let _: () = msg_send![cursor, set];
         }

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -4,7 +4,7 @@ use crate::{
     font_cache::FontCache,
     geometry::rect::RectF,
     json::{self, ToJson},
-    platform::Event,
+    platform::{CursorStyle, Event},
     text_layout::TextLayoutCache,
     Action, AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AssetCache, ElementBox,
     ElementStateContext, Entity, FontSystem, ModelHandle, ReadModel, ReadView, Scene,
@@ -22,6 +22,7 @@ pub struct Presenter {
     window_id: usize,
     pub(crate) rendered_views: HashMap<usize, ElementBox>,
     parents: HashMap<usize, usize>,
+    cursor_styles: Vec<(RectF, CursorStyle)>,
     font_cache: Arc<FontCache>,
     text_layout_cache: TextLayoutCache,
     asset_cache: Arc<AssetCache>,
@@ -42,6 +43,7 @@ impl Presenter {
             window_id,
             rendered_views: cx.render_views(window_id, titlebar_height),
             parents: HashMap::new(),
+            cursor_styles: Default::default(),
             font_cache,
             text_layout_cache,
             asset_cache,
@@ -118,6 +120,7 @@ impl Presenter {
                 RectF::new(Vector2F::zero(), window_size),
             );
             self.text_layout_cache.finish_frame();
+            self.cursor_styles = scene.cursor_styles();
 
             if let Some(event) = self.last_mouse_moved_event.clone() {
                 self.dispatch_event(event, cx)
@@ -171,8 +174,21 @@ impl Presenter {
     pub fn dispatch_event(&mut self, event: Event, cx: &mut MutableAppContext) {
         if let Some(root_view_id) = cx.root_view_id(self.window_id) {
             match event {
-                Event::MouseMoved { .. } => {
+                Event::MouseMoved {
+                    position,
+                    left_mouse_down,
+                } => {
                     self.last_mouse_moved_event = Some(event.clone());
+
+                    if !left_mouse_down {
+                        cx.platform().set_cursor_style(CursorStyle::Arrow);
+                        for (bounds, style) in self.cursor_styles.iter().rev() {
+                            if bounds.contains_point(position) {
+                                cx.platform().set_cursor_style(*style);
+                                break;
+                            }
+                        }
+                    }
                 }
                 Event::LeftMouseDragged { position } => {
                     self.last_mouse_moved_event = Some(Event::MouseMoved {

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -99,8 +99,6 @@ impl<D: PickerDelegate> View for Picker<D> {
             .constrained()
             .with_max_width(self.max_size.x())
             .with_max_height(self.max_size.y())
-            .aligned()
-            .top()
             .named("picker")
     }
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -43,6 +43,7 @@ pub struct Workspace {
     pub status_bar: StatusBar,
     pub toolbar: Toolbar,
     pub disconnected_overlay: ContainedText,
+    pub modal: ContainerStyle,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1983,7 +1983,14 @@ impl View for Workspace {
                                 content.add_child(self.right_sidebar.render(&theme, cx));
                                 content.boxed()
                             })
-                            .with_children(self.modal.as_ref().map(|m| ChildView::new(m).boxed()))
+                            .with_children(self.modal.as_ref().map(|m| {
+                                ChildView::new(m)
+                                    .contained()
+                                    .with_style(theme.workspace.modal)
+                                    .aligned()
+                                    .top()
+                                    .boxed()
+                            }))
                             .flex(1.0, true)
                             .boxed(),
                     )

--- a/styles/src/styleTree/selectorModal.ts
+++ b/styles/src/styleTree/selectorModal.ts
@@ -50,10 +50,6 @@ export default function selectorModal(theme: Theme): Object {
         top: 7,
       },
     },
-    margin: {
-      bottom: 52,
-      top: 52,
-    },
     shadow: shadow(theme),
   };
 }

--- a/styles/src/styleTree/workspace.ts
+++ b/styles/src/styleTree/workspace.ts
@@ -75,6 +75,13 @@ export default function workspace(theme: Theme) {
     leaderBorderWidth: 2.0,
     tab,
     activeTab,
+    modal: {
+      margin: {
+        bottom: 52,
+        top: 52,
+      },
+      cursor: "Arrow"
+    },
     leftSidebar: {
       ...sidebar,
       border: border(theme, "primary", { right: true }),


### PR DESCRIPTION
In this PR, we drop our previous imperative approach to setting the cursor style and instead decide on the cursor style for specific regions of the window during paint. The scene builds up a series of (rect, style) pairs and then we select the style based on the frontmost rectangle pushed into the scene.