### PR TITLE
In Help menu, replace 'zed.dev' item with 'Documentation'

### DIFF
--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -298,15 +298,15 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
-                    name: "Give Feedback",
+                    name: "Documentation",
                     action: Box::new(crate::OpenBrowser {
-                        url: super::feedback::NEW_ISSUE_URL.into(),
+                        url: "https://zed.dev/docs".into(),
                     }),
                 },
                 MenuItem::Action {
-                    name: "Zed.dev",
+                    name: "Give Feedback",
                     action: Box::new(crate::OpenBrowser {
-                        url: "https://zed.dev".into(),
+                        url: super::feedback::NEW_ISSUE_URL.into(),
                     }),
                 },
                 MenuItem::Action {


### PR DESCRIPTION
We want people to find the docs.