### PR TITLE
Introduce `pane::ReopenClosedItem` bound to `cmd-shift-t`

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -212,6 +212,7 @@
         "bindings": {
             "ctrl--": "pane::GoBack",
             "shift-ctrl-_": "pane::GoForward",
+            "cmd-shift-T": "pane::ReopenClosedItem",
             "cmd-shift-F": "project_search::ToggleFocus"
         }
     },

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -83,7 +83,9 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(|pane: &mut Pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx));
     cx.add_action(|pane: &mut Pane, _: &SplitRight, cx| pane.split(SplitDirection::Right, cx));
     cx.add_action(|pane: &mut Pane, _: &SplitDown, cx| pane.split(SplitDirection::Down, cx));
-    cx.add_action(Pane::reopen_closed_item);
+    cx.add_action(|workspace: &mut Workspace, _: &ReopenClosedItem, cx| {
+        Pane::reopen_closed_item(workspace, cx).detach();
+    });
     cx.add_action(|workspace: &mut Workspace, action: &GoBack, cx| {
         Pane::go_back(
             workspace,
@@ -207,16 +209,14 @@ impl Pane {
 
     pub fn reopen_closed_item(
         workspace: &mut Workspace,
-        _: &ReopenClosedItem,
         cx: &mut ViewContext<Workspace>,
-    ) {
+    ) -> Task<()> {
         Self::navigate_history(
             workspace,
             workspace.active_pane().clone(),
             NavigationMode::ReopeningClosed,
             cx,
         )
-        .detach();
     }
 
     fn navigate_history(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -147,7 +147,7 @@ enum NavigationMode {
     GoingBack,
     GoingForward,
     ClosingItem,
-    ReopeningClosed,
+    ReopeningClosedItem,
     Disabled,
 }
 
@@ -214,7 +214,7 @@ impl Pane {
         Self::navigate_history(
             workspace,
             workspace.active_pane().clone(),
-            NavigationMode::ReopeningClosed,
+            NavigationMode::ReopeningClosedItem,
             cx,
         )
     }
@@ -968,7 +968,7 @@ impl NavHistory {
             NavigationMode::Normal | NavigationMode::Disabled | NavigationMode::ClosingItem => None,
             NavigationMode::GoingBack => self.pop_backward(),
             NavigationMode::GoingForward => self.pop_forward(),
-            NavigationMode::ReopeningClosed => self.pop_closed(),
+            NavigationMode::ReopeningClosedItem => self.pop_closed(),
         }
     }
 
@@ -979,7 +979,7 @@ impl NavHistory {
     pub fn push<D: 'static + Any>(&mut self, data: Option<D>, item: Rc<dyn WeakItemHandle>) {
         match self.mode {
             NavigationMode::Disabled => {}
-            NavigationMode::Normal | NavigationMode::ReopeningClosed => {
+            NavigationMode::Normal | NavigationMode::ReopeningClosedItem => {
                 if self.backward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
                     self.backward_stack.pop_front();
                 }


### PR DESCRIPTION
Closes https://github.com/zed-industries/feedback/issues/33

This pull request introduces the ability to re-open closed items on a pane. This was implemented re-using the same history logic we use for navigation and leaning on calling `Item::deactivate` when closing an item. As with other navigation facilities, reopening closed items works on a per-pane fashion.