### PR TITLE
Determine `Buffer::is_dirty` based on the rope's fingerprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bromberg_sl2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed88064f69518b7e3ea50ecfc1b61d43f19248618a377b95ae5c8b611134d4d"
+dependencies = [
+ "digest 0.9.0",
+ "lazy_static",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,6 +4169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9f47faea3cad316faa914d013d24f471cd90bfca1a0c70f05a3f42c6441e99"
+
+[[package]]
 name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4806,9 +4824,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
+ "bromberg_sl2",
  "clock",
  "collections",
  "ctor",
+ "digest 0.9.0",
  "env_logger",
  "gpui",
  "lazy_static",

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -5364,7 +5364,7 @@ impl TestClient {
                             (buffer.version(), buffer.save(cx))
                         });
                         let save = cx.background().spawn(async move {
-                            let (saved_version, _) = save
+                            let (saved_version, _, _) = save
                                 .await
                                 .map_err(|err| anyhow!("save request failed: {:?}", err))?;
                             assert!(saved_version.observed_all(&requested_version));

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -568,7 +568,10 @@ impl workspace::Item for ProjectDiagnosticsEditor {
     }
 
     fn should_update_tab_on_event(event: &Event) -> bool {
-        matches!(event, Event::Saved | Event::Dirtied | Event::TitleChanged)
+        matches!(
+            event,
+            Event::Saved | Event::DirtyChanged | Event::TitleChanged
+        )
     }
 
     fn set_nav_history(&mut self, nav_history: ItemNavHistory, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -370,22 +370,10 @@ impl FoldMap {
 
                     if fold.end > fold.start {
                         let output_text = "…";
-                        let chars = output_text.chars().count() as u32;
-                        let lines = Point::new(0, output_text.len() as u32);
-                        let lines_utf16 =
-                            PointUtf16::new(0, output_text.encode_utf16().count() as u32);
                         new_transforms.push(
                             Transform {
                                 summary: TransformSummary {
-                                    output: TextSummary {
-                                        bytes: output_text.len(),
-                                        lines,
-                                        lines_utf16,
-                                        first_line_chars: chars,
-                                        last_line_chars: chars,
-                                        longest_row: 0,
-                                        longest_row_chars: chars,
-                                    },
+                                    output: TextSummary::from(output_text),
                                     input: new_buffer.text_summary_for_range(fold.start..fold.end),
                                 },
                                 output_text: Some(output_text),

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use collections::BTreeMap;
 use gpui::fonts::HighlightStyle;
-use language::{Chunk, Edit, Point, PointUtf16, TextSummary};
+use language::{Chunk, Edit, Point, TextSummary};
 use parking_lot::Mutex;
 use std::{
     any::TypeId,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5508,7 +5508,7 @@ impl Editor {
                 cx.emit(Event::BufferEdited);
             }
             language::Event::Reparsed => cx.emit(Event::Reparsed),
-            language::Event::Dirtied => cx.emit(Event::Dirtied),
+            language::Event::DirtyChanged => cx.emit(Event::Dirtied),
             language::Event::Saved => cx.emit(Event::Saved),
             language::Event::FileHandleChanged => cx.emit(Event::TitleChanged),
             language::Event::Reloaded => cx.emit(Event::TitleChanged),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5508,7 +5508,7 @@ impl Editor {
                 cx.emit(Event::BufferEdited);
             }
             language::Event::Reparsed => cx.emit(Event::Reparsed),
-            language::Event::DirtyChanged => cx.emit(Event::Dirtied),
+            language::Event::DirtyChanged => cx.emit(Event::DirtyChanged),
             language::Event::Saved => cx.emit(Event::Saved),
             language::Event::FileHandleChanged => cx.emit(Event::TitleChanged),
             language::Event::Reloaded => cx.emit(Event::TitleChanged),
@@ -5665,7 +5665,7 @@ pub enum Event {
     Edited,
     Reparsed,
     Blurred,
-    Dirtied,
+    DirtyChanged,
     Saved,
     TitleChanged,
     SelectionsChanged { local: bool },
@@ -6181,7 +6181,10 @@ mod tests {
             let events = events.clone();
             |cx| {
                 cx.subscribe(&cx.handle(), move |_, _, event, _| {
-                    if matches!(event, Event::Edited | Event::BufferEdited | Event::Dirtied) {
+                    if matches!(
+                        event,
+                        Event::Edited | Event::BufferEdited | Event::DirtyChanged
+                    ) {
                         events.borrow_mut().push(("editor1", *event));
                     }
                 })
@@ -6193,7 +6196,10 @@ mod tests {
             let events = events.clone();
             |cx| {
                 cx.subscribe(&cx.handle(), move |_, _, event, _| {
-                    if matches!(event, Event::Edited | Event::BufferEdited | Event::Dirtied) {
+                    if matches!(
+                        event,
+                        Event::Edited | Event::BufferEdited | Event::DirtyChanged
+                    ) {
                         events.borrow_mut().push(("editor2", *event));
                     }
                 })
@@ -6211,8 +6217,8 @@ mod tests {
                 ("editor1", Event::Edited),
                 ("editor1", Event::BufferEdited),
                 ("editor2", Event::BufferEdited),
-                ("editor1", Event::Dirtied),
-                ("editor2", Event::Dirtied)
+                ("editor1", Event::DirtyChanged),
+                ("editor2", Event::DirtyChanged)
             ]
         );
 
@@ -6235,6 +6241,8 @@ mod tests {
                 ("editor1", Event::Edited),
                 ("editor1", Event::BufferEdited),
                 ("editor2", Event::BufferEdited),
+                ("editor1", Event::DirtyChanged),
+                ("editor2", Event::DirtyChanged),
             ]
         );
 
@@ -6246,6 +6254,8 @@ mod tests {
                 ("editor1", Event::Edited),
                 ("editor1", Event::BufferEdited),
                 ("editor2", Event::BufferEdited),
+                ("editor1", Event::DirtyChanged),
+                ("editor2", Event::DirtyChanged),
             ]
         );
 
@@ -6257,6 +6267,8 @@ mod tests {
                 ("editor2", Event::Edited),
                 ("editor1", Event::BufferEdited),
                 ("editor2", Event::BufferEdited),
+                ("editor1", Event::DirtyChanged),
+                ("editor2", Event::DirtyChanged),
             ]
         );
 
@@ -6268,6 +6280,8 @@ mod tests {
                 ("editor2", Event::Edited),
                 ("editor1", Event::BufferEdited),
                 ("editor2", Event::BufferEdited),
+                ("editor1", Event::DirtyChanged),
+                ("editor2", Event::DirtyChanged),
             ]
         );
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -440,7 +440,10 @@ impl Item for Editor {
     }
 
     fn should_update_tab_on_event(event: &Event) -> bool {
-        matches!(event, Event::Saved | Event::Dirtied | Event::TitleChanged)
+        matches!(
+            event,
+            Event::Saved | Event::DirtyChanged | Event::TitleChanged
+        )
     }
 }
 

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1923,15 +1923,7 @@ impl MultiBufferSnapshot {
             );
 
             if range.end > end_before_newline {
-                summary.add_assign(&D::from_text_summary(&TextSummary {
-                    bytes: 1,
-                    lines: Point::new(1 as u32, 0),
-                    lines_utf16: PointUtf16::new(1 as u32, 0),
-                    first_line_chars: 0,
-                    last_line_chars: 0,
-                    longest_row: 0,
-                    longest_row_chars: 0,
-                }));
+                summary.add_assign(&D::from_text_summary(&TextSummary::from("\n")));
             }
 
             cursor.next(&());

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -430,7 +430,7 @@ impl Buffer {
         Self {
             saved_mtime,
             saved_version: buffer.version(),
-            saved_version_fingerprint: buffer.text_summary().hex_fingerprint(),
+            saved_version_fingerprint: buffer.as_rope().fingerprint(),
             transaction_depth: 0,
             was_dirty_before_starting_transaction: None,
             text: buffer,
@@ -544,7 +544,7 @@ impl Buffer {
                     if let Some(transaction) = this.apply_diff(diff, cx).cloned() {
                         this.did_reload(
                             this.version(),
-                            this.text_summary().hex_fingerprint(),
+                            this.as_rope().fingerprint(),
                             new_mtime,
                             cx,
                         );
@@ -994,12 +994,12 @@ impl Buffer {
     }
 
     pub fn is_dirty(&self) -> bool {
-        self.saved_version_fingerprint != self.as_rope().summary().hex_fingerprint()
+        self.saved_version_fingerprint != self.as_rope().fingerprint()
             || self.file.as_ref().map_or(false, |file| file.is_deleted())
     }
 
     pub fn has_conflict(&self) -> bool {
-        self.saved_version_fingerprint != self.as_rope().summary().hex_fingerprint()
+        self.saved_version_fingerprint != self.as_rope().fingerprint()
             && self
                 .file
                 .as_ref()

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -51,7 +51,10 @@ pub struct Buffer {
     text: TextBuffer,
     file: Option<Arc<dyn File>>,
     saved_version: clock::Global,
+    saved_version_fingerprint: String,
     saved_mtime: SystemTime,
+    transaction_depth: usize,
+    was_dirty_before_starting_transaction: Option<bool>,
     language: Option<Arc<Language>>,
     autoindent_requests: Vec<Arc<AutoindentRequest>>,
     pending_autoindent: Option<Task<()>>,
@@ -155,7 +158,7 @@ pub enum Operation {
 pub enum Event {
     Operation(Operation),
     Edited,
-    Dirtied,
+    DirtyChanged,
     Saved,
     FileHandleChanged,
     Reloaded,
@@ -192,7 +195,7 @@ pub trait File: Send + Sync {
         text: Rope,
         version: clock::Global,
         cx: &mut MutableAppContext,
-    ) -> Task<Result<(clock::Global, SystemTime)>>;
+    ) -> Task<Result<(clock::Global, String, SystemTime)>>;
 
     fn as_any(&self) -> &dyn Any;
 
@@ -209,6 +212,7 @@ pub trait LocalFile: File {
         &self,
         buffer_id: u64,
         version: &clock::Global,
+        fingerprint: String,
         mtime: SystemTime,
         cx: &mut MutableAppContext,
     );
@@ -426,6 +430,9 @@ impl Buffer {
         Self {
             saved_mtime,
             saved_version: buffer.version(),
+            saved_version_fingerprint: buffer.text_summary().hex_fingerprint(),
+            transaction_depth: 0,
+            was_dirty_before_starting_transaction: None,
             text: buffer,
             file,
             syntax_tree: Mutex::new(None),
@@ -476,7 +483,7 @@ impl Buffer {
     pub fn save(
         &mut self,
         cx: &mut ModelContext<Self>,
-    ) -> Task<Result<(clock::Global, SystemTime)>> {
+    ) -> Task<Result<(clock::Global, String, SystemTime)>> {
         let file = if let Some(file) = self.file.as_ref() {
             file
         } else {
@@ -486,11 +493,11 @@ impl Buffer {
         let version = self.version();
         let save = file.save(self.remote_id(), text, version, cx.as_mut());
         cx.spawn(|this, mut cx| async move {
-            let (version, mtime) = save.await?;
+            let (version, fingerprint, mtime) = save.await?;
             this.update(&mut cx, |this, cx| {
-                this.did_save(version.clone(), mtime, None, cx);
+                this.did_save(version.clone(), fingerprint.clone(), mtime, None, cx);
             });
-            Ok((version, mtime))
+            Ok((version, fingerprint, mtime))
         })
     }
 
@@ -507,12 +514,14 @@ impl Buffer {
     pub fn did_save(
         &mut self,
         version: clock::Global,
+        fingerprint: String,
         mtime: SystemTime,
         new_file: Option<Arc<dyn File>>,
         cx: &mut ModelContext<Self>,
     ) {
-        self.saved_mtime = mtime;
         self.saved_version = version;
+        self.saved_version_fingerprint = fingerprint;
+        self.saved_mtime = mtime;
         if let Some(new_file) = new_file {
             self.file = Some(new_file);
             self.file_update_count += 1;
@@ -533,7 +542,12 @@ impl Buffer {
                     .await;
                 this.update(&mut cx, |this, cx| {
                     if let Some(transaction) = this.apply_diff(diff, cx).cloned() {
-                        this.did_reload(this.version(), new_mtime, cx);
+                        this.did_reload(
+                            this.version(),
+                            this.text_summary().hex_fingerprint(),
+                            new_mtime,
+                            cx,
+                        );
                         Ok(Some(transaction))
                     } else {
                         Ok(None)
@@ -548,13 +562,21 @@ impl Buffer {
     pub fn did_reload(
         &mut self,
         version: clock::Global,
+        fingerprint: String,
         mtime: SystemTime,
         cx: &mut ModelContext<Self>,
     ) {
-        self.saved_mtime = mtime;
         self.saved_version = version;
+        self.saved_version_fingerprint = fingerprint;
+        self.saved_mtime = mtime;
         if let Some(file) = self.file.as_ref().and_then(|f| f.as_local()) {
-            file.buffer_reloaded(self.remote_id(), &self.saved_version, self.saved_mtime, cx);
+            file.buffer_reloaded(
+                self.remote_id(),
+                &self.saved_version,
+                self.saved_version_fingerprint.clone(),
+                self.saved_mtime,
+                cx,
+            );
         }
         cx.emit(Event::Reloaded);
         cx.notify();
@@ -581,7 +603,7 @@ impl Buffer {
             if !old_file.is_deleted() {
                 file_changed = true;
                 if !self.is_dirty() {
-                    cx.emit(Event::Dirtied);
+                    cx.emit(Event::DirtyChanged);
                 }
             }
         } else {
@@ -972,12 +994,12 @@ impl Buffer {
     }
 
     pub fn is_dirty(&self) -> bool {
-        !self.saved_version.observed_all(&self.version)
+        self.saved_version_fingerprint != self.as_rope().summary().hex_fingerprint()
             || self.file.as_ref().map_or(false, |file| file.is_deleted())
     }
 
     pub fn has_conflict(&self) -> bool {
-        !self.saved_version.observed_all(&self.version)
+        self.saved_version_fingerprint != self.as_rope().summary().hex_fingerprint()
             && self
                 .file
                 .as_ref()
@@ -993,6 +1015,10 @@ impl Buffer {
     }
 
     pub fn start_transaction_at(&mut self, now: Instant) -> Option<TransactionId> {
+        self.transaction_depth += 1;
+        if self.was_dirty_before_starting_transaction.is_none() {
+            self.was_dirty_before_starting_transaction = Some(self.is_dirty());
+        }
         self.text.start_transaction_at(now)
     }
 
@@ -1005,8 +1031,14 @@ impl Buffer {
         now: Instant,
         cx: &mut ModelContext<Self>,
     ) -> Option<TransactionId> {
+        assert!(self.transaction_depth > 0);
+        self.transaction_depth -= 1;
+        let was_dirty = if self.transaction_depth == 0 {
+            self.was_dirty_before_starting_transaction.take().unwrap()
+        } else {
+            false
+        };
         if let Some((transaction_id, start_version)) = self.text.end_transaction_at(now) {
-            let was_dirty = start_version != self.saved_version;
             self.did_edit(&start_version, was_dirty, cx);
             Some(transaction_id)
         } else {
@@ -1217,8 +1249,8 @@ impl Buffer {
         self.reparse(cx);
 
         cx.emit(Event::Edited);
-        if !was_dirty {
-            cx.emit(Event::Dirtied);
+        if was_dirty != self.is_dirty() {
+            cx.emit(Event::DirtyChanged);
         }
         cx.notify();
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -8112,7 +8112,7 @@ mod tests {
             events.borrow_mut().clear();
             buffer.did_save(
                 buffer.version(),
-                buffer.as_rope().summary().hex_fingerprint(),
+                buffer.as_rope().fingerprint(),
                 buffer.file().unwrap().mtime(),
                 None,
                 cx,

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -634,6 +634,7 @@ impl LocalWorktree {
     ) -> Task<Result<()>> {
         let buffer = buffer_handle.read(cx);
         let text = buffer.as_rope().clone();
+        let fingerprint = text.summary().hex_fingerprint();
         let version = buffer.version();
         let save = self.write_file(path, text, cx);
         let handle = cx.handle();
@@ -648,7 +649,7 @@ impl LocalWorktree {
             };
 
             buffer_handle.update(&mut cx, |buffer, cx| {
-                buffer.did_save(version, file.mtime, Some(Arc::new(file)), cx);
+                buffer.did_save(version, fingerprint, file.mtime, Some(Arc::new(file)), cx);
             });
 
             Ok(())
@@ -1702,11 +1703,12 @@ impl language::File for File {
         text: Rope,
         version: clock::Global,
         cx: &mut MutableAppContext,
-    ) -> Task<Result<(clock::Global, SystemTime)>> {
+    ) -> Task<Result<(clock::Global, String, SystemTime)>> {
         self.worktree.update(cx, |worktree, cx| match worktree {
             Worktree::Local(worktree) => {
                 let rpc = worktree.client.clone();
                 let project_id = worktree.share.as_ref().map(|share| share.project_id);
+                let fingerprint = text.summary().hex_fingerprint();
                 let save = worktree.write_file(self.path.clone(), text, cx);
                 cx.background().spawn(async move {
                     let entry = save.await?;
@@ -1716,9 +1718,10 @@ impl language::File for File {
                             buffer_id,
                             version: serialize_version(&version),
                             mtime: Some(entry.mtime.into()),
+                            fingerprint: fingerprint.clone(),
                         })?;
                     }
-                    Ok((version, entry.mtime))
+                    Ok((version, fingerprint, entry.mtime))
                 })
             }
             Worktree::Remote(worktree) => {
@@ -1737,7 +1740,7 @@ impl language::File for File {
                         .mtime
                         .ok_or_else(|| anyhow!("missing mtime"))?
                         .into();
-                    Ok((version, mtime))
+                    Ok((version, response.fingerprint, mtime))
                 })
             }
         })
@@ -1779,6 +1782,7 @@ impl language::LocalFile for File {
         &self,
         buffer_id: u64,
         version: &clock::Global,
+        fingerprint: String,
         mtime: SystemTime,
         cx: &mut MutableAppContext,
     ) {
@@ -1791,6 +1795,7 @@ impl language::LocalFile for File {
                     buffer_id,
                     version: serialize_version(&version),
                     mtime: Some(mtime.into()),
+                    fingerprint,
                 })
                 .log_err();
         }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -634,7 +634,7 @@ impl LocalWorktree {
     ) -> Task<Result<()>> {
         let buffer = buffer_handle.read(cx);
         let text = buffer.as_rope().clone();
-        let fingerprint = text.summary().hex_fingerprint();
+        let fingerprint = text.fingerprint();
         let version = buffer.version();
         let save = self.write_file(path, text, cx);
         let handle = cx.handle();
@@ -1708,7 +1708,7 @@ impl language::File for File {
             Worktree::Local(worktree) => {
                 let rpc = worktree.client.clone();
                 let project_id = worktree.share.as_ref().map(|share| share.project_id);
-                let fingerprint = text.summary().hex_fingerprint();
+                let fingerprint = text.fingerprint();
                 let save = worktree.write_file(self.path.clone(), text, cx);
                 cx.background().spawn(async move {
                     let entry = save.await?;

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -364,6 +364,7 @@ message BufferSaved {
     uint64 buffer_id = 2;
     repeated VectorClockEntry version = 3;
     Timestamp mtime = 4;
+    string fingerprint = 5;
 }
 
 message BufferReloaded {
@@ -371,6 +372,7 @@ message BufferReloaded {
     uint64 buffer_id = 2;
     repeated VectorClockEntry version = 3;
     Timestamp mtime = 4;
+    string fingerprint = 5;
 }
 
 message ReloadBuffers {

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 24;
+pub const PROTOCOL_VERSION: u32 = 25;

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -16,6 +16,8 @@ collections = { path = "../collections" }
 sum_tree = { path = "../sum_tree" }
 anyhow = "1.0.38"
 arrayvec = "0.7.1"
+digest = { version = "0.9", features = ["std"] }
+bromberg_sl2 = "0.6"
 lazy_static = "1.4"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 parking_lot = "0.11"

--- a/crates/text/src/rope.rs
+++ b/crates/text/src/rope.rs
@@ -2,7 +2,7 @@ use crate::PointUtf16;
 
 use super::Point;
 use arrayvec::ArrayString;
-use bromberg_sl2::HashMatrix;
+use bromberg_sl2::{DigestString, HashMatrix};
 use smallvec::SmallVec;
 use std::{cmp, fmt, io, mem, ops::Range, str};
 use sum_tree::{Bias, Dimension, SumTree};
@@ -727,6 +727,12 @@ pub struct TextSummary {
     pub longest_row: u32,
     pub longest_row_chars: u32,
     pub fingerprint: HashMatrix,
+}
+
+impl TextSummary {
+    pub fn hex_fingerprint(&self) -> String {
+        self.fingerprint.to_hex()
+    }
 }
 
 impl<'a> From<&'a str> for TextSummary {

--- a/crates/text/src/rope.rs
+++ b/crates/text/src/rope.rs
@@ -2,6 +2,7 @@ use crate::PointUtf16;
 
 use super::Point;
 use arrayvec::ArrayString;
+use bromberg_sl2::HashMatrix;
 use smallvec::SmallVec;
 use std::{cmp, fmt, io, mem, ops::Range, str};
 use sum_tree::{Bias, Dimension, SumTree};
@@ -725,6 +726,7 @@ pub struct TextSummary {
     pub last_line_chars: u32,
     pub longest_row: u32,
     pub longest_row_chars: u32,
+    pub fingerprint: HashMatrix,
 }
 
 impl<'a> From<&'a str> for TextSummary {
@@ -764,6 +766,7 @@ impl<'a> From<&'a str> for TextSummary {
             last_line_chars,
             longest_row,
             longest_row_chars,
+            fingerprint: bromberg_sl2::hash_strict(text.as_bytes()),
         }
     }
 }
@@ -810,6 +813,7 @@ impl<'a> std::ops::AddAssign<&'a Self> for TextSummary {
         self.bytes += other.bytes;
         self.lines += other.lines;
         self.lines_utf16 += other.lines_utf16;
+        self.fingerprint = self.fingerprint * other.fingerprint;
     }
 }
 

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -226,6 +226,7 @@ fn test_text_summary_for_range() {
             last_line_chars: 0,
             longest_row: 0,
             longest_row_chars: 1,
+            fingerprint: bromberg_sl2::hash_strict(b"b\n")
         }
     );
     assert_eq!(
@@ -238,6 +239,7 @@ fn test_text_summary_for_range() {
             last_line_chars: 0,
             longest_row: 2,
             longest_row_chars: 4,
+            fingerprint: bromberg_sl2::hash_strict(b"b\nefg\nhklm\n")
         }
     );
     assert_eq!(
@@ -250,6 +252,7 @@ fn test_text_summary_for_range() {
             last_line_chars: 1,
             longest_row: 3,
             longest_row_chars: 6,
+            fingerprint: bromberg_sl2::hash_strict(b"ab\nefg\nhklm\nnopqrs\nt")
         }
     );
     assert_eq!(
@@ -262,6 +265,7 @@ fn test_text_summary_for_range() {
             last_line_chars: 3,
             longest_row: 3,
             longest_row_chars: 6,
+            fingerprint: bromberg_sl2::hash_strict(b"ab\nefg\nhklm\nnopqrs\ntuv")
         }
     );
     assert_eq!(
@@ -274,6 +278,7 @@ fn test_text_summary_for_range() {
             last_line_chars: 3,
             longest_row: 1,
             longest_row_chars: 6,
+            fingerprint: bromberg_sl2::hash_strict(b"hklm\nnopqrs\ntuv")
         }
     );
 }

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -226,7 +226,6 @@ fn test_text_summary_for_range() {
             last_line_chars: 0,
             longest_row: 0,
             longest_row_chars: 1,
-            fingerprint: bromberg_sl2::hash_strict(b"b\n")
         }
     );
     assert_eq!(
@@ -239,7 +238,6 @@ fn test_text_summary_for_range() {
             last_line_chars: 0,
             longest_row: 2,
             longest_row_chars: 4,
-            fingerprint: bromberg_sl2::hash_strict(b"b\nefg\nhklm\n")
         }
     );
     assert_eq!(
@@ -252,7 +250,6 @@ fn test_text_summary_for_range() {
             last_line_chars: 1,
             longest_row: 3,
             longest_row_chars: 6,
-            fingerprint: bromberg_sl2::hash_strict(b"ab\nefg\nhklm\nnopqrs\nt")
         }
     );
     assert_eq!(
@@ -265,7 +262,6 @@ fn test_text_summary_for_range() {
             last_line_chars: 3,
             longest_row: 3,
             longest_row_chars: 6,
-            fingerprint: bromberg_sl2::hash_strict(b"ab\nefg\nhklm\nnopqrs\ntuv")
         }
     );
     assert_eq!(
@@ -278,7 +274,6 @@ fn test_text_summary_for_range() {
             last_line_chars: 3,
             longest_row: 1,
             longest_row_chars: 6,
-            fingerprint: bromberg_sl2::hash_strict(b"hklm\nnopqrs\ntuv")
         }
     );
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/25

This pull request introduces a new `fingerprint` field to `TextSummary`. This is calculated in `Rope` and uses the [`bromberg_sl2`](https://github.com/benwr/bromberg_sl2) homomorphic hash function to determine the fingerprint of a single chunk and then compose each chunk's fingerprint into a single fingerprint for the entire rope that is equivalent to hashing all the rope's bytes at once.

We synchronously discussed potentially doing a more expensive check in the background to determine dirtiness in case of collisions, but the authors of the [paper](https://eprint.iacr.org/2014/814.pdf) claim "there are no known attacks at this time that would affect security of the corresponding hash functions". Given that we are using this for something that doesn't need cryptographically-guaranteed properties, I think we could assume that statement is true and avoid the background check altogether.
