### PR TITLE
Completions Menu Setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1,29 +1,25 @@
 {
     // The name of the Zed theme to use for the UI
     "theme": "cave-dark",
-
     // The name of a font to use for rendering text in the editor
     "buffer_font_family": "Zed Mono",
-
     // The default font size for text in the editor
     "buffer_font_size": 15,
-
     // Whether to enable vim modes and key bindings
     "vim_mode": false,
-
     // Whether to show the informational hover box when moving the mouse
     // over symbols in the editor.
     "hover_popover_enabled": true,
-
+    // Whether to pop the completions menu while typing in an editor without
+    // explicitly requesting it.
+    "show_completions_on_input": true,
     // Whether new projects should start out 'online'. Online projects
     // appear in the contacts panel under your name, so that your contacts
     // can see which projects you are working on. Regardless of this
     // setting, projects keep their last online status when you reopen them.
     "projects_online_by_default": true,
-
     // Whether to use language servers to provide code intelligence.
     "enable_language_server": true,
-
     // When to automatically save edited buffers. This setting can
     // take four values.
     //
@@ -36,7 +32,6 @@
     // 4. Save when idle for a certain amount of time:
     //     "autosave": { "after_delay": {"milliseconds": 500} },
     "autosave": "off",
-
     // How to auto-format modified buffers when saving them. This
     // setting can take three values:
     //
@@ -52,7 +47,6 @@
     //       }
     //     },
     "format_on_save": "language_server",
-
     // How to soft-wrap long lines of text. This setting can take
     // three values:
     //
@@ -63,18 +57,14 @@
     // 2. Soft wrap lines at the preferred line length
     //      "soft_wrap": "preferred_line_length",
     "soft_wrap": "none",
-
     // The column at which to soft-wrap lines, for buffers where soft-wrap
     // is enabled.
     "preferred_line_length": 80,
-
     // Whether to indent lines using tab characters, as opposed to multiple
     // spaces.
     "hard_tabs": false,
-
     // How many columns a tab should occupy.
     "tab_size": 4,
-
     // Different settings for specific languages.
     "languages": {
         "Plain Text": {

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -342,17 +342,16 @@ mod tests {
                 test();"});
 
         let mut requests =
-            cx.lsp
-                .handle_request::<lsp::request::GotoDefinition, _, _>(move |_, _| async move {
-                    Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                        lsp::LocationLink {
-                            origin_selection_range: Some(symbol_range),
-                            target_uri: lsp::Url::from_file_path("/root/dir/file.rs").unwrap(),
-                            target_range,
-                            target_selection_range: target_range,
-                        },
-                    ])))
-                });
+            cx.handle_request::<lsp::request::GotoDefinition, _, _>(move |url, _, _| async move {
+                Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
+                    lsp::LocationLink {
+                        origin_selection_range: Some(symbol_range),
+                        target_uri: url.clone(),
+                        target_range,
+                        target_selection_range: target_range,
+                    },
+                ])))
+            });
         cx.update_editor(|editor, cx| {
             update_go_to_definition_link(
                 editor,
@@ -387,18 +386,17 @@ mod tests {
         // Response without source range still highlights word
         cx.update_editor(|editor, _| editor.link_go_to_definition_state.last_mouse_location = None);
         let mut requests =
-            cx.lsp
-                .handle_request::<lsp::request::GotoDefinition, _, _>(move |_, _| async move {
-                    Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                        lsp::LocationLink {
-                            // No origin range
-                            origin_selection_range: None,
-                            target_uri: lsp::Url::from_file_path("/root/dir/file.rs").unwrap(),
-                            target_range,
-                            target_selection_range: target_range,
-                        },
-                    ])))
-                });
+            cx.handle_request::<lsp::request::GotoDefinition, _, _>(move |url, _, _| async move {
+                Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
+                    lsp::LocationLink {
+                        // No origin range
+                        origin_selection_range: None,
+                        target_uri: url.clone(),
+                        target_range,
+                        target_selection_range: target_range,
+                    },
+                ])))
+            });
         cx.update_editor(|editor, cx| {
             update_go_to_definition_link(
                 editor,
@@ -495,17 +493,16 @@ mod tests {
                 test();"});
 
         let mut requests =
-            cx.lsp
-                .handle_request::<lsp::request::GotoDefinition, _, _>(move |_, _| async move {
-                    Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                        lsp::LocationLink {
-                            origin_selection_range: Some(symbol_range),
-                            target_uri: lsp::Url::from_file_path("/root/dir/file.rs").unwrap(),
-                            target_range,
-                            target_selection_range: target_range,
-                        },
-                    ])))
-                });
+            cx.handle_request::<lsp::request::GotoDefinition, _, _>(move |url, _, _| async move {
+                Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
+                    lsp::LocationLink {
+                        origin_selection_range: Some(symbol_range),
+                        target_uri: url,
+                        target_range,
+                        target_selection_range: target_range,
+                    },
+                ])))
+            });
         cx.update_editor(|editor, cx| {
             cmd_changed(editor, &CmdChanged { cmd_down: true }, cx);
         });
