### PR TITLE
Add solarized dark and light syntax themes

### DIFF
--- a/assets/themes/solarized-dark.json
+++ b/assets/themes/solarized-dark.json
@@ -1,0 +1,1338 @@
+{
+  "selector": {
+    "background": "#073642",
+    "corner_radius": 8,
+    "padding": 8,
+    "item": {
+      "padding": {
+        "bottom": 4,
+        "left": 12,
+        "right": 12,
+        "top": 4
+      },
+      "corner_radius": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "highlight_text": {
+        "family": "Zed Sans",
+        "color": "#268bd2",
+        "weight": "bold",
+        "size": 14
+      }
+    },
+    "active_item": {
+      "padding": {
+        "bottom": 4,
+        "left": 12,
+        "right": 12,
+        "top": 4
+      },
+      "corner_radius": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#eee8d5",
+        "size": 14
+      },
+      "highlight_text": {
+        "family": "Zed Sans",
+        "color": "#268bd2",
+        "weight": "bold",
+        "size": 14
+      },
+      "background": "#586e75"
+    },
+    "border": {
+      "color": "#002b36",
+      "width": 1
+    },
+    "empty": {
+      "text": {
+        "family": "Zed Sans",
+        "color": "#839496",
+        "size": 14
+      },
+      "padding": {
+        "bottom": 4,
+        "left": 12,
+        "right": 12,
+        "top": 8
+      }
+    },
+    "input_editor": {
+      "background": "#002b36",
+      "corner_radius": 8,
+      "placeholder_text": {
+        "family": "Zed Sans",
+        "color": "#839496",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "text": {
+        "family": "Zed Mono",
+        "color": "#eee8d5",
+        "size": 14
+      },
+      "border": {
+        "color": "#073642",
+        "width": 1
+      },
+      "padding": {
+        "bottom": 7,
+        "left": 16,
+        "right": 16,
+        "top": 7
+      }
+    },
+    "margin": {
+      "bottom": 52,
+      "top": 52
+    },
+    "shadow": {
+      "blur": 16,
+      "color": "#00000052",
+      "offset": [
+        0,
+        2
+      ]
+    }
+  },
+  "workspace": {
+    "background": "#073642",
+    "leader_border_opacity": 0.7,
+    "leader_border_width": 2,
+    "tab": {
+      "height": 32,
+      "background": "#073642",
+      "icon_close": "#93a1a1",
+      "icon_close_active": "#fdf6e3",
+      "icon_conflict": "#b58900",
+      "icon_dirty": "#268bd2",
+      "icon_width": 8,
+      "spacing": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "border": {
+        "color": "#002b36",
+        "width": 1,
+        "left": true,
+        "bottom": true,
+        "overlay": true
+      },
+      "padding": {
+        "left": 8,
+        "right": 8
+      }
+    },
+    "active_tab": {
+      "height": 32,
+      "background": "#002b36",
+      "icon_close": "#93a1a1",
+      "icon_close_active": "#fdf6e3",
+      "icon_conflict": "#b58900",
+      "icon_dirty": "#268bd2",
+      "icon_width": 8,
+      "spacing": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#fdf6e3",
+        "size": 14
+      },
+      "border": {
+        "color": "#002b36",
+        "width": 1,
+        "left": true,
+        "bottom": false,
+        "overlay": true
+      },
+      "padding": {
+        "left": 8,
+        "right": 8
+      }
+    },
+    "left_sidebar": {
+      "width": 30,
+      "background": "#073642",
+      "border": {
+        "color": "#002b36",
+        "width": 1,
+        "right": true
+      },
+      "item": {
+        "height": 32,
+        "icon_color": "#93a1a1",
+        "icon_size": 18
+      },
+      "active_item": {
+        "height": 32,
+        "icon_color": "#fdf6e3",
+        "icon_size": 18
+      },
+      "resize_handle": {
+        "background": "#002b36",
+        "padding": {
+          "left": 1
+        }
+      }
+    },
+    "right_sidebar": {
+      "width": 30,
+      "background": "#073642",
+      "border": {
+        "color": "#002b36",
+        "width": 1,
+        "left": true
+      },
+      "item": {
+        "height": 32,
+        "icon_color": "#93a1a1",
+        "icon_size": 18
+      },
+      "active_item": {
+        "height": 32,
+        "icon_color": "#fdf6e3",
+        "icon_size": 18
+      },
+      "resize_handle": {
+        "background": "#002b36",
+        "padding": {
+          "left": 1
+        }
+      }
+    },
+    "pane_divider": {
+      "color": "#073642",
+      "width": 1
+    },
+    "status_bar": {
+      "height": 24,
+      "item_spacing": 8,
+      "padding": {
+        "left": 6,
+        "right": 6
+      },
+      "border": {
+        "color": "#002b36",
+        "width": 1,
+        "top": true,
+        "overlay": true
+      },
+      "cursor_position": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "diagnostic_message": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "lsp_message": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "auto_update_progress_message": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "auto_update_done_message": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      }
+    },
+    "titlebar": {
+      "avatar_width": 18,
+      "height": 32,
+      "background": "#073642",
+      "share_icon_color": "#93a1a1",
+      "share_icon_active_color": "#268bd2",
+      "title": {
+        "family": "Zed Sans",
+        "color": "#eee8d5",
+        "size": 14
+      },
+      "avatar": {
+        "corner_radius": 10,
+        "border": {
+          "color": "#00000088",
+          "width": 1
+        }
+      },
+      "avatar_ribbon": {
+        "height": 3,
+        "width": 12
+      },
+      "border": {
+        "color": "#002b36",
+        "width": 1,
+        "bottom": true
+      },
+      "sign_in_prompt": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 12,
+        "border": {
+          "color": "#002b36",
+          "width": 1
+        },
+        "corner_radius": 6,
+        "margin": {
+          "top": 1,
+          "right": 6
+        },
+        "padding": {
+          "left": 6,
+          "right": 6
+        }
+      },
+      "hovered_sign_in_prompt": {
+        "family": "Zed Sans",
+        "color": "#fdf6e3",
+        "size": 12,
+        "border": {
+          "color": "#002b36",
+          "width": 1
+        },
+        "corner_radius": 6,
+        "margin": {
+          "top": 1,
+          "right": 6
+        },
+        "padding": {
+          "left": 6,
+          "right": 6
+        }
+      },
+      "offline_icon": {
+        "color": "#93a1a1",
+        "width": 16,
+        "padding": {
+          "right": 4
+        }
+      },
+      "outdated_warning": {
+        "family": "Zed Sans",
+        "color": "#b58900",
+        "size": 13
+      }
+    },
+    "toolbar": {
+      "height": 34,
+      "background": "#002b36",
+      "border": {
+        "color": "#073642",
+        "width": 1,
+        "bottom": true
+      },
+      "item_spacing": 8,
+      "padding": {
+        "left": 16,
+        "right": 8,
+        "top": 4,
+        "bottom": 4
+      }
+    },
+    "breadcrumbs": {
+      "family": "Zed Mono",
+      "color": "#93a1a1",
+      "size": 14,
+      "padding": {
+        "left": 6
+      }
+    },
+    "disconnected_overlay": {
+      "family": "Zed Sans",
+      "color": "#fdf6e3",
+      "size": 14,
+      "background": "#000000aa"
+    }
+  },
+  "editor": {
+    "text_color": "#fdf6e3",
+    "background": "#002b36",
+    "active_line_background": "#fdf6e312",
+    "code_actions_indicator": "#93a1a1",
+    "diff_background_deleted": "#dc322f",
+    "diff_background_inserted": "#859900",
+    "document_highlight_read_background": "#657b831f",
+    "document_highlight_write_background": "#657b8329",
+    "error_color": "#dc322f",
+    "gutter_background": "#002b36",
+    "gutter_padding_factor": 3.5,
+    "highlighted_line_background": "#fdf6e31f",
+    "line_number": "#839496",
+    "line_number_active": "#fdf6e3",
+    "rename_fade": 0.6,
+    "unnecessary_code_fade": 0.5,
+    "selection": {
+      "cursor": "#268bd2",
+      "selection": "#268bd23d"
+    },
+    "guest_selections": [
+      {
+        "cursor": "#859900",
+        "selection": "#8599003d"
+      },
+      {
+        "cursor": "#d33682",
+        "selection": "#d336823d"
+      },
+      {
+        "cursor": "#cb4b16",
+        "selection": "#cb4b163d"
+      },
+      {
+        "cursor": "#6c71c4",
+        "selection": "#6c71c43d"
+      },
+      {
+        "cursor": "#2aa198",
+        "selection": "#2aa1983d"
+      },
+      {
+        "cursor": "#dc322f",
+        "selection": "#dc322f3d"
+      },
+      {
+        "cursor": "#b58900",
+        "selection": "#b589003d"
+      }
+    ],
+    "autocomplete": {
+      "background": "#002b36",
+      "corner_radius": 8,
+      "padding": 4,
+      "border": {
+        "color": "#073642",
+        "width": 1
+      },
+      "item": {
+        "corner_radius": 6,
+        "padding": {
+          "bottom": 2,
+          "left": 6,
+          "right": 6,
+          "top": 2
+        }
+      },
+      "hovered_item": {
+        "corner_radius": 6,
+        "padding": {
+          "bottom": 2,
+          "left": 6,
+          "right": 6,
+          "top": 2
+        },
+        "background": "#073642"
+      },
+      "margin": {
+        "left": -14
+      },
+      "match_highlight": {
+        "family": "Zed Mono",
+        "color": "#268bd2",
+        "size": 14
+      },
+      "selected_item": {
+        "corner_radius": 6,
+        "padding": {
+          "bottom": 2,
+          "left": 6,
+          "right": 6,
+          "top": 2
+        },
+        "background": "#073642"
+      }
+    },
+    "diagnostic_header": {
+      "background": "#073642",
+      "icon_width_factor": 1.5,
+      "text_scale_factor": 0.857,
+      "border": {
+        "color": "#073642",
+        "width": 1,
+        "bottom": true,
+        "top": true
+      },
+      "code": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 14,
+        "margin": {
+          "left": 10
+        }
+      },
+      "message": {
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#eee8d5",
+          "size": 14,
+          "weight": "bold"
+        },
+        "text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        }
+      }
+    },
+    "diagnostic_path_header": {
+      "background": "#fdf6e312",
+      "text_scale_factor": 0.857,
+      "filename": {
+        "family": "Zed Mono",
+        "color": "#eee8d5",
+        "size": 14
+      },
+      "path": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 14,
+        "margin": {
+          "left": 12
+        }
+      }
+    },
+    "error_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#dc322f",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#dc322f",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "warning_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#b58900",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#b58900",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "information_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "hint_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_error_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_hint_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_information_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_warning_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#002b36",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "syntax": {
+      "keyword": "#268bd2",
+      "function": "#b58900",
+      "string": "#cb4b16",
+      "type": "#2aa198",
+      "number": "#859900",
+      "comment": "#eee8d5",
+      "property": "#268bd2",
+      "variant": "#268bd2",
+      "constant": "#839496",
+      "title": {
+        "color": "#b58900",
+        "weight": "bold"
+      },
+      "emphasis": "#268bd2",
+      "emphasis_strong": {
+        "color": "#268bd2",
+        "weight": "bold"
+      },
+      "link_uri": {
+        "color": "#859900",
+        "underline": true
+      },
+      "link_text": {
+        "color": "#cb4b16",
+        "italic": true
+      },
+      "list_marker": "#93a1a1"
+    }
+  },
+  "project_diagnostics": {
+    "tab_icon_spacing": 4,
+    "tab_icon_width": 13,
+    "tab_summary_spacing": 10,
+    "empty_message": {
+      "family": "Zed Sans",
+      "color": "#eee8d5",
+      "size": 18
+    },
+    "status_bar_item": {
+      "family": "Zed Sans",
+      "color": "#93a1a1",
+      "size": 14,
+      "margin": {
+        "right": 10
+      }
+    }
+  },
+  "command_palette": {
+    "keystroke_spacing": 8,
+    "key": {
+      "text": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 12
+      },
+      "corner_radius": 4,
+      "background": "#073642",
+      "border": {
+        "color": "#073642",
+        "width": 1
+      },
+      "padding": {
+        "top": 2,
+        "bottom": 2,
+        "left": 8,
+        "right": 8
+      },
+      "margin": {
+        "left": 2
+      }
+    }
+  },
+  "project_panel": {
+    "padding": {
+      "top": 6,
+      "left": 12
+    },
+    "entry": {
+      "height": 22,
+      "icon_color": "#93a1a1",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 14
+      }
+    },
+    "hovered_entry": {
+      "height": 22,
+      "background": "#586e75",
+      "icon_color": "#93a1a1",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 14
+      }
+    },
+    "selected_entry": {
+      "height": 22,
+      "icon_color": "#93a1a1",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#eee8d5",
+        "size": 14
+      }
+    },
+    "hovered_selected_entry": {
+      "height": 22,
+      "background": "#586e75",
+      "icon_color": "#93a1a1",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#eee8d5",
+        "size": 14
+      }
+    }
+  },
+  "chat_panel": {
+    "padding": {
+      "top": 12,
+      "left": 12,
+      "bottom": 12,
+      "right": 12
+    },
+    "channel_name": {
+      "family": "Zed Sans",
+      "color": "#eee8d5",
+      "weight": "bold",
+      "size": 14
+    },
+    "channel_name_hash": {
+      "family": "Zed Sans",
+      "color": "#93a1a1",
+      "size": 14,
+      "padding": {
+        "right": 8
+      }
+    },
+    "channel_select": {
+      "header": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#eee8d5",
+          "size": 14
+        },
+        "padding": {
+          "bottom": 4,
+          "left": 0
+        },
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "corner_radius": 0
+      },
+      "item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "corner_radius": 0
+      },
+      "hovered_item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "background": "#586e75",
+        "corner_radius": 6
+      },
+      "active_item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#eee8d5",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "corner_radius": 0
+      },
+      "hovered_active_item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#eee8d5",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#93a1a1",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "background": "#586e75",
+        "corner_radius": 6
+      },
+      "menu": {
+        "background": "#002b36",
+        "corner_radius": 6,
+        "padding": 4,
+        "border": {
+          "color": "#002b36",
+          "width": 1
+        },
+        "shadow": {
+          "blur": 16,
+          "color": "#00000052",
+          "offset": [
+            0,
+            2
+          ]
+        }
+      }
+    },
+    "sign_in_prompt": {
+      "family": "Zed Sans",
+      "color": "#93a1a1",
+      "underline": true,
+      "size": 14
+    },
+    "hovered_sign_in_prompt": {
+      "family": "Zed Sans",
+      "color": "#eee8d5",
+      "underline": true,
+      "size": 14
+    },
+    "message": {
+      "body": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "timestamp": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "padding": {
+        "bottom": 6
+      },
+      "sender": {
+        "family": "Zed Sans",
+        "color": "#eee8d5",
+        "weight": "bold",
+        "size": 14,
+        "margin": {
+          "right": 8
+        }
+      }
+    },
+    "pending_message": {
+      "body": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "timestamp": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "size": 14
+      },
+      "padding": {
+        "bottom": 6
+      },
+      "sender": {
+        "family": "Zed Sans",
+        "color": "#93a1a1",
+        "weight": "bold",
+        "size": 14,
+        "margin": {
+          "right": 8
+        }
+      }
+    },
+    "input_editor": {
+      "background": "#002b36",
+      "corner_radius": 6,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#eee8d5",
+        "size": 14
+      },
+      "placeholder_text": {
+        "family": "Zed Mono",
+        "color": "#839496",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "border": {
+        "color": "#073642",
+        "width": 1
+      },
+      "padding": {
+        "bottom": 7,
+        "left": 8,
+        "right": 8,
+        "top": 7
+      }
+    }
+  },
+  "contacts_panel": {
+    "padding": {
+      "top": 12,
+      "left": 12,
+      "bottom": 12,
+      "right": 12
+    },
+    "host_row_height": 28,
+    "tree_branch_color": "#586e75",
+    "tree_branch_width": 1,
+    "host_avatar": {
+      "corner_radius": 10,
+      "width": 18
+    },
+    "host_username": {
+      "family": "Zed Mono",
+      "color": "#eee8d5",
+      "size": 14,
+      "padding": {
+        "left": 8
+      }
+    },
+    "project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#839496",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      }
+    },
+    "shared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      },
+      "background": "#073642",
+      "corner_radius": 6
+    },
+    "hovered_shared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#93a1a1",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      },
+      "background": "#586e75",
+      "corner_radius": 6
+    },
+    "unshared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#839496",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      }
+    },
+    "hovered_unshared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#839496",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      },
+      "corner_radius": 6
+    }
+  },
+  "search": {
+    "match_background": "#6c71c480",
+    "tab_icon_spacing": 8,
+    "tab_icon_width": 14,
+    "active_hovered_option_button": {
+      "family": "Zed Mono",
+      "color": "#fdf6e3",
+      "size": 14,
+      "background": "#586e75",
+      "corner_radius": 4,
+      "border": {
+        "color": "#586e75",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "active_option_button": {
+      "family": "Zed Mono",
+      "color": "#fdf6e3",
+      "size": 14,
+      "background": "#586e75",
+      "corner_radius": 4,
+      "border": {
+        "color": "#586e75",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "editor": {
+      "background": "#002b36",
+      "corner_radius": 8,
+      "min_width": 200,
+      "max_width": 500,
+      "placeholder_text": {
+        "family": "Zed Mono",
+        "color": "#839496",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "text": {
+        "family": "Zed Mono",
+        "color": "#fdf6e3",
+        "size": 14
+      },
+      "border": {
+        "color": "#073642",
+        "width": 1
+      },
+      "margin": {
+        "right": 6
+      },
+      "padding": {
+        "top": 3,
+        "bottom": 3,
+        "left": 12,
+        "right": 8
+      }
+    },
+    "hovered_option_button": {
+      "family": "Zed Mono",
+      "color": "#fdf6e3",
+      "size": 14,
+      "background": "#073642",
+      "corner_radius": 4,
+      "border": {
+        "color": "#586e75",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "invalid_editor": {
+      "background": "#002b36",
+      "corner_radius": 8,
+      "min_width": 200,
+      "max_width": 500,
+      "placeholder_text": {
+        "family": "Zed Mono",
+        "color": "#839496",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "text": {
+        "family": "Zed Mono",
+        "color": "#fdf6e3",
+        "size": 14
+      },
+      "border": {
+        "color": "#dc322f",
+        "width": 1
+      },
+      "margin": {
+        "right": 6
+      },
+      "padding": {
+        "top": 3,
+        "bottom": 3,
+        "left": 12,
+        "right": 8
+      }
+    },
+    "match_index": {
+      "family": "Zed Mono",
+      "color": "#93a1a1",
+      "size": 14,
+      "padding": 6
+    },
+    "option_button": {
+      "family": "Zed Mono",
+      "color": "#93a1a1",
+      "size": 14,
+      "background": "#073642",
+      "corner_radius": 4,
+      "border": {
+        "color": "#073642",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "option_button_group": {
+      "padding": {
+        "left": 4,
+        "right": 4
+      }
+    },
+    "results_status": {
+      "family": "Zed Mono",
+      "color": "#eee8d5",
+      "size": 18
+    }
+  },
+  "breadcrumbs": {
+    "family": "Zed Sans",
+    "color": "#93a1a1",
+    "size": 14,
+    "padding": {
+      "left": 6
+    }
+  }
+}

--- a/assets/themes/solarized-dark.json
+++ b/assets/themes/solarized-dark.json
@@ -89,10 +89,6 @@
         "top": 7
       }
     },
-    "margin": {
-      "bottom": 52,
-      "top": 52
-    },
     "shadow": {
       "blur": 16,
       "color": "#00000052",
@@ -157,6 +153,13 @@
         "left": 8,
         "right": 8
       }
+    },
+    "modal": {
+      "margin": {
+        "bottom": 52,
+        "top": 52
+      },
+      "cursor": "Arrow"
     },
     "left_sidebar": {
       "width": 30,
@@ -689,33 +692,88 @@
       }
     },
     "syntax": {
-      "keyword": "#268bd2",
-      "function": "#b58900",
-      "string": "#cb4b16",
-      "type": "#2aa198",
-      "number": "#859900",
-      "comment": "#eee8d5",
-      "property": "#268bd2",
-      "variant": "#268bd2",
-      "constant": "#839496",
+      "primary": {
+        "color": "#fdf6e3",
+        "weight": "normal"
+      },
+      "comment": {
+        "color": "#eee8d5",
+        "weight": "normal"
+      },
+      "punctuation": {
+        "color": "#93a1a1",
+        "weight": "normal"
+      },
+      "constant": {
+        "color": "#839496",
+        "weight": "normal"
+      },
+      "keyword": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "function": {
+        "color": "#b58900",
+        "weight": "normal"
+      },
+      "type": {
+        "color": "#2aa198",
+        "weight": "normal"
+      },
+      "variant": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "property": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "enum": {
+        "color": "#cb4b16",
+        "weight": "normal"
+      },
+      "operator": {
+        "color": "#cb4b16",
+        "weight": "normal"
+      },
+      "string": {
+        "color": "#cb4b16",
+        "weight": "normal"
+      },
+      "number": {
+        "color": "#859900",
+        "weight": "normal"
+      },
+      "boolean": {
+        "color": "#859900",
+        "weight": "normal"
+      },
+      "predictive": {
+        "color": "#93a1a1",
+        "weight": "normal"
+      },
       "title": {
         "color": "#b58900",
         "weight": "bold"
       },
-      "emphasis": "#268bd2",
-      "emphasis_strong": {
+      "emphasis": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "emphasis.strong": {
         "color": "#268bd2",
         "weight": "bold"
       },
       "link_uri": {
         "color": "#859900",
+        "weight": "normal",
         "underline": true
       },
       "link_text": {
         "color": "#cb4b16",
+        "weight": "normal",
         "italic": true
-      },
-      "list_marker": "#93a1a1"
+      }
     }
   },
   "project_diagnostics": {

--- a/assets/themes/solarized-dark.json
+++ b/assets/themes/solarized-dark.json
@@ -745,7 +745,7 @@
         "size": 12
       },
       "corner_radius": 4,
-      "background": "#073642",
+      "background": "#002b36",
       "border": {
         "color": "#073642",
         "width": 1

--- a/assets/themes/solarized-light.json
+++ b/assets/themes/solarized-light.json
@@ -89,10 +89,6 @@
         "top": 7
       }
     },
-    "margin": {
-      "bottom": 52,
-      "top": 52
-    },
     "shadow": {
       "blur": 16,
       "color": "#00000052",
@@ -157,6 +153,13 @@
         "left": 8,
         "right": 8
       }
+    },
+    "modal": {
+      "margin": {
+        "bottom": 52,
+        "top": 52
+      },
+      "cursor": "Arrow"
     },
     "left_sidebar": {
       "width": 30,
@@ -689,33 +692,88 @@
       }
     },
     "syntax": {
-      "keyword": "#268bd2",
-      "function": "#b58900",
-      "string": "#cb4b16",
-      "type": "#2aa198",
-      "number": "#859900",
-      "comment": "#073642",
-      "property": "#268bd2",
-      "variant": "#268bd2",
-      "constant": "#657b83",
+      "primary": {
+        "color": "#002b36",
+        "weight": "normal"
+      },
+      "comment": {
+        "color": "#073642",
+        "weight": "normal"
+      },
+      "punctuation": {
+        "color": "#586e75",
+        "weight": "normal"
+      },
+      "constant": {
+        "color": "#657b83",
+        "weight": "normal"
+      },
+      "keyword": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "function": {
+        "color": "#b58900",
+        "weight": "normal"
+      },
+      "type": {
+        "color": "#2aa198",
+        "weight": "normal"
+      },
+      "variant": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "property": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "enum": {
+        "color": "#cb4b16",
+        "weight": "normal"
+      },
+      "operator": {
+        "color": "#cb4b16",
+        "weight": "normal"
+      },
+      "string": {
+        "color": "#cb4b16",
+        "weight": "normal"
+      },
+      "number": {
+        "color": "#859900",
+        "weight": "normal"
+      },
+      "boolean": {
+        "color": "#859900",
+        "weight": "normal"
+      },
+      "predictive": {
+        "color": "#586e75",
+        "weight": "normal"
+      },
       "title": {
         "color": "#b58900",
         "weight": "bold"
       },
-      "emphasis": "#268bd2",
-      "emphasis_strong": {
+      "emphasis": {
+        "color": "#268bd2",
+        "weight": "normal"
+      },
+      "emphasis.strong": {
         "color": "#268bd2",
         "weight": "bold"
       },
       "link_uri": {
         "color": "#859900",
+        "weight": "normal",
         "underline": true
       },
       "link_text": {
         "color": "#cb4b16",
+        "weight": "normal",
         "italic": true
-      },
-      "list_marker": "#586e75"
+      }
     }
   },
   "project_diagnostics": {

--- a/assets/themes/solarized-light.json
+++ b/assets/themes/solarized-light.json
@@ -745,7 +745,7 @@
         "size": 12
       },
       "corner_radius": 4,
