### PR TITLE
Improve sorting of project symbols and completions

### DIFF
--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -2589,7 +2589,7 @@ async fn test_project_symbols(cx_a: &mut TestAppContext, cx_b: &mut TestAppConte
 
     // Attempt to craft a symbol and violate host's privacy by opening an arbitrary file.
     let mut fake_symbol = symbols[0].clone();
-    fake_symbol.path = Path::new("/code/secrets").into();
+    fake_symbol.path.path = Path::new("/code/secrets").into();
     let error = project_b
         .update(cx_b, |project, cx| {
             project.open_buffer_for_symbol(&fake_symbol, cx)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -755,9 +755,11 @@ impl CompletionsMenu {
                 .collect()
         };
         matches.sort_unstable_by_key(|mat| {
+            let completion = &self.completions[mat.candidate_id];
             (
+                completion.lsp_completion.sort_text.as_ref(),
                 Reverse(OrderedFloat(mat.score)),
-                self.completions[mat.candidate_id].sort_key(),
+                completion.sort_key(),
             )
         });
 

--- a/crates/fuzzy/src/fuzzy.rs
+++ b/crates/fuzzy/src/fuzzy.rs
@@ -181,7 +181,7 @@ pub async fn match_strings(
     cancel_flag: &AtomicBool,
     background: Arc<executor::Background>,
 ) -> Vec<StringMatch> {
-    if candidates.is_empty() {
+    if candidates.is_empty() || max_results == 0 {
         return Default::default();
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -254,10 +254,9 @@ pub struct DocumentHighlight {
 
 #[derive(Clone, Debug)]
 pub struct Symbol {
-    pub source_worktree_id: WorktreeId,
-    pub worktree_id: WorktreeId,
     pub language_server_name: LanguageServerName,
-    pub path: PathBuf,
+    pub source_worktree_id: WorktreeId,
+    pub path: ProjectPath,
     pub label: CodeLabel,
     pub name: String,
     pub kind: lsp::SymbolKind,
@@ -3324,16 +3323,19 @@ impl Project {
                             if let Some((worktree, rel_path)) =
                                 this.find_local_worktree(&abs_path, cx)
                             {
-                                worktree_id = worktree.read(cx).id();
+                                worktree_id = (&worktree.read(cx)).id();
                                 path = rel_path;
                             } else {
                                 path = relativize_path(&worktree_abs_path, &abs_path);
                             }
 
-                            let signature = this.symbol_signature(worktree_id, &path);
-                            let language = this.languages.select_language(&path);
+                            let project_path = ProjectPath {
+                                worktree_id,
+                                path: path.into(),
+                            };
+                            let signature = this.symbol_signature(&project_path);
+                            let language = this.languages.select_language(&project_path.path);
                             let language_server_name = adapter.name.clone();
-
                             Some(async move {
                                 let label = if let Some(language) = language {
                                     language
@@ -3344,15 +3346,14 @@ impl Project {
                                 };
 
                                 Symbol {
-                                    source_worktree_id,
-                                    worktree_id,
                                     language_server_name,
+                                    source_worktree_id,
+                                    path: project_path,
                                     label: label.unwrap_or_else(|| {
                                         CodeLabel::plain(lsp_symbol.name.clone(), None)
                                     }),
                                     kind: lsp_symbol.kind,
                                     name: lsp_symbol.name,
-                                    path,
                                     range: range_from_lsp(lsp_symbol.location.range),
                                     signature,
                                 }
@@ -3410,7 +3411,7 @@ impl Project {
             };
 
             let worktree_abs_path = if let Some(worktree_abs_path) = self
-                .worktree_for_id(symbol.worktree_id, cx)
+                .worktree_for_id(symbol.path.worktree_id, cx)
                 .and_then(|worktree| worktree.read(cx).as_local())
                 .map(|local_worktree| local_worktree.abs_path())
             {
@@ -3418,7 +3419,7 @@ impl Project {
             } else {
                 return Task::ready(Err(anyhow!("worktree not found for symbol")));
             };
-            let symbol_abs_path = worktree_abs_path.join(&symbol.path);
+            let symbol_abs_path = worktree_abs_path.join(&symbol.path.path);
             let symbol_uri = if let Ok(uri) = lsp::Url::from_file_path(symbol_abs_path) {
                 uri
             } else {
@@ -4622,11 +4623,11 @@ impl Project {
         self.active_entry
     }
 
-    pub fn entry_for_path(&self, path: &ProjectPath, cx: &AppContext) -> Option<ProjectEntryId> {
+    pub fn entry_for_path(&self, path: &ProjectPath, cx: &AppContext) -> Option<Entry> {
         self.worktree_for_id(path.worktree_id, cx)?
             .read(cx)
             .entry_for_path(&path.path)
-            .map(|entry| entry.id)
+            .cloned()
     }
 
     pub fn path_for_entry(&self, entry_id: ProjectEntryId, cx: &AppContext) -> Option<ProjectPath> {
@@ -5436,7 +5437,7 @@ impl Project {
             .read_with(&cx, |this, _| this.deserialize_symbol(symbol))
             .await?;
         let symbol = this.read_with(&cx, |this, _| {
-            let signature = this.symbol_signature(symbol.worktree_id, &symbol.path);
+            let signature = this.symbol_signature(&symbol.path);
             if signature == symbol.signature {
                 Ok(symbol)
             } else {
@@ -5454,10 +5455,10 @@ impl Project {
         })
     }
 
-    fn symbol_signature(&self, worktree_id: WorktreeId, path: &Path) -> [u8; 32] {
+    fn symbol_signature(&self, project_path: &ProjectPath) -> [u8; 32] {
         let mut hasher = Sha256::new();
-        hasher.update(worktree_id.to_proto().to_be_bytes());
-        hasher.update(path.to_string_lossy().as_bytes());
+        hasher.update(project_path.worktree_id.to_proto().to_be_bytes());
+        hasher.update(project_path.path.to_string_lossy().as_bytes());
         hasher.update(self.nonce.to_be_bytes());
         hasher.finalize().as_slice().try_into().unwrap()
     }
@@ -5655,14 +5656,17 @@ impl Project {
                 .end
                 .ok_or_else(|| anyhow!("invalid end"))?;
             let kind = unsafe { mem::transmute(serialized_symbol.kind) };
-            let path = PathBuf::from(serialized_symbol.path);
-            let language = languages.select_language(&path);
-            Ok(Symbol {
-                source_worktree_id,
+            let path = ProjectPath {
                 worktree_id,
+                path: PathBuf::from(serialized_symbol.path).into(),
+            };
+            let language = languages.select_language(&path.path);
+            Ok(Symbol {
                 language_server_name: LanguageServerName(
                     serialized_symbol.language_server_name.into(),
                 ),
+                source_worktree_id,
+                path,
                 label: {
                     match language {
                         Some(language) => {
@@ -5676,7 +5680,6 @@ impl Project {
                 },
 
                 name: serialized_symbol.name,
-                path,
                 range: PointUtf16::new(start.row, start.column)
                     ..PointUtf16::new(end.row, end.column),
                 kind,
@@ -6142,12 +6145,12 @@ impl From<lsp::DeleteFileOptions> for fs::RemoveOptions {
 
 fn serialize_symbol(symbol: &Symbol) -> proto::Symbol {
     proto::Symbol {
-        source_worktree_id: symbol.source_worktree_id.to_proto(),
-        worktree_id: symbol.worktree_id.to_proto(),
         language_server_name: symbol.language_server_name.0.to_string(),
+        source_worktree_id: symbol.source_worktree_id.to_proto(),
+        worktree_id: symbol.path.worktree_id.to_proto(),
+        path: symbol.path.path.to_string_lossy().to_string(),
         name: symbol.name.clone(),
         kind: unsafe { mem::transmute(symbol.kind) },
-        path: symbol.path.to_string_lossy().to_string(),
         start: Some(proto::Point {
             row: symbol.range.start.row,
             column: symbol.range.start.column,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2821,7 +2821,9 @@ mod tests {
         project.read_with(cx, |project, cx| {
             assert_eq!(
                 project.active_entry(),
-                project.entry_for_path(&(worktree_id, "one.txt").into(), cx)
+                project
+                    .entry_for_path(&(worktree_id, "one.txt").into(), cx)
+                    .map(|e| e.id)
             );
         });
         assert_eq!(
@@ -2838,7 +2840,9 @@ mod tests {
         project.read_with(cx, |project, cx| {
             assert_eq!(
                 project.active_entry(),
-                project.entry_for_path(&(worktree_id, "two.txt").into(), cx)
+                project
+                    .entry_for_path(&(worktree_id, "two.txt").into(), cx)
+                    .map(|e| e.id)
             );
         });
 
@@ -2856,7 +2860,9 @@ mod tests {
         project.read_with(cx, |project, cx| {
             assert_eq!(
                 project.active_entry(),
-                project.entry_for_path(&(worktree_id, "one.txt").into(), cx)
+                project
+                    .entry_for_path(&(worktree_id, "one.txt").into(), cx)
+                    .map(|e| e.id)
             );
         });
 


### PR DESCRIPTION
## Description of feature or change

This pull request improves sorting of project symbols and completions:

- For the former, we will now sort visible (as in, non-ignored _and_ located within the project) matches before external ones
- For the latter, we will honor the `sort_text` field provided by the language server and fall back to our internal fuzzy scoring when two completions have the same `sort_text`. 

I think we could improve our completion sorting further by maintaining a spatial index of tokens provided by tree-sitter. We could then query that index to ask e.g., where is this token located in the buffer right now? and sort the completions returned by the language server by favoring ones that are closer to the cursor. That would be significantly more work though, and I think for all the languages we support so far the server-side sorting implemented by this pull request should improve completions quality by quite a lot.

<img width="1289" alt="Screen Shot 2022-07-26 at 14 58 24" src="https://user-images.githubusercontent.com/482957/181012428-29191b59-b2ce-4bbb-8f46-b34d0be5b110.png">

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/286

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
