### PR TITLE
Fix crash when pasting text with CRLF line endings

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -314,30 +314,30 @@ impl CharKind {
 }
 
 impl Buffer {
-    pub fn new<T: Into<Arc<str>>>(
+    pub fn new<T: Into<String>>(
         replica_id: ReplicaId,
         base_text: T,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        let history = History::new(base_text.into());
-        let line_ending = LineEnding::detect(&history.base_text);
+        let base_text = base_text.into();
+        let line_ending = LineEnding::detect(&base_text);
         Self::build(
-            TextBuffer::new(replica_id, cx.model_id() as u64, history),
+            TextBuffer::new(replica_id, cx.model_id() as u64, base_text),
             None,
             line_ending,
         )
     }
 
-    pub fn from_file<T: Into<Arc<str>>>(
+    pub fn from_file<T: Into<String>>(
         replica_id: ReplicaId,
         base_text: T,
         file: Arc<dyn File>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        let history = History::new(base_text.into());
-        let line_ending = LineEnding::detect(&history.base_text);
+        let base_text = base_text.into();
+        let line_ending = LineEnding::detect(&base_text);
         Self::build(
-            TextBuffer::new(replica_id, cx.model_id() as u64, history),
+            TextBuffer::new(replica_id, cx.model_id() as u64, base_text),
             Some(file),
             line_ending,
         )
@@ -349,11 +349,7 @@ impl Buffer {
         file: Option<Arc<dyn File>>,
         cx: &mut ModelContext<Self>,
     ) -> Result<Self> {
-        let buffer = TextBuffer::new(
-            replica_id,
-            message.id,
-            History::new(Arc::from(message.base_text)),
-        );
+        let buffer = TextBuffer::new(replica_id, message.id, message.base_text);
         let line_ending = proto::LineEnding::from_i32(message.line_ending)
             .ok_or_else(|| anyhow!("missing line_ending"))?;
         let mut this = Self::build(buffer, file, LineEnding::from_proto(line_ending));

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -11,6 +11,20 @@ use text::*;
 
 pub use proto::{Buffer, BufferState, LineEnding, SelectionSet};
 
+pub fn deserialize_line_ending(message: proto::LineEnding) -> text::LineEnding {
+    match message {
+        LineEnding::Unix => text::LineEnding::Unix,
+        LineEnding::Windows => text::LineEnding::Windows,
+    }
+}
+
+pub fn serialize_line_ending(message: text::LineEnding) -> proto::LineEnding {
+    match message {
+        text::LineEnding::Unix => proto::LineEnding::Unix,
+        text::LineEnding::Windows => proto::LineEnding::Windows,
+    }
+}
+
 pub fn serialize_operation(operation: &Operation) -> proto::Operation {
     proto::Operation {
         variant: Some(match operation {

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -421,7 +421,7 @@ async fn test_outline(cx: &mut gpui::TestAppContext) {
     async fn search<'a>(
         outline: &'a Outline<Anchor>,
         query: &str,
-        cx: &gpui::TestAppContext,
+        cx: &'a gpui::TestAppContext,
     ) -> Vec<(&'a str, Vec<usize>)> {
         let matches = cx
             .read(|cx| outline.search(query, cx.background().clone()))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -20,12 +20,14 @@ use gpui::{
 };
 use language::{
     point_to_lsp,
-    proto::{deserialize_anchor, deserialize_version, serialize_anchor, serialize_version},
+    proto::{
+        deserialize_anchor, deserialize_line_ending, deserialize_version, serialize_anchor,
+        serialize_version,
+    },
     range_from_lsp, range_to_lsp, Anchor, Bias, Buffer, CharKind, CodeAction, CodeLabel,
     Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Event as BufferEvent, File as _,
-    Language, LanguageRegistry, LanguageServerName, LineEnding, LocalFile, LspAdapter,
-    OffsetRangeExt, Operation, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16,
-    Transaction,
+    Language, LanguageRegistry, LanguageServerName, LocalFile, LspAdapter, OffsetRangeExt,
+    Operation, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction,
 };
 use lsp::{
     DiagnosticSeverity, DiagnosticTag, DocumentHighlightKind, LanguageServer, LanguageString,
@@ -5542,7 +5544,7 @@ impl Project {
     ) -> Result<()> {
         let payload = envelope.payload;
         let version = deserialize_version(payload.version);
-        let line_ending = LineEnding::from_proto(
+        let line_ending = deserialize_line_ending(
             proto::LineEnding::from_i32(payload.line_ending)
                 .ok_or_else(|| anyhow!("missing line ending"))?,
         );

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -23,7 +23,7 @@ use gpui::{
     Task,
 };
 use language::{
-    proto::{deserialize_version, serialize_version},
+    proto::{deserialize_version, serialize_line_ending, serialize_version},
     Buffer, DiagnosticEntry, LineEnding, PointUtf16, Rope,
 };
 use lazy_static::lazy_static;
@@ -1750,7 +1750,7 @@ impl language::LocalFile for File {
                     version: serialize_version(&version),
                     mtime: Some(mtime.into()),
                     fingerprint,
-                    line_ending: line_ending.to_proto() as i32,
+                    line_ending: serialize_line_ending(line_ending) as i32,
                 })
                 .log_err();
         }

--- a/crates/text/src/random_char_iter.rs
+++ b/crates/text/src/random_char_iter.rs
@@ -22,7 +22,7 @@ impl<T: Rng> Iterator for RandomCharIter<T> {
 
         match self.0.gen_range(0..100) {
             // whitespace
-            0..=19 => [' ', '\n', '\t'].choose(&mut self.0).copied(),
+            0..=19 => [' ', '\n', '\r', '\t'].choose(&mut self.0).copied(),
             // two-byte greek letters
             20..=32 => char::from_u32(self.0.gen_range(('α' as u32)..('ω' as u32 + 1))),
             // // three-byte characters

--- a/crates/text/src/rope.rs
+++ b/crates/text/src/rope.rs
@@ -58,19 +58,12 @@ impl Rope {
     pub fn push(&mut self, text: &str) {
         let mut new_chunks = SmallVec::<[_; 16]>::new();
         let mut new_chunk = ArrayString::new();
-        let mut chars = text.chars().peekable();
-        while let Some(mut ch) = chars.next() {
+        for ch in text.chars() {
             if new_chunk.len() + ch.len_utf8() > 2 * CHUNK_BASE {
                 new_chunks.push(Chunk(new_chunk));
                 new_chunk = ArrayString::new();
             }
 
-            if ch == '\r' {
-                ch = '\n';
-                if chars.peek().copied() == Some('\n') {
-                    chars.next();
-                }
-            }
             new_chunk.push(ch);
         }
         if !new_chunk.is_empty() {

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -18,7 +18,7 @@ fn init_logger() {
 
 #[test]
 fn test_edit() {
-    let mut buffer = Buffer::new(0, 0, History::new("abc".into()));
+    let mut buffer = Buffer::new(0, 0, "abc".into());
     assert_eq!(buffer.text(), "abc");
     buffer.edit([(3..3, "def")]);
     assert_eq!(buffer.text(), "abcdef");
@@ -42,7 +42,7 @@ fn test_random_edits(mut rng: StdRng) {
     let mut reference_string = RandomCharIter::new(&mut rng)
         .take(reference_string_len)
         .collect::<String>();
-    let mut buffer = Buffer::new(0, 0, History::new(reference_string.clone().into()));
+    let mut buffer = Buffer::new(0, 0, reference_string.clone().into());
     buffer.history.group_interval = Duration::from_millis(rng.gen_range(0..=200));
     let mut buffer_versions = Vec::new();
     log::info!(
@@ -150,7 +150,7 @@ fn test_random_edits(mut rng: StdRng) {
 
 #[test]
 fn test_line_len() {
-    let mut buffer = Buffer::new(0, 0, History::new("".into()));
+    let mut buffer = Buffer::new(0, 0, "".into());
     buffer.edit([(0..0, "abcd\nefg\nhij")]);
     buffer.edit([(12..12, "kl\nmno")]);
     buffer.edit([(18..18, "\npqrs\n")]);
@@ -167,7 +167,7 @@ fn test_line_len() {
 #[test]
 fn test_common_prefix_at_positionn() {
     let text = "a = str; b = δα";
-    let buffer = Buffer::new(0, 0, History::new(text.into()));
+    let buffer = Buffer::new(0, 0, text.into());
 
     let offset1 = offset_after(text, "str");
     let offset2 = offset_after(text, "δα");
@@ -215,7 +215,7 @@ fn test_common_prefix_at_positionn() {
 
 #[test]
 fn test_text_summary_for_range() {
-    let buffer = Buffer::new(0, 0, History::new("ab\nefg\nhklm\nnopqrs\ntuvwxyz".into()));
+    let buffer = Buffer::new(0, 0, "ab\nefg\nhklm\nnopqrs\ntuvwxyz".into());
     assert_eq!(
         buffer.text_summary_for_range::<TextSummary, _>(1..3),
         TextSummary {
@@ -280,7 +280,7 @@ fn test_text_summary_for_range() {
 
 #[test]
 fn test_chars_at() {
-    let mut buffer = Buffer::new(0, 0, History::new("".into()));
+    let mut buffer = Buffer::new(0, 0, "".into());
     buffer.edit([(0..0, "abcd\nefgh\nij")]);
     buffer.edit([(12..12, "kl\nmno")]);
     buffer.edit([(18..18, "\npqrs")]);
@@ -302,7 +302,7 @@ fn test_chars_at() {
     assert_eq!(chars.collect::<String>(), "PQrs");
 
     // Regression test:
-    let mut buffer = Buffer::new(0, 0, History::new("".into()));
+    let mut buffer = Buffer::new(0, 0, "".into());
     buffer.edit([(0..0, "[workspace]\nmembers = [\n    \"xray_core\",\n    \"xray_server\",\n    \"xray_cli\",\n    \"xray_wasm\",\n]\n")]);
     buffer.edit([(60..60, "\n")]);
 
@@ -312,7 +312,7 @@ fn test_chars_at() {
 
 #[test]
 fn test_anchors() {
-    let mut buffer = Buffer::new(0, 0, History::new("".into()));
+    let mut buffer = Buffer::new(0, 0, "".into());
     buffer.edit([(0..0, "abc")]);
     let left_anchor = buffer.anchor_before(2);
     let right_anchor = buffer.anchor_after(2);
@@ -430,7 +430,7 @@ fn test_anchors() {
 
 #[test]
 fn test_anchors_at_start_and_end() {
-    let mut buffer = Buffer::new(0, 0, History::new("".into()));
+    let mut buffer = Buffer::new(0, 0, "".into());
     let before_start_anchor = buffer.anchor_before(0);
     let after_end_anchor = buffer.anchor_after(0);
 
@@ -453,7 +453,7 @@ fn test_anchors_at_start_and_end() {
 
 #[test]
 fn test_undo_redo() {
-    let mut buffer = Buffer::new(0, 0, History::new("1234".into()));
+    let mut buffer = Buffer::new(0, 0, "1234".into());
     // Set group interval to zero so as to not group edits in the undo stack.
     buffer.history.group_interval = Duration::from_secs(0);
 
@@ -490,7 +490,7 @@ fn test_undo_redo() {
 #[test]
 fn test_history() {
     let mut now = Instant::now();
-    let mut buffer = Buffer::new(0, 0, History::new("123456".into()));
+    let mut buffer = Buffer::new(0, 0, "123456".into());
 
     buffer.start_transaction_at(now);
     buffer.edit([(2..4, "cd")]);
@@ -544,7 +544,7 @@ fn test_history() {
 #[test]
 fn test_finalize_last_transaction() {
     let now = Instant::now();
-    let mut buffer = Buffer::new(0, 0, History::new("123456".into()));
+    let mut buffer = Buffer::new(0, 0, "123456".into());
 
     buffer.start_transaction_at(now);
     buffer.edit([(2..4, "cd")]);
@@ -579,7 +579,7 @@ fn test_finalize_last_transaction() {
 #[test]
 fn test_edited_ranges_for_transaction() {
     let now = Instant::now();
-    let mut buffer = Buffer::new(0, 0, History::new("1234567".into()));
+    let mut buffer = Buffer::new(0, 0, "1234567".into());
 
     buffer.start_transaction_at(now);
     buffer.edit([(2..4, "cd")]);
@@ -618,9 +618,9 @@ fn test_edited_ranges_for_transaction() {
 fn test_concurrent_edits() {
     let text = "abcdef";
 
-    let mut buffer1 = Buffer::new(1, 0, History::new(text.into()));
-    let mut buffer2 = Buffer::new(2, 0, History::new(text.into()));
-    let mut buffer3 = Buffer::new(3, 0, History::new(text.into()));
+    let mut buffer1 = Buffer::new(1, 0, text.into());
+    let mut buffer2 = Buffer::new(2, 0, text.into());
+    let mut buffer3 = Buffer::new(3, 0, text.into());
 
     let buf1_op = buffer1.edit([(1..2, "12")]);
     assert_eq!(buffer1.text(), "a12cdef");
@@ -659,7 +659,7 @@ fn test_random_concurrent_edits(mut rng: StdRng) {
     let mut network = Network::new(rng.clone());
 
     for i in 0..peers {
-        let mut buffer = Buffer::new(i as ReplicaId, 0, History::new(base_text.clone().into()));
+        let mut buffer = Buffer::new(i as ReplicaId, 0, base_text.clone().into());
         buffer.history.group_interval = Duration::from_millis(rng.gen_range(0..=200));
         buffers.push(buffer);
         replica_ids.push(i as u16);

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -43,6 +43,8 @@ fn test_random_edits(mut rng: StdRng) {
         .take(reference_string_len)
         .collect::<String>();
     let mut buffer = Buffer::new(0, 0, reference_string.clone().into());
+    reference_string = reference_string.replace("\r", "");
+
     buffer.history.group_interval = Duration::from_millis(rng.gen_range(0..=200));
     let mut buffer_versions = Vec::new();
     log::info!(
@@ -56,6 +58,8 @@ fn test_random_edits(mut rng: StdRng) {
         for (old_range, new_text) in edits.iter().rev() {
             reference_string.replace_range(old_range.clone(), &new_text);
         }
+        reference_string = reference_string.replace("\r", "");
+
         assert_eq!(buffer.text(), reference_string);
         log::info!(
             "buffer text {:?}, version: {:?}",
@@ -146,6 +150,20 @@ fn test_random_edits(mut rng: StdRng) {
         }
         assert_eq!(text.to_string(), buffer.text());
     }
+}
+
+#[test]
+fn test_line_endings() {
+    let mut buffer = Buffer::new(0, 0, "one\r\ntwo".into());
+    assert_eq!(buffer.text(), "one\ntwo");
+    assert_eq!(buffer.line_ending(), LineEnding::Windows);
+    buffer.check_invariants();
+
+    buffer.edit([(buffer.len()..buffer.len(), "\r\nthree")]);
+    buffer.edit([(0..0, "zero\r\n")]);
+    assert_eq!(buffer.text(), "zero\none\ntwo\nthree");
+    assert_eq!(buffer.line_ending(), LineEnding::Windows);
+    buffer.check_invariants();
 }
 
 #[test]

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -63,6 +63,7 @@ pub struct BufferSnapshot {
     remote_id: u64,
     visible_text: Rope,
     deleted_text: Rope,
+    line_ending: LineEnding,
     undo_map: UndoMap,
     fragments: SumTree<Fragment>,
     insertions: SumTree<InsertionFragment>,
@@ -84,6 +85,12 @@ pub struct Transaction {
     pub start: clock::Global,
     pub end: clock::Global,
     pub ranges: Vec<Range<FullOffset>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LineEnding {
+    Unix,
+    Windows,
 }
 
 impl HistoryEntry {
@@ -539,7 +546,10 @@ pub struct UndoOperation {
 }
 
 impl Buffer {
-    pub fn new(replica_id: u16, remote_id: u64, base_text: String) -> Buffer {
+    pub fn new(replica_id: u16, remote_id: u64, mut base_text: String) -> Buffer {
+        let line_ending = LineEnding::detect(&base_text);
+        LineEnding::strip_carriage_returns(&mut base_text);
+
         let history = History::new(base_text.into());
         let mut fragments = SumTree::new();
         let mut insertions = SumTree::new();
@@ -547,6 +557,7 @@ impl Buffer {
         let mut local_clock = clock::Local::new(replica_id);
         let mut lamport_clock = clock::Lamport::new(replica_id);
         let mut version = clock::Global::new();
+
         let visible_text = Rope::from(history.base_text.as_ref());
         if visible_text.len() > 0 {
             let insertion_timestamp = InsertionTimestamp {
@@ -577,6 +588,7 @@ impl Buffer {
                 remote_id,
                 visible_text,
                 deleted_text: Rope::new(),
+                line_ending,
                 fragments,
                 insertions,
                 version,
@@ -659,7 +671,7 @@ impl Buffer {
         let mut new_insertions = Vec::new();
         let mut insertion_offset = 0;
 
-        let mut ranges = edits
+        let mut edits = edits
             .map(|(range, new_text)| (range.to_offset(&*self), new_text))
             .peekable();
 
@@ -667,12 +679,12 @@ impl Buffer {
             RopeBuilder::new(self.visible_text.cursor(0), self.deleted_text.cursor(0));
         let mut old_fragments = self.fragments.cursor::<FragmentTextSummary>();
         let mut new_fragments =
-            old_fragments.slice(&ranges.peek().unwrap().0.start, Bias::Right, &None);
+            old_fragments.slice(&edits.peek().unwrap().0.start, Bias::Right, &None);
         new_ropes.push_tree(new_fragments.summary().text);
 
         let mut fragment_start = old_fragments.start().visible;
-        for (range, new_text) in ranges {
-            let new_text = new_text.into();
+        for (range, new_text) in edits {
+            let new_text = LineEnding::strip_carriage_returns_from_arc(new_text.into());
             let fragment_end = old_fragments.end(&None).visible;
 
             // If the current fragment ends before this range, then jump ahead to the first fragment
@@ -715,6 +727,7 @@ impl Buffer {
             // Insert the new text before any existing fragments within the range.
             if !new_text.is_empty() {
                 let new_start = new_fragments.summary().text.visible;
+
                 edits_patch.push(Edit {
                     old: fragment_start..fragment_start,
                     new: new_start..new_start + new_text.len(),
@@ -804,6 +817,10 @@ impl Buffer {
         self.snapshot.deleted_text = deleted_text;
         self.subscriptions.publish_mut(&edits_patch);
         edit_op
+    }
+
+    pub fn set_line_ending(&mut self, line_ending: LineEnding) {
+        self.snapshot.line_ending = line_ending;
     }
 
     pub fn apply_ops<I: IntoIterator<Item = Operation>>(&mut self, ops: I) -> Result<()> {
@@ -1413,6 +1430,8 @@ impl Buffer {
             fragment_summary.text.deleted,
             self.snapshot.deleted_text.len()
         );
+
+        assert!(!self.text().contains("\r\n"));
     }
 
     pub fn set_group_interval(&mut self, group_interval: Duration) {
@@ -1548,6 +1567,10 @@ impl BufferSnapshot {
 
     pub fn text(&self) -> String {
         self.visible_text.to_string()
+    }
+
+    pub fn line_ending(&self) -> LineEnding {
+        self.line_ending
     }
 
     pub fn deleted_text(&self) -> String {
@@ -2307,6 +2330,50 @@ impl operation_queue::Operation for Operation {
             Operation::Undo {
                 lamport_timestamp, ..
             } => *lamport_timestamp,
+        }
+    }
+}
+
+impl Default for LineEnding {
+    fn default() -> Self {
+        #[cfg(unix)]
+        return Self::Unix;
+
+        #[cfg(not(unix))]
+        return Self::CRLF;
+    }
+}
+
+impl LineEnding {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LineEnding::Unix => "\n",
+            LineEnding::Windows => "\r\n",
+        }
+    }
+
+    pub fn detect(text: &str) -> Self {
+        if let Some(ix) = text[..cmp::min(text.len(), 1000)].find(&['\n']) {
+            let text = text.as_bytes();
+            if ix > 0 && text[ix - 1] == b'\r' {
+                Self::Windows
+            } else {
+                Self::Unix
+            }
+        } else {
+            Self::default()
+        }
+    }
+
+    pub fn strip_carriage_returns(text: &mut String) {
+        text.retain(|c| c != '\r')
+    }
+
+    fn strip_carriage_returns_from_arc(text: Arc<str>) -> Arc<str> {
+        if text.contains('\r') {
+            text.replace('\r', "").into()
+        } else {
+            text
         }
     }
 }

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -148,9 +148,9 @@ impl HistoryEntry {
 }
 
 #[derive(Clone)]
-pub struct History {
+struct History {
     // TODO: Turn this into a String or Rope, maybe.
-    pub base_text: Arc<str>,
+    base_text: Arc<str>,
     operations: HashMap<clock::Local, Operation>,
     undo_stack: Vec<HistoryEntry>,
     redo_stack: Vec<HistoryEntry>,
@@ -539,7 +539,8 @@ pub struct UndoOperation {
 }
 
 impl Buffer {
-    pub fn new(replica_id: u16, remote_id: u64, history: History) -> Buffer {
+    pub fn new(replica_id: u16, remote_id: u64, base_text: String) -> Buffer {
+        let history = History::new(base_text.into());
         let mut fragments = SumTree::new();
         let mut insertions = SumTree::new();
 


### PR DESCRIPTION
Fixes zed-industries/feedback#220

In https://github.com/zed-industries/zed/pull/1276, we added logic to convert all buffers to internally use LF line endings (even if they used CRLF on disk). This PR fixes some bugs in that PR:

1. The conversion took place inside of `Rope`, but the text buffer's `fragments` tree did not account for the conversion, so the two could become out of sync.
2. The conversion looked for sequences of `\r` `\n` characters *within* a single edit, but that sequence could arise over the course of multiple edits. For example, you could insert a `\n` character after a lone `\r`, or delete a run of characters separating a `\r` from a `\n`.

This fixes the first bug by moving the line-ending normalization logic from `Rope` into `text::Buffer`, so that it applies to both the Rope and the fragments tree.

The second bug is going to take a bit more work to fix properly. For now, we have prevented it by simply **removing all carriage returns** from the text internally. This is a bit more lossy than the former approach, and we may want to relax it going forward. But for the vast majority of use cases, carriage returns are only used as part of CRLF line endings, so we think this is a beneficial change to ship for now.

🍐 'd with @Kethku