### PR TITLE
Fixed keybinding regression

### DIFF
--- a/crates/terminal/src/connected_view.rs
+++ b/crates/terminal/src/connected_view.rs
@@ -146,7 +146,7 @@ impl ConnectedView {
 
 impl View for ConnectedView {
     fn ui_name() -> &'static str {
-        "Connected Terminal View"
+        "Terminal"
     }
 
     fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> ElementBox {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -140,7 +140,7 @@ impl TerminalView {
 
 impl View for TerminalView {
     fn ui_name() -> &'static str {
-        "Terminal"
+        "Terminal View"
     }
 
     fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> ElementBox {
@@ -176,7 +176,7 @@ impl View for TerminalView {
 
 impl View for ErrorView {
     fn ui_name() -> &'static str {
-        "Terminal Error"
+        "DisconnectedTerminal"
     }
 
     fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> ElementBox {

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "styles",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Description of feature or change

Fixes a regression that caused all Terminal keybindings not to fire.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- N/A
- [x] Have you added the necessary settings to configure this feature?
- N/A
- [x] Has documentation been created or updated (including above changes to settings)?
- N/A
