### PR TITLE
Make the 'About Zed' menu item display Zed's version number

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -58,6 +58,7 @@ lazy_static! {
 }
 
 pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
+    cx.add_action(about);
     cx.add_global_action(quit);
     cx.add_global_action(move |_: &IncreaseBufferFontSize, cx| {
         cx.update_global::<Settings, _, _>(|settings, cx| {
@@ -208,6 +209,14 @@ pub fn build_window_options() -> WindowOptions<'static> {
 
 fn quit(_: &Quit, cx: &mut gpui::MutableAppContext) {
     cx.platform().quit();
+}
+
+fn about(_: &mut Workspace, _: &About, cx: &mut gpui::ViewContext<Workspace>) {
+    cx.prompt(
+        gpui::PromptLevel::Info,
+        &format!("Zed {}", env!("CARGO_PKG_VERSION")),
+        &["OK"],
+    );
 }
 
 async fn install_cli(cx: &AsyncAppContext) -> Result<()> {


### PR DESCRIPTION
<img width="956" alt="Screen Shot 2022-04-28 at 4 13 49 PM (2)" src="https://user-images.githubusercontent.com/326587/165862520-b0c46d4c-fd90-4d5f-a21a-e3fe9e11c85a.png">

VS Code shows some other information like the commit sha, and the date the app was built, but I think we keep it simple for now.