### PR TITLE
Fix `offset out of range` panic during `FoldMap::sync`

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -693,7 +693,7 @@ pub mod tests {
                     }
                 }
                 _ => {
-                    buffer.update(cx, |buffer, cx| buffer.randomly_edit(&mut rng, 5, cx));
+                    buffer.update(cx, |buffer, cx| buffer.randomly_mutate(&mut rng, 5, cx));
                 }
             }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -22,6 +22,7 @@ use serde_json::Value;
 use std::{
     any::Any,
     cell::RefCell,
+    mem,
     ops::Range,
     path::{Path, PathBuf},
     str,
@@ -692,5 +693,10 @@ pub fn range_to_lsp(range: Range<PointUtf16>) -> lsp::Range {
 }
 
 pub fn range_from_lsp(range: lsp::Range) -> Range<PointUtf16> {
-    point_from_lsp(range.start)..point_from_lsp(range.end)
+    let mut start = point_from_lsp(range.start);
+    let mut end = point_from_lsp(range.end);
+    if start > end {
+        mem::swap(&mut start, &mut end);
+    }
+    start..end
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -36,7 +36,7 @@ use sha2::{Digest, Sha256};
 use similar::{ChangeTag, TextDiff};
 use std::{
     cell::RefCell,
-    cmp::{self, Ordering, Reverse},
+    cmp::{self, Ordering},
     convert::TryInto,
     ffi::OsString,
     hash::Hash,


### PR DESCRIPTION
Fixes #1106 
Fixes https://github.com/zed-insiders/zed-insiders/issues/8

In v0.36.1, a user saw this panic after saving a React file. This made me suspect the LSP was reporting edits in a weird way, so that led me to investigate what would happen if we did so too in our randomized tests. Indeed, as soon as I started generating edits with the `start` greater than the `end`, I saw this panic pop up.

To fix this, this pull request will:

- Make `Buffer::edit` and `MultiBuffer::edit` be resilient to inverted ranges. This ensures we don't break some invariants in the buffer that would cause e.g. undo/redo to misbehave and operation application to panic. In theory, we should never pass inverted ranges, but when that occurs the whole system will panic and that doesn't seem great.
- Handle out-of-order edits coming from LSP in `Project::edits_from_lsp`. This includes flipping `start` and `end` when they are inverted, as well as sorting edits by `range.start` if they arrive out-of-order.