### PR TITLE
Report collab server metrics to DataDog via OpenMetrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "nanoid",
  "parking_lot 0.11.2",
  "project",
+ "prometheus",
  "rand 0.8.5",
  "reqwest",
  "rpc",
@@ -3402,6 +3403,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3492,12 @@ dependencies = [
  "bytes",
  "prost 0.9.0",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "pulldown-cmark"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -31,6 +31,7 @@ lazy_static = "1.4"
 lipsum = { version = "0.8", optional = true }
 nanoid = "0.4"
 parking_lot = "0.11.1"
+prometheus = "0.13"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["json"], optional = true }
 scrypt = "0.7"

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -27,6 +27,20 @@ kind: Deployment
 metadata:
   namespace: ${ZED_KUBE_NAMESPACE}
   name: collab
+  annotations:
+    ad.datadoghq.com/collab.check_names: |
+      ["openmetrics"]
+    ad.datadoghq.com/collab.init_configs: |
+      [{}]
+    ad.datadoghq.com/collab.instances: |
+      [
+        {
+          "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
+          "namespace": "collab_${ZED_KUBE_NAMESPACE}",
+          "metrics": [".*"]
+        }
+      ]
+
 spec:
   replicas: 1
   selector:

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -27,19 +27,6 @@ kind: Deployment
 metadata:
   namespace: ${ZED_KUBE_NAMESPACE}
   name: collab
-  annotations:
-    ad.datadoghq.com/collab.check_names: |
-      ["openmetrics"]
-    ad.datadoghq.com/collab.init_configs: |
-      [{}]
-    ad.datadoghq.com/collab.instances: |
-      [
-        {
-          "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
-          "namespace": "collab_${ZED_KUBE_NAMESPACE}",
-          "metrics": [".*"]
-        }
-      ]
 
 spec:
   replicas: 1
@@ -50,6 +37,19 @@ spec:
     metadata:
       labels:
         app: collab
+      annotations:
+        ad.datadoghq.com/collab.check_names: |
+          ["openmetrics"]
+        ad.datadoghq.com/collab.init_configs: |
+          [{}]
+        ad.datadoghq.com/collab.instances: |
+          [
+              {
+              "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
+              "namespace": "collab_${ZED_KUBE_NAMESPACE}",
+              "metrics": [".*"]
+              }
+          ]
     spec:
       containers:
         - name: collab


### PR DESCRIPTION
Closes #1120

This PR adds a `/metrics` endpoint to the collab server, which returns metrics about the server's state encoded according to the OpenMetrics protocol. It also updates the Kubernetes manifest, adding the necessary annotations to the `collab` pods so that the datadog agent will poll that `/metrics` endpoint and forward the metrics to Datadog.

I've set up an initial [Dashboard](https://us5.datadoghq.com/dashboard/y2d-gxz-h4h/collab-staging?from_ts=1654900320543&to_ts=1654903920543&live=true) in DataDog, containing a time-series view of the number of active connections and active projects (both shared and unshared).

![Screen Shot 2022-06-10 at 4 36 42 PM](https://user-images.githubusercontent.com/326587/173162834-f5c6fb12-3180-41f7-8408-441c1a0ff8fd.png)
