### PR TITLE
Add Go support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,6 +5298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-go"
+version = "0.19.1"
+source = "git+https://github.com/tree-sitter/tree-sitter-go?rev=aeb2f33b366fd78d5789ff104956ce23508b85db#aeb2f33b366fd78d5789ff104956ce23508b85db"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-json"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6048,6 +6057,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
+ "tree-sitter-go",
  "tree-sitter-json 0.20.0",
  "tree-sitter-markdown",
  "tree-sitter-rust",

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -106,7 +106,7 @@ pub fn line_beginning(
     let soft_line_start = map.clip_point(DisplayPoint::new(display_point.row(), 0), Bias::Right);
     let indent_start = Point::new(
         point.row,
-        map.buffer_snapshot.indent_column_for_line(point.row),
+        map.buffer_snapshot.indent_size_for_line(point.row).len,
     )
     .to_display_point(map);
     let line_start = map.prev_line_boundary(point).1;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2002,15 +2002,15 @@ impl BufferSnapshot {
 pub fn indent_size_for_line(text: &text::BufferSnapshot, row: u32) -> IndentSize {
     let mut result = IndentSize::spaces(0);
     for c in text.chars_at(Point::new(row, 0)) {
-        match (c, &result.kind) {
-            (' ', IndentKind::Space) | ('\t', IndentKind::Tab) => result.len += 1,
-            ('\t', IndentKind::Space) => {
-                if result.len == 0 {
-                    result = IndentSize::tab();
-                }
-            }
+        let kind = match c {
+            ' ' => IndentKind::Space,
+            '\t' => IndentKind::Tab,
             _ => break,
+        };
+        if result.len == 0 {
+            result.kind = kind;
         }
+        result.len += 1;
     }
     result
 }

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -576,13 +576,21 @@ fn test_edit_with_autoindent(cx: &mut MutableAppContext) {
         let text = "fn a() {}";
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit_with_autoindent([(8..8, "\n\n")], 4, cx);
+        buffer.edit_with_autoindent([(8..8, "\n\n")], IndentSize::spaces(4), cx);
         assert_eq!(buffer.text(), "fn a() {\n    \n}");
 
-        buffer.edit_with_autoindent([(Point::new(1, 4)..Point::new(1, 4), "b()\n")], 4, cx);
+        buffer.edit_with_autoindent(
+            [(Point::new(1, 4)..Point::new(1, 4), "b()\n")],
+            IndentSize::spaces(4),
+            cx,
+        );
         assert_eq!(buffer.text(), "fn a() {\n    b()\n    \n}");
 
-        buffer.edit_with_autoindent([(Point::new(2, 4)..Point::new(2, 4), ".c")], 4, cx);
+        buffer.edit_with_autoindent(
+            [(Point::new(2, 4)..Point::new(2, 4), ".c")],
+            IndentSize::spaces(4),
+            cx,
+        );
         assert_eq!(buffer.text(), "fn a() {\n    b()\n        .c\n}");
 
         buffer
@@ -609,7 +617,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
                 (empty(Point::new(1, 1)), "()"),
                 (empty(Point::new(2, 1)), "()"),
             ],
-            4,
+            IndentSize::spaces(4),
             cx,
         );
         assert_eq!(
@@ -630,7 +638,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
                 (empty(Point::new(1, 1)), "\n.f\n.g"),
                 (empty(Point::new(2, 1)), "\n.f\n.g"),
             ],
-            4,
+            IndentSize::spaces(4),
             cx,
         );
         assert_eq!(
@@ -653,13 +661,21 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
     cx.add_model(|cx| {
         let text = "fn a() {\n    {\n        b()?\n    }\n\n    Ok(())\n}";
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
-        buffer.edit_with_autoindent([(Point::new(3, 4)..Point::new(3, 5), "")], 4, cx);
+        buffer.edit_with_autoindent(
+            [(Point::new(3, 4)..Point::new(3, 5), "")],
+            IndentSize::spaces(4),
+            cx,
+        );
         assert_eq!(
             buffer.text(),
             "fn a() {\n    {\n        b()?\n            \n\n    Ok(())\n}"
         );
 
-        buffer.edit_with_autoindent([(Point::new(3, 0)..Point::new(3, 12), "")], 4, cx);
+        buffer.edit_with_autoindent(
+            [(Point::new(3, 0)..Point::new(3, 12), "")],
+            IndentSize::spaces(4),
+            cx,
+        );
         assert_eq!(
             buffer.text(),
             "fn a() {\n    {\n        b()?\n\n\n    Ok(())\n}"
@@ -678,7 +694,7 @@ fn test_autoindent_adjusts_lines_when_only_text_changes(cx: &mut MutableAppConte
 
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit_with_autoindent([(5..5, "\nb")], 4, cx);
+        buffer.edit_with_autoindent([(5..5, "\nb")], IndentSize::spaces(4), cx);
         assert_eq!(
             buffer.text(),
             "
@@ -690,7 +706,11 @@ fn test_autoindent_adjusts_lines_when_only_text_changes(cx: &mut MutableAppConte
 
         // The indentation suggestion changed because `@end` node (a close paren)
         // is now at the beginning of the line.
-        buffer.edit_with_autoindent([(Point::new(1, 4)..Point::new(1, 5), "")], 4, cx);
+        buffer.edit_with_autoindent(
+            [(Point::new(1, 4)..Point::new(1, 5), "")],
+            IndentSize::spaces(4),
+            cx,
+        );
         assert_eq!(
             buffer.text(),
             "
@@ -709,7 +729,7 @@ fn test_autoindent_with_edit_at_end_of_buffer(cx: &mut MutableAppContext) {
     cx.add_model(|cx| {
         let text = "a\nb";
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
-        buffer.edit_with_autoindent([(0..1, "\n"), (2..3, "\n")], 4, cx);
+        buffer.edit_with_autoindent([(0..1, "\n"), (2..3, "\n")], IndentSize::spaces(4), cx);
         assert_eq!(buffer.text(), "\n\n\n");
         buffer
     });

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1927,6 +1927,20 @@ impl Project {
                         })
                         .detach();
 
+                    // Even though we don't have handling for these requests, respond to them to
+                    // avoid stalling any language server like `gopls` which waits for a response
+                    // to these requests when initializing.
+                    language_server
+                        .on_request::<lsp::request::WorkDoneProgressCreate, _, _>(|_, _| async {
+                            Ok(())
+                        })
+                        .detach();
+                    language_server
+                        .on_request::<lsp::request::RegisterCapability, _, _>(|_, _| async {
+                            Ok(())
+                        })
+                        .detach();
+
                     language_server
                         .on_request::<lsp::request::ApplyWorkspaceEdit, _, _>({
                             let this = this.downgrade();
@@ -2159,7 +2173,7 @@ impl Project {
                 return;
             };
         match progress {
-            lsp::WorkDoneProgress::Begin(_) => {
+            lsp::WorkDoneProgress::Begin(report) => {
                 if Some(token.as_str()) == disk_based_diagnostics_progress_token {
                     language_server_status.pending_diagnostic_updates += 1;
                     if language_server_status.pending_diagnostic_updates == 1 {
@@ -2172,11 +2186,22 @@ impl Project {
                         );
                     }
                 } else {
-                    self.on_lsp_work_start(server_id, token.clone(), cx);
+                    self.on_lsp_work_start(
+                        server_id,
+                        token.clone(),
+                        LanguageServerProgress {
+                            message: report.message.clone(),
+                            percentage: report.percentage.map(|p| p as usize),
+                            last_update_at: Instant::now(),
+                        },
+                        cx,
+                    );
                     self.broadcast_language_server_update(
                         server_id,
                         proto::update_language_server::Variant::WorkStart(proto::LspWorkStart {
                             token,
+                            message: report.message,
+                            percentage: report.percentage.map(|p| p as u32),
                         }),
                     );
                 }
@@ -2234,17 +2259,11 @@ impl Project {
         &mut self,
         language_server_id: usize,
         token: String,
+        progress: LanguageServerProgress,
         cx: &mut ModelContext<Self>,
     ) {
         if let Some(status) = self.language_server_statuses.get_mut(&language_server_id) {
-            status.pending_work.insert(
-                token,
-                LanguageServerProgress {
-                    message: None,
-                    percentage: None,
-                    last_update_at: Instant::now(),
-                },
-            );
+            status.pending_work.insert(token, progress);
             cx.notify();
         }
     }
@@ -2257,7 +2276,21 @@ impl Project {
         cx: &mut ModelContext<Self>,
     ) {
         if let Some(status) = self.language_server_statuses.get_mut(&language_server_id) {
-            status.pending_work.insert(token, progress);
+            let entry = status
+                .pending_work
+                .entry(token)
+                .or_insert(LanguageServerProgress {
+                    message: Default::default(),
+                    percentage: Default::default(),
+                    last_update_at: progress.last_update_at,
+                });
+            if progress.message.is_some() {
+                entry.message = progress.message;
+            }
+            if progress.percentage.is_some() {
+                entry.percentage = progress.percentage;
+            }
+            entry.last_update_at = progress.last_update_at;
             cx.notify();
         }
     }
@@ -4472,7 +4505,16 @@ impl Project {
         {
             proto::update_language_server::Variant::WorkStart(payload) => {
                 this.update(&mut cx, |this, cx| {
-                    this.on_lsp_work_start(language_server_id, payload.token, cx);
+                    this.on_lsp_work_start(
+                        language_server_id,
+                        payload.token,
+                        LanguageServerProgress {
+                            message: payload.message,
+                            percentage: payload.percentage.map(|p| p as usize),
+                            last_update_at: Instant::now(),
+                        },
+                        cx,
+                    );
                 })
             }
             proto::update_language_server::Variant::WorkProgress(payload) => {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3054,6 +3054,16 @@ impl Project {
                     Ok(completions
                         .into_iter()
                         .filter_map(|lsp_completion| {
+                            // For now, we can only handle additional edits if they are returned
+                            // when resolving the completion, not if they are present initially.
+                            if lsp_completion
+                                .additional_text_edits
+                                .as_ref()
+                                .map_or(false, |edits| !edits.is_empty())
+                            {
+                                return None;
+                            }
+
                             let (old_range, new_text) = match lsp_completion.text_edit.as_ref() {
                                 // If the language server provides a range to overwrite, then
                                 // check that the range is valid.

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -555,6 +555,8 @@ message UpdateLanguageServer {
 
 message LspWorkStart {
     string token = 1;
+    optional string message = 2;
+    optional uint32 percentage = 3;
 }
 
 message LspWorkProgress {

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -25,6 +25,7 @@ pub struct Settings {
     pub default_buffer_font_size: f32,
     pub vim_mode: bool,
     pub tab_size: u32,
+    pub hard_tabs: bool,
     pub soft_wrap: SoftWrap,
     pub preferred_line_length: u32,
     pub format_on_save: bool,
@@ -35,6 +36,7 @@ pub struct Settings {
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
 pub struct LanguageOverride {
     pub tab_size: Option<u32>,
+    pub hard_tabs: Option<bool>,
     pub soft_wrap: Option<SoftWrap>,
     pub preferred_line_length: Option<u32>,
     pub format_on_save: Option<bool>,
@@ -80,6 +82,7 @@ impl Settings {
             default_buffer_font_size: 15.,
             vim_mode: false,
             tab_size: 4,
+            hard_tabs: false,
             soft_wrap: SoftWrap::None,
             preferred_line_length: 80,
             language_overrides: Default::default(),
@@ -104,6 +107,13 @@ impl Settings {
             .and_then(|language| self.language_overrides.get(language))
             .and_then(|settings| settings.tab_size)
             .unwrap_or(self.tab_size)
+    }
+
+    pub fn hard_tabs(&self, language: Option<&str>) -> bool {
+        language
+            .and_then(|language| self.language_overrides.get(language))
+            .and_then(|settings| settings.hard_tabs)
+            .unwrap_or(self.hard_tabs)
     }
 
     pub fn soft_wrap(&self, language: Option<&str>) -> SoftWrap {
@@ -135,6 +145,7 @@ impl Settings {
             default_buffer_font_size: 14.,
             vim_mode: false,
             tab_size: 4,
+            hard_tabs: false,
             soft_wrap: SoftWrap::None,
             preferred_line_length: 80,
             format_on_save: true,

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1642,18 +1642,6 @@ impl BufferSnapshot {
             .all(|chunk| chunk.matches(|c: char| !c.is_whitespace()).next().is_none())
     }
 
-    pub fn indent_column_for_line(&self, row: u32) -> u32 {
-        let mut result = 0;
-        for c in self.chars_at(Point::new(row, 0)) {
-            if c == ' ' {
-                result += 1;
-            } else {
-                break;
-            }
-        }
-        result
-    }
-
     pub fn text_summary_for_range<'a, D, O: ToOffset>(&'a self, range: Range<O>) -> D
     where
         D: TextDimension,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -202,7 +202,7 @@ mod test {
         cx.enable_vim();
         assert_eq!(cx.mode(), Mode::Normal);
         cx.simulate_keystrokes(["h", "h", "h", "l"]);
-        assert_eq!(cx.editor_text(), "hjkl".to_owned());
+        assert_eq!(cx.buffer_text(), "hjkl".to_owned());
         cx.assert_editor_state("h|jkl");
         cx.simulate_keystrokes(["i", "T", "e", "s", "t"]);
         cx.assert_editor_state("hTest|jkl");

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -89,6 +89,7 @@ toml = "0.5"
 tree-sitter = "0.20.6"
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
+tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
 tree-sitter-rust = "0.20.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -29,6 +29,11 @@ pub fn build_language_registry(login_shell_env_loaded: Task<()>) -> LanguageRegi
             Some(Arc::new(c::CLspAdapter) as Arc<dyn LspAdapter>),
         ),
         (
+            "go",
+            tree_sitter_go::language(),
+            Some(Arc::new(go::GoLspAdapter) as Arc<dyn LspAdapter>),
+        ),
+        (
             "json",
             tree_sitter_json::language(),
             Some(Arc::new(json::JsonLspAdapter)),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -4,6 +4,7 @@ use rust_embed::RustEmbed;
 use std::{borrow::Cow, str, sync::Arc};
 
 mod c;
+mod go;
 mod installation;
 mod json;
 mod rust;

--- a/crates/zed/src/languages/c.rs
+++ b/crates/zed/src/languages/c.rs
@@ -4,7 +4,11 @@ use client::http::HttpClient;
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 pub use language::*;
 use smol::fs::{self, File};
-use std::{any::Any, path::PathBuf, sync::Arc};
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use util::{ResultExt, TryFutureExt};
 
 pub struct CLspAdapter;
@@ -39,7 +43,7 @@ impl super::LspAdapter for CLspAdapter {
         &self,
         version: Box<dyn 'static + Send + Any>,
         http: Arc<dyn HttpClient>,
-        container_dir: PathBuf,
+        container_dir: Arc<Path>,
     ) -> BoxFuture<'static, Result<PathBuf>> {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
         async move {
@@ -88,7 +92,10 @@ impl super::LspAdapter for CLspAdapter {
         .boxed()
     }
 
-    fn cached_server_binary(&self, container_dir: PathBuf) -> BoxFuture<'static, Option<PathBuf>> {
+    fn cached_server_binary(
+        &self,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Option<PathBuf>> {
         async move {
             let mut last_clangd_dir = None;
             let mut entries = fs::read_dir(&container_dir).await?;

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -26,6 +26,10 @@ impl super::LspAdapter for GoLspAdapter {
         LanguageServerName("gopls".into())
     }
 
+    fn server_args(&self) -> &[&str] {
+        &["-mode=stdio"]
+    }
+
     fn fetch_latest_server_version(
         &self,
         http: Arc<dyn HttpClient>,
@@ -99,8 +103,9 @@ impl super::LspAdapter for GoLspAdapter {
             let version_stdout = str::from_utf8(&version_output.stdout)
                 .map_err(|_| anyhow!("gopls version produced invalid utf8"))?;
             let version = GOPLS_VERSION_REGEX
-                .shortest_match(version_stdout)
-                .ok_or_else(|| anyhow!("failed to parse gopls version output"))?;
+                .find(version_stdout)
+                .ok_or_else(|| anyhow!("failed to parse gopls version output"))?
+                .as_str();
             let binary_path = container_dir.join(&format!("gopls_{version}"));
             fs::rename(&installed_binary_path, &binary_path).await?;
 

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -243,6 +243,65 @@ impl super::LspAdapter for GoLspAdapter {
         }
         None
     }
+
+    fn label_for_symbol(
+        &self,
+        name: &str,
+        kind: lsp::SymbolKind,
+        language: &Language,
+    ) -> Option<CodeLabel> {
+        let (text, filter_range, display_range) = match kind {
+            lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
+                let text = format!("func {} () {{}}", name);
+                let filter_range = 5..5 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            lsp::SymbolKind::STRUCT => {
+                let text = format!("type {} struct {{}}", name);
+                let filter_range = 5..5 + name.len();
+                let display_range = 0..text.len();
+                (text, filter_range, display_range)
+            }
+            lsp::SymbolKind::INTERFACE => {
+                let text = format!("type {} interface {{}}", name);
+                let filter_range = 5..5 + name.len();
+                let display_range = 0..text.len();
+                (text, filter_range, display_range)
+            }
+            lsp::SymbolKind::CLASS => {
+                let text = format!("type {} T", name);
+                let filter_range = 5..5 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            lsp::SymbolKind::CONSTANT => {
+                let text = format!("const {} = nil", name);
+                let filter_range = 6..6 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            lsp::SymbolKind::VARIABLE => {
+                let text = format!("var {} = nil", name);
+                let filter_range = 4..4 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            lsp::SymbolKind::MODULE => {
+                let text = format!("package {}", name);
+                let filter_range = 8..8 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            _ => return None,
+        };
+
+        Some(CodeLabel {
+            runs: language.highlight_text(&text.as_str().into(), display_range.clone()),
+            text: text[display_range].to_string(),
+            filter_range,
+        })
+    }
 }
 
 fn adjust_runs(

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -1,0 +1,140 @@
+use super::installation::latest_github_release;
+use anyhow::{anyhow, Result};
+use client::http::HttpClient;
+use futures::{future::BoxFuture, FutureExt, StreamExt};
+pub use language::*;
+use lazy_static::lazy_static;
+use regex::Regex;
+use smol::{fs, process};
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+    str,
+    sync::Arc,
+};
+use util::{ResultExt, TryFutureExt};
+
+#[derive(Copy, Clone)]
+pub struct GoLspAdapter;
+
+lazy_static! {
+    static ref GOPLS_VERSION_REGEX: Regex = Regex::new(r"\d+\.\d+\.\d+").unwrap();
+}
+
+impl super::LspAdapter for GoLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("gopls".into())
+    }
+
+    fn fetch_latest_server_version(
+        &self,
+        http: Arc<dyn HttpClient>,
+    ) -> BoxFuture<'static, Result<Box<dyn 'static + Send + Any>>> {
+        async move {
+            let release = latest_github_release("golang/tools", http).await?;
+            let version: Option<String> = release.name.strip_prefix("gopls/v").map(str::to_string);
+            if version.is_none() {
+                log::warn!(
+                    "couldn't infer gopls version from github release name '{}'",
+                    release.name
+                );
+            }
+            Ok(Box::new(version) as Box<_>)
+        }
+        .boxed()
+    }
+
+    fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        _: Arc<dyn HttpClient>,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Result<PathBuf>> {
+        let version = version.downcast::<Option<String>>().unwrap();
+        let this = *self;
+
+        async move {
+            if let Some(version) = *version {
+                let binary_path = container_dir.join(&format!("gopls_{version}"));
+                if let Ok(metadata) = fs::metadata(&binary_path).await {
+                    if metadata.is_file() {
+                        if let Some(mut entries) = fs::read_dir(&container_dir).await.log_err() {
+                            while let Some(entry) = entries.next().await {
+                                if let Some(entry) = entry.log_err() {
+                                    let entry_path = entry.path();
+                                    if entry_path.as_path() != binary_path
+                                        && entry.file_name() != "gobin"
+                                    {
+                                        fs::remove_file(&entry_path).await.log_err();
+                                    }
+                                }
+                            }
+                        }
+
+                        return Ok(binary_path.to_path_buf());
+                    }
+                }
+            } else if let Some(path) = this.cached_server_binary(container_dir.clone()).await {
+                return Ok(path.to_path_buf());
+            }
+
+            let gobin_dir = container_dir.join("gobin");
+            fs::create_dir_all(&gobin_dir).await?;
+            let install_output = process::Command::new("go")
+                .env("GO111MODULE", "on")
+                .env("GOBIN", &gobin_dir)
+                .args(["install", "golang.org/x/tools/gopls@latest"])
+                .output()
+                .await?;
+            if !install_output.status.success() {
+                Err(anyhow!("failed to install gopls"))?;
+            }
+
+            let installed_binary_path = gobin_dir.join("gopls");
+            let version_output = process::Command::new(&installed_binary_path)
+                .arg("version")
+                .output()
+                .await
+                .map_err(|e| anyhow!("failed to run installed gopls binary {:?}", e))?;
+            let version_stdout = str::from_utf8(&version_output.stdout)
+                .map_err(|_| anyhow!("gopls version produced invalid utf8"))?;
+            let version = GOPLS_VERSION_REGEX
+                .shortest_match(version_stdout)
+                .ok_or_else(|| anyhow!("failed to parse gopls version output"))?;
+            let binary_path = container_dir.join(&format!("gopls_{version}"));
+            fs::rename(&installed_binary_path, &binary_path).await?;
+
+            Ok(binary_path.to_path_buf())
+        }
+        .boxed()
+    }
+
+    fn cached_server_binary(
+        &self,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Option<PathBuf>> {
+        async move {
+            let mut last_binary_path = None;
+            let mut entries = fs::read_dir(&container_dir).await?;
+            while let Some(entry) = entries.next().await {
+                let entry = entry?;
+                if entry.file_type().await?.is_file()
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .map_or(false, |name| name.starts_with("gopls_"))
+                {
+                    last_binary_path = Some(entry.path());
+                }
+            }
+
+            if let Some(path) = last_binary_path {
+                Ok(path.to_path_buf())
+            } else {
+                Err(anyhow!("no cached binary"))
+            }
+        }
+        .log_err()
+        .boxed()
+    }
+}

--- a/crates/zed/src/languages/go/brackets.scm
+++ b/crates/zed/src/languages/go/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/src/languages/go/config.toml
+++ b/crates/zed/src/languages/go/config.toml
@@ -1,0 +1,11 @@
+name = "Go"
+path_suffixes = ["go"]
+line_comment = "// "
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false },
+    { start = "/*", end = " */", close = true, newline = false },
+]

--- a/crates/zed/src/languages/go/highlights.scm
+++ b/crates/zed/src/languages/go/highlights.scm
@@ -1,0 +1,107 @@
+(identifier) @variable
+(type_identifier) @type
+(field_identifier) @property
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method))
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @function.method)
+
+[
+  "--"
+  "-"
+  "-="
+  ":="
+  "!"
+  "!="
+  "..."
+  "*"
+  "*"
+  "*="
+  "/"
+  "/="
+  "&"
+  "&&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "++"
+  "+="
+  "<-"
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "|"
+  "|="
+  "||"
+  "~"
+] @operator
+
+[
+  "break"
+  "case"
+  "chan"
+  "const"
+  "continue"
+  "default"
+  "defer"
+  "else"
+  "fallthrough"
+  "for"
+  "func"
+  "go"
+  "goto"
+  "if"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "range"
+  "return"
+  "select"
+  "struct"
+  "switch"
+  "type"
+  "var"
+] @keyword
+
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (rune_literal)
+] @string
+
+(escape_sequence) @escape
+
+[
+  (int_literal)
+  (float_literal)
+  (imaginary_literal)
+] @number
+
+[
+  (true)
+  (false)
+  (nil)
+  (iota)
+] @constant.builtin
+
+(comment) @comment

--- a/crates/zed/src/languages/go/indents.scm
+++ b/crates/zed/src/languages/go/indents.scm
@@ -1,0 +1,9 @@
+[
+    (assignment_statement)
+    (call_expression)
+    (selector_expression)
+] @indent
+
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent

--- a/crates/zed/src/languages/go/outline.scm
+++ b/crates/zed/src/languages/go/outline.scm
@@ -1,0 +1,26 @@
+(type_declaration
+    "type" @context
+    (type_spec
+        name: (_) @name)) @item
+
+(function_declaration
+    "func" @context
+    name: (identifier) @name) @item
+
+(method_declaration
+    "func" @context
+    receiver: (parameter_list
+        (parameter_declaration
+            type: (_) @context))
+    name: (field_identifier) @name) @item
+
+(const_declaration
+    "const" @context
+    (const_spec
+        name: (identifier) @name)) @item
+
+(source_file
+    (var_declaration
+        "var" @context
+        (var_spec
+            name: (identifier) @name)) @item)

--- a/crates/zed/src/languages/go/outline.scm
+++ b/crates/zed/src/languages/go/outline.scm
@@ -5,22 +5,40 @@
 
 (function_declaration
     "func" @context
-    name: (identifier) @name) @item
+    name: (identifier) @name
+    parameters: (parameter_list
+      "(" @context
+      ")" @context)) @item
 
 (method_declaration
     "func" @context
     receiver: (parameter_list
+        "(" @context
         (parameter_declaration
-            type: (_) @context))
-    name: (field_identifier) @name) @item
+            type: (_) @context)
+        ")" @context)
+    name: (field_identifier) @name
+    parameters: (parameter_list
+      "(" @context
+      ")" @context)) @item
 
 (const_declaration
     "const" @context
     (const_spec
-        name: (identifier) @name)) @item
+        name: (identifier) @name) @item)
 
 (source_file
     (var_declaration
         "var" @context
         (var_spec
-            name: (identifier) @name)) @item)
+            name: (identifier) @name) @item))
+
+(method_spec
+    name: (_) @name
+    parameters: (parameter_list
+      "(" @context
+      ")" @context)) @item
+
+(field_declaration
+    name: (_) @name
+    type: (_) @context) @item

--- a/crates/zed/src/languages/json.rs
+++ b/crates/zed/src/languages/json.rs
@@ -5,7 +5,11 @@ use language::{LanguageServerName, LspAdapter};
 use serde::Deserialize;
 use serde_json::json;
 use smol::fs;
-use std::{any::Any, path::PathBuf, sync::Arc};
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use util::{ResultExt, TryFutureExt};
 
 pub struct JsonLspAdapter;
@@ -56,7 +60,7 @@ impl LspAdapter for JsonLspAdapter {
         &self,
         version: Box<dyn 'static + Send + Any>,
         _: Arc<dyn HttpClient>,
-        container_dir: PathBuf,
+        container_dir: Arc<Path>,
     ) -> BoxFuture<'static, Result<PathBuf>> {
         let version = version.downcast::<String>().unwrap();
         async move {
@@ -95,7 +99,10 @@ impl LspAdapter for JsonLspAdapter {
         .boxed()
     }
 
-    fn cached_server_binary(&self, container_dir: PathBuf) -> BoxFuture<'static, Option<PathBuf>> {
+    fn cached_server_binary(
+        &self,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Option<PathBuf>> {
         async move {
             let mut last_version_dir = None;
             let mut entries = fs::read_dir(&container_dir).await?;

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -7,7 +7,14 @@ pub use language::*;
 use lazy_static::lazy_static;
 use regex::Regex;
 use smol::fs::{self, File};
-use std::{any::Any, borrow::Cow, env::consts, path::PathBuf, str, sync::Arc};
+use std::{
+    any::Any,
+    borrow::Cow,
+    env::consts,
+    path::{Path, PathBuf},
+    str,
+    sync::Arc,
+};
 use util::{ResultExt, TryFutureExt};
 
 pub struct RustLspAdapter;
@@ -42,7 +49,7 @@ impl LspAdapter for RustLspAdapter {
         &self,
         version: Box<dyn 'static + Send + Any>,
         http: Arc<dyn HttpClient>,
-        container_dir: PathBuf,
+        container_dir: Arc<Path>,
     ) -> BoxFuture<'static, Result<PathBuf>> {
         async move {
             let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
@@ -79,7 +86,10 @@ impl LspAdapter for RustLspAdapter {
         .boxed()
     }
 
-    fn cached_server_binary(&self, container_dir: PathBuf) -> BoxFuture<'static, Option<PathBuf>> {
+    fn cached_server_binary(
+        &self,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Option<PathBuf>> {
         async move {
             let mut last = None;
             let mut entries = fs::read_dir(&container_dir).await?;

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -5,7 +5,11 @@ use futures::{future::BoxFuture, FutureExt, StreamExt};
 use language::{LanguageServerName, LspAdapter};
 use serde_json::json;
 use smol::fs;
-use std::{any::Any, path::PathBuf, sync::Arc};
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use util::{ResultExt, TryFutureExt};
 
 pub struct TypeScriptLspAdapter;
@@ -45,7 +49,7 @@ impl LspAdapter for TypeScriptLspAdapter {
         &self,
         versions: Box<dyn 'static + Send + Any>,
         _: Arc<dyn HttpClient>,
-        container_dir: PathBuf,
+        container_dir: Arc<Path>,
     ) -> BoxFuture<'static, Result<PathBuf>> {
         let versions = versions.downcast::<Versions>().unwrap();
         async move {
@@ -88,7 +92,10 @@ impl LspAdapter for TypeScriptLspAdapter {
         .boxed()
     }
 
-    fn cached_server_binary(&self, container_dir: PathBuf) -> BoxFuture<'static, Option<PathBuf>> {
+    fn cached_server_binary(
+        &self,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Option<PathBuf>> {
         async move {
             let mut last_version_dir = None;
             let mut entries = fs::read_dir(&container_dir).await?;

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -95,6 +95,14 @@ fn main() {
             },
         )
         .with_overrides(
+            "Go",
+            settings::LanguageOverride {
+                tab_size: Some(4),
+                hard_tabs: Some(true),
+                ..Default::default()
+            },
+        )
+        .with_overrides(
             "Markdown",
             settings::LanguageOverride {
                 soft_wrap: Some(settings::SoftWrap::PreferredLineLength),


### PR DESCRIPTION
* [x] Download and run the go language server, `gopls`
* [x] Add Tree-sitter queries for syntax highlighting, auto-indent, outline, and brackets
* [x] Support indentation with hard tabs, since all Go files use hard tabs
    *  [x] implementation
    * [x] tests
* [x] Ignore completion items that we can't handle, because they are initialized with `additionalEdits`
* [x] Perform simple syntax coloring of completions and project symbols based on their `kind`, similar to C