### PR TITLE
Show ignored entries in project panel

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1905,6 +1905,7 @@ impl sum_tree::Summary for EntrySummary {
 
     fn add_summary(&mut self, rhs: &Self, _: &()) {
         self.max_path = rhs.max_path.clone();
+        self.count += rhs.count;
         self.visible_count += rhs.visible_count;
         self.file_count += rhs.file_count;
         self.visible_file_count += rhs.visible_file_count;
@@ -2727,6 +2728,18 @@ mod tests {
                     Path::new("a/c"),
                 ]
             );
+            assert_eq!(
+                tree.entries(true)
+                    .map(|entry| entry.path.as_ref())
+                    .collect::<Vec<_>>(),
+                vec![
+                    Path::new(""),
+                    Path::new(".gitignore"),
+                    Path::new("a"),
+                    Path::new("a/b"),
+                    Path::new("a/c"),
+                ]
+            );
         })
     }
 
@@ -3072,12 +3085,18 @@ mod tests {
                 }
             }
 
-            let dfs_paths = self
+            let dfs_paths_via_iter = self
                 .entries_by_path
                 .cursor::<()>()
                 .map(|e| e.path.as_ref())
                 .collect::<Vec<_>>();
-            assert_eq!(bfs_paths, dfs_paths);
+            assert_eq!(bfs_paths, dfs_paths_via_iter);
+
+            let dfs_paths_via_traversal = self
+                .entries(true)
+                .map(|e| e.path.as_ref())
+                .collect::<Vec<_>>();
+            assert_eq!(dfs_paths_via_traversal, dfs_paths_via_iter);
 
             for (ignore_parent_path, _) in &self.ignores {
                 assert!(self.entry_for_path(ignore_parent_path).is_some());

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1179,6 +1179,7 @@ impl Snapshot {
 
         for entry in update.updated_entries {
             let entry = Entry::try_from((&self.root_char_bag, entry))?;
+            println!("{:?} = {}", &entry.path, entry.is_ignored);
             if let Some(PathEntry { path, .. }) = self.entries_by_id.get(&entry.id, &()) {
                 entries_by_path_edits.push(Edit::Remove(PathKey(path.clone())));
             }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -966,7 +966,7 @@ impl LocalWorktree {
                             #[cfg(any(test, feature = "test-support"))]
                             const CHUNK_SIZE: usize = 2;
                             #[cfg(not(any(test, feature = "test-support")))]
-                            const CHUNK_SIZE: usize = 128;
+                            const CHUNK_SIZE: usize = 256;
 
                             let entry = ignored_entries.next();
                             if ignored_entries_to_send.len() >= CHUNK_SIZE || entry.is_none() {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -972,6 +972,7 @@ mod tests {
             visible_entries_as_strings(&panel, 0..50, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    > b",
                 "    > C",
@@ -987,6 +988,7 @@ mod tests {
             visible_entries_as_strings(&panel, 0..50, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b  <== selected",
                 "        > 3",
@@ -1000,7 +1002,7 @@ mod tests {
         );
 
         assert_eq!(
-            visible_entries_as_strings(&panel, 5..8, cx),
+            visible_entries_as_strings(&panel, 6..9, cx),
             &[
                 //
                 "    > C",
@@ -1064,6 +1066,7 @@ mod tests {
             visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1  <== selected",
+                "    > .git",
                 "    > a",
                 "    > b",
                 "    > C",
@@ -1082,6 +1085,7 @@ mod tests {
             visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    > b",
                 "    > C",
@@ -1103,6 +1107,7 @@ mod tests {
             visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    > b",
                 "    > C",
@@ -1119,6 +1124,7 @@ mod tests {
             visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    > b",
                 "    > C",
@@ -1133,9 +1139,10 @@ mod tests {
         select_path(&panel, "root1/b", cx);
         panel.update(cx, |panel, cx| panel.add_file(&AddFile, cx));
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > 3",
@@ -1157,9 +1164,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > 3",
@@ -1174,9 +1182,10 @@ mod tests {
         select_path(&panel, "root1/b/another-filename", cx);
         panel.update(cx, |panel, cx| panel.rename(&Rename, cx));
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > 3",
@@ -1195,9 +1204,10 @@ mod tests {
             panel.confirm(&Confirm, cx).unwrap()
         });
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > 3",
@@ -1211,9 +1221,10 @@ mod tests {
 
         confirm.await.unwrap();
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > 3",
@@ -1227,9 +1238,10 @@ mod tests {
 
         panel.update(cx, |panel, cx| panel.add_directory(&AddDirectory, cx));
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > [EDITOR: '']  <== selected",
@@ -1249,9 +1261,10 @@ mod tests {
         });
         panel.update(cx, |panel, cx| panel.select_next(&Default::default(), cx));
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > [PROCESSING: 'new-dir']",
@@ -1265,9 +1278,10 @@ mod tests {
 
         confirm.await.unwrap();
         assert_eq!(
-            visible_entries_as_strings(&panel, 0..9, cx),
+            visible_entries_as_strings(&panel, 0..10, cx),
             &[
                 "v root1",
+                "    > .git",
                 "    > a",
                 "    v b",
                 "        > 3  <== selected",

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -787,10 +787,9 @@ impl ProjectPanel {
         MouseEventHandler::new::<Self, _, _>(entry_id.to_usize(), cx, |state, _| {
             let padding = theme.container.padding.left + details.depth as f32 * theme.indent_width;
             let mut style = theme.entry.style_for(state, details.is_selected).clone();
-            // TODO: get style from theme.
             if details.is_ignored {
-                style.text.color.fade_out(0.6);
-                style.icon_color.fade_out(0.6);
+                style.text.color.fade_out(theme.ignored_entry_fade);
+                style.icon_color.fade_out(theme.ignored_entry_fade);
             }
             let row_container_style = if show_editor {
                 theme.filename_editor.container

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -223,6 +223,7 @@ pub struct ProjectPanel {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub entry: Interactive<ProjectPanelEntry>,
+    pub ignored_entry_fade: f32,
     pub filename_editor: FieldEditor,
     pub indent_width: f32,
 }

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -227,7 +227,7 @@ pub struct ProjectPanel {
     pub indent_width: f32,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize, Default)]
 pub struct ProjectPanelEntry {
     pub height: f32,
     #[serde(flatten)]

--- a/styles/src/styleTree/projectPanel.ts
+++ b/styles/src/styleTree/projectPanel.ts
@@ -26,6 +26,7 @@ export default function projectPanel(theme: Theme) {
         text: text(theme, "mono", "active", { size: "sm" }),
       }
     },
+    ignoredEntryFade: 0.6,
     filenameEditor: {
       background: backgroundColor(theme, 500, "active"),
       text: text(theme, "mono", "primary", { size: "sm" }),


### PR DESCRIPTION
Closes #195

This pull request introduces support for showing and manipulating ignored entries in the project panel. We don't yet have designs for including ignored entries in the file finder, but I think this may be good enough for the alpha.

<img width="1459" alt="Screen Shot 2022-05-24 at 09 16 40" src="https://user-images.githubusercontent.com/482957/169972187-ebaae4a9-8acc-4b92-9001-ac825c02c55e.png">

Ignored entries significantly increase the footprint of worktrees. As such, the host will send an initial snapshot of all the non-ignored entries (as before) and then, before starting to transmit updates caused by file-system changes, it will stream all the ignored entries one chunk at a time. The size of the chunk was arbitrarily chosen to be `256`: this felt like a good compromise between throughput and latency.

Note that we don't need any change at the protocol level, as we stream chunked ignored entries using the existing `UpdateWorktree` message.
