### PR TITLE
Log instead of showing an alert when exiting due to no GPU

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -13,8 +13,8 @@ use crate::{
 use block::ConcreteBlock;
 use cocoa::{
     appkit::{
-        CGPoint, NSApplication, NSBackingStoreBuffered, NSModalResponse, NSScreen, NSView,
-        NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowButton, NSWindowStyleMask,
+        CGPoint, NSApplication, NSBackingStoreBuffered, NSScreen, NSView, NSViewHeightSizable,
+        NSViewWidthSizable, NSWindow, NSWindowButton, NSWindowStyleMask,
     },
     base::{id, nil},
     foundation::{
@@ -327,14 +327,10 @@ impl Window {
                 native_window.setFrame_display_(screen.visibleFrame(), YES);
             }
 
-            let device = if let Some(device) = metal::Device::system_default() {
+            let device: metal::Device = if let Some(device) = metal::Device::system_default() {
                 device
             } else {
-                let alert: id = msg_send![class!(NSAlert), alloc];
-                let _: () = msg_send![alert, init];
-                let _: () = msg_send![alert, setAlertStyle: 2];
-                let _: () = msg_send![alert, setMessageText: ns_string("Unable to access a compatible graphics device")];
-                let _: NSModalResponse = msg_send![alert, runModal];
+                log::error!("unable to access a compatible graphics device");
                 std::process::exit(1);
             };
 


### PR DESCRIPTION
## Description of feature or change

An alert would be nice, but when we initially tried it, we accidentally introduced another panic. What we didn't anticipate was that even while the alert is showing, the queue of tasks dispatched on the main GCD queue continues to run. This resulted in a double borrow error.

Since this is an extreme edge case, I've replaced that usage of `NSAlert` with a simple log.

## Link to related issues from zed or insiders

Fixes #1372

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
