### PR TITLE
Add Python support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,6 +5278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-python"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d315475c65416274539dd1db9fa2de94918a6ef399dc1287be7cb7bc83dd6d"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-rust"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6030,6 +6040,7 @@ dependencies = [
  "tree-sitter-go",
  "tree-sitter-json 0.20.0",
  "tree-sitter-markdown",
+ "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-toml",
  "tree-sitter-typescript",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d315475c65416274539dd1db9fa2de94918a6ef399dc1287be7cb7bc83dd6d"
+checksum = "713170684ba94376b784b0c6dd23693461e15f96a806ed1848e40996e3cda7c7"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5212,9 +5212,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3b781640108d29892e8b9684642d2cda5ea05951fd58f0fea1db9edeb9b71"
+checksum = "549a9faf45679ad50b7f603253635598cf5e007d8ceb806a23f95355938f76a0"
 dependencies = [
  "cc",
  "regex",

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1902,7 +1902,7 @@ impl BufferSnapshot {
                 }
 
                 while stack.last().map_or(false, |prev_range| {
-                    !prev_range.contains(&item_range.start) || !prev_range.contains(&item_range.end)
+                    prev_range.start > item_range.start || prev_range.end < item_range.end
                 }) {
                     stack.pop();
                 }

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -251,7 +251,7 @@ impl LanguageServer {
         let params = InitializeParams {
             process_id: Default::default(),
             root_path: Default::default(),
-            root_uri: Some(root_uri),
+            root_uri: Some(root_uri.clone()),
             initialization_options: options,
             capabilities: ClientCapabilities {
                 workspace: Some(WorkspaceClientCapabilities {
@@ -312,7 +312,10 @@ impl LanguageServer {
                 ..Default::default()
             },
             trace: Default::default(),
-            workspace_folders: Default::default(),
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: root_uri,
+                name: Default::default(),
+            }]),
             client_info: Default::default(),
             locale: Default::default(),
         };

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -87,7 +87,7 @@ tempdir = { version = "0.3.7" }
 thiserror = "1.0.29"
 tiny_http = "0.8"
 toml = "0.5"
-tree-sitter = "0.20.6"
+tree-sitter = "0.20.7"
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -94,7 +94,7 @@ tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = 
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
 tree-sitter-rust = "0.20.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
-tree-sitter-python = "0.20.0"
+tree-sitter-python = "0.20.1"
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
 tree-sitter-typescript = "0.20.1"
 url = "2.2"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -94,6 +94,7 @@ tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = 
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
 tree-sitter-rust = "0.20.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
+tree-sitter-python = "0.20.0"
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
 tree-sitter-typescript = "0.20.1"
 url = "2.2"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -44,6 +44,11 @@ pub fn build_language_registry(login_shell_env_loaded: Task<()>) -> LanguageRegi
             None, //
         ),
         (
+            "python",
+            tree_sitter_python::language(),
+            None, //
+        ),
+        (
             "rust",
             tree_sitter_rust::language(),
             Some(Arc::new(rust::RustLspAdapter)),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -7,6 +7,7 @@ mod c;
 mod go;
 mod installation;
 mod json;
+mod python;
 mod rust;
 mod typescript;
 
@@ -46,7 +47,7 @@ pub fn build_language_registry(login_shell_env_loaded: Task<()>) -> LanguageRegi
         (
             "python",
             tree_sitter_python::language(),
-            None, //
+            Some(Arc::new(python::PythonLspAdapter)),
         ),
         (
             "rust",

--- a/crates/zed/src/languages/python.rs
+++ b/crates/zed/src/languages/python.rs
@@ -1,0 +1,97 @@
+use super::installation::{npm_install_packages, npm_package_latest_version};
+use anyhow::{anyhow, Context, Result};
+use client::http::HttpClient;
+use futures::{future::BoxFuture, FutureExt, StreamExt};
+use language::{LanguageServerName, LspAdapter};
+use smol::fs;
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::{ResultExt, TryFutureExt};
+
+pub struct PythonLspAdapter;
+
+impl PythonLspAdapter {
+    const BIN_PATH: &'static str = "node_modules/pyright/langserver.index.js";
+}
+
+impl LspAdapter for PythonLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("pyright".into())
+    }
+
+    fn server_args(&self) -> &[&str] {
+        &["--stdio"]
+    }
+
+    fn fetch_latest_server_version(
+        &self,
+        _: Arc<dyn HttpClient>,
+    ) -> BoxFuture<'static, Result<Box<dyn 'static + Any + Send>>> {
+        async move { Ok(Box::new(npm_package_latest_version("pyright").await?) as Box<_>) }.boxed()
+    }
+
+    fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        _: Arc<dyn HttpClient>,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Result<PathBuf>> {
+        let version = version.downcast::<String>().unwrap();
+        async move {
+            let version_dir = container_dir.join(version.as_str());
+            fs::create_dir_all(&version_dir)
+                .await
+                .context("failed to create version directory")?;
+            let binary_path = version_dir.join(Self::BIN_PATH);
+
+            if fs::metadata(&binary_path).await.is_err() {
+                npm_install_packages([("pyright", version.as_str())], &version_dir).await?;
+
+                if let Some(mut entries) = fs::read_dir(&container_dir).await.log_err() {
+                    while let Some(entry) = entries.next().await {
+                        if let Some(entry) = entry.log_err() {
+                            let entry_path = entry.path();
+                            if entry_path.as_path() != version_dir {
+                                fs::remove_dir_all(&entry_path).await.log_err();
+                            }
+                        }
+                    }
+                }
+            }
+
+            Ok(binary_path)
+        }
+        .boxed()
+    }
+
+    fn cached_server_binary(
+        &self,
+        container_dir: Arc<Path>,
+    ) -> BoxFuture<'static, Option<PathBuf>> {
+        async move {
+            let mut last_version_dir = None;
+            let mut entries = fs::read_dir(&container_dir).await?;
+            while let Some(entry) = entries.next().await {
+                let entry = entry?;
+                if entry.file_type().await?.is_dir() {
+                    last_version_dir = Some(entry.path());
+                }
+            }
+            let last_version_dir = last_version_dir.ok_or_else(|| anyhow!("no cached binary"))?;
+            let bin_path = last_version_dir.join(Self::BIN_PATH);
+            if bin_path.exists() {
+                Ok(bin_path)
+            } else {
+                Err(anyhow!(
+                    "missing executable in directory {:?}",
+                    last_version_dir
+                ))
+            }
+        }
+        .log_err()
+        .boxed()
+    }
+}

