### PR TITLE
More intuitive tab ordering

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -562,7 +562,7 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
             if T::should_activate_item_on_event(event) {
                 pane.update(cx, |pane, cx| {
                     if let Some(ix) = pane.index_for_item(&item) {
-                        pane.activate_item(ix, true, true, cx);
+                        pane.activate_item(ix, true, true, false, cx);
                         pane.activate(cx);
                     }
                 });
@@ -1507,7 +1507,7 @@ impl Workspace {
         });
         if let Some((pane, ix)) = result {
             self.activate_pane(pane.clone(), cx);
-            pane.update(cx, |pane, cx| pane.activate_item(ix, true, true, cx));
+            pane.update(cx, |pane, cx| pane.activate_item(ix, true, true, false, cx));
             true
         } else {
             false
@@ -2880,7 +2880,7 @@ mod tests {
 
         let close_items = workspace.update(cx, |workspace, cx| {
             pane.update(cx, |pane, cx| {
-                pane.activate_item(1, true, true, cx);
+                pane.activate_item(1, true, true, false, cx);
                 assert_eq!(pane.active_item().unwrap().id(), item2.id());
             });
 


### PR DESCRIPTION
## Description of feature or change
Makes two changes:
1. When closing a tab, activate the previous tab if possible, not the next one.
2. When requesting to add an item to a pane which already contains that item, reorder the tabs so that the requested item is after the current item.

This makes the tab ordering act like a stack. Opening items adds to the stack (including if the item was opened previously) and closing them pops off of the stack. Makes renames, project finds, and find all references easier to use without resorting to tab management bindings.

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/feedback/issues/280

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
Avoiding for now as we don't have tests verifying this behavior currently 
- [x] Have you added the necessary settings to configure this feature?
None needed
- [x] Has documentation been created or updated (including above changes to settings)?
None needed