### PR TITLE
Highlight files ending in `mdx` as Markdown

### DIFF
--- a/crates/zed/src/languages/markdown/config.toml
+++ b/crates/zed/src/languages/markdown/config.toml
@@ -1,5 +1,5 @@
 name = "Markdown"
-path_suffixes = ["md"]
+path_suffixes = ["md", "mdx"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
Closes https://github.com/zed-industries/feedback/issues/35

This is clearly a stopgap solution but it'll make our life easier while hacking on zed.dev.