-      "background": "#eee8d5",
+      "background": "#fdf6e3",
       "border": {
         "color": "#eee8d5",
         "width": 1

--- a/assets/themes/solarized-light.json
+++ b/assets/themes/solarized-light.json
@@ -1,0 +1,1338 @@
+{
+  "selector": {
+    "background": "#eee8d5",
+    "corner_radius": 8,
+    "padding": 8,
+    "item": {
+      "padding": {
+        "bottom": 4,
+        "left": 12,
+        "right": 12,
+        "top": 4
+      },
+      "corner_radius": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "highlight_text": {
+        "family": "Zed Sans",
+        "color": "#268bd2",
+        "weight": "bold",
+        "size": 14
+      }
+    },
+    "active_item": {
+      "padding": {
+        "bottom": 4,
+        "left": 12,
+        "right": 12,
+        "top": 4
+      },
+      "corner_radius": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#073642",
+        "size": 14
+      },
+      "highlight_text": {
+        "family": "Zed Sans",
+        "color": "#268bd2",
+        "weight": "bold",
+        "size": 14
+      },
+      "background": "#93a1a1"
+    },
+    "border": {
+      "color": "#fdf6e3",
+      "width": 1
+    },
+    "empty": {
+      "text": {
+        "family": "Zed Sans",
+        "color": "#657b83",
+        "size": 14
+      },
+      "padding": {
+        "bottom": 4,
+        "left": 12,
+        "right": 12,
+        "top": 8
+      }
+    },
+    "input_editor": {
+      "background": "#fdf6e3",
+      "corner_radius": 8,
+      "placeholder_text": {
+        "family": "Zed Sans",
+        "color": "#657b83",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "text": {
+        "family": "Zed Mono",
+        "color": "#073642",
+        "size": 14
+      },
+      "border": {
+        "color": "#eee8d5",
+        "width": 1
+      },
+      "padding": {
+        "bottom": 7,
+        "left": 16,
+        "right": 16,
+        "top": 7
+      }
+    },
+    "margin": {
+      "bottom": 52,
+      "top": 52
+    },
+    "shadow": {
+      "blur": 16,
+      "color": "#00000052",
+      "offset": [
+        0,
+        2
+      ]
+    }
+  },
+  "workspace": {
+    "background": "#eee8d5",
+    "leader_border_opacity": 0.7,
+    "leader_border_width": 2,
+    "tab": {
+      "height": 32,
+      "background": "#eee8d5",
+      "icon_close": "#586e75",
+      "icon_close_active": "#002b36",
+      "icon_conflict": "#b58900",
+      "icon_dirty": "#268bd2",
+      "icon_width": 8,
+      "spacing": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "border": {
+        "color": "#fdf6e3",
+        "width": 1,
+        "left": true,
+        "bottom": true,
+        "overlay": true
+      },
+      "padding": {
+        "left": 8,
+        "right": 8
+      }
+    },
+    "active_tab": {
+      "height": 32,
+      "background": "#fdf6e3",
+      "icon_close": "#586e75",
+      "icon_close_active": "#002b36",
+      "icon_conflict": "#b58900",
+      "icon_dirty": "#268bd2",
+      "icon_width": 8,
+      "spacing": 8,
+      "text": {
+        "family": "Zed Sans",
+        "color": "#002b36",
+        "size": 14
+      },
+      "border": {
+        "color": "#fdf6e3",
+        "width": 1,
+        "left": true,
+        "bottom": false,
+        "overlay": true
+      },
+      "padding": {
+        "left": 8,
+        "right": 8
+      }
+    },
+    "left_sidebar": {
+      "width": 30,
+      "background": "#eee8d5",
+      "border": {
+        "color": "#fdf6e3",
+        "width": 1,
+        "right": true
+      },
+      "item": {
+        "height": 32,
+        "icon_color": "#586e75",
+        "icon_size": 18
+      },
+      "active_item": {
+        "height": 32,
+        "icon_color": "#002b36",
+        "icon_size": 18
+      },
+      "resize_handle": {
+        "background": "#fdf6e3",
+        "padding": {
+          "left": 1
+        }
+      }
+    },
+    "right_sidebar": {
+      "width": 30,
+      "background": "#eee8d5",
+      "border": {
+        "color": "#fdf6e3",
+        "width": 1,
+        "left": true
+      },
+      "item": {
+        "height": 32,
+        "icon_color": "#586e75",
+        "icon_size": 18
+      },
+      "active_item": {
+        "height": 32,
+        "icon_color": "#002b36",
+        "icon_size": 18
+      },
+      "resize_handle": {
+        "background": "#fdf6e3",
+        "padding": {
+          "left": 1
+        }
+      }
+    },
+    "pane_divider": {
+      "color": "#eee8d5",
+      "width": 1
+    },
+    "status_bar": {
+      "height": 24,
+      "item_spacing": 8,
+      "padding": {
+        "left": 6,
+        "right": 6
+      },
+      "border": {
+        "color": "#fdf6e3",
+        "width": 1,
+        "top": true,
+        "overlay": true
+      },
+      "cursor_position": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "diagnostic_message": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "lsp_message": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "auto_update_progress_message": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "auto_update_done_message": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      }
+    },
+    "titlebar": {
+      "avatar_width": 18,
+      "height": 32,
+      "background": "#eee8d5",
+      "share_icon_color": "#586e75",
+      "share_icon_active_color": "#268bd2",
+      "title": {
+        "family": "Zed Sans",
+        "color": "#073642",
+        "size": 14
+      },
+      "avatar": {
+        "corner_radius": 10,
+        "border": {
+          "color": "#00000088",
+          "width": 1
+        }
+      },
+      "avatar_ribbon": {
+        "height": 3,
+        "width": 12
+      },
+      "border": {
+        "color": "#fdf6e3",
+        "width": 1,
+        "bottom": true
+      },
+      "sign_in_prompt": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 12,
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1
+        },
+        "corner_radius": 6,
+        "margin": {
+          "top": 1,
+          "right": 6
+        },
+        "padding": {
+          "left": 6,
+          "right": 6
+        }
+      },
+      "hovered_sign_in_prompt": {
+        "family": "Zed Sans",
+        "color": "#002b36",
+        "size": 12,
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1
+        },
+        "corner_radius": 6,
+        "margin": {
+          "top": 1,
+          "right": 6
+        },
+        "padding": {
+          "left": 6,
+          "right": 6
+        }
+      },
+      "offline_icon": {
+        "color": "#586e75",
+        "width": 16,
+        "padding": {
+          "right": 4
+        }
+      },
+      "outdated_warning": {
+        "family": "Zed Sans",
+        "color": "#b58900",
+        "size": 13
+      }
+    },
+    "toolbar": {
+      "height": 34,
+      "background": "#fdf6e3",
+      "border": {
+        "color": "#eee8d5",
+        "width": 1,
+        "bottom": true
+      },
+      "item_spacing": 8,
+      "padding": {
+        "left": 16,
+        "right": 8,
+        "top": 4,
+        "bottom": 4
+      }
+    },
+    "breadcrumbs": {
+      "family": "Zed Mono",
+      "color": "#586e75",
+      "size": 14,
+      "padding": {
+        "left": 6
+      }
+    },
+    "disconnected_overlay": {
+      "family": "Zed Sans",
+      "color": "#002b36",
+      "size": 14,
+      "background": "#000000aa"
+    }
+  },
+  "editor": {
+    "text_color": "#002b36",
+    "background": "#fdf6e3",
+    "active_line_background": "#002b3612",
+    "code_actions_indicator": "#586e75",
+    "diff_background_deleted": "#dc322f",
+    "diff_background_inserted": "#859900",
+    "document_highlight_read_background": "#8394961f",
+    "document_highlight_write_background": "#83949629",
+    "error_color": "#dc322f",
+    "gutter_background": "#fdf6e3",
+    "gutter_padding_factor": 3.5,
+    "highlighted_line_background": "#002b361f",
+    "line_number": "#657b83",
+    "line_number_active": "#002b36",
+    "rename_fade": 0.6,
+    "unnecessary_code_fade": 0.5,
+    "selection": {
+      "cursor": "#268bd2",
+      "selection": "#268bd23d"
+    },
+    "guest_selections": [
+      {
+        "cursor": "#859900",
+        "selection": "#8599003d"
+      },
+      {
+        "cursor": "#d33682",
+        "selection": "#d336823d"
+      },
+      {
+        "cursor": "#cb4b16",
+        "selection": "#cb4b163d"
+      },
+      {
+        "cursor": "#6c71c4",
+        "selection": "#6c71c43d"
+      },
+      {
+        "cursor": "#2aa198",
+        "selection": "#2aa1983d"
+      },
+      {
+        "cursor": "#dc322f",
+        "selection": "#dc322f3d"
+      },
+      {
+        "cursor": "#b58900",
+        "selection": "#b589003d"
+      }
+    ],
+    "autocomplete": {
+      "background": "#fdf6e3",
+      "corner_radius": 8,
+      "padding": 4,
+      "border": {
+        "color": "#eee8d5",
+        "width": 1
+      },
+      "item": {
+        "corner_radius": 6,
+        "padding": {
+          "bottom": 2,
+          "left": 6,
+          "right": 6,
+          "top": 2
+        }
+      },
+      "hovered_item": {
+        "corner_radius": 6,
+        "padding": {
+          "bottom": 2,
+          "left": 6,
+          "right": 6,
+          "top": 2
+        },
+        "background": "#eee8d5"
+      },
+      "margin": {
+        "left": -14
+      },
+      "match_highlight": {
+        "family": "Zed Mono",
+        "color": "#268bd2",
+        "size": 14
+      },
+      "selected_item": {
+        "corner_radius": 6,
+        "padding": {
+          "bottom": 2,
+          "left": 6,
+          "right": 6,
+          "top": 2
+        },
+        "background": "#eee8d5"
+      }
+    },
+    "diagnostic_header": {
+      "background": "#eee8d5",
+      "icon_width_factor": 1.5,
+      "text_scale_factor": 0.857,
+      "border": {
+        "color": "#eee8d5",
+        "width": 1,
+        "bottom": true,
+        "top": true
+      },
+      "code": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 14,
+        "margin": {
+          "left": 10
+        }
+      },
+      "message": {
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#073642",
+          "size": 14,
+          "weight": "bold"
+        },
+        "text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        }
+      }
+    },
+    "diagnostic_path_header": {
+      "background": "#002b3612",
+      "text_scale_factor": 0.857,
+      "filename": {
+        "family": "Zed Mono",
+        "color": "#073642",
+        "size": 14
+      },
+      "path": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 14,
+        "margin": {
+          "left": 12
+        }
+      }
+    },
+    "error_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#dc322f",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#dc322f",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "warning_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#b58900",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#b58900",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "information_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "hint_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#268bd2",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_error_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_hint_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_information_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "invalid_warning_diagnostic": {
+      "text_scale_factor": 0.857,
+      "header": {
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1,
+          "top": true
+        }
+      },
+      "message": {
+        "text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        },
+        "highlight_text": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "weight": "bold"
+        }
+      }
+    },
+    "syntax": {
+      "keyword": "#268bd2",
+      "function": "#b58900",
+      "string": "#cb4b16",
+      "type": "#2aa198",
+      "number": "#859900",
+      "comment": "#073642",
+      "property": "#268bd2",
+      "variant": "#268bd2",
+      "constant": "#657b83",
+      "title": {
+        "color": "#b58900",
+        "weight": "bold"
+      },
+      "emphasis": "#268bd2",
+      "emphasis_strong": {
+        "color": "#268bd2",
+        "weight": "bold"
+      },
+      "link_uri": {
+        "color": "#859900",
+        "underline": true
+      },
+      "link_text": {
+        "color": "#cb4b16",
+        "italic": true
+      },
+      "list_marker": "#586e75"
+    }
+  },
+  "project_diagnostics": {
+    "tab_icon_spacing": 4,
+    "tab_icon_width": 13,
+    "tab_summary_spacing": 10,
+    "empty_message": {
+      "family": "Zed Sans",
+      "color": "#073642",
+      "size": 18
+    },
+    "status_bar_item": {
+      "family": "Zed Sans",
+      "color": "#586e75",
+      "size": 14,
+      "margin": {
+        "right": 10
+      }
+    }
+  },
+  "command_palette": {
+    "keystroke_spacing": 8,
+    "key": {
+      "text": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 12
+      },
+      "corner_radius": 4,
+      "background": "#eee8d5",
+      "border": {
+        "color": "#eee8d5",
+        "width": 1
+      },
+      "padding": {
+        "top": 2,
+        "bottom": 2,
+        "left": 8,
+        "right": 8
+      },
+      "margin": {
+        "left": 2
+      }
+    }
+  },
+  "project_panel": {
+    "padding": {
+      "top": 6,
+      "left": 12
+    },
+    "entry": {
+      "height": 22,
+      "icon_color": "#586e75",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 14
+      }
+    },
+    "hovered_entry": {
+      "height": 22,
+      "background": "#93a1a1",
+      "icon_color": "#586e75",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 14
+      }
+    },
+    "selected_entry": {
+      "height": 22,
+      "icon_color": "#586e75",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#073642",
+        "size": 14
+      }
+    },
+    "hovered_selected_entry": {
+      "height": 22,
+      "background": "#93a1a1",
+      "icon_color": "#586e75",
+      "icon_size": 8,
+      "icon_spacing": 8,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#073642",
+        "size": 14
+      }
+    }
+  },
+  "chat_panel": {
+    "padding": {
+      "top": 12,
+      "left": 12,
+      "bottom": 12,
+      "right": 12
+    },
+    "channel_name": {
+      "family": "Zed Sans",
+      "color": "#073642",
+      "weight": "bold",
+      "size": 14
+    },
+    "channel_name_hash": {
+      "family": "Zed Sans",
+      "color": "#586e75",
+      "size": 14,
+      "padding": {
+        "right": 8
+      }
+    },
+    "channel_select": {
+      "header": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#073642",
+          "size": 14
+        },
+        "padding": {
+          "bottom": 4,
+          "left": 0
+        },
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "corner_radius": 0
+      },
+      "item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "corner_radius": 0
+      },
+      "hovered_item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "background": "#93a1a1",
+        "corner_radius": 6
+      },
+      "active_item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#073642",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "corner_radius": 0
+      },
+      "hovered_active_item": {
+        "name": {
+          "family": "Zed Sans",
+          "color": "#073642",
+          "size": 14
+        },
+        "padding": 4,
+        "hash": {
+          "family": "Zed Sans",
+          "color": "#586e75",
+          "size": 14,
+          "margin": {
+            "right": 8
+          }
+        },
+        "background": "#93a1a1",
+        "corner_radius": 6
+      },
+      "menu": {
+        "background": "#fdf6e3",
+        "corner_radius": 6,
+        "padding": 4,
+        "border": {
+          "color": "#fdf6e3",
+          "width": 1
+        },
+        "shadow": {
+          "blur": 16,
+          "color": "#00000052",
+          "offset": [
+            0,
+            2
+          ]
+        }
+      }
+    },
+    "sign_in_prompt": {
+      "family": "Zed Sans",
+      "color": "#586e75",
+      "underline": true,
+      "size": 14
+    },
+    "hovered_sign_in_prompt": {
+      "family": "Zed Sans",
+      "color": "#073642",
+      "underline": true,
+      "size": 14
+    },
+    "message": {
+      "body": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "timestamp": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "padding": {
+        "bottom": 6
+      },
+      "sender": {
+        "family": "Zed Sans",
+        "color": "#073642",
+        "weight": "bold",
+        "size": 14,
+        "margin": {
+          "right": 8
+        }
+      }
+    },
+    "pending_message": {
+      "body": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "timestamp": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "size": 14
+      },
+      "padding": {
+        "bottom": 6
+      },
+      "sender": {
+        "family": "Zed Sans",
+        "color": "#586e75",
+        "weight": "bold",
+        "size": 14,
+        "margin": {
+          "right": 8
+        }
+      }
+    },
+    "input_editor": {
+      "background": "#fdf6e3",
+      "corner_radius": 6,
+      "text": {
+        "family": "Zed Mono",
+        "color": "#073642",
+        "size": 14
+      },
+      "placeholder_text": {
+        "family": "Zed Mono",
+        "color": "#657b83",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "border": {
+        "color": "#eee8d5",
+        "width": 1
+      },
+      "padding": {
+        "bottom": 7,
+        "left": 8,
+        "right": 8,
+        "top": 7
+      }
+    }
+  },
+  "contacts_panel": {
+    "padding": {
+      "top": 12,
+      "left": 12,
+      "bottom": 12,
+      "right": 12
+    },
+    "host_row_height": 28,
+    "tree_branch_color": "#93a1a1",
+    "tree_branch_width": 1,
+    "host_avatar": {
+      "corner_radius": 10,
+      "width": 18
+    },
+    "host_username": {
+      "family": "Zed Mono",
+      "color": "#073642",
+      "size": 14,
+      "padding": {
+        "left": 8
+      }
+    },
+    "project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#657b83",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      }
+    },
+    "shared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      },
+      "background": "#eee8d5",
+      "corner_radius": 6
+    },
+    "hovered_shared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#586e75",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      },
+      "background": "#93a1a1",
+      "corner_radius": 6
+    },
+    "unshared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#657b83",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      }
+    },
+    "hovered_unshared_project": {
+      "guest_avatar_spacing": 4,
+      "height": 24,
+      "guest_avatar": {
+        "corner_radius": 8,
+        "width": 14
+      },
+      "name": {
+        "family": "Zed Mono",
+        "color": "#657b83",
+        "size": 14,
+        "margin": {
+          "right": 6
+        }
+      },
+      "padding": {
+        "left": 8
+      },
+      "corner_radius": 6
+    }
+  },
+  "search": {
+    "match_background": "#6c71c480",
+    "tab_icon_spacing": 8,
+    "tab_icon_width": 14,
+    "active_hovered_option_button": {
+      "family": "Zed Mono",
+      "color": "#002b36",
+      "size": 14,
+      "background": "#93a1a1",
+      "corner_radius": 4,
+      "border": {
+        "color": "#93a1a1",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "active_option_button": {
+      "family": "Zed Mono",
+      "color": "#002b36",
+      "size": 14,
+      "background": "#93a1a1",
+      "corner_radius": 4,
+      "border": {
+        "color": "#93a1a1",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "editor": {
+      "background": "#fdf6e3",
+      "corner_radius": 8,
+      "min_width": 200,
+      "max_width": 500,
+      "placeholder_text": {
+        "family": "Zed Mono",
+        "color": "#657b83",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "text": {
+        "family": "Zed Mono",
+        "color": "#002b36",
+        "size": 14
+      },
+      "border": {
+        "color": "#eee8d5",
+        "width": 1
+      },
+      "margin": {
+        "right": 6
+      },
+      "padding": {
+        "top": 3,
+        "bottom": 3,
+        "left": 12,
+        "right": 8
+      }
+    },
+    "hovered_option_button": {
+      "family": "Zed Mono",
+      "color": "#002b36",
+      "size": 14,
+      "background": "#eee8d5",
+      "corner_radius": 4,
+      "border": {
+        "color": "#93a1a1",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "invalid_editor": {
+      "background": "#fdf6e3",
+      "corner_radius": 8,
+      "min_width": 200,
+      "max_width": 500,
+      "placeholder_text": {
+        "family": "Zed Mono",
+        "color": "#657b83",
+        "size": 14
+      },
+      "selection": {
+        "cursor": "#268bd2",
+        "selection": "#268bd23d"
+      },
+      "text": {
+        "family": "Zed Mono",
+        "color": "#002b36",
+        "size": 14
+      },
+      "border": {
+        "color": "#dc322f",
+        "width": 1
+      },
+      "margin": {
+        "right": 6
+      },
+      "padding": {
+        "top": 3,
+        "bottom": 3,
+        "left": 12,
+        "right": 8
+      }
+    },
+    "match_index": {
+      "family": "Zed Mono",
+      "color": "#586e75",
+      "size": 14,
+      "padding": 6
+    },
+    "option_button": {
+      "family": "Zed Mono",
+      "color": "#586e75",
+      "size": 14,
+      "background": "#eee8d5",
+      "corner_radius": 4,
+      "border": {
+        "color": "#eee8d5",
+        "width": 1
+      },
+      "margin": {
+        "left": 2,
+        "right": 2
+      },
+      "padding": {
+        "bottom": 3,
+        "left": 8,
+        "right": 8,
+        "top": 3
+      }
+    },
+    "option_button_group": {
+      "padding": {
+        "left": 4,
+        "right": 4
+      }
+    },
+    "results_status": {
+      "family": "Zed Mono",
+      "color": "#073642",
+      "size": 18
+    }
+  },
+  "breadcrumbs": {
+    "family": "Zed Sans",
+    "color": "#586e75",
+    "size": 14,
+    "padding": {
+      "left": 6
+    }
+  }
+}

--- a/styles/dist/solarized-dark.json
+++ b/styles/dist/solarized-dark.json
@@ -1,0 +1,567 @@
+{
+  "meta": {
+    "themeName": "solarized-dark"
+  },
+  "text": {
+    "primary": {
+      "value": "#fdf6e3",
+      "type": "color"
+    },
+    "secondary": {
+      "value": "#eee8d5",
+      "type": "color"
+    },
+    "muted": {
+      "value": "#839496",
+      "type": "color"
+    },
+    "placeholder": {
+      "value": "#839496",
+      "type": "color"
+    },
+    "active": {
+      "value": "#002b36",
+      "type": "color"
+    },
+    "feature": {
+      "value": "#268bd2",
+      "type": "color"
+    },
+    "ok": {
+      "value": "#859900",
+      "type": "color"
+    },
+    "error": {
+      "value": "#dc322f",
+      "type": "color"
+    },
+    "warning": {
+      "value": "#b58900",
+      "type": "color"
+    },
+    "info": {
+      "value": "#268bd2",
+      "type": "color"
+    }
+  },
+  "icon": {
+    "primary": {
+      "value": "#fdf6e3",
+      "type": "color"
+    },
+    "secondary": {
+      "value": "#eee8d5",
+      "type": "color"
+    },
+    "muted": {
+      "value": "#839496",
+      "type": "color"
+    },
+    "placeholder": {
+      "value": "#839496",
+      "type": "color"
+    },
+    "active": {
+      "value": "#002b36",
+      "type": "color"
+    },
+    "feature": {
+      "value": "#268bd2",
+      "type": "color"
+    },
+    "ok": {
+      "value": "#859900",
+      "type": "color"
+    },
+    "error": {
+      "value": "#dc322f",
+      "type": "color"
+    },
+    "warning": {
+      "value": "#b58900",
+      "type": "color"
+    },
+    "info": {
+      "value": "#268bd2",
+      "type": "color"
+    }
+  },
+  "background": {
+    "100": {
+      "base": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#002b36",
+        "type": "color"
+      },
+      "active": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#657b83",
+        "type": "color"
+      }
+    },
+    "300": {
+      "base": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "active": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#839496",
+        "type": "color"
+      }
+    },
+    "500": {
+      "base": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "active": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#839496",
+        "type": "color"
+      }
+    },
+    "on300": {
+      "base": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "active": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#839496",
+        "type": "color"
+      }
+    },
+    "on500": {
+      "base": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "active": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#839496",
+        "type": "color"
+      }
+    },
+    "ok": {
+      "base": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "active": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#859900",
+        "type": "color"
+      }
+    },
+    "error": {
+      "base": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "active": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#dc322f",
+        "type": "color"
+      }
+    },
+    "warning": {
+      "base": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "active": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#b58900",
+        "type": "color"
+      }
+    },
+    "info": {
+      "base": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "hovered": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "active": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    }
+  },
+  "border": {
+    "primary": {
+      "value": "#657b83",
+      "type": "color"
+    },
+    "secondary": {
+      "value": "#586e75",
+      "type": "color"
+    },
+    "muted": {
+      "value": "#073642",
+      "type": "color"
+    },
+    "focused": {
+      "value": "#002b36",
+      "type": "color"
+    },
+    "active": {
+      "value": "#839496",
+      "type": "color"
+    },
+    "ok": {
+      "value": "#859900",
+      "type": "color"
+    },
+    "error": {
+      "value": "#dc322f",
+      "type": "color"
+    },
+    "warning": {
+      "value": "#b58900",
+      "type": "color"
+    },
+    "info": {
+      "value": "#268bd2",
+      "type": "color"
+    }
+  },
+  "editor": {
+    "background": {
+      "value": "#657b83",
+      "type": "color"
+    },
+    "indent_guide": {
+      "value": "#073642",
+      "type": "color"
+    },
+    "indent_guide_active": {
+      "value": "#586e75",
+      "type": "color"
+    },
+    "line": {
+      "active": {
+        "value": "#002b3612",
+        "type": "color"
+      },
+      "highlighted": {
+        "value": "#002b361f",
+        "type": "color"
+      },
+      "inserted": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "deleted": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "modified": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "highlight": {
+      "selection": {
+        "value": "#268bd23d",
+        "type": "color"
+      },
+      "occurrence": {
+        "value": "#002b361f",
+        "type": "color"
+      },
+      "activeOccurrence": {
+        "value": "#002b3629",
+        "type": "color"
+      },
+      "matchingBracket": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "match": {
+        "value": "#6c71c480",
+        "type": "color"
+      },
+      "activeMatch": {
+        "value": "#6c71c4b3",
+        "type": "color"
+      },
+      "related": {
+        "value": "#839496",
+        "type": "color"
+      }
+    },
+    "gutter": {
+      "primary": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "active": {
+        "value": "#002b36",
+        "type": "color"
+      }
+    }
+  },
+  "syntax": {
+    "primary": {
+      "value": "#fdf6e3",
+      "type": "color"
+    },
+    "comment": {
+      "value": "#eee8d5",
+      "type": "color"
+    },
+    "keyword": {
+      "value": "#268bd2",
+      "type": "color"
+    },
+    "function": {
+      "value": "#b58900",
+      "type": "color"
+    },
+    "type": {
+      "value": "#2aa198",
+      "type": "color"
+    },
+    "variant": {
+      "value": "#268bd2",
+      "type": "color"
+    },
+    "property": {
+      "value": "#268bd2",
+      "type": "color"
+    },
+    "enum": {
+      "value": "#cb4b16",
+      "type": "color"
+    },
+    "operator": {
+      "value": "#cb4b16",
+      "type": "color"
+    },
+    "string": {
+      "value": "#cb4b16",
+      "type": "color"
+    },
+    "number": {
+      "value": "#859900",
+      "type": "color"
+    },
+    "boolean": {
+      "value": "#859900",
+      "type": "color"
+    }
+  },
+  "player": {
+    "1": {
+      "baseColor": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#268bd23d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#268bd2cc",
+        "type": "color"
+      }
+    },
+    "2": {
+      "baseColor": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#8599003d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#859900cc",
+        "type": "color"
+      }
+    },
+    "3": {
+      "baseColor": {
+        "value": "#d33682",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#d33682",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#d336823d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#d33682cc",
+        "type": "color"
+      }
+    },
+    "4": {
+      "baseColor": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#cb4b163d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#cb4b16cc",
+        "type": "color"
+      }
+    },
+    "5": {
+      "baseColor": {
+        "value": "#6c71c4",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#6c71c4",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#6c71c43d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#6c71c4cc",
+        "type": "color"
+      }
+    },
+    "6": {
+      "baseColor": {
+        "value": "#2aa198",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#2aa198",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#2aa1983d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#2aa198cc",
+        "type": "color"
+      }
+    },
+    "7": {
+      "baseColor": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#dc322f3d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#dc322fcc",
+        "type": "color"
+      }
+    },
+    "8": {
+      "baseColor": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "cursorColor": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "selectionColor": {
+        "value": "#b589003d",
+        "type": "color"
+      },
+      "borderColor": {
+        "value": "#b58900cc",
+        "type": "color"
+      }
+    }
+  },
+  "shadowAlpha": {
+    "value": 0.32,
+    "type": "number"
+  }
+}

