### PR TITLE
Remove some novel key bindings

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -210,9 +210,11 @@
             "cmd-shift-F": "project_search::Deploy",
             "cmd-k cmd-t": "theme_selector::Toggle",
             "cmd-k t": "theme_selector::Reload",
+            "cmd-k cmd-s": "zed::OpenKeymap",
             "cmd-t": "project_symbols::Toggle",
             "cmd-p": "file_finder::Toggle",
-            "cmd-shift-P": "command_palette::Toggle"
+            "cmd-shift-P": "command_palette::Toggle",
+            "cmd-shift-M": "diagnostics::Deploy"
         }
     },
     // Bindings from Sublime Text
@@ -244,6 +246,7 @@
             "cmd-k cmd-right": "workspace::ActivateNextPane"
         }
     },
+    // Bindings from Atom
     {
         "context": "Pane",
         "bindings": {
@@ -289,18 +292,13 @@
     {
         "bindings": {
             "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
-            "cmd-alt-i": "zed::DebugElements",
-            "alt-cmd-,": "zed::OpenKeymap"
+            "cmd-alt-i": "zed::DebugElements"
         }
     },
     {
         "context": "Editor",
         "bindings": {
-            "ctrl-w": "editor::SelectLargerSyntaxNode",
-            "ctrl-shift-W": "editor::SelectSmallerSyntaxNode",
-            "alt-cmd-f": "editor::FoldSelectedRanges",
-            "alt-enter": "editor::OpenExcerpts",
-            "cmd-f10": "editor::RestartLanguageServer"
+            "alt-enter": "editor::OpenExcerpts"
         }
     },
     {
@@ -312,8 +310,6 @@
     {
         "context": "Workspace",
         "bindings": {
-            "alt-shift-D": "diagnostics::Deploy",
-            "ctrl-alt-cmd-j": "journal::NewJournalEntry",
             "cmd-1": [
                 "workspace::ToggleSidebarItemFocus",
                 {


### PR DESCRIPTION
Closes #714

**Removed** duplicate key bindings:
* `ctrl-w`/`ctrl-shift-w` for selecting larger and smaller syntax nodes

**Removed** key bindings for infrequently-run commands
* `cmd-f10` for restart language server
* `ctrl-alt-cmd j` for creating journal entries
* `alt-cmd-f` for folding the selected ranges

**Changed** key bindings:
* Project diagnostics is now toggled with `cmd-shift-m` instead of `alt-shift-d`. This matches VS Code
* The keyboard shortcuts file can now be opened with `cmd-k cmd-s`. This matches VS Code

---

Further matching of VS Code:

* [ ] Should we adopt VS Code's bindings for focusing panes (`cmd`+ number)? Our current ones (`cmd-k` `cmd`-arrow) are actually based on Atom's.
* [ ] Should we adopt VS Code's bindings for sidebars `cmd-shift-e` for toggling project browser focus, `cmd-b` for opening/closing the sidebar. We're currently using `cmd-1` to focus, `cmd-shift-1` to show/hide.