### PR TITLE
fix theme occurrence color

### DIFF
--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -130,8 +130,8 @@ export function createTheme(
     },
     highlight: {
       selection: player[1].selectionColor,
-      occurrence: withOpacity(rampColor(ramps.neutral, 2), blend),
-      activeOccurrence: withOpacity(rampColor(ramps.neutral, 2), blend * 2), // TODO: Not hooked up - https://github.com/zed-industries/zed/issues/751
+      occurrence: withOpacity(rampColor(ramps.neutral, 3.5), blend),
+      activeOccurrence: withOpacity(rampColor(ramps.neutral, 3.5), blend * 2), // TODO: Not hooked up - https://github.com/zed-industries/zed/issues/751
       matchingBracket: backgroundColor[500].active, // TODO: Not hooked up
       match: rampColor(ramps.violet, 0.15),
       activeMatch: withOpacity(rampColor(ramps.violet, 0.4), blend * 2), // TODO: Not hooked up - https://github.com/zed-industries/zed/issues/751


### PR DESCRIPTION
Theme `occurrence` colors were pushed too light in a recent theme update. This fix makes occurrence easier to see in all themes.

Before:

<img width="705" alt="CleanShot - 2022-05-25 at 10 46 48@2x" src="https://user-images.githubusercontent.com/1714999/170290610-1a66c549-8c6d-4ca2-91fa-ccffd1909adc.png">


<img width="787" alt="CleanShot - 2022-05-25 at 10 46 38@2x" src="https://user-images.githubusercontent.com/1714999/170290571-05ac3353-a8ea-4d6f-8d19-1e4abd442bfb.png">


After:

<img width="828" alt="CleanShot - 2022-05-25 at 10 46 00@2x" src="https://user-images.githubusercontent.com/1714999/170290430-1f76b8b1-3908-410e-b09c-b7e2d10dea20.png">

<img width="636" alt="CleanShot - 2022-05-25 at 10 46 14@2x" src="https://user-images.githubusercontent.com/1714999/170290482-b3eb205c-4fa6-421b-9f48-f28aa7f43b9b.png">