--- a/styles/dist/solarized-light.json
+++ b/styles/dist/solarized-light.json
@@ -1,26 +1,26 @@
 {
   "meta": {
-    "themeName": "solarized-dark"
+    "themeName": "solarized-light"
   },
   "text": {
     "primary": {
-      "value": "#eee8d5",
+      "value": "#073642",
       "type": "color"
     },
     "secondary": {
-      "value": "#93a1a1",
+      "value": "#586e75",
       "type": "color"
     },
     "muted": {
-      "value": "#93a1a1",
+      "value": "#586e75",
       "type": "color"
     },
     "placeholder": {
-      "value": "#839496",
+      "value": "#657b83",
       "type": "color"
     },
     "active": {
-      "value": "#fdf6e3",
+      "value": "#002b36",
       "type": "color"
     },
     "feature": {
@@ -46,23 +46,23 @@
   },
   "icon": {
     "primary": {
-      "value": "#eee8d5",
+      "value": "#073642",
       "type": "color"
     },
     "secondary": {
-      "value": "#93a1a1",
+      "value": "#586e75",
       "type": "color"
     },
     "muted": {
-      "value": "#93a1a1",
+      "value": "#586e75",
       "type": "color"
     },
     "placeholder": {
-      "value": "#839496",
+      "value": "#657b83",
       "type": "color"
     },
     "active": {
-      "value": "#fdf6e3",
+      "value": "#002b36",
       "type": "color"
     },
     "feature": {
@@ -89,91 +89,91 @@
   "background": {
     "100": {
       "base": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "hovered": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       },
       "active": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       },
       "focused": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       }
     },
     "300": {
       "base": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "hovered": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       },
       "active": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       },
       "focused": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       }
     },
     "500": {
       "base": {
-        "value": "#002b36",
+        "value": "#fdf6e3",
         "type": "color"
       },
       "hovered": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "active": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "focused": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       }
     },
     "on300": {
       "base": {
-        "value": "#002b36",
+        "value": "#fdf6e3",
         "type": "color"
       },
       "hovered": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "active": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "focused": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       }
     },
     "on500": {
       "base": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "hovered": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       },
       "active": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       },
       "focused": {
-        "value": "#586e75",
+        "value": "#93a1a1",
         "type": "color"
       }
     },
