### PR TITLE
Fix missing TypeScript outline entries and breadcrumbs

### DIFF
--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -57,6 +57,6 @@ util = { path = "../util", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.8"
 rand = "0.8.3"
-tree-sitter-json = "0.19.0"
-tree-sitter-rust = "0.20.0"
+tree-sitter-json = "*"
+tree-sitter-rust = "*"
 unindent = "0.1.7"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -63,7 +63,7 @@ pub fn build_language_registry(login_shell_env_loaded: Task<()>) -> LanguageRegi
     languages
 }
 
-fn language(
+pub(crate) fn language(
     name: &str,
     grammar: tree_sitter::Language,
     lsp_adapter: Option<Arc<dyn LspAdapter>>,

--- a/crates/zed/src/languages/typescript/outline.scm
+++ b/crates/zed/src/languages/typescript/outline.scm
@@ -6,6 +6,10 @@
     "enum" @context
     name: (_) @name) @item
 
+(type_alias_declaration
+    "type" @context
+    name: (_) @name) @item
+
 (function_declaration
     "async"? @context
     "function" @context
@@ -17,6 +21,12 @@
 (interface_declaration
     "interface" @context
     name: (_) @name) @item
+
+(export_statement
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (_) @name) @item))
 
 (program
     (lexical_declaration


### PR DESCRIPTION
Fixes #893

Also fixes some other general problems I saw with our outline code when experimenting with TypeScript files.