### PR TITLE
Add a Window application menu

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -5856,6 +5856,9 @@ mod tests {
             .update(cx_a, |workspace, cx| {
                 workspace.split_pane(workspace.active_pane().clone(), SplitDirection::Right, cx);
                 assert_ne!(*workspace.active_pane(), pane_a1);
+            });
+        workspace_a
+            .update(cx_a, |workspace, cx| {
                 let leader_id = *project_a.read(cx).collaborators().keys().next().unwrap();
                 workspace
                     .toggle_follow(&workspace::ToggleFollow(leader_id), cx)
@@ -5867,6 +5870,9 @@ mod tests {
             .update(cx_b, |workspace, cx| {
                 workspace.split_pane(workspace.active_pane().clone(), SplitDirection::Right, cx);
                 assert_ne!(*workspace.active_pane(), pane_b1);
+            });
+        workspace_b
+            .update(cx_b, |workspace, cx| {
                 let leader_id = *project_b.read(cx).collaborators().keys().next().unwrap();
                 workspace
                     .toggle_follow(&workspace::ToggleFollow(leader_id), cx)

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -96,6 +96,7 @@ pub trait Window: WindowContext {
     fn on_close(&mut self, callback: Box<dyn FnOnce()>);
     fn prompt(&self, level: PromptLevel, msg: &str, answers: &[&str]) -> oneshot::Receiver<usize>;
     fn activate(&self);
+    fn set_title(&mut self, title: &str);
 }
 
 pub trait WindowContext {

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -202,6 +202,11 @@ impl MacForegroundPlatform {
 
             menu_bar_item.setSubmenu_(menu);
             menu_bar.addItem_(menu_bar_item);
+
+            if menu_name == "Window" {
+                let app: id = msg_send![APP_CLASS, sharedApplication];
+                app.setWindowsMenu_(menu);
+            }
         }
 
         menu_bar

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -386,8 +386,15 @@ impl platform::Window for Window {
     }
 
     fn activate(&self) {
+        unsafe { msg_send![self.0.borrow().native_window, makeKeyAndOrderFront: nil] }
+    }
+
+    fn set_title(&mut self, title: &str) {
         unsafe {
-            let _: () = msg_send![self.0.borrow().native_window, makeKeyAndOrderFront: nil];
+            let app = NSApplication::sharedApplication(nil);
+            let window = self.0.borrow().native_window;
+            let title = ns_string(title);
+            msg_send![app, changeWindowsItem:window title:title filename:false]
         }
     }
 }

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -37,6 +37,7 @@ pub struct Window {
     event_handlers: Vec<Box<dyn FnMut(super::Event)>>,
     resize_handlers: Vec<Box<dyn FnMut()>>,
     close_handlers: Vec<Box<dyn FnOnce()>>,
+    pub(crate) title: Option<String>,
     pub(crate) pending_prompts: RefCell<VecDeque<oneshot::Sender<usize>>>,
 }
 
@@ -189,8 +190,13 @@ impl Window {
             close_handlers: Vec::new(),
             scale_factor: 1.0,
             current_scene: None,
+            title: None,
             pending_prompts: Default::default(),
         }
+    }
+
+    pub fn title(&self) -> Option<String> {
+        self.title.clone()
     }
 }
 
@@ -248,6 +254,10 @@ impl super::Window for Window {
     }
 
     fn activate(&self) {}
+
+    fn set_title(&mut self, title: &str) {
+        self.title = Some(title.to_string())
+    }
 }
 
 pub fn platform() -> Platform {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3603,11 +3603,19 @@ impl Project {
         })
     }
 
-    pub fn remove_worktree(&mut self, id: WorktreeId, cx: &mut ModelContext<Self>) {
+    pub fn remove_worktree(&mut self, id_to_remove: WorktreeId, cx: &mut ModelContext<Self>) {
         self.worktrees.retain(|worktree| {
-            worktree
-                .upgrade(cx)
-                .map_or(false, |w| w.read(cx).id() != id)
+            if let Some(worktree) = worktree.upgrade(cx) {
+                let id = worktree.read(cx).id();
+                if id == id_to_remove {
+                    cx.emit(Event::WorktreeRemoved(id));
+                    false
+                } else {
+                    true
+                }
+            } else {
+                false
+            }
         });
         cx.notify();
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -139,6 +139,7 @@ pub struct Collaborator {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
     ActiveEntryChanged(Option<ProjectEntryId>),
+    WorktreeAdded,
     WorktreeRemoved(WorktreeId),
     DiskBasedDiagnosticsStarted,
     DiskBasedDiagnosticsUpdated,
@@ -3637,6 +3638,7 @@ impl Project {
             self.worktrees
                 .push(WorktreeHandle::Weak(worktree.downgrade()));
         }
+        cx.emit(Event::WorktreeAdded);
         cx.notify();
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -38,6 +38,7 @@ use status_bar::StatusBar;
 pub use status_bar::StatusItemView;
 use std::{
     any::{Any, TypeId},
+    borrow::Cow,
     cell::RefCell,
     fmt,
     future::Future,
@@ -532,7 +533,10 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
             }
 
             if T::should_update_tab_on_event(event) {
-                pane.update(cx, |_, cx| cx.notify());
+                pane.update(cx, |_, cx| {
+                    cx.emit(pane::Event::ChangeItemTitle);
+                    cx.notify();
+                });
             }
         })
         .detach();
@@ -744,6 +748,9 @@ impl Workspace {
                 project::Event::CollaboratorLeft(peer_id) => {
                     this.collaborator_left(*peer_id, cx);
                 }
+                project::Event::WorktreeRemoved(_) | project::Event::WorktreeAdded => {
+                    this.update_window_title(cx);
+                }
                 _ => {}
             }
             if project.read(cx).is_read_only() {
@@ -755,14 +762,8 @@ impl Workspace {
 
         let pane = cx.add_view(|cx| Pane::new(cx));
         let pane_id = pane.id();
-        cx.observe(&pane, move |me, _, cx| {
-            let active_entry = me.active_project_path(cx);
-            me.project
-                .update(cx, |project, cx| project.set_active_path(active_entry, cx));
-        })
-        .detach();
-        cx.subscribe(&pane, move |me, _, event, cx| {
-            me.handle_pane_event(pane_id, event, cx)
+        cx.subscribe(&pane, move |this, _, event, cx| {
+            this.handle_pane_event(pane_id, event, cx)
         })
         .detach();
         cx.focus(&pane);
@@ -825,6 +826,11 @@ impl Workspace {
             _observe_current_user,
         };
         this.project_remote_id_changed(this.project.read(cx).remote_id(), cx);
+
+        cx.defer(|this, cx| {
+            this.update_window_title(cx);
+        });
+
         this
     }
 
@@ -1238,14 +1244,8 @@ impl Workspace {
     fn add_pane(&mut self, cx: &mut ViewContext<Self>) -> ViewHandle<Pane> {
         let pane = cx.add_view(|cx| Pane::new(cx));
         let pane_id = pane.id();
-        cx.observe(&pane, move |me, _, cx| {
-            let active_entry = me.active_project_path(cx);
-            me.project
-                .update(cx, |project, cx| project.set_active_path(active_entry, cx));
-        })
-        .detach();
-        cx.subscribe(&pane, move |me, _, event, cx| {
-            me.handle_pane_event(pane_id, event, cx)
+        cx.subscribe(&pane, move |this, _, event, cx| {
+            this.handle_pane_event(pane_id, event, cx)
         })
         .detach();
         self.panes.push(pane.clone());
@@ -1385,6 +1385,7 @@ impl Workspace {
             self.status_bar.update(cx, |status_bar, cx| {
                 status_bar.set_active_pane(&self.active_pane, cx);
             });
+            self.active_item_path_changed(cx);
             cx.focus(&self.active_pane);
             cx.notify();
         }
@@ -1419,6 +1420,14 @@ impl Workspace {
                     if *local {
                         self.unfollow(&pane, cx);
                     }
+                    if pane == self.active_pane {
+                        self.active_item_path_changed(cx);
+                    }
+                }
+                pane::Event::ChangeItemTitle => {
+                    if pane == self.active_pane {
+                        self.active_item_path_changed(cx);
+                    }
                 }
             }
         } else {
@@ -1451,6 +1460,8 @@ impl Workspace {
             self.unfollow(&pane, cx);
             self.last_leaders_by_pane.remove(&pane.downgrade());
             cx.notify();
+        } else {
+            self.active_item_path_changed(cx);
         }
     }
 
@@ -1638,15 +1649,7 @@ impl Workspace {
 
     fn render_titlebar(&self, theme: &Theme, cx: &mut RenderContext<Self>) -> ElementBox {
         let mut worktree_root_names = String::new();
-        {
-            let mut worktrees = self.project.read(cx).visible_worktrees(cx).peekable();
-            while let Some(worktree) = worktrees.next() {
-                worktree_root_names.push_str(worktree.read(cx).root_name());
-                if worktrees.peek().is_some() {
-                    worktree_root_names.push_str(", ");
-                }
-            }
-        }
+        self.worktree_root_names(&mut worktree_root_names, cx);
 
         ConstrainedBox::new(
             Container::new(
@@ -1680,6 +1683,50 @@ impl Workspace {
         )
         .with_height(theme.workspace.titlebar.height)
         .named("titlebar")
+    }
+
+    fn active_item_path_changed(&mut self, cx: &mut ViewContext<Self>) {
+        let active_entry = self.active_project_path(cx);
+        self.project
+            .update(cx, |project, cx| project.set_active_path(active_entry, cx));
+        self.update_window_title(cx);
+    }
+
+    fn update_window_title(&mut self, cx: &mut ViewContext<Self>) {
+        let mut title = String::new();
+        if let Some(path) = self.active_item(cx).and_then(|item| item.project_path(cx)) {
+            let filename = path
+                .path
+                .file_name()
+                .map(|s| s.to_string_lossy())
+                .or_else(|| {
+                    Some(Cow::Borrowed(
+                        self.project()
+                            .read(cx)
+                            .worktree_for_id(path.worktree_id, cx)?
+                            .read(cx)
+                            .root_name(),
+                    ))
+                });
+            if let Some(filename) = filename {
+                title.push_str(filename.as_ref());
+                title.push_str(" — ");
+            }
+        }
+        self.worktree_root_names(&mut title, cx);
+        if title.is_empty() {
+            title = "empty project".to_string();
+        }
+        cx.set_window_title(&title);
+    }
+
+    fn worktree_root_names(&self, string: &mut String, cx: &mut MutableAppContext) {
+        for (i, worktree) in self.project.read(cx).visible_worktrees(cx).enumerate() {
+            if i != 0 {
+                string.push_str(", ");
+            }
+            string.push_str(worktree.read(cx).root_name());
+        }
     }
 
     fn render_collaborators(&self, theme: &Theme, cx: &mut RenderContext<Self>) -> Vec<ElementBox> {
@@ -2418,6 +2465,110 @@ mod tests {
     use serde_json::json;
 
     #[gpui::test]
+    async fn test_tracking_active_path(cx: &mut TestAppContext) {
+        cx.foreground().forbid_parking();
+        Settings::test_async(cx);
+        let fs = FakeFs::new(cx.background());
+        fs.insert_tree(
+            "/root1",
+            json!({
+                "one.txt": "",
+                "two.txt": "",
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            "/root2",
+            json!({
+                "three.txt": "",
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs, ["root1".as_ref()], cx).await;
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::new(project.clone(), cx));
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+
+        let item1 = cx.add_view(window_id, |_| {
+            let mut item = TestItem::new();
+            item.project_path = Some((worktree_id, "one.txt").into());
+            item
+        });
+        let item2 = cx.add_view(window_id, |_| {
+            let mut item = TestItem::new();
+            item.project_path = Some((worktree_id, "two.txt").into());
+            item
+        });
+
+        // Add an item to an empty pane
+        workspace.update(cx, |workspace, cx| workspace.add_item(Box::new(item1), cx));
+        project.read_with(cx, |project, cx| {
+            assert_eq!(
+                project.active_entry(),
+                project.entry_for_path(&(worktree_id, "one.txt").into(), cx)
+            );
+        });
+        assert_eq!(
+            cx.current_window_title(window_id).as_deref(),
+            Some("one.txt — root1")
+        );
+
+        // Add a second item to a non-empty pane
+        workspace.update(cx, |workspace, cx| workspace.add_item(Box::new(item2), cx));
+        assert_eq!(
+            cx.current_window_title(window_id).as_deref(),
+            Some("two.txt — root1")
+        );
+        project.read_with(cx, |project, cx| {
+            assert_eq!(
+                project.active_entry(),
+                project.entry_for_path(&(worktree_id, "two.txt").into(), cx)
+            );
+        });
+
+        // Close the active item
+        workspace
+            .update(cx, |workspace, cx| {
+                Pane::close_active_item(workspace, &Default::default(), cx).unwrap()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            cx.current_window_title(window_id).as_deref(),
+            Some("one.txt — root1")
+        );
+        project.read_with(cx, |project, cx| {
+            assert_eq!(
+                project.active_entry(),
+                project.entry_for_path(&(worktree_id, "one.txt").into(), cx)
+            );
+        });
+
+        // Add a project folder
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_local_worktree("/root2", true, cx)
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            cx.current_window_title(window_id).as_deref(),
+            Some("one.txt — root1, root2")
+        );
+
+        // Remove a project folder
+        project.update(cx, |project, cx| {
+            project.remove_worktree(worktree_id, cx);
+        });
+        assert_eq!(
+            cx.current_window_title(window_id).as_deref(),
+            Some("one.txt — root2")
+        );
+    }
+
+    #[gpui::test]
     async fn test_close_window(cx: &mut TestAppContext) {
         cx.foreground().forbid_parking();
         Settings::test_async(cx);
@@ -2446,18 +2597,6 @@ mod tests {
             item.project_entry_ids = vec![ProjectEntryId::from_proto(1)];
             item
         });
-        workspace.update(cx, |w, cx| {
-            w.add_item(Box::new(item2.clone()), cx);
-            w.add_item(Box::new(item3.clone()), cx);
-        });
-        let task = workspace.update(cx, |w, cx| w.prepare_to_close(cx));
-        cx.foreground().run_until_parked();
-        cx.simulate_prompt_answer(window_id, 2 /* cancel */);
-        cx.foreground().run_until_parked();
-        assert!(!cx.has_pending_prompt(window_id));
-        assert_eq!(task.await.unwrap(), false);
-
-        // If there are multiple dirty items representing the same project entry.
         workspace.update(cx, |w, cx| {
             w.add_item(Box::new(item2.clone()), cx);
             w.add_item(Box::new(item3.clone()), cx);
@@ -2667,6 +2806,7 @@ mod tests {
         is_dirty: bool,
         has_conflict: bool,
         project_entry_ids: Vec<ProjectEntryId>,
+        project_path: Option<ProjectPath>,
         is_singleton: bool,
     }
 
@@ -2679,6 +2819,7 @@ mod tests {
                 is_dirty: false,
                 has_conflict: false,
                 project_entry_ids: Vec::new(),
+                project_path: None,
                 is_singleton: true,
             }
         }
@@ -2704,7 +2845,7 @@ mod tests {
         }
 
         fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
-            None
+            self.project_path.clone()
         }
 
         fn project_entry_ids(&self, _: &AppContext) -> SmallVec<[ProjectEntryId; 3]> {
@@ -2762,6 +2903,10 @@ mod tests {
         ) -> Task<anyhow::Result<()>> {
             self.reload_count += 1;
             Task::ready(Ok(()))
+        }
+
+        fn should_update_tab_on_event(_: &Self::Event) -> bool {
+            true
         }
     }
 }

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -230,6 +230,10 @@ pub fn menus() -> Vec<Menu<'static>> {
             ],
         },
         Menu {
+            name: "Window",
+            items: vec![MenuItem::Separator],
+        },
+        Menu {
             name: "Help",
             items: vec![MenuItem::Action {
                 name: "Command Palette",


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/914

![image](https://user-images.githubusercontent.com/326587/170765170-404a3ab7-1851-41c7-8be1-9cd70fab6e02.png)

This PR also refactors the way that we emit events when activating items in panes, and maintain the active entry on the project, since that logic is related to maintaining the active file path in the window title.
