### PR TITLE
Add Abruzzo Dark color theme

### DIFF
--- a/styles/src/themes/abruzzo.ts
+++ b/styles/src/themes/abruzzo.ts
@@ -1,0 +1,28 @@
+import chroma from "chroma-js";
+import { colorRamp, createTheme } from "./common/base16";
+
+const name = "abruzzo";
+
+const ramps = {
+  neutral: chroma.scale([
+    "#1b0d05",
+    "#2c1e18",
+    "#654035",
+    "#9d5e4a",
+    "#b37354",
+    "#c1825a",
+    "#dda66e",
+    "#fbf3e2",
+  ]),
+  red: colorRamp(chroma("#e594c4")),
+  orange: colorRamp(chroma("#d9e87e")),
+  yellow: colorRamp(chroma("#fdb262")),
+  green: colorRamp(chroma("#96adf7")),
+  cyan: colorRamp(chroma("#fc798f")),
+  blue: colorRamp(chroma("#BCD0F5")),
+  violet: colorRamp(chroma("#dac5eb")),
+  magenta: colorRamp(chroma("#c1a3ef")),
+};
+
+export const dark = createTheme(`${name}`, false, ramps);
+// export const light = createTheme(`${name}-light`, true, ramps);

--- a/styles/src/themes/abruzzo.ts
+++ b/styles/src/themes/abruzzo.ts
@@ -16,7 +16,7 @@ const ramps = {
   ]),
   red: colorRamp(chroma("#e594c4")),
   orange: colorRamp(chroma("#d9e87e")),
-  yellow: colorRamp(chroma("#fdb262")),
+  yellow: colorRamp(chroma("#fd9d83")),
   green: colorRamp(chroma("#96adf7")),
   cyan: colorRamp(chroma("#fc798f")),
   blue: colorRamp(chroma("#BCD0F5")),


### PR DESCRIPTION
Before I start next week, I've been poking around the codebase and writing some themes. Here's a new theme I was working on based on the fall colors of Abruzzo, where I went last thanksgiving.

<img width="1188" alt="Screen Shot 2022-05-24 at 6 38 52 PM" src="https://user-images.githubusercontent.com/54823450/170087862-fd46f523-0724-4c73-9716-e76f9be84738.png">
 
It's very brown, so I might desaturate it a bit.