### PR TITLE
Added settings for common terminal configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5365,6 +5365,7 @@ dependencies = [
  "ordered-float",
  "project",
  "settings",
+ "shellexpand",
  "smallvec",
  "theme",
  "util",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -68,8 +68,7 @@
     // Settings specific to the terminal
     "terminal": {
         // What shell to use when opening a terminal. May take 3 values: 
-        // 1. Use the system's terminal configuration (e.g. $TERM). Note this is not
-        //    A substitution, only an exact text match
+        // 1. Use the system's default terminal configuration (e.g. $TERM).
         //      "shell": "system"
         // 2. A program:
         //      "shell": {
@@ -107,10 +106,10 @@
         "env": [
             //["KEY", "value1:value2"]
         ]
-        //Set the terminal's font size. If this option is not listed,
+        //Set the terminal's font size. If this option is not included,
         //the terminal will default to matching the buffer's font size.
         //"font_size": "15"
-        //Set the terminal's font family. If this option is not listed,
+        //Set the terminal's font family. If this option is not included,
         //the terminal will default to matching the buffer's font family.
         //"font_family": "Zed Mono"
     },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -54,7 +54,7 @@
     //      "soft_wrap": "none",
     // 2. Soft wrap lines that overflow the editor:
     //      "soft_wrap": "editor_width",
-    // 2. Soft wrap lines at the preferred line length
+    // 3. Soft wrap lines at the preferred line length
     //      "soft_wrap": "preferred_line_length",
     "soft_wrap": "none",
     // The column at which to soft-wrap lines, for buffers where soft-wrap
@@ -65,6 +65,55 @@
     "hard_tabs": false,
     // How many columns a tab should occupy.
     "tab_size": 4,
+    // Settings specific to the terminal
+    "terminal": {
+        // What shell to use when opening a terminal. May take 3 values: 
+        // 1. Use the system's terminal configuration (e.g. $TERM). Note this is not
+        //    A substitution, only an exact text match
+        //      "shell": "system"
+        // 2. A program:
+        //      "shell": {
+        //        "program": "sh"
+        //      }
+        // 3. A program with arguments:
+        //     "shell": {
+        //         "with_arguments": {
+        //           "program": "/bin/bash",
+        //           "arguments": ["--login"]
+        //         }
+        //     }
+        "shell": "system",
+        // What working directory to use when launching the terminal.
+        // May take 4 values:
+        // 1. Use the current file's project directory.
+        //      "working_directory": "current_project_directory"
+        // 2. Use the first project in this workspace's directory
+        //      "working_directory": "first_project_directory"
+        // 3. Always use this platform's home directory (if we can find it)
+        //     "working_directory": "always_home"
+        // 4. Always use a specific directory. This value will be shell expanded.
+        //    If this path is not a valid directory the terminal will default to
+        //    this platform's home directory  (if we can find it)
+        //      "working_directory": { 
+        //        "always": {
+        //          "directory": "~/zed/projects/"
+        //        }
+        //      }
+        //
+        //
+        "working_directory": "current_project_directory",
+        //Any key-value pairs added to this list will be added to the terminal's
+        //enviroment. Use `:` to seperate multiple values, not multiple list items
+        "env": [
+            //["KEY", "value1:value2"]
+        ]
+        //Set the terminal's font size. If this option is not listed,
+        //the terminal will default to matching the buffer's font size.
+        //"font_size": "15"
+        //Set the terminal's font family. If this option is not listed,
+        //the terminal will default to matching the buffer's font family.
+        //"font_family": "Zed Mono"
+    },
     // Different settings for specific languages.
     "languages": {
         "Plain Text": {

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3"
 ordered-float = "2.1.1"
 itertools = "0.10"
 dirs = "4.0.0"
+shellexpand = "2.1.0"
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -27,6 +27,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use settings::Settings;
 use theme::TerminalStyle;
+use util::ResultExt;
 
 use std::{cmp::min, ops::Range, rc::Rc, sync::Arc};
 use std::{fmt::Debug, ops::Sub};
@@ -256,10 +257,11 @@ impl Element for TerminalEl {
                 for layout_line in &layout.layout_lines {
                     for layout_cell in &layout_line.cells {
                         let position = vec2f(
-                            origin.x() + layout_cell.point.column as f32 * layout.em_width.0,
+                            (origin.x() + layout_cell.point.column as f32 * layout.em_width.0)
+                                .floor(),
                             origin.y() + layout_cell.point.line as f32 * layout.line_height.0,
                         );
-                        let size = vec2f(layout.em_width.0, layout.line_height.0);
+                        let size = vec2f(layout.em_width.0.ceil(), layout.line_height.0);
 
                         cx.scene.push_quad(Quad {
                             bounds: RectF::new(position, size),
@@ -318,7 +320,7 @@ impl Element for TerminalEl {
 
                         //Don't actually know the start_x for a line, until here:
                         let cell_origin = vec2f(
-                            origin.x() + point.column as f32 * layout.em_width.0,
+                            (origin.x() + point.column as f32 * layout.em_width.0).floor(),
                             origin.y() + point.line as f32 * layout.line_height.0,
                         );
 
@@ -420,14 +422,33 @@ pub fn mouse_to_cell_data(
 
 ///Configures a text style from the current settings.
 fn make_text_style(font_cache: &FontCache, settings: &Settings) -> TextStyle {
+    // Pull the font family from settings properly overriding
+    let family_id = settings
+        .terminal_overrides
+        .font_family
+        .as_ref()
+        .and_then(|family_name| dbg!(font_cache.load_family(&[family_name]).log_err()))
+        .or_else(|| {
+            settings
+                .terminal_defaults
+                .font_family
+                .as_ref()
+                .and_then(|family_name| font_cache.load_family(&[family_name]).log_err())
+        })
+        .unwrap_or(settings.buffer_font_family);
+
     TextStyle {
         color: settings.theme.editor.text_color,
-        font_family_id: settings.buffer_font_family,
-        font_family_name: font_cache.family_name(settings.buffer_font_family).unwrap(),
+        font_family_id: family_id,
+        font_family_name: font_cache.family_name(family_id).unwrap(),
         font_id: font_cache
-            .select_font(settings.buffer_font_family, &Default::default())
+            .select_font(family_id, &Default::default())
             .unwrap(),
-        font_size: settings.buffer_font_size,
+        font_size: settings
+            .terminal_overrides
+            .font_size
+            .or(settings.terminal_defaults.font_size)
+            .unwrap_or(settings.buffer_font_size),
         font_properties: Default::default(),
         underline: Default::default(),
     }

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -427,7 +427,7 @@ fn make_text_style(font_cache: &FontCache, settings: &Settings) -> TextStyle {
         .terminal_overrides
         .font_family
         .as_ref()
-        .and_then(|family_name| dbg!(font_cache.load_family(&[family_name]).log_err()))
+        .and_then(|family_name| font_cache.load_family(&[family_name]).log_err())
         .or_else(|| {
             settings
                 .terminal_defaults

--- a/crates/terminal/src/tests/terminal_test_context.rs
+++ b/crates/terminal/src/tests/terminal_test_context.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use alacritty_terminal::term::SizeInfo;
-use gpui::{AppContext, ModelContext, ModelHandle, ReadModelWith, TestAppContext};
+use gpui::{AppContext, ModelHandle, ReadModelWith, TestAppContext};
 use itertools::Itertools;
 
 use crate::{
@@ -28,7 +28,8 @@ impl<'a> TerminalTestContext<'a> {
             false,
         );
 
-        let connection = cx.add_model(|cx| TerminalConnection::new(None, size_info, cx));
+        let connection =
+            cx.add_model(|cx| TerminalConnection::new(None, None, None, size_info, cx));
 
         TerminalTestContext { cx, connection }
     }
@@ -54,13 +55,6 @@ impl<'a> TerminalTestContext<'a> {
             .read_model_with(&self.connection, &mut |conn, _: &AppContext| {
                 Self::grid_as_str(conn)
             })
-    }
-
-    pub fn update_connection<F, S>(&mut self, f: F) -> S
-    where
-        F: FnOnce(&mut TerminalConnection, &mut ModelContext<TerminalConnection>) -> S,
-    {
-        self.connection.update(self.cx, |conn, cx| f(conn, cx))
     }
 
     fn grid_as_str(connection: &TerminalConnection) -> String {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -79,18 +79,25 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     cx.add_global_action(move |_: &IncreaseBufferFontSize, cx| {
         cx.update_global::<Settings, _, _>(|settings, cx| {
             settings.buffer_font_size = (settings.buffer_font_size + 1.0).max(MIN_FONT_SIZE);
+            if let Some(terminal_font_size) = settings.terminal_overrides.font_size.as_mut() {
+                *terminal_font_size = (*terminal_font_size + 1.0).max(MIN_FONT_SIZE);
+            }
             cx.refresh_windows();
         });
     });
     cx.add_global_action(move |_: &DecreaseBufferFontSize, cx| {
         cx.update_global::<Settings, _, _>(|settings, cx| {
             settings.buffer_font_size = (settings.buffer_font_size - 1.0).max(MIN_FONT_SIZE);
+            if let Some(terminal_font_size) = settings.terminal_overrides.font_size.as_mut() {
+                *terminal_font_size = (*terminal_font_size - 1.0).max(MIN_FONT_SIZE);
+            }
             cx.refresh_windows();
         });
     });
     cx.add_global_action(move |_: &ResetBufferFontSize, cx| {
         cx.update_global::<Settings, _, _>(|settings, cx| {
             settings.buffer_font_size = settings.default_buffer_font_size;
+            settings.terminal_overrides.font_size = settings.terminal_defaults.font_size;
             cx.refresh_windows();
         });
     });


### PR DESCRIPTION
## Description of feature or change

This adds a `terminal` section to the default settings, with options to configure the shell to open, the working directory  strategy, additional environment variables to inject, and overrides for the terminal font and font_size. 

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/262

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
- [x] Gracefully handle mis-configured shells.
