### PR TITLE
Hover fixes

### DIFF
--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -16,6 +16,7 @@ test-support = [
     "project/test-support",
     "util/test-support",
     "workspace/test-support",
+    "tree-sitter-rust"
 ]
 
 [dependencies]
@@ -48,6 +49,7 @@ rand = { version = "0.8.3", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"] }
 smallvec = { version = "1.6", features = ["union"] }
 smol = "1.2"
+tree-sitter-rust = { version = "*", optional = true }
 
 [dev-dependencies]
 text = { path = "../text", features = ["test-support"] }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -193,9 +193,9 @@ impl DisplayMap {
         self.text_highlights.remove(&Some(type_id))
     }
 
-    pub fn set_font(&self, font_id: FontId, font_size: f32, cx: &mut ModelContext<Self>) {
+    pub fn set_font(&self, font_id: FontId, font_size: f32, cx: &mut ModelContext<Self>) -> bool {
         self.wrap_map
-            .update(cx, |map, cx| map.set_font(font_id, font_size, cx));
+            .update(cx, |map, cx| map.set_font(font_id, font_size, cx))
     }
 
     pub fn set_wrap_width(&self, width: Option<f32>, cx: &mut ModelContext<Self>) -> bool {

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -121,10 +121,18 @@ impl WrapMap {
         (self.snapshot.clone(), mem::take(&mut self.edits_since_sync))
     }
 
-    pub fn set_font(&mut self, font_id: FontId, font_size: f32, cx: &mut ModelContext<Self>) {
+    pub fn set_font(
+        &mut self,
+        font_id: FontId,
+        font_size: f32,
+        cx: &mut ModelContext<Self>,
+    ) -> bool {
         if (font_id, font_size) != self.font {
             self.font = (font_id, font_size);
-            self.rewrap(cx)
+            self.rewrap(cx);
+            true
+        } else {
+            false
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1,5 +1,6 @@
 pub mod display_map;
 mod element;
+mod hover;
 pub mod items;
 pub mod movement;
 mod multi_buffer;
@@ -431,7 +432,6 @@ pub struct Editor {
     next_completion_id: CompletionId,
     available_code_actions: Option<(ModelHandle<Buffer>, Arc<[CodeAction]>)>,
     code_actions_task: Option<Task<()>>,
-    hover_task: Option<Task<Option<()>>>,
     document_highlights_task: Option<Task<()>>,
     pending_rename: Option<RenameState>,
     searchable: bool,
@@ -440,39 +440,6 @@ pub struct Editor {
     input_enabled: bool,
     leader_replica_id: Option<u16>,
     hover_state: HoverState,
-}
-
-/// Keeps track of the state of the [`HoverPopover`].
-/// Times out the initial delay and the grace period.
-pub struct HoverState {
-    popover: Option<HoverPopover>,
-    last_hover: std::time::Instant,
-    start_grace: std::time::Instant,
-}
-
-impl HoverState {
-    /// Takes whether the cursor is currently hovering over a symbol,
-    /// and returns a tuple containing whether there was a recent hover,
-    /// and whether the hover is still in the grace period.
-    pub fn determine_state(&mut self, hovering: bool) -> (bool, bool) {
-        // NOTE: We use some sane defaults, but it might be
-        //       nice to make these values configurable.
-        let recent_hover = self.last_hover.elapsed() < std::time::Duration::from_millis(500);
-        if !hovering {
-            self.last_hover = std::time::Instant::now();
-        }
-
-        let in_grace = self.start_grace.elapsed() < std::time::Duration::from_millis(250);
-        if hovering && !recent_hover {
-            self.start_grace = std::time::Instant::now();
-        }
-
-        return (recent_hover, in_grace);
-    }
-
-    pub fn close(&mut self) {
-        self.popover.take();
-    }
 }
 
 pub struct EditorSnapshot {
@@ -896,67 +863,6 @@ impl CodeActionsMenu {
         }
 
         (cursor_position, element)
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct HoverPopover {
-    pub project: ModelHandle<Project>,
-    pub hover_point: DisplayPoint,
-    pub range: Range<DisplayPoint>,
-    pub contents: Vec<HoverBlock>,
-}
-
-impl HoverPopover {
-    fn render(
-        &self,
-        style: EditorStyle,
-        cx: &mut RenderContext<Editor>,
-    ) -> (DisplayPoint, ElementBox) {
-        let element = MouseEventHandler::new::<HoverPopover, _, _>(0, cx, |_, cx| {
-            let mut flex = Flex::new(Axis::Vertical).scrollable::<HoverBlock, _>(1, None, cx);
-            flex.extend(self.contents.iter().map(|content| {
-                let project = self.project.read(cx);
-                if let Some(language) = content
-                    .language
-                    .clone()
-                    .and_then(|language| project.languages().get_language(&language))
-                {
-                    let runs = language
-                        .highlight_text(&content.text.as_str().into(), 0..content.text.len());
-
-                    Text::new(content.text.clone(), style.text.clone())
-                        .with_soft_wrap(true)
-                        .with_highlights(
-                            runs.iter()
-                                .filter_map(|(range, id)| {
-                                    id.style(style.theme.syntax.as_ref())
-                                        .map(|style| (range.clone(), style))
-                                })
-                                .collect(),
-                        )
-                        .boxed()
-                } else {
-                    Text::new(content.text.clone(), style.hover_popover.prose.clone())
-                        .with_soft_wrap(true)
-                        .contained()
-                        .with_style(style.hover_popover.block_style)
-                        .boxed()
-                }
-            }));
-            flex.contained()
-                .with_style(style.hover_popover.container)
-                .boxed()
-        })
-        .with_cursor_style(CursorStyle::Arrow)
-        .with_padding(Padding {
-            bottom: 5.,
-            top: 5.,
-            ..Default::default()
-        })
-        .boxed();
-
-        (self.range.start, element)
     }
 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5688,9 +5688,22 @@ impl Entity for Editor {
 impl View for Editor {
     fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {
         let style = self.style(cx);
-        self.display_map.update(cx, |map, cx| {
+        let font_changed = self.display_map.update(cx, |map, cx| {
             map.set_font(style.text.font_id, style.text.font_size, cx)
         });
+
+        // If the
+        if font_changed {
+            let handle = self.handle.clone();
+            cx.defer(move |cx| {
+                if let Some(editor) = handle.upgrade(cx) {
+                    editor.update(cx, |editor, cx| {
+                        hide_hover(editor, cx);
+                    })
+                }
+            });
+        }
+
         EditorElement::new(self.handle.clone(), style.clone(), self.cursor_shape).boxed()
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -43,7 +43,7 @@ pub use multi_buffer::{
     ToPoint,
 };
 use ordered_float::OrderedFloat;
-use project::{HoverBlock, Project, ProjectPath, ProjectTransaction};
+use project::{Project, ProjectPath, ProjectTransaction};
 use selections_collection::{resolve_multiple, MutableSelectionsCollection, SelectionsCollection};
 use serde::{Deserialize, Serialize};
 use settings::Settings;
@@ -6148,10 +6148,7 @@ pub fn styled_runs_for_code_label<'a>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        hover_popover::{
-            hover, hover_at, HoverAt, HOVER_DELAY_MILLIS, HOVER_GRACE_MILLIS,
-            HOVER_REQUEST_DELAY_MILLIS,
-        },
+        hover_popover::{hover, hover_at, HoverAt, HOVER_DELAY_MILLIS, HOVER_GRACE_MILLIS},
         test::{
             assert_text_with_selections, build_editor, select_ranges, EditorLspTestContext,
             EditorTestContext,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1,0 +1,94 @@
+/// Keeps track of the state of the [`HoverPopover`].
+/// Times out the initial delay and the grace period.
+pub struct HoverState {
+    popover: Option<HoverPopover>,
+    last_hover: std::time::Instant,
+    start_grace: std::time::Instant,
+}
+
+impl HoverState {
+    /// Takes whether the cursor is currently hovering over a symbol,
+    /// and returns a tuple containing whether there was a recent hover,
+    /// and whether the hover is still in the grace period.
+    pub fn determine_state(&mut self, hovering: bool) -> (bool, bool) {
+        // NOTE: We use some sane defaults, but it might be
+        //       nice to make these values configurable.
+        let recent_hover = self.last_hover.elapsed() < std::time::Duration::from_millis(500);
+        if !hovering {
+            self.last_hover = std::time::Instant::now();
+        }
+
+        let in_grace = self.start_grace.elapsed() < std::time::Duration::from_millis(250);
+        if hovering && !recent_hover {
+            self.start_grace = std::time::Instant::now();
+        }
+
+        return (recent_hover, in_grace);
+    }
+
+    pub fn close(&mut self) {
+        self.popover.take();
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct HoverPopover {
+    pub project: ModelHandle<Project>,
+    pub hover_point: DisplayPoint,
+    pub range: Range<DisplayPoint>,
+    pub contents: Vec<HoverBlock>,
+    pub task: Option<Task<()>>,
+}
+
+impl HoverPopover {
+    fn render(
+        &self,
+        style: EditorStyle,
+        cx: &mut RenderContext<Editor>,
+    ) -> (DisplayPoint, ElementBox) {
+        let element = MouseEventHandler::new::<HoverPopover, _, _>(0, cx, |_, cx| {
+            let mut flex = Flex::new(Axis::Vertical).scrollable::<HoverBlock, _>(1, None, cx);
+            flex.extend(self.contents.iter().map(|content| {
+                let project = self.project.read(cx);
+                if let Some(language) = content
+                    .language
+                    .clone()
+                    .and_then(|language| project.languages().get_language(&language))
+                {
+                    let runs = language
+                        .highlight_text(&content.text.as_str().into(), 0..content.text.len());
+
+                    Text::new(content.text.clone(), style.text.clone())
+                        .with_soft_wrap(true)
+                        .with_highlights(
+                            runs.iter()
+                                .filter_map(|(range, id)| {
+                                    id.style(style.theme.syntax.as_ref())
+                                        .map(|style| (range.clone(), style))
+                                })
+                                .collect(),
+                        )
+                        .boxed()
+                } else {
+                    Text::new(content.text.clone(), style.hover_popover.prose.clone())
+                        .with_soft_wrap(true)
+                        .contained()
+                        .with_style(style.hover_popover.block_style)
+                        .boxed()
+                }
+            }));
+            flex.contained()
+                .with_style(style.hover_popover.container)
+                .boxed()
+        })
+        .with_cursor_style(CursorStyle::Arrow)
+        .with_padding(Padding {
+            bottom: 5.,
+            top: 5.,
+            ..Default::default()
+        })
+        .boxed();
+
+        (self.range.start, element)
+    }
+}

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1,48 +1,240 @@
-/// Keeps track of the state of the [`HoverPopover`].
-/// Times out the initial delay and the grace period.
-pub struct HoverState {
-    popover: Option<HoverPopover>,
-    last_hover: std::time::Instant,
-    start_grace: std::time::Instant,
+use std::{
+    ops::Range,
+    time::{Duration, Instant},
+};
+
+use gpui::{
+    actions,
+    elements::{Flex, MouseEventHandler, Padding, Text},
+    impl_internal_actions,
+    platform::CursorStyle,
+    Axis, Element, ElementBox, ModelHandle, MutableAppContext, RenderContext, Task, ViewContext,
+};
+use language::Bias;
+use project::{HoverBlock, Project};
+use util::TryFutureExt;
+
+use crate::{
+    display_map::ToDisplayPoint, Anchor, AnchorRangeExt, DisplayPoint, Editor, EditorSnapshot,
+    EditorStyle,
+};
+
+#[derive(Clone, PartialEq)]
+pub struct HoverAt {
+    pub point: Option<DisplayPoint>,
 }
 
-impl HoverState {
-    /// Takes whether the cursor is currently hovering over a symbol,
-    /// and returns a tuple containing whether there was a recent hover,
-    /// and whether the hover is still in the grace period.
-    pub fn determine_state(&mut self, hovering: bool) -> (bool, bool) {
-        // NOTE: We use some sane defaults, but it might be
-        //       nice to make these values configurable.
-        let recent_hover = self.last_hover.elapsed() < std::time::Duration::from_millis(500);
-        if !hovering {
-            self.last_hover = std::time::Instant::now();
-        }
+actions!(editor, [Hover]);
+impl_internal_actions!(editor, [HoverAt]);
 
-        let in_grace = self.start_grace.elapsed() < std::time::Duration::from_millis(250);
-        if hovering && !recent_hover {
-            self.start_grace = std::time::Instant::now();
-        }
+pub fn init(cx: &mut MutableAppContext) {
+    cx.add_action(hover);
+    cx.add_action(hover_at);
+}
 
-        return (recent_hover, in_grace);
+/// Bindable action which uses the most recent selection head to trigger a hover
+fn hover(editor: &mut Editor, _: &Hover, cx: &mut ViewContext<Editor>) {
+    let head = editor.selections.newest_display(cx).head();
+    show_hover(editor, head, true, cx);
+}
+
+/// The internal hover action dispatches between `show_hover` or `hide_hover`
+/// depending on whether a point to hover over is provided.
+fn hover_at(editor: &mut Editor, action: &HoverAt, cx: &mut ViewContext<Editor>) {
+    if let Some(point) = action.point {
+        show_hover(editor, point, false, cx);
+    } else {
+        hide_hover(editor, cx);
+    }
+}
+
+/// Hides the type information popup.
+/// Triggered by the `Hover` action when the cursor is not over a symbol or when the
+/// selections changed.
+pub fn hide_hover(editor: &mut Editor, cx: &mut ViewContext<Editor>) -> bool {
+    let mut did_hide = false;
+
+    // only notify the context once
+    if editor.hover_state.popover.is_some() {
+        editor.hover_state.popover = None;
+        editor.hover_state.hidden_at = Some(Instant::now());
+        editor.hover_state.symbol_range = None;
+        did_hide = true;
+        cx.notify();
     }
 
-    pub fn close(&mut self) {
-        self.popover.take();
+    editor.clear_background_highlights::<HoverState>(cx);
+
+    editor.hover_state.task = None;
+
+    did_hide
+}
+
+/// Queries the LSP and shows type info and documentation
+/// about the symbol the mouse is currently hovering over.
+/// Triggered by the `Hover` action when the cursor may be over a symbol.
+fn show_hover(
+    editor: &mut Editor,
+    point: DisplayPoint,
+    ignore_timeout: bool,
+    cx: &mut ViewContext<Editor>,
+) {
+    if editor.pending_rename.is_some() {
+        return;
     }
+
+    let snapshot = editor.snapshot(cx);
+    let multibuffer_offset = point.to_offset(&snapshot.display_snapshot, Bias::Left);
+
+    if let Some(range) = &editor.hover_state.symbol_range {
+        if range
+            .to_offset(&snapshot.buffer_snapshot)
+            .contains(&multibuffer_offset)
+        {
+            // Hover triggered from same location as last time. Don't show again.
+            return;
+        }
+    }
+
+    let (buffer, buffer_position) = if let Some(output) = editor
+        .buffer
+        .read(cx)
+        .text_anchor_for_position(multibuffer_offset, cx)
+    {
+        output
+    } else {
+        return;
+    };
+
+    let excerpt_id = if let Some((excerpt_id, _, _)) = editor
+        .buffer()
+        .read(cx)
+        .excerpt_containing(multibuffer_offset, cx)
+    {
+        excerpt_id
+    } else {
+        return;
+    };
+
+    let project = if let Some(project) = editor.project.clone() {
+        project
+    } else {
+        return;
+    };
+
+    // query the LSP for hover info
+    let hover_request = project.update(cx, |project, cx| {
+        project.hover(&buffer, buffer_position.clone(), cx)
+    });
+
+    // We should only delay if the hover popover isn't visible, it wasn't recently hidden, and
+    // the hover wasn't triggered from the keyboard
+    let should_delay = editor.hover_state.popover.is_none() // Hover visible currently
+        && editor
+            .hover_state
+            .hidden_at
+            .map(|hidden| hidden.elapsed().as_millis() > 200)
+            .unwrap_or(true) // Hover was visible recently enough
+        && !ignore_timeout; // Hover triggered from keyboard
+
+    // Get input anchor
+    let anchor = snapshot
+        .buffer_snapshot
+        .anchor_at(multibuffer_offset, Bias::Left);
+
+    let task = cx.spawn_weak(|this, mut cx| {
+        async move {
+            let delay = if should_delay {
+                Some(cx.background().timer(Duration::from_millis(500)))
+            } else {
+                None
+            };
+
+            // Construct new hover popover from hover request
+            let hover_popover = hover_request.await.ok().flatten().and_then(|hover_result| {
+                if hover_result.contents.is_empty() {
+                    return None;
+                }
+
+                let range = if let Some(range) = hover_result.range {
+                    let start = snapshot
+                        .buffer_snapshot
+                        .anchor_in_excerpt(excerpt_id.clone(), range.start);
+                    let end = snapshot
+                        .buffer_snapshot
+                        .anchor_in_excerpt(excerpt_id.clone(), range.end);
+
+                    start..end
+                } else {
+                    anchor.clone()..anchor.clone()
+                };
+
+                if let Some(this) = this.upgrade(&cx) {
+                    this.update(&mut cx, |this, _| {
+                        this.hover_state.symbol_range = Some(range.clone());
+                    });
+                }
+
+                Some(HoverPopover {
+                    project: project.clone(),
+                    anchor: range.start.clone(),
+                    contents: hover_result.contents,
+                })
+            });
+
+            if let Some(delay) = delay {
+                delay.await;
+            }
+
+            if let Some(this) = this.upgrade(&cx) {
+                this.update(&mut cx, |this, cx| {
+                    if this.hover_state.popover.is_some() || hover_popover.is_some() {
+                        // Highlight the selected symbol using a background highlight
+                        if let Some(range) = this.hover_state.symbol_range.clone() {
+                            this.highlight_background::<HoverState>(
+                                vec![range],
+                                |theme| theme.editor.hover_popover.highlight,
+                                cx,
+                            );
+                        }
+
+                        this.hover_state.popover = hover_popover;
+
+                        if this.hover_state.popover.is_none() {
+                            this.hover_state.hidden_at = Some(Instant::now());
+                        }
+
+                        cx.notify();
+                    }
+                });
+            }
+            Ok::<_, anyhow::Error>(())
+        }
+        .log_err()
+    });
+
+    editor.hover_state.task = Some(task);
+}
+
+#[derive(Default)]
+pub struct HoverState {
+    pub popover: Option<HoverPopover>,
+    pub hidden_at: Option<Instant>,
+    pub symbol_range: Option<Range<Anchor>>,
+    pub task: Option<Task<Option<()>>>,
 }
 
 #[derive(Clone)]
-pub(crate) struct HoverPopover {
+pub struct HoverPopover {
     pub project: ModelHandle<Project>,
-    pub hover_point: DisplayPoint,
-    pub range: Range<DisplayPoint>,
+    pub anchor: Anchor,
     pub contents: Vec<HoverBlock>,
-    pub task: Option<Task<()>>,
 }
 
 impl HoverPopover {
-    fn render(
+    pub fn render(
         &self,
+        snapshot: &EditorSnapshot,
         style: EditorStyle,
         cx: &mut RenderContext<Editor>,
     ) -> (DisplayPoint, ElementBox) {
@@ -70,7 +262,10 @@ impl HoverPopover {
                         )
                         .boxed()
                 } else {
-                    Text::new(content.text.clone(), style.hover_popover.prose.clone())
+                    let mut text_style = style.hover_popover.prose.clone();
+                    text_style.font_size = style.text.font_size;
+
+                    Text::new(content.text.clone(), text_style)
                         .with_soft_wrap(true)
                         .contained()
                         .with_style(style.hover_popover.block_style)
@@ -89,6 +284,7 @@ impl HoverPopover {
         })
         .boxed();
 
-        (self.range.start, element)
+        let display_point = self.anchor.to_display_point(&snapshot.display_snapshot);
+        (display_point, element)
     }
 }

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -217,7 +217,7 @@ fn show_hover(
                         this.hover_state.popover = hover_popover;
                         cx.notify();
                     } else {
-                        if this.hover_state.popover.is_some() {
+                        if this.hover_state.visible() {
                             // Popover was visible, but now is hidden. Dismiss it
                             hide_hover(this, cx);
                         } else {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -937,7 +937,7 @@ impl MultiBuffer {
         &self,
         position: impl ToOffset,
         cx: &AppContext,
-    ) -> Option<(ModelHandle<Buffer>, Range<text::Anchor>)> {
+    ) -> Option<(ExcerptId, ModelHandle<Buffer>, Range<text::Anchor>)> {
         let snapshot = self.read(cx);
         let position = position.to_offset(&snapshot);
 
@@ -945,6 +945,7 @@ impl MultiBuffer {
         cursor.seek(&position, Bias::Right, &());
         cursor.item().map(|excerpt| {
             (
+                excerpt.id.clone(),
                 self.buffers
                     .borrow()
                     .get(&excerpt.buffer_id)

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -467,7 +467,7 @@ impl<'a> EditorLspTestContext<'a> {
     // Constructs lsp range using a marked string with '[', ']' range delimiters
     pub fn lsp_range(&mut self, marked_text: &str) -> lsp::Range {
         let (unmarked, mut ranges) = marked_text_ranges_by(marked_text, vec![('[', ']').into()]);
-        assert_eq!(unmarked, self.cx.editor_text());
+        assert_eq!(unmarked, self.cx.buffer_text());
         let snapshot = self.update_editor(|editor, cx| editor.snapshot(cx));
 
         let offset_range = ranges.remove(&('[', ']').into()).unwrap()[0].clone();

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -449,6 +449,7 @@ impl<'a> EditorLspTestContext<'a> {
         }
     }
 
+    #[cfg(feature = "test-support")]
     pub async fn new_rust(
         capabilities: lsp::ServerCapabilities,
         cx: &'a mut gpui::TestAppContext,

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -9,7 +9,6 @@ use indoc::indoc;
 use collections::BTreeMap;
 use gpui::{keymap::Keystroke, AppContext, ModelHandle, ViewContext, ViewHandle};
 use language::{point_to_lsp, FakeLspAdapter, Language, LanguageConfig, Selection};
-use lsp::request;
 use project::{FakeFs, Project};
 use settings::Settings;
 use util::{
@@ -390,7 +389,7 @@ impl<'a> DerefMut for EditorTestContext<'a> {
 
 pub struct EditorLspTestContext<'a> {
     pub cx: EditorTestContext<'a>,
-    lsp: lsp::FakeLanguageServer,
+    pub lsp: lsp::FakeLanguageServer,
 }
 
 impl<'a> EditorLspTestContext<'a> {
@@ -449,7 +448,6 @@ impl<'a> EditorLspTestContext<'a> {
         }
     }
 
-    #[cfg(feature = "test-support")]
     pub async fn new_rust(
         capabilities: lsp::ServerCapabilities,
         cx: &'a mut gpui::TestAppContext,
@@ -464,22 +462,6 @@ impl<'a> EditorLspTestContext<'a> {
         );
 
         Self::new(language, capabilities, cx).await
-    }
-
-    pub async fn handle_request<T, F>(&mut self, mut construct_result: F)
-    where
-        T: 'static + request::Request,
-        T::Params: 'static + Send,
-        T::Result: 'static + Send + Clone,
-        F: 'static + Send + FnMut(T::Params) -> T::Result,
-    {
-        self.lsp
-            .handle_request::<T, _, _>(move |params, _| {
-                let result = construct_result(params);
-                async move { Ok(result.clone()) }
-            })
-            .next()
-            .await;
     }
 
     // Constructs lsp range using a marked string with '[', ']' range delimiters

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -467,7 +467,7 @@ impl<'a> EditorLspTestContext<'a> {
     // Constructs lsp range using a marked string with '[', ']' range delimiters
     pub fn lsp_range(&mut self, marked_text: &str) -> lsp::Range {
         let (unmarked, mut ranges) = marked_text_ranges_by(marked_text, vec![('[', ']').into()]);
-        assert_eq!(unmarked, self.editor_text());
+        assert_eq!(unmarked, self.cx.editor_text());
         let snapshot = self.update_editor(|editor, cx| editor.snapshot(cx));
 
         let offset_range = ranges.remove(&('[', ']').into()).unwrap()[0].clone();

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -1,10 +1,16 @@
-use std::ops::{Deref, DerefMut, Range};
+use std::{
+    ops::{Deref, DerefMut, Range},
+    sync::Arc,
+};
 
+use futures::StreamExt;
 use indoc::indoc;
 
 use collections::BTreeMap;
-use gpui::{keymap::Keystroke, ModelHandle, ViewContext, ViewHandle};
-use language::Selection;
+use gpui::{keymap::Keystroke, AppContext, ModelHandle, ViewContext, ViewHandle};
+use language::{point_to_lsp, FakeLspAdapter, Language, LanguageConfig, Selection};
+use lsp::request;
+use project::{FakeFs, Project};
 use settings::Settings;
 use util::{
     set_eq,
@@ -13,7 +19,8 @@ use util::{
 
 use crate::{
     display_map::{DisplayMap, DisplaySnapshot, ToDisplayPoint},
-    Autoscroll, DisplayPoint, Editor, EditorMode, MultiBuffer,
+    multi_buffer::ToPointUtf16,
+    Autoscroll, DisplayPoint, Editor, EditorMode, MultiBuffer, ToPoint,
 };
 
 #[cfg(test)]
@@ -102,6 +109,13 @@ impl<'a> EditorTestContext<'a> {
         }
     }
 
+    pub fn editor<F, T>(&mut self, read: F) -> T
+    where
+        F: FnOnce(&Editor, &AppContext) -> T,
+    {
+        self.editor.read_with(self.cx, read)
+    }
+
     pub fn update_editor<F, T>(&mut self, update: F) -> T
     where
         F: FnOnce(&mut Editor, &mut ViewContext<Editor>) -> T,
@@ -130,6 +144,14 @@ impl<'a> EditorTestContext<'a> {
         for keystroke_text in keystroke_texts.into_iter() {
             self.simulate_keystroke(keystroke_text);
         }
+    }
+
+    pub fn display_point(&mut self, cursor_location: &str) -> DisplayPoint {
+        let (_, locations) = marked_text(cursor_location);
+        let snapshot = self
+            .editor
+            .update(self.cx, |editor, cx| editor.snapshot(cx));
+        locations[0].to_display_point(&snapshot.display_snapshot)
     }
 
     // Sets the editor state via a marked string.
@@ -361,6 +383,144 @@ impl<'a> Deref for EditorTestContext<'a> {
 }
 
 impl<'a> DerefMut for EditorTestContext<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cx
+    }
+}
+
+pub struct EditorLspTestContext<'a> {
+    pub cx: EditorTestContext<'a>,
+    lsp: lsp::FakeLanguageServer,
+}
+
+impl<'a> EditorLspTestContext<'a> {
+    pub async fn new(
+        mut language: Language,
+        capabilities: lsp::ServerCapabilities,
+        cx: &'a mut gpui::TestAppContext,
+    ) -> EditorLspTestContext<'a> {
+        let file_name = format!(
+            "/file.{}",
+            language
+                .path_suffixes()
+                .first()
+                .unwrap_or(&"txt".to_string())
+        );
+
+        let mut fake_servers = language.set_fake_lsp_adapter(FakeLspAdapter {
+            capabilities,
+            ..Default::default()
+        });
+
+        let fs = FakeFs::new(cx.background().clone());
+        fs.insert_file(file_name.clone(), "".to_string()).await;
+
+        let project = Project::test(fs, [file_name.as_ref()], cx).await;
+        project.update(cx, |project, _| project.languages().add(Arc::new(language)));
+        let buffer = project
+            .update(cx, |project, cx| project.open_local_buffer(file_name, cx))
+            .await
+            .unwrap();
+
+        let (window_id, editor) = cx.update(|cx| {
+            cx.set_global(Settings::test(cx));
+            crate::init(cx);
+
+            let (window_id, editor) = cx.add_window(Default::default(), |cx| {
+                let buffer = cx.add_model(|cx| MultiBuffer::singleton(buffer, cx));
+
+                Editor::new(EditorMode::Full, buffer, Some(project), None, None, cx)
+            });
+
+            editor.update(cx, |_, cx| cx.focus_self());
+
+            (window_id, editor)
+        });
+
+        let lsp = fake_servers.next().await.unwrap();
+
+        Self {
+            cx: EditorTestContext {
+                cx,
+                window_id,
+                editor,
+            },
+            lsp,
+        }
+    }
+
+    pub async fn new_rust(
+        capabilities: lsp::ServerCapabilities,
+        cx: &'a mut gpui::TestAppContext,
+    ) -> EditorLspTestContext<'a> {
+        let language = Language::new(
+            LanguageConfig {
+                name: "Rust".into(),
+                path_suffixes: vec!["rs".to_string()],
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::language()),
+        );
+
+        Self::new(language, capabilities, cx).await
+    }
+
+    pub async fn handle_request<T, F>(&mut self, mut construct_result: F)
+    where
+        T: 'static + request::Request,
+        T::Params: 'static + Send,
+        T::Result: 'static + Send + Clone,
+        F: 'static + Send + FnMut(T::Params) -> T::Result,
+    {
+        self.lsp
+            .handle_request::<T, _, _>(move |params, _| {
+                let result = construct_result(params);
+                async move { Ok(result.clone()) }
+            })
+            .next()
+            .await;
+    }
+
+    // Constructs lsp range using a marked string with '[', ']' range delimiters
+    pub fn lsp_range(&mut self, marked_text: &str) -> lsp::Range {
+        let (unmarked, mut ranges) = marked_text_ranges_by(marked_text, vec![('[', ']').into()]);
+        assert_eq!(unmarked, self.editor_text());
+        let snapshot = self.update_editor(|editor, cx| editor.snapshot(cx));
+
+        let offset_range = ranges.remove(&('[', ']').into()).unwrap()[0].clone();
+        let start_point = offset_range.start.to_point(&snapshot.buffer_snapshot);
+        let end_point = offset_range.end.to_point(&snapshot.buffer_snapshot);
+        self.editor(|editor, cx| {
+            let buffer = editor.buffer().read(cx);
+            let start = point_to_lsp(
+                buffer
+                    .point_to_buffer_offset(start_point, cx)
+                    .unwrap()
+                    .1
+                    .to_point_utf16(&buffer.read(cx)),
+            );
+            let end = point_to_lsp(
+                buffer
+                    .point_to_buffer_offset(end_point, cx)
+                    .unwrap()
+                    .1
+                    .to_point_utf16(&buffer.read(cx)),
+            );
+
+            lsp::Range { start, end }
+        })
+    }
+}
+
+impl<'a> Deref for EditorLspTestContext<'a> {
+    type Target = EditorTestContext<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cx
+    }
+}
+
+impl<'a> DerefMut for EditorLspTestContext<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.cx
     }

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -330,6 +330,11 @@ impl Deterministic {
         Timer::Deterministic(DeterministicTimer { rx, id, state })
     }
 
+    pub fn now(&self) -> std::time::Instant {
+        let state = self.state.lock();
+        state.now.clone()
+    }
+
     pub fn advance_clock(&self, duration: Duration) {
         let new_now = self.state.lock().now + duration;
         loop {
@@ -644,6 +649,14 @@ impl Background {
             Background::Production { .. } => Timer::Production(smol::Timer::after(duration)),
             #[cfg(any(test, feature = "test-support"))]
             Background::Deterministic { executor } => executor.timer(duration),
+        }
+    }
+
+    pub fn now(&self) -> std::time::Instant {
+        match self {
+            Background::Production { .. } => std::time::Instant::now(),
+            #[cfg(any(test, feature = "test-support"))]
+            Background::Deterministic { executor } => executor.now(),
         }
     }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -571,6 +571,10 @@ impl Language {
         &self.config.brackets
     }
 
+    pub fn path_suffixes(&self) -> &[String] {
+        &self.config.path_suffixes
+    }
+
     pub fn should_autoclose_before(&self, c: char) -> bool {
         c.is_whitespace() || self.config.autoclose_before.contains(c)
     }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -988,7 +988,6 @@ impl LspCommand for GetHover {
         _: ModelHandle<Buffer>,
         _: AsyncAppContext,
     ) -> Result<Self::Response> {
-        println!("Response from proto");
         let range = if let (Some(start), Some(end)) = (message.start, message.end) {
             language::proto::deserialize_anchor(start)
                 .and_then(|start| language::proto::deserialize_anchor(end).map(|end| start..end))

--- a/styles/src/buildTokens.ts
+++ b/styles/src/buildTokens.ts
@@ -30,7 +30,7 @@ function themeTokens(theme: Theme) {
       boolean: theme.syntax.boolean.color,
     },
     player: theme.player,
-    shadowAlpha: theme.shadowAlpha,
+    shadow: theme.shadow,
   };
 }
 


### PR DESCRIPTION
Addresses issues in https://github.com/zed-industries/zed/issues/1133 and reworks hover to use anchors instead of display points to handle slow lsp response times

Also extracts hover logic into it's own file just to keep things organized