@@ -584,17 +581,16 @@ mod tests {
                 test();"});
 
         let mut requests =
-            cx.lsp
-                .handle_request::<lsp::request::GotoDefinition, _, _>(move |_, _| async move {
-                    Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                        lsp::LocationLink {
-                            origin_selection_range: None,
-                            target_uri: lsp::Url::from_file_path("/root/dir/file.rs").unwrap(),
-                            target_range,
-                            target_selection_range: target_range,
-                        },
-                    ])))
-                });
+            cx.handle_request::<lsp::request::GotoDefinition, _, _>(move |url, _, _| async move {
+                Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
+                    lsp::LocationLink {
+                        origin_selection_range: None,
+                        target_uri: url,
+                        target_range,
+                        target_selection_range: target_range,
+                    },
+                ])))
+            });
         cx.update_workspace(|workspace, cx| {
             go_to_fetched_definition(workspace, &GoToFetchedDefinition { point: hover_point }, cx);
         });

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -25,6 +25,7 @@ pub struct Settings {
     pub buffer_font_size: f32,
     pub default_buffer_font_size: f32,
     pub hover_popover_enabled: bool,
+    pub show_completions_on_input: bool,
     pub vim_mode: bool,
     pub autosave: Autosave,
     pub editor_defaults: EditorSettings,
@@ -83,6 +84,8 @@ pub struct SettingsFileContent {
     #[serde(default)]
     pub hover_popover_enabled: Option<bool>,
     #[serde(default)]
+    pub show_completions_on_input: Option<bool>,
+    #[serde(default)]
     pub vim_mode: Option<bool>,
     #[serde(default)]
     pub autosave: Option<Autosave>,
@@ -118,6 +121,7 @@ impl Settings {
             buffer_font_size: defaults.buffer_font_size.unwrap(),
             default_buffer_font_size: defaults.buffer_font_size.unwrap(),
             hover_popover_enabled: defaults.hover_popover_enabled.unwrap(),
+            show_completions_on_input: defaults.show_completions_on_input.unwrap(),
             projects_online_by_default: defaults.projects_online_by_default.unwrap(),
             vim_mode: defaults.vim_mode.unwrap(),
             autosave: defaults.autosave.unwrap(),
@@ -219,6 +223,7 @@ impl Settings {
             buffer_font_size: 14.,
             default_buffer_font_size: 14.,
             hover_popover_enabled: true,
+            show_completions_on_input: true,
             vim_mode: false,
             autosave: Autosave::Off,
             editor_defaults: EditorSettings {

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -164,6 +164,10 @@ impl Settings {
         merge(&mut self.buffer_font_size, data.buffer_font_size);
         merge(&mut self.default_buffer_font_size, data.buffer_font_size);
         merge(&mut self.hover_popover_enabled, data.hover_popover_enabled);
+        merge(
+            &mut self.show_completions_on_input,
+            data.show_completions_on_input,
+        );
         merge(&mut self.vim_mode, data.vim_mode);
         merge(&mut self.autosave, data.autosave);
 

--- a/crates/util/src/test/marked_text.rs
+++ b/crates/util/src/test/marked_text.rs
@@ -24,7 +24,7 @@ pub fn marked_text(marked_text: &str) -> (String, Vec<usize>) {
     (unmarked_text, markers.remove(&'|').unwrap_or_default())
 }
 
-#[derive(Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub enum TextRangeMarker {
     Empty(char),
     Range(char, char),

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "styles",
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {


### PR DESCRIPTION
## Description of feature or change
add show_completions_on_input setting to disable popping the completions menu automatically. Set to true by default so that users can disable it if they like.
Also rewrites the test_completions test in editor.rs to use the EditorLspTestContext to remove boilerplate and make the test slightly more readable/debuggable.

## Link to related issues from zed or insiders
No issue, this is a response to a message in the feedback discord

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
