### PR TITLE
Add bracketed paste support

### DIFF
--- a/crates/terminal/src/connection.rs
+++ b/crates/terminal/src/connection.rs
@@ -7,7 +7,7 @@ use alacritty_terminal::{
     event_loop::{EventLoop, Msg, Notifier},
     grid::Scroll,
     sync::FairMutex,
-    term::SizeInfo,
+    term::{SizeInfo, TermMode},
     tty::{self, setup_env},
     Term,
 };
@@ -226,6 +226,17 @@ impl TerminalConnection {
             true
         } else {
             false
+        }
+    }
+
+    ///Paste text into the terminal
+    pub fn paste(&mut self, text: &str) {
+        if self.term.lock().mode().contains(TermMode::BRACKETED_PASTE) {
+            self.write_to_pty("\x1b[200~".to_string());
+            self.write_to_pty(text.replace('\x1b', "").to_string());
+            self.write_to_pty("\x1b[201~".to_string());
+        } else {
+            self.write_to_pty(text.replace("\r\n", "\r").replace('\n', "\r"));
         }
     }
 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -191,7 +191,7 @@ impl Terminal {
     fn paste(&mut self, _: &Paste, cx: &mut ViewContext<Self>) {
         if let Some(item) = cx.read_from_clipboard() {
             self.connection.update(cx, |connection, _| {
-                connection.write_to_pty(item.text().to_owned());
+                connection.paste(item.text());
             })
         }
     }


### PR DESCRIPTION
## Description of feature or change

Properly normalizes line endings and brackets pasted data (if in the correct mode)

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
  - N/A
- [x] Have you added the necessary settings to configure this feature?
  - N/A
- [x] Has documentation been created or updated (including above changes to settings)?
