### PR TITLE
Add script for summarizing changes since last release

### DIFF
--- a/script/changes-since-last-release
+++ b/script/changes-since-last-release
@@ -1,0 +1,72 @@
+#!/usr/bin/env node --redirect-warnings=/dev/null
+
+const { execFileSync } = require("child_process");
+const { GITHUB_ACCESS_TOKEN } = process.env;
+const PR_REGEX = /pull request #(\d+)/;
+const FIXES_REGEX = /(fixes|closes) (.+[/#]\d+.*)$/im;
+
+main();
+
+async function main() {
+  // Get the last two tags
+  const [newTag, oldTag] = execFileSync(
+    "git",
+    ["tag", "--sort", "-committerdate"],
+    { encoding: "utf8" }
+  )
+    .split("\n")
+    .filter((t) => t.startsWith("v"));
+
+  // Print the previous release
+  console.log(`Changes from ${oldTag} to ${newTag}\n`);
+
+  const hasProtocolChanges =
+    execFileSync("git", ["diff", oldTag, newTag, "--", "crates/rpc"]).status != 0;
+
+  if (hasProtocolChanges) {
+    console.log("No RPC protocol changes\n");
+  } else {
+    console.warn("RPC protocol changes\n");
+  }
+
+  // Get the PRs merged between those two tags.
+  const pullRequestNumbers = execFileSync(
+    "git",
+    [
+      "log",
+      `${oldTag}..${newTag}`,
+      "--oneline",
+      "--grep",
+      "Merge pull request",
+    ],
+    { encoding: "utf8" }
+  )
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => line.match(PR_REGEX)[1]);
+
+  // Fetch the pull requests from the GitHub API.
+  console.log("Merged Pull requests:")
+  for (const pullRequestNumber of pullRequestNumbers) {
+    const webURL = `https://github.com/zed-industries/zed/pull/${pullRequestNumber}`;
+    const apiURL = `https://api.github.com/repos/zed-industries/zed/pulls/${pullRequestNumber}`;
+
+    const response = await fetch(apiURL, {
+      headers: {
+        Authorization: `token ${GITHUB_ACCESS_TOKEN}`,
+      },
+    });
+
+    // Print the pull request title and URL.
+    const pullRequest = await response.json();
+    console.log("*", pullRequest.title);
+    console.log("  URL:    ", webURL);
+
+    // If the pull request contains a 'closes' line, print the closed issue.
+    const fixesMatch = pullRequest.body.match(FIXES_REGEX);
+    if (fixesMatch) {
+      const fixedIssueURL = fixesMatch[2];
+      console.log("  Issue: ", fixedIssueURL);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a script called `script/changes-since-last-release`, which uses Git and the GitHub API to print out a summary of changes since the last release. My goal is to speed up the process of creating releases by automating some of the tedious parts.

Important data the script harvests:
* Are there any RPC protocol changes (just looking at changes in `crates/rpc`)
* For each PR merged since the last release:
    * Title of the PR
    * URL of the PR (in case more information is needed)
    * URL of any issue that was "fixed"/"closed" by the PR

Sample output for 0.46:

```
Changes from v0.45.0 to v0.46.0

No RPC protocol changes

Merged Pull requests:
* Fix hang due to tree-sitter query
  URL:     https://github.com/zed-industries/zed/pull/1312
  Issue:  https://github.com/zed-industries/zed/issues/1303
* Proposal: Terminal modal
  URL:     https://github.com/zed-industries/zed/pull/1294
* Honor `.gitignore` files above worktree's root
  URL:     https://github.com/zed-industries/zed/pull/1309
  Issue:  https://github.com/zed-industries/feedback/issues/85
* Terminal selections
  URL:     https://github.com/zed-industries/zed/pull/1299
* GPUI change proposals
  URL:     https://github.com/zed-industries/zed/pull/1300
* Mouse Event Refactor
  URL:     https://github.com/zed-industries/zed/pull/1298
* Add tooltips to pane nav buttons and make them trigger on click
  URL:     https://github.com/zed-industries/zed/pull/1307
  Issue:  https://github.com/zed-industries/zed/issues/1301
* Fixed terminal clone on split
  URL:     https://github.com/zed-industries/zed/pull/1306
  Issue:  https://github.com/zed-industries/feedback/issues/229 / https://github.com/zed-industries/zed/issues/1272
* Now defaults to using user's shell
  URL:     https://github.com/zed-industries/zed/pull/1305
  Issue:  https://github.com/zed-industries/feedback/issues/225 /
* Fixed working directory issues, added tests.
  URL:     https://github.com/zed-industries/zed/pull/1304
* Introduce support for formatting via an external command
  URL:     https://github.com/zed-industries/zed/pull/1302
  Issue:  https://github.com/zed-industries/feedback/issues/91
* Back and forward buttons
  URL:     https://github.com/zed-industries/zed/pull/1297
  Issue:  https://github.com/zed-industries/feedback/issues/38
 ```