@@ -252,23 +252,23 @@
   },
   "border": {
     "primary": {
-      "value": "#002b36",
+      "value": "#fdf6e3",
       "type": "color"
     },
     "secondary": {
-      "value": "#073642",
+      "value": "#eee8d5",
       "type": "color"
     },
     "muted": {
-      "value": "#586e75",
+      "value": "#93a1a1",
       "type": "color"
     },
     "focused": {
-      "value": "#586e75",
+      "value": "#93a1a1",
       "type": "color"
     },
     "active": {
-      "value": "#586e75",
+      "value": "#93a1a1",
       "type": "color"
     },
     "ok": {
@@ -290,24 +290,24 @@
   },
   "editor": {
     "background": {
-      "value": "#002b36",
+      "value": "#fdf6e3",
       "type": "color"
     },
     "indent_guide": {
-      "value": "#586e75",
+      "value": "#93a1a1",
       "type": "color"
     },
     "indent_guide_active": {
-      "value": "#073642",
+      "value": "#eee8d5",
       "type": "color"
     },
     "line": {
       "active": {
-        "value": "#fdf6e312",
+        "value": "#002b3612",
         "type": "color"
       },
       "highlighted": {
-        "value": "#fdf6e31f",
+        "value": "#002b361f",
         "type": "color"
       },
       "inserted": {
@@ -329,15 +329,15 @@
         "type": "color"
       },
       "occurrence": {
-        "value": "#657b831f",
+        "value": "#8394961f",
         "type": "color"
       },
       "activeOccurrence": {
-        "value": "#657b8329",
+        "value": "#83949629",
         "type": "color"
       },
       "matchingBracket": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       },
       "match": {
@@ -349,28 +349,28 @@
         "type": "color"
       },
       "related": {
-        "value": "#073642",
+        "value": "#eee8d5",
         "type": "color"
       }
     },
     "gutter": {
       "primary": {
-        "value": "#839496",
+        "value": "#657b83",
         "type": "color"
       },
       "active": {
-        "value": "#fdf6e3",
+        "value": "#002b36",
         "type": "color"
       }
     }
   },
   "syntax": {
     "primary": {
-      "value": "#fdf6e3",
+      "value": "#002b36",
       "type": "color"
     },
     "comment": {
-      "value": "#eee8d5",
+      "value": "#073642",
       "type": "color"
     },
     "keyword": {

--- a/styles/dist/tokens.json
+++ b/styles/dist/tokens.json
@@ -2522,15 +2522,15 @@
     },
     "text": {
       "primary": {
-        "value": "#fdf6e3",
-        "type": "color"
-      },
-      "secondary": {
         "value": "#eee8d5",
         "type": "color"
       },
+      "secondary": {
+        "value": "#93a1a1",
+        "type": "color"
+      },
       "muted": {
-        "value": "#839496",
+        "value": "#93a1a1",
         "type": "color"
       },
       "placeholder": {
@@ -2538,7 +2538,7 @@
         "type": "color"
       },
       "active": {
-        "value": "#002b36",
+        "value": "#fdf6e3",
         "type": "color"
       },
       "feature": {
@@ -2564,15 +2564,15 @@
     },
     "icon": {
       "primary": {
-        "value": "#fdf6e3",
-        "type": "color"
-      },
-      "secondary": {
         "value": "#eee8d5",
         "type": "color"
       },
+      "secondary": {
+        "value": "#93a1a1",
+        "type": "color"
+      },
       "muted": {
-        "value": "#839496",
+        "value": "#93a1a1",
         "type": "color"
       },
       "placeholder": {
@@ -2580,7 +2580,7 @@
         "type": "color"
       },
       "active": {
-        "value": "#002b36",
+        "value": "#fdf6e3",
         "type": "color"
       },
       "feature": {
@@ -2611,7 +2611,7 @@
           "type": "color"
         },
         "hovered": {
-          "value": "#002b36",
+          "value": "#586e75",
           "type": "color"
         },
         "active": {
@@ -2619,49 +2619,49 @@
           "type": "color"
         },
         "focused": {
-          "value": "#657b83",
+          "value": "#586e75",
           "type": "color"
         }
       },
       "300": {
         "base": {
-          "value": "#586e75",
-          "type": "color"
-        },
-        "hovered": {
           "value": "#073642",
           "type": "color"
         },
+        "hovered": {
+          "value": "#586e75",
+          "type": "color"
+        },
         "active": {
-          "value": "#657b83",
+          "value": "#586e75",
           "type": "color"
         },
         "focused": {
-          "value": "#839496",
+          "value": "#586e75",
           "type": "color"
         }
       },
       "500": {
         "base": {
-          "value": "#657b83",
+          "value": "#002b36",
           "type": "color"
         },
         "hovered": {
-          "value": "#586e75",
+          "value": "#073642",
           "type": "color"
         },
         "active": {
-          "value": "#839496",
+          "value": "#073642",
           "type": "color"
         },
         "focused": {
-          "value": "#839496",
+          "value": "#073642",
           "type": "color"
         }
       },
       "on300": {
         "base": {
-          "value": "#586e75",
+          "value": "#002b36",
           "type": "color"
         },
         "hovered": {
@@ -2669,29 +2669,29 @@
           "type": "color"
         },
         "active": {
-          "value": "#657b83",
+          "value": "#073642",
           "type": "color"
         },
         "focused": {
-          "value": "#839496",
+          "value": "#073642",
           "type": "color"
         }
       },
       "on500": {
         "base": {
-          "value": "#586e75",
-          "type": "color"
-        },
-        "hovered": {
           "value": "#073642",
           "type": "color"
         },
+        "hovered": {
+          "value": "#586e75",
+          "type": "color"
+        },
         "active": {
-          "value": "#657b83",
+          "value": "#586e75",
           "type": "color"
         },
         "focused": {
-          "value": "#839496",
+          "value": "#586e75",
           "type": "color"
         }
       },
@@ -2770,23 +2770,23 @@
     },
     "border": {
       "primary": {
-        "value": "#657b83",
-        "type": "color"
-      },
-      "secondary": {
-        "value": "#586e75",
-        "type": "color"
-      },
-      "muted": {
-        "value": "#073642",
-        "type": "color"
-      },
-      "focused": {
         "value": "#002b36",
         "type": "color"
       },
+      "secondary": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#586e75",
+        "type": "color"
+      },
       "active": {
-        "value": "#839496",
+        "value": "#586e75",
         "type": "color"
       },
       "ok": {
@@ -2808,15 +2808,582 @@
     },
     "editor": {
       "background": {
-        "value": "#657b83",
+        "value": "#002b36",
         "type": "color"
       },
       "indent_guide": {
-        "value": "#073642",
+        "value": "#586e75",
         "type": "color"
       },
       "indent_guide_active": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "line": {
+        "active": {
+          "value": "#fdf6e312",
+          "type": "color"
+        },
+        "highlighted": {
+          "value": "#fdf6e31f",
+          "type": "color"
+        },
+        "inserted": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "deleted": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "modified": {
+          "value": "#268bd2",
+          "type": "color"
+        }
+      },
+      "highlight": {
+        "selection": {
+          "value": "#268bd23d",
+          "type": "color"
+        },
+        "occurrence": {
+          "value": "#657b831f",
+          "type": "color"
+        },
+        "activeOccurrence": {
+          "value": "#657b8329",
+          "type": "color"
+        },
+        "matchingBracket": {
+          "value": "#073642",
+          "type": "color"
+        },
+        "match": {
+          "value": "#6c71c480",
+          "type": "color"
+        },
+        "activeMatch": {
+          "value": "#6c71c4b3",
+          "type": "color"
+        },
+        "related": {
+          "value": "#073642",
+          "type": "color"
+        }
+      },
+      "gutter": {
+        "primary": {
+          "value": "#839496",
+          "type": "color"
+        },
+        "active": {
+          "value": "#fdf6e3",
+          "type": "color"
+        }
+      }
+    },
+    "syntax": {
+      "primary": {
+        "value": "#fdf6e3",
+        "type": "color"
+      },
+      "comment": {
+        "value": "#eee8d5",
+        "type": "color"
+      },
+      "keyword": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "function": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "type": {
+        "value": "#2aa198",
+        "type": "color"
+      },
+      "variant": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "property": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "enum": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "operator": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "string": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "number": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "boolean": {
+        "value": "#859900",
+        "type": "color"
+      }
+    },
+    "player": {
+      "1": {
+        "baseColor": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#268bd23d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#268bd2cc",
+          "type": "color"
+        }
+      },
+      "2": {
+        "baseColor": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#8599003d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#859900cc",
+          "type": "color"
+        }
+      },
+      "3": {
+        "baseColor": {
+          "value": "#d33682",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#d33682",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#d336823d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#d33682cc",
+          "type": "color"
+        }
+      },
+      "4": {
+        "baseColor": {
+          "value": "#cb4b16",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#cb4b16",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#cb4b163d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#cb4b16cc",
+          "type": "color"
+        }
+      },
+      "5": {
+        "baseColor": {
+          "value": "#6c71c4",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#6c71c4",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#6c71c43d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#6c71c4cc",
+          "type": "color"
+        }
+      },
+      "6": {
+        "baseColor": {
+          "value": "#2aa198",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#2aa198",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#2aa1983d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#2aa198cc",
+          "type": "color"
+        }
+      },
+      "7": {
+        "baseColor": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#dc322f3d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#dc322fcc",
+          "type": "color"
+        }
+      },
+      "8": {
+        "baseColor": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#b589003d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#b58900cc",
+          "type": "color"
+        }
+      }
+    },
+    "shadowAlpha": {
+      "value": 0.32,
+      "type": "number"
+    }
+  },
+  "solarized-light": {
+    "meta": {
+      "themeName": "solarized-light"
+    },
+    "text": {
+      "primary": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "secondary": {
         "value": "#586e75",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "placeholder": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "active": {
+        "value": "#002b36",
+        "type": "color"
+      },
+      "feature": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "ok": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "error": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "warning": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "info": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "icon": {
+      "primary": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "placeholder": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "active": {
+        "value": "#002b36",
+        "type": "color"
+      },
+      "feature": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "ok": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "error": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "warning": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "info": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "background": {
+      "100": {
+        "base": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#93a1a1",
+          "type": "color"
+        },
+        "active": {
+          "value": "#93a1a1",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#93a1a1",
+          "type": "color"
+        }
+      },
+      "300": {
+        "base": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#93a1a1",
+          "type": "color"
+        },
+        "active": {
+          "value": "#93a1a1",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#93a1a1",
+          "type": "color"
+        }
+      },
+      "500": {
+        "base": {
+          "value": "#fdf6e3",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "active": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#eee8d5",
+          "type": "color"
+        }
+      },
+      "on300": {
+        "base": {
+          "value": "#fdf6e3",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "active": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#eee8d5",
+          "type": "color"
+        }
+      },
+      "on500": {
+        "base": {
+          "value": "#eee8d5",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#93a1a1",
+          "type": "color"
+        },
+        "active": {
+          "value": "#93a1a1",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#93a1a1",
+          "type": "color"
+        }
+      },
+      "ok": {
+        "base": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "active": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#859900",
+          "type": "color"
+        }
+      },
+      "error": {
+        "base": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "active": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#dc322f",
+          "type": "color"
+        }
+      },
+      "warning": {
+        "base": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "active": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#b58900",
+          "type": "color"
+        }
+      },
+      "info": {
+        "base": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "active": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#268bd2",
+          "type": "color"
+        }
+      }
+    },
+    "border": {
+      "primary": {
+        "value": "#fdf6e3",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "#eee8d5",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#93a1a1",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#93a1a1",
+        "type": "color"
+      },
+      "active": {
+        "value": "#93a1a1",
+        "type": "color"
+      },
+      "ok": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "error": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "warning": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "info": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "editor": {
+      "background": {
+        "value": "#fdf6e3",
+        "type": "color"
+      },
+      "indent_guide": {
+        "value": "#93a1a1",
+        "type": "color"
+      },
+      "indent_guide_active": {
+        "value": "#eee8d5",
         "type": "color"
       },
       "line": {
@@ -2847,15 +3414,15 @@
           "type": "color"
         },
         "occurrence": {
-          "value": "#002b361f",
+          "value": "#8394961f",
           "type": "color"
         },
         "activeOccurrence": {
-          "value": "#002b3629",
+          "value": "#83949629",
           "type": "color"
         },
         "matchingBracket": {
-          "value": "#839496",
+          "value": "#eee8d5",
           "type": "color"
         },
         "match": {
@@ -2867,13 +3434,13 @@
           "type": "color"
         },
         "related": {
-          "value": "#839496",
+          "value": "#eee8d5",
           "type": "color"
         }
       },
       "gutter": {
         "primary": {
-          "value": "#839496",
+          "value": "#657b83",
           "type": "color"
         },
         "active": {
@@ -2884,11 +3451,11 @@
     },
     "syntax": {
       "primary": {
-        "value": "#fdf6e3",
+        "value": "#002b36",
         "type": "color"
       },
       "comment": {
-        "value": "#eee8d5",
+        "value": "#073642",
         "type": "color"
       },
       "keyword": {

--- a/styles/dist/tokens.json
+++ b/styles/dist/tokens.json
@@ -2515,5 +2515,572 @@
       "value": 0.12,
       "type": "number"
     }
+  },
+  "solarized-dark": {
+    "meta": {
+      "themeName": "solarized-dark"
+    },
+    "text": {
+      "primary": {
+        "value": "#fdf6e3",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "#eee8d5",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "placeholder": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "active": {
+        "value": "#002b36",
+        "type": "color"
+      },
+      "feature": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "ok": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "error": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "warning": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "info": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "icon": {
+      "primary": {
+        "value": "#fdf6e3",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "#eee8d5",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "placeholder": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "active": {
+        "value": "#002b36",
+        "type": "color"
+      },
+      "feature": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "ok": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "error": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "warning": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "info": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "background": {
+      "100": {
+        "base": {
+          "value": "#073642",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#002b36",
+          "type": "color"
+        },
+        "active": {
+          "value": "#586e75",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#657b83",
+          "type": "color"
+        }
+      },
+      "300": {
+        "base": {
+          "value": "#586e75",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#073642",
+          "type": "color"
+        },
+        "active": {
+          "value": "#657b83",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#839496",
+          "type": "color"
+        }
+      },
+      "500": {
+        "base": {
+          "value": "#657b83",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#586e75",
+          "type": "color"
+        },
+        "active": {
+          "value": "#839496",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#839496",
+          "type": "color"
+        }
+      },
+      "on300": {
+        "base": {
+          "value": "#586e75",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#073642",
+          "type": "color"
+        },
+        "active": {
+          "value": "#657b83",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#839496",
+          "type": "color"
+        }
+      },
+      "on500": {
+        "base": {
+          "value": "#586e75",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#073642",
+          "type": "color"
+        },
+        "active": {
+          "value": "#657b83",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#839496",
+          "type": "color"
+        }
+      },
+      "ok": {
+        "base": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "active": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#859900",
+          "type": "color"
+        }
+      },
+      "error": {
+        "base": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "active": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#dc322f",
+          "type": "color"
+        }
+      },
+      "warning": {
+        "base": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "active": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#b58900",
+          "type": "color"
+        }
+      },
+      "info": {
+        "base": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "hovered": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "active": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "focused": {
+          "value": "#268bd2",
+          "type": "color"
+        }
+      }
+    },
+    "border": {
+      "primary": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "muted": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "focused": {
+        "value": "#002b36",
+        "type": "color"
+      },
+      "active": {
+        "value": "#839496",
+        "type": "color"
+      },
+      "ok": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "error": {
+        "value": "#dc322f",
+        "type": "color"
+      },
+      "warning": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "info": {
+        "value": "#268bd2",
+        "type": "color"
+      }
+    },
+    "editor": {
+      "background": {
+        "value": "#657b83",
+        "type": "color"
+      },
+      "indent_guide": {
+        "value": "#073642",
+        "type": "color"
+      },
+      "indent_guide_active": {
+        "value": "#586e75",
+        "type": "color"
+      },
+      "line": {
+        "active": {
+          "value": "#002b3612",
+          "type": "color"
+        },
+        "highlighted": {
+          "value": "#002b361f",
+          "type": "color"
+        },
+        "inserted": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "deleted": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "modified": {
+          "value": "#268bd2",
+          "type": "color"
+        }
+      },
+      "highlight": {
+        "selection": {
+          "value": "#268bd23d",
+          "type": "color"
+        },
+        "occurrence": {
+          "value": "#002b361f",
+          "type": "color"
+        },
+        "activeOccurrence": {
+          "value": "#002b3629",
+          "type": "color"
+        },
+        "matchingBracket": {
+          "value": "#839496",
+          "type": "color"
+        },
+        "match": {
+          "value": "#6c71c480",
+          "type": "color"
+        },
+        "activeMatch": {
+          "value": "#6c71c4b3",
+          "type": "color"
+        },
+        "related": {
+          "value": "#839496",
+          "type": "color"
+        }
+      },
+      "gutter": {
+        "primary": {
+          "value": "#839496",
+          "type": "color"
+        },
+        "active": {
+          "value": "#002b36",
+          "type": "color"
+        }
+      }
+    },
+    "syntax": {
+      "primary": {
+        "value": "#fdf6e3",
+        "type": "color"
+      },
+      "comment": {
+        "value": "#eee8d5",
+        "type": "color"
+      },
+      "keyword": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "function": {
+        "value": "#b58900",
+        "type": "color"
+      },
+      "type": {
+        "value": "#2aa198",
+        "type": "color"
+      },
+      "variant": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "property": {
+        "value": "#268bd2",
+        "type": "color"
+      },
+      "enum": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "operator": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "string": {
+        "value": "#cb4b16",
+        "type": "color"
+      },
+      "number": {
+        "value": "#859900",
+        "type": "color"
+      },
+      "boolean": {
+        "value": "#859900",
+        "type": "color"
+      }
+    },
+    "player": {
+      "1": {
+        "baseColor": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#268bd2",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#268bd23d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#268bd2cc",
+          "type": "color"
+        }
+      },
+      "2": {
+        "baseColor": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#859900",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#8599003d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#859900cc",
+          "type": "color"
+        }
+      },
+      "3": {
+        "baseColor": {
+          "value": "#d33682",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#d33682",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#d336823d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#d33682cc",
+          "type": "color"
+        }
+      },
+      "4": {
+        "baseColor": {
+          "value": "#cb4b16",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#cb4b16",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#cb4b163d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#cb4b16cc",
+          "type": "color"
+        }
+      },
+      "5": {
+        "baseColor": {
+          "value": "#6c71c4",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#6c71c4",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#6c71c43d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#6c71c4cc",
+          "type": "color"
+        }
+      },
+      "6": {
+        "baseColor": {
+          "value": "#2aa198",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#2aa198",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#2aa1983d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#2aa198cc",
+          "type": "color"
+        }
+      },
+      "7": {
+        "baseColor": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#dc322f",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#dc322f3d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#dc322fcc",
+          "type": "color"
+        }
+      },
+      "8": {
+        "baseColor": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "cursorColor": {
+          "value": "#b58900",
+          "type": "color"
+        },
+        "selectionColor": {
+          "value": "#b589003d",
+          "type": "color"
+        },
+        "borderColor": {
+          "value": "#b58900cc",
+          "type": "color"
+        }
+      }
+    },
+    "shadowAlpha": {
+      "value": 0.32,
+      "type": "number"
+    }
   }
 }

