### PR TITLE
Fix panic on paste when editing with auto-indent

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1233,7 +1233,8 @@ impl Buffer {
 
             let inserted_ranges = edits
                 .into_iter()
-                .filter_map(|(range, new_text)| {
+                .zip(&edit_operation.as_edit().unwrap().new_text)
+                .filter_map(|((range, _), new_text)| {
                     let first_newline_ix = new_text.find('\n')?;
                     let new_text_len = new_text.len();
                     let start = (delta + range.start as isize) as usize + first_newline_ix + 1;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -964,7 +964,7 @@ impl Buffer {
         cx.background().spawn(async move {
             let old_text = old_text.to_string();
             let line_ending = LineEnding::detect(&new_text);
-            LineEnding::strip_carriage_returns(&mut new_text);
+            LineEnding::normalize(&mut new_text);
             let changes = TextDiff::from_lines(old_text.as_str(), new_text.as_str())
                 .iter_all_changes()
                 .map(|c| (c.tag(), c.value().len()))

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -23,6 +23,29 @@ fn init_logger() {
 }
 
 #[gpui::test]
+fn test_line_endings(cx: &mut gpui::MutableAppContext) {
+    cx.add_model(|cx| {
+        let mut buffer =
+            Buffer::new(0, "one\r\ntwo\rthree", cx).with_language(Arc::new(rust_lang()), cx);
+        assert_eq!(buffer.text(), "one\ntwo\nthree");
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+
+        buffer.check_invariants();
+        buffer.edit_with_autoindent(
+            [(buffer.len()..buffer.len(), "\r\nfour")],
+            IndentSize::spaces(2),
+            cx,
+        );
+        buffer.edit([(0..0, "zero\r\n")], cx);
+        assert_eq!(buffer.text(), "zero\none\ntwo\nthree\nfour");
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+        buffer.check_invariants();
+
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_select_language() {
     let registry = LanguageRegistry::test();
     registry.add(Arc::new(Language::new(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -26,8 +26,9 @@ use language::{
     },
     range_from_lsp, range_to_lsp, Anchor, Bias, Buffer, CharKind, CodeAction, CodeLabel,
     Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Event as BufferEvent, File as _,
-    Language, LanguageRegistry, LanguageServerName, LocalFile, LspAdapter, OffsetRangeExt,
-    Operation, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction,
+    Language, LanguageRegistry, LanguageServerName, LineEnding, LocalFile, LspAdapter,
+    OffsetRangeExt, Operation, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16,
+    Transaction,
 };
 use lsp::{
     DiagnosticSeverity, DiagnosticTag, DocumentHighlightKind, LanguageServer, LanguageString,
@@ -3381,7 +3382,8 @@ impl Project {
                                 return None;
                             }
 
-                            let (old_range, new_text) = match lsp_completion.text_edit.as_ref() {
+                            let (old_range, mut new_text) = match lsp_completion.text_edit.as_ref()
+                            {
                                 // If the language server provides a range to overwrite, then
                                 // check that the range is valid.
                                 Some(lsp::CompletionTextEdit::Edit(edit)) => {
@@ -3431,6 +3433,7 @@ impl Project {
                                 }
                             };
 
+                            LineEnding::normalize(&mut new_text);
                             Some(Completion {
                                 old_range,
                                 new_text,

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -43,7 +43,7 @@ fn test_random_edits(mut rng: StdRng) {
         .take(reference_string_len)
         .collect::<String>();
     let mut buffer = Buffer::new(0, 0, reference_string.clone().into());
-    LineEnding::strip_carriage_returns(&mut reference_string);
+    LineEnding::normalize(&mut reference_string);
 
     buffer.history.group_interval = Duration::from_millis(rng.gen_range(0..=200));
     let mut buffer_versions = Vec::new();

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -555,7 +555,7 @@ pub struct UndoOperation {
 impl Buffer {
     pub fn new(replica_id: u16, remote_id: u64, mut base_text: String) -> Buffer {
         let line_ending = LineEnding::detect(&base_text);
-        LineEnding::strip_carriage_returns(&mut base_text);
+        LineEnding::normalize(&mut base_text);
 
         let history = History::new(base_text.into());
         let mut fragments = SumTree::new();
@@ -691,7 +691,7 @@ impl Buffer {
 
         let mut fragment_start = old_fragments.start().visible;
         for (range, new_text) in edits {
-            let new_text = LineEnding::strip_carriage_returns_from_arc(new_text.into());
+            let new_text = LineEnding::normalize_arc(new_text.into());
             let fragment_end = old_fragments.end(&None).visible;
 
             // If the current fragment ends before this range, then jump ahead to the first fragment
@@ -2385,13 +2385,13 @@ impl LineEnding {
         }
     }
 
-    pub fn strip_carriage_returns(text: &mut String) {
+    pub fn normalize(text: &mut String) {
         if let Cow::Owned(replaced) = CARRIAGE_RETURNS_REGEX.replace_all(text, "\n") {
             *text = replaced;
         }
     }
 
-    fn strip_carriage_returns_from_arc(text: Arc<str>) -> Arc<str> {
+    fn normalize_arc(text: Arc<str>) -> Arc<str> {
         if let Cow::Owned(replaced) = CARRIAGE_RETURNS_REGEX.replace_all(&text, "\n") {
             replaced.into()
         } else {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/228

Instead of accepting text as it's input by the user, we will read it out of the edit operation after it gets sanitized by the buffer.