### PR TITLE
Filter overlapping multibuffer edits

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9801,7 +9801,17 @@ mod tests {
     #[gpui::test]
     fn test_editing_overlapping_excerpts(cx: &mut gpui::MutableAppContext) {
         cx.set_global(Settings::test(cx));
-        let buffer = cx.add_model(|cx| Buffer::new(0, sample_text(3, 4, 'a'), cx));
+        let buffer = cx.add_model(|cx| {
+            Buffer::new(
+                0,
+                indoc! {"
+                    aaaa
+                    bbbb
+                    cccc"},
+                cx,
+            )
+        });
+
         let multibuffer = cx.add_model(|cx| {
             let mut multibuffer = MultiBuffer::new(0);
             multibuffer.push_excerpts(

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -378,13 +378,11 @@ impl MultiBuffer {
                     let mut insertions = Vec::new();
                     let mut deletions = Vec::new();
                     let empty_str: Arc<str> = "".into();
-                    while let Some((mut range, mut new_text, mut is_insertion)) = edits.next() {
-                        while let Some((next_range, next_new_text, next_is_insertion)) =
-                            edits.peek()
-                        {
+                    while let Some((mut range, new_text, mut is_insertion)) = edits.next() {
+                        while let Some((next_range, _, next_is_insertion)) = edits.peek() {
                             if range.end >= next_range.start {
                                 range.end = cmp::max(next_range.end, range.end);
-                                new_text = format!("{new_text}{next_new_text}").into();
+
                                 is_insertion |= *next_is_insertion;
                                 edits.next();
                             } else {
@@ -395,7 +393,7 @@ impl MultiBuffer {
                         if is_insertion {
                             insertions.push((
                                 buffer.anchor_before(range.start)..buffer.anchor_before(range.end),
-                                new_text,
+                                new_text.clone(),
                             ));
                         } else if !range.is_empty() {
                             deletions.push((

--- a/crates/util/src/test/marked_text.rs
+++ b/crates/util/src/test/marked_text.rs
@@ -55,10 +55,18 @@ pub fn marked_text_ranges_by(
     (unmarked_text, range_lookup)
 }
 
-pub fn marked_text_ranges(marked_text: &str) -> (String, Vec<Range<usize>>) {
-    let (unmarked_text, mut ranges) = marked_text_ranges_by(marked_text, vec![('[', ']')]);
+// Returns ranges delimited by (), [], and <> ranges. Ranges using the same markers
+// must not be overlapping. May also include | for empty ranges
+pub fn marked_text_ranges(full_marked_text: &str) -> (String, Vec<Range<usize>>) {
+    let (range_marked_text, empty_offsets) = marked_text(full_marked_text);
+    let (unmarked, range_lookup) =
+        marked_text_ranges_by(&range_marked_text, vec![('[', ']'), ('(', ')'), ('<', '>')]);
     (
-        unmarked_text,
-        ranges.remove(&('[', ']')).unwrap_or_else(Vec::new),
+        unmarked,
+        range_lookup
+            .into_values()
+            .flatten()
+            .chain(empty_offsets.into_iter().map(|offset| offset..offset))
+            .collect(),
     )
 }


### PR DESCRIPTION
Also updates marked_text_ranges method to be more flexible by default.
Fixes https://github.com/zed-industries/zed/issues/974