### PR TITLE
Fix mismatched compilation settings in plugins

### DIFF
--- a/crates/plugin_runtime/README.md
+++ b/crates/plugin_runtime/README.md
@@ -154,8 +154,6 @@ Plugins in the `plugins` directory are automatically recompiled and serialized t
 
 - `plugin.wasm.pre` is the plugin compiled to Wasm *and additionally* precompiled to host-platform-agnostic cranelift-specific IR. This should be about 700KB for debug builds and 500KB in release builds. Each plugin takes about 1 or 2 seconds to compile to native code using cranelift, so precompiling plugins drastically reduces the startup time required to begin to run a plugin.
 
-> TODO: Rework precompiled plugins.
-
 For all intents and purposes, it is *highly recommended* that you use precompiled plugins where possible, as they are much more lightweight and take much less time to instantiate.
 
 ### Instantiating a plugin

--- a/crates/plugin_runtime/README.md
+++ b/crates/plugin_runtime/README.md
@@ -154,6 +154,8 @@ Plugins in the `plugins` directory are automatically recompiled and serialized t
 
 - `plugin.wasm.pre` is the plugin compiled to Wasm *and additionally* precompiled to host-platform-agnostic cranelift-specific IR. This should be about 700KB for debug builds and 500KB in release builds. Each plugin takes about 1 or 2 seconds to compile to native code using cranelift, so precompiling plugins drastically reduces the startup time required to begin to run a plugin.
 
+> TODO: Rework precompiled plugins.
+
 For all intents and purposes, it is *highly recommended* that you use precompiled plugins where possible, as they are much more lightweight and take much less time to instantiate.
 
 ### Instantiating a plugin

--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -88,7 +88,7 @@ fn precompile(path: &Path, engine: &Engine, engine_name: &str) {
         .precompile_module(&bytes)
         .expect("Could not precompile module");
     let out_path = path.parent().unwrap().join(&format!(
-        "{}.{}.pre",
+        "{}.{}",
         path.file_name().unwrap().to_string_lossy(),
         engine_name,
     ));

--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -68,7 +68,7 @@ fn main() {
 
 /// Creates an engine with the default configuration.
 /// N.B. This must create an engine with the same config as the one
-/// in `plugin_runtime/build.rs`.
+/// in `plugin_runtime/src/plugin.rs`.
 fn create_default_engine() -> Engine {
     let mut config = Config::default();
     config.async_support(true);

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
         }
 
         async {
-            let mut runtime = PluginBuilder::new_fuel_with_default_ctx(PluginYield::default_fuel())
+            let mut runtime = PluginBuilder::new_default()
                 .unwrap()
                 .host_function("mystery_number", |input: u32| input + 7)
                 .unwrap()

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -26,7 +26,7 @@ pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
                 .map(|output| output.stdout)
         })?
         .init(PluginBinary::Precompiled(include_bytes!(
-            "../../../../plugins/bin/json_language.wasm.pre"
+            "../../../../plugins/bin/json_language.wasm.epoch.pre"
         )))
         .await?;
 

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -5,16 +5,12 @@ use collections::HashMap;
 use futures::lock::Mutex;
 use gpui::executor::Background;
 use language::{LanguageServerName, LspAdapter};
-use plugin_runtime::{Plugin, PluginBinary, PluginBuilder, PluginYield, WasiFn};
+use plugin_runtime::{Plugin, PluginBinary, PluginBuilder, WasiFn};
 use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
-    let executor_ref = executor.clone();
-    let plugin =
-        PluginBuilder::new_epoch_with_default_ctx(PluginYield::default_epoch(), move |future| {
-            executor_ref.spawn(future).detach()
-        })?
+    let plugin = PluginBuilder::new_default()?
         .host_function_async("command", |command: String| async move {
             let mut args = command.split(' ');
             let command = args.next().unwrap();
@@ -26,7 +22,7 @@ pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
                 .map(|output| output.stdout)
         })?
         .init(PluginBinary::Precompiled(include_bytes!(
-            "../../../../plugins/bin/json_language.wasm.epoch"
+            "../../../../plugins/bin/json_language.wasm.pre"
         )))
         .await?;
 

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -26,7 +26,7 @@ pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
                 .map(|output| output.stdout)
         })?
         .init(PluginBinary::Precompiled(include_bytes!(
-            "../../../../plugins/bin/json_language.wasm.epoch.pre"
+            "../../../../plugins/bin/json_language.wasm.epoch"
         )))
         .await?;
 


### PR DESCRIPTION
## Description of feature or change
This PR removes epoch-based metering, in favor of fuel-based metering. This simplifies the API for creating plugins.

This PR should be merged ASAP, but leaves some issues unaddressed, see #1344.

## Link to related issues from zed or insiders
See #1344 as a part of #1325. 
