### PR TITLE
Restore document highlights when canceling a rename

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4979,6 +4979,8 @@ impl Editor {
             self.change_selections(None, cx, |s| {
                 s.select_ranges(vec![cursor_in_editor..cursor_in_editor])
             });
+        } else {
+            self.refresh_document_highlights(cx);
         }
 
         Some(rename)


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/213

When renaming, we replace document highlights with a different "fade-out" effect. When canceling the rename without moving the cursor, we need to restore the highlights.