### PR TITLE
Mitigate `RefCell` panics

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -402,7 +402,8 @@ impl platform::Window for Window {
     }
 
     fn activate(&self) {
-        unsafe { msg_send![self.0.borrow().native_window, makeKeyAndOrderFront: nil] }
+        let window = self.0.borrow().native_window;
+        unsafe { msg_send![window, makeKeyAndOrderFront: nil] }
     }
 
     fn set_title(&mut self, title: &str) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -802,7 +802,7 @@ extern "C" fn view_did_change_backing_properties(this: &Object, _: Sel) {
 
 extern "C" fn set_frame_size(this: &Object, _: Sel, size: NSSize) {
     let window_state = unsafe { get_window_state(this) };
-    let mut window_state_borrow = window_state.as_ref().borrow_mut();
+    let window_state_borrow = window_state.as_ref().borrow();
 
     if window_state_borrow.size() == vec2f(size.width as f32, size.height as f32) {
         return;
@@ -822,6 +822,8 @@ extern "C" fn set_frame_size(this: &Object, _: Sel, size: NSSize) {
         let _: () = msg_send![window_state_borrow.layer, setDrawableSize: drawable_size];
     }
 
+    drop(window_state_borrow);
+    let mut window_state_borrow = window_state.borrow_mut();
     if let Some(mut callback) = window_state_borrow.resize_callback.take() {
         drop(window_state_borrow);
         callback();

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -392,18 +392,33 @@ impl platform::Window for Window {
             });
             let block = block.copy();
             let native_window = self.0.borrow().native_window;
-            let _: () = msg_send![
-                alert,
-                beginSheetModalForWindow: native_window
-                completionHandler: block
-            ];
+            self.0
+                .borrow()
+                .executor
+                .spawn(async move {
+                    let _: () = msg_send![
+                        alert,
+                        beginSheetModalForWindow: native_window
+                        completionHandler: block
+                    ];
+                })
+                .detach();
+
             done_rx
         }
     }
 
     fn activate(&self) {
         let window = self.0.borrow().native_window;
-        unsafe { msg_send![window, makeKeyAndOrderFront: nil] }
+        self.0
+            .borrow()
+            .executor
+            .spawn(async move {
+                unsafe {
+                    let _: () = msg_send![window, makeKeyAndOrderFront: nil];
+                }
+            })
+            .detach();
     }
 
     fn set_title(&mut self, title: &str) {


### PR DESCRIPTION
## Description of feature or change
I was unable to reproduce the panics in the issue linked below, so this pull request is a collection of defensive approaches to prevent the panic. It looks like the panic is caused by double borrows of `App` and `WindowState` as part of calling `Window::activate` and `Window::prompt`, which in turn cause us Cocoa to call `setFrameSize` and panic because we borrow again there.

With these changes we are spawning before activating or creating prompts: it seems fine for those actions to be invoked in the next tick of the loop. I thought of spawning the contents of `setFrameSize` but that leads to some weird visual artifacts due to not responding to the resize event synchronously.

## Link to related issues from zed or insiders
Closes https://github.com/zed-industries/zed/issues/1319

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
