### PR TITLE
Autoscroll to newest selection when adding it via the cursor

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1582,7 +1582,7 @@ impl Editor {
             }
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::Newest), cx, |s| {
             if !add {
                 s.clear_disjoint();
             } else if click_count > 1 {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/28