### PR TITLE
Allow diagnostics to be published for hidden worktrees

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -995,9 +995,9 @@ impl Workspace {
         // Sort the paths to ensure we add worktrees for parents before their children.
         abs_paths.sort_unstable();
         cx.spawn(|this, mut cx| async move {
-            let mut entries = Vec::new();
+            let mut project_paths = Vec::new();
             for path in &abs_paths {
-                entries.push(
+                project_paths.push(
                     this.update(&mut cx, |this, cx| {
                         this.project_path_for_path(path, visible, cx)
                     })
@@ -1009,7 +1009,7 @@ impl Workspace {
             let tasks = abs_paths
                 .iter()
                 .cloned()
-                .zip(entries.into_iter())
+                .zip(project_paths.into_iter())
                 .map(|(abs_path, project_path)| {
                     let this = this.clone();
                     cx.spawn(|mut cx| {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/1233

Previously, we explicitly ignored diagnostics that were published for "hidden" worktrees in the project. There are several cases where we add hidden worktrees to a project:
* When jumping to a file outside your project via go-to-definition or find-all-refs
* Opening your settings
* Opening the keymap

I think that the reason that we explicitly ignored these diagnostics is that we don't want them to be counted in the project-level diagnostic count indicator, or to show up in the project diagnostics view. The way that I think of it is that hidden worktrees are, in some sense, not *really* a part of the project.

I think the proper behavior is to show the diagnostics when editing buffers from hidden worktrees, but to avoid including these diagnostics in the projects' diagnostic summary, or the project diagnostics view.

* [x] Allow diagnostics to be updated on hidden worktrees
* [x] Avoid including hidden worktrees' diagnostics in project's diagnostic summary
* [x] Unit test
