### PR TITLE
Select the last worktree root when right-clicking below all project panel entries

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1042,7 +1042,7 @@ impl Project {
     pub fn worktrees<'a>(
         &'a self,
         cx: &'a AppContext,
-    ) -> impl 'a + Iterator<Item = ModelHandle<Worktree>> {
+    ) -> impl 'a + DoubleEndedIterator<Item = ModelHandle<Worktree>> {
         self.worktrees
             .iter()
             .filter_map(move |worktree| worktree.upgrade(cx))
@@ -1051,7 +1051,7 @@ impl Project {
     pub fn visible_worktrees<'a>(
         &'a self,
         cx: &'a AppContext,
-    ) -> impl 'a + Iterator<Item = ModelHandle<Worktree>> {
+    ) -> impl 'a + DoubleEndedIterator<Item = ModelHandle<Worktree>> {
         self.worktrees.iter().filter_map(|worktree| {
             worktree.upgrade(cx).and_then(|worktree| {
                 if worktree.read(cx).is_visible() {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/90

When right clicking in the project panel below any entry, we now act as if you right-clicked the root of the last visible worktree. This seems to match the behavior of VS Code.