### PR TITLE
Use rustup directly on CI instead of actions-rs/toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,19 +25,10 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-          profile: minimal
-          default: true
-
-      - name: Install Rust wasm32-wasi target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-wasi
-          profile: minimal
+        run: |
+          rustup set profile minimal
+          rustup update stable
+          rustup target add wasm32-wasi
 
       - name: Install Node
         uses: actions/setup-node@v2
@@ -66,27 +57,13 @@ jobs:
       APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
       APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
     steps:
-      - name: Install Rust aarch64-apple-darwin target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-          profile: minimal
-          default: true
-
-      - name: Install Rust x86_64-apple-darwin target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-apple-darwin
-          profile: minimal
-          
-      - name: Install Rust wasm32-wasi target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-wasi
-          profile: minimal
+      - name: Install Rust
+        run: |
+          rustup set profile minimal
+          rustup update stable
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+          rustup target add wasm32-wasi
 
       - name: Install Node
         uses: actions/setup-node@v2


### PR DESCRIPTION
Trying to fix hangs while running rustup in GitHub actions.