### PR TITLE
Clip invalid edits from LSP instead of reporting an error

### DIFF
--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1565,7 +1565,7 @@ async fn test_invalid_edits_from_lsp(cx: &mut gpui::TestAppContext) {
         .unwrap();
 
     // Simulate the language server sending us edits in a non-ordered fashion,
-    // with ranges sometimes being inverted.
+    // with ranges sometimes being inverted or pointing to invalid locations.
     let edits = project
         .update(cx, |project, cx| {
             project.edits_from_lsp(
@@ -1580,7 +1580,7 @@ async fn test_invalid_edits_from_lsp(cx: &mut gpui::TestAppContext) {
                         new_text: "a::{b, c}".into(),
                     },
                     lsp::TextEdit {
-                        range: lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(7, 0)),
+                        range: lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(99, 0)),
                         new_text: "".into(),
                     },
                     lsp::TextEdit {


### PR DESCRIPTION
## Description of feature or change

This fixes an issue with the Go language server, which reports invalid formatting ranges when there's a missing newline at the end of the file. Specifically, if the buffer is `N` lines long, it will try to insert the newline at `Point(N + 1, 0)`.

I confirmed the behavior is the same in VS Code, and they indeed clip the LSP ranges as well.

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/365

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- ~~Have you added the necessary settings to configure this feature?~~
- ~~Has documentation been created or updated (including above changes to settings)?~~
