### PR TITLE
Capture mouse events when rendering disconnected overlay

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1878,7 +1878,7 @@ impl Workspace {
                     .with_style(theme.workspace.disconnected_overlay.container)
                     .boxed(),
                 )
-                .capture(|_, _, _| true)
+                .capture_all::<Self>(0)
                 .boxed(),
             )
         } else {


### PR DESCRIPTION
Fixes #1108 

We do so by replacing `EventHandler::capture` with a new `::capture_all` method. After switching to mouse regions as part of zed-industries/zed#1081, overriding `dispatch_event` on `EventHandler` wasn't enough anymore because mouse interactions take place on a privileged code path that runs *before* dispatching any event.

With this change, `EventHandler` will now push a mouse region that intercepts all mouse interactions, as well as pushing a cursor region that resets the cursor style to `Arrow`.

One interesting change as part of this is that we've removed the ability to see which event we are capturing: we were not using this capability anyway and `capture_all` provides a simpler interface, so I went with that. In the future, we can opt into capturing specific events or mouse interactions if there's a code path that needs that.