### PR TITLE
Fix association of 'json' lsp language id with JSON language

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -74,7 +74,7 @@ pub struct CachedLspAdapter {
     pub initialization_options: Option<Value>,
     pub disk_based_diagnostic_sources: Vec<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
-    pub id_for_language: Option<String>,
+    pub language_ids: HashMap<String, String>,
     pub adapter: Box<dyn LspAdapter>,
 }
 
@@ -87,7 +87,7 @@ impl CachedLspAdapter {
         let disk_based_diagnostic_sources = adapter.disk_based_diagnostic_sources().await;
         let disk_based_diagnostics_progress_token =
             adapter.disk_based_diagnostics_progress_token().await;
-        let id_for_language = adapter.id_for_language(name.0.as_ref()).await;
+        let language_ids = adapter.language_ids().await;
 
         Arc::new(CachedLspAdapter {
             name,
@@ -95,7 +95,7 @@ impl CachedLspAdapter {
             initialization_options,
             disk_based_diagnostic_sources,
             disk_based_diagnostics_progress_token,
-            id_for_language,
+            language_ids,
             adapter,
         })
     }
@@ -199,8 +199,8 @@ pub trait LspAdapter: 'static + Send + Sync {
         None
     }
 
-    async fn id_for_language(&self, _name: &str) -> Option<String> {
-        None
+    async fn language_ids(&self) -> HashMap<String, String> {
+        Default::default()
     }
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1821,7 +1821,7 @@ impl Project {
                 if let Some(language) = buffer.language() {
                     let worktree_id = file.worktree_id(cx);
                     if let Some(adapter) = language.lsp_adapter() {
-                        language_id = adapter.id_for_language.clone();
+                        language_id = adapter.language_ids.get(language.name().as_ref()).cloned();
                         language_server = self
                             .language_server_ids
                             .get(&(worktree_id, adapter.name.clone()))
@@ -2320,8 +2320,9 @@ impl Project {
                                                 text_document: lsp::TextDocumentItem::new(
                                                     uri,
                                                     adapter
-                                                        .id_for_language
-                                                        .clone()
+                                                        .language_ids
+                                                        .get(language.name().as_ref())
+                                                        .cloned()
                                                         .unwrap_or_default(),
                                                     *version,
                                                     initial_snapshot.text(),

--- a/plugins/json_language/src/lib.rs
+++ b/plugins/json_language/src/lib.rs
@@ -94,10 +94,6 @@ pub fn initialization_options() -> Option<String> {
 }
 
 #[export]
-pub fn id_for_language(name: String) -> Option<String> {
-    if name == "JSON" {
-        Some("jsonc".into())
-    } else {
-        None
-    }
+pub fn language_ids() -> Vec<(String, String)> {
+    vec![("JSON".into(), "jsonc".into())]
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/1332

The `LspAdapter::id_for_language` expected to be called with the name of a buffer's language, so that it could decide which "language id" to return. But that meant that it wasn't really a 'static' method whose return value could be cached on construction.

I decided to replace that method with a new method `language_ids` that **is** suitable for up-front caching. The new method just returns a fixed mapping of Zed language names to LSP language ids.

/cc @slightknack @as-cii 