### PR TITLE
Introduce a new `BlockStyle` field for blocks

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use collections::{BTreeMap, HashSet};
 use editor::{
     diagnostic_block_renderer,
-    display_map::{BlockDisposition, BlockId, BlockProperties, RenderBlock},
+    display_map::{BlockDisposition, BlockId, BlockProperties, BlockStyle, RenderBlock},
     highlight_diagnostic_message, Autoscroll, Editor, ExcerptId, ExcerptRange, MultiBuffer,
     ToOffset,
 };
@@ -348,6 +348,7 @@ impl ProjectDiagnosticsEditor {
                                 blocks_to_add.push(BlockProperties {
                                     position: header_position,
                                     height: 2,
+                                    style: BlockStyle::Sticky,
                                     render: diagnostic_header_renderer(primary),
                                     disposition: BlockDisposition::Above,
                                 });
@@ -366,6 +367,7 @@ impl ProjectDiagnosticsEditor {
                                     blocks_to_add.push(BlockProperties {
                                         position: (excerpt_id.clone(), entry.range.start.clone()),
                                         height: diagnostic.message.matches('\n').count() as u8 + 1,
+                                        style: BlockStyle::Fixed,
                                         render: diagnostic_block_renderer(diagnostic, true),
                                         disposition: BlockDisposition::Below,
                                     });
@@ -402,6 +404,7 @@ impl ProjectDiagnosticsEditor {
                     BlockProperties {
                         position: excerpts_snapshot.anchor_in_excerpt(excerpt_id, text_anchor),
                         height: block.height,
+                        style: block.style,
                         render: block.render,
                         disposition: block.disposition,
                     }
@@ -621,7 +624,6 @@ fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
                 .with_color(theme.warning_diagnostic.message.text.color)
         };
 
-        let x_padding = cx.gutter_padding + cx.scroll_x * cx.em_width;
         Flex::row()
             .with_child(
                 icon.constrained()
@@ -651,8 +653,8 @@ fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
             }))
             .contained()
             .with_style(style.container)
-            .with_padding_left(x_padding)
-            .with_padding_right(x_padding)
+            .with_padding_left(cx.gutter_padding)
+            .with_padding_right(cx.gutter_padding)
             .expanded()
             .named("diagnostic header")
     })

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -20,7 +20,7 @@ use wrap_map::WrapMap;
 
 pub use block_map::{
     BlockBufferRows as DisplayBufferRows, BlockChunks as DisplayChunks, BlockContext,
-    BlockDisposition, BlockId, BlockProperties, RenderBlock, TransformBlock,
+    BlockDisposition, BlockId, BlockProperties, BlockStyle, RenderBlock, TransformBlock,
 };
 
 pub trait ToDisplayPoint {
@@ -650,6 +650,7 @@ pub mod tests {
                                         height
                                     );
                                     BlockProperties {
+                                        style: BlockStyle::Fixed,
                                         position,
                                         height,
                                         disposition,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -56,6 +56,7 @@ pub struct Block {
     id: BlockId,
     position: Anchor,
     height: u8,
+    style: BlockStyle,
     render: Mutex<RenderBlock>,
     disposition: BlockDisposition,
 }
@@ -67,8 +68,16 @@ where
 {
     pub position: P,
     pub height: u8,
+    pub style: BlockStyle,
     pub render: Arc<dyn Fn(&mut BlockContext) -> ElementBox>,
     pub disposition: BlockDisposition,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum BlockStyle {
+    Fixed,
+    Flex,
+    Sticky,
 }
 
 pub struct BlockContext<'a, 'b> {
@@ -513,6 +522,7 @@ impl<'a> BlockMapWriter<'a> {
                     height: block.height,
                     render: Mutex::new(block.render),
                     disposition: block.disposition,
+                    style: block.style,
                 }),
             );
 
@@ -940,6 +950,10 @@ impl Block {
     pub fn position(&self) -> &Anchor {
         &self.position
     }
+
+    pub fn style(&self) -> BlockStyle {
+        self.style
+    }
 }
 
 impl Debug for Block {
@@ -1018,18 +1032,21 @@ mod tests {
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
         let block_ids = writer.insert(vec![
             BlockProperties {
+                style: BlockStyle::Fixed,
                 position: buffer_snapshot.anchor_after(Point::new(1, 0)),
                 height: 1,
                 disposition: BlockDisposition::Above,
                 render: Arc::new(|_| Empty::new().named("block 1")),
             },
             BlockProperties {
+                style: BlockStyle::Fixed,
                 position: buffer_snapshot.anchor_after(Point::new(1, 2)),
                 height: 2,
                 disposition: BlockDisposition::Above,
                 render: Arc::new(|_| Empty::new().named("block 2")),
             },
             BlockProperties {
+                style: BlockStyle::Fixed,
                 position: buffer_snapshot.anchor_after(Point::new(3, 3)),
                 height: 3,
                 disposition: BlockDisposition::Below,
@@ -1183,12 +1200,14 @@ mod tests {
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
         writer.insert(vec![
             BlockProperties {
+                style: BlockStyle::Fixed,
                 position: buffer_snapshot.anchor_after(Point::new(1, 12)),
                 disposition: BlockDisposition::Above,
                 render: Arc::new(|_| Empty::new().named("block 1")),
                 height: 1,
             },
             BlockProperties {
+                style: BlockStyle::Fixed,
                 position: buffer_snapshot.anchor_after(Point::new(1, 1)),
                 disposition: BlockDisposition::Below,
                 render: Arc::new(|_| Empty::new().named("block 2")),
@@ -1286,6 +1305,7 @@ mod tests {
                                 height
                             );
                             BlockProperties {
+                                style: BlockStyle::Fixed,
                                 position,
                                 height,
                                 disposition,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4801,6 +4801,7 @@ impl Editor {
                     cx.focus(&rename_editor);
                     let block_id = this.insert_blocks(
                         [BlockProperties {
+                            style: BlockStyle::Flex,
                             position: range.start.clone(),
                             height: 1,
                             render: Arc::new({
@@ -4985,6 +4986,7 @@ impl Editor {
                         let diagnostic = entry.diagnostic.clone();
                         let message_height = diagnostic.message.lines().count() as u8;
                         BlockProperties {
+                            style: BlockStyle::Fixed,
                             position: buffer.anchor_after(entry.range.start),
                             height: message_height,
                             render: diagnostic_block_renderer(diagnostic, true),
@@ -7932,6 +7934,7 @@ mod tests {
         editor.update(cx, |editor, cx| {
             editor.insert_blocks(
                 [BlockProperties {
+                    style: BlockStyle::Fixed,
                     position: snapshot.anchor_after(Point::new(2, 0)),
                     disposition: BlockDisposition::Below,
                     height: 1,


### PR DESCRIPTION
Fixes #951 
Fixes #1136 

This new field allows blocks to specify how they want to be laid out:

- If `Fixed` they can take up all the width they want and they will impact the scroll width of the editor. This is useful for diagnostic messages and allows scrolling the editor further to the right to visualize the entire message.
- If `Flex` they can extend all the way to the scroll width without impacting it any further. This is useful for the rename editor that we insert as a block decoration when hitting `F2`.
- If `Sticky`, they will be as wide as the editor element and won't participate in the horizontal scrolling of the editor. This is useful for headers in general, where we want e.g. the filename and the jump button to always be visible independently of how much the user has scrolled to the right. 

<img width="1200" alt="Screen Shot 2022-06-10 at 12 11 52" src="https://user-images.githubusercontent.com/482957/173043883-bb0c1cc4-bacf-49be-a7c6-8fe3207df3e1.png">

