### PR TITLE
Update rose pine theme

### DIFF
--- a/styles/src/themes/rose-pine-dawn.ts
+++ b/styles/src/themes/rose-pine-dawn.ts
@@ -5,23 +5,23 @@ const name = "rosé-pine-dawn";
 
 const ramps = {
   neutral: chroma.scale([
-    "#26233a",
-    "#555169",
     "#575279",
-    "#6e6a86",
-    "#9893a5",
-    "#f2e9de",
-    "#fffaf3",
-    "#faf4ed",
+    "#797593",
+    "#9893A5",
+    "#B5AFB8",
+    "#D3CCCC",
+    "#F2E9E1",
+    "#FFFAF3",
+    "#FAF4ED",
   ]),
-  red: colorRamp(chroma("#1f1d2e")),
-  orange: colorRamp(chroma("#b4637a")),
-  yellow: colorRamp(chroma("#ea9d34")),
-  green: colorRamp(chroma("#d7827e")),
+  red: colorRamp(chroma("#B4637A")),
+  orange: colorRamp(chroma("#D7827E")),
+  yellow: colorRamp(chroma("#EA9D34")),
+  green: colorRamp(chroma("#679967")),
   cyan: colorRamp(chroma("#286983")),
-  blue: colorRamp(chroma("#56949f")),
-  violet: colorRamp(chroma("#907aa9")),
-  magenta: colorRamp(chroma("#c5c3ce")),
+  blue: colorRamp(chroma("#56949F")),
+  violet: colorRamp(chroma("#907AA9")),
+  magenta: colorRamp(chroma("#79549F")),
 };
 
 export const light = createTheme(`${name}`, true, ramps);

--- a/styles/src/themes/rose-pine-moon.ts
+++ b/styles/src/themes/rose-pine-moon.ts
@@ -1,13 +1,13 @@
 import chroma from "chroma-js";
 import { colorRamp, createTheme } from "./common/base16";
 
-const name = "rosé-pine";
+const name = "rosé-pine-moon";
 
 const ramps = {
   neutral: chroma.scale([
-    "#191724",
-    "#1f1d2e",
-    "#26233A",
+    "#232136",
+    "#2A273F",
+    "#393552",
     "#3E3A53",
     "#56526C",
     "#6E6A86",


### PR DESCRIPTION
## Description of feature or change

This PR updates the `Rose Pine` theme. Previously it didn't have all the correct accents (errors were white, some accent's weren't mapped correctly.) These changes bring the themes up to spec with https://rosepinetheme.com/palette

*Rose Pine*

![CleanShot - 2022-07-13 at 14 31 11@2x](https://user-images.githubusercontent.com/1714999/178805575-06fb5d00-2a34-47c1-b842-78f9b429ac16.png)

*Rose Pine Moon*

![CleanShot - 2022-07-13 at 14 31 24@2x](https://user-images.githubusercontent.com/1714999/178805619-82eef1dd-776c-4cc2-8678-b022111bf4ae.png)

*Rose Pine Dawn*

![CleanShot - 2022-07-13 at 14 31 51@2x](https://user-images.githubusercontent.com/1714999/178805702-2abaf80b-6f80-4dd8-a21f-fad2842811bf.png)

Changes:
- Update Rose Pine & Rose Pine Dawn with the correct semantic colors
- Add Rose Pine Moon

## Link to related issues from zed or insiders

N/A

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
