### PR TITLE
Fix spurious borrow checker error

### DIFF
--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -443,7 +443,7 @@ async fn test_outline(cx: &mut gpui::TestAppContext) {
 
     async fn search<'a>(
         outline: &'a Outline<Anchor>,
-        query: &str,
+        query: &'a str,
         cx: &'a gpui::TestAppContext,
     ) -> Vec<(&'a str, Vec<usize>)> {
         let matches = cx


### PR DESCRIPTION
## Description of feature or change

This fixes a borrow checker error that would sometimes show up in rust-analyzer (but, interestingly, not when running `cargo check`)

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
