### PR TITLE
Fixed regression in working directory code

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -84,7 +84,8 @@
         "shell": "system",
         // What working directory to use when launching the terminal.
         // May take 4 values:
-        // 1. Use the current file's project directory.
+        // 1. Use the current file's project directory.  Will Fallback to the 
+        //    first project directory strategy if unsuccessful
         //      "working_directory": "current_project_directory"
         // 2. Use the first project in this workspace's directory
         //      "working_directory": "first_project_directory"

--- a/crates/terminal/src/modal_view.rs
+++ b/crates/terminal/src/modal_view.rs
@@ -1,4 +1,5 @@
 use gpui::{ModelHandle, ViewContext};
+use settings::{Settings, WorkingDirectory};
 use workspace::Workspace;
 
 use crate::{
@@ -27,7 +28,14 @@ pub fn deploy_modal(workspace: &mut Workspace, _: &DeployModal, cx: &mut ViewCon
         // No connection was stored, create a new terminal
         if let Some(closed_terminal_handle) = workspace.toggle_modal(cx, |workspace, cx| {
             // No terminal modal visible, construct a new one.
-            let working_directory = get_working_directory(workspace, cx);
+            let wd_strategy = cx
+                .global::<Settings>()
+                .terminal_overrides
+                .working_directory
+                .clone()
+                .unwrap_or(WorkingDirectory::CurrentProjectDirectory);
+
+            let working_directory = get_working_directory(workspace, cx, wd_strategy);
 
             let this = cx.add_view(|cx| TerminalView::new(working_directory, true, cx));
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -335,7 +335,8 @@ fn get_working_directory(workspace: &Workspace, cx: &AppContext) -> Option<PathB
         .clone()
         .unwrap_or(WorkingDirectory::CurrentProjectDirectory);
     let res = match wd_setting {
-        WorkingDirectory::CurrentProjectDirectory => current_project_directory(workspace, cx),
+        WorkingDirectory::CurrentProjectDirectory => current_project_directory(workspace, cx)
+            .or_else(|| first_project_directory(workspace, cx)),
         WorkingDirectory::FirstProjectDirectory => first_project_directory(workspace, cx),
         WorkingDirectory::AlwaysHome => None,
         WorkingDirectory::Always { directory } => {


### PR DESCRIPTION
## Description of feature or change

When using the 'current project directory' strategy from within a single file worktree, the terminal would default to the home directory instead of falling back on the 'first project directory' strategy. This is because I separated the two strategies and moved the fallback into code that works with the real file system, and is therefore harder to test.
 
## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
