### PR TITLE
Add version number to dmg name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
+name = "cargo-get"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "359bbb7e7ca4fb789be0405afecfd750ab58ea519875a93c145f4d5f2eee1663"
+dependencies = [
+ "cargo_toml",
+ "clap 2.34.0",
+ "semver",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363c7cfaa15f101415c4ac9e68706ca4a2277773932828b33f96e59d28c68e62"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "castaway"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6169,6 +6191,7 @@ dependencies = [
  "auto_update",
  "backtrace",
  "breadcrumbs",
+ "cargo-get",
  "chat_panel",
  "chrono",
  "cli",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -112,6 +112,7 @@ client = { path = "../client", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
+cargo-get = "0.3.3"
 env_logger = "0.9"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 unindent = "0.1.7"

--- a/script/bundle
+++ b/script/bundle
@@ -52,7 +52,8 @@ else
 fi
 
 RELEASE_DIR_PATH=target/release
-DMG_PATH=$RELEASE_DIR_PATH/Zed.dmg
+VERSION=$(cd crates/zed && cargo-get version)
+DMG_PATH=$RELEASE_DIR_PATH/Zed_v$VERSION.dmg
 
 echo "Creating DMG"
 mkdir -p $RELEASE_DIR_PATH

--- a/script/bundle
+++ b/script/bundle
@@ -19,17 +19,20 @@ cargo build --release --package cli --target x86_64-apple-darwin
 echo "Creating application bundle"
 (cd crates/zed && cargo bundle --release --target x86_64-apple-darwin)
 
+TEMP_RELEASE_DIR_PATH=target/x86_64-apple-darwin/release/bundle/osx
+APP_PATH=$TEMP_RELEASE_DIR_PATH/Zed.app
+
 echo "Creating fat binaries"
 lipo \
     -create \
     target/{x86_64-apple-darwin,aarch64-apple-darwin}/release/Zed \
     -output \
-    target/x86_64-apple-darwin/release/bundle/osx/Zed.app/Contents/MacOS/zed
+    $APP_PATH/Contents/MacOS/zed
 lipo \
     -create \
     target/{x86_64-apple-darwin,aarch64-apple-darwin}/release/cli \
     -output \
-    target/x86_64-apple-darwin/release/bundle/osx/Zed.app/Contents/MacOS/cli
+    $APP_PATH/Contents/MacOS/cli
 
 if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then
     echo "Signing bundle with Apple-issued certificate"
@@ -40,28 +43,35 @@ if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTAR
     security import /tmp/zed-certificate.p12 -k zed.keychain -P $MACOS_CERTIFICATE_PASSWORD -T /usr/bin/codesign
     rm /tmp/zed-certificate.p12
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
-    /usr/bin/codesign --force --deep --timestamp --options runtime --sign "Zed Industries, Inc." target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+    /usr/bin/codesign --force --deep --timestamp --options runtime --sign "Zed Industries, Inc." $APP_PATH -v
     security default-keychain -s login.keychain
 else
     echo "One or more of the following variables are missing: MACOS_CERTIFICATE, MACOS_CERTIFICATE_PASSWORD, APPLE_NOTARIZATION_USERNAME, APPLE_NOTARIZATION_PASSWORD"
     echo "Performing an ad-hoc signature, but this bundle should not be distributed"
-    codesign --force --deep --sign - target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+    codesign --force --deep --sign - $APP_PATH -v
 fi
 
+RELEASE_DIR_PATH=target/release
+DMG_PATH=$RELEASE_DIR_PATH/Zed.dmg
+
 echo "Creating DMG"
-mkdir -p target/release
-hdiutil create -volname Zed -srcfolder target/x86_64-apple-darwin/release/bundle/osx -ov -format UDZO target/release/Zed.dmg
+mkdir -p $RELEASE_DIR_PATH
+ln -s /Applications $TEMP_RELEASE_DIR_PATH
+hdiutil create -volname Zed -srcfolder $TEMP_RELEASE_DIR_PATH -ov -format UDZO $DMG_PATH
+# If someone runs this bundle script locally, a symlink will be placed in `TEMP_RELEASE_DIR_PATH`.  
+# This symlink causes CPU issues with Zed if the Zed codebase is opened in Zed, so we simply remove it for now.
+rm $TEMP_RELEASE_DIR_PATH/Applications
 
 if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then
     echo "Notarizing DMG with Apple"
     npm install -g notarize-cli
-    npx notarize-cli --file target/release/Zed.dmg --bundle-id dev.zed.Zed --username $APPLE_NOTARIZATION_USERNAME --password $APPLE_NOTARIZATION_PASSWORD
+    npx notarize-cli --file $DMG_PATH --bundle-id dev.zed.Zed --username $APPLE_NOTARIZATION_USERNAME --password $APPLE_NOTARIZATION_PASSWORD
 fi
 
-# If -o option is specified, open the target/release directory in Finder to reveal the DMG
+# If -o option is specified, open the $RELEASE_DIR_PATH directory in Finder to reveal the DMG
 while getopts o flag
 do
     case "${flag}" in
-        o) open target/release;;
+        o) open $RELEASE_DIR_PATH;;
     esac
 done

--- a/script/bundle
+++ b/script/bundle
@@ -19,8 +19,8 @@ cargo build --release --package cli --target x86_64-apple-darwin
 echo "Creating application bundle"
 (cd crates/zed && cargo bundle --release --target x86_64-apple-darwin)
 
-TEMP_RELEASE_DIR_PATH=target/x86_64-apple-darwin/release/bundle/osx
-APP_PATH=$TEMP_RELEASE_DIR_PATH/Zed.app
+TEMP_RELEASE_DIR_PATH="target/x86_64-apple-darwin/release/bundle/osx"
+APP_PATH="${TEMP_RELEASE_DIR_PATH}/Zed.app"
 
 echo "Creating fat binaries"
 lipo \
@@ -51,8 +51,8 @@ else
     codesign --force --deep --sign - $APP_PATH -v
 fi
 
-RELEASE_DIR_PATH=target/release
-DMG_PATH=$RELEASE_DIR_PATH/Zed.dmg
+RELEASE_DIR_PATH="target/release"
+DMG_PATH="${RELEASE_DIR_PATH}/Zed.dmg"
 
 echo "Creating DMG"
 mkdir -p $RELEASE_DIR_PATH


### PR DESCRIPTION
This PR adds the version number to the dmg name, in the format of `Zed_vX.Y.Z.dmg`.  This can be in another format, this is just what was suggested in:
- https://github.com/zed-industries/feedback/issues/2

<img width="203" alt="image" src="https://user-images.githubusercontent.com/19867440/177654783-daf380fc-529e-42dd-b582-57c894184b7b.png">

This PR is branched off of https://github.com/zed-industries/zed/pull/1280. As stated in that PR, I can't double check that this works because the GH actions did not run, so apologies if this doesn't run correctly after that is enabled.