### PR TITLE
Fix problems that arise when large numbers of files change on disk

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -28,10 +28,7 @@ use std::{
     convert::TryFrom,
     fmt::Write as _,
     future::Future,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, Weak,
-    },
+    sync::{Arc, Weak},
     time::{Duration, Instant},
 };
 use thiserror::Error;
@@ -232,12 +229,8 @@ impl Drop for Subscription {
 
 impl Client {
     pub fn new(http: Arc<dyn HttpClient>) -> Arc<Self> {
-        lazy_static! {
-            static ref NEXT_CLIENT_ID: AtomicUsize = AtomicUsize::default();
-        }
-
         Arc::new(Self {
-            id: NEXT_CLIENT_ID.fetch_add(1, Ordering::SeqCst),
+            id: 0,
             peer: Peer::new(),
             http,
             state: Default::default(),
@@ -255,6 +248,12 @@ impl Client {
 
     pub fn http_client(&self) -> Arc<dyn HttpClient> {
         self.http.clone()
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn set_id(&mut self, id: usize) -> &Self {
+        self.id = id;
+        self
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -2117,7 +2117,7 @@ pub mod tests {
             Self {
                 background,
                 users: Default::default(),
-                next_user_id: Mutex::new(1),
+                next_user_id: Mutex::new(0),
                 projects: Default::default(),
                 worktree_extensions: Default::default(),
                 next_project_id: Mutex::new(1),

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -2181,6 +2181,7 @@ pub mod tests {
         }
 
         async fn get_user_by_id(&self, id: UserId) -> Result<Option<User>> {
+            self.background.simulate_random_delay().await;
             Ok(self.get_users_by_ids(vec![id]).await?.into_iter().next())
         }
 
@@ -2195,6 +2196,7 @@ pub mod tests {
         }
 
         async fn get_user_by_github_login(&self, github_login: &str) -> Result<Option<User>> {
+            self.background.simulate_random_delay().await;
             Ok(self
                 .users
                 .lock()
@@ -2228,6 +2230,7 @@ pub mod tests {
         }
 
         async fn get_invite_code_for_user(&self, _id: UserId) -> Result<Option<(String, u32)>> {
+            self.background.simulate_random_delay().await;
             Ok(None)
         }
 
@@ -2265,6 +2268,7 @@ pub mod tests {
         }
 
         async fn unregister_project(&self, project_id: ProjectId) -> Result<()> {
+            self.background.simulate_random_delay().await;
             self.projects
                 .lock()
                 .get_mut(&project_id)
@@ -2370,6 +2374,7 @@ pub mod tests {
             requester_id: UserId,
             responder_id: UserId,
         ) -> Result<()> {
+            self.background.simulate_random_delay().await;
             let mut contacts = self.contacts.lock();
             for contact in contacts.iter_mut() {
                 if contact.requester_id == requester_id && contact.responder_id == responder_id {
@@ -2399,6 +2404,7 @@ pub mod tests {
         }
 
         async fn remove_contact(&self, requester_id: UserId, responder_id: UserId) -> Result<()> {
+            self.background.simulate_random_delay().await;
             self.contacts.lock().retain(|contact| {
                 !(contact.requester_id == requester_id && contact.responder_id == responder_id)
             });
@@ -2410,6 +2416,7 @@ pub mod tests {
             user_id: UserId,
             contact_user_id: UserId,
         ) -> Result<()> {
+            self.background.simulate_random_delay().await;
             let mut contacts = self.contacts.lock();
             for contact in contacts.iter_mut() {
                 if contact.requester_id == contact_user_id
@@ -2436,6 +2443,7 @@ pub mod tests {
             requester_id: UserId,
             accept: bool,
         ) -> Result<()> {
+            self.background.simulate_random_delay().await;
             let mut contacts = self.contacts.lock();
             for (ix, contact) in contacts.iter_mut().enumerate() {
                 if contact.requester_id == requester_id && contact.responder_id == responder_id {
@@ -2631,6 +2639,7 @@ pub mod tests {
             count: usize,
             before_id: Option<MessageId>,
         ) -> Result<Vec<ChannelMessage>> {
+            self.background.simulate_random_delay().await;
             let mut messages = self
                 .channel_messages
                 .lock()

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -1472,6 +1472,7 @@ async fn test_collaborating_with_diagnostics(
 
     // Join project as client C and observe the diagnostics.
     let project_c = client_c.build_remote_project(&project_a, cx_a, cx_c).await;
+    deterministic.run_until_parked();
     project_c.read_with(cx_c, |project, cx| {
         assert_eq!(
             project.diagnostic_summaries(cx).collect::<Vec<_>>(),

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -51,7 +51,7 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::{
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{Mutex, MutexGuard},
     time::Sleep,
 };
 use tower::ServiceBuilder;
@@ -97,7 +97,7 @@ impl<R: RequestMessage> Response<R> {
 
 pub struct Server {
     peer: Arc<Peer>,
-    pub(crate) store: RwLock<Store>,
+    pub(crate) store: Mutex<Store>,
     app_state: Arc<AppState>,
     handlers: HashMap<TypeId, MessageHandler>,
     notifications: Option<mpsc::UnboundedSender<()>>,
@@ -115,13 +115,8 @@ pub struct RealExecutor;
 const MESSAGE_COUNT_PER_PAGE: usize = 100;
 const MAX_MESSAGE_LEN: usize = 1024;
 
-struct StoreReadGuard<'a> {
-    guard: RwLockReadGuard<'a, Store>,
-    _not_send: PhantomData<Rc<()>>,
-}
-
-struct StoreWriteGuard<'a> {
-    guard: RwLockWriteGuard<'a, Store>,
+pub(crate) struct StoreGuard<'a> {
+    guard: MutexGuard<'a, Store>,
     _not_send: PhantomData<Rc<()>>,
 }
 
@@ -129,7 +124,7 @@ struct StoreWriteGuard<'a> {
 pub struct ServerSnapshot<'a> {
     peer: &'a Peer,
     #[serde(serialize_with = "serialize_deref")]
-    store: RwLockReadGuard<'a, Store>,
+    store: StoreGuard<'a>,
 }
 
 pub fn serialize_deref<S, T, U>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
@@ -384,7 +379,7 @@ impl Server {
             ).await?;
 
             {
-                let mut store = this.store_mut().await;
+                let mut store = this.store().await;
                 store.add_connection(connection_id, user_id, user.admin);
                 this.peer.send(connection_id, store.build_initial_contacts_update(contacts))?;
 
@@ -471,7 +466,7 @@ impl Server {
         let mut projects_to_unregister = Vec::new();
         let removed_user_id;
         {
-            let mut store = self.store_mut().await;
+            let mut store = self.store().await;
             let removed_connection = store.remove_connection(connection_id)?;
 
             for (project_id, project) in removed_connection.hosted_projects {
@@ -605,7 +600,7 @@ impl Server {
             .await
             .user_id_for_connection(request.sender_id)?;
         let project_id = self.app_state.db.register_project(user_id).await?;
-        self.store_mut()
+        self.store()
             .await
             .register_project(request.sender_id, project_id)?;
 
@@ -623,7 +618,7 @@ impl Server {
     ) -> Result<()> {
         let project_id = ProjectId::from_proto(request.payload.project_id);
         let (user_id, project) = {
-            let mut state = self.store_mut().await;
+            let mut state = self.store().await;
             let project = state.unregister_project(project_id, request.sender_id)?;
             (state.user_id_for_connection(request.sender_id)?, project)
         };
@@ -725,7 +720,7 @@ impl Server {
             return Err(anyhow!("no such project"))?;
         }
 
-        self.store_mut().await.request_join_project(
+        self.store().await.request_join_project(
             guest_user_id,
             project_id,
             response.into_receipt(),
@@ -747,7 +742,7 @@ impl Server {
         let host_user_id;
 
         {
-            let mut state = self.store_mut().await;
+            let mut state = self.store().await;
             let project_id = ProjectId::from_proto(request.payload.project_id);
             let project = state.project(project_id)?;
             if project.host_connection_id != request.sender_id {
@@ -897,7 +892,7 @@ impl Server {
         let project_id = ProjectId::from_proto(request.payload.project_id);
         let project;
         {
-            let mut store = self.store_mut().await;
+            let mut store = self.store().await;
             project = store.leave_project(sender_id, project_id)?;
             tracing::info!(
                 %project_id,
@@ -948,7 +943,7 @@ impl Server {
         let project_id = ProjectId::from_proto(request.payload.project_id);
         let user_id;
         {
-            let mut state = self.store_mut().await;
+            let mut state = self.store().await;
             user_id = state.user_id_for_connection(request.sender_id)?;
             let guest_connection_ids = state
                 .read_project(project_id, request.sender_id)?
@@ -967,7 +962,7 @@ impl Server {
         self: Arc<Server>,
         request: TypedEnvelope<proto::RegisterProjectActivity>,
     ) -> Result<()> {
-        self.store_mut().await.register_project_activity(
+        self.store().await.register_project_activity(
             ProjectId::from_proto(request.payload.project_id),
             request.sender_id,
         )?;
@@ -982,7 +977,7 @@ impl Server {
         let project_id = ProjectId::from_proto(request.payload.project_id);
         let worktree_id = request.payload.worktree_id;
         let (connection_ids, metadata_changed, extension_counts) = {
-            let mut store = self.store_mut().await;
+            let mut store = self.store().await;
             let (connection_ids, metadata_changed, extension_counts) = store.update_worktree(
                 request.sender_id,
                 project_id,
@@ -1024,7 +1019,7 @@ impl Server {
             .summary
             .clone()
             .ok_or_else(|| anyhow!("invalid summary"))?;
-        let receiver_ids = self.store_mut().await.update_diagnostic_summary(
+        let receiver_ids = self.store().await.update_diagnostic_summary(
             ProjectId::from_proto(request.payload.project_id),
             request.payload.worktree_id,
             request.sender_id,
@@ -1042,7 +1037,7 @@ impl Server {
         self: Arc<Server>,
         request: TypedEnvelope<proto::StartLanguageServer>,
     ) -> Result<()> {
-        let receiver_ids = self.store_mut().await.start_language_server(
+        let receiver_ids = self.store().await.start_language_server(
             ProjectId::from_proto(request.payload.project_id),
             request.sender_id,
             request
@@ -1081,20 +1076,23 @@ impl Server {
     where
         T: EntityMessage + RequestMessage,
     {
+        let project_id = ProjectId::from_proto(request.payload.remote_entity_id());
         let host_connection_id = self
             .store()
             .await
-            .read_project(
-                ProjectId::from_proto(request.payload.remote_entity_id()),
-                request.sender_id,
-            )?
+            .read_project(project_id, request.sender_id)?
             .host_connection_id;
+        let payload = self
+            .peer
+            .forward_request(request.sender_id, host_connection_id, request.payload)
+            .await?;
 
-        response.send(
-            self.peer
-                .forward_request(request.sender_id, host_connection_id, request.payload)
-                .await?,
-        )?;
+        // Ensure project still exists by the time we get the response from the host.
+        self.store()
+            .await
+            .read_project(project_id, request.sender_id)?;
+
+        response.send(payload)?;
         Ok(())
     }
 
@@ -1135,7 +1133,7 @@ impl Server {
     ) -> Result<()> {
         let project_id = ProjectId::from_proto(request.payload.project_id);
         let receiver_ids = {
-            let mut store = self.store_mut().await;
+            let mut store = self.store().await;
             store.register_project_activity(project_id, request.sender_id)?;
             store.project_connection_ids(project_id, request.sender_id)?
         };
@@ -1202,7 +1200,7 @@ impl Server {
         let leader_id = ConnectionId(request.payload.leader_id);
         let follower_id = request.sender_id;
         {
-            let mut store = self.store_mut().await;
+            let mut store = self.store().await;
             if !store
                 .project_connection_ids(project_id, follower_id)?
                 .contains(&leader_id)
@@ -1227,7 +1225,7 @@ impl Server {
     async fn unfollow(self: Arc<Self>, request: TypedEnvelope<proto::Unfollow>) -> Result<()> {
         let project_id = ProjectId::from_proto(request.payload.project_id);
         let leader_id = ConnectionId(request.payload.leader_id);
-        let mut store = self.store_mut().await;
+        let mut store = self.store().await;
         if !store
             .project_connection_ids(project_id, request.sender_id)?
             .contains(&leader_id)
@@ -1245,7 +1243,7 @@ impl Server {
         request: TypedEnvelope<proto::UpdateFollowers>,
     ) -> Result<()> {
         let project_id = ProjectId::from_proto(request.payload.project_id);
-        let mut store = self.store_mut().await;
+        let mut store = self.store().await;
         store.register_project_activity(project_id, request.sender_id)?;
         let connection_ids = store.project_connection_ids(project_id, request.sender_id)?;
         let leader_id = request
@@ -1503,7 +1501,7 @@ impl Server {
             Err(anyhow!("access denied"))?;
         }
 
-        self.store_mut()
+        self.store()
             .await
             .join_channel(request.sender_id, channel_id);
         let messages = self
@@ -1545,7 +1543,7 @@ impl Server {
             Err(anyhow!("access denied"))?;
         }
 
-        self.store_mut()
+        self.store()
             .await
             .leave_channel(request.sender_id, channel_id);
 
@@ -1653,25 +1651,13 @@ impl Server {
         Ok(())
     }
 
-    async fn store<'a>(self: &'a Arc<Self>) -> StoreReadGuard<'a> {
+    pub(crate) async fn store<'a>(&'a self) -> StoreGuard<'a> {
         #[cfg(test)]
         tokio::task::yield_now().await;
-        let guard = self.store.read().await;
+        let guard = self.store.lock().await;
         #[cfg(test)]
         tokio::task::yield_now().await;
-        StoreReadGuard {
-            guard,
-            _not_send: PhantomData,
-        }
-    }
-
-    async fn store_mut<'a>(self: &'a Arc<Self>) -> StoreWriteGuard<'a> {
-        #[cfg(test)]
-        tokio::task::yield_now().await;
-        let guard = self.store.write().await;
-        #[cfg(test)]
-        tokio::task::yield_now().await;
-        StoreWriteGuard {
+        StoreGuard {
             guard,
             _not_send: PhantomData,
         }
@@ -1679,13 +1665,13 @@ impl Server {
 
     pub async fn snapshot<'a>(self: &'a Arc<Self>) -> ServerSnapshot<'a> {
         ServerSnapshot {
-            store: self.store.read().await,
+            store: self.store().await,
             peer: &self.peer,
         }
     }
 }
 
-impl<'a> Deref for StoreReadGuard<'a> {
+impl<'a> Deref for StoreGuard<'a> {
     type Target = Store;
 
     fn deref(&self) -> &Self::Target {
@@ -1693,21 +1679,13 @@ impl<'a> Deref for StoreReadGuard<'a> {
     }
 }
 
-impl<'a> Deref for StoreWriteGuard<'a> {
-    type Target = Store;
-
-    fn deref(&self) -> &Self::Target {
-        &*self.guard
-    }
-}
-
-impl<'a> DerefMut for StoreWriteGuard<'a> {
+impl<'a> DerefMut for StoreGuard<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.guard
     }
 }
 
-impl<'a> Drop for StoreWriteGuard<'a> {
+impl<'a> Drop for StoreGuard<'a> {
     fn drop(&mut self) {
         #[cfg(test)]
         self.check_invariants();

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -804,6 +804,7 @@ impl Server {
                             .collect(),
                         visible: worktree.visible,
                         scan_id: shared_worktree.scan_id,
+                        is_complete: worktree.is_complete,
                     })
                 })
                 .collect::<Vec<_>>();
@@ -963,6 +964,7 @@ impl Server {
                 &request.payload.removed_entries,
                 &request.payload.updated_entries,
                 request.payload.scan_id,
+                request.payload.is_last_update,
             )?;
             (connection_ids, metadata_changed, extension_counts.clone())
         };

--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -62,6 +62,7 @@ pub struct Worktree {
     #[serde(skip)]
     pub diagnostic_summaries: BTreeMap<PathBuf, proto::DiagnosticSummary>,
     pub scan_id: u64,
+    pub is_complete: bool,
 }
 
 #[derive(Default)]
@@ -615,6 +616,7 @@ impl Store {
         removed_entries: &[u64],
         updated_entries: &[proto::Entry],
         scan_id: u64,
+        is_last_update: bool,
     ) -> Result<(Vec<ConnectionId>, bool, HashMap<String, usize>)> {
         let project = self.write_project(project_id, connection_id)?;
         let connection_ids = project.connection_ids();
@@ -657,6 +659,7 @@ impl Store {
         }
 
         worktree.scan_id = scan_id;
+        worktree.is_complete = is_last_update;
         Ok((
             connection_ids,
             metadata_changed,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1332,12 +1332,13 @@ impl Project {
             let client = self.client.clone();
             cx.foreground()
                 .spawn(async move {
-                    share.await?;
                     client.send(proto::RespondToJoinProjectRequest {
                         requester_id,
                         project_id,
                         allow,
-                    })
+                    })?;
+                    share.await?;
+                    anyhow::Ok(())
                 })
                 .detach_and_log_err(cx);
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1081,7 +1081,7 @@ impl Project {
                     .ok_or_else(|| anyhow!("missing entry in response"))?;
                 worktree
                     .update(&mut cx, |worktree, cx| {
-                        worktree.as_remote().unwrap().insert_entry(
+                        worktree.as_remote_mut().unwrap().insert_entry(
                             entry,
                             response.worktree_scan_id as usize,
                             cx,
@@ -1124,7 +1124,7 @@ impl Project {
                     .ok_or_else(|| anyhow!("missing entry in response"))?;
                 worktree
                     .update(&mut cx, |worktree, cx| {
-                        worktree.as_remote().unwrap().insert_entry(
+                        worktree.as_remote_mut().unwrap().insert_entry(
                             entry,
                             response.worktree_scan_id as usize,
                             cx,
@@ -1167,7 +1167,7 @@ impl Project {
                     .ok_or_else(|| anyhow!("missing entry in response"))?;
                 worktree
                     .update(&mut cx, |worktree, cx| {
-                        worktree.as_remote().unwrap().insert_entry(
+                        worktree.as_remote_mut().unwrap().insert_entry(
                             entry,
                             response.worktree_scan_id as usize,
                             cx,
@@ -1200,7 +1200,7 @@ impl Project {
                     .await?;
                 worktree
                     .update(&mut cx, move |worktree, cx| {
-                        worktree.as_remote().unwrap().delete_entry(
+                        worktree.as_remote_mut().unwrap().delete_entry(
                             entry_id,
                             response.worktree_scan_id as usize,
                             cx,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4447,6 +4447,7 @@ impl Project {
                         diagnostic_summaries: Default::default(),
                         visible: worktree.visible,
                         scan_id: 0,
+                        is_complete: false,
                     };
                     let (worktree, load_task) =
                         Worktree::remote(remote_id, replica_id, worktree, client.clone(), cx);

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -2718,10 +2718,11 @@ async fn send_worktree_update(
     #[cfg(not(any(test, feature = "test-support")))]
     const MAX_CHUNK_SIZE: usize = 256;
 
-    loop {
+    let mut is_last_update = false;
+    while !is_last_update {
         let chunk_size = cmp::min(update.updated_entries.len(), MAX_CHUNK_SIZE);
         let updated_entries = update.updated_entries.drain(..chunk_size).collect();
-        let is_last_update = update.updated_entries.is_empty();
+        is_last_update = update.updated_entries.is_empty();
         client
             .request(proto::UpdateWorktree {
                 project_id: update.project_id,
@@ -2733,9 +2734,6 @@ async fn send_worktree_update(
                 is_last_update,
             })
             .await?;
-        if is_last_update {
-            break;
-        }
     }
 
     Ok(())

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -569,7 +569,6 @@ impl LocalWorktree {
                         .refresh_entry(path, abs_path, None, cx)
                 })
                 .await?;
-            this.update(&mut cx, |this, cx| this.poll_snapshot(cx));
             Ok((
                 File {
                     entry_id: Some(entry.id),
@@ -710,10 +709,6 @@ impl LocalWorktree {
                     )
                 })
                 .await?;
-            this.update(&mut cx, |this, cx| {
-                let this = this.as_local_mut().unwrap();
-                this.poll_snapshot(cx);
-            });
             Ok(entry)
         }))
     }
@@ -749,10 +744,6 @@ impl LocalWorktree {
                     )
                 })
                 .await?;
-            this.update(&mut cx, |this, cx| {
-                let this = this.as_local_mut().unwrap();
-                this.poll_snapshot(cx);
-            });
             Ok(entry)
         }))
     }
@@ -786,10 +777,6 @@ impl LocalWorktree {
                         .refresh_entry(path, abs_path, None, cx)
                 })
                 .await?;
-            this.update(&mut cx, |this, cx| {
-                let this = this.as_local_mut().unwrap();
-                this.poll_snapshot(cx);
-            });
             Ok(entry)
         })
     }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -980,7 +980,11 @@ impl LocalWorktree {
                         }
                     }
 
-                    while let Ok(snapshot) = snapshots_to_send_rx.recv().await {
+                    while let Ok(mut snapshot) = snapshots_to_send_rx.recv().await {
+                        while let Ok(newer_snapshot) = snapshots_to_send_rx.try_recv() {
+                            snapshot = newer_snapshot;
+                        }
+
                         let message =
                             snapshot.build_update(&prev_snapshot, project_id, worktree_id, true);
                         rpc.request(message).await?;

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -970,6 +970,7 @@ impl RemoteWorktree {
 
     pub fn disconnected_from_host(&mut self) {
         self.updates_tx.take();
+        self.snapshot_subscriptions.clear();
     }
 
     pub fn update_from_remote(&mut self, update: proto::UpdateWorktree) {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -195,6 +195,7 @@ message UpdateWorktree {
     repeated Entry updated_entries = 4;
     repeated uint64 removed_entries = 5;
     uint64 scan_id = 6;
+    bool is_last_update = 7;
 }
 
 message CreateProjectEntry {
@@ -772,6 +773,7 @@ message Worktree {
     repeated DiagnosticSummary diagnostic_summaries = 4;
     bool visible = 5;
     uint64 scan_id = 6;
+    bool is_complete = 7;
 }
 
 message File {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -168,7 +168,7 @@ message JoinProjectResponse {
 
     message Accept {
         uint32 replica_id = 1;
-        repeated Worktree worktrees = 2;
+        repeated WorktreeMetadata worktrees = 2;
         repeated Collaborator collaborators = 3;
         repeated LanguageServer language_servers = 4;        
     }
@@ -764,16 +764,6 @@ message User {
     uint64 id = 1;
     string github_login = 2;
     string avatar_url = 3;
-}
-
-message Worktree {
-    uint64 id = 1;
-    string root_name = 2;
-    repeated Entry entries = 3;
-    repeated DiagnosticSummary diagnostic_summaries = 4;
-    bool visible = 5;
-    uint64 scan_id = 6;
-    bool is_complete = 7;
 }
 
 message File {

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -5,6 +5,7 @@ use futures::{SinkExt as _, StreamExt as _};
 use prost::Message as _;
 use serde::Serialize;
 use std::any::{Any, TypeId};
+use std::{cmp, iter, mem};
 use std::{
     fmt::Debug,
     io,
@@ -388,6 +389,31 @@ impl From<Nonce> for u128 {
         let lower_half = nonce.lower_half as u128;
         upper_half | lower_half
     }
+}
+
+pub fn split_worktree_update(
+    mut message: UpdateWorktree,
+    max_chunk_size: usize,
+) -> impl Iterator<Item = UpdateWorktree> {
+    let mut done = false;
+    iter::from_fn(move || {
+        if done {
+            return None;
+        }
+
+        let chunk_size = cmp::min(message.updated_entries.len(), max_chunk_size);
+        let updated_entries = message.updated_entries.drain(..chunk_size).collect();
+        done = message.updated_entries.is_empty();
+        Some(UpdateWorktree {
+            project_id: message.project_id,
+            worktree_id: message.worktree_id,
+            root_name: message.root_name.clone(),
+            updated_entries,
+            removed_entries: mem::take(&mut message.removed_entries),
+            scan_id: message.scan_id,
+            is_last_update: done && message.is_last_update,
+        })
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1249

TODO:

* [x] Avoid copying the background snapshot over to the main thread while processing an FS event
* [x] Refactor - use a watch channel to store the "snaphots to send"