### PR TITLE
Prevent deadlocks when two clients perform a request to each other

### DIFF
--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -4722,7 +4722,7 @@ async fn test_random_collaboration(
                 op_start_signals.remove(guest_ix);
                 server.forbid_connections();
                 server.disconnect_client(removed_guest_id);
-                deterministic.advance_clock(RECEIVE_TIMEOUT);
+                deterministic.advance_clock(5 * RECEIVE_TIMEOUT);
                 deterministic.start_waiting();
                 let (guest, guest_project, mut guest_cx, guest_err) = guest.await;
                 deterministic.finish_waiting();

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -4722,7 +4722,7 @@ async fn test_random_collaboration(
                 op_start_signals.remove(guest_ix);
                 server.forbid_connections();
                 server.disconnect_client(removed_guest_id);
-                deterministic.advance_clock(5 * RECEIVE_TIMEOUT);
+                deterministic.advance_clock(RECEIVE_TIMEOUT);
                 deterministic.start_waiting();
                 let (guest, guest_project, mut guest_cx, guest_err) = guest.await;
                 deterministic.finish_waiting();

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -4353,17 +4353,7 @@ async fn test_peers_simultaneously_following_each_other(
     cx_a.update(editor::init);
     cx_b.update(editor::init);
 
-    client_a
-        .fs
-        .insert_tree(
-            "/a",
-            json!({
-                "1.txt": "one",
-                "2.txt": "two",
-                "3.txt": "three",
-            }),
-        )
-        .await;
+    client_a.fs.insert_tree("/a", json!({})).await;
     let (project_a, _) = client_a.build_local_project("/a", cx_a).await;
     let workspace_a = client_a.build_workspace(&project_a, cx_a);
 

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -366,6 +366,14 @@ impl Deterministic {
         self.state.lock().now = new_now;
     }
 
+    pub fn start_waiting(&self) {
+        self.state.lock().waiting_backtrace = Some(backtrace::Backtrace::new_unresolved());
+    }
+
+    pub fn finish_waiting(&self) {
+        self.state.lock().waiting_backtrace.take();
+    }
+
     pub fn forbid_parking(&self) {
         use rand::prelude::*;
 
@@ -500,10 +508,7 @@ impl Foreground {
     #[cfg(any(test, feature = "test-support"))]
     pub fn start_waiting(&self) {
         match self {
-            Self::Deterministic { executor, .. } => {
-                executor.state.lock().waiting_backtrace =
-                    Some(backtrace::Backtrace::new_unresolved());
-            }
+            Self::Deterministic { executor, .. } => executor.start_waiting(),
             _ => panic!("this method can only be called on a deterministic executor"),
         }
     }
@@ -511,9 +516,7 @@ impl Foreground {
     #[cfg(any(test, feature = "test-support"))]
     pub fn finish_waiting(&self) {
         match self {
-            Self::Deterministic { executor, .. } => {
-                executor.state.lock().waiting_backtrace.take();
-            }
+            Self::Deterministic { executor, .. } => executor.finish_waiting(),
             _ => panic!("this method can only be called on a deterministic executor"),
         }
     }


### PR DESCRIPTION
Fixes #1221 
Supersedes and closes #1222 

This pull request prevents deadlocks when e.g., client A performs a request to client B and client B performs a request to client A. If both clients stop processing further messages until their respective request completes, they won't have a chance to respond to the other client's request and cause a deadlock.

By using a `FuturesUnordered` to process foreground messages, we will still attempt to process earlier messages first, but fall back to processing messages arrived later in the spirit of making progress.