### PR TITLE
Vim visual mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5555,6 +5555,7 @@ dependencies = [
  "editor",
  "gpui",
  "indoc",
+ "itertools",
  "language",
  "log",
  "project",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -68,7 +68,11 @@
             "shift-X": "vim::DeleteLeft",
             "shift-^": "vim::FirstNonWhitespace",
             "o": "vim::InsertLineBelow",
-            "shift-O": "vim::InsertLineAbove"
+            "shift-O": "vim::InsertLineAbove",
+            "v": [
+                "vim::SwitchMode",
+                "Visual"
+            ]
         }
     },
     {
@@ -98,6 +102,14 @@
         "context": "Editor && vim_operator == d",
         "bindings": {
             "d": "vim::CurrentLine"
+        }
+    },
+    {
+        "context": "Editor && vim_mode == visual",
+        "bindings": {
+            "c": "vim::VisualChange",
+            "d": "vim::VisualDelete",
+            "x": "vim::VisualDelete"
         }
     },
     {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -355,11 +355,19 @@ impl DisplaySnapshot {
 
     pub fn clip_point(&self, point: DisplayPoint, bias: Bias) -> DisplayPoint {
         let mut clipped = self.blocks_snapshot.clip_point(point.0, bias);
-        if self.clip_at_line_ends && clipped.column == self.line_len(clipped.row) {
-            clipped.column = clipped.column.saturating_sub(1);
-            clipped = self.blocks_snapshot.clip_point(clipped, Bias::Left);
+        if self.clip_at_line_ends {
+            clipped = self.clip_at_line_end(DisplayPoint(clipped)).0
         }
         DisplayPoint(clipped)
+    }
+
+    pub fn clip_at_line_end(&self, point: DisplayPoint) -> DisplayPoint {
+        let mut point = point.0;
+        if point.column == self.line_len(point.row) {
+            point.column = point.column.saturating_sub(1);
+            point = self.blocks_snapshot.clip_point(point, Bias::Left);
+        }
+        DisplayPoint(point)
     }
 
     pub fn folds_in_range<'a, T>(

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -85,6 +85,19 @@ impl<T: Copy + Ord> Selection<T> {
     }
 }
 
+impl Selection<usize> {
+    #[cfg(feature = "test-support")]
+    pub fn from_offset(offset: usize) -> Self {
+        Selection {
+            id: 0,
+            start: offset,
+            end: offset,
+            goal: SelectionGoal::None,
+            reversed: false,
+        }
+    }
+}
+
 impl Selection<Anchor> {
     pub fn resolve<'a, D: 'a + TextDimension>(
         &'a self,

--- a/crates/util/src/test/assertions.rs
+++ b/crates/util/src/test/assertions.rs
@@ -1,19 +1,62 @@
+pub enum SetEqError<T> {
+    LeftMissing(T),
+    RightMissing(T),
+}
+
+impl<T> SetEqError<T> {
+    pub fn map<R, F: FnOnce(T) -> R>(self, update: F) -> SetEqError<R> {
+        match self {
+            SetEqError::LeftMissing(missing) => SetEqError::LeftMissing(update(missing)),
+            SetEqError::RightMissing(missing) => SetEqError::RightMissing(update(missing)),
+        }
+    }
+}
+
 #[macro_export]
-macro_rules! assert_set_eq {
+macro_rules! set_eq {
     ($left:expr,$right:expr) => {{
+        use util::test::*;
+
         let left = $left;
         let right = $right;
 
-        for left_value in left.iter() {
-            if !right.contains(left_value) {
-                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nright does not contain {:?}", left, right, left_value);
+        let mut result = Ok(());
+        for right_value in right.iter() {
+            if !left.contains(right_value) {
+                result = Err(SetEqError::LeftMissing(right_value.clone()));
+                break;
             }
         }
 
-        for right_value in right.iter() {
-            if !left.contains(right_value) {
-                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nleft does not contain {:?}", left, right, right_value);
+        if result.is_ok() {
+            for left_value in left.iter() {
+                if !right.contains(left_value) {
+                    result = Err(SetEqError::RightMissing(left_value.clone()));
+                }
             }
+        }
+
+        result
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_set_eq {
+    ($left:expr,$right:expr) => {{
+        use util::test::*;
+        use util::set_eq;
+
+        let left = $left;
+        let right = $right;
+
+        match set_eq!(left, right) {
+            Err(SetEqError::LeftMissing(missing)) => {
+                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nright does not contain {:?}", left, right, missing);
+            },
+            Err(SetEqError::RightMissing(missing)) => {
+                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nleft does not contain {:?}", left, right, missing);
+            },
+            _ => {}
         }
     }};
 }

--- a/crates/util/src/test/assertions.rs
+++ b/crates/util/src/test/assertions.rs
@@ -49,12 +49,12 @@ macro_rules! assert_set_eq {
         let left = $left;
         let right = $right;
 
-        match set_eq!(left, right) {
+        match set_eq!(&left, &right) {
             Err(SetEqError::LeftMissing(missing)) => {
-                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nright does not contain {:?}", left, right, missing);
+                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nright does not contain {:?}", &left, &right, &missing);
             },
             Err(SetEqError::RightMissing(missing)) => {
-                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nleft does not contain {:?}", left, right, missing);
+                panic!("assertion failed: `(left == right)`\n left: {:?}\nright: {:?}\nleft does not contain {:?}", &left, &right, &missing);
             },
             _ => {}
         }

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -16,6 +16,7 @@ language = { path = "../language" }
 serde = { version = "1", features = ["derive"] }
 settings = { path = "../settings" }
 workspace = { path = "../workspace" }
+itertools = "0.10"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 
 [dev-dependencies]

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -11,6 +11,7 @@ use workspace::Workspace;
 use crate::{
     normal::normal_motion,
     state::{Mode, Operator},
+    visual::visual_motion,
     Vim,
 };
 
@@ -110,6 +111,7 @@ fn motion(motion: Motion, cx: &mut MutableAppContext) {
     });
     match Vim::read(cx).state.mode {
         Mode::Normal => normal_motion(motion, cx),
+        Mode::Visual => visual_motion(motion, cx),
         Mode::Insert => {
             // Shouldn't execute a motion in insert mode. Ignoring
         }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -136,7 +136,7 @@ fn insert_line_above(_: &mut Workspace, _: &InsertLineAbove, cx: &mut ViewContex
                     new_text.push('\n');
                     (start_of_line..start_of_line, new_text)
                 });
-                editor.edit(edits, cx);
+                editor.edit_with_autoindent(edits, cx);
                 editor.move_cursors(cx, |map, mut cursor, _| {
                     *cursor.row_mut() -= 1;
                     *cursor.column_mut() = map.line_len(cursor.row());
@@ -169,7 +169,7 @@ fn insert_line_below(_: &mut Workspace, _: &InsertLineBelow, cx: &mut ViewContex
                 editor.move_cursors(cx, |map, cursor, goal| {
                     Motion::EndOfLine.move_point(map, cursor, goal)
                 });
-                editor.edit(edits, cx);
+                editor.edit_with_autoindent(edits, cx);
             });
         });
     });
@@ -178,6 +178,7 @@ fn insert_line_below(_: &mut Workspace, _: &InsertLineBelow, cx: &mut ViewContex
 #[cfg(test)]
 mod test {
     use indoc::indoc;
+    use language::Selection;
     use util::test::marked_text;
 
     use crate::{
@@ -420,7 +421,7 @@ mod test {
 
         for cursor_offset in cursor_offsets {
             cx.simulate_keystroke("w");
-            cx.assert_newest_selection_head_offset(cursor_offset);
+            cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
 
         // Reset and test ignoring punctuation
@@ -442,7 +443,7 @@ mod test {
 
         for cursor_offset in cursor_offsets {
             cx.simulate_keystroke("shift-W");
-            cx.assert_newest_selection_head_offset(cursor_offset);
+            cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
     }
 
@@ -467,7 +468,7 @@ mod test {
 
         for cursor_offset in cursor_offsets {
             cx.simulate_keystroke("e");
-            cx.assert_newest_selection_head_offset(cursor_offset);
+            cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
 
         // Reset and test ignoring punctuation
@@ -488,7 +489,7 @@ mod test {
         );
         for cursor_offset in cursor_offsets {
             cx.simulate_keystroke("shift-E");
-            cx.assert_newest_selection_head_offset(cursor_offset);
+            cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
     }
 
@@ -513,7 +514,7 @@ mod test {
 
         for cursor_offset in cursor_offsets.into_iter().rev() {
             cx.simulate_keystroke("b");
-            cx.assert_newest_selection_head_offset(cursor_offset);
+            cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
 
         // Reset and test ignoring punctuation
@@ -534,7 +535,7 @@ mod test {
         );
         for cursor_offset in cursor_offsets.into_iter().rev() {
             cx.simulate_keystroke("shift-B");
-            cx.assert_newest_selection_head_offset(cursor_offset);
+            cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
     }
 
@@ -821,25 +822,21 @@ mod test {
         );
         cx.assert(
             indoc! {"
-                fn test() {
-                    println!(|);
-                }"},
+                fn test()
+                    println!(|);"},
             indoc! {"
-                fn test() {
+                fn test()
                     println!();
-                    |
-                }"},
+                    |"},
         );
         cx.assert(
             indoc! {"
-                fn test(|) {
-                    println!();
-                }"},
+                fn test(|)
+                    println!();"},
             indoc! {"
-                fn test() {
+                fn test()
                 |
-                    println!();
-                }"},
+                    println!();"},
         );
     }
 
@@ -906,25 +903,21 @@ mod test {
         );
         cx.assert(
             indoc! {"
-                fn test() {
-                    println!(|);
-                }"},
+                fn test()
+                    println!(|);"},
             indoc! {"
-                fn test() {
+                fn test()
                     |
-                    println!();
-                }"},
+                    println!();"},
         );
         cx.assert(
             indoc! {"
-                fn test(|) {
-                    println!();
-                }"},
+                fn test(|)
+                    println!();"},
             indoc! {"
                 |
-                fn test() {
-                    println!();
-                }"},
+                fn test()
+                    println!();"},
         );
     }
 

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 pub enum Mode {
     Normal,
     Insert,
+    Visual,
 }
 
 impl Default for Mode {
@@ -36,6 +37,7 @@ impl VimState {
     pub fn cursor_shape(&self) -> CursorShape {
         match self.mode {
             Mode::Normal => CursorShape::Block,
+            Mode::Visual => CursorShape::Block,
             Mode::Insert => CursorShape::Bar,
         }
     }
@@ -50,6 +52,7 @@ impl VimState {
             "vim_mode".to_string(),
             match self.mode {
                 Mode::Normal => "normal",
+                Mode::Visual => "visual",
                 Mode::Insert => "insert",
             }
             .to_string(),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -6,6 +6,7 @@ mod insert;
 mod motion;
 mod normal;
 mod state;
+mod visual;
 
 use collections::HashMap;
 use editor::{CursorShape, Editor};
@@ -27,6 +28,7 @@ impl_actions!(vim, [SwitchMode, PushOperator]);
 pub fn init(cx: &mut MutableAppContext) {
     editor_events::init(cx);
     normal::init(cx);
+    visual::init(cx);
     insert::init(cx);
     motion::init(cx);
 
@@ -116,6 +118,7 @@ impl Vim {
 
     fn sync_editor_options(&self, cx: &mut MutableAppContext) {
         let state = &self.state;
+
         let cursor_shape = state.cursor_shape();
         for editor in self.editors.values() {
             if let Some(editor) = editor.upgrade(cx) {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -1,0 +1,277 @@
+use editor::Bias;
+use gpui::{actions, MutableAppContext, ViewContext};
+use workspace::Workspace;
+
+use crate::{motion::Motion, state::Mode, Vim};
+
+actions!(vim, [VisualDelete, VisualChange]);
+
+pub fn init(cx: &mut MutableAppContext) {
+    cx.add_action(change);
+    cx.add_action(delete);
+}
+
+pub fn visual_motion(motion: Motion, cx: &mut MutableAppContext) {
+    Vim::update(cx, |vim, cx| {
+        vim.update_active_editor(cx, |editor, cx| {
+            editor.move_selections(cx, |map, selection| {
+                let (new_head, goal) = motion.move_point(map, selection.head(), selection.goal);
+                let new_head = map.clip_at_line_end(new_head);
+                let was_reversed = selection.reversed;
+                selection.set_head(new_head, goal);
+
+                if was_reversed && !selection.reversed {
+                    // Head was at the start of the selection, and now is at the end. We need to move the start
+                    // back by one if possible in order to compensate for this change.
+                    *selection.start.column_mut() = selection.start.column().saturating_sub(1);
+                    selection.start = map.clip_point(selection.start, Bias::Left);
+                } else if !was_reversed && selection.reversed {
+                    // Head was at the end of the selection, and now is at the start. We need to move the end
+                    // forward by one if possible in order to compensate for this change.
+                    *selection.end.column_mut() = selection.end.column() + 1;
+                    selection.end = map.clip_point(selection.end, Bias::Left);
+                }
+            });
+        });
+    });
+}
+
+pub fn change(_: &mut Workspace, _: &VisualChange, cx: &mut ViewContext<Workspace>) {
+    Vim::update(cx, |vim, cx| {
+        vim.update_active_editor(cx, |editor, cx| {
+            editor.set_clip_at_line_ends(false, cx);
+            editor.move_selections(cx, |map, selection| {
+                if !selection.reversed {
+                    // Head was at the end of the selection, and now is at the start. We need to move the end
+                    // forward by one if possible in order to compensate for this change.
+                    *selection.end.column_mut() = selection.end.column() + 1;
+                    selection.end = map.clip_point(selection.end, Bias::Left);
+                }
+            });
+            editor.insert("", cx);
+        });
+        vim.switch_mode(Mode::Insert, cx);
+    });
+}
+
+pub fn delete(_: &mut Workspace, _: &VisualDelete, cx: &mut ViewContext<Workspace>) {
+    Vim::update(cx, |vim, cx| {
+        vim.update_active_editor(cx, |editor, cx| {
+            editor.set_clip_at_line_ends(false, cx);
+            editor.move_selections(cx, |map, selection| {
+                if !selection.reversed {
+                    // Head was at the end of the selection, and now is at the start. We need to move the end
+                    // forward by one if possible in order to compensate for this change.
+                    *selection.end.column_mut() = selection.end.column() + 1;
+                    selection.end = map.clip_point(selection.end, Bias::Left);
+                }
+            });
+            editor.insert("", cx);
+        });
+        vim.switch_mode(Mode::Normal, cx);
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use indoc::indoc;
+
+    use crate::{state::Mode, vim_test_context::VimTestContext};
+
+    #[gpui::test]
+    async fn test_enter_visual_mode(cx: &mut gpui::TestAppContext) {
+        let cx = VimTestContext::new(cx, true).await;
+        let mut cx = cx.binding(["v", "w", "j"]).mode_after(Mode::Visual);
+        cx.assert(
+            indoc! {"
+                The |quick brown
+                fox jumps over
+                the lazy dog"},
+            indoc! {"
+                The [quick brown
+                fox jumps }over
+                the lazy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |lazy dog"},
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the [lazy }dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps |over
+                the lazy dog"},
+            indoc! {"
+                The quick brown
+                fox jumps [over
+                }the lazy dog"},
+        );
+        let mut cx = cx.binding(["v", "b", "k"]).mode_after(Mode::Visual);
+        cx.assert(
+            indoc! {"
+                The |quick brown
+                fox jumps over
+                the lazy dog"},
+            indoc! {"
+                {The q]uick brown
+                fox jumps over
+                the lazy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |lazy dog"},
+            indoc! {"
+                The quick brown
+                {fox jumps over
+                the l]azy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps |over
+                the lazy dog"},
+            indoc! {"
+                The {quick brown
+                fox jumps o]ver
+                the lazy dog"},
+        );
+    }
+
+    #[gpui::test]
+    async fn test_visual_delete(cx: &mut gpui::TestAppContext) {
+        let cx = VimTestContext::new(cx, true).await;
+        let mut cx = cx.binding(["v", "w", "x"]);
+        cx.assert("The quick |brown", "The quick| ");
+        let mut cx = cx.binding(["v", "w", "j", "x"]);
+        cx.assert(
+            indoc! {"
+                The |quick brown
+                fox jumps over
+                the lazy dog"},
+            indoc! {"
+                The |ver
+                the lazy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |lazy dog"},
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |og"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps |over
+                the lazy dog"},
+            indoc! {"
+                The quick brown
+                fox jumps |he lazy dog"},
+        );
+        let mut cx = cx.binding(["v", "b", "k", "x"]);
+        cx.assert(
+            indoc! {"
+                The |quick brown
+                fox jumps over
+                the lazy dog"},
+            indoc! {"
+                |uick brown
+                fox jumps over
+                the lazy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |lazy dog"},
+            indoc! {"
+                The quick brown
+                |azy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps |over
+                the lazy dog"},
+            indoc! {"
+                The |ver
+                the lazy dog"},
+        );
+    }
+
+    #[gpui::test]
+    async fn test_visual_change(cx: &mut gpui::TestAppContext) {
+        let cx = VimTestContext::new(cx, true).await;
+        let mut cx = cx.binding(["v", "w", "x"]).mode_after(Mode::Insert);
+        cx.assert("The quick |brown", "The quick |");
+        let mut cx = cx.binding(["v", "w", "j", "c"]).mode_after(Mode::Insert);
+        cx.assert(
+            indoc! {"
+                The |quick brown
+                fox jumps over
+                the lazy dog"},
+            indoc! {"
+                The |ver
+                the lazy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |lazy dog"},
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |og"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps |over
+                the lazy dog"},
+            indoc! {"
+                The quick brown
+                fox jumps |he lazy dog"},
+        );
+        let mut cx = cx.binding(["v", "b", "k", "c"]).mode_after(Mode::Insert);
+        cx.assert(
+            indoc! {"
+                The |quick brown
+                fox jumps over
+                the lazy dog"},
+            indoc! {"
+                |uick brown
+                fox jumps over
+                the lazy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps over
+                the |lazy dog"},
+            indoc! {"
+                The quick brown
+                |azy dog"},
+        );
+        cx.assert(
+            indoc! {"
+                The quick brown
+                fox jumps |over
+                the lazy dog"},
+            indoc! {"
+                The |ver
+                the lazy dog"},
+        );
+    }
+}


### PR DESCRIPTION
Adds basic visual mode with c, x, and d commands to change, and delete over the selection