### PR TITLE
Fix visual paste

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -141,7 +141,7 @@
             "d": "vim::VisualDelete",
             "x": "vim::VisualDelete",
             "y": "vim::VisualYank",
-            "p": "vim::Paste"
+            "p": "vim::VisualPaste"
         }
     },
     {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -140,7 +140,8 @@
             "c": "vim::VisualChange",
             "d": "vim::VisualDelete",
             "x": "vim::VisualDelete",
-            "y": "vim::VisualYank"
+            "y": "vim::VisualYank",
+            "p": "vim::Paste"
         }
     },
     {

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -149,6 +149,28 @@ impl SelectionsCollection {
         selections
     }
 
+    pub fn all_adjusted_display(
+        &self,
+        cx: &mut MutableAppContext,
+    ) -> (DisplaySnapshot, Vec<Selection<DisplayPoint>>) {
+        if self.line_mode {
+            let selections = self.all::<Point>(cx);
+            let map = self.display_map(cx);
+            let result = selections
+                .into_iter()
+                .map(|mut selection| {
+                    let new_range = map.expand_to_line(selection.range());
+                    selection.start = new_range.start;
+                    selection.end = new_range.end;
+                    selection.map(|point| point.to_display_point(&map))
+                })
+                .collect();
+            (map, result)
+        } else {
+            self.all_display(cx)
+        }
+    }
+
     pub fn disjoint_in_range<'a, D>(
         &self,
         range: Range<Anchor>,
@@ -175,7 +197,7 @@ impl SelectionsCollection {
     }
 
     pub fn all_display(
-        &mut self,
+        &self,
         cx: &mut MutableAppContext,
     ) -> (DisplaySnapshot, Vec<Selection<DisplayPoint>>) {
         let display_map = self.display_map(cx);

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -7,7 +7,6 @@ use std::borrow::Cow;
 use crate::{
     motion::Motion,
     state::{Mode, Operator},
-    utils::copy_selections_content,
     Vim,
 };
 use change::init as change_init;
@@ -195,18 +194,17 @@ fn insert_line_below(_: &mut Workspace, _: &InsertLineBelow, cx: &mut ViewContex
     });
 }
 
