### PR TITLE
Fixed modal terminal bindings to not show in command palette

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -409,7 +409,6 @@
         "bindings": {
             "ctrl-c": "terminal::Sigint",
             "escape": "terminal::Escape",
-            "shift-escape": "terminal::DeployModal",
             "ctrl-d": "terminal::Quit",
             "backspace": "terminal::Del",
             "enter": "terminal::Return",
@@ -421,6 +420,12 @@
             "cmd-v": "terminal::Paste",
             "cmd-c": "terminal::Copy",
             "ctrl-l": "terminal::Clear"
+        }
+    },
+    {
+        "context": "ModalTerminal",
+        "bindings": {
+            "shift-escape": "terminal::DeployModal"
         }
     }
 ]

--- a/crates/terminal/src/modal.rs
+++ b/crates/terminal/src/modal.rs
@@ -16,8 +16,11 @@ pub fn deploy_modal(workspace: &mut Workspace, _: &DeployModal, cx: &mut ViewCon
     if let Some(StoredConnection(stored_connection)) = possible_connection {
         // Create a view from the stored connection
         workspace.toggle_modal(cx, |_, cx| {
-            cx.add_view(|cx| Terminal::from_connection(stored_connection, true, cx))
+            cx.add_view(|cx| Terminal::from_connection(stored_connection.clone(), true, cx))
         });
+        cx.set_global::<Option<StoredConnection>>(Some(StoredConnection(
+            stored_connection.clone(),
+        )));
     } else {
         // No connection was stored, create a new terminal
         if let Some(closed_terminal_handle) = workspace.toggle_modal(cx, |workspace, cx| {

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "styles",
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {


### PR DESCRIPTION
## Description of feature or change

Fixed Terminal Modal showing up in Command Palette and not being correctly persistent. Really need to get on that blocking modal design.

## Link to related issues from zed or insiders

@JosephTLyons Can you confirm this is working properly this time?