--- a/crates/zed/src/languages/python/brackets.scm
+++ b/crates/zed/src/languages/python/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/crates/zed/src/languages/python/config.toml
+++ b/crates/zed/src/languages/python/config.toml
@@ -1,5 +1,5 @@
 name = "Python"
-path_suffixes = ["py"]
+path_suffixes = ["py", "pyi"]
 line_comment = "# "
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/crates/zed/src/languages/python/config.toml
+++ b/crates/zed/src/languages/python/config.toml
@@ -1,0 +1,11 @@
+name = "Python"
+path_suffixes = ["py"]
+line_comment = "# "
+autoclose_before = ";:.,=}])>"
+brackets = [
+  { start = "{", end = "}", close = true, newline = true },
+  { start = "[", end = "]", close = true, newline = true },
+  { start = "(", end = ")", close = true, newline = true },
+  { start = "\"", end = "\"", close = true, newline = false },
+  { start = "'", end = "'", close = false, newline = false },
+]

--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -17,8 +17,8 @@
 
 ; Identifier naming conventions
 
-((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z_]*$"))

--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -1,0 +1,125 @@
+(attribute attribute: (identifier) @property)
+(type (identifier) @type)
+
+; Function calls
+
+(decorator) @function
+
+(call
+  function: (attribute attribute: (identifier) @function.method))
+(call
+  function: (identifier) @function)
+
+; Function definitions
+
+(function_definition
+  name: (identifier) @function)
+
+; Identifier naming conventions
+
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z_]*$"))
+
+; Builtin functions
+
+((call
+  function: (identifier) @function.builtin)
+ (#match?
+   @function.builtin
+   "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
+
+; Literals
+
+[
+  (none)
+  (true)
+  (false)
+] @constant.builtin
+
+[
+  (integer)
+  (float)
+] @number
+
+(comment) @comment
+(string) @string
+(escape_sequence) @escape
+
+(interpolation
+  "{" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  "-"
+  "-="
+  "!="
+  "*"
+  "**"
+  "**="
+  "*="
+  "/"
+  "//"
+  "//="
+  "/="
+  "&"
+  "%"
+  "%="
+  "^"
+  "+"
+  "->"
+  "+="
+  "<"
+  "<<"
+  "<="
+  "<>"
+  "="
+  ":="
+  "=="
+  ">"
+  ">="
+  ">>"
+  "|"
+  "~"
+  "and"
+  "in"
+  "is"
+  "not"
+  "or"
+] @operator
+
+[
+  "as"
+  "assert"
+  "async"
+  "await"
+  "break"
+  "class"
+  "continue"
+  "def"
+  "del"
+  "elif"
+  "else"
+  "except"
+  "exec"
+  "finally"
+  "for"
+  "from"
+  "global"
+  "if"
+  "import"
+  "lambda"
+  "nonlocal"
+  "pass"
+  "print"
+  "raise"
+  "return"
+  "try"
+  "while"
+  "with"
+  "yield"
+  "match"
+  "case"
+] @keyword

--- a/crates/zed/src/languages/python/indents.scm
+++ b/crates/zed/src/languages/python/indents.scm
@@ -1,6 +1,4 @@
-(class_definition body: (block)) @indent
-(function_definition body: (block)) @indent
-
+(_ (block)) @indent
 (_ "[" "]" @end) @indent
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent

--- a/crates/zed/src/languages/python/indents.scm
+++ b/crates/zed/src/languages/python/indents.scm
@@ -1,0 +1,6 @@
+(class_definition body: (block)) @indent
+(function_definition body: (block)) @indent
+
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent

--- a/crates/zed/src/languages/python/outline.scm
+++ b/crates/zed/src/languages/python/outline.scm
@@ -1,0 +1,9 @@
+(class_definition
+    "class" @context
+    name: (identifier) @name
+    ) @item
+
+(function_definition
+    "async"? @context
+    "def" @context
+    name: (_) @name) @item

--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -171,6 +171,10 @@ export function createTheme(
       color: sample(ramps.cyan, 0.5),
       weight: fontWeights.normal,
     },
+    constructor: {
+      color: sample(ramps.blue, 0.5),
+      weight: fontWeights.normal,
+    },
     variant: {
       color: sample(ramps.blue, 0.5),
       weight: fontWeights.normal,


### PR DESCRIPTION
This PR adds basic support for Python, with [pyright](https://github.com/microsoft/pyright) as the language server.

From my basic testing, Pyright seems to work out-of-the box, though there seems to be support for [configuration](https://github.com/microsoft/pyright/blob/main/docs/configuration.md) via the `pyproject.toml` or `pyrightconfig.json ` files.

Todo:

* [x] highlight project symbols
* [x] highlight completions
