### PR TITLE
Fix theme build issue in build.rs

### DIFF
--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -5,7 +5,7 @@ fn main() {
 
     let output = Command::new("npm")
         .current_dir("../../styles")
-        .args(["ci"])
+        .args(["install"])
         .output()
         .expect("failed to run npm");
     if !output.status.success() {
@@ -27,5 +27,5 @@ fn main() {
         );
     }
 
-    println!("cargo:rerun-if-changed=../../styles");
+    println!("cargo:rerun-if-changed=../../styles/src");
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/1063

Turns out `npm ci` deletes the node_modules files first and then installs. This combined with rust-analyzer leads to the `build.rs` script getting run every time a file in the styles directory changes, leads to missing node_modules issues when multiple instances of zed are running.

Swapping to `npm install` avoids this issue by leaving the node_modules directory intact instead of nuking it.