-// Supports non empty selections so it can be bound and called from visual mode
 fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
     Vim::update(cx, |vim, cx| {
         vim.update_active_editor(cx, |editor, cx| {
             editor.transact(cx, |editor, cx| {
+                editor.set_clip_at_line_ends(false, cx);
                 if let Some(item) = cx.as_mut().read_from_clipboard() {
-                    copy_selections_content(editor, editor.selections.line_mode, cx);
                     let mut clipboard_text = Cow::Borrowed(item.text());
                     if let Some(mut clipboard_selections) =
                         item.metadata::<Vec<ClipboardSelection>>()
                     {
-                        let (display_map, selections) = editor.selections.all_adjusted_display(cx);
+                        let (display_map, selections) = editor.selections.all_display(cx);
                         let all_selections_were_entire_line =
                             clipboard_selections.iter().all(|s| s.is_entire_line);
                         if clipboard_selections.len() != selections.len() {
@@ -246,7 +244,7 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
                                 // If the clipboard text was copied linewise, and the current selection
                                 // is empty, then paste the text after this line and move the selection
                                 // to the start of the pasted text
-                                let range = if selection.is_empty() && linewise {
+                                let insert_at = if linewise {
                                     let (point, _) = display_map
                                         .next_line_boundary(selection.start.to_point(&display_map));
 
@@ -257,37 +255,26 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
                                     // Drop selection at the start of the next line
                                     let selection_point = Point::new(point.row + 1, 0);
                                     new_selections.push(selection.map(|_| selection_point.clone()));
-                                    point..point
+                                    point
                                 } else {
-                                    let mut selection = selection.clone();
-                                    if !selection.reversed {
-                                        let mut adjusted = selection.end;
-                                        // Head is at the end of the selection. Adjust the end position to
-                                        // to include the character under the cursor.
-                                        *adjusted.column_mut() = adjusted.column() + 1;
-                                        adjusted = display_map.clip_point(adjusted, Bias::Right);
-                                        // If the selection is empty, move both the start and end forward one
-                                        // character
-                                        if selection.is_empty() {
-                                            selection.start = adjusted;
-                                            selection.end = adjusted;
-                                        } else {
-                                            selection.end = adjusted;
-                                        }
-                                    }
+                                    let mut point = selection.end;
+                                    // Paste the text after the current selection
+                                    *point.column_mut() = point.column() + 1;
+                                    let point = display_map
+                                        .clip_point(point, Bias::Right)
+                                        .to_point(&display_map);
 
-                                    let range = selection.map(|p| p.to_point(&display_map)).range();
-                                    new_selections.push(selection.map(|_| range.start.clone()));
-                                    range
+                                    new_selections.push(selection.map(|_| point));
+                                    point
                                 };
 
                                 if linewise && to_insert.ends_with('\n') {
                                     edits.push((
-                                        range,
+                                        insert_at..insert_at,
                                         &to_insert[0..to_insert.len().saturating_sub(1)],
                                     ))
                                 } else {
-                                    edits.push((range, to_insert));
+                                    edits.push((insert_at..insert_at, to_insert));
                                 }
                             }
                             drop(snapshot);
@@ -301,6 +288,7 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
                         editor.insert(&clipboard_text, cx);
                     }
                 }
+                editor.set_clip_at_line_ends(true, cx);
             });
         });
     });
@@ -1157,10 +1145,13 @@ mod test {
             the la|zy dog"});
 
         cx.simulate_keystroke("p");
-        cx.assert_editor_state(indoc! {"
-            The quick brown
-            the lazy dog
-            |fox jumps over"});
+        cx.assert_state(
+            indoc! {"
+                The quick brown
+                the lazy dog
+                |fox jumps over"},
+            Mode::Normal,
+        );
 
         cx.set_state(
             indoc! {"
@@ -1173,14 +1164,17 @@ mod test {
         cx.set_state(
             indoc! {"
                 The quick brown
-                fox jump|s over
+                fox jumps ove|r
                 the lazy dog"},
             Mode::Normal,
         );
         cx.simulate_keystroke("p");
-        cx.assert_editor_state(indoc! {"
-            The quick brown
-            fox jumps|jumps over
-            the lazy dog"});
+        cx.assert_state(
+            indoc! {"
+                The quick brown
+                fox jumps over|jumps
+                the lazy dog"},
+            Mode::Normal,
+        );
     }
 }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 use crate::{
     motion::Motion,
     state::{Mode, Operator},
+    utils::copy_selections_content,
     Vim,
 };
 use change::init as change_init;
@@ -200,11 +201,12 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
         vim.update_active_editor(cx, |editor, cx| {
             editor.transact(cx, |editor, cx| {
                 if let Some(item) = cx.as_mut().read_from_clipboard() {
+                    copy_selections_content(editor, editor.selections.line_mode, cx);
                     let mut clipboard_text = Cow::Borrowed(item.text());
                     if let Some(mut clipboard_selections) =
                         item.metadata::<Vec<ClipboardSelection>>()
                     {
-                        let (display_map, selections) = editor.selections.all_display(cx);
+                        let (display_map, selections) = editor.selections.all_adjusted_display(cx);
                         let all_selections_were_entire_line =
                             clipboard_selections.iter().all(|s| s.is_entire_line);
                         if clipboard_selections.len() != selections.len() {

--- a/crates/vim/src/vim_test_context.rs
+++ b/crates/vim/src/vim_test_context.rs
@@ -125,6 +125,11 @@ impl<'a> VimTestContext<'a> {
         self.cx.set_state(text);
     }
 
+    pub fn assert_state(&mut self, text: &str, mode: Mode) {
+        self.assert_editor_state(text);
+        assert_eq!(self.mode(), mode);
+    }
+
     pub fn assert_binding<const COUNT: usize>(
         &mut self,
         keystrokes: [&str; COUNT],

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -6,7 +6,7 @@ use workspace::Workspace;
 
 use crate::{motion::Motion, state::Mode, utils::copy_selections_content, Vim};
 
-actions!(vim, [VisualDelete, VisualChange, VisualYank]);
+actions!(vim, [VisualDelete, VisualChange, VisualYank, VisualPaste]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(change);


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/1283 and enables pasting from visual mode.