### PR TITLE
Expose collaboration metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /crates/collab/static/styles.css
 /vendor/bin
 /assets/themes/*.json
-dump.rdb

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: cd ../zed.dev && PORT=3000 npx next dev
 collab: cd crates/collab && cargo run
-redis: redis-server

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ script/sqlx migrate run
 script/seed-db
 ```
 
-Install Redis:
-
-```
-brew install redis
-```
-
 Run the web frontend and the collaboration server.
 
 ```

--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -304,6 +304,8 @@ struct ActiveUserCountParams {
     #[serde(flatten)]
     period: TimePeriodParams,
     durations_in_minutes: String,
+    #[serde(default)]
+    only_collaborative: bool,
 }
 
 #[derive(Serialize)]
@@ -329,6 +331,7 @@ async fn get_active_user_counts(
                 .get_active_user_count(
                     params.period.start..params.period.end,
                     Duration::from_secs(duration * 60),
+                    params.only_collaborative,
                 )
                 .await?,
         })


### PR DESCRIPTION
## Description of feature or change

This pull request adds the necessary APIs to show collaboration metrics in zed.dev, specifically:

- Changes `GET /user_activity/summary` to include a boolean for each project exposing whether that project was ever collaborative
- Changes `GET /user_activity/counts` to allow passing a `only_collaborative` parameter that counts users only when they participated in collaborative projects

## Link to related issues from zed or insiders

https://github.com/zed-industries/zed.dev/issues/92

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
