### PR TITLE
Correctly populate application menus' keystrokes and enabled status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "fuzzy",
  "gpui",
  "picker",
+ "project",
  "serde_json",
  "settings",
  "theme",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -18,7 +18,8 @@
             "cmd-s": "workspace::Save",
             "cmd-=": "zed::IncreaseBufferFontSize",
             "cmd--": "zed::DecreaseBufferFontSize",
-            "cmd-,": "zed::OpenSettings"
+            "cmd-,": "zed::OpenSettings",
+            "cmd-q": "zed::Quit"
         }
     },
     {

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -19,7 +19,9 @@
             "cmd-=": "zed::IncreaseBufferFontSize",
             "cmd--": "zed::DecreaseBufferFontSize",
             "cmd-,": "zed::OpenSettings",
-            "cmd-q": "zed::Quit"
+            "cmd-q": "zed::Quit",
+            "cmd-n": "workspace::OpenNew",
+            "cmd-o": "workspace::Open"
         }
     },
     {

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -6598,7 +6598,7 @@ mod tests {
                 themes: ThemeRegistry::new((), cx.font_cache()),
                 fs: FakeFs::new(cx.background()),
                 build_window_options: || Default::default(),
-                build_workspace: |_, _, _| unimplemented!(),
+                initialize_workspace: |_, _, _| unimplemented!(),
             });
 
             Channel::init(&client);

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1630,7 +1630,7 @@ mod tests {
     use gpui::{
         executor::{self, Deterministic},
         geometry::vector::vec2f,
-        ModelHandle, TestAppContext, ViewHandle,
+        ModelHandle, Task, TestAppContext, ViewHandle,
     };
     use language::{
         range_to_lsp, tree_sitter_rust, Diagnostic, DiagnosticEntry, FakeLspAdapter, Language,
@@ -1662,7 +1662,7 @@ mod tests {
         time::Duration,
     };
     use theme::ThemeRegistry;
-    use workspace::{Item, SplitDirection, ToggleFollow, Workspace, WorkspaceParams};
+    use workspace::{Item, SplitDirection, ToggleFollow, Workspace};
 
     #[cfg(test)]
     #[ctor::ctor]
@@ -4322,13 +4322,7 @@ mod tests {
 
         // Join the project as client B.
         let project_b = client_b.build_remote_project(&project_a, cx_a, cx_b).await;
-        let mut params = cx_b.update(WorkspaceParams::test);
-        params.languages = lang_registry.clone();
-        params.project = project_b.clone();
-        params.client = client_b.client.clone();
-        params.user_store = client_b.user_store.clone();
-
-        let (_window_b, workspace_b) = cx_b.add_window(|cx| Workspace::new(&params, cx));
+        let (_window_b, workspace_b) = cx_b.add_window(|cx| Workspace::new(project_b.clone(), cx));
         let editor_b = workspace_b
             .update(cx_b, |workspace, cx| {
                 workspace.open_path((worktree_id, "main.rs"), true, cx)
@@ -4563,13 +4557,7 @@ mod tests {
 
         // Join the worktree as client B.
         let project_b = client_b.build_remote_project(&project_a, cx_a, cx_b).await;
-        let mut params = cx_b.update(WorkspaceParams::test);
-        params.languages = lang_registry.clone();
-        params.project = project_b.clone();
-        params.client = client_b.client.clone();
-        params.user_store = client_b.user_store.clone();
-
-        let (_window_b, workspace_b) = cx_b.add_window(|cx| Workspace::new(&params, cx));
+        let (_window_b, workspace_b) = cx_b.add_window(|cx| Workspace::new(project_b.clone(), cx));
         let editor_b = workspace_b
             .update(cx_b, |workspace, cx| {
                 workspace.open_path((worktree_id, "one.rs"), true, cx)
@@ -6602,13 +6590,21 @@ mod tests {
                     })
                 });
 
-            Channel::init(&client);
-            Project::init(&client);
-            cx.update(|cx| {
-                workspace::init(&client, cx);
+            let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http, cx));
+            let app_state = Arc::new(workspace::AppState {
+                client: client.clone(),
+                user_store: user_store.clone(),
+                languages: Arc::new(LanguageRegistry::new(Task::ready(()))),
+                themes: ThemeRegistry::new((), cx.font_cache()),
+                fs: FakeFs::new(cx.background()),
+                build_window_options: || Default::default(),
+                build_workspace: |_, _, _| unimplemented!(),
             });
 
-            let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http, cx));
+            Channel::init(&client);
+            Project::init(&client);
+            cx.update(|cx| workspace::init(app_state.clone(), cx));
+
             client
                 .authenticate_and_connect(false, &cx.to_async())
                 .await
@@ -6846,23 +6842,7 @@ mod tests {
             cx: &mut TestAppContext,
         ) -> ViewHandle<Workspace> {
             let (window_id, _) = cx.add_window(|_| EmptyView);
-            cx.add_view(window_id, |cx| {
-                let fs = project.read(cx).fs().clone();
-                Workspace::new(
-                    &WorkspaceParams {
-                        fs,
-                        project: project.clone(),
-                        user_store: self.user_store.clone(),
-                        languages: self.language_registry.clone(),
-                        themes: ThemeRegistry::new((), cx.font_cache().clone()),
-                        channel_list: cx.add_model(|cx| {
-                            ChannelList::new(self.user_store.clone(), self.client.clone(), cx)
-                        }),
-                        client: self.client.clone(),
-                    },
-                    cx,
-                )
-            })
+            cx.add_view(window_id, |cx| Workspace::new(project.clone(), cx))
         }
 
         async fn simulate_host(

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -12,6 +12,7 @@ editor = { path = "../editor" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
 picker = { path = "../picker" }
+project = { path = "../project" }
 settings = { path = "../settings" }
 util = { path = "../util" }
 theme = { path = "../theme" }
@@ -20,6 +21,7 @@ workspace = { path = "../workspace" }
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
 editor = { path = "../editor", features = ["test-support"] }
+project = { path = "../project", features = ["test-support"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 workspace = { path = "../workspace", features = ["test-support"] }
 ctor = "0.1"

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -299,7 +299,8 @@ mod tests {
     use super::*;
     use editor::Editor;
     use gpui::TestAppContext;
-    use workspace::{Workspace, WorkspaceParams};
+    use project::Project;
+    use workspace::{AppState, Workspace};
 
     #[test]
     fn test_humanize_action_name() {
@@ -319,15 +320,16 @@ mod tests {
 
     #[gpui::test]
     async fn test_command_palette(cx: &mut TestAppContext) {
-        let params = cx.update(WorkspaceParams::test);
+        let app_state = cx.update(AppState::test);
 
         cx.update(|cx| {
             editor::init(cx);
-            workspace::init(&params.client, cx);
+            workspace::init(app_state.clone(), cx);
             init(cx);
         });
 
-        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(project, cx));
         let editor = cx.add_view(window_id, |cx| {
             let mut editor = Editor::single_line(None, cx);
             editor.set_text("abc", cx);

--- a/crates/contacts_panel/src/contacts_panel.rs
+++ b/crates/contacts_panel/src/contacts_panel.rs
@@ -1111,8 +1111,8 @@ mod tests {
                 client,
                 user_store: user_store.clone(),
                 fs,
-                build_window_options: || unimplemented!(),
-                build_workspace: |_, _, _| unimplemented!(),
+                build_window_options: || Default::default(),
+                initialize_workspace: |_, _, _| {},
             }),
             server,
         )

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8815,7 +8815,7 @@ mod tests {
         let fs = FakeFs::new(cx.background().clone());
         fs.insert_file("/file.rs", Default::default()).await;
 
-        let project = Project::test(fs, ["/file.rs"], cx).await;
+        let project = Project::test(fs, ["/file.rs".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages().add(Arc::new(language)));
         let buffer = project
             .update(cx, |project, cx| project.open_local_buffer("/file.rs", cx))
@@ -8937,7 +8937,7 @@ mod tests {
         let fs = FakeFs::new(cx.background().clone());
         fs.insert_file("/file.rs", text).await;
 
-        let project = Project::test(fs, ["/file.rs"], cx).await;
+        let project = Project::test(fs, ["/file.rs".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages().add(Arc::new(language)));
         let buffer = project
             .update(cx, |project, cx| project.open_local_buffer("/file.rs", cx))

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -192,11 +192,18 @@ impl App {
                 cx.borrow_mut().quit();
             }
         }));
+        foreground_platform.on_will_open_menu(Box::new({
+            let cx = app.0.clone();
+            move || {
+                let mut cx = cx.borrow_mut();
+                cx.keystroke_matcher.clear_pending();
+            }
+        }));
         foreground_platform.on_validate_menu_command(Box::new({
             let cx = app.0.clone();
             move |action| {
                 let cx = cx.borrow_mut();
-                cx.is_action_available(action)
+                !cx.keystroke_matcher.has_pending_keystrokes() && cx.is_action_available(action)
             }
         }));
         foreground_platform.on_menu_command(Box::new({

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -154,7 +154,6 @@ pub struct Menu<'a> {
 pub enum MenuItem<'a> {
     Action {
         name: &'a str,
-        keystroke: Option<&'a str>,
         action: Box<dyn Action>,
     },
     Separator,
@@ -1070,7 +1069,8 @@ impl MutableAppContext {
     }
 
     pub fn set_menus(&mut self, menus: Vec<Menu>) {
-        self.foreground_platform.set_menus(menus);
+        self.foreground_platform
+            .set_menus(menus, &self.keystroke_matcher);
     }
 
     fn prompt(

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -192,6 +192,13 @@ impl App {
                 cx.borrow_mut().quit();
             }
         }));
+        foreground_platform.on_validate_menu_command(Box::new({
+            let cx = app.0.clone();
+            move |action| {
+                let cx = cx.borrow_mut();
+                cx.is_action_available(action)
+            }
+        }));
         foreground_platform.on_menu_command(Box::new({
             let cx = app.0.clone();
             move |action| {
@@ -1362,6 +1369,26 @@ impl MutableAppContext {
                     None
                 }
             })
+    }
+
+    pub fn is_action_available(&self, action: &dyn Action) -> bool {
+        let action_type = action.as_any().type_id();
+        if let Some(window_id) = self.cx.platform.key_window_id() {
+            if let Some((presenter, _)) = self.presenters_and_platform_windows.get(&window_id) {
+                let dispatch_path = presenter.borrow().dispatch_path(&self.cx);
+                for view_id in dispatch_path {
+                    if let Some(view) = self.views.get(&(window_id, view_id)) {
+                        let view_type = view.as_any().type_id();
+                        if let Some(actions) = self.actions.get(&view_type) {
+                            if actions.contains_key(&action_type) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.global_actions.contains_key(&action_type)
     }
 
     pub fn dispatch_action_at(&mut self, window_id: usize, view_id: usize, action: &dyn Action) {

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -215,12 +215,12 @@ where
         self.autoscroll(scroll_max, size.y(), item_height);
 
         let start = cmp::min(
-            ((self.scroll_top() - self.padding_top) / item_height) as usize,
+            ((self.scroll_top() - self.padding_top) / item_height.max(1.)) as usize,
             self.item_count,
         );
         let end = cmp::min(
             self.item_count,
-            start + (size.y() / item_height).ceil() as usize + 1,
+            start + (size.y() / item_height.max(1.)).ceil() as usize + 1,
         );
 
         if (start..end).contains(&sample_item_ix) {

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -123,6 +123,10 @@ impl Matcher {
         self.pending.clear();
     }
 
+    pub fn has_pending_keystrokes(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
     pub fn push_keystroke(
         &mut self,
         keystroke: Keystroke,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -73,6 +73,7 @@ pub(crate) trait ForegroundPlatform {
     fn run(&self, on_finish_launching: Box<dyn FnOnce() -> ()>);
 
     fn on_menu_command(&self, callback: Box<dyn FnMut(&dyn Action)>);
+    fn on_validate_menu_command(&self, callback: Box<dyn FnMut(&dyn Action) -> bool>);
     fn set_menus(&self, menus: Vec<Menu>, matcher: &keymap::Matcher);
     fn prompt_for_paths(
         &self,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -74,6 +74,7 @@ pub(crate) trait ForegroundPlatform {
 
     fn on_menu_command(&self, callback: Box<dyn FnMut(&dyn Action)>);
     fn on_validate_menu_command(&self, callback: Box<dyn FnMut(&dyn Action) -> bool>);
+    fn on_will_open_menu(&self, callback: Box<dyn FnMut()>);
     fn set_menus(&self, menus: Vec<Menu>, matcher: &keymap::Matcher);
     fn prompt_for_paths(
         &self,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -14,6 +14,7 @@ use crate::{
         rect::{RectF, RectI},
         vector::Vector2F,
     },
+    keymap,
     text_layout::{LineLayout, RunStyle},
     Action, ClipboardItem, Menu, Scene,
 };
@@ -72,7 +73,7 @@ pub(crate) trait ForegroundPlatform {
     fn run(&self, on_finish_launching: Box<dyn FnOnce() -> ()>);
 
     fn on_menu_command(&self, callback: Box<dyn FnMut(&dyn Action)>);
-    fn set_menus(&self, menus: Vec<Menu>);
+    fn set_menus(&self, menus: Vec<Menu>, matcher: &keymap::Matcher);
     fn prompt_for_paths(
         &self,
         options: PathPromptOptions,

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -8,7 +8,35 @@ use cocoa::{
     base::{id, nil, YES},
     foundation::NSString as _,
 };
-use std::{ffi::CStr, os::raw::c_char};
+use std::{borrow::Cow, ffi::CStr, os::raw::c_char};
+
+pub fn key_to_native(key: &str) -> Cow<str> {
+    use cocoa::appkit::*;
+    let code = match key {
+        "backspace" => 0x7F,
+        "up" => NSUpArrowFunctionKey,
+        "down" => NSDownArrowFunctionKey,
+        "left" => NSLeftArrowFunctionKey,
+        "right" => NSRightArrowFunctionKey,
+        "pageup" => NSPageUpFunctionKey,
+        "pagedown" => NSPageDownFunctionKey,
+        "delete" => NSDeleteFunctionKey,
+        "f1" => NSF1FunctionKey,
+        "f2" => NSF2FunctionKey,
+        "f3" => NSF3FunctionKey,
+        "f4" => NSF4FunctionKey,
+        "f5" => NSF5FunctionKey,
+        "f6" => NSF6FunctionKey,
+        "f7" => NSF7FunctionKey,
+        "f8" => NSF8FunctionKey,
+        "f9" => NSF9FunctionKey,
+        "f10" => NSF10FunctionKey,
+        "f11" => NSF11FunctionKey,
+        "f12" => NSF12FunctionKey,
+        _ => return Cow::Borrowed(key),
+    };
+    Cow::Owned(String::from_utf16(&[code]).unwrap())
+}
 
 impl Event {
     pub unsafe fn from_native(native_event: id, window_height: Option<f32>) -> Option<Self> {

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -1,4 +1,4 @@
-use super::{BoolExt as _, Dispatcher, FontSystem, Window};
+use super::{event::key_to_native, BoolExt as _, Dispatcher, FontSystem, Window};
 use crate::{
     executor, keymap,
     platform::{self, CursorStyle},
@@ -165,7 +165,7 @@ impl MacForegroundPlatform {
                                 .initWithTitle_action_keyEquivalent_(
                                     ns_string(name),
                                     selector("handleGPUIMenuItem:"),
-                                    ns_string(&keystroke.key),
+                                    ns_string(key_to_native(&keystroke.key).as_ref()),
                                 )
                                 .autorelease();
                             item.setKeyEquivalentModifierMask_(mask);

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -1,7 +1,7 @@
 use super::{AppVersion, CursorStyle, WindowBounds};
 use crate::{
     geometry::vector::{vec2f, Vector2F},
-    Action, ClipboardItem,
+    keymap, Action, ClipboardItem,
 };
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
@@ -74,7 +74,7 @@ impl super::ForegroundPlatform for ForegroundPlatform {
 
     fn on_menu_command(&self, _: Box<dyn FnMut(&dyn Action)>) {}
 
-    fn set_menus(&self, _: Vec<crate::Menu>) {}
+    fn set_menus(&self, _: Vec<crate::Menu>, _: &keymap::Matcher) {}
 
     fn prompt_for_paths(
         &self,

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -74,6 +74,8 @@ impl super::ForegroundPlatform for ForegroundPlatform {
 
     fn on_menu_command(&self, _: Box<dyn FnMut(&dyn Action)>) {}
 
+    fn on_validate_menu_command(&self, _: Box<dyn FnMut(&dyn Action) -> bool>) {}
+
     fn set_menus(&self, _: Vec<crate::Menu>, _: &keymap::Matcher) {}
 
     fn prompt_for_paths(

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -73,9 +73,8 @@ impl super::ForegroundPlatform for ForegroundPlatform {
     }
 
     fn on_menu_command(&self, _: Box<dyn FnMut(&dyn Action)>) {}
-
     fn on_validate_menu_command(&self, _: Box<dyn FnMut(&dyn Action) -> bool>) {}
-
+    fn on_will_open_menu(&self, _: Box<dyn FnMut()>) {}
     fn set_menus(&self, _: Vec<crate::Menu>, _: &keymap::Matcher) {}
 
     fn prompt_for_paths(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -497,7 +497,7 @@ impl Project {
     #[cfg(any(test, feature = "test-support"))]
     pub async fn test(
         fs: Arc<dyn Fs>,
-        root_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+        root_paths: impl IntoIterator<Item = &Path>,
         cx: &mut gpui::TestAppContext,
     ) -> ModelHandle<Project> {
         let languages = Arc::new(LanguageRegistry::test());
@@ -526,6 +526,14 @@ impl Project {
 
     pub fn languages(&self) -> &Arc<LanguageRegistry> {
         &self.languages
+    }
+
+    pub fn client(&self) -> Arc<Client> {
+        self.client.clone()
+    }
+
+    pub fn user_store(&self) -> ModelHandle<UserStore> {
+        self.user_store.clone()
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -5294,7 +5302,7 @@ mod tests {
         )
         .unwrap();
 
-        let project = Project::test(Arc::new(RealFs), [root_link_path], cx).await;
+        let project = Project::test(Arc::new(RealFs), [root_link_path.as_ref()], cx).await;
 
         project.read_with(cx, |project, cx| {
             let tree = project.worktrees(cx).next().unwrap().read(cx);
@@ -5378,7 +5386,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/the-root"], cx).await;
+        let project = Project::test(fs.clone(), ["/the-root".as_ref()], cx).await;
         project.update(cx, |project, _| {
             project.languages.add(Arc::new(rust_language));
             project.languages.add(Arc::new(json_language));
@@ -5714,7 +5722,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir/a.rs", "/dir/b.rs"], cx).await;
+        let project = Project::test(fs, ["/dir/a.rs".as_ref(), "/dir/b.rs".as_ref()], cx).await;
 
         let buffer_a = project
             .update(cx, |project, cx| project.open_local_buffer("/dir/a.rs", cx))
@@ -5825,7 +5833,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
         let worktree_id =
             project.read_with(cx, |p, cx| p.worktrees(cx).next().unwrap().read(cx).id());
@@ -5947,7 +5955,7 @@ mod tests {
         let fs = FakeFs::new(cx.background());
         fs.insert_tree("/dir", json!({ "a.rs": "" })).await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
 
         let buffer = project
@@ -6016,7 +6024,7 @@ mod tests {
         let fs = FakeFs::new(cx.background());
         fs.insert_tree("/dir", json!({ "a.rs": text })).await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
 
         let buffer = project
@@ -6285,7 +6293,7 @@ mod tests {
         let fs = FakeFs::new(cx.background());
         fs.insert_tree("/dir", json!({ "a.rs": text })).await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         let buffer = project
             .update(cx, |project, cx| project.open_local_buffer("/dir/a.rs", cx))
             .await
@@ -6376,7 +6384,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
         let buffer = project
             .update(cx, |project, cx| project.open_local_buffer("/dir/a.rs", cx))
@@ -6530,7 +6538,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         let buffer = project
             .update(cx, |project, cx| project.open_local_buffer("/dir/a.rs", cx))
             .await
@@ -6686,7 +6694,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir/b.rs"], cx).await;
+        let project = Project::test(fs, ["/dir/b.rs".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
 
         let buffer = project
@@ -6780,7 +6788,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
         let buffer = project
             .update(cx, |p, cx| p.open_local_buffer("/dir/a.ts", cx))
@@ -6838,7 +6846,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs, ["/dir"], cx).await;
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
         let buffer = project
             .update(cx, |p, cx| p.open_local_buffer("/dir/a.ts", cx))
@@ -6944,7 +6952,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let buffer = project
             .update(cx, |p, cx| p.open_local_buffer("/dir/file1", cx))
             .await
@@ -6973,7 +6981,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/dir/file1"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir/file1".as_ref()], cx).await;
         let buffer = project
             .update(cx, |p, cx| p.open_local_buffer("/dir/file1", cx))
             .await
@@ -6995,7 +7003,7 @@ mod tests {
         let fs = FakeFs::new(cx.background());
         fs.insert_tree("/dir", json!({})).await;
 
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let buffer = project.update(cx, |project, cx| {
             project.create_buffer("", None, cx).unwrap()
         });
@@ -7182,7 +7190,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
 
         // Spawn multiple tasks to open paths, repeating some paths.
         let (buffer_a_1, buffer_b, buffer_a_2) = project.update(cx, |p, cx| {
@@ -7227,7 +7235,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
 
         let buffer1 = project
             .update(cx, |p, cx| p.open_local_buffer("/dir/file1", cx))
@@ -7359,7 +7367,7 @@ mod tests {
             }),
         )
         .await;
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let buffer = project
             .update(cx, |p, cx| p.open_local_buffer("/dir/the-file", cx))
             .await
@@ -7444,7 +7452,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/the-dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/the-dir".as_ref()], cx).await;
         let buffer = project
             .update(cx, |p, cx| p.open_local_buffer("/the-dir/a.rs", cx))
             .await
@@ -7708,7 +7716,7 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages.add(Arc::new(language)));
         let buffer = project
             .update(cx, |project, cx| {
@@ -7827,7 +7835,7 @@ mod tests {
             }),
         )
         .await;
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         assert_eq!(
             search(&project, SearchQuery::text("TWO", false, true), cx)
                 .await

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -913,11 +913,14 @@ mod tests {
     use project::FakeFs;
     use serde_json::json;
     use std::{collections::HashSet, path::Path};
-    use workspace::WorkspaceParams;
 
     #[gpui::test]
     async fn test_visible_list(cx: &mut gpui::TestAppContext) {
         cx.foreground().forbid_parking();
+        cx.update(|cx| {
+            let settings = Settings::test(cx);
+            cx.set_global(settings);
+        });
 
         let fs = FakeFs::new(cx.background());
         fs.insert_tree(
@@ -956,9 +959,8 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/root1", "/root2"], cx).await;
-        let params = cx.update(WorkspaceParams::test);
-        let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
+        let project = Project::test(fs.clone(), ["/root1".as_ref(), "/root2".as_ref()], cx).await;
+        let (_, workspace) = cx.add_window(|cx| Workspace::new(project.clone(), cx));
         let panel = workspace.update(cx, |_, cx| ProjectPanel::new(project, cx));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..50, cx),
@@ -1005,6 +1007,10 @@ mod tests {
     #[gpui::test(iterations = 30)]
     async fn test_editing_files(cx: &mut gpui::TestAppContext) {
         cx.foreground().forbid_parking();
+        cx.update(|cx| {
+            let settings = Settings::test(cx);
+            cx.set_global(settings);
+        });
 
         let fs = FakeFs::new(cx.background());
         fs.insert_tree(
@@ -1043,9 +1049,8 @@ mod tests {
         )
         .await;
 
-        let project = Project::test(fs.clone(), ["/root1", "/root2"], cx).await;
-        let params = cx.update(WorkspaceParams::test);
-        let (_, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
+        let project = Project::test(fs.clone(), ["/root1".as_ref(), "/root2".as_ref()], cx).await;
+        let (_, workspace) = cx.add_window(|cx| Workspace::new(project.clone(), cx));
         let panel = workspace.update(cx, |_, cx| ProjectPanel::new(project, cx));
 
         select_path(&panel, "root1", cx);

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -295,7 +295,7 @@ mod tests {
         let fs = FakeFs::new(cx.background());
         fs.insert_tree("/dir", json!({ "test.rs": "" })).await;
 
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         project.update(cx, |project, _| project.languages().add(Arc::new(language)));
 
         let _buffer = project

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -848,7 +848,7 @@ mod tests {
             }),
         )
         .await;
-        let project = Project::test(fs.clone(), ["/dir"], cx).await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let search = cx.add_model(|cx| ProjectSearch::new(project, cx));
         let search_view = cx.add_view(Default::default(), |cx| {
             ProjectSearchView::new(search.clone(), cx)

--- a/crates/vim/src/vim_test_context.rs
+++ b/crates/vim/src/vim_test_context.rs
@@ -7,11 +7,12 @@ use editor::{display_map::ToDisplayPoint, Autoscroll};
 use gpui::{json::json, keymap::Keystroke, ViewHandle};
 use indoc::indoc;
 use language::Selection;
+use project::Project;
 use util::{
     set_eq,
     test::{marked_text, marked_text_ranges_by, SetEqError},
 };
-use workspace::{WorkspaceHandle, WorkspaceParams};
+use workspace::{AppState, WorkspaceHandle};
 
 use crate::{state::Operator, *};
 
@@ -30,7 +31,8 @@ impl<'a> VimTestContext<'a> {
             settings::KeymapFileContent::load("keymaps/vim.json", cx).unwrap();
         });
 
-        let params = cx.update(WorkspaceParams::test);
+        let params = cx.update(AppState::test);
+        let project = Project::test(params.fs.clone(), [], cx).await;
 
         cx.update(|cx| {
             cx.update_global(|settings: &mut Settings, _| {
@@ -44,9 +46,8 @@ impl<'a> VimTestContext<'a> {
             .insert_tree("/root", json!({ "dir": { "test.txt": "" } }))
             .await;
 
-        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
-        params
-            .project
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(project.clone(), cx));
+        project
             .update(cx, |project, cx| {
                 project.find_or_create_local_worktree("/root", true, cx)
             })

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -920,7 +920,7 @@ impl NavHistory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::WorkspaceParams;
+    use crate::AppState;
     use gpui::{ModelHandle, TestAppContext, ViewContext};
     use project::Project;
     use std::sync::atomic::AtomicUsize;
@@ -929,8 +929,9 @@ mod tests {
     async fn test_close_items(cx: &mut TestAppContext) {
         cx.foreground().forbid_parking();
 
-        let params = cx.update(WorkspaceParams::test);
-        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
+        let app_state = cx.update(AppState::test);
+        let project = Project::test(app_state.fs.clone(), None, cx).await;
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(project, cx));
         let item1 = cx.add_view(window_id, |_| {
             let mut item = TestItem::new();
             item.is_dirty = true;
@@ -1019,8 +1020,9 @@ mod tests {
     async fn test_prompting_only_on_last_item_for_entry(cx: &mut TestAppContext) {
         cx.foreground().forbid_parking();
 
-        let params = cx.update(WorkspaceParams::test);
-        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(&params, cx));
+        let app_state = cx.update(AppState::test);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(project, cx));
         let item = cx.add_view(window_id, |_| {
             let mut item = TestItem::new();
             item.is_dirty = true;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9,8 +9,7 @@ mod waiting_room;
 
 use anyhow::{anyhow, Context, Result};
 use client::{
-    proto, Authenticate, ChannelList, Client, Contact, PeerId, Subscription, TypedEnvelope, User,
-    UserStore,
+    proto, Authenticate, Client, Contact, PeerId, Subscription, TypedEnvelope, User, UserStore,
 };
 use clock::ReplicaId;
 use collections::{hash_map, HashMap, HashSet};
@@ -75,6 +74,8 @@ type FollowableItemBuilders = HashMap<
 actions!(
     workspace,
     [
+        Open,
+        OpenNew,
         Unfollow,
         Save,
         ActivatePreviousPane,
@@ -84,15 +85,8 @@ actions!(
 );
 
 #[derive(Clone)]
-pub struct Open(pub Arc<AppState>);
-
-#[derive(Clone)]
-pub struct OpenNew(pub Arc<AppState>);
-
-#[derive(Clone)]
 pub struct OpenPaths {
     pub paths: Vec<PathBuf>,
-    pub app_state: Arc<AppState>,
 }
 
 #[derive(Clone)]
@@ -102,31 +96,37 @@ pub struct ToggleFollow(pub PeerId);
 pub struct JoinProject {
     pub contact: Arc<Contact>,
     pub project_index: usize,
-    pub app_state: Arc<AppState>,
 }
 
-impl_internal_actions!(
-    workspace,
-    [Open, OpenNew, OpenPaths, ToggleFollow, JoinProject]
-);
+impl_internal_actions!(workspace, [OpenPaths, ToggleFollow, JoinProject]);
 
-pub fn init(client: &Arc<Client>, cx: &mut MutableAppContext) {
+pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
     pane::init(cx);
 
     cx.add_global_action(open);
-    cx.add_global_action(move |action: &OpenPaths, cx: &mut MutableAppContext| {
-        open_paths(&action.paths, &action.app_state, cx).detach();
+    cx.add_global_action({
+        let app_state = Arc::downgrade(&app_state);
+        move |action: &OpenPaths, cx: &mut MutableAppContext| {
+            if let Some(app_state) = app_state.upgrade() {
+                open_paths(&action.paths, &app_state, cx).detach();
+            }
+        }
     });
-    cx.add_global_action(move |action: &OpenNew, cx: &mut MutableAppContext| {
-        open_new(&action.0, cx)
+    cx.add_global_action({
+        let app_state = Arc::downgrade(&app_state);
+        move |_: &OpenNew, cx: &mut MutableAppContext| {
+            if let Some(app_state) = app_state.upgrade() {
+                open_new(&app_state, cx)
+            }
+        }
     });
-    cx.add_global_action(move |action: &JoinProject, cx: &mut MutableAppContext| {
-        join_project(
-            action.contact.clone(),
-            action.project_index,
-            &action.app_state,
-            cx,
-        );
+    cx.add_global_action({
+        let app_state = Arc::downgrade(&app_state);
+        move |action: &JoinProject, cx: &mut MutableAppContext| {
+            if let Some(app_state) = app_state.upgrade() {
+                join_project(action.contact.clone(), action.project_index, &app_state, cx);
+            }
+        }
     });
 
     cx.add_async_action(Workspace::toggle_follow);
@@ -151,6 +151,7 @@ pub fn init(client: &Arc<Client>, cx: &mut MutableAppContext) {
         workspace.activate_next_pane(cx)
     });
 
+    let client = &app_state.client;
     client.add_view_request_handler(Workspace::handle_follow);
     client.add_view_message_handler(Workspace::handle_unfollow);
     client.add_view_message_handler(Workspace::handle_update_followers);
@@ -188,7 +189,6 @@ pub struct AppState {
     pub client: Arc<client::Client>,
     pub user_store: ModelHandle<client::UserStore>,
     pub fs: Arc<dyn fs::Fs>,
-    pub channel_list: ModelHandle<client::ChannelList>,
     pub build_window_options: fn() -> WindowOptions<'static>,
     pub build_workspace:
         fn(ModelHandle<Project>, &Arc<AppState>, &mut ViewContext<Workspace>) -> Workspace,
@@ -636,20 +636,9 @@ impl Into<AnyViewHandle> for &dyn NotificationHandle {
     }
 }
 
-#[derive(Clone)]
-pub struct WorkspaceParams {
-    pub project: ModelHandle<Project>,
-    pub client: Arc<Client>,
-    pub fs: Arc<dyn Fs>,
-    pub languages: Arc<LanguageRegistry>,
-    pub themes: Arc<ThemeRegistry>,
-    pub user_store: ModelHandle<UserStore>,
-    pub channel_list: ModelHandle<ChannelList>,
-}
-
-impl WorkspaceParams {
+impl AppState {
     #[cfg(any(test, feature = "test-support"))]
-    pub fn test(cx: &mut MutableAppContext) -> Self {
+    pub fn test(cx: &mut MutableAppContext) -> Arc<Self> {
         let settings = Settings::test(cx);
         cx.set_global(settings);
 
@@ -658,42 +647,16 @@ impl WorkspaceParams {
         let http_client = client::test::FakeHttpClient::with_404_response();
         let client = Client::new(http_client.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http_client, cx));
-        let project = Project::local(
-            client.clone(),
-            user_store.clone(),
-            languages.clone(),
-            fs.clone(),
-            cx,
-        );
-        Self {
-            project,
-            channel_list: cx
-                .add_model(|cx| ChannelList::new(user_store.clone(), client.clone(), cx)),
+        let themes = ThemeRegistry::new((), cx.font_cache().clone());
+        Arc::new(Self {
             client,
-            themes: ThemeRegistry::new((), cx.font_cache().clone()),
+            themes,
             fs,
             languages,
             user_store,
-        }
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn local(app_state: &Arc<AppState>, cx: &mut MutableAppContext) -> Self {
-        Self {
-            project: Project::local(
-                app_state.client.clone(),
-                app_state.user_store.clone(),
-                app_state.languages.clone(),
-                app_state.fs.clone(),
-                cx,
-            ),
-            client: app_state.client.clone(),
-            fs: app_state.fs.clone(),
-            themes: app_state.themes.clone(),
-            languages: app_state.languages.clone(),
-            user_store: app_state.user_store.clone(),
-            channel_list: app_state.channel_list.clone(),
-        }
+            build_workspace: |project, _, cx| Workspace::new(project, cx),
+            build_window_options: || Default::default(),
+        })
     }
 }
 
@@ -708,7 +671,6 @@ pub struct Workspace {
     user_store: ModelHandle<client::UserStore>,
     remote_entity_subscription: Option<Subscription>,
     fs: Arc<dyn Fs>,
-    themes: Arc<ThemeRegistry>,
     modal: Option<AnyViewHandle>,
     center: PaneGroup,
     left_sidebar: ViewHandle<Sidebar>,
@@ -744,8 +706,8 @@ enum FollowerItem {
 }
 
 impl Workspace {
-    pub fn new(params: &WorkspaceParams, cx: &mut ViewContext<Self>) -> Self {
-        cx.observe(&params.project, |_, project, cx| {
+    pub fn new(project: ModelHandle<Project>, cx: &mut ViewContext<Self>) -> Self {
+        cx.observe(&project, |_, project, cx| {
             if project.read(cx).is_read_only() {
                 cx.blur();
             }
@@ -753,7 +715,7 @@ impl Workspace {
         })
         .detach();
 
-        cx.subscribe(&params.project, move |this, project, event, cx| {
+        cx.subscribe(&project, move |this, project, event, cx| {
             match event {
                 project::Event::RemoteIdChanged(remote_id) => {
                     this.project_remote_id_changed(*remote_id, cx);
@@ -785,8 +747,11 @@ impl Workspace {
         cx.focus(&pane);
         cx.emit(Event::PaneAdded(pane.clone()));
 
-        let mut current_user = params.user_store.read(cx).watch_current_user().clone();
-        let mut connection_status = params.client.status().clone();
+        let fs = project.read(cx).fs().clone();
+        let user_store = project.read(cx).user_store();
+        let client = project.read(cx).client();
+        let mut current_user = user_store.read(cx).watch_current_user().clone();
+        let mut connection_status = client.status().clone();
         let _observe_current_user = cx.spawn_weak(|this, mut cx| async move {
             current_user.recv().await;
             connection_status.recv().await;
@@ -826,14 +791,13 @@ impl Workspace {
             active_pane: pane.clone(),
             status_bar,
             notifications: Default::default(),
-            client: params.client.clone(),
+            client,
             remote_entity_subscription: None,
-            user_store: params.user_store.clone(),
-            fs: params.fs.clone(),
-            themes: params.themes.clone(),
+            user_store,
+            fs,
             left_sidebar,
             right_sidebar,
-            project: params.project.clone(),
+            project,
             leader_state: Default::default(),
             follower_states_by_leader: Default::default(),
             last_leaders_by_pane: Default::default(),
@@ -865,10 +829,6 @@ impl Workspace {
 
     pub fn project(&self) -> &ModelHandle<Project> {
         &self.project
-    }
-
-    pub fn themes(&self) -> Arc<ThemeRegistry> {
-        self.themes.clone()
     }
 
     pub fn worktrees<'a>(
@@ -2203,8 +2163,7 @@ impl std::fmt::Debug for OpenPaths {
     }
 }
 
-fn open(action: &Open, cx: &mut MutableAppContext) {
-    let app_state = action.0.clone();
+fn open(_: &Open, cx: &mut MutableAppContext) {
     let mut paths = cx.prompt_for_paths(PathPromptOptions {
         files: true,
         directories: true,
@@ -2212,7 +2171,7 @@ fn open(action: &Open, cx: &mut MutableAppContext) {
     });
     cx.spawn(|mut cx| async move {
         if let Some(paths) = paths.recv().await.flatten() {
-            cx.update(|cx| cx.dispatch_global_action(OpenPaths { paths, app_state }));
+            cx.update(|cx| cx.dispatch_global_action(OpenPaths { paths }));
         }
     })
     .detach();
@@ -2320,7 +2279,7 @@ fn open_new(app_state: &Arc<AppState>, cx: &mut MutableAppContext) {
             app_state.fs.clone(),
             cx,
         );
-        (app_state.build_workspace)(project, &app_state, cx)
+        (app_state.build_workspace)(project, app_state, cx)
     });
-    cx.dispatch_action(window_id, vec![workspace.id()], &OpenNew(app_state.clone()));
+    cx.dispatch_action(window_id, vec![workspace.id()], &OpenNew);
 }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -40,9 +40,9 @@ use theme::{ThemeRegistry, DEFAULT_THEME_NAME};
 use util::{ResultExt, TryFutureExt};
 use workspace::{self, AppState, OpenNew, OpenPaths};
 use zed::{
-    self, build_window_options, build_workspace,
+    self, build_window_options,
     fs::RealFs,
-    languages, menus,
+    initialize_workspace, languages, menus,
     settings_file::{settings_from_files, watch_keymap_file, WatchedJsonFile},
 };
 
@@ -193,7 +193,7 @@ fn main() {
             user_store,
             fs,
             build_window_options,
-            build_workspace,
+            initialize_workspace,
         });
         workspace::init(app_state.clone(), cx);
         journal::init(app_state.clone(), cx);

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -38,6 +38,14 @@ pub fn menus() -> Vec<Menu<'static>> {
                     name: "Open…",
                     action: Box::new(workspace::Open),
                 },
+                MenuItem::Action {
+                    name: "Save",
+                    action: Box::new(workspace::Save),
+                },
+                MenuItem::Action {
+                    name: "Close Editor",
+                    action: Box::new(workspace::CloseActiveItem),
+                },
             ],
         },
         Menu {
@@ -63,6 +71,141 @@ pub fn menus() -> Vec<Menu<'static>> {
                 MenuItem::Action {
                     name: "Paste",
                     action: Box::new(editor::Paste),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Find",
+                    action: Box::new(search::buffer_search::Deploy { focus: true }),
+                },
+                MenuItem::Action {
+                    name: "Find In Project",
+                    action: Box::new(search::project_search::Deploy),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Toggle Line Comment",
+                    action: Box::new(editor::ToggleComments),
+                },
+            ],
+        },
+        Menu {
+            name: "Selection",
+            items: vec![
+                MenuItem::Action {
+                    name: "Select All",
+                    action: Box::new(editor::SelectAll),
+                },
+                MenuItem::Action {
+                    name: "Expand Selection",
+                    action: Box::new(editor::SelectLargerSyntaxNode),
+                },
+                MenuItem::Action {
+                    name: "Shrink Selection",
+                    action: Box::new(editor::SelectSmallerSyntaxNode),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Add Cursor Above",
+                    action: Box::new(editor::AddSelectionAbove),
+                },
+                MenuItem::Action {
+                    name: "Add Cursor Below",
+                    action: Box::new(editor::AddSelectionBelow),
+                },
+                MenuItem::Action {
+                    name: "Select Next Occurrence",
+                    action: Box::new(editor::SelectNext {
+                        replace_newest: false,
+                    }),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Move Line Up",
+                    action: Box::new(editor::MoveLineUp),
+                },
+                MenuItem::Action {
+                    name: "Move Line Down",
+                    action: Box::new(editor::MoveLineDown),
+                },
+                MenuItem::Action {
+                    name: "Duplicate Selection",
+                    action: Box::new(editor::DuplicateLine),
+                },
+            ],
+        },
+        Menu {
+            name: "View",
+            items: vec![
+                MenuItem::Action {
+                    name: "Zoom In",
+                    action: Box::new(super::IncreaseBufferFontSize),
+                },
+                MenuItem::Action {
+                    name: "Zoom Out",
+                    action: Box::new(super::DecreaseBufferFontSize),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Project Browser",
+                    action: Box::new(workspace::sidebar::ToggleSidebarItemFocus {
+                        side: workspace::sidebar::Side::Left,
+                        item_index: 0,
+                    }),
+                },
+                MenuItem::Action {
+                    name: "Command Palette",
+                    action: Box::new(command_palette::Toggle),
+                },
+                MenuItem::Action {
+                    name: "Diagnostics",
+                    action: Box::new(diagnostics::Deploy),
+                },
+            ],
+        },
+        Menu {
+            name: "Go",
+            items: vec![
+                MenuItem::Action {
+                    name: "Back",
+                    action: Box::new(workspace::GoBack { pane: None }),
+                },
+                MenuItem::Action {
+                    name: "Forward",
+                    action: Box::new(workspace::GoForward { pane: None }),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Go to File",
+                    action: Box::new(file_finder::Toggle),
+                },
+                MenuItem::Action {
+                    name: "Go to Symbol in Project",
+                    action: Box::new(project_symbols::Toggle),
+                },
+                MenuItem::Action {
+                    name: "Go to Symbol in Editor",
+                    action: Box::new(outline::Toggle),
+                },
+                MenuItem::Action {
+                    name: "Go to Definition",
+                    action: Box::new(editor::GoToDefinition),
+                },
+                MenuItem::Action {
+                    name: "Go to References",
+                    action: Box::new(editor::FindAllReferences),
+                },
+                MenuItem::Action {
+                    name: "Go to Line/Column",
+                    action: Box::new(go_to_line::Toggle),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Next Problem",
+                    action: Box::new(editor::GoToNextDiagnostic),
+                },
+                MenuItem::Action {
+                    name: "Previous Problem",
+                    action: Box::new(editor::GoToPrevDiagnostic),
                 },
             ],
         },

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -10,24 +10,20 @@ pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
             items: vec![
                 MenuItem::Action {
                     name: "About Zed…",
-                    keystroke: None,
                     action: Box::new(super::About),
                 },
                 MenuItem::Action {
                     name: "Check for Updates",
-                    keystroke: None,
                     action: Box::new(auto_update::Check),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Install CLI",
-                    keystroke: None,
                     action: Box::new(super::InstallCommandLineInterface),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Quit",
-                    keystroke: Some("cmd-q"),
                     action: Box::new(super::Quit),
                 },
             ],
@@ -37,13 +33,11 @@ pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
             items: vec![
                 MenuItem::Action {
                     name: "New",
-                    keystroke: Some("cmd-n"),
                     action: Box::new(workspace::OpenNew(state.clone())),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Open…",
-                    keystroke: Some("cmd-o"),
                     action: Box::new(workspace::Open(state.clone())),
                 },
             ],
@@ -53,28 +47,23 @@ pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
             items: vec![
                 MenuItem::Action {
                     name: "Undo",
-                    keystroke: Some("cmd-z"),
                     action: Box::new(editor::Undo),
                 },
                 MenuItem::Action {
                     name: "Redo",
-                    keystroke: Some("cmd-Z"),
                     action: Box::new(editor::Redo),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Cut",
-                    keystroke: Some("cmd-x"),
                     action: Box::new(editor::Cut),
                 },
                 MenuItem::Action {
                     name: "Copy",
-                    keystroke: Some("cmd-c"),
                     action: Box::new(editor::Copy),
                 },
                 MenuItem::Action {
                     name: "Paste",
-                    keystroke: Some("cmd-v"),
                     action: Box::new(editor::Paste),
                 },
             ],

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -1,9 +1,7 @@
-use crate::AppState;
 use gpui::{Menu, MenuItem};
-use std::sync::Arc;
 
 #[cfg(target_os = "macos")]
-pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
+pub fn menus() -> Vec<Menu<'static>> {
     vec![
         Menu {
             name: "Zed",
@@ -33,12 +31,12 @@ pub fn menus(state: &Arc<AppState>) -> Vec<Menu<'static>> {
             items: vec![
                 MenuItem::Action {
                     name: "New",
-                    action: Box::new(workspace::OpenNew(state.clone())),
+                    action: Box::new(workspace::OpenNew),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Open…",
-                    action: Box::new(workspace::Open(state.clone())),
+                    action: Box::new(workspace::Open),
                 },
             ],
         },

--- a/crates/zed/src/test.rs
+++ b/crates/zed/src/test.rs
@@ -1,46 +1,7 @@
-use crate::{build_window_options, build_workspace, AppState};
-use assets::Assets;
-use client::{test::FakeHttpClient, ChannelList, Client, UserStore};
-use gpui::MutableAppContext;
-use language::LanguageRegistry;
-use project::fs::FakeFs;
-use settings::Settings;
-use std::sync::Arc;
-use theme::ThemeRegistry;
-
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
     if std::env::var("RUST_LOG").is_ok() {
         env_logger::init();
     }
-}
-
-pub fn test_app_state(cx: &mut MutableAppContext) -> Arc<AppState> {
-    let settings = Settings::test(cx);
-    editor::init(cx);
-    cx.set_global(settings);
-    let themes = ThemeRegistry::new(Assets, cx.font_cache().clone());
-    let http = FakeHttpClient::with_404_response();
-    let client = Client::new(http.clone());
-    let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http, cx));
-    let languages = LanguageRegistry::test();
-    languages.add(Arc::new(language::Language::new(
-        language::LanguageConfig {
-            name: "Rust".into(),
-            path_suffixes: vec!["rs".to_string()],
-            ..Default::default()
-        },
-        Some(tree_sitter_rust::language()),
-    )));
-    Arc::new(AppState {
-        themes,
-        languages: Arc::new(languages),
-        channel_list: cx.add_model(|cx| ChannelList::new(user_store.clone(), client.clone(), cx)),
-        client,
-        user_store,
-        fs: FakeFs::new(cx.background().clone()),
-        build_window_options,
-        build_workspace,
-    })
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -162,8 +162,9 @@ pub fn build_workspace(
     });
 
     let project_panel = ProjectPanel::new(project, cx);
-    let contact_panel =
-        cx.add_view(|cx| ContactsPanel::new(app_state.clone(), workspace.weak_handle(), cx));
+    let contact_panel = cx.add_view(|cx| {
+        ContactsPanel::new(app_state.user_store.clone(), workspace.weak_handle(), cx)
+    });
 
     workspace.left_sidebar().update(cx, |sidebar, cx| {
         sidebar.add_item("icons/folder-tree-solid-14.svg", project_panel.into(), cx)


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/914

Previously, the key equivalents in Zed's application menus were hard-coded, and didn't take into account the user's custom key bindings. They also were shown as enabled even if their actions were not applicable to the focused view.

This PR integrates the application menus more tightly with the GPUI key-map and action handlers. Items are correctly enabled/disabled based on whether or not their action is applicable to any descendant of the focused view, and their key equivalent is populated based on the key map.

### Refactor

The key bindings for `File > New` and `File > Open` were previously *only* hard-coded in `menus.rs`; they weren't in the keymap file. In order to move them to the keymap file, they needed to become *deserializable*. This meant that they can no longer have an `Arc<AppState>` as a field.

As part of removing this field, I restructured how `AppState` was used. It's now used in fewer places (although the test helper method `AppState::test` is still used in many crates). There was also another closely-related type called `WorkspaceParams` that I removed entirely.

### Tasks

* [x] Correctly convert non-printable keystrokes (e.g. arrow keys, function keys) back into macOS "key equivalents"
* [x] Figure out what to do about application menus whose key equivalents conflict with other multi-stroke bindings. For example, right now, when you try to toggle the theme selector with `cmd-k cmd-t`, the project symbols view deploys, because the application menu system responds to the `cmd-t`.

### Next Steps

To close out #914, we need to add a number of new commands (*Save As*, *New Window*, *Close Window*..., *Add Folder to Project*...). We also need to add the ability to create submenus, although we may be able to defer that a while longer.