### PR TITLE
hide hover on editor blur

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5693,7 +5693,6 @@ impl View for Editor {
             map.set_font(style.text.font_id, style.text.font_size, cx)
         });
 
-        // If the
         if font_changed {
             let handle = self.handle.clone();
             cx.defer(move |cx| {
@@ -5740,6 +5739,7 @@ impl View for Editor {
         self.buffer
             .update(cx, |buffer, cx| buffer.remove_active_selections(cx));
         self.hide_context_menu(cx);
+        hide_hover(self, cx);
         cx.emit(Event::Blurred);
         cx.notify();
     }


### PR DESCRIPTION
Hide hover on editor blur. This fixes outline issues, and hover dialog rendering out of order on disconnect.

Fixes https://github.com/zed-industries/zed/issues/1186
Fixes https://github.com/zed-industries/zed/issues/1169