### PR TITLE
Introduce autosave

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -1361,7 +1361,7 @@ pub mod tests {
     use super::*;
     use anyhow::anyhow;
     use collections::BTreeMap;
-    use gpui::executor::Background;
+    use gpui::executor::{Background, Deterministic};
     use lazy_static::lazy_static;
     use parking_lot::Mutex;
     use rand::prelude::*;
@@ -1376,7 +1376,7 @@ pub mod tests {
     async fn test_get_users_by_ids() {
         for test_db in [
             TestDb::postgres().await,
-            TestDb::fake(Arc::new(gpui::executor::Background::new())),
+            TestDb::fake(build_background_executor()),
         ] {
             let db = test_db.db();
 
@@ -1687,7 +1687,7 @@ pub mod tests {
     async fn test_recent_channel_messages() {
         for test_db in [
             TestDb::postgres().await,
-            TestDb::fake(Arc::new(gpui::executor::Background::new())),
+            TestDb::fake(build_background_executor()),
         ] {
             let db = test_db.db();
             let user = db.create_user("user", None, false).await.unwrap();
@@ -1726,7 +1726,7 @@ pub mod tests {
     async fn test_channel_message_nonces() {
         for test_db in [
             TestDb::postgres().await,
-            TestDb::fake(Arc::new(gpui::executor::Background::new())),
+            TestDb::fake(build_background_executor()),
         ] {
             let db = test_db.db();
             let user = db.create_user("user", None, false).await.unwrap();
@@ -1834,7 +1834,7 @@ pub mod tests {
     async fn test_add_contacts() {
         for test_db in [
             TestDb::postgres().await,
-            TestDb::fake(Arc::new(gpui::executor::Background::new())),
+            TestDb::fake(build_background_executor()),
         ] {
             let db = test_db.db();
 
@@ -2835,5 +2835,9 @@ pub mod tests {
         fn as_fake(&self) -> Option<&FakeDb> {
             Some(self)
         }
+    }
+
+    fn build_background_executor() -> Arc<Background> {
+        Deterministic::new(0).build_background()
     }
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5596,9 +5596,9 @@ impl Editor {
                             .timer(Duration::from_millis(milliseconds))
                             .fuse();
                         pending_autosave.await;
-                        futures::select! {
-                            _ = timer => {}
+                        futures::select_biased! {
                             _ = cancel_rx => return None,
+                            _ = timer => {}
                         }
 
                         this.upgrade(&cx)?

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5591,11 +5591,11 @@ impl Editor {
                     let (cancel_tx, mut cancel_rx) = oneshot::channel();
                     self.cancel_pending_autosave = Some(cancel_tx);
                     self.pending_autosave = Some(cx.spawn_weak(|this, mut cx| async move {
-                        let mut timer = futures::future::join(
-                            cx.background().timer(Duration::from_millis(milliseconds)),
-                            pending_autosave,
-                        )
-                        .fuse();
+                        let mut timer = cx
+                            .background()
+                            .timer(Duration::from_millis(milliseconds))
+                            .fuse();
+                        pending_autosave.await;
                         futures::select! {
                             _ = timer => {}
                             _ = cancel_rx => return None,
@@ -6634,8 +6634,8 @@ mod tests {
             editor.read(cx).selections.ranges(cx)
         );
         assert_set_eq!(
-            cloned_editor.update(cx, |e, cx| dbg!(e.selections.display_ranges(cx))),
-            editor.update(cx, |e, cx| dbg!(e.selections.display_ranges(cx)))
+            cloned_editor.update(cx, |e, cx| e.selections.display_ranges(cx)),
+            editor.update(cx, |e, cx| e.selections.display_ranges(cx))
         );
     }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4451,7 +4451,7 @@ impl AnyViewHandle {
                 handle_id: self.handle_id,
             });
             unsafe {
-                Arc::decrement_strong_count(&self.ref_counts);
+                Arc::decrement_strong_count(Arc::as_ptr(&self.ref_counts));
             }
             std::mem::forget(self);
             result
@@ -4517,8 +4517,9 @@ impl<T: View> From<ViewHandle<T>> for AnyViewHandle {
             #[cfg(any(test, feature = "test-support"))]
             handle_id: handle.handle_id,
         };
+
         unsafe {
-            Arc::decrement_strong_count(&handle.ref_counts);
+            Arc::decrement_strong_count(Arc::as_ptr(&handle.ref_counts));
         }
         std::mem::forget(handle);
         any_handle
@@ -4580,7 +4581,7 @@ impl AnyModelHandle {
                 handle_id: self.handle_id,
             });
             unsafe {
-                Arc::decrement_strong_count(&self.ref_counts);
+                Arc::decrement_strong_count(Arc::as_ptr(&self.ref_counts));
             }
             std::mem::forget(self);
             result

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -783,6 +783,7 @@ type FocusObservationCallback = Box<dyn FnMut(&mut MutableAppContext) -> bool>;
 type GlobalObservationCallback = Box<dyn FnMut(&mut MutableAppContext)>;
 type ReleaseObservationCallback = Box<dyn FnOnce(&dyn Any, &mut MutableAppContext)>;
 type ActionObservationCallback = Box<dyn FnMut(TypeId, &mut MutableAppContext)>;
+type WindowActivationCallback = Box<dyn FnMut(bool, &mut MutableAppContext) -> bool>;
 type DeserializeActionCallback = fn(json: &str) -> anyhow::Result<Box<dyn Action>>;
 type WindowShouldCloseSubscriptionCallback = Box<dyn FnMut(&mut MutableAppContext) -> bool>;
 
@@ -809,6 +810,8 @@ pub struct MutableAppContext {
     global_observations:
         Arc<Mutex<HashMap<TypeId, BTreeMap<usize, Option<GlobalObservationCallback>>>>>,
     release_observations: Arc<Mutex<HashMap<usize, BTreeMap<usize, ReleaseObservationCallback>>>>,
+    window_activation_observations:
+        Arc<Mutex<HashMap<usize, BTreeMap<usize, Option<WindowActivationCallback>>>>>,
     action_dispatch_observations: Arc<Mutex<BTreeMap<usize, ActionObservationCallback>>>,
     presenters_and_platform_windows:
         HashMap<usize, (Rc<RefCell<Presenter>>, Box<dyn platform::Window>)>,
@@ -862,6 +865,7 @@ impl MutableAppContext {
             focus_observations: Default::default(),
             release_observations: Default::default(),
             global_observations: Default::default(),
+            window_activation_observations: Default::default(),
             action_dispatch_observations: Default::default(),
             presenters_and_platform_windows: HashMap::new(),
             foreground,
@@ -1358,6 +1362,24 @@ impl MutableAppContext {
         }
     }
 
+    fn observe_window_activation<F>(&mut self, window_id: usize, callback: F) -> Subscription
+    where
+        F: 'static + FnMut(bool, &mut MutableAppContext) -> bool,
+    {
+        let subscription_id = post_inc(&mut self.next_subscription_id);
+        self.pending_effects
+            .push_back(Effect::WindowActivationObservation {
+                window_id,
+                subscription_id,
+                callback: Box::new(callback),
+            });
+        Subscription::WindowActivationObservation {
+            id: subscription_id,
+            window_id,
+            observations: Some(Arc::downgrade(&self.window_activation_observations)),
+        }
+    }
+
     pub fn defer(&mut self, callback: impl 'static + FnOnce(&mut MutableAppContext)) {
         self.pending_effects.push_back(Effect::Deferred {
             callback: Box::new(callback),
@@ -1715,19 +1737,16 @@ impl MutableAppContext {
         self.update(|this| {
             let window_id = post_inc(&mut this.next_window_id);
             let root_view = this.add_view(window_id, build_root_view);
-
             this.cx.windows.insert(
                 window_id,
                 Window {
                     root_view: root_view.clone().into(),
                     focused_view_id: Some(root_view.id()),
-                    is_active: true,
+                    is_active: false,
                     invalidation: None,
                 },
             );
-            root_view.update(this, |view, cx| {
-                view.on_focus(cx);
-            });
+            root_view.update(this, |view, cx| view.on_focus(cx));
             this.open_platform_window(window_id, window_options);
 
             (window_id, root_view)
@@ -1995,10 +2014,19 @@ impl MutableAppContext {
                                     .get_or_insert(WindowInvalidation::default());
                             }
                         }
+                        Effect::WindowActivationObservation {
+                            window_id,
+                            subscription_id,
+                            callback,
+                        } => self.handle_window_activation_observation_effect(
+                            window_id,
+                            subscription_id,
+                            callback,
+                        ),
                         Effect::ActivateWindow {
                             window_id,
                             is_active,
-                        } => self.handle_activation_effect(window_id, is_active),
+                        } => self.handle_window_activation_effect(window_id, is_active),
                         Effect::RefreshWindows => {
                             refreshing = true;
                         }
@@ -2361,7 +2389,31 @@ impl MutableAppContext {
         }
     }
 
-    fn handle_activation_effect(&mut self, window_id: usize, active: bool) {
+    fn handle_window_activation_observation_effect(
+        &mut self,
+        window_id: usize,
+        subscription_id: usize,
+        callback: WindowActivationCallback,
+    ) {
+        match self
+            .window_activation_observations
+            .lock()
+            .entry(window_id)
+            .or_default()
+            .entry(subscription_id)
+        {
+            btree_map::Entry::Vacant(entry) => {
+                entry.insert(Some(callback));
+            }
+            // Observation was dropped before effect was processed
+            btree_map::Entry::Occupied(entry) => {
+                debug_assert!(entry.get().is_none());
+                entry.remove();
+            }
+        }
+    }
+
+    fn handle_window_activation_effect(&mut self, window_id: usize, active: bool) {
         if self
             .cx
             .windows
@@ -2383,6 +2435,34 @@ impl MutableAppContext {
                     view.on_blur(this, window_id, view_id);
                 }
                 this.cx.views.insert((window_id, view_id), view);
+            }
+
+            let callbacks = this
+                .window_activation_observations
+                .lock()
+                .remove(&window_id);
+            if let Some(callbacks) = callbacks {
+                for (id, callback) in callbacks {
+                    if let Some(mut callback) = callback {
+                        let alive = callback(active, this);
+                        if alive {
+                            match this
+                                .window_activation_observations
+                                .lock()
+                                .entry(window_id)
+                                .or_default()
+                                .entry(id)
+                            {
+                                btree_map::Entry::Vacant(entry) => {
+                                    entry.insert(Some(callback));
+                                }
+                                btree_map::Entry::Occupied(entry) => {
+                                    entry.remove();
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             Some(())
@@ -2842,6 +2922,11 @@ pub enum Effect {
         window_id: usize,
         is_active: bool,
     },
+    WindowActivationObservation {
+        window_id: usize,
+        subscription_id: usize,
+        callback: WindowActivationCallback,
+    },
     RefreshWindows,
     ActionDispatchNotification {
         action_id: TypeId,
@@ -2933,6 +3018,15 @@ impl Debug for Effect {
             Effect::ResizeWindow { window_id } => f
                 .debug_struct("Effect::RefreshWindow")
                 .field("window_id", window_id)
+                .finish(),
+            Effect::WindowActivationObservation {
+                window_id,
+                subscription_id,
+                ..
+            } => f
+                .debug_struct("Effect::WindowActivationObservation")
+                .field("window_id", window_id)
+                .field("subscription_id", subscription_id)
                 .finish(),
             Effect::ActivateWindow {
                 window_id,
@@ -3516,6 +3610,24 @@ impl<'a, T: View> ViewContext<'a, T> {
                 });
             }
         })
+    }
+
+    pub fn observe_window_activation<F>(&mut self, mut callback: F) -> Subscription
+    where
+        F: 'static + FnMut(&mut T, bool, &mut ViewContext<T>),
+    {
+        let observer = self.weak_handle();
+        self.app
+            .observe_window_activation(self.window_id(), move |active, cx| {
+                if let Some(observer) = observer.upgrade(cx) {
+                    observer.update(cx, |observer, cx| {
+                        callback(observer, active, cx);
+                    });
+                    true
+                } else {
+                    false
+                }
+            })
     }
 
     pub fn emit(&mut self, payload: T::Event) {
@@ -4833,6 +4945,12 @@ pub enum Subscription {
         id: usize,
         observations: Option<Weak<Mutex<BTreeMap<usize, ActionObservationCallback>>>>,
     },
+    WindowActivationObservation {
+        id: usize,
+        window_id: usize,
+        observations:
+            Option<Weak<Mutex<HashMap<usize, BTreeMap<usize, Option<WindowActivationCallback>>>>>>,
+    },
 }
 
 impl Subscription {
@@ -4857,6 +4975,9 @@ impl Subscription {
                 observations.take();
             }
             Subscription::ActionObservation { observations, .. } => {
+                observations.take();
+            }
+            Subscription::WindowActivationObservation { observations, .. } => {
                 observations.take();
             }
         }
@@ -4970,6 +5091,27 @@ impl Drop for Subscription {
             Subscription::ActionObservation { id, observations } => {
                 if let Some(observations) = observations.as_ref().and_then(Weak::upgrade) {
                     observations.lock().remove(&id);
+                }
+            }
+            Subscription::WindowActivationObservation {
+                id,
+                window_id,
+                observations,
+            } => {
+                if let Some(observations) = observations.as_ref().and_then(Weak::upgrade) {
+                    match observations
+                        .lock()
+                        .entry(*window_id)
+                        .or_default()
+                        .entry(*id)
+                    {
+                        btree_map::Entry::Vacant(entry) => {
+                            entry.insert(None);
+                        }
+                        btree_map::Entry::Occupied(entry) => {
+                            entry.remove();
+                        }
+                    }
                 }
             }
         }

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -675,9 +675,7 @@ impl Background {
                 }
             }
             _ => {
-                log::info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-
-                // panic!("this method can only be called on a deterministic executor")
+                panic!("this method can only be called on a deterministic executor")
             }
         }
     }

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -37,6 +37,7 @@ pub struct Window {
     event_handlers: Vec<Box<dyn FnMut(super::Event) -> bool>>,
     resize_handlers: Vec<Box<dyn FnMut()>>,
     close_handlers: Vec<Box<dyn FnOnce()>>,
+    pub(crate) active_status_change_handlers: Vec<Box<dyn FnMut(bool)>>,
     pub(crate) should_close_handler: Option<Box<dyn FnMut() -> bool>>,
     pub(crate) title: Option<String>,
     pub(crate) edited: bool,
@@ -191,6 +192,7 @@ impl Window {
             resize_handlers: Default::default(),
             close_handlers: Default::default(),
             should_close_handler: Default::default(),
+            active_status_change_handlers: Default::default(),
             scale_factor: 1.0,
             current_scene: None,
             title: None,
@@ -241,7 +243,9 @@ impl super::Window for Window {
         self.event_handlers.push(callback);
     }
 
-    fn on_active_status_change(&mut self, _: Box<dyn FnMut(bool)>) {}
+    fn on_active_status_change(&mut self, callback: Box<dyn FnMut(bool)>) {
+        self.active_status_change_handlers.push(callback);
+    }
 
     fn on_resize(&mut self, callback: Box<dyn FnMut()>) {
         self.resize_handlers.push(callback);

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -39,6 +39,7 @@ pub struct LanguageSettings {
     pub preferred_line_length: Option<u32>,
     pub format_on_save: Option<bool>,
     pub enable_language_server: Option<bool>,
+    pub autosave: Option<Autosave>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -47,6 +48,15 @@ pub enum SoftWrap {
     None,
     EditorWidth,
     PreferredLineLength,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Autosave {
+    Off,
+    AfterDelay { milliseconds: usize },
+    OnFocusChange,
+    OnWindowChange,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
@@ -126,6 +136,11 @@ impl Settings {
     pub fn format_on_save(&self, language: Option<&str>) -> bool {
         self.language_setting(language, |settings| settings.format_on_save)
             .unwrap_or(true)
+    }
+
+    pub fn autosave(&self, language: Option<&str>) -> Autosave {
+        self.language_setting(language, |settings| settings.autosave)
+            .unwrap_or(Autosave::Off)
     }
 
     pub fn enable_language_server(&self, language: Option<&str>) -> bool {
@@ -212,6 +227,7 @@ impl Settings {
             &mut self.language_settings.preferred_line_length,
             data.editor.preferred_line_length,
         );
+        merge_option(&mut self.language_settings.autosave, data.editor.autosave);
 
         for (language_name, settings) in data.language_overrides.clone().into_iter() {
             let target = self
@@ -230,6 +246,7 @@ impl Settings {
                 &mut target.preferred_line_length,
                 settings.preferred_line_length,
             );
+            merge_option(&mut target.autosave, settings.autosave);
         }
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -97,7 +97,6 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     cx.add_action({
         let app_state = app_state.clone();
         move |_: &mut Workspace, _: &OpenSettings, cx: &mut ViewContext<Workspace>| {
-            println!("open settings");
             open_config_file(&SETTINGS_PATH, app_state.clone(), cx);
         }
     });


### PR DESCRIPTION
Closes https://github.com/zed-industries/feedback/issues/31

This new feature can be enabled in three different modes:

1. Autosave when focus changes:
    ```json
    {
        "autosave": "on_focus_change"
    }
    ```
2. Autosave when window is unfocused:
    ```json
    {
        "autosave": "on_window_change"
    }
    ```
3. Autosave when timeout expires:
    ```json
    {
        "autosave": {
            "after_delay": {
                "milliseconds": 1000
            }
    }
    ```

As part of this, I also fixed what seems to be a pretty bad unsafe memory access in GPUI. We were using `Arc::decrement_strong_count` without first accessing the raw pointer and instead passing a reference to the `Arc` which was then coerced into a pointer. I am actually surprised we didn't notice this earlier so maybe it's the result of some recent Rust API change or we just got lucky. For more information, see [7a6010e](https://github.com/zed-industries/zed/pull/1279/commits/7a6010e7dc6492ab16d18d07bf5bfe60b85fb152).