### PR TITLE
Themes in app menu

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -133,11 +133,12 @@ pub struct Menu<'a> {
 }
 
 pub enum MenuItem<'a> {
+    Separator,
+    Submenu(Menu<'a>),
     Action {
         name: &'a str,
         action: Box<dyn Action>,
     },
-    Separator,
 }
 
 #[derive(Clone)]

--- a/crates/gpui/src/elements/keystroke_label.rs
+++ b/crates/gpui/src/elements/keystroke_label.rs
@@ -40,13 +40,10 @@ impl Element for KeystrokeLabel {
         let mut element = if let Some(keystrokes) = cx.keystrokes_for_action(self.action.as_ref()) {
             Flex::row()
                 .with_children(keystrokes.iter().map(|keystroke| {
-                    Label::new(
-                        keystroke.to_string().to_uppercase(),
-                        self.text_style.clone(),
-                    )
-                    .contained()
-                    .with_style(self.container_style)
-                    .boxed()
+                    Label::new(keystroke.to_string(), self.text_style.clone())
+                        .contained()
+                        .with_style(self.container_style)
+                        .boxed()
                 }))
                 .boxed()
         } else {

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
     collections::{HashMap, HashSet},
-    fmt::Debug,
+    fmt::{Debug, Write},
 };
 use tree_sitter::{Language, Node, Parser};
 
@@ -318,28 +318,34 @@ impl Keystroke {
 impl std::fmt::Display for Keystroke {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.ctrl {
-            write!(f, "{}", "^")?;
+            f.write_char('^')?;
         }
         if self.alt {
-            write!(f, "{}", "⎇")?;
+            f.write_char('⎇')?;
         }
         if self.cmd {
-            write!(f, "{}", "⌘")?;
+            f.write_char('⌘')?;
         }
         if self.shift {
-            write!(f, "{}", "⇧")?;
+            f.write_char('⇧')?;
         }
         let key = match self.key.as_str() {
-            "backspace" => "⌫",
-            "up" => "↑",
-            "down" => "↓",
-            "left" => "←",
-            "right" => "→",
-            "tab" => "⇥",
-            "escape" => "⎋",
-            key => key,
+            "backspace" => '⌫',
+            "up" => '↑',
+            "down" => '↓',
+            "left" => '←',
+            "right" => '→',
+            "tab" => '⇥',
+            "escape" => '⎋',
+            key => {
+                if key.len() == 1 {
+                    key.chars().next().unwrap().to_ascii_uppercase()
+                } else {
+                    return f.write_str(key);
+                }
+            }
         };
-        write!(f, "{}", key)
+        f.write_char(key)
     }
 }
 

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -15,14 +15,23 @@ pub fn menus() -> Vec<Menu<'static>> {
                     action: Box::new(auto_update::Check),
                 },
                 MenuItem::Separator,
-                MenuItem::Action {
-                    name: "Open Settings",
-                    action: Box::new(super::OpenSettings),
-                },
-                MenuItem::Action {
-                    name: "Open Key Bindings",
-                    action: Box::new(super::OpenKeymap),
-                },
+                MenuItem::Submenu(Menu {
+                    name: "Preferences",
+                    items: vec![
+                        MenuItem::Action {
+                            name: "Open Settings",
+                            action: Box::new(super::OpenSettings),
+                        },
+                        MenuItem::Action {
+                            name: "Open Key Bindings",
+                            action: Box::new(super::OpenKeymap),
+                        },
+                        MenuItem::Action {
+                            name: "Select Theme",
+                            action: Box::new(theme_selector::Toggle),
+                        },
+                    ],
+                }),
                 MenuItem::Action {
                     name: "Install CLI",
                     action: Box::new(super::InstallCommandLineInterface),


### PR DESCRIPTION
Closes #1163

This PR also enhances Zed's application menus in the following ways:
* Adds the ability to create submenus
* Renders multi-keystroke bindings in the application menu
* Creates a `Zed > Preferences` submenu which contains the new "Select Theme" item, along with the settings and key bindings