### PR TITLE
Configurable Plugin Yielding

### DIFF
--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -60,7 +60,7 @@ fn main() {
 fn create_default_engine() -> Engine {
     let mut config = Config::default();
     config.async_support(true);
-    // config.epoch_interruption(true);
+    config.epoch_interruption(true);
     Engine::new(&config).expect("Could not create engine")
 }
 

--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -60,7 +60,7 @@ fn main() {
 fn create_default_engine() -> Engine {
     let mut config = Config::default();
     config.async_support(true);
-    config.epoch_interruption(true);
+    config.consume_fuel(true);
     Engine::new(&config).expect("Could not create engine")
 }
 

--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -54,13 +54,9 @@ fn main() {
 }
 
 /// Creates a default engine for compiling Wasm.
-/// N.B.: this must create the same `Engine` as
-/// the `create_default_engine` function
-/// in `plugin_runtime/src/plugin.rs`.
 fn create_default_engine() -> Engine {
     let mut config = Config::default();
     config.async_support(true);
-    config.consume_fuel(true);
     Engine::new(&config).expect("Could not create engine")
 }
 

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
         }
 
         async {
-            let mut runtime = PluginBuilder::new_with_default_ctx()
+            let (mut runtime, incrementer) = PluginBuilder::new_with_default_ctx()
                 .unwrap()
                 .host_function("mystery_number", |input: u32| input + 7)
                 .unwrap()
@@ -52,6 +52,8 @@ mod tests {
                 )
                 .await
                 .unwrap();
+
+            std::thread::spawn(move || incrementer.block_on());
 
             let plugin = TestPlugin {
                 noop: runtime.function("noop").unwrap(),

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
         }
 
         async {
-            let mut runtime = PluginBuilder::new_with_default_ctx(PluginYield::default_fuel())
+            let mut runtime = PluginBuilder::new_fuel_with_default_ctx(PluginYield::default_fuel())
                 .unwrap()
                 .host_function("mystery_number", |input: u32| input + 7)
                 .unwrap()

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
         }
 
         async {
-            let (mut runtime, incrementer) = PluginBuilder::new_with_default_ctx()
+            let mut runtime = PluginBuilder::new_with_default_ctx()
                 .unwrap()
                 .host_function("mystery_number", |input: u32| input + 7)
                 .unwrap()
@@ -52,8 +52,6 @@ mod tests {
                 )
                 .await
                 .unwrap();
-
-            std::thread::spawn(move || incrementer.block_on());
 
             let plugin = TestPlugin {
                 noop: runtime.function("noop").unwrap(),

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -46,10 +46,9 @@ mod tests {
                         .map(|output| output.stdout)
                 })
                 .unwrap()
-                .init(
-                    false,
-                    include_bytes!("../../../plugins/bin/test_plugin.wasm"),
-                )
+                .init(PluginBinary::Wasm(
+                    include_bytes!("../../../plugins/bin/test_plugin.wasm").as_ref(),
+                ))
                 .await
                 .unwrap();
 

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
         }
 
         async {
-            let mut runtime = PluginBuilder::new_with_default_ctx()
+            let mut runtime = PluginBuilder::new_with_default_ctx(PluginYield::default_fuel())
                 .unwrap()
                 .host_function("mystery_number", |input: u32| input + 7)
                 .unwrap()

--- a/crates/plugin_runtime/src/plugin.rs
+++ b/crates/plugin_runtime/src/plugin.rs
@@ -345,8 +345,6 @@ impl PluginBuilder {
 
     /// Initializes a [`Plugin`] from a given compiled Wasm module.
     /// Both binary (`.wasm`) and text (`.wat`) module formats are supported.
-    /// Will panic if this is plugin uses `PluginYield::Epoch`,
-    /// but an epoch incrementer has not yet been created.
     pub async fn init<T: AsRef<[u8]>>(self, precompiled: bool, module: T) -> Result<Plugin, Error> {
         Plugin::init(precompiled, module.as_ref(), self).await
     }

--- a/crates/plugin_runtime/src/plugin.rs
+++ b/crates/plugin_runtime/src/plugin.rs
@@ -105,8 +105,6 @@ impl PluginBuilder {
     fn create_engine(yield_when: &PluginYield) -> Result<(Engine, Linker<WasiCtxAlloc>), Error> {
         let mut config = Config::default();
         config.async_support(true);
-        let engine = Engine::new(&config)?;
-        let linker = Linker::new(&engine);
 
         match yield_when {
             PluginYield::Epoch { .. } => {
@@ -117,6 +115,8 @@ impl PluginBuilder {
             }
         }
 
+        let engine = Engine::new(&config)?;
+        let linker = Linker::new(&engine);
         Ok((engine, linker))
     }
 

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -9,7 +9,10 @@ use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
-    let plugin = PluginBuilder::new_with_default_ctx(PluginYield::default_epoch())?
+    let plugin =
+        PluginBuilder::new_epoch_with_default_ctx(PluginYield::default_epoch(), |future| {
+            executor.spawn(future).detach()
+        })?
         .host_function_async("command", |command: String| async move {
             let mut args = command.split(' ');
             let command = args.next().unwrap();

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -9,9 +9,10 @@ use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
+    let executor_ref = executor.clone();
     let plugin =
-        PluginBuilder::new_epoch_with_default_ctx(PluginYield::default_epoch(), |future| {
-            executor.spawn(future).detach()
+        PluginBuilder::new_epoch_with_default_ctx(PluginYield::default_epoch(), move |future| {
+            executor_ref.spawn(future).detach()
         })?
         .host_function_async("command", |command: String| async move {
             let mut args = command.split(' ');

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -4,12 +4,12 @@ use client::http::HttpClient;
 use futures::lock::Mutex;
 use gpui::executor::Background;
 use language::{LanguageServerName, LspAdapter};
-use plugin_runtime::{Plugin, PluginBuilder, WasiFn};
+use plugin_runtime::{Plugin, PluginBuilder, PluginYield, WasiFn};
 use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
-    let plugin = PluginBuilder::new_with_default_ctx()?
+    let plugin = PluginBuilder::new_with_default_ctx(PluginYield::default_epoch())?
         .host_function_async("command", |command: String| async move {
             let mut args = command.split(' ');
             let command = args.next().unwrap();

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -4,7 +4,7 @@ use client::http::HttpClient;
 use futures::lock::Mutex;
 use gpui::executor::Background;
 use language::{LanguageServerName, LspAdapter};
-use plugin_runtime::{Plugin, PluginBuilder, PluginYield, WasiFn};
+use plugin_runtime::{Plugin, PluginBinary, PluginBuilder, PluginYield, WasiFn};
 use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
@@ -24,10 +24,9 @@ pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
                 .log_err()
                 .map(|output| output.stdout)
         })?
-        .init(
-            true,
-            include_bytes!("../../../../plugins/bin/json_language.wasm.pre"),
-        )
+        .init(PluginBinary::Precompiled(include_bytes!(
+            "../../../../plugins/bin/json_language.wasm.pre"
+        )))
         .await?;
 
     PluginLspAdapter::new(plugin, executor).await

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -9,7 +9,7 @@ use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
-    let plugin = PluginBuilder::new_with_default_ctx()?
+    let (plugin, incrementer) = PluginBuilder::new_with_default_ctx()?
         .host_function_async("command", |command: String| async move {
             let mut args = command.split(' ');
             let command = args.next().unwrap();
@@ -25,6 +25,8 @@ pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
             include_bytes!("../../../../plugins/bin/json_language.wasm.pre"),
         )
         .await?;
+
+    executor.spawn(incrementer).detach();
     PluginLspAdapter::new(plugin, executor).await
 }
 

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -9,7 +9,7 @@ use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
-    let (plugin, incrementer) = PluginBuilder::new_with_default_ctx()?
+    let plugin = PluginBuilder::new_with_default_ctx()?
         .host_function_async("command", |command: String| async move {
             let mut args = command.split(' ');
             let command = args.next().unwrap();
@@ -26,7 +26,6 @@ pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
         )
         .await?;
 
-    executor.spawn(incrementer).detach();
     PluginLspAdapter::new(plugin, executor).await
 }
 


### PR DESCRIPTION
## Description of feature or change
Currently plugins do not yield unless they call an async host function. This PR adds support for duration-based time-slicing, meaning plugins yield back control every 100ms (which we could make configurable). See the documentation about [epoch interruption](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.epoch_interruption) and [async yielding](https://docs.rs/wasmtime/latest/wasmtime/struct.Store.html#method.epoch_deadline_async_yield_and_update) for more info.

This probably isn't ready to merge, a couple things:

- I'd like for all plugins to derive from a single engine and store, if possible, meaning we'd only have to maintain one incrementer across all plugins. (Also less per-plugin startup overhead).
- I'm not sure that this is the right approach (e.g. returning a future for the caller to figure out how to run in the background), but I can't think of anything better atm.
- I'm not sure whether the values I've selected (epoch = 100ms, delta = 1 epoch) are optimal.
- I tested/built this and didn't notice any regressions, but it'd be nice to do some debugging and tracing to make sure this is working as intended.

## Link to related issues from zed or insiders
See #1325.

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
