### PR TITLE
Illustrate `format_on_save` external command using prettier

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -42,10 +42,10 @@
     // 3. Format code using an external command:
     //     "format_on_save": {
     //       "external": {
-    //         "command": "sed",
-    //         "arguments": ["-e", "s/ *$//"]
+    //         "command": "prettier",
+    //         "arguments": ["--stdin-filepath", "{buffer_path}"]
     //       }
-    //     },
+    //     }
     "format_on_save": "language_server",
     // How to soft-wrap long lines of text. This setting can take
     // three values:


### PR DESCRIPTION
## Description of feature or change

This gives us a chance to highlight a real-world scenario that a lot of our users will want to use, as well as showcasing the special `{buffer_path}` argument.

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/309

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
