### PR TITLE
Mouse Event Refactor

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -23,9 +23,10 @@ use gpui::{
     json::{self, ToJson},
     platform::CursorStyle,
     text_layout::{self, Line, RunStyle, TextLayoutCache},
-    AppContext, Axis, Border, CursorRegion, Element, ElementBox, Event, EventContext,
-    LayoutContext, MutableAppContext, PaintContext, Quad, Scene, SizeConstraint, ViewContext,
-    WeakViewHandle,
+    AppContext, Axis, Border, CursorRegion, Element, ElementBox, Event, EventContext, KeyDownEvent,
+    LayoutContext, LeftMouseDownEvent, LeftMouseDraggedEvent, LeftMouseUpEvent,
+    ModifiersChangedEvent, MouseMovedEvent, MutableAppContext, PaintContext, Quad, Scene,
+    ScrollWheelEvent, SizeConstraint, ViewContext, WeakViewHandle,
 };
 use json::json;
 use language::{Bias, DiagnosticSeverity, Selection};
@@ -1463,14 +1464,14 @@ impl Element for EditorElement {
         }
 
         match event {
-            Event::LeftMouseDown {
+            Event::LeftMouseDown(LeftMouseDownEvent {
                 position,
                 cmd,
                 alt,
                 shift,
                 click_count,
                 ..
-            } => self.mouse_down(
+            }) => self.mouse_down(
                 *position,
                 *cmd,
                 *alt,
@@ -1480,18 +1481,20 @@ impl Element for EditorElement {
                 paint,
                 cx,
             ),
-            Event::LeftMouseUp { position, .. } => self.mouse_up(*position, cx),
-            Event::LeftMouseDragged { position, .. } => {
+            Event::LeftMouseUp(LeftMouseUpEvent { position, .. }) => self.mouse_up(*position, cx),
+            Event::LeftMouseDragged(LeftMouseDraggedEvent { position, .. }) => {
                 self.mouse_dragged(*position, layout, paint, cx)
             }
-            Event::ScrollWheel {
+            Event::ScrollWheel(ScrollWheelEvent {
                 position,
                 delta,
                 precise,
-            } => self.scroll(*position, *delta, *precise, layout, paint, cx),
-            Event::KeyDown { input, .. } => self.key_down(input.as_deref(), cx),
-            Event::ModifiersChanged { cmd, .. } => self.modifiers_changed(*cmd, cx),
-            Event::MouseMoved { position, cmd, .. } => {
+            }) => self.scroll(*position, *delta, *precise, layout, paint, cx),
+            Event::KeyDown(KeyDownEvent { input, .. }) => self.key_down(input.as_deref(), cx),
+            Event::ModifiersChanged(ModifiersChangedEvent { cmd, .. }) => {
+                self.modifiers_changed(*cmd, cx)
+            }
+            Event::MouseMoved(MouseMovedEvent { position, cmd, .. }) => {
                 self.mouse_moved(*position, *cmd, layout, paint, cx)
             }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -24,9 +24,9 @@ use gpui::{
     platform::CursorStyle,
     text_layout::{self, Line, RunStyle, TextLayoutCache},
     AppContext, Axis, Border, CursorRegion, Element, ElementBox, Event, EventContext, KeyDownEvent,
-    LayoutContext, LeftMouseDownEvent, LeftMouseDraggedEvent, LeftMouseUpEvent,
-    ModifiersChangedEvent, MouseMovedEvent, MutableAppContext, PaintContext, Quad, Scene,
-    ScrollWheelEvent, SizeConstraint, ViewContext, WeakViewHandle,
+    LayoutContext, ModifiersChangedEvent, MouseButton, MouseEvent, MouseMovedEvent,
+    MutableAppContext, PaintContext, Quad, Scene, ScrollWheelEvent, SizeConstraint, ViewContext,
+    WeakViewHandle,
 };
 use json::json;
 use language::{Bias, DiagnosticSeverity, Selection};
@@ -1464,7 +1464,8 @@ impl Element for EditorElement {
         }
 
         match event {
-            Event::LeftMouseDown(LeftMouseDownEvent {
+            Event::MouseDown(MouseEvent {
+                button: MouseButton::Left,
                 position,
                 cmd,
                 alt,
@@ -1481,10 +1482,16 @@ impl Element for EditorElement {
                 paint,
                 cx,
             ),
-            Event::LeftMouseUp(LeftMouseUpEvent { position, .. }) => self.mouse_up(*position, cx),
-            Event::LeftMouseDragged(LeftMouseDraggedEvent { position, .. }) => {
-                self.mouse_dragged(*position, layout, paint, cx)
-            }
+            Event::MouseUp(MouseEvent {
+                button: MouseButton::Left,
+                position,
+                ..
+            }) => self.mouse_up(*position, cx),
+            Event::MouseMoved(MouseMovedEvent {
+                pressed_button: Some(MouseButton::Left),
+                position,
+                ..
+            }) => self.mouse_dragged(*position, layout, paint, cx),
             Event::ScrollWheel(ScrollWheelEvent {
                 position,
                 delta,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
     elements::ElementBox,
     executor::{self, Task},
     keymap::{self, Binding, Keystroke},
-    platform::{self, Platform, PromptLevel, WindowOptions},
+    platform::{self, KeyDownEvent, Platform, PromptLevel, WindowOptions},
     presenter::Presenter,
     util::post_inc,
     AssetCache, AssetSource, ClipboardItem, FontCache, MouseRegionId, PathPromptOptions,
@@ -377,11 +377,11 @@ impl TestAppContext {
 
             if !cx.dispatch_keystroke(window_id, dispatch_path, &keystroke) {
                 presenter.borrow_mut().dispatch_event(
-                    Event::KeyDown {
+                    Event::KeyDown(KeyDownEvent {
                         keystroke,
                         input,
                         is_held,
-                    },
+                    }),
                     cx,
                 );
             }
@@ -1820,7 +1820,7 @@ impl MutableAppContext {
             window.on_event(Box::new(move |event| {
                 app.update(|cx| {
                     if let Some(presenter) = presenter.upgrade() {
-                        if let Event::KeyDown { keystroke, .. } = &event {
+                        if let Event::KeyDown(KeyDownEvent { keystroke, .. }) = &event {
                             if cx.dispatch_keystroke(
                                 window_id,
                                 presenter.borrow().dispatch_path(cx.as_ref()),
@@ -5381,7 +5381,7 @@ impl RefCounts {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{actions, elements::*, impl_actions};
+    use crate::{actions, elements::*, impl_actions, LeftMouseDownEvent};
     use serde::Deserialize;
     use smol::future::poll_once;
     use std::{
@@ -5734,14 +5734,14 @@ mod tests {
         let presenter = cx.presenters_and_platform_windows[&window_id].0.clone();
         // Ensure window's root element is in a valid lifecycle state.
         presenter.borrow_mut().dispatch_event(
-            Event::LeftMouseDown {
+            Event::LeftMouseDown(LeftMouseDownEvent {
                 position: Default::default(),
                 ctrl: false,
                 alt: false,
                 shift: false,
                 cmd: false,
                 click_count: 1,
-            },
+            }),
             cx,
         );
         assert_eq!(mouse_down_count.load(SeqCst), 1);

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -5381,7 +5381,7 @@ impl RefCounts {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{actions, elements::*, impl_actions, LeftMouseDownEvent};
+    use crate::{actions, elements::*, impl_actions, MouseButton, MouseEvent};
     use serde::Deserialize;
     use smol::future::poll_once;
     use std::{
@@ -5734,8 +5734,9 @@ mod tests {
         let presenter = cx.presenters_and_platform_windows[&window_id].0.clone();
         // Ensure window's root element is in a valid lifecycle state.
         presenter.borrow_mut().dispatch_event(
-            Event::LeftMouseDown(LeftMouseDownEvent {
+            Event::MouseDown(MouseEvent {
                 position: Default::default(),
+                button: MouseButton::Left,
                 ctrl: false,
                 alt: false,
                 shift: false,

--- a/crates/gpui/src/elements/event_handler.rs
+++ b/crates/gpui/src/elements/event_handler.rs
@@ -1,6 +1,7 @@
 use crate::{
     geometry::vector::Vector2F, CursorRegion, DebugContext, Element, ElementBox, Event,
-    EventContext, LayoutContext, MouseRegion, NavigationDirection, PaintContext, SizeConstraint,
+    EventContext, LayoutContext, LeftMouseDownEvent, MouseRegion, NavigateMouseDownEvent,
+    NavigationDirection, PaintContext, RightMouseDownEvent, SizeConstraint,
 };
 use pathfinder_geometry::rect::RectF;
 use serde_json::json;
@@ -116,7 +117,7 @@ impl Element for EventHandler {
             true
         } else {
             match event {
-                Event::LeftMouseDown { position, .. } => {
+                Event::LeftMouseDown(LeftMouseDownEvent { position, .. }) => {
                     if let Some(callback) = self.mouse_down.as_mut() {
                         if visible_bounds.contains_point(*position) {
                             return callback(cx);
@@ -124,7 +125,7 @@ impl Element for EventHandler {
                     }
                     false
                 }
-                Event::RightMouseDown { position, .. } => {
+                Event::RightMouseDown(RightMouseDownEvent { position, .. }) => {
                     if let Some(callback) = self.right_mouse_down.as_mut() {
                         if visible_bounds.contains_point(*position) {
                             return callback(cx);
@@ -132,11 +133,11 @@ impl Element for EventHandler {
                     }
                     false
                 }
-                Event::NavigateMouseDown {
+                Event::NavigateMouseDown(NavigateMouseDownEvent {
                     position,
                     direction,
                     ..
-                } => {
+                }) => {
                     if let Some(callback) = self.navigate_mouse_down.as_mut() {
                         if visible_bounds.contains_point(*position) {
                             return callback(*direction, cx);

--- a/crates/gpui/src/elements/event_handler.rs
+++ b/crates/gpui/src/elements/event_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     geometry::vector::Vector2F, CursorRegion, DebugContext, Element, ElementBox, Event,
-    EventContext, LayoutContext, LeftMouseDownEvent, MouseRegion, NavigateMouseDownEvent,
-    NavigationDirection, PaintContext, RightMouseDownEvent, SizeConstraint,
+    EventContext, LayoutContext, MouseButton, MouseEvent, MouseRegion, NavigationDirection,
+    PaintContext, SizeConstraint,
 };
 use pathfinder_geometry::rect::RectF;
 use serde_json::json;
@@ -117,7 +117,11 @@ impl Element for EventHandler {
             true
         } else {
             match event {
-                Event::LeftMouseDown(LeftMouseDownEvent { position, .. }) => {
+                Event::MouseDown(MouseEvent {
+                    button: MouseButton::Left,
+                    position,
+                    ..
+                }) => {
                     if let Some(callback) = self.mouse_down.as_mut() {
                         if visible_bounds.contains_point(*position) {
                             return callback(cx);
@@ -125,7 +129,11 @@ impl Element for EventHandler {
                     }
                     false
                 }
-                Event::RightMouseDown(RightMouseDownEvent { position, .. }) => {
+                Event::MouseDown(MouseEvent {
+                    button: MouseButton::Right,
+                    position,
+                    ..
+                }) => {
                     if let Some(callback) = self.right_mouse_down.as_mut() {
                         if visible_bounds.contains_point(*position) {
                             return callback(cx);
@@ -133,9 +141,9 @@ impl Element for EventHandler {
                     }
                     false
                 }
-                Event::NavigateMouseDown(NavigateMouseDownEvent {
+                Event::MouseDown(MouseEvent {
+                    button: MouseButton::Navigate(direction),
                     position,
-                    direction,
                     ..
                 }) => {
                     if let Some(callback) = self.navigate_mouse_down.as_mut() {

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -3,7 +3,8 @@ use std::{any::Any, f32::INFINITY};
 use crate::{
     json::{self, ToJson, Value},
     Axis, DebugContext, Element, ElementBox, ElementStateHandle, Event, EventContext,
-    LayoutContext, PaintContext, RenderContext, SizeConstraint, Vector2FExt, View,
+    LayoutContext, MouseMovedEvent, PaintContext, RenderContext, ScrollWheelEvent, SizeConstraint,
+    Vector2FExt, View,
 };
 use pathfinder_geometry::{
     rect::RectF,
@@ -287,11 +288,11 @@ impl Element for Flex {
             handled = child.dispatch_event(event, cx) || handled;
         }
         if !handled {
-            if let &Event::ScrollWheel {
+            if let &Event::ScrollWheel(ScrollWheelEvent {
                 position,
                 delta,
                 precise,
-            } = event
+            }) = event
             {
                 if *remaining_space < 0. && bounds.contains_point(position) {
                     if let Some(scroll_state) = self.scroll_state.as_ref() {
@@ -321,7 +322,7 @@ impl Element for Flex {
         }
 
         if !handled {
-            if let &Event::MouseMoved { position, .. } = event {
+            if let &Event::MouseMoved(MouseMovedEvent { position, .. }) = event {
                 // If this is a scrollable flex, and the mouse is over it, eat the scroll event to prevent
                 // propogating it to the element below.
                 if self.scroll_state.is_some() && bounds.contains_point(position) {

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     json::json,
     DebugContext, Element, ElementBox, ElementRc, Event, EventContext, LayoutContext, PaintContext,
-    RenderContext, SizeConstraint, View, ViewContext,
+    RenderContext, ScrollWheelEvent, SizeConstraint, View, ViewContext,
 };
 use std::{cell::RefCell, collections::VecDeque, ops::Range, rc::Rc};
 use sum_tree::{Bias, SumTree};
@@ -311,11 +311,11 @@ impl Element for List {
         state.items = new_items;
 
         match event {
-            Event::ScrollWheel {
+            Event::ScrollWheel(ScrollWheelEvent {
                 position,
                 delta,
                 precise,
-            } => {
+            }) => {
                 if bounds.contains_point(*position) {
                     if state.scroll(scroll_top, bounds.height(), *delta, *precise, cx) {
                         handled = true;

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -5,7 +5,7 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     json::{self, json},
-    ElementBox, RenderContext, View,
+    ElementBox, RenderContext, ScrollWheelEvent, View,
 };
 use json::ToJson;
 use std::{cell::RefCell, cmp, ops::Range, rc::Rc};
@@ -310,11 +310,11 @@ impl Element for UniformList {
         }
 
         match event {
-            Event::ScrollWheel {
+            Event::ScrollWheel(ScrollWheelEvent {
                 position,
                 delta,
                 precise,
-            } => {
+            }) => {
                 if bounds.contains_point(*position) {
                     if self.scroll(*position, *delta, *precise, layout.scroll_max, cx) {
                         handled = true;

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -28,8 +28,7 @@ pub mod json;
 pub mod keymap;
 pub mod platform;
 pub use gpui_macros::test;
-pub use platform::FontSystem;
-pub use platform::{Event, NavigationDirection, PathPromptOptions, Platform, PromptLevel};
+pub use platform::*;
 pub use presenter::{
     Axis, DebugContext, EventContext, LayoutContext, PaintContext, SizeConstraint, Vector2FExt,
 };

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use async_task::Runnable;
-pub use event::{Event, NavigationDirection};
+pub use event::*;
 use postage::oneshot;
 use serde::Deserialize;
 use std::{

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -1,11 +1,5 @@
 use crate::{geometry::vector::Vector2F, keymap::Keystroke};
 
-#[derive(Copy, Clone, Debug)]
-pub enum NavigationDirection {
-    Back,
-    Forward,
-}
-
 #[derive(Clone, Debug)]
 pub struct KeyDownEvent {
     pub keystroke: Keystroke,
@@ -34,8 +28,23 @@ pub struct ScrollWheelEvent {
     pub precise: bool,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum NavigationDirection {
+    Back,
+    Forward,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+    Navigate(NavigationDirection),
+}
+
 #[derive(Clone, Debug)]
-pub struct LeftMouseDownEvent {
+pub struct MouseEvent {
+    pub button: MouseButton,
     pub position: Vector2F,
     pub ctrl: bool,
     pub alt: bool,
@@ -44,58 +53,10 @@ pub struct LeftMouseDownEvent {
     pub click_count: usize,
 }
 
-#[derive(Clone, Debug)]
-pub struct LeftMouseUpEvent {
-    pub position: Vector2F,
-    pub click_count: usize,
-}
-
-#[derive(Clone, Debug)]
-pub struct LeftMouseDraggedEvent {
-    pub position: Vector2F,
-    pub ctrl: bool,
-    pub alt: bool,
-    pub shift: bool,
-    pub cmd: bool,
-}
-
-#[derive(Clone, Debug)]
-pub struct RightMouseDownEvent {
-    pub position: Vector2F,
-    pub ctrl: bool,
-    pub alt: bool,
-    pub shift: bool,
-    pub cmd: bool,
-    pub click_count: usize,
-}
-
-#[derive(Clone, Debug)]
-pub struct RightMouseUpEvent {
-    pub position: Vector2F,
-    pub click_count: usize,
-}
-
-#[derive(Clone, Debug)]
-pub struct NavigateMouseDownEvent {
-    pub position: Vector2F,
-    pub direction: NavigationDirection,
-    pub ctrl: bool,
-    pub alt: bool,
-    pub shift: bool,
-    pub cmd: bool,
-    pub click_count: usize,
-}
-
-#[derive(Clone, Debug)]
-pub struct NavigateMouseUpEvent {
-    pub position: Vector2F,
-    pub direction: NavigationDirection,
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MouseMovedEvent {
     pub position: Vector2F,
-    pub left_mouse_down: bool,
+    pub pressed_button: Option<MouseButton>,
     pub ctrl: bool,
     pub cmd: bool,
     pub alt: bool,
@@ -107,15 +68,10 @@ pub enum Event {
     KeyDown(KeyDownEvent),
     KeyUp(KeyUpEvent),
     ModifiersChanged(ModifiersChangedEvent),
-    ScrollWheel(ScrollWheelEvent),
-    LeftMouseDown(LeftMouseDownEvent),
-    LeftMouseUp(LeftMouseUpEvent),
-    LeftMouseDragged(LeftMouseDraggedEvent),
-    RightMouseDown(RightMouseDownEvent),
-    RightMouseUp(RightMouseUpEvent),
-    NavigateMouseDown(NavigateMouseDownEvent),
-    NavigateMouseUp(NavigateMouseUpEvent),
+    MouseDown(MouseEvent),
+    MouseUp(MouseEvent),
     MouseMoved(MouseMovedEvent),
+    ScrollWheel(ScrollWheelEvent),
 }
 
 impl Event {
@@ -124,15 +80,9 @@ impl Event {
             Event::KeyDown { .. } => None,
             Event::KeyUp { .. } => None,
             Event::ModifiersChanged { .. } => None,
-            Event::ScrollWheel(ScrollWheelEvent { position, .. })
-            | Event::LeftMouseDown(LeftMouseDownEvent { position, .. })
-            | Event::LeftMouseUp(LeftMouseUpEvent { position, .. })
-            | Event::LeftMouseDragged(LeftMouseDraggedEvent { position, .. })
-            | Event::RightMouseDown(RightMouseDownEvent { position, .. })
-            | Event::RightMouseUp(RightMouseUpEvent { position, .. })
-            | Event::NavigateMouseDown(NavigateMouseDownEvent { position, .. })
-            | Event::NavigateMouseUp(NavigateMouseUpEvent { position, .. })
-            | Event::MouseMoved(MouseMovedEvent { position, .. }) => Some(*position),
+            Event::MouseDown(event) | Event::MouseUp(event) => Some(event.position),
+            Event::MouseMoved(event) => Some(event.position),
+            Event::ScrollWheel(event) => Some(event.position),
         }
     }
 }

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -7,79 +7,115 @@ pub enum NavigationDirection {
 }
 
 #[derive(Clone, Debug)]
+pub struct KeyDownEvent {
+    pub keystroke: Keystroke,
+    pub input: Option<String>,
+    pub is_held: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct KeyUpEvent {
+    pub keystroke: Keystroke,
+    pub input: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ModifiersChangedEvent {
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub cmd: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ScrollWheelEvent {
+    pub position: Vector2F,
+    pub delta: Vector2F,
+    pub precise: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct LeftMouseDownEvent {
+    pub position: Vector2F,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub cmd: bool,
+    pub click_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct LeftMouseUpEvent {
+    pub position: Vector2F,
+    pub click_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct LeftMouseDraggedEvent {
+    pub position: Vector2F,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub cmd: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct RightMouseDownEvent {
+    pub position: Vector2F,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub cmd: bool,
+    pub click_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct RightMouseUpEvent {
+    pub position: Vector2F,
+    pub click_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct NavigateMouseDownEvent {
+    pub position: Vector2F,
+    pub direction: NavigationDirection,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub cmd: bool,
+    pub click_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct NavigateMouseUpEvent {
+    pub position: Vector2F,
+    pub direction: NavigationDirection,
+}
+
+#[derive(Clone, Debug)]
+pub struct MouseMovedEvent {
+    pub position: Vector2F,
+    pub left_mouse_down: bool,
+    pub ctrl: bool,
+    pub cmd: bool,
+    pub alt: bool,
+    pub shift: bool,
+}
+
+#[derive(Clone, Debug)]
 pub enum Event {
-    KeyDown {
-        keystroke: Keystroke,
-        input: Option<String>,
-        is_held: bool,
-    },
-    KeyUp {
-        keystroke: Keystroke,
-        input: Option<String>,
-    },
-    ModifiersChanged {
-        ctrl: bool,
-        alt: bool,
-        shift: bool,
-        cmd: bool,
-    },
-    ScrollWheel {
-        position: Vector2F,
-        delta: Vector2F,
-        precise: bool,
-    },
-    LeftMouseDown {
-        position: Vector2F,
-        ctrl: bool,
-        alt: bool,
-        shift: bool,
-        cmd: bool,
-        click_count: usize,
-    },
-    LeftMouseUp {
-        position: Vector2F,
-        click_count: usize,
-    },
-    LeftMouseDragged {
-        position: Vector2F,
-        ctrl: bool,
-        alt: bool,
-        shift: bool,
-        cmd: bool,
-    },
-    RightMouseDown {
-        position: Vector2F,
-        ctrl: bool,
-        alt: bool,
-        shift: bool,
-        cmd: bool,
-        click_count: usize,
-    },
-    RightMouseUp {
-        position: Vector2F,
-        click_count: usize,
-    },
-    NavigateMouseDown {
-        position: Vector2F,
-        direction: NavigationDirection,
-        ctrl: bool,
-        alt: bool,
-        shift: bool,
-        cmd: bool,
-        click_count: usize,
-    },
-    NavigateMouseUp {
-        position: Vector2F,
-        direction: NavigationDirection,
-    },
-    MouseMoved {
-        position: Vector2F,
-        left_mouse_down: bool,
-        ctrl: bool,
-        cmd: bool,
-        alt: bool,
-        shift: bool,
-    },
+    KeyDown(KeyDownEvent),
+    KeyUp(KeyUpEvent),
+    ModifiersChanged(ModifiersChangedEvent),
+    ScrollWheel(ScrollWheelEvent),
+    LeftMouseDown(LeftMouseDownEvent),
+    LeftMouseUp(LeftMouseUpEvent),
+    LeftMouseDragged(LeftMouseDraggedEvent),
+    RightMouseDown(RightMouseDownEvent),
+    RightMouseUp(RightMouseUpEvent),
+    NavigateMouseDown(NavigateMouseDownEvent),
+    NavigateMouseUp(NavigateMouseUpEvent),
+    MouseMoved(MouseMovedEvent),
 }
 
 impl Event {
@@ -88,15 +124,15 @@ impl Event {
             Event::KeyDown { .. } => None,
             Event::KeyUp { .. } => None,
             Event::ModifiersChanged { .. } => None,
-            Event::ScrollWheel { position, .. }
-            | Event::LeftMouseDown { position, .. }
-            | Event::LeftMouseUp { position, .. }
-            | Event::LeftMouseDragged { position, .. }
-            | Event::RightMouseDown { position, .. }
-            | Event::RightMouseUp { position, .. }
-            | Event::NavigateMouseDown { position, .. }
-            | Event::NavigateMouseUp { position, .. }
-            | Event::MouseMoved { position, .. } => Some(*position),
+            Event::ScrollWheel(ScrollWheelEvent { position, .. })
+            | Event::LeftMouseDown(LeftMouseDownEvent { position, .. })
+            | Event::LeftMouseUp(LeftMouseUpEvent { position, .. })
+            | Event::LeftMouseDragged(LeftMouseDraggedEvent { position, .. })
+            | Event::RightMouseDown(RightMouseDownEvent { position, .. })
+            | Event::RightMouseUp(RightMouseUpEvent { position, .. })
+            | Event::NavigateMouseDown(NavigateMouseDownEvent { position, .. })
+            | Event::NavigateMouseUp(NavigateMouseUpEvent { position, .. })
+            | Event::MouseMoved(MouseMovedEvent { position, .. }) => Some(*position),
         }
     }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     keymap::Keystroke,
     platform::{self, Event, WindowBounds, WindowContext},
-    Scene,
+    KeyDownEvent, LeftMouseDraggedEvent, ModifiersChangedEvent, Scene,
 };
 use block::ConcreteBlock;
 use cocoa::{
@@ -562,11 +562,11 @@ extern "C" fn handle_key_equivalent(this: &Object, _: Sel, native_event: id) -> 
     let event = unsafe { Event::from_native(native_event, Some(window_state_borrow.size().y())) };
     if let Some(event) = event {
         match &event {
-            Event::KeyDown {
+            Event::KeyDown(KeyDownEvent {
                 keystroke,
                 input,
                 is_held,
-            } => {
+            }) => {
                 let keydown = (keystroke.clone(), input.clone());
                 // Ignore events from held-down keys after some of the initially-pressed keys
                 // were released.
@@ -603,7 +603,7 @@ extern "C" fn handle_view_event(this: &Object, _: Sel, native_event: id) {
 
     if let Some(event) = event {
         match &event {
-            Event::LeftMouseDragged { position, .. } => {
+            Event::LeftMouseDragged(LeftMouseDraggedEvent { position, .. }) => {
                 window_state_borrow.synthetic_drag_counter += 1;
                 window_state_borrow
                     .executor
@@ -617,19 +617,19 @@ extern "C" fn handle_view_event(this: &Object, _: Sel, native_event: id) {
             Event::LeftMouseUp { .. } => {
                 window_state_borrow.synthetic_drag_counter += 1;
             }
-            Event::ModifiersChanged {
+            Event::ModifiersChanged(ModifiersChangedEvent {
                 ctrl,
                 alt,
                 shift,
                 cmd,
-            } => {
+            }) => {
                 // Only raise modifiers changed event when they have actually changed
-                if let Some(Event::ModifiersChanged {
+                if let Some(Event::ModifiersChanged(ModifiersChangedEvent {
                     ctrl: prev_ctrl,
                     alt: prev_alt,
                     shift: prev_shift,
                     cmd: prev_cmd,
-                }) = &window_state_borrow.previous_modifiers_changed_event
+                })) = &window_state_borrow.previous_modifiers_changed_event
                 {
                     if prev_ctrl == ctrl
                         && prev_alt == alt
@@ -667,11 +667,11 @@ extern "C" fn cancel_operation(this: &Object, _sel: Sel, _sender: id) {
         shift: false,
         key: chars.clone(),
     };
-    let event = Event::KeyDown {
+    let event = Event::KeyDown(KeyDownEvent {
         keystroke: keystroke.clone(),
         input: Some(chars.clone()),
         is_held: false,
-    };
+    });
 
     window_state_borrow.last_fresh_keydown = Some((keystroke, Some(chars)));
     if let Some(mut callback) = window_state_borrow.event_callback.take() {
@@ -844,14 +844,14 @@ async fn synthetic_drag(
             if window_state_borrow.synthetic_drag_counter == drag_id {
                 if let Some(mut callback) = window_state_borrow.event_callback.take() {
                     drop(window_state_borrow);
-                    callback(Event::LeftMouseDragged {
+                    callback(Event::LeftMouseDragged(LeftMouseDraggedEvent {
                         // TODO: Make sure empty modifiers is correct for this
                         position,
                         shift: false,
                         ctrl: false,
                         alt: false,
                         cmd: false,
-                    });
+                    }));
                     window_state.borrow_mut().event_callback = Some(callback);
                 }
             } else {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -128,6 +128,10 @@ unsafe fn build_classes() {
             handle_view_event as extern "C" fn(&Object, Sel, id),
         );
         decl.add_method(
+            sel!(mouseDragged:),
+            handle_view_event as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
             sel!(scrollWheel:),
             handle_view_event as extern "C" fn(&Object, Sel, id),
         );

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -9,10 +9,9 @@ use crate::{
     scene::CursorRegion,
     text_layout::TextLayoutCache,
     Action, AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AssetCache, ElementBox, Entity,
-    FontSystem, LeftMouseDownEvent, LeftMouseDraggedEvent, LeftMouseUpEvent, ModelHandle,
-    MouseMovedEvent, MouseRegion, MouseRegionId, ReadModel, ReadView, RenderContext, RenderParams,
-    RightMouseDownEvent, RightMouseUpEvent, Scene, UpgradeModelHandle, UpgradeViewHandle, View,
-    ViewHandle, WeakModelHandle, WeakViewHandle,
+    FontSystem, ModelHandle, MouseButton, MouseEvent, MouseMovedEvent, MouseRegion, MouseRegionId,
+    ReadModel, ReadView, RenderContext, RenderParams, Scene, UpgradeModelHandle, UpgradeViewHandle,
+    View, ViewHandle, WeakModelHandle, WeakViewHandle,
 };
 use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
@@ -236,7 +235,11 @@ impl Presenter {
             let mut dragged_region = None;
 
             match event {
-                Event::LeftMouseDown(LeftMouseDownEvent { position, .. }) => {
+                Event::MouseDown(MouseEvent {
+                    position,
+                    button: MouseButton::Left,
+                    ..
+                }) => {
                     let mut hit = false;
                     for (region, _) in self.mouse_regions.iter().rev() {
                         if region.bounds.contains_point(position) {
@@ -252,9 +255,10 @@ impl Presenter {
                         }
                     }
                 }
-                Event::LeftMouseUp(LeftMouseUpEvent {
+                Event::MouseUp(MouseEvent {
                     position,
                     click_count,
+                    button: MouseButton::Left,
                     ..
                 }) => {
                     self.prev_drag_position.take();
@@ -265,7 +269,11 @@ impl Presenter {
                         }
                     }
                 }
-                Event::RightMouseDown(RightMouseDownEvent { position, .. }) => {
+                Event::MouseDown(MouseEvent {
+                    position,
+                    button: MouseButton::Right,
+                    ..
+                }) => {
                     let mut hit = false;
                     for (region, _) in self.mouse_regions.iter().rev() {
                         if region.bounds.contains_point(position) {
@@ -280,9 +288,10 @@ impl Presenter {
                         }
                     }
                 }
-                Event::RightMouseUp(RightMouseUpEvent {
+                Event::MouseUp(MouseEvent {
                     position,
                     click_count,
+                    button: MouseButton::Right,
                     ..
                 }) => {
                     if let Some(region) = self.right_clicked_region.take() {
@@ -292,34 +301,37 @@ impl Presenter {
                         }
                     }
                 }
-                Event::MouseMoved { .. } => {
-                    self.last_mouse_moved_event = Some(event.clone());
-                }
-                Event::LeftMouseDragged(LeftMouseDraggedEvent {
+                Event::MouseMoved(MouseMovedEvent {
+                    pressed_button,
                     position,
                     shift,
                     ctrl,
                     alt,
                     cmd,
+                    ..
                 }) => {
-                    if let Some((clicked_region, prev_drag_position)) = self
-                        .clicked_region
-                        .as_ref()
-                        .zip(self.prev_drag_position.as_mut())
-                    {
-                        dragged_region =
-                            Some((clicked_region.clone(), position - *prev_drag_position));
-                        *prev_drag_position = position;
+                    if let Some(MouseButton::Left) = pressed_button {
+                        if let Some((clicked_region, prev_drag_position)) = self
+                            .clicked_region
+                            .as_ref()
+                            .zip(self.prev_drag_position.as_mut())
+                        {
+                            dragged_region =
+                                Some((clicked_region.clone(), position - *prev_drag_position));
+                            *prev_drag_position = position;
+                        }
+
+                        self.last_mouse_moved_event = Some(Event::MouseMoved(MouseMovedEvent {
+                            position,
+                            pressed_button: Some(MouseButton::Left),
+                            shift,
+                            ctrl,
+                            alt,
+                            cmd,
+                        }));
                     }
 
-                    self.last_mouse_moved_event = Some(Event::MouseMoved(MouseMovedEvent {
-                        position,
-                        left_mouse_down: true,
-                        shift,
-                        ctrl,
-                        alt,
-                        cmd,
-                    }));
+                    self.last_mouse_moved_event = Some(event.clone());
                 }
                 _ => {}
             }
@@ -413,11 +425,11 @@ impl Presenter {
 
         if let Event::MouseMoved(MouseMovedEvent {
             position,
-            left_mouse_down,
+            pressed_button,
             ..
         }) = event
         {
-            if !left_mouse_down {
+            if let None = pressed_button {
                 let mut style_to_assign = CursorStyle::Arrow;
                 for region in self.cursor_regions.iter().rev() {
                     if region.bounds.contains_point(*position) {

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -8,7 +8,7 @@ use crate::{
     geometry::{rect::RectF, vector::Vector2F},
     json::ToJson,
     platform::CursorStyle,
-    EventContext, ImageData,
+    EventContext, ImageData, MouseEvent, MouseMovedEvent, ScrollWheelEvent,
 };
 
 pub struct Scene {
@@ -44,11 +44,22 @@ pub struct CursorRegion {
     pub style: CursorStyle,
 }
 
+pub enum MouseRegionEvent {
+    Moved(MouseMovedEvent),
+    Hover(MouseEvent),
+    Down(MouseEvent),
+    Up(MouseEvent),
+    Click(MouseEvent),
+    DownOut(MouseEvent),
+    ScrollWheel(ScrollWheelEvent),
+}
+
 #[derive(Clone, Default)]
 pub struct MouseRegion {
     pub view_id: usize,
     pub discriminant: Option<(TypeId, usize)>,
     pub bounds: RectF,
+
     pub hover: Option<Rc<dyn Fn(Vector2F, bool, &mut EventContext)>>,
     pub mouse_down: Option<Rc<dyn Fn(Vector2F, &mut EventContext)>>,
     pub click: Option<Rc<dyn Fn(Vector2F, usize, &mut EventContext)>>,

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -18,8 +18,8 @@ use gpui::{
     },
     json::json,
     text_layout::{Line, RunStyle},
-    Event, FontCache, MouseRegion, PaintContext, Quad, SizeConstraint, TextLayoutCache,
-    WeakViewHandle,
+    Event, FontCache, KeyDownEvent, MouseRegion, PaintContext, Quad, ScrollWheelEvent,
+    SizeConstraint, TextLayoutCache, WeakViewHandle,
 };
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
@@ -276,9 +276,9 @@ impl Element for TerminalEl {
         cx: &mut gpui::EventContext,
     ) -> bool {
         match event {
-            Event::ScrollWheel {
+            Event::ScrollWheel(ScrollWheelEvent {
                 delta, position, ..
-            } => visible_bounds
+            }) => visible_bounds
                 .contains_point(*position)
                 .then(|| {
                     let vertical_scroll =
@@ -286,9 +286,9 @@ impl Element for TerminalEl {
                     cx.dispatch_action(ScrollTerminal(vertical_scroll.round() as i32));
                 })
                 .is_some(),
-            Event::KeyDown {
+            Event::KeyDown(KeyDownEvent {
                 input: Some(input), ..
-            } => cx
+            }) => cx
                 .is_parent_view_focused()
                 .then(|| {
                     cx.dispatch_action(Input(input.to_string()));


### PR DESCRIPTION
Refactor mouse events to use a common MouseEvent and MouseDraggedEvent struct rather than repeating the shared fields across each enum variant.

This is a step toward addressing https://github.com/zed-industries/zed/issues/1218. 