### PR TITLE
Fix disconnected from project message

### DIFF
--- a/styles/src/styleTree/workspace.ts
+++ b/styles/src/styleTree/workspace.ts
@@ -1,4 +1,5 @@
 import Theme from "../themes/common/theme";
+import { withOpacity } from "../utils/color";
 import { backgroundColor, border, iconColor, shadow, text } from "./components";
 import statusBar from "./statusBar";
 
@@ -155,8 +156,8 @@ export default function workspace(theme: Theme) {
       padding: { left: 6 },
     },
     disconnectedOverlay: {
-      ...text(theme, "sans", "onMedia"),
-      background: "#000000aa",
+      ...text(theme, "sans", "active"),
+      background: withOpacity(theme.backgroundColor[500].base, 0.8).value,
     },
     notification: {
       margin: { top: 10 },


### PR DESCRIPTION
Fixes #777. Message will always show up with a transparent version of the editor background, with primary text on top.

Screenshots:

![CleanShot - 2022-05-25 at 11 20 55@2x](https://user-images.githubusercontent.com/1714999/170298287-4dcbf2d1-dade-4739-85d1-dcd21bccf17b.png)

![CleanShot - 2022-05-25 at 11 21 24@2x](https://user-images.githubusercontent.com/1714999/170298385-a9627036-3727-4127-aef8-290c8b1e3f44.png)

![CleanShot - 2022-05-25 at 11 21 59@2x](https://user-images.githubusercontent.com/1714999/170298522-6e8d7ace-3371-43e9-aad3-e6525b81aabc.png)
