### PR TITLE
Bump `FoldSnapshot` version if excerpt gets edited outside of its bounds

### DIFF
--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -271,7 +271,8 @@ impl FoldMap {
     ) -> Vec<FoldEdit> {
         if buffer_edits.is_empty() {
             let mut buffer = self.buffer.lock();
-            if buffer.parse_count() != new_buffer.parse_count()
+            if buffer.edit_count() != new_buffer.edit_count()
+                || buffer.parse_count() != new_buffer.parse_count()
                 || buffer.diagnostics_update_count() != new_buffer.diagnostics_update_count()
                 || buffer.trailing_excerpt_update_count()
                     != new_buffer.trailing_excerpt_update_count()


### PR DESCRIPTION
Fixes #1008 

This will cause layers above `FoldMap` to grab a fresh snapshot of the `FoldMap` and, as a result, of the underlying `MultiBufferSnapshot`. It is a necessary change because, even though the coordinate space is not affected, a buffer edit taking place *before* an excerpt range could cause the excerpt buffer rows to change, e.g. if lines were added or removed. This manifested itself in a randomized test.

I am guessing this also fixes the above issue because, even though we didn't soft-wrap, we always impose a wrap width due to #866, so I think we were going down the same code path that prevented the `WrapMap` from accessing the freshest version of the `FoldSnapshot`.