### PR TITLE
Remove opentelemetry tracing subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,8 +878,6 @@ dependencies = [
  "log",
  "lsp",
  "nanoid",
- "opentelemetry",
- "opentelemetry-otlp",
  "parking_lot",
  "project",
  "rand 0.8.3",
@@ -900,7 +898,6 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-log",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "util",
  "workspace",
@@ -1531,12 +1528,6 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
@@ -3042,45 +3033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel 0.5.0",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.3",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http",
- "opentelemetry",
- "prost 0.9.0",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
 name = "ordered-float"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,17 +3172,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset 0.2.0",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
-dependencies = [
- "fixedbitset 0.4.1",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -3515,29 +3457,9 @@ dependencies = [
  "itertools",
  "log",
  "multimap",
- "petgraph 0.5.1",
+ "petgraph",
  "prost 0.8.0",
- "prost-types 0.8.0",
- "tempfile",
- "which 4.1.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph 0.6.0",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "regex",
+ "prost-types",
  "tempfile",
  "which 4.1.0",
 ]
@@ -3576,16 +3498,6 @@ checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost 0.8.0",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
 ]
 
 [[package]]
@@ -3905,7 +3817,7 @@ dependencies = [
  "gpui",
  "parking_lot",
  "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost-build",
  "rand 0.8.3",
  "rsa",
  "serde",
@@ -4004,18 +3916,6 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -5225,9 +5125,7 @@ dependencies = [
  "pin-project",
  "prost 0.9.0",
  "prost-derive 0.9.0",
- "rustls-native-certs",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tower",
@@ -5235,18 +5133,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build 0.9.0",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5353,19 +5239,6 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
-dependencies = [
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -30,8 +30,6 @@ hyper = "0.14"
 lazy_static = "1.4"
 lipsum = { version = "0.8", optional = true }
 nanoid = "0.4"
-opentelemetry = { version = "0.17", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.10", features = ["tls-roots"] }
 parking_lot = "0.11.1"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["json"], optional = true }
@@ -47,7 +45,6 @@ tower = "0.4"
 toml = "0.5.8"
 tracing = "0.1.34"
 tracing-log = "0.1.3"
-tracing-opentelemetry = "0.17"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 
 [dependencies.sqlx]


### PR DESCRIPTION
Closes #1057

This dramatically reduced the server's memory consumption. We still observed a small increase in the server's memory usage every time we reconnected and shared a project, though it appeared that it was starting to taper off. We'll investigate further after tackling some simple improvement opportunities we captured in #1083.
