### PR TITLE
Only synthesize mouse moves on scene construction if window is active

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1005,6 +1005,13 @@ impl MutableAppContext {
             .and_then(|window| window.root_view.clone().downcast::<T>())
     }
 
+    pub fn window_is_active(&self, window_id: usize) -> bool {
+        self.cx
+            .windows
+            .get(&window_id)
+            .map_or(false, |window| window.is_active)
+    }
+
     pub fn render_view(
         &mut self,
         window_id: usize,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -122,8 +122,10 @@ impl Presenter {
             self.text_layout_cache.finish_frame();
             self.cursor_styles = scene.cursor_styles();
 
-            if let Some(event) = self.last_mouse_moved_event.clone() {
-                self.dispatch_event(event, cx)
+            if cx.window_is_active(self.window_id) {
+                if let Some(event) = self.last_mouse_moved_event.clone() {
+                    self.dispatch_event(event, cx)
+                }
             }
         } else {
             log::error!("could not find root_view_id for window {}", self.window_id);


### PR DESCRIPTION
I'm hoping that this resolves issues with the cursor style flickering. Whenever we build a scene, we always synthesize a mouse move event in order to set the cursor style and update hover styles etc for moved elements. It actually only makes sense to do this if the window is active.