### PR TITLE
Minor vim fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5768,6 +5768,7 @@ dependencies = [
  "language",
  "log",
  "project",
+ "search",
  "serde",
  "settings",
  "util",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -37,16 +37,12 @@
                     "ignorePunctuation": true
                 }
             ],
-            "escape": [
-                "vim::SwitchMode",
-                "Normal"
-            ]
+            "escape": "editor::Cancel"
         }
     },
     {
-        "context": "Editor && vim_mode == normal",
+        "context": "Editor && vim_mode == normal && vim_operator == none",
         "bindings": {
-            "escape": "editor::Cancel",
             "c": [
                 "vim::PushOperator",
                 "Change"
@@ -92,7 +88,13 @@
             "p": "vim::Paste",
             "u": "editor::Undo",
             "ctrl-r": "editor::Redo",
-            "ctrl-o": "pane::GoBack"
+            "ctrl-o": "pane::GoBack",
+            "/": [
+                "buffer_search::Deploy",
+                {
+                    "focus": true
+                }
+            ]
         }
     },
     {
@@ -145,12 +147,6 @@
         "bindings": {
             "escape": "vim::NormalBefore",
             "ctrl-c": "vim::NormalBefore"
-        }
-    },
-    {
-        "context": "Editor && mode == singleline",
-        "bindings": {
-            "escape": "editor::Cancel"
         }
     }
 ]

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -58,7 +58,7 @@ fn add_toggle_option_action<A: Action>(option: SearchOption, cx: &mut MutableApp
 }
 
 pub struct BufferSearchBar {
-    query_editor: ViewHandle<Editor>,
+    pub query_editor: ViewHandle<Editor>,
     active_editor: Option<ViewHandle<Editor>>,
     active_match_index: Option<usize>,
     active_editor_subscription: Option<Subscription>,

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -14,6 +14,7 @@ command_palette = { path = "../command_palette" }
 editor = { path = "../editor" }
 gpui = { path = "../gpui" }
 language = { path = "../language" }
+search = { path = "../search" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 settings = { path = "../settings" }
 workspace = { path = "../workspace" }

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -29,8 +29,17 @@ fn editor_focused(EditorFocused(editor): &EditorFocused, cx: &mut MutableAppCont
             }
         }));
 
-        if editor.read(cx).mode() != EditorMode::Full {
-            vim.switch_mode(Mode::Insert, cx);
+        if !vim.enabled {
+            return;
+        }
+
+        let editor = editor.read(cx);
+        if editor.selections.newest::<usize>(cx).is_empty() {
+            if editor.mode() != EditorMode::Full {
+                vim.switch_mode(Mode::Insert, cx);
+            }
+        } else {
+            vim.switch_mode(Mode::Visual { line: false }, cx);
         }
     });
 }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1165,7 +1165,7 @@ mod test {
                 The quick brown
                 fox [jump}s over
                 the lazy dog"},
-            Mode::Normal,
+            Mode::Visual { line: false },
         );
         cx.simulate_keystroke("y");
         cx.set_state(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -97,6 +97,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     cx.add_action({
         let app_state = app_state.clone();
         move |_: &mut Workspace, _: &OpenSettings, cx: &mut ViewContext<Workspace>| {
+            println!("open settings");
             open_config_file(&SETTINGS_PATH, app_state.clone(), cx);
         }
     });

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "styles",
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {


### PR DESCRIPTION
Cancels pending normal mode operators when pressing escape or an unbound key
Addresses issues with clearing selections when focusing a new single line editor (buffer search, rename, etc)