### PR TITLE
Diagnostics Popover

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -190,7 +190,7 @@
             "alt-down": "editor::SelectSmallerSyntaxNode",
             "cmd-u": "editor::UndoSelection",
             "cmd-shift-U": "editor::RedoSelection",
-            "f8": "editor::GoToNextDiagnostic",
+            "f8": "editor::GoToDiagnostic",
             "shift-f8": "editor::GoToPrevDiagnostic",
             "f2": "editor::Rename",
             "f12": "editor::GoToDefinition",

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -1,5 +1,5 @@
 use collections::HashSet;
-use editor::{Editor, GoToNextDiagnostic};
+use editor::{Editor, GoToDiagnostic};
 use gpui::{
     elements::*, platform::CursorStyle, serde_json, Entity, ModelHandle, MouseButton,
     MutableAppContext, RenderContext, Subscription, View, ViewContext, ViewHandle, WeakViewHandle,
@@ -48,10 +48,10 @@ impl DiagnosticIndicator {
         }
     }
 
-    fn go_to_next_diagnostic(&mut self, _: &GoToNextDiagnostic, cx: &mut ViewContext<Self>) {
+    fn go_to_next_diagnostic(&mut self, _: &GoToDiagnostic, cx: &mut ViewContext<Self>) {
         if let Some(editor) = self.active_editor.as_ref().and_then(|e| e.upgrade(cx)) {
             editor.update(cx, |editor, cx| {
-                editor.go_to_diagnostic(editor::Direction::Next, cx);
+                editor.go_to_diagnostic_impl(editor::Direction::Next, cx);
             })
         }
     }
@@ -202,7 +202,7 @@ impl View for DiagnosticIndicator {
                 })
                 .with_cursor_style(CursorStyle::PointingHand)
                 .on_click(MouseButton::Left, |_, cx| {
-                    cx.dispatch_action(GoToNextDiagnostic)
+                    cx.dispatch_action(GoToDiagnostic)
                 })
                 .boxed(),
             );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -83,9 +83,6 @@ pub struct SelectNext {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct GoToDiagnostic(pub Direction);
-
-#[derive(Clone, PartialEq)]
 pub struct Scroll(pub Vector2F);
 
 #[derive(Clone, PartialEq)]
@@ -138,7 +135,7 @@ actions!(
         Backspace,
         Delete,
         Newline,
-        GoToNextDiagnostic,
+        GoToDiagnostic,
         GoToPrevDiagnostic,
         Indent,
         Outdent,
@@ -300,7 +297,7 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::move_to_enclosing_bracket);
     cx.add_action(Editor::undo_selection);
     cx.add_action(Editor::redo_selection);
-    cx.add_action(Editor::go_to_next_diagnostic);
+    cx.add_action(Editor::go_to_diagnostic);
     cx.add_action(Editor::go_to_prev_diagnostic);
     cx.add_action(Editor::go_to_definition);
     cx.add_action(Editor::page_up);
@@ -4564,17 +4561,32 @@ impl Editor {
         self.selection_history.mode = SelectionHistoryMode::Normal;
     }
 
-    fn go_to_next_diagnostic(&mut self, _: &GoToNextDiagnostic, cx: &mut ViewContext<Self>) {
-        self.go_to_diagnostic(Direction::Next, cx)
+    fn go_to_diagnostic(&mut self, _: &GoToDiagnostic, cx: &mut ViewContext<Self>) {
+        self.go_to_diagnostic_impl(Direction::Next, cx)
     }
 
     fn go_to_prev_diagnostic(&mut self, _: &GoToPrevDiagnostic, cx: &mut ViewContext<Self>) {
-        self.go_to_diagnostic(Direction::Prev, cx)
+        self.go_to_diagnostic_impl(Direction::Prev, cx)
     }
 
-    pub fn go_to_diagnostic(&mut self, direction: Direction, cx: &mut ViewContext<Self>) {
+    pub fn go_to_diagnostic_impl(&mut self, direction: Direction, cx: &mut ViewContext<Self>) {
         let buffer = self.buffer.read(cx).snapshot(cx);
         let selection = self.selections.newest::<usize>(cx);
+
+        // If there is an active Diagnostic Popover. Jump to it's diagnostic instead.
+        if direction == Direction::Next {
+            if let Some(popover) = self.hover_state.diagnostic_popover.as_ref() {
+                let (group_id, jump_to) = popover.activation_info();
+                self.activate_diagnostics(group_id, cx);
+                self.change_selections(Some(Autoscroll::Center), cx, |s| {
+                    let mut new_selection = s.newest_anchor().clone();
+                    new_selection.collapse_to(jump_to, SelectionGoal::None);
+                    s.select_anchors(vec![new_selection.clone()]);
+                });
+                return;
+            }
+        }
+
         let mut active_primary_range = self.active_diagnostics.as_ref().map(|active_diagnostics| {
             active_diagnostics
                 .primary_range

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1335,8 +1335,11 @@ impl Element for EditorElement {
                     .map(|indicator| (newest_selection_head.row(), indicator));
             }
 
-            hover = view.hover_state.popover.clone().and_then(|hover| {
+            hover = view.hover_state.info_popover.clone().and_then(|hover| {
                 let (point, rendered) = hover.render(&snapshot, style.clone(), cx);
+                // The scroll position is a fractional point, the whole number of which represents
+                // the top of the window in terms of display rows.
+                // Ensure the hover point is above the scroll position
                 if point.row() >= snapshot.scroll_position().y() as u32 {
                     if line_layouts.len() > (point.row() - start_row) as usize {
                         return Some((point, rendered));

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -420,7 +420,6 @@ mod tests {
     use indoc::indoc;
 
     use language::{Diagnostic, DiagnosticSet};
-    use lsp::notification;
     use project::HoverBlock;
 
     use crate::test::EditorLspTestContext;

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -27,8 +27,7 @@ use workspace::{pane, AppState, Workspace, WorkspaceHandle};
 use crate::{
     display_map::{DisplayMap, DisplaySnapshot, ToDisplayPoint},
     multi_buffer::ToPointUtf16,
-    AnchorRangeExt, Autoscroll, DisplayPoint, Editor, EditorMode, EditorSnapshot, MultiBuffer,
-    ToPoint,
+    AnchorRangeExt, Autoscroll, DisplayPoint, Editor, EditorMode, MultiBuffer, ToPoint,
 };
 
 #[cfg(test)]

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2462,11 +2462,11 @@ impl operation_queue::Operation for Operation {
 impl Default for Diagnostic {
     fn default() -> Self {
         Self {
-            code: Default::default(),
+            code: None,
             severity: DiagnosticSeverity::ERROR,
             message: Default::default(),
-            group_id: Default::default(),
-            is_primary: Default::default(),
+            group_id: 0,
+            is_primary: false,
             is_valid: true,
             is_disk_based: false,
             is_unnecessary: false,

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -54,6 +54,13 @@ impl<T: Clone> Selection<T> {
             goal: self.goal,
         }
     }
+
+    pub fn collapse_to(&mut self, point: T, new_goal: SelectionGoal) {
+        self.start = point.clone();
+        self.end = point;
+        self.goal = new_goal;
+        self.reversed = false;
+    }
 }
 
 impl<T: Copy + Ord> Selection<T> {
@@ -76,13 +83,6 @@ impl<T: Copy + Ord> Selection<T> {
             self.end = head;
         }
         self.goal = new_goal;
-    }
-
-    pub fn collapse_to(&mut self, point: T, new_goal: SelectionGoal) {
-        self.start = point;
-        self.end = point;
-        self.goal = new_goal;
-        self.reversed = false;
     }
 
     pub fn range(&self) -> Range<T> {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -627,6 +627,9 @@ impl<'de> Deserialize<'de> for SyntaxTheme {
 #[derive(Clone, Deserialize, Default)]
 pub struct HoverPopover {
     pub container: ContainerStyle,
+    pub info_container: ContainerStyle,
+    pub warning_container: ContainerStyle,
+    pub error_container: ContainerStyle,
     pub block_style: ContainerStyle,
     pub prose: TextStyle,
     pub highlight: Color,

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -281,7 +281,7 @@ pub fn menus() -> Vec<Menu<'static>> {
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Next Problem",
-                    action: Box::new(editor::GoToNextDiagnostic),
+                    action: Box::new(editor::GoToDiagnostic),
                 },
                 MenuItem::Action {
                     name: "Previous Problem",

--- a/styles/src/styleTree/hoverPopover.ts
+++ b/styles/src/styleTree/hoverPopover.ts
@@ -2,21 +2,47 @@ import Theme from "../themes/common/theme";
 import { backgroundColor, border, popoverShadow, text } from "./components";
 
 export default function HoverPopover(theme: Theme) {
+  let baseContainer = {
+    background: backgroundColor(theme, "on500"),
+    cornerRadius: 8,
+    padding: {
+      left: 8,
+      right: 8,
+      top: 4,
+      bottom: 4
+    },
+    shadow: popoverShadow(theme),
+    border: border(theme, "secondary"),
+    margin: {
+      left: -8,
+    },
+  };
+
   return {
-    container: {
-      background: backgroundColor(theme, "on500"),
-      cornerRadius: 8,
-      padding: {
-        left: 8,
-        right: 8,
-        top: 4,
-        bottom: 4,
+    container: baseContainer,
+    infoContainer: {
+      ...baseContainer,
+      background: backgroundColor(theme, "on500Info"),
+      border: {
+        color: theme.ramps.blue(0.2).hex(),
+        width: 1,
       },
-      shadow: popoverShadow(theme),
-      border: border(theme, "primary"),
-      margin: {
-        left: -8,
+    },
+    warningContainer: {
+      ...baseContainer,
+      background: backgroundColor(theme, "on500Warning"),
+      border: {
+        color: theme.ramps.yellow(0.2).hex(),
+        width: 1,
       },
+    },
+    errorContainer: {
+      ...baseContainer,
+      background: backgroundColor(theme, "on500Error"),
+      border: {
+        color: theme.ramps.red(0.2).hex(),
+        width: 1,
+      }
     },
     block_style: {
       padding: { top: 4 },

--- a/styles/src/styleTree/hoverPopover.ts
+++ b/styles/src/styleTree/hoverPopover.ts
@@ -24,7 +24,7 @@ export default function HoverPopover(theme: Theme) {
       ...baseContainer,
       background: backgroundColor(theme, "on500Info"),
       border: {
-        color: theme.ramps.blue(0.2).hex(),
+        color: theme.ramps.blue(0).hex(),
         width: 1,
       },
     },
@@ -32,7 +32,7 @@ export default function HoverPopover(theme: Theme) {
       ...baseContainer,
       background: backgroundColor(theme, "on500Warning"),
       border: {
-        color: theme.ramps.yellow(0.2).hex(),
+        color: theme.ramps.yellow(0).hex(),
         width: 1,
       },
     },
@@ -40,7 +40,7 @@ export default function HoverPopover(theme: Theme) {
       ...baseContainer,
       background: backgroundColor(theme, "on500Error"),
       border: {
-        color: theme.ramps.red(0.2).hex(),
+        color: theme.ramps.red(0).hex(),
         width: 1,
       }
     },

--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -88,15 +88,30 @@ export function createTheme(
       hovered: withOpacity(sample(ramps.red, 0.5), 0.2),
       active: withOpacity(sample(ramps.red, 0.5), 0.25),
     },
+    on500Error: {
+      base: sample(ramps.red, 0.1),
+      hovered: sample(ramps.red, 0.15),
+      active: sample(ramps.red, 0.2),
+    },
     warning: {
       base: withOpacity(sample(ramps.yellow, 0.5), 0.15),
       hovered: withOpacity(sample(ramps.yellow, 0.5), 0.2),
       active: withOpacity(sample(ramps.yellow, 0.5), 0.25),
     },
+    on500Warning: {
+      base: sample(ramps.yellow, 0.1),
+      hovered: sample(ramps.yellow, 0.15),
+      active: sample(ramps.yellow, 0.2),
+    },
     info: {
       base: withOpacity(sample(ramps.blue, 0.5), 0.15),
       hovered: withOpacity(sample(ramps.blue, 0.5), 0.2),
       active: withOpacity(sample(ramps.blue, 0.5), 0.25),
+    },
+    on500Info: {
+      base: sample(ramps.blue, 0.1),
+      hovered: sample(ramps.blue, 0.15),
+      active: sample(ramps.blue, 0.2),
     },
   };
 
@@ -106,10 +121,10 @@ export function createTheme(
     muted: sample(ramps.neutral, isLight ? 1 : 3),
     active: sample(ramps.neutral, isLight ? 4 : 3),
     onMedia: withOpacity(darkest, 0.1),
-    ok: withOpacity(sample(ramps.green, 0.5), 0.15),
-    error: withOpacity(sample(ramps.red, 0.5), 0.15),
-    warning: withOpacity(sample(ramps.yellow, 0.5), 0.15),
-    info: withOpacity(sample(ramps.blue, 0.5), 0.15),
+    ok: sample(ramps.green, 0.3),
+    error: sample(ramps.red, 0.3),
+    warning: sample(ramps.yellow, 0.3),
+    info: sample(ramps.blue, 0.3),
   };
 
   const textColor = {

--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -89,9 +89,9 @@ export function createTheme(
       active: withOpacity(sample(ramps.red, 0.5), 0.25),
     },
     on500Error: {
-      base: sample(ramps.red, 0.1),
-      hovered: sample(ramps.red, 0.15),
-      active: sample(ramps.red, 0.2),
+      base: sample(ramps.red, 0.05),
+      hovered: sample(ramps.red, 0.1),
+      active: sample(ramps.red, 0.15),
     },
     warning: {
       base: withOpacity(sample(ramps.yellow, 0.5), 0.15),
@@ -99,9 +99,9 @@ export function createTheme(
       active: withOpacity(sample(ramps.yellow, 0.5), 0.25),
     },
     on500Warning: {
-      base: sample(ramps.yellow, 0.1),
-      hovered: sample(ramps.yellow, 0.15),
-      active: sample(ramps.yellow, 0.2),
+      base: sample(ramps.yellow, 0.05),
+      hovered: sample(ramps.yellow, 0.1),
+      active: sample(ramps.yellow, 0.15),
     },
     info: {
       base: withOpacity(sample(ramps.blue, 0.5), 0.15),
@@ -109,9 +109,9 @@ export function createTheme(
       active: withOpacity(sample(ramps.blue, 0.5), 0.25),
     },
     on500Info: {
-      base: sample(ramps.blue, 0.1),
-      hovered: sample(ramps.blue, 0.15),
-      active: sample(ramps.blue, 0.2),
+      base: sample(ramps.blue, 0.05),
+      hovered: sample(ramps.blue, 0.1),
+      active: sample(ramps.blue, 0.15),
     },
   };
 

--- a/styles/src/themes/common/theme.ts
+++ b/styles/src/themes/common/theme.ts
@@ -79,8 +79,11 @@ export default interface Theme {
     on500: BackgroundColorSet;
     ok: BackgroundColorSet;
     error: BackgroundColorSet;
+    on500Error: BackgroundColorSet;
     warning: BackgroundColorSet;
+    on500Warning: BackgroundColorSet;
     info: BackgroundColorSet;
+    on500Info: BackgroundColorSet;
   };
   borderColor: {
     primary: string;


### PR DESCRIPTION
## Description of feature or change
<img width="484" alt="image" src="https://user-images.githubusercontent.com/3323631/179336398-fb061f72-477f-4092-a6a8-9e18eeea0bb0.png">

- Reworks Hover Popover to enable multiple popovers that appear as a stack
- Added Diagnostic Popover which appears when you hover over a diagnostic squiggle
- Renamed GoToNextDiagnostic to GoToDiagnostic and changed it's handler to jump to the popover diagnostic if it is visible
- Modified theme.ts and base16.ts to have on300Error/Warning/Info background colors
- Adjusted on300 and on500 to have more reasonable elevations (this will be reworked soon, so I'm not super worried about it)

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/zed/issues/1321

## Before Merging 
- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
Unless somebody asks explicitly, I think the existing hover setting is enough
- [x] Has documentation been created or updated (including above changes to settings)?
