### PR TITLE
Use visible bounds to determine hit bounds for cursor/mouse regions

### DIFF
--- a/crates/gpui/src/elements/container.rs
+++ b/crates/gpui/src/elements/container.rs
@@ -212,11 +212,13 @@ impl Element for Container {
             });
         }
 
-        if let Some(style) = self.style.cursor {
-            cx.scene.push_cursor_region(CursorRegion {
-                bounds: quad_bounds,
-                style,
-            });
+        if let Some(hit_bounds) = quad_bounds.intersection(visible_bounds) {
+            if let Some(style) = self.style.cursor {
+                cx.scene.push_cursor_region(CursorRegion {
+                    bounds: hit_bounds,
+                    style,
+                });
+            }
         }
 
         let child_origin =

--- a/crates/gpui/src/elements/event_handler.rs
+++ b/crates/gpui/src/elements/event_handler.rs
@@ -78,13 +78,13 @@ impl Element for EventHandler {
         if let Some(discriminant) = self.capture_all {
             cx.scene.push_stacking_context(None);
             cx.scene.push_cursor_region(CursorRegion {
-                bounds,
+                bounds: visible_bounds,
                 style: Default::default(),
             });
             cx.scene.push_mouse_region(MouseRegion {
                 view_id: cx.current_view_id(),
                 discriminant: Some(discriminant),
-                bounds,
+                bounds: visible_bounds,
                 hover: Some(Rc::new(|_, _, _| {})),
                 mouse_down: Some(Rc::new(|_, _| {})),
                 click: Some(Rc::new(|_, _, _| {})),

--- a/crates/gpui/src/elements/mouse_event_handler.rs
+++ b/crates/gpui/src/elements/mouse_event_handler.rs
@@ -152,9 +152,10 @@ impl Element for MouseEventHandler {
         _: &mut Self::LayoutState,
         cx: &mut PaintContext,
     ) -> Self::PaintState {
+        let hit_bounds = self.hit_bounds(visible_bounds);
         if let Some(style) = self.cursor_style {
             cx.scene.push_cursor_region(CursorRegion {
-                bounds: self.hit_bounds(bounds),
+                bounds: hit_bounds,
                 style,
             });
         }
@@ -162,7 +163,7 @@ impl Element for MouseEventHandler {
         cx.scene.push_mouse_region(MouseRegion {
             view_id: cx.current_view_id(),
             discriminant: Some((self.tag, self.id)),
-            bounds: self.hit_bounds(bounds),
+            bounds: hit_bounds,
             hover: self.hover.clone(),
             click: self.click.clone(),
             mouse_down: self.mouse_down.clone(),

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -250,11 +250,15 @@ impl Scene {
     }
 
     pub fn push_cursor_region(&mut self, region: CursorRegion) {
-        self.active_layer().push_cursor_region(region);
+        if can_draw(region.bounds) {
+            self.active_layer().push_cursor_region(region);
+        }
     }
 
     pub fn push_mouse_region(&mut self, region: MouseRegion) {
-        self.active_layer().push_mouse_region(region);
+        if can_draw(region.bounds) {
+            self.active_layer().push_mouse_region(region);
+        }
     }
 
     pub fn push_image(&mut self, image: Image) {


### PR DESCRIPTION
Fixes #1137 