### PR TITLE
Precompile plugins depending on target triple

### DIFF
--- a/crates/plugin_runtime/Cargo.toml
+++ b/crates/plugin_runtime/Cargo.toml
@@ -15,4 +15,4 @@ pollster = "0.2.5"
 smol = "1.2.5"
 
 [build-dependencies]
-wasmtime = "0.38"
+wasmtime = { version = "0.38", features = ["all-arch"] }

--- a/crates/plugin_runtime/README.md
+++ b/crates/plugin_runtime/README.md
@@ -152,7 +152,7 @@ Plugins in the `plugins` directory are automatically recompiled and serialized t
 
 - `plugin.wasm` is the plugin compiled to Wasm. As a baseline, this should be about 4MB for debug builds and 2MB for release builds, but it depends on the specific plugin being built.
 
-- `plugin.wasm.pre` is the plugin compiled to Wasm *and additionally* precompiled to host-platform-agnostic cranelift-specific IR. This should be about 700KB for debug builds and 500KB in release builds. Each plugin takes about 1 or 2 seconds to compile to native code using cranelift, so precompiling plugins drastically reduces the startup time required to begin to run a plugin.
+- `plugin.wasm.the-target-triple` is the plugin compiled to Wasm *and additionally* precompiled to host-platform-specific native code, determined by the `TARGET` cargo exposes at compile-time. This should be about 700KB for debug builds and 500KB in release builds. Each plugin takes about 1 or 2 seconds to compile to native code using cranelift, so precompiling plugins drastically reduces the startup time required to begin to run a plugin.
 
 For all intents and purposes, it is *highly recommended* that you use precompiled plugins where possible, as they are much more lightweight and take much less time to instantiate.
 
@@ -246,18 +246,36 @@ Once all imports are marked, we can instantiate the plugin. To instantiate the p
 ```rust
 let plugin = builder
     .init(
-        true,
-        include_bytes!("../../../plugins/bin/cool_plugin.wasm.pre"),
+        PluginBinary::Precompiled(bytes),
     )
     .await
     .unwrap();
 ```
 
-The `.init` method currently takes two arguments:
+The `.init` method takes a single argument containing the plugin binary. 
 
-1. First, the 'precompiled' flag, indicating whether the plugin is *normal* (`.wasm`) or precompiled (`.wasm.pre`). When using a precompiled plugin, set this flag to `true`.
+1. If not precompiled, use `PluginBinary::Wasm(bytes)`. This supports both the WebAssembly Textual format (`.wat`) and the WebAssembly Binary format (`.wasm`). 
 
-2. Second, the raw plugin Wasm itself, as an array of bytes. When not precompiled, this can be either the Wasm binary format (`.wasm`) or the Wasm textual format (`.wat`). When precompiled, this must be the precompiled plugin (`.wasm.pre`).
+2. If precompiled, use `PluginBinary::Precompiled(bytes)`. This supports precompiled plugins ending in `.wasm.the-target-triple`. You need to be extra-careful when using precompiled plugins to ensure that the plugin target matches the target of the binary you are compiling:
+
+    a. To tell the current crate what the current `target` triple is, add the following line to the crate's `build.rs`:
+    
+    ```rust
+    println!(
+        "cargo:rustc-env=TARGET_TRIPLE={}",
+        std::env::var("TARGET").unwrap()
+    );
+    ```
+    
+    b. To get the correct precompiled binary in the crate itself, read this exposed environment variable and include the plugin:
+    
+    ```rust
+    let bytes = include_bytes!(concat!(
+        "../../../plugins/bin/plugin.wasm.",
+        env!("TARGET_TRIPLE"),
+    ));
+    let precompiled = PluginBinary::Precompiled(bytes);
+    ```
 
 The `.init` method is asynchronous, and must be `.await`ed upon. If the plugin is malformed or doesn't import the right functions, an error will be raised.
 

--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -28,9 +28,7 @@ fn main() {
     };
 
     // Get the target architecture for pre-cross-compilation of plugins
-    // and write it to disk to be used when embedding plugins
     let target_triple = std::env::var("TARGET").unwrap().to_string();
-    println!("cargo:rerun-if-env-changed=TARGET");
 
     // Invoke cargo to build the plugins
     let build_successful = std::process::Command::new("cargo")

