### PR TITLE
Show a notification after Zed auto-updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,12 +346,15 @@ dependencies = [
  "isahc",
  "lazy_static",
  "log",
+ "menu",
+ "project",
  "serde",
  "serde_json",
  "settings",
  "smol",
  "tempdir",
  "theme",
+ "util",
  "workspace",
 ]
 

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -10,9 +10,12 @@ doctest = false
 [dependencies]
 client = { path = "../client" }
 gpui = { path = "../gpui" }
+menu = { path = "../menu" }
+project = { path = "../project" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
 workspace = { path = "../workspace" }
+util = { path = "../util" }
 anyhow = "1.0.38"
 isahc = "1.7"
 lazy_static = "1.4"

--- a/crates/auto_update/src/update_notification.rs
+++ b/crates/auto_update/src/update_notification.rs
@@ -1,0 +1,106 @@
+use crate::ViewReleaseNotes;
+use gpui::{
+    elements::{Flex, MouseEventHandler, Padding, ParentElement, Svg, Text},
+    platform::{AppVersion, CursorStyle},
+    Element, Entity, View, ViewContext,
+};
+use menu::Cancel;
+use settings::Settings;
+use workspace::Notification;
+
+pub struct UpdateNotification {
+    version: AppVersion,
+}
+
+pub enum Event {
+    Dismiss,
+}
+
+impl Entity for UpdateNotification {
+    type Event = Event;
+}
+
+impl View for UpdateNotification {
+    fn ui_name() -> &'static str {
+        "UpdateNotification"
+    }
+
+    fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
+        let theme = cx.global::<Settings>().theme.clone();
+        let theme = &theme.update_notification;
+
+        MouseEventHandler::new::<ViewReleaseNotes, _, _>(0, cx, |state, cx| {
+            Flex::column()
+                .with_child(
+                    Flex::row()
+                        .with_child(
+                            Text::new(
+                                format!("Updated to Zed {}", self.version),
+                                theme.message.text.clone(),
+                            )
+                            .contained()
+                            .with_style(theme.message.container)
+                            .aligned()
+                            .top()
+                            .left()
+                            .flex(1., true)
+                            .boxed(),
+                        )
+                        .with_child(
+                            MouseEventHandler::new::<Cancel, _, _>(0, cx, |state, _| {
+                                let style = theme.dismiss_button.style_for(state, false);
+                                Svg::new("icons/decline.svg")
+                                    .with_color(style.color)
+                                    .constrained()
+                                    .with_width(style.icon_width)
+                                    .aligned()
+                                    .contained()
+                                    .with_style(style.container)
+                                    .constrained()
+                                    .with_width(style.button_width)
+                                    .with_height(style.button_width)
+                                    .boxed()
+                            })
+                            .with_padding(Padding::uniform(5.))
+                            .on_click(move |_, _, cx| cx.dispatch_action(Cancel))
+                            .aligned()
+                            .constrained()
+                            .with_height(cx.font_cache().line_height(theme.message.text.font_size))
+                            .aligned()
+                            .top()
+                            .flex_float()
+                            .boxed(),
+                        )
+                        .boxed(),
+                )
+                .with_child({
+                    let style = theme.action_message.style_for(state, false);
+                    Text::new("View the release notes".to_string(), style.text.clone())
+                        .contained()
+                        .with_style(style.container)
+                        .boxed()
+                })
+                .contained()
+                .boxed()
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_click(|_, _, cx| cx.dispatch_action(ViewReleaseNotes))
+        .boxed()
+    }
+}
+
+impl Notification for UpdateNotification {
+    fn should_dismiss_notification_on_event(&self, event: &<Self as Entity>::Event) -> bool {
+        matches!(event, Event::Dismiss)
+    }
+}
+
+impl UpdateNotification {
+    pub fn new(version: AppVersion) -> Self {
+        Self { version }
+    }
+
+    pub fn dismiss(&mut self, _: &Cancel, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::Dismiss);
+    }
+}

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -31,6 +31,7 @@ pub struct Theme {
     pub project_diagnostics: ProjectDiagnostics,
     pub breadcrumbs: ContainedText,
     pub contact_notification: ContactNotification,
+    pub update_notification: UpdateNotification,
     pub tooltip: TooltipStyle,
 }
 
