### PR TITLE
Sort themes by light/dark first and then alphabetically

### DIFF
--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -36,7 +36,12 @@ impl ThemeSelector {
         let handle = cx.weak_handle();
         let picker = cx.add_view(|cx| Picker::new(handle, cx));
         let original_theme = cx.global::<Settings>().theme.clone();
-        let theme_names = registry.list().collect::<Vec<_>>();
+        let mut theme_names = registry.list().collect::<Vec<_>>();
+        theme_names.sort_unstable_by(|a, b| {
+            a.ends_with("dark")
+                .cmp(&b.ends_with("dark"))
+                .then_with(|| a.cmp(&b))
+        });
         let matches = theme_names
             .iter()
             .map(|name| StringMatch {


### PR DESCRIPTION
Closes #888 

<img width="1308" alt="Screen Shot 2022-04-26 at 12 09 51" src="https://user-images.githubusercontent.com/482957/165277200-5ddedfc9-fd3e-49ea-bbd1-cc66c680b4b9.png">

