### PR TITLE
Use NonZeroU32 to ensure settings tabsize cannot be zero

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -13,7 +13,7 @@ use gpui::{
 };
 use language::{Point, Subscription as BufferSubscription};
 use settings::Settings;
-use std::{any::TypeId, fmt::Debug, ops::Range, sync::Arc};
+use std::{any::TypeId, fmt::Debug, num::NonZeroU32, ops::Range, sync::Arc};
 use sum_tree::{Bias, TreeMap};
 use tab_map::TabMap;
 use wrap_map::WrapMap;
@@ -203,7 +203,7 @@ impl DisplayMap {
             .update(cx, |map, cx| map.set_wrap_width(width, cx))
     }
 
-    fn tab_size(buffer: &ModelHandle<MultiBuffer>, cx: &mut ModelContext<Self>) -> u32 {
+    fn tab_size(buffer: &ModelHandle<MultiBuffer>, cx: &mut ModelContext<Self>) -> NonZeroU32 {
         let language_name = buffer
             .read(cx)
             .as_singleton()
@@ -966,7 +966,7 @@ pub mod tests {
         language.set_theme(&theme);
         cx.update(|cx| {
             let mut settings = Settings::test(cx);
-            settings.language_settings.tab_size = Some(2);
+            settings.language_settings.tab_size = Some(2.try_into().unwrap());
             cx.set_global(settings);
         });
 

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1025,7 +1025,7 @@ mod tests {
         let buffer_snapshot = buffer.read(cx).snapshot(cx);
         let subscription = buffer.update(cx, |buffer, _| buffer.subscribe());
         let (fold_map, folds_snapshot) = FoldMap::new(buffer_snapshot.clone());
-        let (tab_map, tabs_snapshot) = TabMap::new(folds_snapshot.clone(), 1);
+        let (tab_map, tabs_snapshot) = TabMap::new(folds_snapshot.clone(), 1.try_into().unwrap());
         let (wrap_map, wraps_snapshot) = WrapMap::new(tabs_snapshot, font_id, 14.0, None, cx);
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
@@ -1170,7 +1170,8 @@ mod tests {
 
         let (folds_snapshot, fold_edits) =
             fold_map.read(buffer_snapshot, subscription.consume().into_inner());
-        let (tabs_snapshot, tab_edits) = tab_map.sync(folds_snapshot, fold_edits, 4);
+        let (tabs_snapshot, tab_edits) =
+            tab_map.sync(folds_snapshot, fold_edits, 4.try_into().unwrap());
         let (wraps_snapshot, wrap_edits) = wrap_map.update(cx, |wrap_map, cx| {
             wrap_map.sync(tabs_snapshot, tab_edits, cx)
         });
@@ -1193,7 +1194,7 @@ mod tests {
         let buffer = MultiBuffer::build_simple(text, cx);
         let buffer_snapshot = buffer.read(cx).snapshot(cx);
         let (_, folds_snapshot) = FoldMap::new(buffer_snapshot.clone());
-        let (_, tabs_snapshot) = TabMap::new(folds_snapshot.clone(), 1);
+        let (_, tabs_snapshot) = TabMap::new(folds_snapshot.clone(), 1.try_into().unwrap());
         let (_, wraps_snapshot) = WrapMap::new(tabs_snapshot, font_id, 14.0, Some(60.), cx);
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
@@ -1237,7 +1238,7 @@ mod tests {
         } else {
             Some(rng.gen_range(0.0..=100.0))
         };
-        let tab_size = 1;
+        let tab_size = 1.try_into().unwrap();
         let family_id = cx.font_cache().load_family(&["Helvetica"]).unwrap();
         let font_id = cx
             .font_cache()

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -1033,7 +1033,7 @@ mod tests {
     use rand::prelude::*;
     use settings::Settings;
     use smol::stream::StreamExt;
-    use std::{cmp, env};
+    use std::{cmp, env, num::NonZeroU32};
     use text::Rope;
 
     #[gpui::test(iterations = 100)]
@@ -1052,7 +1052,7 @@ mod tests {
         } else {
             Some(rng.gen_range(0.0..=1000.0))
         };
-        let tab_size = rng.gen_range(1..=4);
+        let tab_size = NonZeroU32::new(rng.gen_range(1..=4)).unwrap();
         let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
         let font_id = font_cache
             .select_font(family_id, &Default::default())
@@ -1194,7 +1194,7 @@ mod tests {
                     log::info!("{} summary: {:?}", ix, item.summary.output,);
                 }
 
-                if tab_size == 1
+                if tab_size.get() == 1
                     || !wrapped_snapshot
                         .tab_snapshot
                         .fold_snapshot

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -347,7 +347,7 @@ impl MultiBuffer {
                     let indent_size = if settings.hard_tabs(language_name.as_deref()) {
                         IndentSize::tab()
                     } else {
-                        IndentSize::spaces(settings.tab_size(language_name.as_deref()))
+                        IndentSize::spaces(settings.tab_size(language_name.as_deref()).get())
                     };
                     buffer.edit_with_autoindent(edits, indent_size, cx);
                 } else {
@@ -473,7 +473,7 @@ impl MultiBuffer {
                         let indent_size = if settings.hard_tabs(language_name.as_deref()) {
                             IndentSize::tab()
                         } else {
-                            IndentSize::spaces(settings.tab_size(language_name.as_deref()))
+                            IndentSize::spaces(settings.tab_size(language_name.as_deref()).get())
                         };
 
                         buffer.edit_with_autoindent(deletions, indent_size, cx);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2848,7 +2848,7 @@ impl Project {
                         .request::<lsp::request::Formatting>(lsp::DocumentFormattingParams {
                             text_document,
                             options: lsp::FormattingOptions {
-                                tab_size,
+                                tab_size: tab_size.into(),
                                 insert_spaces: true,
                                 insert_final_newline: Some(true),
                                 ..Default::default()
@@ -2870,7 +2870,7 @@ impl Project {
                                 text_document,
                                 range: lsp::Range::new(buffer_start, buffer_end),
                                 options: lsp::FormattingOptions {
-                                    tab_size,
+                                    tab_size: tab_size.into(),
                                     insert_spaces: true,
                                     insert_final_newline: Some(true),
                                     ..Default::default()

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -11,7 +11,7 @@ use schemars::{
 };
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, num::NonZeroU32, sync::Arc};
 use theme::{Theme, ThemeRegistry};
 use util::ResultExt as _;
 
@@ -32,7 +32,7 @@ pub struct Settings {
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
 pub struct LanguageSettings {
-    pub tab_size: Option<u32>,
+    pub tab_size: Option<NonZeroU32>,
     pub hard_tabs: Option<bool>,
     pub soft_wrap: Option<SoftWrap>,
     pub preferred_line_length: Option<u32>,
@@ -99,9 +99,9 @@ impl Settings {
         self
     }
 
-    pub fn tab_size(&self, language: Option<&str>) -> u32 {
+    pub fn tab_size(&self, language: Option<&str>) -> NonZeroU32 {
         self.language_setting(language, |settings| settings.tab_size)
-            .unwrap_or(4)
+            .unwrap_or(4.try_into().unwrap())
     }
 
     pub fn hard_tabs(&self, language: Option<&str>) -> bool {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -83,21 +83,21 @@ fn main() {
         .with_language_defaults(
             "C",
             settings::LanguageSettings {
-                tab_size: Some(2),
+                tab_size: Some(2.try_into().unwrap()),
                 ..Default::default()
             },
         )
         .with_language_defaults(
             "C++",
             settings::LanguageSettings {
-                tab_size: Some(2),
+                tab_size: Some(2.try_into().unwrap()),
                 ..Default::default()
             },
         )
         .with_language_defaults(
             "Go",
             settings::LanguageSettings {
-                tab_size: Some(4),
+                tab_size: Some(4.try_into().unwrap()),
                 hard_tabs: Some(true),
                 ..Default::default()
             },
@@ -112,28 +112,28 @@ fn main() {
         .with_language_defaults(
             "Rust",
             settings::LanguageSettings {
-                tab_size: Some(4),
+                tab_size: Some(4.try_into().unwrap()),
                 ..Default::default()
             },
         )
         .with_language_defaults(
             "JavaScript",
             settings::LanguageSettings {
-                tab_size: Some(2),
+                tab_size: Some(2.try_into().unwrap()),
                 ..Default::default()
             },
         )
         .with_language_defaults(
             "TypeScript",
             settings::LanguageSettings {
-                tab_size: Some(2),
+                tab_size: Some(2.try_into().unwrap()),
                 ..Default::default()
             },
         )
         .with_language_defaults(
             "TSX",
             settings::LanguageSettings {
-                tab_size: Some(2),
+                tab_size: Some(2.try_into().unwrap()),
                 ..Default::default()
             },
         );

--- a/crates/zed/src/settings_file.rs
+++ b/crates/zed/src/settings_file.rs
@@ -128,7 +128,7 @@ mod tests {
         let settings = cx.read(Settings::test).with_language_defaults(
             "JavaScript",
             LanguageSettings {
-                tab_size: Some(2),
+                tab_size: Some(2.try_into().unwrap()),
                 ..Default::default()
             },
         );
@@ -156,9 +156,9 @@ mod tests {
         assert_eq!(settings.preferred_line_length(Some("Markdown")), 100);
         assert_eq!(settings.preferred_line_length(Some("JavaScript")), 80);
 
-        assert_eq!(settings.tab_size(None), 8);
-        assert_eq!(settings.tab_size(Some("Markdown")), 2);
-        assert_eq!(settings.tab_size(Some("JavaScript")), 8);
+        assert_eq!(settings.tab_size(None).get(), 8);
+        assert_eq!(settings.tab_size(Some("Markdown")).get(), 2);
+        assert_eq!(settings.tab_size(Some("JavaScript")).get(), 8);
 
         fs.save(
             "/settings2.json".as_ref(),
@@ -192,9 +192,9 @@ mod tests {
         assert_eq!(settings.preferred_line_length(Some("Markdown")), 120);
         assert_eq!(settings.preferred_line_length(Some("JavaScript")), 80);
 
-        assert_eq!(settings.tab_size(None), 2);
-        assert_eq!(settings.tab_size(Some("Markdown")), 2);
-        assert_eq!(settings.tab_size(Some("JavaScript")), 2);
+        assert_eq!(settings.tab_size(None).get(), 2);
+        assert_eq!(settings.tab_size(Some("Markdown")).get(), 2);
+        assert_eq!(settings.tab_size(Some("JavaScript")).get(), 2);
 
         fs.remove_file("/settings2.json".as_ref(), Default::default())
             .await
@@ -217,8 +217,8 @@ mod tests {
         assert_eq!(settings.preferred_line_length(Some("Markdown")), 100);
         assert_eq!(settings.preferred_line_length(Some("JavaScript")), 80);
 
-        assert_eq!(settings.tab_size(None), 8);
-        assert_eq!(settings.tab_size(Some("Markdown")), 2);
-        assert_eq!(settings.tab_size(Some("JavaScript")), 8);
+        assert_eq!(settings.tab_size(None).get(), 8);
+        assert_eq!(settings.tab_size(Some("Markdown")).get(), 2);
+        assert_eq!(settings.tab_size(Some("JavaScript")).get(), 8);
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -166,6 +166,9 @@ pub fn initialize_workspace(
         let action_names = cx.all_action_names().collect::<Vec<_>>();
         project.set_language_server_settings(serde_json::json!({
             "json": {
+                "format": {
+                    "enable": true,
+                },
                 "schemas": [
                     {
                         "fileMatch": [".zed/settings.json"],


### PR DESCRIPTION
Note: this does technically modify the json schema to include the bound (schemars does this automatically) but for some reason the json language server isn't producing diagnostics to match.