@@ -409,6 +410,13 @@ pub struct ContactNotification {
     pub header_height: f32,
     pub body_message: ContainedText,
     pub button: Interactive<ContainedText>,
+    pub dismiss_button: Interactive<IconButton>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct UpdateNotification {
+    pub message: ContainedText,
+    pub action_message: Interactive<ContainedText>,
     pub dismiss_button: Interactive<IconButton>,
 }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -158,7 +158,6 @@ fn main() {
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
 
         context_menu::init(cx);
-        auto_update::init(http, client::ZED_SERVER_URL.clone(), cx);
         project::Project::init(&client);
         client::Channel::init(&client);
         client::init(client.clone(), cx);
@@ -211,7 +210,7 @@ fn main() {
         .detach();
         cx.set_global(settings);
 
-        let project_store = cx.add_model(|_| ProjectStore::new(db));
+        let project_store = cx.add_model(|_| ProjectStore::new(db.clone()));
         let app_state = Arc::new(AppState {
             languages,
             themes,
@@ -222,6 +221,7 @@ fn main() {
             build_window_options,
             initialize_workspace,
         });
+        auto_update::init(db, http, client::ZED_SERVER_URL.clone(), cx);
         workspace::init(app_state.clone(), cx);
         journal::init(app_state.clone(), cx);
         theme_selector::init(app_state.clone(), cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -209,6 +209,8 @@ pub fn initialize_workspace(
         status_bar.add_right_item(cursor_position, cx);
         status_bar.add_right_item(auto_update, cx);
     });
+
+    auto_update::notify_of_any_new_update(cx.weak_handle(), cx);
 }
 
 pub fn build_window_options() -> WindowOptions<'static> {

--- a/styles/src/styleTree/app.ts
+++ b/styles/src/styleTree/app.ts
@@ -12,6 +12,7 @@ import workspace from "./workspace";
 import contextMenu from "./contextMenu";
 import projectDiagnostics from "./projectDiagnostics";
 import contactNotification from "./contactNotification";
+import updateNotification from "./updateNotification";
 import tooltip from "./tooltip";
 
 export const panel = {
@@ -38,6 +39,7 @@ export default function app(theme: Theme): Object {
       },
     },
     contactNotification: contactNotification(theme),
+    updateNotification: updateNotification(theme),
     tooltip: tooltip(theme),
   };
 }

--- a/styles/src/styleTree/updateNotification.ts
+++ b/styles/src/styleTree/updateNotification.ts
@@ -1,0 +1,30 @@
+import Theme from "../themes/common/theme";
+import { iconColor, text } from "./components";
+
+const headerPadding = 8;
+
+export default function updateNotification(theme: Theme): Object {
+  return {
+    message: {
+      ...text(theme, "sans", "primary", { size: "xs" }),
+      margin: { left: headerPadding, right: headerPadding }
+    },
+    actionMessage: {
+      ...text(theme, "sans", "secondary", { size: "xs" }),
+      margin: { left: headerPadding, top: 6, bottom: 6 },
+      hover: {
+        color: theme.textColor["active"].value
+      }
+    },
+    dismissButton: {
+      color: iconColor(theme, "secondary"),
+      iconWidth: 8,
+      iconHeight: 8,
+      buttonWidth: 8,
+      buttonHeight: 8,
+      hover: {
+        color: iconColor(theme, "primary")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1080

![Screen Shot 2022-06-06 at 5 38 52 PM](https://user-images.githubusercontent.com/326587/172271796-e987604b-f8c9-48df-83d8-50a81c70264b.png)

Clicking on the notification opens `https://zed.dev/releases` in the browser.

The way I have it right now, the notification will only be shown for the first window opened after updating Zed.