### PR TITLE
Graceful terminal exit, better settings, a new GPUI method: `try_add_model()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5355,6 +5355,7 @@ name = "terminal"
 version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
+ "anyhow",
  "client",
  "dirs 4.0.0",
  "editor",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -102,10 +102,10 @@
         //
         "working_directory": "current_project_directory",
         //Any key-value pairs added to this list will be added to the terminal's
-        //enviroment. Use `:` to seperate multiple values, not multiple list items
-        "env": [
-            //["KEY", "value1:value2"]
-        ]
+        //enviroment. Use `:` to seperate multiple values.
+        "env": {
+            //"KEY": "value1:value2"
+        }
         //Set the terminal's font size. If this option is not included,
         //the terminal will default to matching the buffer's font size.
         //"font_size": "15"

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1781,6 +1781,21 @@ impl MutableAppContext {
         })
     }
 
+    pub fn try_add_model<T, F>(&mut self, build_model: F) -> Result<ModelHandle<T>>
+    where
+        T: Entity,
+        F: FnOnce(&mut ModelContext<T>) -> Result<T>,
+    {
+        self.update(|this| {
+            let model_id = post_inc(&mut this.next_entity_id);
+            let handle = ModelHandle::new(model_id, &this.cx.ref_counts);
+            let mut cx = ModelContext::new(this, model_id);
+            let model = build_model(&mut cx)?;
+            this.cx.models.insert(model_id, Box::new(model));
+            Ok(handle)
+        })
+    }
+
     pub fn add_window<T, F>(
         &mut self,
         window_options: WindowOptions,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1970,10 +1970,13 @@ impl MutableAppContext {
             for model_id in dropped_models {
                 self.subscriptions.lock().remove(&model_id);
                 self.observations.lock().remove(&model_id);
-                let mut model = self.cx.models.remove(&model_id).unwrap();
-                model.release(self);
-                self.pending_effects
-                    .push_back(Effect::ModelRelease { model_id, model });
+                //Model handles and IDs may have been created to instantiate a model without
+                //finishing successfully (`try_add_model()`)
+                if let Some(mut model) = self.cx.models.remove(&model_id) {
+                    model.release(self);
+                    self.pending_effects
+                        .push_back(Effect::ModelRelease { model_id, model });
+                }
             }
 
             for (window_id, view_id) in dropped_views {

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -81,7 +81,7 @@ pub struct TerminalSettings {
     pub working_directory: Option<WorkingDirectory>,
     pub font_size: Option<f32>,
     pub font_family: Option<String>,
-    pub env: Option<Vec<(String, String)>>,
+    pub env: Option<HashMap<String, String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -23,6 +23,8 @@ ordered-float = "2.1.1"
 itertools = "0.10"
 dirs = "4.0.0"
 shellexpand = "2.1.0"
+anyhow = "1"
+
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/terminal/src/modal.rs
+++ b/crates/terminal/src/modal.rs
@@ -25,7 +25,12 @@ pub fn deploy_modal(workspace: &mut Workspace, _: &DeployModal, cx: &mut ViewCon
         // No connection was stored, create a new terminal
         if let Some(closed_terminal_handle) = workspace.toggle_modal(cx, |workspace, cx| {
             let wd = get_wd_for_workspace(workspace, cx);
-            let this = cx.add_view(|cx| Terminal::new(wd, true, cx));
+
+            //TODO: Anything other than crash.
+            let this = cx
+                .add_option_view(|cx| Terminal::new(wd, true, cx).ok())
+                .unwrap();
+
             let connection_handle = this.read(cx).connection.clone();
             cx.subscribe(&connection_handle, on_event).detach();
             //Set the global immediately, in case the user opens the command palette

--- a/crates/terminal/src/modal.rs
+++ b/crates/terminal/src/modal.rs
@@ -1,4 +1,5 @@
 use gpui::{ModelHandle, ViewContext};
+use util::ResultExt;
 use workspace::Workspace;
 
 use crate::{get_wd_for_workspace, DeployModal, Event, Terminal, TerminalConnection};
@@ -26,9 +27,9 @@ pub fn deploy_modal(workspace: &mut Workspace, _: &DeployModal, cx: &mut ViewCon
         if let Some(closed_terminal_handle) = workspace.toggle_modal(cx, |workspace, cx| {
             let wd = get_wd_for_workspace(workspace, cx);
 
-            //TODO: Anything other than crash.
+            //TODO: Create a 'failed to launch' view which prints the error and config details.
             let this = cx
-                .add_option_view(|cx| Terminal::new(wd, true, cx).ok())
+                .add_option_view(|cx| Terminal::new(wd, true, cx).log_err())
                 .unwrap();
 
             let connection_handle = this.read(cx).connection.clone();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -7,7 +7,7 @@ use alacritty_terminal::{
     event::{Event as AlacTermEvent, EventListener},
     term::SizeInfo,
 };
-
+use anyhow::Result;
 use connection::{Event, TerminalConnection};
 use dirs::home_dir;
 use editor::Input;
@@ -98,7 +98,11 @@ impl Entity for Terminal {
 impl Terminal {
     ///Create a new Terminal view. This spawns a task, a thread, and opens the TTY devices
     ///To get the right working directory from a workspace, use: `get_wd_for_workspace()`
-    fn new(working_directory: Option<PathBuf>, modal: bool, cx: &mut ViewContext<Self>) -> Self {
+    fn new(
+        working_directory: Option<PathBuf>,
+        modal: bool,
+        cx: &mut ViewContext<Self>,
+    ) -> Result<Self> {
         //The details here don't matter, the terminal will be resized on the first layout
         let size_info = SizeInfo::new(
             DEBUG_TERMINAL_WIDTH,
@@ -117,10 +121,11 @@ impl Terminal {
             (shell, envs)
         };
 
-        let connection = cx
-            .add_model(|cx| TerminalConnection::new(working_directory, shell, envs, size_info, cx));
+        let connection = cx.try_add_model(|cx| {
+            TerminalConnection::new(working_directory, shell, envs, size_info, cx)
+        })?;
 
-        Terminal::from_connection(connection, modal, cx)
+        Ok(Terminal::from_connection(connection, modal, cx))
     }
 
     fn from_connection(
@@ -174,7 +179,9 @@ impl Terminal {
     ///Create a new Terminal in the current working directory or the user's home directory
     fn deploy(workspace: &mut Workspace, _: &Deploy, cx: &mut ViewContext<Workspace>) {
         let wd = get_wd_for_workspace(workspace, cx);
-        workspace.add_item(Box::new(cx.add_view(|cx| Terminal::new(wd, false, cx))), cx);
+        if let Some(view) = cx.add_option_view(|cx| Terminal::new(wd, false, cx).ok()) {
+            workspace.add_item(Box::new(view), cx);
+        }
     }
 
     ///Attempt to paste the clipboard into the terminal
@@ -309,13 +316,14 @@ impl Item for Terminal {
 
     fn clone_on_split(&self, cx: &mut ViewContext<Self>) -> Option<Self> {
         //From what I can tell, there's no  way to tell the current working
-        //Directory of the terminal from outside the terminal. There might be
+        //Directory of the terminal from outside the shell. There might be
         //solutions to this, but they are non-trivial and require more IPC
-        Some(Terminal::new(
+        Terminal::new(
             self.connection.read(cx).associated_directory.clone(),
             false,
             cx,
-        ))
+        )
+        .ok()
     }
 
     fn project_path(&self, _cx: &gpui::AppContext) -> Option<ProjectPath> {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -22,6 +22,7 @@ use project::{LocalWorktree, Project, ProjectPath};
 use settings::{Settings, WorkingDirectory};
 use smallvec::SmallVec;
 use std::path::{Path, PathBuf};
+use util::ResultExt;
 use workspace::{Item, Workspace};
 
 use crate::terminal_element::TerminalEl;
@@ -179,7 +180,7 @@ impl Terminal {
     ///Create a new Terminal in the current working directory or the user's home directory
     fn deploy(workspace: &mut Workspace, _: &Deploy, cx: &mut ViewContext<Workspace>) {
         let wd = get_wd_for_workspace(workspace, cx);
-        if let Some(view) = cx.add_option_view(|cx| Terminal::new(wd, false, cx).ok()) {
+        if let Some(view) = cx.add_option_view(|cx| Terminal::new(wd, false, cx).log_err()) {
             workspace.add_item(Box::new(view), cx);
         }
     }

--- a/crates/terminal/src/tests/terminal_test_context.rs
+++ b/crates/terminal/src/tests/terminal_test_context.rs
@@ -29,7 +29,7 @@ impl<'a> TerminalTestContext<'a> {
         );
 
         let connection =
-            cx.add_model(|cx| TerminalConnection::new(None, None, None, size_info, cx));
+            cx.add_model(|cx| TerminalConnection::new(None, None, None, size_info, cx).unwrap());
 
         TerminalTestContext { cx, connection }
     }


### PR DESCRIPTION
## Description of feature or change

1. Makes the terminal launch code fallible, bubbles errors up to the relevant deploy action.
2. Changes the type of the `terminal.env` setting from `Vec<(String, String)>` to  `HashMap<String, String>`
3. Adds the following method to `gpui::MutableAppContext`:

```
pub fn try_add_model<T, F>(&mut self, build_model: F) -> Result<ModelHandle<T>>
    where
        T: Entity,
        F: FnOnce(&mut ModelContext<T>) -> Result<T>,
    {
        self.update(|this| {
            let model_id = post_inc(&mut this.next_entity_id);
            let handle = ModelHandle::new(model_id, &this.cx.ref_counts);
            let mut cx = ModelContext::new(this, model_id);
            let model = build_model(&mut cx)?;
            this.cx.models.insert(model_id, Box::new(model));
            Ok(handle)
        })
    }
```

When I was testing this change, I had a panic in `remove_dropped_entities()` for breaking the assumptions that `add_model()` always inserts the new model into it's map. I fixed that panic but am uncertain about what else might be effected by this change.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
