### PR TITLE
Add an API that returns the most active zed users and the projects where they've been active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
 dependencies = [
  "futures-core",
  "futures-io",
- "rustls",
- "webpki",
- "webpki-roots",
+ "rustls 0.19.1",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "atoi"
-version = "0.4.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
 dependencies = [
  "num-traits",
 ]
@@ -445,12 +445,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base-x"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
 
 [[package]]
 name = "base64"
@@ -670,7 +664,7 @@ dependencies = [
  "postage",
  "settings",
  "theme",
- "time 0.3.9",
+ "time 0.3.10",
  "util",
  "workspace",
 ]
@@ -803,7 +797,7 @@ dependencies = [
  "smol",
  "sum_tree",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.10",
  "tiny_http",
  "url",
  "util",
@@ -893,7 +887,7 @@ dependencies = [
  "sha-1 0.9.8",
  "sqlx",
  "theme",
- "time 0.2.27",
+ "time 0.3.10",
  "tokio",
  "tokio-tungstenite",
  "toml",
@@ -945,12 +939,6 @@ checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "contacts_panel"
@@ -1056,18 +1044,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "1.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
 
 [[package]]
 name = "crc32fast"
@@ -1339,12 +1327,6 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dotenv"
@@ -1930,7 +1912,7 @@ dependencies = [
  "smallvec",
  "smol",
  "sum_tree",
- "time 0.3.9",
+ "time 0.3.10",
  "tiny-skia",
  "tree-sitter",
  "usvg",
@@ -1971,17 +1953,23 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -2229,7 +2217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2271,7 +2259,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tempfile",
- "uuid",
+ "uuid 0.8.2",
  "winapi 0.3.9",
 ]
 
@@ -3120,7 +3108,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff"
 dependencies = [
- "rustc_version 0.3.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3250,7 +3238,7 @@ dependencies = [
  "indexmap",
  "line-wrap",
  "serde",
- "time 0.3.9",
+ "time 0.3.10",
  "xml-rs",
 ]
 
@@ -3330,12 +3318,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -3929,20 +3911,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver 0.11.0",
+ "semver",
 ]
 
 [[package]]
@@ -3954,8 +3927,29 @@ dependencies = [
  "base64 0.13.0",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -4084,6 +4078,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4137,27 +4141,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -4320,21 +4309,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.3",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -4526,9 +4500,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551873805652ba0d912fec5bbb0f8b4cdd96baf8e2ebf5970e5671092966019b"
+checksum = "1f82cbe94f41641d6c410ded25bbf5097c240cefdf8e3b06d04198d0a96af6a4"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4536,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
+checksum = "6b69bf218860335ddda60d6ce85ee39f6cf6e5630e300e19757d1de15886a093"
 dependencies = [
  "ahash",
  "atoi",
@@ -4569,7 +4543,8 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rand 0.8.5",
- "rustls",
+ "rustls 0.20.6",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha-1 0.10.0",
@@ -4579,20 +4554,19 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.2.27",
+ "time 0.3.10",
  "tokio-stream",
  "url",
- "uuid",
- "webpki",
- "webpki-roots",
+ "uuid 1.1.2",
+ "webpki-roots 0.22.3",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0fba2b0cae21fc00fe6046f8baa4c7fcb49e379f0f592b04696607f69ed2e1"
+checksum = "f40c63177cf23d356b159b60acd27c54af7423f1736988502e36bae9a712118f"
 dependencies = [
  "dotenv",
  "either",
@@ -4609,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db708cd3e459078f85f39f96a00960bd841f66ee2a669e90bf36907f5a79aae"
+checksum = "874e93a365a598dc3dadb197565952cb143ae4aa716f7bcc933a8d836f6bf89f"
 dependencies = [
  "once_cell",
  "tokio",
@@ -4619,68 +4593,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"
@@ -4945,52 +4861,22 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "82501a4c1c0330d640a6e176a3d6a204f5ec5237aca029029d21864a902e27b0"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
+ "time-macros",
 ]
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny-skia"
@@ -5087,13 +4973,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.6",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5652,6 +5538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5840,12 +5732,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/crates/chat_panel/Cargo.toml
+++ b/crates/chat_panel/Cargo.toml
@@ -17,4 +17,4 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 postage = { version = "0.4.1", features = ["futures-traits"] }
-time = "0.3"
+time = { version = "0.3", features = ["serde", "serde-well-known"] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -29,7 +29,7 @@ postage = { version = "0.4.1", features = ["futures-traits"] }
 rand = "0.8.3"
 smol = "1.2.5"
 thiserror = "1.0.29"
-time = "0.3"
+time = { version = "0.3", features = ["serde", "serde-well-known"] }
 tiny_http = "0.8"
 url = "2.2"
 

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -38,7 +38,7 @@ scrypt = "0.7"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha-1 = "0.9"
-time = "0.2"
+time = { version = "0.3", features = ["serde", "serde-well-known"] }
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.17"
 tonic = "0.6"
@@ -49,7 +49,7 @@ tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 
 [dependencies.sqlx]
-version = "0.5.2"
+version = "0.6"
 features = ["runtime-tokio-rustls", "postgres", "time", "uuid"]
 
 [dev-dependencies]

--- a/crates/collab/migrations/20220620211403_create_project_activity_periods.sql
+++ b/crates/collab/migrations/20220620211403_create_project_activity_periods.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "project_activity_periods" (
+    "id" SERIAL PRIMARY KEY,
+    "duration_millis" INTEGER NOT NULL,
+    "ended_at" TIMESTAMP NOT NULL,
+    "user_id" INTEGER REFERENCES users (id) NOT NULL,
+    "project_id" INTEGER
+);
+
+CREATE INDEX "index_project_activity_periods_on_ended_at" ON "project_activity_periods" ("ended_at");

--- a/crates/collab/migrations/20220620211403_create_project_activity_periods.sql
+++ b/crates/collab/migrations/20220620211403_create_project_activity_periods.sql
@@ -1,9 +1,0 @@
-CREATE TABLE IF NOT EXISTS "project_activity_periods" (
-    "id" SERIAL PRIMARY KEY,
-    "duration_millis" INTEGER NOT NULL,
-    "ended_at" TIMESTAMP NOT NULL,
-    "user_id" INTEGER REFERENCES users (id) NOT NULL,
-    "project_id" INTEGER
-);
-
-CREATE INDEX "index_project_activity_periods_on_ended_at" ON "project_activity_periods" ("ended_at");

--- a/crates/collab/migrations/20220620211403_create_projects.sql
+++ b/crates/collab/migrations/20220620211403_create_projects.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "projects" (
+    "id" SERIAL PRIMARY KEY,
+    "host_user_id" INTEGER REFERENCES users (id) NOT NULL,
+    "unregistered" BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE TABLE IF NOT EXISTS "worktree_extensions" (
+    "id" SERIAL PRIMARY KEY,
+    "project_id" INTEGER REFERENCES projects (id) NOT NULL,
+    "worktree_id" INTEGER NOT NULL,
+    "extension" VARCHAR(255),
+    "count" INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "project_activity_periods" (
+    "id" SERIAL PRIMARY KEY,
+    "duration_millis" INTEGER NOT NULL,
+    "ended_at" TIMESTAMP NOT NULL,
+    "user_id" INTEGER REFERENCES users (id) NOT NULL,
+    "project_id" INTEGER REFERENCES projects (id) NOT NULL
+);
+
+CREATE INDEX "index_project_activity_periods_on_ended_at" ON "project_activity_periods" ("ended_at");
+CREATE UNIQUE INDEX "index_worktree_extensions_on_project_id_and_worktree_id_and_extension" ON "worktree_extensions" ("project_id", "worktree_id", "extension");

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -178,8 +178,8 @@ impl Db for PostgresDb {
     async fn get_all_users(&self, page: u32, limit: u32) -> Result<Vec<User>> {
         let query = "SELECT * FROM users ORDER BY github_login ASC LIMIT $1 OFFSET $2";
         Ok(sqlx::query_as(query)
-            .bind(limit)
-            .bind(page * limit)
+            .bind(limit as i32)
+            .bind((page * limit) as i32)
             .fetch_all(&self.pool)
             .await?)
     }
@@ -196,7 +196,7 @@ impl Db for PostgresDb {
                     .push_bind(email_address)
                     .push_bind(false)
                     .push_bind(nanoid!(16))
-                    .push_bind(invite_count as u32);
+                    .push_bind(invite_count as i32);
             },
         );
         query.push(
@@ -231,7 +231,7 @@ impl Db for PostgresDb {
         Ok(sqlx::query_as(query)
             .bind(like_string)
             .bind(name_query)
-            .bind(limit)
+            .bind(limit as i32)
             .fetch_all(&self.pool)
             .await?)
     }
@@ -322,7 +322,7 @@ impl Db for PostgresDb {
             WHERE id = $2
             ",
         )
-        .bind(count)
+        .bind(count as i32)
         .bind(id)
         .execute(&mut tx)
         .await?;
@@ -488,7 +488,7 @@ impl Db for PostgresDb {
                 .push_bind(project_id)
                 .push_bind(worktree_id as i32)
                 .push_bind(extension)
-                .push_bind(count as u32);
+                .push_bind(count as i32);
         });
         query.push(
             "
@@ -825,7 +825,7 @@ impl Db for PostgresDb {
         sqlx::query(cleanup_query)
             .bind(user_id.0)
             .bind(access_token_hash)
-            .bind(max_access_token_count as u32)
+            .bind(max_access_token_count as i32)
             .execute(&mut tx)
             .await?;
         Ok(tx.commit().await?)

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -465,7 +465,7 @@ impl Db for PostgresDb {
             "
             UPDATE projects
             SET unregistered = 't'
-            WHERE project_id = $1
+            WHERE id = $1
             ",
         )
         .bind(project_id)

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::{tests::TestDb, UserId},
+    db::{tests::TestDb, ProjectId, UserId},
     rpc::{Executor, Server, Store},
     AppState,
 };
@@ -1447,7 +1447,7 @@ async fn test_collaborating_with_diagnostics(
     deterministic.run_until_parked();
     {
         let store = server.store.read().await;
-        let project = store.project(project_id).unwrap();
+        let project = store.project(ProjectId::from_proto(project_id)).unwrap();
         let worktree = project.worktrees.get(&worktree_id.to_proto()).unwrap();
         assert!(!worktree.diagnostic_summaries.is_empty());
     }

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -4722,7 +4722,7 @@ impl TestServer {
         foreground: Rc<executor::Foreground>,
         background: Arc<executor::Background>,
     ) -> Self {
-        let test_db = TestDb::fake(background);
+        let test_db = TestDb::fake(background.clone());
         let app_state = Self::build_app_state(&test_db).await;
         let peer = Peer::new();
         let notifications = mpsc::unbounded();

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use std::{
     net::{SocketAddr, TcpListener},
     sync::Arc,
+    time::Duration,
 };
 use tracing_log::LogTracer;
 use tracing_subscriber::{filter::EnvFilter, fmt::format::JsonFields, Layer};
@@ -65,6 +66,8 @@ async fn main() -> Result<()> {
     let listener = TcpListener::bind(&format!("0.0.0.0:{}", config.http_port))
         .expect("failed to bind TCP listener");
     let rpc_server = rpc::Server::new(state.clone(), None);
+
+    rpc_server.start_recording_project_activity(Duration::from_secs(5 * 60), rpc::RealExecutor);
 
     let app = Router::<Body>::new()
         .merge(api::routes(&rpc_server, state.clone()))

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -314,9 +314,10 @@ impl Server {
                         |(project_id, project)| {
                             project.guests.values().chain([&project.host]).filter_map(
                                 |collaborator| {
-                                    if collaborator
-                                        .last_activity
-                                        .map_or(false, |activity| activity > period_start)
+                                    if !collaborator.admin
+                                        && collaborator
+                                            .last_activity
+                                            .map_or(false, |activity| activity > period_start)
                                     {
                                         Some((collaborator.user_id, *project_id))
                                     } else {

--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -52,6 +52,7 @@ pub struct Collaborator {
     pub user_id: UserId,
     #[serde(skip)]
     pub last_activity: Option<OffsetDateTime>,
+    pub admin: bool,
 }
 
 #[derive(Default, Serialize)]
@@ -340,6 +341,7 @@ impl Store {
                     user_id: connection.user_id,
                     replica_id: 0,
                     last_activity: None,
+                    admin: connection.admin,
                 },
                 guests: Default::default(),
                 join_requests: Default::default(),
@@ -541,6 +543,7 @@ impl Store {
                     replica_id,
                     user_id: requester_id,
                     last_activity: Some(OffsetDateTime::now_utc()),
+                    admin: requester_connection.admin,
                 },
             );
             receipts_with_replica_ids.push((receipt, replica_id));

--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -9,8 +9,9 @@ use std::{
     mem,
     path::{Path, PathBuf},
     str,
-    time::{Duration, Instant},
+    time::Duration,
 };
+use time::OffsetDateTime;
 use tracing::instrument;
 
 #[derive(Default, Serialize)]
@@ -35,15 +36,21 @@ struct ConnectionState {
 #[derive(Serialize)]
 pub struct Project {
     pub host_connection_id: ConnectionId,
-    pub host_user_id: UserId,
-    pub guests: HashMap<ConnectionId, (ReplicaId, UserId)>,
+    pub host: Collaborator,
+    pub guests: HashMap<ConnectionId, Collaborator>,
     #[serde(skip)]
     pub join_requests: HashMap<UserId, Vec<Receipt<proto::JoinProject>>>,
     pub active_replica_ids: HashSet<ReplicaId>,
     pub worktrees: BTreeMap<u64, Worktree>,
     pub language_servers: Vec<proto::LanguageServer>,
+}
+
+#[derive(Serialize)]
+pub struct Collaborator {
+    pub replica_id: ReplicaId,
+    pub user_id: UserId,
     #[serde(skip)]
-    last_activity: Option<Instant>,
+    pub last_activity: Option<OffsetDateTime>,
 }
 
 #[derive(Default, Serialize)]
@@ -93,6 +100,9 @@ pub struct Metrics {
 
 impl Store {
     pub fn metrics(&self) -> Metrics {
+        const ACTIVE_PROJECT_TIMEOUT: Duration = Duration::from_secs(60);
+        let active_window_start = OffsetDateTime::now_utc() - ACTIVE_PROJECT_TIMEOUT;
+
         let connections = self.connections.values().filter(|c| !c.admin).count();
         let mut registered_projects = 0;
         let mut active_projects = 0;
@@ -101,7 +111,7 @@ impl Store {
             if let Some(connection) = self.connections.get(&project.host_connection_id) {
                 if !connection.admin {
                     registered_projects += 1;
-                    if project.is_active() {
+                    if project.is_active_since(active_window_start) {
                         active_projects += 1;
                         if !project.guests.is_empty() {
                             shared_projects += 1;
@@ -289,7 +299,7 @@ impl Store {
         let mut metadata = Vec::new();
         for project_id in project_ids {
             if let Some(project) = self.projects.get(&project_id) {
-                if project.host_user_id == user_id {
+                if project.host.user_id == user_id {
                     metadata.push(proto::ProjectMetadata {
                         id: project_id,
                         visible_worktree_root_names: project
@@ -301,7 +311,7 @@ impl Store {
                         guests: project
                             .guests
                             .values()
-                            .map(|(_, user_id)| user_id.to_proto())
+                            .map(|guest| guest.user_id.to_proto())
                             .collect(),
                     });
                 }
@@ -321,13 +331,16 @@ impl Store {
             project_id,
             Project {
                 host_connection_id,
-                host_user_id,
+                host: Collaborator {
+                    user_id: host_user_id,
+                    replica_id: 0,
+                    last_activity: None,
+                },
                 guests: Default::default(),
                 join_requests: Default::default(),
                 active_replica_ids: Default::default(),
                 worktrees: Default::default(),
                 language_servers: Default::default(),
-                last_activity: None,
             },
         );
         if let Some(connection) = self.connections.get_mut(&host_connection_id) {
@@ -470,7 +483,6 @@ impl Store {
             .get_mut(&project_id)
             .ok_or_else(|| anyhow!("no such project"))?;
         connection.requested_projects.insert(project_id);
-        project.last_activity = Some(Instant::now());
         project
             .join_requests
             .entry(requester_id)
@@ -495,7 +507,7 @@ impl Store {
             let requester_connection = self.connections.get_mut(&receipt.sender_id)?;
             requester_connection.requested_projects.remove(&project_id);
         }
-        project.last_activity = Some(Instant::now());
+        project.host.last_activity = Some(OffsetDateTime::now_utc());
 
         Some(receipts)
     }
@@ -522,13 +534,18 @@ impl Store {
                 replica_id += 1;
             }
             project.active_replica_ids.insert(replica_id);
-            project
-                .guests
-                .insert(receipt.sender_id, (replica_id, requester_id));
+            project.guests.insert(
+                receipt.sender_id,
+                Collaborator {
+                    replica_id,
+                    user_id: requester_id,
+                    last_activity: Some(OffsetDateTime::now_utc()),
+                },
+            );
             receipts_with_replica_ids.push((receipt, replica_id));
         }
 
-        project.last_activity = Some(Instant::now());
+        project.host.last_activity = Some(OffsetDateTime::now_utc());
         Some((receipts_with_replica_ids, project))
     }
 
@@ -544,13 +561,12 @@ impl Store {
             .ok_or_else(|| anyhow!("no such project"))?;
 
         // If the connection leaving the project is a collaborator, remove it.
-        let remove_collaborator =
-            if let Some((replica_id, _)) = project.guests.remove(&connection_id) {
-                project.active_replica_ids.remove(&replica_id);
-                true
-            } else {
-                false
-            };
+        let remove_collaborator = if let Some(guest) = project.guests.remove(&connection_id) {
+            project.active_replica_ids.remove(&guest.replica_id);
+            true
+        } else {
+            false
+        };
 
         // If the connection leaving the project has a pending request, remove it.
         // If that user has no other pending requests on other connections, indicate that the request should be cancelled.
@@ -579,11 +595,9 @@ impl Store {
             }
         }
 
-        project.last_activity = Some(Instant::now());
-
         Ok(LeftProject {
             host_connection_id: project.host_connection_id,
-            host_user_id: project.host_user_id,
+            host_user_id: project.host.user_id,
             connection_ids,
             cancel_request,
             unshare,
@@ -674,8 +688,23 @@ impl Store {
         project_id: u64,
         connection_id: ConnectionId,
     ) -> Result<()> {
-        self.write_project(project_id, connection_id)?.last_activity = Some(Instant::now());
+        let project = self
+            .projects
+            .get_mut(&project_id)
+            .ok_or_else(|| anyhow!("no such project"))?;
+        let collaborator = if connection_id == project.host_connection_id {
+            &mut project.host
+        } else if let Some(guest) = project.guests.get_mut(&connection_id) {
+            guest
+        } else {
+            return Err(anyhow!("no such project"))?;
+        };
+        collaborator.last_activity = Some(OffsetDateTime::now_utc());
         Ok(())
+    }
+
+    pub fn projects(&self) -> impl Iterator<Item = (&u64, &Project)> {
+        self.projects.iter()
     }
 
     pub fn read_project(&self, project_id: u64, connection_id: ConnectionId) -> Result<&Project> {
@@ -768,7 +797,7 @@ impl Store {
                 project
                     .guests
                     .values()
-                    .map(|(replica_id, _)| *replica_id)
+                    .map(|guest| guest.replica_id)
                     .collect::<HashSet<_>>(),
             );
         }
@@ -783,11 +812,15 @@ impl Store {
 }
 
 impl Project {
-    fn is_active(&self) -> bool {
-        const ACTIVE_PROJECT_TIMEOUT: Duration = Duration::from_secs(60);
-        self.last_activity.map_or(false, |last_activity| {
-            last_activity.elapsed() < ACTIVE_PROJECT_TIMEOUT
-        })
+    fn is_active_since(&self, start_time: OffsetDateTime) -> bool {
+        self.guests
+            .values()
+            .chain([&self.host])
+            .any(|collaborator| {
+                collaborator
+                    .last_activity
+                    .map_or(false, |active_time| active_time > start_time)
+            })
     }
 
     pub fn guest_connection_ids(&self) -> Vec<ConnectionId> {

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 smallvec = { version = "1.6", features = ["union"] }
 smol = "1.2"
-time = { version = "0.3" }
+time = { version = "0.3", features = ["serde", "serde-well-known"] }
 tiny-skia = "0.5"
 tree-sitter = "0.20"
 usvg = "0.14"


### PR DESCRIPTION
* [x] Expose a sorted list of the most active users
* [x] Expose which projects each person is active in
* [x] Decide what information to expose about the projects themselves. Options:
    * ~~Nothing. We just have to manually look for the project ids in the logs, and see if there are extension counts~~
    * [x] Put the extension counts of shared projects in the database too
* [x] Accept a date time range when querying project activity