### PR TITLE
Cap context menu's width to cover at most 70% of the window

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1264,7 +1264,7 @@ impl Element for EditorElement {
                 SizeConstraint {
                     min: Vector2F::zero(),
                     max: vec2f(
-                        f32::INFINITY,
+                        cx.window_size.x() * 0.7,
                         (12. * line_height).min((size.y() - line_height) / 2.),
                     ),
                 },


### PR DESCRIPTION
Fixes #1187 

Previously, we were allowing the context menu to be as big as the window but that looked pretty bad when there were long suggestions. This pull request fixes that visual glitch by letting the context menu cover at most 70% of the window's width.

Before:
<img width="1543" alt="Screen Shot 2022-06-16 at 10 46 19" src="https://user-images.githubusercontent.com/482957/174031320-4d0b6f95-d625-4087-85f8-1e11271cf98d.png">

After:
<img width="1543" alt="Screen Shot 2022-06-16 at 10 45 46" src="https://user-images.githubusercontent.com/482957/174031363-9dc92e7f-ff38-40e2-95db-27747e5f860e.png">



/cc: @mikayla-maki, can you check if this makes things a bit better?