### PR TITLE
Add a few more important menu items

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -20,6 +20,7 @@
             "cmd-shift-S": "workspace::SaveAs",
             "cmd-=": "zed::IncreaseBufferFontSize",
             "cmd--": "zed::DecreaseBufferFontSize",
+            "cmd-0": "zed::ResetBufferFontSize",
             "cmd-,": "zed::OpenSettings",
             "cmd-q": "zed::Quit",
             "cmd-n": "workspace::NewFile",

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -21,6 +21,7 @@ pub use keymap_file::{keymap_file_json_schema, KeymapFileContent};
 pub struct Settings {
     pub buffer_font_family: FamilyId,
     pub buffer_font_size: f32,
+    pub default_buffer_font_size: f32,
     pub vim_mode: bool,
     pub tab_size: u32,
     pub soft_wrap: SoftWrap,
@@ -73,6 +74,7 @@ impl Settings {
         Ok(Self {
             buffer_font_family: font_cache.load_family(&[buffer_font_family])?,
             buffer_font_size: 15.,
+            default_buffer_font_size: 15.,
             vim_mode: false,
             tab_size: 4,
             soft_wrap: SoftWrap::None,
@@ -126,6 +128,7 @@ impl Settings {
         Settings {
             buffer_font_family: cx.font_cache().load_family(&["Monaco"]).unwrap(),
             buffer_font_size: 14.,
+            default_buffer_font_size: 14.,
             vim_mode: false,
             tab_size: 4,
             soft_wrap: SoftWrap::None,
@@ -162,6 +165,7 @@ impl Settings {
         }
 
         merge(&mut self.buffer_font_size, data.buffer_font_size);
+        merge(&mut self.default_buffer_font_size, data.buffer_font_size);
         merge(&mut self.vim_mode, data.vim_mode);
         merge(&mut self.format_on_save, data.format_on_save);
         merge(&mut self.soft_wrap, data.editor.soft_wrap);

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -247,10 +247,25 @@ pub fn menus() -> Vec<Menu<'static>> {
         },
         Menu {
             name: "Help",
-            items: vec![MenuItem::Action {
-                name: "Command Palette",
-                action: Box::new(command_palette::Toggle),
-            }],
+            items: vec![
+                MenuItem::Action {
+                    name: "Command Palette",
+                    action: Box::new(command_palette::Toggle),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Zed.dev",
+                    action: Box::new(crate::OpenBrowser {
+                        url: "https://zed.dev".into(),
+                    }),
+                },
+                MenuItem::Action {
+                    name: "Zed Twitter",
+                    action: Box::new(crate::OpenBrowser {
+                        url: "https://twitter.com/zeddotdev".into(),
+                    }),
+                },
+            ],
         },
     ]
 }

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -16,6 +16,14 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
+                    name: "Open Settings",
+                    action: Box::new(super::OpenSettings),
+                },
+                MenuItem::Action {
+                    name: "Open Key Bindings",
+                    action: Box::new(super::OpenKeymap),
+                },
+                MenuItem::Action {
                     name: "Install CLI",
                     action: Box::new(super::InstallCommandLineInterface),
                 },

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -164,6 +164,10 @@ pub fn menus() -> Vec<Menu<'static>> {
                     name: "Zoom Out",
                     action: Box::new(super::DecreaseBufferFontSize),
                 },
+                MenuItem::Action {
+                    name: "Reset Zoom",
+                    action: Box::new(super::ResetBufferFontSize),
+                },
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Project Browser",

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -14,6 +14,7 @@ use editor::Editor;
 use gpui::{
     actions,
     geometry::vector::vec2f,
+    impl_actions,
     platform::{WindowBounds, WindowOptions},
     AsyncAppContext, ViewContext,
 };
@@ -23,6 +24,7 @@ use project::Project;
 pub use project::{self, fs};
 use project_panel::ProjectPanel;
 use search::{BufferSearchBar, ProjectSearchBar};
+use serde::Deserialize;
 use serde_json::to_string_pretty;
 use settings::{keymap_file_json_schema, settings_file_json_schema, Settings};
 use std::{
@@ -32,6 +34,13 @@ use std::{
 use util::ResultExt;
 pub use workspace;
 use workspace::{AppState, Workspace};
+
+#[derive(Deserialize, Clone)]
+struct OpenBrowser {
+    url: Arc<str>,
+}
+
+impl_actions!(zed, [OpenBrowser]);
 
 actions!(
     zed,
@@ -61,6 +70,7 @@ lazy_static! {
 pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     cx.add_action(about);
     cx.add_global_action(quit);
+    cx.add_global_action(move |action: &OpenBrowser, cx| cx.platform().open_url(&action.url));
     cx.add_global_action(move |_: &IncreaseBufferFontSize, cx| {
         cx.update_global::<Settings, _, _>(|settings, cx| {
             settings.buffer_font_size = (settings.buffer_font_size + 1.0).max(MIN_FONT_SIZE);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -43,6 +43,7 @@ actions!(
         OpenKeymap,
         IncreaseBufferFontSize,
         DecreaseBufferFontSize,
+        ResetBufferFontSize,
         InstallCommandLineInterface,
     ]
 );
@@ -69,6 +70,12 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     cx.add_global_action(move |_: &DecreaseBufferFontSize, cx| {
         cx.update_global::<Settings, _, _>(|settings, cx| {
             settings.buffer_font_size = (settings.buffer_font_size - 1.0).max(MIN_FONT_SIZE);
+            cx.refresh_windows();
+        });
+    });
+    cx.add_global_action(move |_: &ResetBufferFontSize, cx| {
+        cx.update_global::<Settings, _, _>(|settings, cx| {
+            settings.buffer_font_size = settings.default_buffer_font_size;
             cx.refresh_windows();
         });
     });


### PR DESCRIPTION
Closes #914

* `Reset Zoom`, bound to `cmd-0`
* Open settings, Open key bindings
* Help > Zed.dev, Zed Twitter

There are still things we'll want to add to the application menu, but I think with these additions, we're ready to proceed with the alpha release.

