### PR TITLE
Reduce memory footprint on server

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -228,8 +228,8 @@ impl Server {
                 );
                 span.in_scope(|| {
                     tracing::info!(
-                        payload = format!("{:?}", envelope.payload).as_str(),
-                        "message payload"
+                        payload_type = envelope.payload_type_name(),
+                        "message received"
                     );
                 });
                 let future = (handler)(server, *envelope);

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -24,7 +24,7 @@ use std::{
 };
 use tracing::instrument;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 pub struct ConnectionId(pub u32);
 
 impl fmt::Display for ConnectionId {


### PR DESCRIPTION
The biggest culprit was tracing message payloads: the reason for that is that `tracing` would allocate a buffer for formatting messages that was long-lived. Receiving large worktree update messages would make that buffer grow. I guess it's not that big of a deal because it's not exactly a memory leak: it will plateau at some point, it's just a bummer to have >1gb of memory allocated for no reason and makes our life a lot harder when investigating memory problems.

We will now log only message types, which should be enough to investigate most problems.