### PR TITLE
Draft: Search in only in a selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4643,6 +4643,7 @@ dependencies = [
  "anyhow",
  "collections",
  "editor",
+ "futures",
  "gpui",
  "language",
  "log",

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -224,4 +224,8 @@ impl SearchQuery {
     pub fn is_regex(&self) -> bool {
         matches!(self, Self::Regex { .. })
     }
+
+    pub fn is_selection(&self) -> bool {
+        matches!(self, Self::Regex { .. })
+    }
 }

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -19,6 +19,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 anyhow = "1.0"
+futures = "0.3"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 postage = { version = "0.4.1", features = ["futures-traits"] }
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -71,6 +71,7 @@ pub struct ProjectSearchView {
     case_sensitive: bool,
     whole_word: bool,
     regex: bool,
+    selection: bool,
     query_contains_error: bool,
     active_match_index: Option<usize>,
     results_editor_was_focused: bool,
@@ -359,6 +360,7 @@ impl ProjectSearchView {
         let mut regex = false;
         let mut case_sensitive = false;
         let mut whole_word = false;
+        let mut selection = false;
 
         {
             let model = model.read(cx);
@@ -367,6 +369,7 @@ impl ProjectSearchView {
             if let Some(active_query) = model.active_query.as_ref() {
                 query_text = active_query.as_str().to_string();
                 regex = active_query.is_regex();
+                selection = active_query.is_selection();
                 case_sensitive = active_query.case_sensitive();
                 whole_word = active_query.whole_word();
             }
@@ -421,6 +424,7 @@ impl ProjectSearchView {
             case_sensitive,
             whole_word,
             regex,
+            selection,
             query_contains_error: false,
             active_match_index: None,
             results_editor_was_focused: false,
@@ -700,6 +704,7 @@ impl ProjectSearchBar {
                     SearchOption::WholeWord => &mut search_view.whole_word,
                     SearchOption::CaseSensitive => &mut search_view.case_sensitive,
                     SearchOption::Regex => &mut search_view.regex,
+                    SearchOption::Selection => &mut search_view.selection,
                 };
                 *value = !*value;
                 search_view.search(cx);
@@ -800,6 +805,7 @@ impl ProjectSearchBar {
                 SearchOption::WholeWord => search.whole_word,
                 SearchOption::CaseSensitive => search.case_sensitive,
                 SearchOption::Regex => search.regex,
+                SearchOption::Selection => search.selection,
             }
         } else {
             false
@@ -874,6 +880,11 @@ impl View for ProjectSearchBar {
                         ))
                         .with_child(self.render_option_button("Word", SearchOption::WholeWord, cx))
                         .with_child(self.render_option_button("Regex", SearchOption::Regex, cx))
+                        // .with_child(self.render_option_button(
+                        //     "Selection",
+                        //     SearchOption::Selection,
+                        //     cx,
+                        // ))
                         .contained()
                         .with_style(theme.search.option_button_group)
                         .aligned()

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -21,6 +21,7 @@ actions!(
         ToggleWholeWord,
         ToggleCaseSensitive,
         ToggleRegex,
+        ToggleSelection,
         SelectNextMatch,
         SelectPrevMatch
     ]
@@ -31,6 +32,7 @@ pub enum SearchOption {
     WholeWord,
     CaseSensitive,
     Regex,
+    Selection,
 }
 
 impl SearchOption {
@@ -39,6 +41,7 @@ impl SearchOption {
             SearchOption::WholeWord => "Match Whole Word",
             SearchOption::CaseSensitive => "Match Case",
             SearchOption::Regex => "Use Regular Expression",
+            SearchOption::Selection => "Only in Selection",
         }
     }
 
@@ -47,6 +50,7 @@ impl SearchOption {
             SearchOption::WholeWord => Box::new(ToggleWholeWord),
             SearchOption::CaseSensitive => Box::new(ToggleCaseSensitive),
             SearchOption::Regex => Box::new(ToggleRegex),
+            SearchOption::Selection => Box::new(ToggleSelection),
         }
     }
 }


### PR DESCRIPTION
## Description of feature or change
This change adds support for searching inside of buffers. 

https://user-images.githubusercontent.com/54823450/180480945-8b66782f-a2fd-4ebd-9e9f-d7433ac00617.mov

https://user-images.githubusercontent.com/54823450/180480988-14b19db1-259a-4166-945f-531e7ee8cd45.mov

To be done:

- [X] Searching in selections in single buffers
- [ ] Searching in selections across entire project

## Link to related issues from zed or insiders
N/A, but someone metioned it on the Discord: 

<img width="494" alt="Screen Shot 2022-07-22 at 6 17 24 PM" src="https://user-images.githubusercontent.com/54823450/180481396-89350af3-672e-4e15-8f6f-704a38ed489d.png">

I tried to model the behavior after Atom's.

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
