### PR TITLE
Use word boundaries instead of syntax to infer completion edit ranges

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -18,10 +18,10 @@ use gpui::{
 use language::{
     point_to_lsp,
     proto::{deserialize_anchor, deserialize_version, serialize_anchor, serialize_version},
-    range_from_lsp, range_to_lsp, Anchor, Bias, Buffer, CodeAction, CodeLabel, Completion,
-    Diagnostic, DiagnosticEntry, DiagnosticSet, Event as BufferEvent, File as _, Language,
-    LanguageRegistry, LanguageServerName, LocalFile, LspAdapter, OffsetRangeExt, Operation, Patch,
-    PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction,
+    range_from_lsp, range_to_lsp, Anchor, Bias, Buffer, CharKind, CodeAction, CodeLabel,
+    Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Event as BufferEvent, File as _,
+    Language, LanguageRegistry, LanguageServerName, LocalFile, LspAdapter, OffsetRangeExt,
+    Operation, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction,
 };
 use lsp::{
     DiagnosticSeverity, DiagnosticTag, DocumentHighlightKind, LanguageServer, LanguageString,
@@ -3182,9 +3182,12 @@ impl Project {
                                     let Range { start, end } = range_for_token
                                         .get_or_insert_with(|| {
                                             let offset = position.to_offset(&snapshot);
-                                            snapshot
-                                                .range_for_word_token_at(offset)
-                                                .unwrap_or_else(|| offset..offset)
+                                            let (range, kind) = snapshot.surrounding_word(offset);
+                                            if kind == Some(CharKind::Word) {
+                                                range
+                                            } else {
+                                                offset..offset
+                                            }
                                         })
                                         .clone();
                                     let text = lsp_completion


### PR DESCRIPTION
Fixes #1047 

Quoting the language server specification (emphasis mine):

> Completion item provides an insertText / label without a text edit: in the model the client should filter against what the user has already typed using the word boundary rules of the language (e.g. **resolving the word under the cursor position**). The reason for this mode is that it makes it extremely easy for a server to implement a basic completion list and get it filtered on the client.

Therefore, I went ahead and replace our syntax-aware range detection (introduced in #900) with a word boundary scanner. It seems like it works nicely in all situations in TypeScript and I verified it doesn't cause #839 to pop back up.

I guess we could potentially still use the syntax tree to ensure that the word we found doesn't escape a certain syntactic token but I am not sure it'd be worth the extra CPU given that any non-alphanumeric character would likely start a different syntactic token anyway and the word boundary logic would already catch that. In the future, we may wanna offer a setting such as [`wordPattern`](https://code.visualstudio.com/api/language-extensions/language-configuration-guide#word-pattern) in VS Code that's specific to each language, but I think this will do for quite a long time.

/cc: @maxbrunsfeld for 👀 