### PR TITLE
Replace `pane::Split` action with `Split{Left,Up,Right,Down}`

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -258,22 +258,10 @@
     {
         "context": "Pane",
         "bindings": {
-            "cmd-k up": [
-                "pane::Split",
-                "Up"
-            ],
-            "cmd-k down": [
-                "pane::Split",
-                "Down"
-            ],
-            "cmd-k left": [
-                "pane::Split",
-                "Left"
-            ],
-            "cmd-k right": [
-                "pane::Split",
-                "Right"
-            ]
+            "cmd-k up": "pane::SplitUp",
+            "cmd-k down": "pane::SplitDown",
+            "cmd-k left": "pane::SplitLeft",
+            "cmd-k right": "pane::SplitRight"
         }
     },
     // Bindings that should be unified with bindings for more general actions

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -25,11 +25,12 @@ actions!(
         ActivateNextItem,
         CloseActiveItem,
         CloseInactiveItems,
+        SplitLeft,
+        SplitUp,
+        SplitRight,
+        SplitDown,
     ]
 );
-
-#[derive(Clone, Deserialize, PartialEq)]
-pub struct Split(pub SplitDirection);
 
 #[derive(Clone, PartialEq)]
 pub struct CloseItem {
@@ -52,7 +53,7 @@ pub struct GoForward {
     pub pane: Option<WeakViewHandle<Pane>>,
 }
 
-impl_actions!(pane, [Split, GoBack, GoForward]);
+impl_actions!(pane, [GoBack, GoForward]);
 impl_internal_actions!(pane, [CloseItem, ActivateItem]);
 
 const MAX_NAVIGATION_HISTORY_LEN: usize = 1024;
@@ -77,9 +78,10 @@ pub fn init(cx: &mut MutableAppContext) {
             Ok(())
         }))
     });
-    cx.add_action(|pane: &mut Pane, action: &Split, cx| {
-        pane.split(action.0, cx);
-    });
+    cx.add_action(|pane: &mut Pane, _: &SplitLeft, cx| pane.split(SplitDirection::Left, cx));
+    cx.add_action(|pane: &mut Pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx));
+    cx.add_action(|pane: &mut Pane, _: &SplitRight, cx| pane.split(SplitDirection::Right, cx));
+    cx.add_action(|pane: &mut Pane, _: &SplitDown, cx| pane.split(SplitDirection::Down, cx));
     cx.add_action(|workspace: &mut Workspace, action: &GoBack, cx| {
         Pane::go_back(
             workspace,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -948,7 +948,7 @@ mod tests {
             (editor.downgrade(), buffer)
         });
 
-        cx.dispatch_action(window_id, pane::Split(SplitDirection::Right));
+        cx.dispatch_action(window_id, pane::SplitRight);
         let editor_2 = cx.update(|cx| {
             let pane_2 = workspace.read(cx).active_pane().clone();
             assert_ne!(pane_1, pane_2);


### PR DESCRIPTION
Fixes #1128 

This allows us to show them in the command palette.