### PR TITLE
Document using Redis and launch it in `Procfile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /crates/collab/static/styles.css
 /vendor/bin
 /assets/themes/*.json
+dump.rdb

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: cd ../zed.dev && PORT=3000 npx next dev
 collab: cd crates/collab && cargo run
+redis: redis-server

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ script/sqlx migrate run
 script/seed-db
 ```
 
+Install Redis:
+
+```
+brew install redis
+```
+
 Run the web frontend and the collaboration server.
 
 ```


### PR DESCRIPTION
## Description of feature or change

As per the title, we will now be using Redis to cache release information. This pull request adds a section to the README indicating how to install Redis, as well as an entry in the `Procfile` that launches `redis-server` along with `collab` and `zed.dev`.

## Link to related issues from zed or insiders

Refs https://github.com/zed-industries/zed.dev/pull/86

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
