### PR TITLE
Avoid copying all default settings to initial user settings

### DIFF
--- a/assets/settings/initial_user_settings.json
+++ b/assets/settings/initial_user_settings.json
@@ -6,3 +6,6 @@
 // To see all of Zed's default settings without changing your
 // custom settings, run the `open default settings` command
 // from the command palette or from `Zed` application menu.
+{
+    "buffer_font_size": 15
+}

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -102,14 +102,14 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
         let app_state = app_state.clone();
         move |_: &mut Workspace, _: &OpenSettings, cx: &mut ViewContext<Workspace>| {
             open_config_file(&SETTINGS_PATH, app_state.clone(), cx, || {
-                let header = Assets.load("settings/header-comments.json").unwrap();
-                let json = Assets.load("settings/default.json").unwrap();
-                let header = str::from_utf8(header.as_ref()).unwrap();
-                let json = str::from_utf8(json.as_ref()).unwrap();
-                let mut content = Rope::new();
-                content.push(header);
-                content.push(json);
-                content
+                str::from_utf8(
+                    Assets
+                        .load("settings/initial_user_settings.json")
+                        .unwrap()
+                        .as_ref(),
+                )
+                .unwrap()
+                .into()
             });
         }
     });


### PR DESCRIPTION
This would cause top-level default editor settings to override language-specific default settings.