### PR TITLE
Rename focus-toggling commands for project panel and contacts panel

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -302,7 +302,7 @@
             "cmd-p": "file_finder::Toggle",
             "cmd-shift-P": "command_palette::Toggle",
             "cmd-shift-M": "diagnostics::Deploy",
-            "cmd-shift-E": "project_panel::Toggle",
+            "cmd-shift-E": "project_panel::ToggleFocus",
             "cmd-alt-s": "workspace::SaveAll"
         }
     },
@@ -387,7 +387,7 @@
     {
         "context": "Workspace",
         "bindings": {
-            "cmd-shift-C": "contacts_panel::Toggle",
+            "cmd-shift-C": "contacts_panel::ToggleFocus",
             "cmd-shift-B": "workspace::ToggleRightSidebar"
         }
     },

--- a/crates/contacts_panel/src/contacts_panel.rs
+++ b/crates/contacts_panel/src/contacts_panel.rs
@@ -25,7 +25,7 @@ use std::{ops::DerefMut, sync::Arc};
 use theme::IconButton;
 use workspace::{sidebar::SidebarItem, JoinProject, ToggleProjectOnline, Workspace};
 
-actions!(contacts_panel, [Toggle]);
+actions!(contacts_panel, [ToggleFocus]);
 
 impl_actions!(
     contacts_panel,

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -63,7 +63,7 @@ impl Element for Text {
         cx: &mut LayoutContext,
     ) -> (Vector2F, Self::LayoutState) {
         // Convert the string and highlight ranges into an iterator of highlighted chunks.
-        
+
         let mut offset = 0;
         let mut highlight_ranges = self.highlights.iter().peekable();
         let chunks = std::iter::from_fn(|| {
@@ -81,7 +81,8 @@ impl Element for Text {
                         "Highlight out of text range. Text len: {}, Highlight range: {}..{}",
                         self.text.len(),
                         range.start,
-                        range.end);
+                        range.end
+                    );
                     result = None;
                 }
             } else if offset < self.text.len() {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -110,7 +110,7 @@ actions!(
         Paste,
         Delete,
         Rename,
-        Toggle
+        ToggleFocus
     ]
 );
 impl_internal_actions!(project_panel, [Open, ToggleExpanded, DeployContextMenu]);

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -222,11 +222,11 @@ pub fn menus() -> Vec<Menu<'static>> {
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Project Panel",
-                    action: Box::new(project_panel::Toggle),
+                    action: Box::new(project_panel::ToggleFocus),
                 },
                 MenuItem::Action {
                     name: "Contacts Panel",
-                    action: Box::new(contacts_panel::Toggle),
+                    action: Box::new(contacts_panel::ToggleFocus),
                 },
                 MenuItem::Action {
                     name: "Command Palette",

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -157,12 +157,16 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
         },
     );
     cx.add_action(
-        |workspace: &mut Workspace, _: &project_panel::Toggle, cx: &mut ViewContext<Workspace>| {
+        |workspace: &mut Workspace,
+         _: &project_panel::ToggleFocus,
+         cx: &mut ViewContext<Workspace>| {
             workspace.toggle_sidebar_item_focus(Side::Left, 0, cx);
         },
     );
     cx.add_action(
-        |workspace: &mut Workspace, _: &contacts_panel::Toggle, cx: &mut ViewContext<Workspace>| {
+        |workspace: &mut Workspace,
+         _: &contacts_panel::ToggleFocus,
+         cx: &mut ViewContext<Workspace>| {
             workspace.toggle_sidebar_item_focus(Side::Right, 0, cx);
         },
     );


### PR DESCRIPTION
As per the suggestion [here](https://github.com/zed-industries/feedback/issues/223#issuecomment-1176638750), this PR renames:

`contacts_panel::Toggle` -> `contacts_panel::ToggleFocus`
`project_search::Toggle` -> `project_search::ToggleFocus`

I went with `ToggleFocus` because that convention is already being used for `project_search::ToggleFocus`, so it seemed to fit nicely.