### PR TITLE
Temporarily remove JSON plugin + restore native JSON LspAdapter

### DIFF
--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -2,11 +2,11 @@ use gpui::executor::Background;
 pub use language::*;
 use rust_embed::RustEmbed;
 use std::{borrow::Cow, str, sync::Arc};
-use util::ResultExt;
 
 mod c;
 mod go;
 mod installation;
+mod json;
 mod language_plugin;
 mod python;
 mod rust;
@@ -17,7 +17,7 @@ mod typescript;
 #[exclude = "*.rs"]
 struct LanguageDir;
 
-pub async fn init(languages: Arc<LanguageRegistry>, executor: Arc<Background>) {
+pub async fn init(languages: Arc<LanguageRegistry>, _executor: Arc<Background>) {
     for (name, grammar, lsp_adapter) in [
         (
             "c",
@@ -37,10 +37,7 @@ pub async fn init(languages: Arc<LanguageRegistry>, executor: Arc<Background>) {
         (
             "json",
             tree_sitter_json::language(),
-            match language_plugin::new_json(executor).await.log_err() {
-                Some(lang) => Some(CachedLspAdapter::new(lang).await),
-                None => None,
-            },
+            Some(CachedLspAdapter::new(json::JsonLspAdapter).await),
         ),
         (
             "markdown",

--- a/crates/zed/src/languages/json.rs
+++ b/crates/zed/src/languages/json.rs
@@ -1,0 +1,106 @@
+use super::installation::{npm_install_packages, npm_package_latest_version};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use client::http::HttpClient;
+use collections::HashMap;
+use futures::StreamExt;
+use language::{LanguageServerName, LspAdapter};
+use serde_json::json;
+use smol::fs;
+use std::{any::Any, path::PathBuf, sync::Arc};
+use util::ResultExt;
+
+pub struct JsonLspAdapter;
+
+impl JsonLspAdapter {
+    const BIN_PATH: &'static str =
+        "node_modules/vscode-json-languageserver/bin/vscode-json-languageserver";
+}
+
+#[async_trait]
+impl LspAdapter for JsonLspAdapter {
+    async fn name(&self) -> LanguageServerName {
+        LanguageServerName("vscode-json-languageserver".into())
+    }
+
+    async fn server_args(&self) -> Vec<String> {
+        vec!["--stdio".into()]
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: Arc<dyn HttpClient>,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(npm_package_latest_version("vscode-json-languageserver").await?) as Box<_>)
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        _: Arc<dyn HttpClient>,
+        container_dir: PathBuf,
+    ) -> Result<PathBuf> {
+        let version = version.downcast::<String>().unwrap();
+        let version_dir = container_dir.join(version.as_str());
+        fs::create_dir_all(&version_dir)
+            .await
+            .context("failed to create version directory")?;
+        let binary_path = version_dir.join(Self::BIN_PATH);
+
+        if fs::metadata(&binary_path).await.is_err() {
+            npm_install_packages(
+                [("vscode-json-languageserver", version.as_str())],
+                &version_dir,
+            )
+            .await?;
+
+            if let Some(mut entries) = fs::read_dir(&container_dir).await.log_err() {
+                while let Some(entry) = entries.next().await {
+                    if let Some(entry) = entry.log_err() {
+                        let entry_path = entry.path();
+                        if entry_path.as_path() != version_dir {
+                            fs::remove_dir_all(&entry_path).await.log_err();
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(binary_path)
+    }
+
+    async fn cached_server_binary(&self, container_dir: PathBuf) -> Option<PathBuf> {
+        (|| async move {
+            let mut last_version_dir = None;
+            let mut entries = fs::read_dir(&container_dir).await?;
+            while let Some(entry) = entries.next().await {
+                let entry = entry?;
+                if entry.file_type().await?.is_dir() {
+                    last_version_dir = Some(entry.path());
+                }
+            }
+            let last_version_dir = last_version_dir.ok_or_else(|| anyhow!("no cached binary"))?;
+            let bin_path = last_version_dir.join(Self::BIN_PATH);
+            if bin_path.exists() {
+                Ok(bin_path)
+            } else {
+                Err(anyhow!(
+                    "missing executable in directory {:?}",
+                    last_version_dir
+                ))
+            }
+        })()
+        .await
+        .log_err()
+    }
+
+    async fn initialization_options(&self) -> Option<serde_json::Value> {
+        Some(json!({
+            "provideFormatter": true
+        }))
+    }
+
+    async fn language_ids(&self) -> HashMap<String, String> {
+        [("JSON".into(), "jsonc".into())].into_iter().collect()
+    }
+}


### PR DESCRIPTION
We hit one unforeseen issue with the new WASM plugin system: our current approach to pre-compiling the WASM to native code is not working when we cross-compile to the x86 architecture.

We think that we should actually fix this by pre-compiling the WASM lazily, on the user's machine, instead of shipping the pre-compiled code as part of the app. But for now, in order to restore `main` to a working state, we are going to remove the use of the WASM plugin for now, and switch back to our old implementation of the JSON LSP adapter.