--- a/crates/plugin_runtime/build.rs
+++ b/crates/plugin_runtime/build.rs
@@ -29,6 +29,7 @@ fn main() {
 
     // Get the target architecture for pre-cross-compilation of plugins
     let target_triple = std::env::var("TARGET").unwrap().to_string();
+    println!("cargo:rerun-if-env-changed=TARGET");
 
     // Invoke cargo to build the plugins
     let build_successful = std::process::Command::new("cargo")

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -2,6 +2,10 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.14");
+    println!(
+        "cargo:rustc-env=TARGET_TRIPLE={}",
+        std::env::var("TARGET").unwrap()
+    );
 
     let output = Command::new("npm")
         .current_dir("../../styles")

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -3,6 +3,7 @@ pub use language::*;
 use lazy_static::lazy_static;
 use rust_embed::RustEmbed;
 use std::{borrow::Cow, str, sync::Arc};
+// use util::ResultExt;
 
 mod c;
 mod go;
@@ -54,6 +55,11 @@ pub async fn init(languages: Arc<LanguageRegistry>, _executor: Arc<Background>) 
             "json",
             tree_sitter_json::language(),
             Some(CachedLspAdapter::new(json::JsonLspAdapter).await),
+            // TODO: switch back to plugin
+            // match language_plugin::new_json(executor).await.log_err() {
+            //     Some(lang) => Some(CachedLspAdapter::new(lang).await),
+            //     None => None,
+            // },
         ),
         (
             "markdown",

--- a/crates/zed/src/languages/language_plugin.rs
+++ b/crates/zed/src/languages/language_plugin.rs
@@ -5,30 +5,33 @@ use collections::HashMap;
 use futures::lock::Mutex;
 use gpui::executor::Background;
 use language::{LanguageServerName, LspAdapter};
-// use plugin_runtime::{Plugin, PluginBinary, PluginBuilder, WasiFn};
-use plugin_runtime::{Plugin, WasiFn};
+use plugin_runtime::{Plugin, PluginBinary, PluginBuilder, WasiFn};
 use std::{any::Any, path::PathBuf, sync::Arc};
 use util::ResultExt;
 
-// pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
-//     let plugin = PluginBuilder::new_default()?
-//         .host_function_async("command", |command: String| async move {
-//             let mut args = command.split(' ');
-//             let command = args.next().unwrap();
-//             smol::process::Command::new(command)
-//                 .args(args)
-//                 .output()
-//                 .await
-//                 .log_err()
-//                 .map(|output| output.stdout)
-//         })?
-//         .init(PluginBinary::Precompiled(include_bytes!(
-//             "../../../../plugins/bin/json_language.wasm.pre"
-//         )))
-//         .await?;
-//
-//     PluginLspAdapter::new(plugin, executor).await
-// }
+#[allow(dead_code)]
+pub async fn new_json(executor: Arc<Background>) -> Result<PluginLspAdapter> {
+    let bytes = include_bytes!(concat!(
+        "../../../../plugins/bin/json_language.wasm.",
+        env!("TARGET_TRIPLE"),
+    ));
+
+    let plugin = PluginBuilder::new_default()?
+        .host_function_async("command", |command: String| async move {
+            let mut args = command.split(' ');
+            let command = args.next().unwrap();
+            smol::process::Command::new(command)
+                .args(args)
+                .output()
+                .await
+                .log_err()
+                .map(|output| output.stdout)
+        })?
+        .init(PluginBinary::Precompiled(bytes))
+        .await?;
+
+    PluginLspAdapter::new(plugin, executor).await
+}
 
 pub struct PluginLspAdapter {
     name: WasiFn<(), String>,

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "styles",
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {


### PR DESCRIPTION
## Description of feature or change
Correctly detect and compile plugins for the currently specified `TARGET` architecture. Quoting #1350:

> our current approach to pre-compiling the WASM to native code is not working when we cross-compile to the x86 architecture.
> 
> We think that we should actually fix this by pre-compiling the WASM lazily, on the user's machine

This PR adds support for cross-compiling on the `x86` architecture (and others). It's important to note that we fix the original issue and do not precompile Wasm lazily in this PR.

## Link to related issues from zed or insiders
Part of #1325. Fixes #1350, but does not enable the JSON plugin yet.

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
