### PR TITLE
Upgrade tree-sitter to v0.20.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5381,9 +5381,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.4"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e34327f8eac545e3f037382471b2b19367725a242bba7bc45edb9efb49fe39a"
+checksum = "09b3b781640108d29892e8b9684642d2cda5ea05951fd58f0fea1db9edeb9b71"
 dependencies = [
  "cc",
  "regex",

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -649,6 +649,23 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
         );
         buffer
     });
+
+    cx.add_model(|cx| {
+        let text = "fn a() {\n    {\n        b()?\n    }\n\n    Ok(())\n}";
+        let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
+        buffer.edit_with_autoindent([(Point::new(3, 4)..Point::new(3, 5), "")], 4, cx);
+        assert_eq!(
+            buffer.text(),
+            "fn a() {\n    {\n        b()?\n            \n\n    Ok(())\n}"
+        );
+
+        buffer.edit_with_autoindent([(Point::new(3, 0)..Point::new(3, 12), "")], 4, cx);
+        assert_eq!(
+            buffer.text(),
+            "fn a() {\n    {\n        b()?\n\n\n    Ok(())\n}"
+        );
+        buffer
+    });
 }
 
 #[gpui::test]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -85,7 +85,7 @@ tempdir = { version = "0.3.7" }
 thiserror = "1.0.29"
 tiny_http = "0.8"
 toml = "0.5"
-tree-sitter = "0.20.4"
+tree-sitter = "0.20.6"
 tree-sitter-c = "0.20.1"
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
 tree-sitter-rust = "0.20.1"


### PR DESCRIPTION
Fixes #975 

Previously, when computing the old and new suggestions for an edited line, tree-sitter would report different suggestions even if the change was due to leading whitespace only when the AST contained an error. This was causing the infinite back and forth as the user deleted leading whitespace characters in the issue above. 

As I was diving into what was causing that in tree-sitter, I decided to first upgrade it to the newest version to see if anything changed: and it did! I added a regression test to verify this and, indeed, it works in the new version and fails in the old one. I don't exactly know _what_ fixed it, but there have been fixes around incremental parsing in presence of errors so I assume what we were experiencing was related.

/cc: @maxbrunsfeld, it looks like you had already fixed this in a recent tree-sitter release, but cc'ing you for extra 👀 in case I am tripping.