### PR TITLE
Disable auto-indent entirely for markdown

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9810,26 +9810,30 @@ mod tests {
     #[gpui::test]
     async fn test_extra_newline_insertion(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| cx.set_global(Settings::test(cx)));
-        let language = Arc::new(Language::new(
-            LanguageConfig {
-                brackets: vec![
-                    BracketPair {
-                        start: "{".to_string(),
-                        end: "}".to_string(),
-                        close: true,
-                        newline: true,
-                    },
-                    BracketPair {
-                        start: "/* ".to_string(),
-                        end: " */".to_string(),
-                        close: true,
-                        newline: true,
-                    },
-                ],
-                ..Default::default()
-            },
-            Some(tree_sitter_rust::language()),
-        ));
+        let language = Arc::new(
+            Language::new(
+                LanguageConfig {
+                    brackets: vec![
+                        BracketPair {
+                            start: "{".to_string(),
+                            end: "}".to_string(),
+                            close: true,
+                            newline: true,
+                        },
+                        BracketPair {
+                            start: "/* ".to_string(),
+                            end: " */".to_string(),
+                            close: true,
+                            newline: true,
+                        },
+                    ],
+                    ..Default::default()
+                },
+                Some(tree_sitter_rust::language()),
+            )
+            .with_indents_query("")
+            .unwrap(),
+        );
 
         let text = concat!(
             "{   }\n",     // Suppress rustfmt

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -785,6 +785,47 @@ fn test_autoindent_with_edit_at_end_of_buffer(cx: &mut MutableAppContext) {
 }
 
 #[gpui::test]
+fn test_autoindent_disabled(cx: &mut MutableAppContext) {
+    cx.add_model(|cx| {
+        let text = "
+            * one
+                - a
+                - b
+            * two
+        "
+        .unindent();
+
+        let mut buffer = Buffer::new(0, text, cx).with_language(
+            Arc::new(Language::new(
+                LanguageConfig {
+                    name: "Markdown".into(),
+                    ..Default::default()
+                },
+                Some(tree_sitter_json::language()),
+            )),
+            cx,
+        );
+        buffer.edit_with_autoindent(
+            [(Point::new(3, 0)..Point::new(3, 0), "\n")],
+            IndentSize::spaces(4),
+            cx,
+        );
+        assert_eq!(
+            buffer.text(),
+            "
+            * one
+                - a
+                - b
+
+            * two
+            "
+            .unindent()
+        );
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_serialization(cx: &mut gpui::MutableAppContext) {
     let mut now = Instant::now();
 


### PR DESCRIPTION
Fixes #1116

This PR makes a language's `indents` query *optional*. Code paths that *adjust* indentation are completely skipped for languages without indents queries (currently just Markdown). Indentation is still preserved when inserting newlines, but there is no attempt to adjust indentation on the fly.

This also fixes the bad experience of pasting some indented markdown, where Zed would strip out all of the indentation. Now the indentation is preserved, because we're not attempting to adjust it.