### PR TITLE
Fix incomplete language names list being used for JSON schema

### DIFF
--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -248,7 +248,7 @@ impl Settings {
 
 pub fn settings_file_json_schema(
     theme_names: Vec<String>,
-    language_names: Vec<String>,
+    language_names: &[String],
 ) -> serde_json::Value {
     let settings = SchemaSettings::draft07().with(|settings| {
         settings.option_add_null_type = false;
@@ -275,8 +275,13 @@ pub fn settings_file_json_schema(
         instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
         object: Some(Box::new(ObjectValidation {
             properties: language_names
-                .into_iter()
-                .map(|name| (name, Schema::new_ref("#/definitions/EditorSettings".into())))
+                .iter()
+                .map(|name| {
+                    (
+                        name.clone(),
+                        Schema::new_ref("#/definitions/EditorSettings".into()),
+                    )
+                })
                 .collect(),
             ..Default::default()
         })),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -209,7 +209,7 @@ pub fn initialize_workspace(
     cx.emit(workspace::Event::PaneAdded(workspace.active_pane().clone()));
 
     let theme_names = app_state.themes.list().collect();
-    let language_names = app_state.languages.language_names();
+    let language_names = &languages::LANGUAGE_NAMES;
 
     workspace.project().update(cx, |project, cx| {
         let action_names = cx.all_action_names().collect::<Vec<_>>();


### PR DESCRIPTION
For now, since initializing the languages themselves is still async, create a parallel duplicated code path that is synchronous, and just provided the language names.