### PR TITLE
Fix autosave when closing a tab

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -568,10 +568,11 @@ impl workspace::Item for ProjectDiagnosticsEditor {
     }
 
     fn should_update_tab_on_event(event: &Event) -> bool {
-        matches!(
-            event,
-            Event::Saved | Event::DirtyChanged | Event::TitleChanged
-        )
+        Editor::should_update_tab_on_event(event)
+    }
+
+    fn is_edit_event(event: &Self::Event) -> bool {
+        Editor::is_edit_event(event)
     }
 
     fn set_nav_history(&mut self, nav_history: ItemNavHistory, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -445,6 +445,10 @@ impl Item for Editor {
             Event::Saved | Event::DirtyChanged | Event::TitleChanged
         )
     }
+
+    fn is_edit_event(event: &Self::Event) -> bool {
+        matches!(event, Event::BufferEdited)
+    }
 }
 
 impl ProjectItem for Editor {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -329,6 +329,14 @@ impl Item for ProjectSearchView {
     fn should_update_tab_on_event(event: &ViewEvent) -> bool {
         matches!(event, ViewEvent::UpdateTab)
     }
+
+    fn is_edit_event(event: &Self::Event) -> bool {
+        if let ViewEvent::EditorEvent(editor_event) = event {
+            Editor::is_edit_event(editor_event)
+        } else {
+            false
+        }
+    }
 }
 
 impl ProjectSearchView {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -365,8 +365,10 @@ impl ProjectSearchView {
             cx.emit(ViewEvent::EditorEvent(event.clone()))
         })
         .detach();
-        cx.observe_focus(&query_editor, |this, _, _| {
-            this.results_editor_was_focused = false;
+        cx.observe_focus(&query_editor, |this, _, focused, _| {
+            if focused {
+                this.results_editor_was_focused = false;
+            }
         })
         .detach();
 
@@ -377,8 +379,10 @@ impl ProjectSearchView {
         });
         cx.observe(&results_editor, |_, _, cx| cx.emit(ViewEvent::UpdateTab))
             .detach();
-        cx.observe_focus(&results_editor, |this, _, _| {
-            this.results_editor_was_focused = true;
+        cx.observe_focus(&results_editor, |this, _, focused, _| {
+            if focused {
+                this.results_editor_was_focused = true;
+            }
         })
         .detach();
         cx.subscribe(&results_editor, |this, _, event, cx| {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -718,6 +718,18 @@ impl Pane {
         Ok(true)
     }
 
+    pub fn autosave_item(
+        item: &dyn ItemHandle,
+        project: ModelHandle<Project>,
+        cx: &mut MutableAppContext,
+    ) -> Task<Result<()>> {
+        if item.is_dirty(cx) && !item.has_conflict(cx) && item.can_save(cx) {
+            item.save(project, cx)
+        } else {
+            Task::ready(Ok(()))
+        }
+    }
+
     pub fn focus_active_item(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(active_item) = self.active_item() {
             cx.focus(active_item);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -14,7 +14,7 @@ use gpui::{
 };
 use project::{Project, ProjectEntryId, ProjectPath};
 use serde::Deserialize;
-use settings::Settings;
+use settings::{Autosave, Settings};
 use std::{any::Any, cell::RefCell, mem, path::Path, rc::Rc};
 use util::ResultExt;
 
@@ -677,7 +677,13 @@ impl Pane {
                 _ => return Ok(false),
             }
         } else if is_dirty && (can_save || is_singleton) {
-            let should_save = if should_prompt_for_save {
+            let autosave_enabled = cx.read(|cx| {
+                matches!(
+                    cx.global::<Settings>().autosave,
+                    Autosave::OnFocusChange | Autosave::OnWindowChange
+                )
+            });
+            let should_save = if should_prompt_for_save && !autosave_enabled {
                 let mut answer = pane.update(cx, |pane, cx| {
                     pane.activate_item(item_ix, true, true, cx);
                     cx.prompt(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -396,9 +396,11 @@ mod tests {
     };
     use project::{Project, ProjectPath};
     use serde_json::json;
+    use settings::Autosave;
     use std::{
         collections::HashSet,
         path::{Path, PathBuf},
+        time::Duration,
     };
     use theme::{Theme, ThemeRegistry, DEFAULT_THEME_NAME};
     use workspace::{
@@ -975,6 +977,79 @@ mod tests {
                 editor.read(cx).buffer().read(cx).as_singleton().unwrap()
             );
         })
+    }
+
+    #[gpui::test]
+    async fn test_autosave(deterministic: Arc<Deterministic>, cx: &mut gpui::TestAppContext) {
+        let app_state = init(cx);
+        let fs = app_state.fs.clone();
+        fs.as_fake()
+            .insert_tree("/root", json!({ "a.txt": "" }))
+            .await;
+
+        let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+        let (_, workspace) = cx.add_window(|cx| Workspace::new(project, cx));
+        cx.update(|cx| {
+            workspace.update(cx, |view, cx| {
+                view.open_paths(vec![PathBuf::from("/root/a.txt")], true, cx)
+            })
+        })
+        .await;
+        let editor = cx.read(|cx| {
+            let pane = workspace.read(cx).active_pane().read(cx);
+            let item = pane.active_item().unwrap();
+            item.downcast::<Editor>().unwrap()
+        });
+
+        // Autosave on window change.
+        editor.update(cx, |editor, cx| {
+            cx.update_global(|settings: &mut Settings, _| {
+                settings.autosave = Autosave::OnWindowChange;
+            });
+            editor.insert("X", cx);
+            assert!(editor.is_dirty(cx))
+        });
+
+        // Deactivating the window saves the file.
+        cx.simulate_window_activation(None);
+        deterministic.run_until_parked();
+        assert_eq!(fs.load(Path::new("/root/a.txt")).await.unwrap(), "X");
+        editor.read_with(cx, |editor, cx| assert!(!editor.is_dirty(cx)));
+
+        // Autosave on focus change.
+        editor.update(cx, |editor, cx| {
+            cx.focus_self();
+            cx.update_global(|settings: &mut Settings, _| {
+                settings.autosave = Autosave::OnFocusChange;
+            });
+            editor.insert("X", cx);
+            assert!(editor.is_dirty(cx))
+        });
+
+        // Blurring the editor saves the file.
+        editor.update(cx, |_, cx| cx.blur());
+        deterministic.run_until_parked();
+        assert_eq!(fs.load(Path::new("/root/a.txt")).await.unwrap(), "XX");
+        editor.read_with(cx, |editor, cx| assert!(!editor.is_dirty(cx)));
+
+        // Autosave after delay.
+        editor.update(cx, |editor, cx| {
+            cx.update_global(|settings: &mut Settings, _| {
+                settings.autosave = Autosave::AfterDelay { milliseconds: 500 };
+            });
+            editor.insert("X", cx);
+            assert!(editor.is_dirty(cx))
+        });
+
+        // Delay hasn't fully expired, so the file is still dirty and unsaved.
+        deterministic.advance_clock(Duration::from_millis(250));
+        assert_eq!(fs.load(Path::new("/root/a.txt")).await.unwrap(), "XX");
+        editor.read_with(cx, |editor, cx| assert!(editor.is_dirty(cx)));
+
+        // After delay expires, the file is saved.
+        deterministic.advance_clock(Duration::from_millis(250));
+        assert_eq!(fs.load(Path::new("/root/a.txt")).await.unwrap(), "XXX");
+        editor.read_with(cx, |editor, cx| assert!(!editor.is_dirty(cx)));
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/222

This pull request moves the auto-save functionality up into `Workspace` and `Pane`. This enables a couple of things:

1. Items that are not `Editor`s automatically inherit the autosave functionality, so it's a bit more future-proof
2. We can control the autosave behavior better when closing a tab. Specifically, we will now avoid prompting for user confirmation when a tab is closed if "autosave on focus/window change" is enabled.

With these changes we will also avoid autosaving altogether if the tab in question points to a deleted file to prevent it from re-appearing, thus fixing the aforementioned issue.