### PR TITLE
Don't wait for host's worktree updates if they disconnected

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -230,11 +230,6 @@ impl UserStore {
                 Task::ready(Ok(()))
             }
             UpdateContacts::Update(message) => {
-                log::info!(
-                    "update contacts on client {}: {:?}",
-                    self.client.upgrade().unwrap().id,
-                    message
-                );
                 let mut user_ids = HashSet::default();
                 for contact in &message.contacts {
                     user_ids.insert(contact.user_id);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1343,6 +1343,15 @@ impl Project {
         {
             *sharing_has_stopped = true;
             self.collaborators.clear();
+            for worktree in &self.worktrees {
+                if let Some(worktree) = worktree.upgrade(cx) {
+                    worktree.update(cx, |worktree, _| {
+                        if let Some(worktree) = worktree.as_remote_mut() {
+                            worktree.disconnected_from_host();
+                        }
+                    });
+                }
+            }
             cx.notify();
         }
     }


### PR DESCRIPTION
This fixes a randomized test failure we caught at the ~90k iteration mark 😢 