--- a/styles/src/buildThemes.ts
+++ b/styles/src/buildThemes.ts
@@ -3,9 +3,11 @@ import * as path from "path";
 import app from "./styleTree/app";
 import dark from "./themes/dark";
 import light from "./themes/light";
+import solarizedDark from "./themes/solarized-dark";
+import solarizedLight from "./themes/solarized-light";
 import snakeCase from "./utils/snakeCase";
 
-const themes = [dark, light];
+const themes = [dark, light, solarizedDark, solarizedLight];
 for (let theme of themes) {
   let styleTree = snakeCase(app(theme));
   let styleTreeJSON = JSON.stringify(styleTree, null, 2);

--- a/styles/src/buildTokens.ts
+++ b/styles/src/buildTokens.ts
@@ -2,6 +2,8 @@ import * as fs from "fs";
 import * as path from "path";
 import dark from "./themes/dark";
 import light from "./themes/light";
+import solarizedDark from "./themes/solarized-dark";
+import solarizedLight from "./themes/solarized-light";
 import Theme from "./themes/theme";
 import { colors, fontFamilies, fontSizes, fontWeights } from "./tokens";
 
@@ -96,7 +98,7 @@ combinedTokens.core = coreTokens;
 
 // Add each theme to the combined tokens and write ${theme}.json.
 // We write `${theme}.json` as a separate file for the design team's convenience, but it isn't consumed by Figma Tokens directly.
-let themes = [dark, light];
+let themes = [dark, light, solarizedDark, solarizedLight];
 themes.forEach((theme) => {
   const themePath = `${distPath}/${theme.name}.json`
   fs.writeFileSync(themePath, JSON.stringify(themeTokens(theme), null, 2));

--- a/styles/src/themes/dark.ts
+++ b/styles/src/themes/dark.ts
@@ -1,4 +1,4 @@
-import { colors, fontWeights, NumberToken } from "../tokens";
+import { color, colors, fontWeights, NumberToken } from "../tokens";
 import { withOpacity } from "../utils/color";
 import Theme, { buildPlayer, Syntax } from "./theme";
 

--- a/styles/src/themes/solarized-dark.ts
+++ b/styles/src/themes/solarized-dark.ts
@@ -1,0 +1,3 @@
+import { solarized } from "./solarized";
+
+export default solarized(true);

--- a/styles/src/themes/solarized-light.ts
+++ b/styles/src/themes/solarized-light.ts
@@ -1,0 +1,3 @@
+import { solarized } from "./solarized";
+
+export default solarized(false);

--- a/styles/src/themes/solarized.ts
+++ b/styles/src/themes/solarized.ts
@@ -1,0 +1,255 @@
+import { color, fontWeights, NumberToken } from "../tokens";
+import { withOpacity } from "../utils/color";
+import Theme, { buildPlayer, Syntax } from "./theme";
+
+const dark = {
+  0: color("#657b83"),
+  1: color("#586e75"),
+  2: color("#073642"),
+  3: color("#002b36"),
+};
+const light = {
+  0: color("#839496"),
+  1: color("#93a1a1"),
+  2: color("#eee8d5"),
+  3: color("#fdf6e3"),
+};
+
+const colors = {
+  "yellow": color("#b58900"),
+  "orange": color("#cb4b16"),
+  "red": color("#dc322f"),
+  "magenta": color("#d33682"),
+  "violet": color("#6c71c4"),
+  "blue": color("#268bd2"),
+  "cyan": color("#2aa198"),
+  "green": color("#859900"),
+};
+
+export function solarized(darkTheme: boolean): Theme {
+  let fg = darkTheme ? light : dark;
+  let bg = darkTheme ? dark : light;
+  let name = darkTheme ? "solarized-dark" : "solarized-light";
+
+  const backgroundColor = {
+    100: {
+      base: bg[2],
+      hovered: bg[1],
+      active: bg[1],
+      focused: bg[1],
+    },
+    300: {
+      base: bg[2],
+      hovered: bg[1],
+      active: bg[1],
+      focused: bg[1],
+    },
+    500: {
+      base: bg[3],
+      hovered: bg[2],
+      active: bg[2],
+      focused: bg[2],
+    },
+    on300: {
+      base: bg[2],
+      hovered: bg[1],
+      active: bg[1],
+      focused: bg[1],
+    },
+    on500: {
+      base: bg[2],
+      hovered: bg[1],
+      active: bg[1],
+      focused: bg[1],
+    },
+    ok: {
+      base: colors.green,
+      hovered: colors.green,
+      active: colors.green,
+      focused: colors.green,
+    },
+    error: {
+      base: colors.red,
+      hovered: colors.red,
+      active: colors.red,
+      focused: colors.red,
+    },
+    warning: {
+      base: colors.yellow,
+      hovered: colors.yellow,
+      active: colors.yellow,
+      focused: colors.yellow,
+    },
+    info: {
+      base: colors.blue,
+      hovered: colors.blue,
+      active: colors.blue,
+      focused: colors.blue,
+    },
+  };
+
+  const borderColor = {
+    primary: bg[3],
+    secondary: bg[2],
+    muted: bg[1],
+    focused: bg[1],
+    active: bg[1],
+    ok: colors.green,
+    error: colors.red,
+    warning: colors.yellow,
+    info: colors.blue,
+  };
+
+  const textColor = {
+    primary: fg[2],
+    secondary: fg[1],
+    muted: fg[1],
+    placeholder: fg[0],
+    active: fg[3],
+    //TODO: (design) define feature and it's correct value
+    feature: colors.blue,
+    ok: colors.green,
+    error: colors.red,
+    warning: colors.yellow,
+    info: colors.blue,
+  };
+
+  const player = {
+    1: buildPlayer(colors.blue),
+    2: buildPlayer(colors.green),
+    3: buildPlayer(colors.magenta),
+    4: buildPlayer(colors.orange),
+    5: buildPlayer(colors.violet),
+    6: buildPlayer(colors.cyan),
+    7: buildPlayer(colors.red),
+    8: buildPlayer(colors.yellow),
+  };
+
+  const editor = {
+    background: backgroundColor[500].base,
+    indent_guide: borderColor.muted,
+    indent_guide_active: borderColor.secondary,
+    line: {
+      active: withOpacity(fg[3], 0.07),
+      highlighted: withOpacity(fg[3], 0.12),
+      inserted: backgroundColor.ok.active,
+      deleted: backgroundColor.error.active,
+      modified: backgroundColor.info.active,
+    },
+    highlight: {
+      selection: player[1].selectionColor,
+      occurrence: withOpacity(bg[0], 0.12),
+      activeOccurrence: withOpacity(bg[0], 0.16), // TODO: This is not correctly hooked up to occurences on the rust side
+      matchingBracket: backgroundColor[500].active,
+      match: withOpacity(colors.violet, 0.5),
+      activeMatch: withOpacity(colors.violet, 0.7),
+      related: backgroundColor[500].focused,
+    },
+    gutter: {
+      primary: textColor.placeholder,
+      active: textColor.active,
+    },
+  };
+
+  const syntax: Syntax = {
+    primary: {
+      color: fg[3],
+      weight: fontWeights.normal,
+    },
+    comment: {
+      color: fg[2],
+      weight: fontWeights.normal,
+    },
+    punctuation: {
+      color: fg[1],
+      weight: fontWeights.normal,
+    },
+    constant: {
+      color: fg[0],
+      weight: fontWeights.normal,
+    },
+    keyword: {
+      color: colors.blue,
+      weight: fontWeights.normal,
+    },
+    function: {
+      color: colors.yellow,
+      weight: fontWeights.normal,
+    },
+    type: {
+      color: colors.cyan,
+      weight: fontWeights.normal,
+    },
+    variant: {
+      color: colors.blue,
+      weight: fontWeights.normal,
+    },
+    property: {
+      color: colors.blue,
+      weight: fontWeights.normal,
+    },
+    enum: {
+      color: colors.orange,
+      weight: fontWeights.normal,
+    },
+    operator: {
+      color: colors.orange,
+      weight: fontWeights.normal,
+    },
+    string: {
+      color: colors.orange,
+      weight: fontWeights.normal,
+    },
+    number: {
+      color: colors.green,
+      weight: fontWeights.normal,
+    },
+    boolean: {
+      color: colors.green,
+      weight: fontWeights.normal,
+    },
+    predictive: {
+      color: textColor.muted,
+      weight: fontWeights.normal,
+    },
+    title: {
+      color: colors.yellow,
+      weight: fontWeights.bold,
+    },
+    emphasis: {
+      color: textColor.active,
+      weight: fontWeights.normal,
+    },
+    emphasisStrong: {
+      color: textColor.active,
+      weight: fontWeights.bold,
+    },
+    linkUrl: {
+      color: colors.green,
+      weight: fontWeights.normal,
+      // TODO: add underline
+    },
+    linkText: {
+      color: colors.orange,
+      weight: fontWeights.normal,
+      // TODO: add italic
+    },
+  };
+
+  const shadowAlpha: NumberToken = {
+    value: 0.32,
+    type: "number",
+  };
+
+  return {
+    name,
+    backgroundColor,
+    borderColor,
+    textColor,
+    iconColor: textColor,
+    editor,
+    syntax,
+    player,
+    shadowAlpha,
+  };
+}

--- a/styles/src/themes/solarized.ts
+++ b/styles/src/themes/solarized.ts
@@ -51,10 +51,10 @@ export function solarized(darkTheme: boolean): Theme {
       focused: bg[2],
     },
     on300: {
-      base: bg[2],
-      hovered: bg[1],
-      active: bg[1],
-      focused: bg[1],
+      base: bg[3],
+      hovered: bg[2],
+      active: bg[2],
+      focused: bg[2],
     },
     on500: {
       base: bg[2],

--- a/styles/src/themes/solarized.ts
+++ b/styles/src/themes/solarized.ts
@@ -217,22 +217,22 @@ export function solarized(darkTheme: boolean): Theme {
       weight: fontWeights.bold,
     },
     emphasis: {
-      color: textColor.active,
+      color: textColor.feature,
       weight: fontWeights.normal,
     },
-    emphasisStrong: {
-      color: textColor.active,
+    "emphasis.strong": {
+      color: textColor.feature,
       weight: fontWeights.bold,
     },
-    linkUrl: {
+    linkUri: {
       color: colors.green,
       weight: fontWeights.normal,
-      // TODO: add underline
+      underline: true,
     },
     linkText: {
       color: colors.orange,
       weight: fontWeights.normal,
-      // TODO: add italic
+      italic: true,
     },
   };
 

--- a/styles/src/themes/theme.ts
+++ b/styles/src/themes/theme.ts
@@ -62,10 +62,19 @@ export interface Syntax {
 export default interface Theme {
   name: string;
   backgroundColor: {
+    // Basically just Title Bar
+    // Lowest background level
     100: BackgroundColorSet;
+    // Tab bars, panels, popovers
+    // Mid-ground
     300: BackgroundColorSet;
+    // The editor
+    // Foreground
     500: BackgroundColorSet;
+    // Hacks for elements on top of the midground
+    // Buttons in a panel, tab bar, or panel
     on300: BackgroundColorSet;
+    // Hacks for elements on top of the editor
     on500: BackgroundColorSet;
     ok: BackgroundColorSet;
     error: BackgroundColorSet;

--- a/styles/src/tokens.ts
+++ b/styles/src/tokens.ts
@@ -71,6 +71,12 @@ export interface ColorToken {
   type: "color",
   step?: number,
 }
+export function color(value: string): ColorToken {
+  return {
+    value,
+    type: "color",
+  };
+}
 export const colors = {
   neutral: colorRamp(["white", "black"], { steps: 37, increment: 25 }), // (900/25) + 1
   rose: colorRamp("#F43F5EFF"),


### PR DESCRIPTION
Adds solarized light and dark taking advantage of solarized's symmetries

<img width="1045" alt="Screen Shot 2022-04-22 at 12 09 31 PM" src="https://user-images.githubusercontent.com/3323631/164778957-0d0fb4c4-4fa8-4362-83ef-010a6e266a9f.png">
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/3323631/164779053-84d5a308-395f-4e10-98b7-95a6b0af8b05.png">
