### PR TITLE
Style jump to buffer arrows in diagnostics

### DIFF
--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -140,11 +140,19 @@ export default function editor(theme: Theme) {
     invalidWarningDiagnostic: diagnostic(theme, "muted"),
     hover_popover: hoverPopover(theme),
     jumpIcon: {
-      color: iconColor(theme, "primary"),
-      iconWidth: 10,
-      buttonWidth: 10,
+      color: iconColor(theme, "muted"),
+      iconWidth: 20,
+      buttonWidth: 20,
+      cornerRadius: 6,
+      padding: {
+        top: 6,
+        bottom: 6,
+        left: 6,
+        right: 6,
+      },
       hover: {
-        color: iconColor(theme, "active")
+        color: iconColor(theme, "active"),
+        background: backgroundColor(theme, "on500", "base"),
       }
     },
     syntax,


### PR DESCRIPTION
This PR adds styling to Jump to Buffer arrows in the diagnostics tab. I had to add padding to the icons to create the hover container. @as-cii , it's possible that the padding may have shifted the arrows in?

Take a look and let me know what you think.

Default:
![CleanShot - 2022-06-09 at 12 30 40@2x](https://user-images.githubusercontent.com/1714999/172898107-a22426b1-cfb6-4736-83c2-bac71842fbba.png)

Hovered:
![CleanShot - 2022-06-09 at 12 31 37@2x](https://user-images.githubusercontent.com/1714999/172898147-e2df99e4-c8e4-4289-8362-a56ba6889083.png)

In a few themes:
![CleanShot - 2022-06-09 at 12 32 18@2x](https://user-images.githubusercontent.com/1714999/172898271-2a974170-ad71-47d1-b372-000521f24d7e.png)

![CleanShot - 2022-06-09 at 12 32 39@2x](https://user-images.githubusercontent.com/1714999/172898288-c3bbb56c-386b-4933-973d-b6c4375c1234.png)

![CleanShot - 2022-06-09 at 12 32 49@2x](https://user-images.githubusercontent.com/1714999/172898317-c54921d9-a307-4438-aac7-9d5ab522c5a0.png)
