### PR TITLE
Differentiate among tabs with the same name

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -501,7 +501,12 @@ impl ProjectDiagnosticsEditor {
 }
 
 impl workspace::Item for ProjectDiagnosticsEditor {
-    fn tab_content(&self, style: &theme::Tab, cx: &AppContext) -> ElementBox {
+    fn tab_content(
+        &self,
+        _detail: Option<usize>,
+        style: &theme::Tab,
+        cx: &AppContext,
+    ) -> ElementBox {
         render_summary(
             &self.summary,
             &style.label.text,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -35,6 +35,7 @@ use gpui::{
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HoverState};
+pub use items::MAX_TAB_TITLE_LEN;
 pub use language::{char_kind, CharKind};
 use language::{
     BracketPair, Buffer, CodeAction, CodeLabel, Completion, Diagnostic, DiagnosticSeverity,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1073,7 +1073,7 @@ impl Editor {
         &self.buffer
     }
 
-    pub fn title(&self, cx: &AppContext) -> String {
+    pub fn title<'a>(&self, cx: &'a AppContext) -> Cow<'a, str> {
         self.buffer().read(cx).title(cx)
     }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -23,6 +23,7 @@ use util::TryFutureExt;
 use workspace::{FollowableItem, Item, ItemHandle, ItemNavHistory, ProjectItem, StatusItemView};
 
 pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
+pub const MAX_TAB_TITLE_LEN: usize = 24;
 
 impl FollowableItem for Editor {
     fn from_state_proto(
@@ -320,9 +321,14 @@ impl Item for Editor {
             )
             .with_children(detail.and_then(|detail| {
                 let path = path_for_buffer(&self.buffer, detail, false, cx)?;
+                let description = path.to_string_lossy();
                 Some(
                     Label::new(
-                        path.to_string_lossy().into(),
+                        if description.len() > MAX_TAB_TITLE_LEN {
+                            description[..MAX_TAB_TITLE_LEN].to_string() + "…"
+                        } else {
+                            description.into()
+                        },
                         style.description.text.clone(),
                     )
                     .contained()

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -14,6 +14,7 @@ use language::{
 use settings::Settings;
 use smallvec::SmallVec;
 use std::{
+    borrow::Cow,
     cell::{Ref, RefCell},
     cmp, fmt, io,
     iter::{self, FromIterator},
@@ -1194,14 +1195,14 @@ impl MultiBuffer {
             .collect()
     }
 
-    pub fn title(&self, cx: &AppContext) -> String {
-        if let Some(title) = self.title.clone() {
-            return title;
+    pub fn title<'a>(&'a self, cx: &'a AppContext) -> Cow<'a, str> {
+        if let Some(title) = self.title.as_ref() {
+            return title.into();
         }
 
         if let Some(buffer) = self.as_singleton() {
             if let Some(file) = buffer.read(cx).file() {
-                return file.file_name(cx).to_string_lossy().into();
+                return file.file_name(cx).to_string_lossy();
             }
         }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -20,7 +20,7 @@ use std::{
     any::Any,
     cmp::{self, Ordering},
     collections::{BTreeMap, HashMap},
-    ffi::OsString,
+    ffi::OsStr,
     future::Future,
     iter::{self, Iterator, Peekable},
     mem,
@@ -185,7 +185,7 @@ pub trait File: Send + Sync {
 
     /// Returns the last component of this handle's absolute path. If this handle refers to the root
     /// of its worktree, then this method will return the name of the worktree itself.
-    fn file_name(&self, cx: &AppContext) -> OsString;
+    fn file_name<'a>(&'a self, cx: &'a AppContext) -> &'a OsStr;
 
     fn is_deleted(&self) -> bool;
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1646,11 +1646,10 @@ impl language::File for File {
 
     /// Returns the last component of this handle's absolute path. If this handle refers to the root
     /// of its worktree, then this method will return the name of the worktree itself.
-    fn file_name(&self, cx: &AppContext) -> OsString {
+    fn file_name<'a>(&'a self, cx: &'a AppContext) -> &'a OsStr {
         self.path
             .file_name()
-            .map(|name| name.into())
-            .unwrap_or_else(|| OsString::from(&self.worktree.read(cx).root_name))
+            .unwrap_or_else(|| OsStr::new(&self.worktree.read(cx).root_name))
     }
 
     fn is_deleted(&self) -> bool {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -220,7 +220,12 @@ impl Item for ProjectSearchView {
             .update(cx, |editor, cx| editor.deactivated(cx));
     }
 
-    fn tab_content(&self, tab_theme: &theme::Tab, cx: &gpui::AppContext) -> ElementBox {
+    fn tab_content(
+        &self,
+        _detail: Option<usize>,
+        tab_theme: &theme::Tab,
+        cx: &gpui::AppContext,
+    ) -> ElementBox {
         let settings = cx.global::<Settings>();
         let search_theme = &settings.theme.search;
         Flex::row()

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -4,7 +4,7 @@ use crate::{
     ToggleWholeWord,
 };
 use collections::HashMap;
-use editor::{Anchor, Autoscroll, Editor, MultiBuffer, SelectAll};
+use editor::{Anchor, Autoscroll, Editor, MultiBuffer, SelectAll, MAX_TAB_TITLE_LEN};
 use gpui::{
     actions, elements::*, platform::CursorStyle, Action, AppContext, ElementBox, Entity,
     ModelContext, ModelHandle, MutableAppContext, RenderContext, Subscription, Task, View,
@@ -25,8 +25,6 @@ use workspace::{
 };
 
 actions!(project_search, [Deploy, SearchInNew, ToggleFocus]);
-
-const MAX_TAB_TITLE_LEN: usize = 24;
 
 #[derive(Default)]
 struct ActiveSearches(HashMap<WeakModelHandle<Project>, WeakViewHandle<ProjectSearchView>>);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -324,7 +324,12 @@ impl View for Terminal {
 }
 
 impl Item for Terminal {
-    fn tab_content(&self, tab_theme: &theme::Tab, cx: &gpui::AppContext) -> ElementBox {
+    fn tab_content(
+        &self,
+        _detail: Option<usize>,
+        tab_theme: &theme::Tab,
+        cx: &gpui::AppContext,
+    ) -> ElementBox {
         let settings = cx.global::<Settings>();
         let search_theme = &settings.theme.search; //TODO properly integrate themes
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -93,6 +93,7 @@ pub struct Tab {
     pub container: ContainerStyle,
     #[serde(flatten)]
     pub label: LabelStyle,
+    pub description: ContainedText,
     pub spacing: f32,
     pub icon_width: f32,
     pub icon_close: Color,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -840,8 +840,10 @@ impl Pane {
             } else {
                 None
             };
+
             let mut row = Flex::row().scrollable::<Tabs, _>(1, autoscroll, cx);
-            for (ix, item) in self.items.iter().enumerate() {
+            for (ix, (item, detail)) in self.items.iter().zip(self.tab_details(cx)).enumerate() {
+                let detail = if detail == 0 { None } else { Some(detail) };
                 let is_active = ix == self.active_item_index;
 
                 row.add_child({
@@ -850,7 +852,7 @@ impl Pane {
                     } else {
                         theme.workspace.tab.clone()
                     };
-                    let title = item.tab_content(&tab_style, cx);
+                    let title = item.tab_content(detail, &tab_style, cx);
 
                     let mut style = if is_active {
                         theme.workspace.active_tab.clone()
@@ -970,6 +972,43 @@ impl Pane {
 
             row.boxed()
         })
+    }
+
+    fn tab_details(&self, cx: &AppContext) -> Vec<usize> {
+        let mut tab_details = (0..self.items.len()).map(|_| 0).collect::<Vec<_>>();
+
+        let mut tab_descriptions = HashMap::default();
+        let mut done = false;
+        while !done {
+            done = true;
+
+            // Store item indices by their tab description.
+            for (ix, (item, detail)) in self.items.iter().zip(&tab_details).enumerate() {
+                if let Some(description) = item.tab_description(*detail, cx) {
+                    if *detail == 0
+                        || Some(&description) != item.tab_description(detail - 1, cx).as_ref()
+                    {
+                        tab_descriptions
+                            .entry(description)
+                            .or_insert(Vec::new())
+                            .push(ix);
+                    }
+                }
+            }
+
+            // If two or more items have the same tab description, increase their level
+            // of detail and try again.
+            for (_, item_ixs) in tab_descriptions.drain() {
+                if item_ixs.len() > 1 {
+                    done = false;
+                    for ix in item_ixs {
+                        tab_details[ix] += 1;
+                    }
+                }
+            }
+        }
+
+        tab_details
     }
 }
 

--- a/styles/src/styleTree/workspace.ts
+++ b/styles/src/styleTree/workspace.ts
@@ -27,6 +27,10 @@ export default function workspace(theme: Theme) {
       left: 8,
       right: 8,
     },
+    description: {
+      margin: { left: 6, top: 1 },
+      ...text(theme, "sans", "muted", { size: "2xs" })
+    }
   };
 
   const activeTab = {


### PR DESCRIPTION
## Description of feature or change

This pull request introduces a new, optional `Item::tab_description` method that lets implementers define a description for the tab with a certain `detail`. When two or more tabs match the same description, we will increase the `detail` until tabs don't match anymore or increasing the `detail` doesn't disambiguate tabs any further.

As soon as we find a valid `detail` that disambiguates tabs enough, we will pass it to `Item::tab_content`. In `Editor`, this is implemented by showing more and more of the path's suffix as `detail` is increased.


<img width="1148" alt="Screen Shot 2022-07-14 at 12 07 00" src="https://user-images.githubusercontent.com/482957/178958520-ef634a03-fe54-4868-888b-078f40b3fa5e.png">

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/feedback/issues/17

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
