### PR TITLE
Adjust pane, tab, panel management bindings to match VS Code

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -210,6 +210,43 @@
     {
         "context": "Pane",
         "bindings": {
+            "ctrl-1": [
+                "pane::ActivateItem",
+                0
+            ],
+            "ctrl-2": [
+                "pane::ActivateItem",
+                1
+            ],
+            "ctrl-3": [
+                "pane::ActivateItem",
+                2
+            ],
+            "ctrl-4": [
+                "pane::ActivateItem",
+                3
+            ],
+            "ctrl-5": [
+                "pane::ActivateItem",
+                4
+            ],
+            "ctrl-6": [
+                "pane::ActivateItem",
+                5
+            ],
+            "ctrl-7": [
+                "pane::ActivateItem",
+                6
+            ],
+            "ctrl-8": [
+                "pane::ActivateItem",
+                7
+            ],
+            "ctrl-9": [
+                "pane::ActivateItem",
+                8
+            ],
+            "ctrl-0": "pane::ActivateLastItem",
             "ctrl--": "pane::GoBack",
             "shift-ctrl-_": "pane::GoForward",
             "cmd-shift-T": "pane::ReopenClosedItem",
@@ -219,6 +256,43 @@
     {
         "context": "Workspace",
         "bindings": {
+            "cmd-1": [
+                "workspace::ActivatePane",
+                0
+            ],
+            "cmd-2": [
+                "workspace::ActivatePane",
+                1
+            ],
+            "cmd-3": [
+                "workspace::ActivatePane",
+                2
+            ],
+            "cmd-4": [
+                "workspace::ActivatePane",
+                3
+            ],
+            "cmd-5": [
+                "workspace::ActivatePane",
+                4
+            ],
+            "cmd-6": [
+                "workspace::ActivatePane",
+                5
+            ],
+            "cmd-7": [
+                "workspace::ActivatePane",
+                6
+            ],
+            "cmd-8": [
+                "workspace::ActivatePane",
+                7
+            ],
+            "cmd-9": [
+                "workspace::ActivatePane",
+                8
+            ],
+            "cmd-b": "workspace::ToggleLeftSidebar",
             "cmd-shift-F": "project_search::Deploy",
             "cmd-k cmd-t": "theme_selector::Toggle",
             "cmd-k cmd-s": "zed::OpenKeymap",
@@ -226,6 +300,7 @@
             "cmd-p": "file_finder::Toggle",
             "cmd-shift-P": "command_palette::Toggle",
             "cmd-shift-M": "diagnostics::Deploy",
+            "cmd-shift-E": "project_panel::Toggle",
             "cmd-alt-s": "workspace::SaveAll"
         }
     },
@@ -310,34 +385,8 @@
     {
         "context": "Workspace",
         "bindings": {
-            "cmd-1": [
-                "workspace::ToggleSidebarItemFocus",
-                {
-                    "side": "Left",
-                    "item_index": 0
-                }
-            ],
-            "cmd-shift-!": [
-                "workspace::ToggleSidebarItem",
-                {
-                    "side": "Left",
-                    "item_index": 0
-                }
-            ],
-            "cmd-9": [
-                "workspace::ToggleSidebarItemFocus",
-                {
-                    "side": "Right",
-                    "item_index": 0
-                }
-            ],
-            "cmd-shift-(": [
-                "workspace::ToggleSidebarItem",
-                {
-                    "side": "Right",
-                    "item_index": 0
-                }
-            ]
+            "cmd-shift-C": "contacts_panel::Toggle",
+            "cmd-shift-B": "workspace::ToggleRightSidebar"
         }
     },
     {

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -13,6 +13,8 @@
             "ctrl-c": "menu::Cancel",
             "shift-cmd-{": "pane::ActivatePrevItem",
             "shift-cmd-}": "pane::ActivateNextItem",
+            "alt-cmd-left": "pane::ActivatePrevItem",
+            "alt-cmd-right": "pane::ActivateNextItem",
             "cmd-w": "pane::CloseActiveItem",
             "cmd-shift-W": "workspace::CloseWindow",
             "alt-cmd-t": "pane::CloseInactiveItems",

--- a/crates/contacts_panel/src/contacts_panel.rs
+++ b/crates/contacts_panel/src/contacts_panel.rs
@@ -8,6 +8,7 @@ use contact_notification::ContactNotification;
 use editor::{Cancel, Editor};
 use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{
+    actions,
     elements::*,
     geometry::{rect::RectF, vector::vec2f},
     impl_actions, impl_internal_actions,
@@ -23,6 +24,8 @@ use settings::Settings;
 use std::{ops::DerefMut, sync::Arc};
 use theme::IconButton;
 use workspace::{sidebar::SidebarItem, JoinProject, ToggleProjectOnline, Workspace};
+
+actions!(contacts_panel, [Toggle]);
 
 impl_actions!(
     contacts_panel,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -108,7 +108,8 @@ actions!(
         Cut,
         Paste,
         Delete,
-        Rename
+        Rename,
+        Toggle
     ]
 );
 impl_internal_actions!(project_panel, [Open, ToggleExpanded, DeployContextMenu]);

--- a/crates/workspace/src/waiting_room.rs
+++ b/crates/workspace/src/waiting_room.rs
@@ -1,7 +1,4 @@
-use crate::{
-    sidebar::{Side, ToggleSidebarItem},
-    AppState, ToggleFollow, Workspace,
-};
+use crate::{sidebar::Side, AppState, ToggleFollow, Workspace};
 use anyhow::Result;
 use client::{proto, Client, Contact};
 use gpui::{
@@ -104,13 +101,7 @@ impl WaitingRoom {
                                             &app_state,
                                             cx,
                                         );
-                                        workspace.toggle_sidebar_item(
-                                            &ToggleSidebarItem {
-                                                side: Side::Left,
-                                                item_index: 0,
-                                            },
-                                            cx,
-                                        );
+                                        workspace.toggle_sidebar(Side::Left, cx);
                                         if let Some((host_peer_id, _)) =
                                             workspace.project.read(cx).collaborators().iter().find(
                                                 |(_, collaborator)| collaborator.replica_id == 0,

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -194,6 +194,27 @@ pub fn menus() -> Vec<Menu<'static>> {
                     name: "Toggle Right Sidebar",
                     action: Box::new(workspace::ToggleRightSidebar),
                 },
+                MenuItem::Submenu(Menu {
+                    name: "Editor Layout",
+                    items: vec![
+                        MenuItem::Action {
+                            name: "Split Up",
+                            action: Box::new(workspace::SplitUp),
+                        },
+                        MenuItem::Action {
+                            name: "Split Down",
+                            action: Box::new(workspace::SplitDown),
+                        },
+                        MenuItem::Action {
+                            name: "Split Left",
+                            action: Box::new(workspace::SplitLeft),
+                        },
+                        MenuItem::Action {
+                            name: "Split Right",
+                            action: Box::new(workspace::SplitRight),
+                        },
+                    ],
+                }),
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Project Panel",

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -187,11 +187,21 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
-                    name: "Project Browser",
-                    action: Box::new(workspace::sidebar::ToggleSidebarItemFocus {
-                        side: workspace::sidebar::Side::Left,
-                        item_index: 0,
-                    }),
+                    name: "Toggle Left Sidebar",
+                    action: Box::new(workspace::ToggleLeftSidebar),
+                },
+                MenuItem::Action {
+                    name: "Toggle Right Sidebar",
+                    action: Box::new(workspace::ToggleRightSidebar),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Project Panel",
+                    action: Box::new(project_panel::Toggle),
+                },
+                MenuItem::Action {
+                    name: "Contacts Panel",
+                    action: Box::new(contacts_panel::Toggle),
                 },
                 MenuItem::Action {
                     name: "Command Palette",

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -34,7 +34,7 @@ use std::{
 };
 use util::ResultExt;
 pub use workspace;
-use workspace::{AppState, Workspace};
+use workspace::{sidebar::Side, AppState, Workspace};
 
 #[derive(Deserialize, Clone, PartialEq)]
 struct OpenBrowser {
@@ -126,6 +126,16 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
                     cx,
                 );
             }
+        },
+    );
+    cx.add_action(
+        |workspace: &mut Workspace, _: &project_panel::Toggle, cx: &mut ViewContext<Workspace>| {
+            workspace.toggle_sidebar_item_focus(Side::Left, 0, cx);
+        },
+    );
+    cx.add_action(
+        |workspace: &mut Workspace, _: &contacts_panel::Toggle, cx: &mut ViewContext<Workspace>| {
+            workspace.toggle_sidebar_item_focus(Side::Right, 0, cx);
         },
     );
 
@@ -429,7 +439,7 @@ mod tests {
         let workspace_1 = cx.root_view::<Workspace>(cx.window_ids()[0]).unwrap();
         workspace_1.update(cx, |workspace, cx| {
             assert_eq!(workspace.worktrees(cx).count(), 2);
-            assert!(workspace.left_sidebar().read(cx).active_item().is_some());
+            assert!(workspace.left_sidebar().read(cx).is_open());
             assert!(workspace.active_pane().is_focused(cx));
         });
 


### PR DESCRIPTION
Closes zed-industries/feedback#156

Bindings that exactly match VS Code's:

| action| binding |
|-------|--------|
| Activate an existing pane | `cmd-1`, `cmd-2`, `cmd-3`... |
| Create a new pane | `cmd`+ a number greater than the current pane count |
| Activate items in the current pane | `ctrl-1`, `ctrl-2`, `ctrl-3`... |
| Activate the *last* item in the current pane| `ctrl-0` |
| Focus the project panel | `cmd-shift-E` ("**e**xplorer") |
| Toggle the left sidebar | `cmd-b` ("**b**ar") |

Similar bindings for concepts that don't exist in VS Code:

| action| binding |
|-------|--------|
| Focus the contacts panel | `cmd-shift-C` ("**c**ontacts") |
| Toggle the right sidebar | `cmd-shift-B` (another "**b**ar") |
