### PR TITLE
Add status bar link and help menu item to open an issue on feedback repo

### DIFF
--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -157,6 +157,7 @@ pub struct StatusBar {
     pub auto_update_progress_message: TextStyle,
     pub auto_update_done_message: TextStyle,
     pub lsp_status: Interactive<StatusBarLspStatus>,
+    pub feedback: Interactive<TextStyle>,
     pub sidebar_buttons: StatusBarSidebarButtons,
     pub diagnostic_summary: Interactive<StatusBarDiagnosticSummary>,
     pub diagnostic_message: Interactive<ContainedText>,

--- a/crates/zed/src/feedback.rs
+++ b/crates/zed/src/feedback.rs
@@ -1,0 +1,51 @@
+use crate::OpenBrowser;
+use gpui::{
+    elements::{MouseEventHandler, Text},
+    platform::CursorStyle,
+    Element, Entity, RenderContext, View,
+};
+use settings::Settings;
+use workspace::StatusItemView;
+
+pub const NEW_ISSUE_URL: &'static str =
+    "https://github.com/zed-industries/feedback/issues/new/choose";
+
+pub struct FeedbackLink;
+
+impl Entity for FeedbackLink {
+    type Event = ();
+}
+
+impl View for FeedbackLink {
+    fn ui_name() -> &'static str {
+        "FeedbackLink"
+    }
+
+    fn render(&mut self, cx: &mut RenderContext<'_, Self>) -> gpui::ElementBox {
+        MouseEventHandler::new::<Self, _, _>(0, cx, |state, cx| {
+            let theme = &cx.global::<Settings>().theme;
+            let theme = &theme.workspace.status_bar.feedback;
+            Text::new(
+                "Give Feedback".to_string(),
+                theme.style_for(state, false).clone(),
+            )
+            .boxed()
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_click(|_, _, cx| {
+            cx.dispatch_action(OpenBrowser {
+                url: NEW_ISSUE_URL.into(),
+            })
+        })
+        .boxed()
+    }
+}
+
+impl StatusItemView for FeedbackLink {
+    fn set_active_pane_item(
+        &mut self,
+        _: Option<&dyn workspace::ItemHandle>,
+        _: &mut gpui::ViewContext<Self>,
+    ) {
+    }
+}

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -254,6 +254,12 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
+                    name: "Give Feedback",
+                    action: Box::new(crate::OpenBrowser {
+                        url: super::feedback::NEW_ISSUE_URL.into(),
+                    }),
+                },
+                MenuItem::Action {
                     name: "Zed.dev",
                     action: Box::new(crate::OpenBrowser {
                         url: "https://zed.dev".into(),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1,3 +1,4 @@
+mod feedback;
 pub mod languages;
 pub mod menus;
 pub mod settings_file;
@@ -203,11 +204,13 @@ pub fn initialize_workspace(
     });
     let cursor_position = cx.add_view(|_| editor::items::CursorPosition::new());
     let auto_update = cx.add_view(|cx| auto_update::AutoUpdateIndicator::new(cx));
+    let feedback_link = cx.add_view(|_| feedback::FeedbackLink);
     workspace.status_bar().update(cx, |status_bar, cx| {
         status_bar.add_left_item(diagnostic_summary, cx);
         status_bar.add_left_item(lsp_status, cx);
         status_bar.add_right_item(cursor_position, cx);
         status_bar.add_right_item(auto_update, cx);
+        status_bar.add_right_item(feedback_link, cx);
     });
 
     auto_update::notify_of_any_new_update(cx.weak_handle(), cx);

--- a/styles/src/styleTree/statusBar.ts
+++ b/styles/src/styleTree/statusBar.ts
@@ -43,6 +43,10 @@ export default function statusBar(theme: Theme) {
       ...text(theme, "sans", "muted"),
       hover: text(theme, "sans", "secondary"),
     },
+    feedback: {
+      ...text(theme, "sans", "muted"),
+      hover: text(theme, "sans", "active"),
+    },
     diagnosticSummary: {
       height: 16,
       iconWidth: 14,


### PR DESCRIPTION
Fixes #1079

Clicking this takes you [here](https://github.com/zed-industries/feedback/issues/new/choose).

<img width="1010" alt="Screen Shot 2022-06-07 at 3 51 50 PM" src="https://user-images.githubusercontent.com/326587/172496214-e072844a-9cd2-4301-9d25-2af90c05f693.png">

