### PR TITLE
Update terminal to use the editor's cursor rendering

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1630,7 +1630,7 @@ impl Default for CursorShape {
     }
 }
 
-struct Cursor {
+pub struct Cursor {
     origin: Vector2F,
     block_width: f32,
     line_height: f32,
@@ -1640,7 +1640,25 @@ struct Cursor {
 }
 
 impl Cursor {
-    fn paint(&self, cx: &mut PaintContext) {
+    pub fn new(
+        origin: Vector2F,
+        block_width: f32,
+        line_height: f32,
+        color: Color,
+        shape: CursorShape,
+        block_text: Option<Line>,
+    ) -> Cursor {
+        Cursor {
+            origin,
+            block_width,
+            line_height,
+            color,
+            shape,
+            block_text,
+        }
+    }
+
+    pub fn paint(&self, cx: &mut PaintContext) {
         let bounds = match self.shape {
             CursorShape::Bar => RectF::new(self.origin, vec2f(2.0, self.line_height)),
             CursorShape::Block => {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -490,7 +490,7 @@ impl EditorElement {
                         }
 
                         let block_text =
-                            if matches!(self.cursor_shape, CursorShape::Block) {
+                            if let CursorShape::Block = self.cursor_shape {
                                 layout.snapshot.chars_at(cursor_position).next().and_then(
                                     |character| {
                                         let font_id =

--- a/crates/gpui/src/text_layout.rs
+++ b/crates/gpui/src/text_layout.rs
@@ -164,7 +164,7 @@ impl<'a> Hash for CacheKeyRef<'a> {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Line {
     layout: Arc<LineLayout>,
     style_runs: SmallVec<[(u32, Color, Underline); 32]>,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -262,8 +262,7 @@ impl Terminal {
             .active_entry()
             .and_then(|entry_id| project.worktree_for_entry(entry_id, cx))
             .and_then(|worktree_handle| worktree_handle.read(cx).as_local())
-            .map(|wt| wt.abs_path().to_path_buf())
-            .or_else(|| Some("~".into()));
+            .map(|wt| wt.abs_path().to_path_buf());
 
         workspace.add_item(Box::new(cx.add_view(|cx| Terminal::new(cx, abs_path))), cx);
     }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -484,7 +484,6 @@ mod tests {
                 let (chunks, _) = build_chunks(
                     term.lock().renderable_content().display_iter,
                     &Default::default(),
-                    0.,
                 );
                 let content = chunks.iter().map(|e| e.0.trim()).collect::<String>();
                 content.contains("7")

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -484,6 +484,7 @@ mod tests {
                 let (chunks, _) = build_chunks(
                     term.lock().renderable_content().display_iter,
                     &Default::default(),
+                    0.,
                 );
                 let content = chunks.iter().map(|e| e.0.trim()).collect::<String>();
                 content.contains("7")

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -464,7 +464,7 @@ fn to_alac_rgb(color: Color) -> AlacRgb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal_element::build_chunks;
+    use crate::terminal_element::{build_chunks, BuiltChunks};
     use gpui::TestAppContext;
 
     ///Basic integration test, can we get the terminal to show up, execute a command,
@@ -481,9 +481,10 @@ mod tests {
         terminal
             .condition(cx, |terminal, _cx| {
                 let term = terminal.term.clone();
-                let (chunks, _) = build_chunks(
+                let BuiltChunks { chunks, .. } = build_chunks(
                     term.lock().renderable_content().display_iter,
                     &Default::default(),
+                    Default::default(),
                 );
                 let content = chunks.iter().map(|e| e.0.trim()).collect::<String>();
                 content.contains("7")

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -1,6 +1,6 @@
 use alacritty_terminal::{
     ansi::Color as AnsiColor,
-    grid::{Dimensions, GridIterator, Indexed},
+    grid::{GridIterator, Indexed},
     index::Point,
     term::{
         cell::{Cell, Flags},
@@ -121,13 +121,8 @@ impl Element for TerminalEl {
         let term = view_handle.read(cx).term.lock();
         let content = term.renderable_content();
 
-        //TODO: Remove
-        // dbg!("*******");
-        // dbg!(cur_size.columns());
-
         //And we're off! Begin layouting
-        let (chunks, line_count) =
-            build_chunks(content.display_iter, &terminal_theme, cell_width.0);
+        let (chunks, line_count) = build_chunks(content.display_iter, &terminal_theme);
 
         let shaped_lines = layout_highlighted_chunks(
             chunks
@@ -139,11 +134,6 @@ impl Element for TerminalEl {
             usize::MAX,
             line_count,
         );
-
-        //TODO: Remove
-        // for shaped_line in &shaped_lines {
-        //     dbg!(shaped_line.width());
-        // }
 
         let backgrounds = chunks
             .iter()
@@ -191,16 +181,6 @@ impl Element for TerminalEl {
             bounds: visible_bounds,
             ..Default::default()
         });
-
-        //TODO: Implement cursor region based styling
-        // cx.scene.push_cursor_region(CursorRegion {
-        //     bounds,
-        //     style: if !view.link_go_to_definition_state.definitions.is_empty() {
-        //         CursorStyle::PointingHand
-        //     } else {
-        //         CursorStyle::IBeam
-        //     },
-        // });
 
         let origin = bounds.origin() + vec2f(layout.em_width.0, 0.);
 
@@ -336,7 +316,6 @@ fn make_new_size(
 pub(crate) fn build_chunks(
     grid_iterator: GridIterator<Cell>,
     theme: &TerminalStyle,
-    em_width: f32,
 ) -> (Vec<(String, Option<HighlightStyle>, RectSpan)>, usize) {
     let mut line_count: usize = 0;
     //Every `group_by()` -> `into_iter()` pair needs to be seperated by a local variable so
@@ -369,14 +348,6 @@ pub(crate) fn build_chunks(
                 .chain(iter::once(("\n".to_string(), None, Default::default())))
                 .collect::<Vec<(String, Option<HighlightStyle>, RectSpan)>>()
         })
-        //TODO: Remove
-        // .inspect(|line_chunks| {
-        //     let mut line_len = 0;
-        //     for chunk in line_chunks {
-        //         line_len += chunk.0.len();
-        //     }
-        //     dbg!((line_len, line_len as f32 * em_width));
-        // })
         .flatten()
         //We have a Vec<Vec<>> (Vec of lines of styled chunks), flatten to just Vec<> (the styled chunks)
         .collect::<Vec<(String, Option<HighlightStyle>, RectSpan)>>();

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -119,6 +119,9 @@ impl Element for TerminalEl {
         //Now that we're done with the mutable portion, grab the immutable settings and view again
         let terminal_theme = &(cx.global::<Settings>()).theme.terminal;
         let term = view_handle.read(cx).term.lock();
+
+        dbg!(term.grid());
+
         let content = term.renderable_content();
 
         //And we're off! Begin layouting
@@ -390,7 +393,7 @@ fn get_cursor_position(
 ) -> Option<Vector2F> {
     let cursor_line = cursor_point.line.0 as usize + display_offset;
     shaped_lines.get(cursor_line).map(|layout_line| {
-        let cursor_x = layout_line.x_for_index(cursor_point.column.0 + 3);
+        let cursor_x = layout_line.x_for_index(cursor_point.column.0);
         vec2f(cursor_x, cursor_line as f32 * line_height.0)
     })
 }

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -78,7 +78,7 @@ pub struct LayoutState {
     lines: Vec<Line>,
     line_height: LineHeight,
     em_width: CellWidth,
-    cursor: Option<(Vector2F, Color, Option<Line>)>,
+    cursor: Option<Cursor>,
     cur_size: SizeInfo,
     background_color: Color,
     background_rects: Vec<(RectF, Color)>, //Vec index == Line index for the LineSpan
@@ -120,18 +120,18 @@ impl Element for TerminalEl {
         let terminal_theme = &(cx.global::<Settings>()).theme.terminal;
         let term = view_handle.read(cx).term.lock();
 
-        // let cursor_char = term.grid().cursor_cell().c.to_string();
-
-        let cursor_text = {
-            let grid = term.grid();
-            let cursor_point = grid.cursor.point;
-            grid[cursor_point.line][cursor_point.column].c.to_string()
-        };
+        let grid = term.grid();
+        let cursor_point = grid.cursor.point;
+        let cursor_text = grid[cursor_point.line][cursor_point.column].c.to_string();
 
         let content = term.renderable_content();
 
         //And we're off! Begin layouting
-        let (chunks, line_count) = build_chunks(content.display_iter, &terminal_theme);
+        let BuiltChunks {
+            chunks,
+            line_count,
+            cursor_index,
+        } = build_chunks(content.display_iter, &terminal_theme, cursor_point);
 
         let shaped_lines = layout_highlighted_chunks(
             chunks
@@ -163,13 +163,30 @@ impl Element for TerminalEl {
                 },
             )],
         );
+
         let cursor = get_cursor_position(
-            content.cursor.point,
+            content.cursor.point.line.0 as usize,
+            cursor_index,
             &shaped_lines,
             content.display_offset,
             &line_height,
         )
-        .map(|cursor_rect| (cursor_rect, terminal_theme.cursor, Some(block_text)));
+        .map(move |(cursor_position, block_width)| {
+            let block_width = if block_width != 0.0 {
+                block_width
+            } else {
+                cell_width.0
+            };
+
+            Cursor::new(
+                cursor_position,
+                block_width,
+                line_height.0,
+                terminal_theme.cursor,
+                CursorShape::Block,
+                Some(block_text.clone()),
+            )
+        });
 
         (
             constraint.max,
@@ -239,20 +256,11 @@ impl Element for TerminalEl {
         cx.scene.pop_layer();
 
         //Draw cursor
-        cx.scene.push_layer(Some(visible_bounds));
-        if let Some((c, color, block_text)) = &layout.cursor {
-            let editor_cursor = Cursor::new(
-                origin + *c,
-                layout.em_width.0,
-                layout.line_height.0,
-                *color,
-                CursorShape::Block,
-                block_text.clone(), //TODO fix this
-            );
-
-            editor_cursor.paint(cx);
+        if let Some(cursor) = &layout.cursor {
+            cx.scene.push_layer(Some(visible_bounds));
+            cursor.paint(origin, cx);
+            cx.scene.pop_layer();
         }
-        cx.scene.pop_layer();
 
         #[cfg(debug_assertions)]
         if DEBUG_GRID {
@@ -339,21 +347,30 @@ fn make_new_size(
     )
 }
 
+pub struct BuiltChunks {
+    pub chunks: Vec<(String, Option<HighlightStyle>, RectSpan)>,
+    pub line_count: usize,
+    pub cursor_index: usize,
+}
+
 ///In a single pass, this function generates the background and foreground color info for every item in the grid.
 pub(crate) fn build_chunks(
     grid_iterator: GridIterator<Cell>,
     theme: &TerminalStyle,
-) -> (Vec<(String, Option<HighlightStyle>, RectSpan)>, usize) {
+    cursor_point: Point,
+) -> BuiltChunks {
     let mut line_count: usize = 0;
+    let mut cursor_index: usize = 0;
     //Every `group_by()` -> `into_iter()` pair needs to be seperated by a local variable so
     //rust knows where to put everything.
     //Start by grouping by lines
     let lines = grid_iterator.group_by(|i| i.point.line.0);
     let result = lines
         .into_iter()
-        .map(|(_, line)| {
+        .map(|(_line_grid_index, line)| {
             line_count += 1;
             let mut col_index = 0;
+            //Setup a variable
 
             //Then group by style
             let chunks = line.group_by(|i| cell_style(&i, theme));
@@ -361,9 +378,20 @@ pub(crate) fn build_chunks(
                 .into_iter()
                 .map(|(style, fragment)| {
                     //And assemble the styled fragment into it's background and foreground information
-                    let str_fragment = fragment.map(|indexed| indexed.c).collect::<String>();
+                    let mut str_fragment = String::new();
+                    for indexed_cell in fragment {
+                        if cursor_point.line.0 == indexed_cell.point.line.0
+                            && indexed_cell.point.column < cursor_point.column.0
+                        {
+                            cursor_index += indexed_cell.c.to_string().len();
+                        }
+                        str_fragment.push(indexed_cell.c);
+                    }
+
                     let start = col_index;
                     let end = start + str_fragment.len() as i32;
+
+                    //munge it here
                     col_index = end;
                     (
                         str_fragment,
@@ -378,7 +406,12 @@ pub(crate) fn build_chunks(
         .flatten()
         //We have a Vec<Vec<>> (Vec of lines of styled chunks), flatten to just Vec<> (the styled chunks)
         .collect::<Vec<(String, Option<HighlightStyle>, RectSpan)>>();
-    (result, line_count)
+
+    BuiltChunks {
+        chunks: result,
+        line_count,
+        cursor_index,
+    }
 }
 
 ///Convert a RectSpan in terms of character offsets, into RectFs of exact offsets
@@ -408,17 +441,23 @@ fn make_background_rects(
         .collect::<Vec<(RectF, Color)>>()
 }
 
-///Create the rectangle for a cursor, exactly positioned according to the text
+// Compute the cursor position and expected block width, may return a zero width if x_for_index returns
+// the same position for sequential indexes. Use em_width instead
 fn get_cursor_position(
-    cursor_point: Point,
+    line: usize,
+    line_index: usize,
     shaped_lines: &Vec<Line>,
     display_offset: usize,
     line_height: &LineHeight,
-) -> Option<Vector2F> {
-    let cursor_line = cursor_point.line.0 as usize + display_offset;
+) -> Option<(Vector2F, f32)> {
+    let cursor_line = line + display_offset;
     shaped_lines.get(cursor_line).map(|layout_line| {
-        let cursor_x = layout_line.x_for_index(cursor_point.column.0);
-        vec2f(cursor_x, cursor_line as f32 * line_height.0)
+        let cursor_x = layout_line.x_for_index(line_index);
+        let next_char_x = layout_line.x_for_index(line_index + 1);
+        (
+            vec2f(cursor_x, cursor_line as f32 * line_height.0),
+            next_char_x - cursor_x,
+        )
     })
 }
 


### PR DESCRIPTION
Includes a small change to the editor crate so that I can use the same rendering logic as the editor's cursor. Would like to double check that this kind of change is ok.