### PR TITLE
Log JSON in Kubernetes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5334,6 +5334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5343,12 +5353,15 @@ dependencies = [
  "lazy_static",
  "matchers",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -45,7 +45,7 @@ toml = "0.5.8"
 tracing = "0.1.34"
 tracing-log = "0.1.3"
 tracing-opentelemetry = "0.17"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 
 [dependencies.sqlx]
 version = "0.5.2"

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -83,6 +83,8 @@ spec:
                   key: token
             - name: RUST_LOG
               value: ${RUST_LOG}
+            - name: LOG_JSON
+              value: "true"
             - name: HONEYCOMB_DATASET
               value: "collab"
             - name: HONEYCOMB_API_KEY


### PR DESCRIPTION
If you set LOG_JSON=true, we'll output JSON from the tracing subscriber instead of pretty-printing trace output. This is in preparation to use Datadog for logging.