### PR TITLE
Auto-indent improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,6 +2761,7 @@ dependencies = [
  "rpc",
  "serde",
  "serde_json",
+ "settings",
  "similar",
  "smallvec",
  "smol",

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -82,6 +82,7 @@ impl ActivityIndicator {
                     buffer.update(cx, |buffer, cx| {
                         buffer.edit(
                             [(0..0, format!("Language server error: {}\n\n", lsp_name))],
+                            None,
                             cx,
                         );
                     });

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -842,8 +842,8 @@ async fn test_propagate_saves_and_fs_changes(
         .update(cx_c, |p, cx| p.open_buffer((worktree_id, "file1"), cx))
         .await
         .unwrap();
-    buffer_b.update(cx_b, |buf, cx| buf.edit([(0..0, "i-am-b, ")], cx));
-    buffer_c.update(cx_c, |buf, cx| buf.edit([(0..0, "i-am-c, ")], cx));
+    buffer_b.update(cx_b, |buf, cx| buf.edit([(0..0, "i-am-b, ")], None, cx));
+    buffer_c.update(cx_c, |buf, cx| buf.edit([(0..0, "i-am-c, ")], None, cx));
 
     // Open and edit that buffer as the host.
     let buffer_a = project_a
@@ -855,7 +855,7 @@ async fn test_propagate_saves_and_fs_changes(
         .condition(cx_a, |buf, _| buf.text() == "i-am-c, i-am-b, ")
         .await;
     buffer_a.update(cx_a, |buf, cx| {
-        buf.edit([(buf.len()..buf.len(), "i-am-a")], cx)
+        buf.edit([(buf.len()..buf.len(), "i-am-a")], None, cx)
     });
 
     // Wait for edits to propagate
@@ -871,7 +871,7 @@ async fn test_propagate_saves_and_fs_changes(
 
     // Edit the buffer as the host and concurrently save as guest B.
     let save_b = buffer_b.update(cx_b, |buf, cx| buf.save(cx));
-    buffer_a.update(cx_a, |buf, cx| buf.edit([(0..0, "hi-a, ")], cx));
+    buffer_a.update(cx_a, |buf, cx| buf.edit([(0..0, "hi-a, ")], None, cx));
     save_b.await.unwrap();
     assert_eq!(
         client_a.fs.load("/a/file1".as_ref()).await.unwrap(),
@@ -1237,7 +1237,7 @@ async fn test_buffer_conflict_after_save(cx_a: &mut TestAppContext, cx_b: &mut T
         .await
         .unwrap();
 
-    buffer_b.update(cx_b, |buf, cx| buf.edit([(0..0, "world ")], cx));
+    buffer_b.update(cx_b, |buf, cx| buf.edit([(0..0, "world ")], None, cx));
     buffer_b.read_with(cx_b, |buf, _| {
         assert!(buf.is_dirty());
         assert!(!buf.has_conflict());
@@ -1251,7 +1251,7 @@ async fn test_buffer_conflict_after_save(cx_a: &mut TestAppContext, cx_b: &mut T
         assert!(!buf.has_conflict());
     });
 
-    buffer_b.update(cx_b, |buf, cx| buf.edit([(0..0, "hello ")], cx));
+    buffer_b.update(cx_b, |buf, cx| buf.edit([(0..0, "hello ")], None, cx));
     buffer_b.read_with(cx_b, |buf, _| {
         assert!(buf.is_dirty());
         assert!(!buf.has_conflict());
@@ -1342,9 +1342,9 @@ async fn test_editing_while_guest_opens_buffer(
 
     // Edit the buffer as client A while client B is still opening it.
     cx_b.background().simulate_random_delay().await;
-    buffer_a.update(cx_a, |buf, cx| buf.edit([(0..0, "X")], cx));
+    buffer_a.update(cx_a, |buf, cx| buf.edit([(0..0, "X")], None, cx));
     cx_b.background().simulate_random_delay().await;
-    buffer_a.update(cx_a, |buf, cx| buf.edit([(1..1, "Y")], cx));
+    buffer_a.update(cx_a, |buf, cx| buf.edit([(1..1, "Y")], None, cx));
 
     let text = buffer_a.read_with(cx_a, |buf, _| buf.text());
     let buffer_b = buffer_b.await.unwrap();
@@ -1882,8 +1882,8 @@ async fn test_reloading_buffer_manually(cx_a: &mut TestAppContext, cx_b: &mut Te
         .await
         .unwrap();
     buffer_b.update(cx_b, |buffer, cx| {
-        buffer.edit([(4..7, "six")], cx);
-        buffer.edit([(10..11, "6")], cx);
+        buffer.edit([(4..7, "six")], None, cx);
+        buffer.edit([(10..11, "6")], None, cx);
         assert_eq!(buffer.text(), "let six = 6;");
         assert!(buffer.is_dirty());
         assert!(!buffer.has_conflict());
@@ -2964,7 +2964,7 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
         );
         rename.editor.update(cx, |rename_editor, cx| {
             rename_editor.buffer().update(cx, |rename_buffer, cx| {
-                rename_buffer.edit([(0..3, "THREE")], cx);
+                rename_buffer.edit([(0..3, "THREE")], None, cx);
             });
         });
     });

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -897,7 +897,7 @@ pub mod tests {
 
         let ix = snapshot.buffer_snapshot.text().find("seven").unwrap();
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(ix..ix, "and ")], cx);
+            buffer.edit([(ix..ix, "and ")], None, cx);
         });
 
         let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
@@ -936,6 +936,7 @@ pub mod tests {
                     (Point::new(1, 1)..Point::new(1, 1), "\t"),
                     (Point::new(2, 1)..Point::new(2, 1), "\t"),
                 ],
+                None,
                 cx,
             )
         });

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1164,7 +1164,7 @@ mod tests {
 
         // Insert a line break, separating two block decorations into separate lines.
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(1, 1)..Point::new(1, 1), "!!!\n")], cx);
+            buffer.edit([(Point::new(1, 1)..Point::new(1, 1), "!!!\n")], None, cx);
             buffer.snapshot(cx)
         });
 

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1240,6 +1240,7 @@ mod tests {
                     (Point::new(0, 0)..Point::new(0, 1), "123"),
                     (Point::new(2, 3)..Point::new(2, 3), "123"),
                 ],
+                None,
                 cx,
             );
             buffer.snapshot(cx)
@@ -1262,7 +1263,7 @@ mod tests {
         );
 
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(2, 6)..Point::new(4, 3), "456")], cx);
+            buffer.edit([(Point::new(2, 6)..Point::new(4, 3), "456")], None, cx);
             buffer.snapshot(cx)
         });
         let (snapshot4, _) = map.read(buffer_snapshot.clone(), subscription.consume().into_inner());
@@ -1318,7 +1319,7 @@ mod tests {
 
             // Edit within one of the folds.
             let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-                buffer.edit([(0..1, "12345")], cx);
+                buffer.edit([(0..1, "12345")], None, cx);
                 buffer.snapshot(cx)
             });
             let (snapshot, _) =
@@ -1360,7 +1361,7 @@ mod tests {
         assert_eq!(snapshot.text(), "aa…cccc\nd…eeeee");
 
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(2, 2)..Point::new(3, 1), "")], cx);
+            buffer.edit([(Point::new(2, 2)..Point::new(3, 1), "")], None, cx);
             buffer.snapshot(cx)
         });
         let (snapshot, _) = map.read(buffer_snapshot.clone(), subscription.consume().into_inner());

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1476,7 +1476,7 @@ impl Editor {
         T: Into<Arc<str>>,
     {
         self.buffer.update(cx, |buffer, cx| {
-            buffer.edit(edits, Some(AutoindentMode::Independent), cx)
+            buffer.edit(edits, Some(AutoindentMode::EachLine), cx)
         });
     }
 
@@ -1927,7 +1927,7 @@ impl Editor {
                     old_selections
                         .iter()
                         .map(|s| (s.start..s.end, text.clone())),
-                    Some(AutoindentMode::Independent),
+                    Some(AutoindentMode::EachLine),
                     cx,
                 );
                 anchors
@@ -2369,7 +2369,7 @@ impl Editor {
                 this.buffer.update(cx, |buffer, cx| {
                     buffer.edit(
                         ranges.iter().map(|range| (range.clone(), text)),
-                        Some(AutoindentMode::Independent),
+                        Some(AutoindentMode::EachLine),
                         cx,
                     );
                 });
@@ -2737,7 +2737,7 @@ impl Editor {
                     .iter()
                     .cloned()
                     .map(|range| (range, snippet_text.clone())),
-                Some(AutoindentMode::Independent),
+                Some(AutoindentMode::EachLine),
                 cx,
             );
 
@@ -3513,10 +3513,7 @@ impl Editor {
                 clipboard_selections.push(ClipboardSelection {
                     len,
                     is_entire_line,
-                    first_line_indent: cmp::min(
-                        selection.start.column,
-                        buffer.indent_size_for_line(selection.start.row).len,
-                    ),
+                    first_line_indent: buffer.indent_size_for_line(selection.start.row).len,
                 });
             }
         }
@@ -3554,10 +3551,7 @@ impl Editor {
                 clipboard_selections.push(ClipboardSelection {
                     len,
                     is_entire_line,
-                    first_line_indent: cmp::min(
-                        start.column,
-                        buffer.indent_size_for_line(start.row).len,
-                    ),
+                    first_line_indent: buffer.indent_size_for_line(start.row).len,
                 });
             }
         }
@@ -3626,7 +3620,13 @@ impl Editor {
                             start_columns.push(start_column);
                         }
                         drop(snapshot);
-                        buffer.edit(edits, Some(AutoindentMode::Block { start_columns }), cx);
+                        buffer.edit(
+                            edits,
+                            Some(AutoindentMode::Block {
+                                original_indent_columns: start_columns,
+                            }),
+                            cx,
+                        );
                     });
 
                     let selections = this.selections.all::<usize>(cx);

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -11,7 +11,6 @@ use language::{
     IndentSize, Language, OffsetRangeExt, Outline, OutlineItem, Selection, ToOffset as _,
     ToOffsetUtf16 as _, ToPoint as _, ToPointUtf16 as _, TransactionId,
 };
-use settings::Settings;
 use smallvec::SmallVec;
 use std::{
     borrow::Cow,
@@ -347,14 +346,7 @@ impl MultiBuffer {
         if let Some(buffer) = self.as_singleton() {
             return buffer.update(cx, |buffer, cx| {
                 if autoindent {
-                    let language_name = buffer.language().map(|language| language.name());
-                    let settings = cx.global::<Settings>();
-                    let indent_size = if settings.hard_tabs(language_name.as_deref()) {
-                        IndentSize::tab()
-                    } else {
-                        IndentSize::spaces(settings.tab_size(language_name.as_deref()).get())
-                    };
-                    buffer.edit_with_autoindent(edits, indent_size, cx);
+                    buffer.edit_with_autoindent(edits, cx);
                 } else {
                     buffer.edit(edits, cx);
                 }
@@ -471,18 +463,10 @@ impl MultiBuffer {
                             ));
                         }
                     }
-                    let language_name = buffer.language().map(|l| l.name());
 
                     if autoindent {
-                        let settings = cx.global::<Settings>();
-                        let indent_size = if settings.hard_tabs(language_name.as_deref()) {
-                            IndentSize::tab()
-                        } else {
-                            IndentSize::spaces(settings.tab_size(language_name.as_deref()).get())
-                        };
-
-                        buffer.edit_with_autoindent(deletions, indent_size, cx);
-                        buffer.edit_with_autoindent(insertions, indent_size, cx);
+                        buffer.edit_with_autoindent(deletions, cx);
+                        buffer.edit_with_autoindent(insertions, cx);
                     } else {
                         buffer.edit(deletions, cx);
                         buffer.edit(insertions, cx);
@@ -3220,6 +3204,7 @@ mod tests {
     use gpui::MutableAppContext;
     use language::{Buffer, Rope};
     use rand::prelude::*;
+    use settings::Settings;
     use std::{env, rc::Rc};
     use text::{Point, RandomCharIter};
     use util::test::sample_text;

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -27,6 +27,7 @@ fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
 lsp = { path = "../lsp" }
 rpc = { path = "../rpc" }
+settings = { path = "../settings" }
 sum_tree = { path = "../sum_tree" }
 text = { path = "../text" }
 theme = { path = "../theme" }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -16,6 +16,7 @@ test-support = [
     "text/test-support",
     "tree-sitter-rust",
     "tree-sitter-typescript",
+    "settings/test-support",
     "util/test-support",
 ]
 
@@ -57,6 +58,7 @@ collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
 text = { path = "../text", features = ["test-support"] }
+settings = { path = "../settings", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.9"

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -944,7 +944,9 @@ fn test_autoindent_block_mode(cx: &mut MutableAppContext) {
         // so that the first line matches the previous line's indentation.
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), inserted_text.clone())],
-            Some(AutoindentMode::Block),
+            Some(AutoindentMode::Block {
+                start_columns: vec![0],
+            }),
             cx,
         );
         assert_eq!(
@@ -967,7 +969,9 @@ fn test_autoindent_block_mode(cx: &mut MutableAppContext) {
         buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "        ")], None, cx);
         buffer.edit(
             [(Point::new(2, 8)..Point::new(2, 8), inserted_text.clone())],
-            Some(AutoindentMode::Block),
+            Some(AutoindentMode::Block {
+                start_columns: vec![0],
+            }),
             cx,
         );
         assert_eq!(

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -35,7 +35,7 @@ fn test_line_endings(cx: &mut gpui::MutableAppContext) {
         buffer.check_invariants();
         buffer.edit(
             [(buffer.len()..buffer.len(), "\r\nfour")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         buffer.edit([(0..0, "zero\r\n")], None, cx);
@@ -630,12 +630,12 @@ fn test_autoindent_with_soft_tabs(cx: &mut MutableAppContext) {
         let text = "fn a() {}";
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::Independent), cx);
+        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
         assert_eq!(buffer.text(), "fn a() {\n    \n}");
 
         buffer.edit(
             [(Point::new(1, 4)..Point::new(1, 4), "b()\n")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n    b()\n    \n}");
@@ -644,7 +644,7 @@ fn test_autoindent_with_soft_tabs(cx: &mut MutableAppContext) {
         // to be indented.
         buffer.edit(
             [(Point::new(2, 4)..Point::new(2, 4), ".c")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n    b()\n        .c\n}");
@@ -653,7 +653,7 @@ fn test_autoindent_with_soft_tabs(cx: &mut MutableAppContext) {
         // causing the line to be outdented.
         buffer.edit(
             [(Point::new(2, 8)..Point::new(2, 9), "")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n    b()\n    c\n}");
@@ -672,12 +672,12 @@ fn test_autoindent_with_hard_tabs(cx: &mut MutableAppContext) {
         let text = "fn a() {}";
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::Independent), cx);
+        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
         assert_eq!(buffer.text(), "fn a() {\n\t\n}");
 
         buffer.edit(
             [(Point::new(1, 1)..Point::new(1, 1), "b()\n")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n\tb()\n\t\n}");
@@ -686,7 +686,7 @@ fn test_autoindent_with_hard_tabs(cx: &mut MutableAppContext) {
         // to be indented.
         buffer.edit(
             [(Point::new(2, 1)..Point::new(2, 1), ".c")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n\tb()\n\t\t.c\n}");
@@ -695,7 +695,7 @@ fn test_autoindent_with_hard_tabs(cx: &mut MutableAppContext) {
         // causing the line to be outdented.
         buffer.edit(
             [(Point::new(2, 2)..Point::new(2, 3), "")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n\tb()\n\tc\n}");
@@ -727,7 +727,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
                 (empty(Point::new(1, 1)), "()"),
                 (empty(Point::new(2, 1)), "()"),
             ],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(
@@ -748,7 +748,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
                 (empty(Point::new(1, 1)), "\n.f\n.g"),
                 (empty(Point::new(2, 1)), "\n.f\n.g"),
             ],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(
@@ -783,7 +783,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
         // Delete a closing curly brace changes the suggested indent for the line.
         buffer.edit(
             [(Point::new(3, 4)..Point::new(3, 5), "")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(
@@ -803,7 +803,7 @@ fn test_autoindent_does_not_adjust_lines_with_unchanged_suggestion(cx: &mut Muta
         // Manually editing the leading whitespace
         buffer.edit(
             [(Point::new(3, 0)..Point::new(3, 12), "")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(
@@ -833,7 +833,7 @@ fn test_autoindent_adjusts_lines_when_only_text_changes(cx: &mut MutableAppConte
 
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit([(5..5, "\nb")], Some(AutoindentMode::Independent), cx);
+        buffer.edit([(5..5, "\nb")], Some(AutoindentMode::EachLine), cx);
         assert_eq!(
             buffer.text(),
             "
@@ -847,7 +847,7 @@ fn test_autoindent_adjusts_lines_when_only_text_changes(cx: &mut MutableAppConte
         // is now at the beginning of the line.
         buffer.edit(
             [(Point::new(1, 4)..Point::new(1, 5), "")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(
@@ -871,7 +871,7 @@ fn test_autoindent_with_edit_at_end_of_buffer(cx: &mut MutableAppContext) {
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
         buffer.edit(
             [(0..1, "\n"), (2..3, "\n")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(buffer.text(), "\n\n\n");
@@ -896,7 +896,7 @@ fn test_autoindent_multi_line_insertion(cx: &mut MutableAppContext) {
         let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
         buffer.edit(
             [(Point::new(3, 0)..Point::new(3, 0), "e(\n    f()\n);\n")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(
@@ -945,7 +945,7 @@ fn test_autoindent_block_mode(cx: &mut MutableAppContext) {
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), inserted_text.clone())],
             Some(AutoindentMode::Block {
-                start_columns: vec![0],
+                original_indent_columns: vec![0],
             }),
             cx,
         );
@@ -970,7 +970,7 @@ fn test_autoindent_block_mode(cx: &mut MutableAppContext) {
         buffer.edit(
             [(Point::new(2, 8)..Point::new(2, 8), inserted_text.clone())],
             Some(AutoindentMode::Block {
-                start_columns: vec![0],
+                original_indent_columns: vec![0],
             }),
             cx,
         );
@@ -1017,7 +1017,7 @@ fn test_autoindent_language_without_indents_query(cx: &mut MutableAppContext) {
         );
         buffer.edit(
             [(Point::new(3, 0)..Point::new(3, 0), "\n")],
-            Some(AutoindentMode::Independent),
+            Some(AutoindentMode::EachLine),
             cx,
         );
         assert_eq!(

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -900,6 +900,53 @@ fn test_autoindent_multi_line_insertion(cx: &mut MutableAppContext) {
 }
 
 #[gpui::test]
+fn test_autoindent_preserves_relative_indentation_in_multi_line_insertion(
+    cx: &mut MutableAppContext,
+) {
+    cx.add_model(|cx| {
+        let text = "
+            fn a() {
+                b();
+            }
+        "
+        .unindent();
+        let mut buffer = Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx);
+
+        let pasted_text = r#"
+            "
+              c
+                d
+                  e
+            "
+        "#
+        .unindent();
+
+        // insert at the beginning of a line
+        buffer.edit_with_autoindent(
+            [(Point::new(2, 0)..Point::new(2, 0), pasted_text.clone())],
+            IndentSize::spaces(4),
+            cx,
+        );
+        assert_eq!(
+            buffer.text(),
+            r#"
+            fn a() {
+                b();
+                "
+                  c
+                    d
+                      e
+                "
+            }
+            "#
+            .unindent()
+        );
+
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_autoindent_disabled(cx: &mut MutableAppContext) {
     cx.add_model(|cx| {
         let text = "

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3168,7 +3168,7 @@ impl Project {
                 buffer.finalize_last_transaction();
                 buffer.start_transaction();
                 for (range, text) in edits {
-                    buffer.edit([(range, text)], cx);
+                    buffer.edit([(range, text)], None, cx);
                 }
                 if buffer.end_transaction(cx).is_some() {
                     let transaction = buffer.finalize_last_transaction().unwrap().clone();
@@ -3663,7 +3663,7 @@ impl Project {
                         buffer.finalize_last_transaction();
                         buffer.start_transaction();
                         for (range, text) in edits {
-                            buffer.edit([(range, text)], cx);
+                            buffer.edit([(range, text)], None, cx);
                         }
                         let transaction = if buffer.end_transaction(cx).is_some() {
                             let transaction = buffer.finalize_last_transaction().unwrap().clone();
@@ -4023,7 +4023,7 @@ impl Project {
                         buffer.finalize_last_transaction();
                         buffer.start_transaction();
                         for (range, text) in edits {
-                            buffer.edit([(range, text)], cx);
+                            buffer.edit([(range, text)], None, cx);
                         }
                         let transaction = if buffer.end_transaction(cx).is_some() {
                             let transaction = buffer.finalize_last_transaction().unwrap().clone();

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -169,7 +169,7 @@ async fn test_managing_language_servers(
     });
 
     // Edit a buffer. The changes are reported to the language server.
-    rust_buffer.update(cx, |buffer, cx| buffer.edit([(16..16, "2")], cx));
+    rust_buffer.update(cx, |buffer, cx| buffer.edit([(16..16, "2")], None, cx));
     assert_eq!(
         fake_rust_server
             .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -226,8 +226,10 @@ async fn test_managing_language_servers(
     });
 
     // Changes are reported only to servers matching the buffer's language.
-    toml_buffer.update(cx, |buffer, cx| buffer.edit([(5..5, "23")], cx));
-    rust_buffer2.update(cx, |buffer, cx| buffer.edit([(0..0, "let x = 1;")], cx));
+    toml_buffer.update(cx, |buffer, cx| buffer.edit([(5..5, "23")], None, cx));
+    rust_buffer2.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "let x = 1;")], None, cx)
+    });
     assert_eq!(
         fake_rust_server
             .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -348,7 +350,7 @@ async fn test_managing_language_servers(
     });
 
     // The renamed file's version resets after changing language server.
-    rust_buffer2.update(cx, |buffer, cx| buffer.edit([(0..0, "// ")], cx));
+    rust_buffer2.update(cx, |buffer, cx| buffer.edit([(0..0, "// ")], None, cx));
     assert_eq!(
         fake_json_server
             .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -972,7 +974,7 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
         .await;
 
     // Edit the buffer, moving the content down
-    buffer.update(cx, |buffer, cx| buffer.edit([(0..0, "\n\n")], cx));
+    buffer.update(cx, |buffer, cx| buffer.edit([(0..0, "\n\n")], None, cx));
     let change_notification_1 = fake_server
         .receive_notification::<lsp::notification::DidChangeTextDocument>()
         .await;
@@ -1137,9 +1139,13 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
     // Keep editing the buffer and ensure disk-based diagnostics get translated according to the
     // changes since the last save.
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "    ")], cx);
-        buffer.edit([(Point::new(2, 8)..Point::new(2, 10), "(x: usize)")], cx);
-        buffer.edit([(Point::new(3, 10)..Point::new(3, 10), "xxx")], cx);
+        buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "    ")], None, cx);
+        buffer.edit(
+            [(Point::new(2, 8)..Point::new(2, 10), "(x: usize)")],
+            None,
+            cx,
+        );
+        buffer.edit([(Point::new(3, 10)..Point::new(3, 10), "xxx")], None, cx);
     });
     let change_notification_2 = fake_server
         .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -1330,6 +1336,7 @@ async fn test_edits_from_lsp_with_past_version(cx: &mut gpui::TestAppContext) {
                 Point::new(0, 0)..Point::new(0, 0),
                 "// above first function\n",
             )],
+            None,
             cx,
         );
         buffer.edit(
@@ -1337,6 +1344,7 @@ async fn test_edits_from_lsp_with_past_version(cx: &mut gpui::TestAppContext) {
                 Point::new(2, 0)..Point::new(2, 0),
                 "    // inside first function\n",
             )],
+            None,
             cx,
         );
         buffer.edit(
@@ -1344,6 +1352,7 @@ async fn test_edits_from_lsp_with_past_version(cx: &mut gpui::TestAppContext) {
                 Point::new(6, 4)..Point::new(6, 4),
                 "// inside second function ",
             )],
+            None,
             cx,
         );
 
@@ -1405,7 +1414,7 @@ async fn test_edits_from_lsp_with_past_version(cx: &mut gpui::TestAppContext) {
 
     buffer.update(cx, |buffer, cx| {
         for (range, new_text) in edits {
-            buffer.edit([(range, new_text)], cx);
+            buffer.edit([(range, new_text)], None, cx);
         }
         assert_eq!(
             buffer.text(),
@@ -1517,7 +1526,7 @@ async fn test_edits_from_lsp_with_edits_on_adjacent_lines(cx: &mut gpui::TestApp
         );
 
         for (range, new_text) in edits {
-            buffer.edit([(range, new_text)], cx);
+            buffer.edit([(range, new_text)], None, cx);
         }
         assert_eq!(
             buffer.text(),
@@ -1620,7 +1629,7 @@ async fn test_invalid_edits_from_lsp(cx: &mut gpui::TestAppContext) {
         );
 
         for (range, new_text) in edits {
-            buffer.edit([(range, new_text)], cx);
+            buffer.edit([(range, new_text)], None, cx);
         }
         assert_eq!(
             buffer.text(),
@@ -2025,7 +2034,7 @@ async fn test_save_file(cx: &mut gpui::TestAppContext) {
     buffer
         .update(cx, |buffer, cx| {
             assert_eq!(buffer.text(), "the old contents");
-            buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], cx);
+            buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
             buffer.save(cx)
         })
         .await
@@ -2053,7 +2062,7 @@ async fn test_save_in_single_file_worktree(cx: &mut gpui::TestAppContext) {
         .unwrap();
     buffer
         .update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], cx);
+            buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
             buffer.save(cx)
         })
         .await
@@ -2073,7 +2082,7 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
         project.create_buffer("", None, cx).unwrap()
     });
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "abc")], cx);
+        buffer.edit([(0..0, "abc")], None, cx);
         assert!(buffer.is_dirty());
         assert!(!buffer.has_conflict());
     });
@@ -2329,7 +2338,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
         assert!(!buffer.is_dirty());
         assert!(events.borrow().is_empty());
 
-        buffer.edit([(1..2, "")], cx);
+        buffer.edit([(1..2, "")], None, cx);
     });
 
     // after the first edit, the buffer is dirty, and emits a dirtied event.
@@ -2356,8 +2365,8 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
         assert_eq!(*events.borrow(), &[language::Event::Saved]);
         events.borrow_mut().clear();
 
-        buffer.edit([(1..1, "B")], cx);
-        buffer.edit([(2..2, "D")], cx);
+        buffer.edit([(1..1, "B")], None, cx);
+        buffer.edit([(2..2, "D")], None, cx);
     });
 
     // after editing again, the buffer is dirty, and emits another dirty event.
@@ -2376,7 +2385,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
 
         // After restoring the buffer to its previously-saved state,
         // the buffer is not considered dirty anymore.
-        buffer.edit([(1..3, "")], cx);
+        buffer.edit([(1..3, "")], None, cx);
         assert!(buffer.text() == "ac");
         assert!(!buffer.is_dirty());
     });
@@ -2427,7 +2436,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
     });
 
     buffer3.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "x")], cx);
+        buffer.edit([(0..0, "x")], None, cx);
     });
     events.borrow_mut().clear();
     fs.remove_file("/dir/file3".as_ref(), Default::default())
@@ -2495,7 +2504,7 @@ async fn test_buffer_file_changes_on_disk(cx: &mut gpui::TestAppContext) {
 
     // Modify the buffer
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, " ")], cx);
+        buffer.edit([(0..0, " ")], None, cx);
         assert!(buffer.is_dirty());
         assert!(!buffer.has_conflict());
     });
@@ -2986,7 +2995,7 @@ async fn test_search(cx: &mut gpui::TestAppContext) {
         .unwrap();
     buffer_4.update(cx, |buffer, cx| {
         let text = "two::TWO";
-        buffer.edit([(20..28, text), (31..43, text)], cx);
+        buffer.edit([(20..28, text), (31..43, text)], None, cx);
     });
 
     assert_eq!(

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -260,7 +260,7 @@ impl BufferSearchBar {
         self.query_editor.update(cx, |query_editor, cx| {
             query_editor.buffer().update(cx, |query_buffer, cx| {
                 let len = query_buffer.len(cx);
-                query_buffer.edit([(0..len, query)], cx);
+                query_buffer.edit([(0..len, query)], None, cx);
             });
         });
     }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -278,7 +278,7 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
                                 }
                             }
                             drop(snapshot);
-                            buffer.edit(edits, Some(AutoindentMode::Independent), cx);
+                            buffer.edit(edits, Some(AutoindentMode::EachLine), cx);
                         });
 
                         editor.change_selections(Some(Autoscroll::Fit), cx, |s| {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -13,7 +13,7 @@ use change::init as change_init;
 use collections::HashSet;
 use editor::{Autoscroll, Bias, ClipboardSelection, DisplayPoint};
 use gpui::{actions, MutableAppContext, ViewContext};
-use language::{Point, SelectionGoal};
+use language::{AutoindentMode, Point, SelectionGoal};
 use workspace::Workspace;
 
 use self::{change::change_over, delete::delete_over, yank::yank_over};
@@ -278,7 +278,7 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
                                 }
                             }
                             drop(snapshot);
-                            buffer.edit_with_autoindent(edits, cx);
+                            buffer.edit(edits, Some(AutoindentMode::Independent), cx);
                         });
 
                         editor.change_selections(Some(Autoscroll::Fit), cx, |s| {

--- a/crates/vim/src/utils.rs
+++ b/crates/vim/src/utils.rs
@@ -1,6 +1,5 @@
 use editor::{ClipboardSelection, Editor};
 use gpui::{ClipboardItem, MutableAppContext};
-use std::cmp;
 
 pub fn copy_selections_content(editor: &mut Editor, linewise: bool, cx: &mut MutableAppContext) {
     let selections = editor.selections.all_adjusted(cx);
@@ -18,10 +17,7 @@ pub fn copy_selections_content(editor: &mut Editor, linewise: bool, cx: &mut Mut
             clipboard_selections.push(ClipboardSelection {
                 len: text.len() - initial_len,
                 is_entire_line: linewise,
-                first_line_indent: cmp::min(
-                    start.column,
-                    buffer.indent_size_for_line(start.row).len,
-                ),
+                first_line_indent: buffer.indent_size_for_line(start.row).len,
             });
         }
     }

--- a/crates/vim/src/utils.rs
+++ b/crates/vim/src/utils.rs
@@ -1,5 +1,6 @@
 use editor::{ClipboardSelection, Editor};
 use gpui::{ClipboardItem, MutableAppContext};
+use std::cmp;
 
 pub fn copy_selections_content(editor: &mut Editor, linewise: bool, cx: &mut MutableAppContext) {
     let selections = editor.selections.all_adjusted(cx);
@@ -17,6 +18,10 @@ pub fn copy_selections_content(editor: &mut Editor, linewise: bool, cx: &mut Mut
             clipboard_selections.push(ClipboardSelection {
                 len: text.len() - initial_len,
                 is_entire_line: linewise,
+                first_line_indent: cmp::min(
+                    start.column,
+                    buffer.indent_size_for_line(start.row).len,
+                ),
             });
         }
     }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -254,7 +254,7 @@ pub fn paste(_: &mut Workspace, _: &VisualPaste, cx: &mut ViewContext<Workspace>
                                 }
                             }
                             drop(snapshot);
-                            buffer.edit(edits, Some(AutoindentMode::Independent), cx);
+                            buffer.edit(edits, Some(AutoindentMode::EachLine), cx);
                         });
 
                         editor.change_selections(Some(Autoscroll::Fit), cx, |s| {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use collections::HashMap;
 use editor::{display_map::ToDisplayPoint, Autoscroll, Bias, ClipboardSelection};
 use gpui::{actions, MutableAppContext, ViewContext};
-use language::SelectionGoal;
+use language::{AutoindentMode, SelectionGoal};
 use workspace::Workspace;
 
 use crate::{motion::Motion, state::Mode, utils::copy_selections_content, Vim};
@@ -254,7 +254,7 @@ pub fn paste(_: &mut Workspace, _: &VisualPaste, cx: &mut ViewContext<Workspace>
                                 }
                             }
                             drop(snapshot);
-                            buffer.edit_with_autoindent(edits, cx);
+                            buffer.edit(edits, Some(AutoindentMode::Independent), cx);
                         });
 
                         editor.change_selections(Some(Autoscroll::Fit), cx, |s| {

--- a/crates/zed/src/languages/c.rs
+++ b/crates/zed/src/languages/c.rs
@@ -249,7 +249,7 @@ impl super::LspAdapter for CLspAdapter {
 #[cfg(test)]
 mod tests {
     use gpui::MutableAppContext;
-    use language::Buffer;
+    use language::{AutoindentMode, Buffer};
     use settings::Settings;
     use std::sync::Arc;
 
@@ -265,21 +265,25 @@ mod tests {
             let mut buffer = Buffer::new(0, "", cx).with_language(Arc::new(language), cx);
 
             // empty function
-            buffer.edit_with_autoindent([(0..0, "int main() {}")], cx);
+            buffer.edit([(0..0, "int main() {}")], None, cx);
 
             // indent inside braces
             let ix = buffer.len() - 1;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n")], cx);
+            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "int main() {\n  \n}");
 
             // indent body of single-statement if statement
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "if (a)\nb;")], cx);
+            buffer.edit(
+                [(ix..ix, "if (a)\nb;")],
+                Some(AutoindentMode::Independent),
+                cx,
+            );
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b;\n}");
 
             // indent inside field expression
             let ix = buffer.len() - 3;
-            buffer.edit_with_autoindent([(ix..ix, "\n.c")], cx);
+            buffer.edit([(ix..ix, "\n.c")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b\n      .c;\n}");
 
             buffer

--- a/crates/zed/src/languages/c.rs
+++ b/crates/zed/src/languages/c.rs
@@ -249,34 +249,37 @@ impl super::LspAdapter for CLspAdapter {
 #[cfg(test)]
 mod tests {
     use gpui::MutableAppContext;
-    use language::{Buffer, IndentSize};
+    use language::Buffer;
+    use settings::Settings;
     use std::sync::Arc;
 
     #[gpui::test]
     fn test_c_autoindent(cx: &mut MutableAppContext) {
         cx.foreground().set_block_on_ticks(usize::MAX..=usize::MAX);
+        let mut settings = Settings::test(cx);
+        settings.editor_overrides.tab_size = Some(2.try_into().unwrap());
+        cx.set_global(settings);
         let language = crate::languages::language("c", tree_sitter_c::language(), None);
 
         cx.add_model(|cx| {
             let mut buffer = Buffer::new(0, "", cx).with_language(Arc::new(language), cx);
-            let size = IndentSize::spaces(2);
 
             // empty function
-            buffer.edit_with_autoindent([(0..0, "int main() {}")], size, cx);
+            buffer.edit_with_autoindent([(0..0, "int main() {}")], cx);
 
             // indent inside braces
             let ix = buffer.len() - 1;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n\n")], cx);
             assert_eq!(buffer.text(), "int main() {\n  \n}");
 
             // indent body of single-statement if statement
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "if (a)\nb;")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "if (a)\nb;")], cx);
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b;\n}");
 
             // indent inside field expression
             let ix = buffer.len() - 3;
-            buffer.edit_with_autoindent([(ix..ix, "\n.c")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n.c")], cx);
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b\n      .c;\n}");
 
             buffer

--- a/crates/zed/src/languages/c.rs
+++ b/crates/zed/src/languages/c.rs
@@ -269,21 +269,17 @@ mod tests {
 
             // indent inside braces
             let ix = buffer.len() - 1;
-            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "int main() {\n  \n}");
 
             // indent body of single-statement if statement
             let ix = buffer.len() - 2;
-            buffer.edit(
-                [(ix..ix, "if (a)\nb;")],
-                Some(AutoindentMode::Independent),
-                cx,
-            );
+            buffer.edit([(ix..ix, "if (a)\nb;")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b;\n}");
 
             // indent inside field expression
             let ix = buffer.len() - 3;
-            buffer.edit([(ix..ix, "\n.c")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n.c")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b\n      .c;\n}");
 
             buffer

--- a/crates/zed/src/languages/python.rs
+++ b/crates/zed/src/languages/python.rs
@@ -163,7 +163,7 @@ mod tests {
             let mut buffer = Buffer::new(0, "", cx).with_language(Arc::new(language), cx);
             let append = |buffer: &mut Buffer, text: &str, cx: &mut ModelContext<Buffer>| {
                 let ix = buffer.len();
-                buffer.edit([(ix..ix, text)], Some(AutoindentMode::Independent), cx);
+                buffer.edit([(ix..ix, text)], Some(AutoindentMode::EachLine), cx);
             };
 
             // indent after "def():"
@@ -209,7 +209,7 @@ mod tests {
             let argument_ix = buffer.text().find("1").unwrap();
             buffer.edit(
                 [(argument_ix..argument_ix + 1, "")],
-                Some(AutoindentMode::Independent),
+                Some(AutoindentMode::EachLine),
                 cx,
             );
             assert_eq!(
@@ -228,7 +228,7 @@ mod tests {
             let end_whitespace_ix = buffer.len() - 4;
             buffer.edit(
                 [(end_whitespace_ix..buffer.len(), "")],
-                Some(AutoindentMode::Independent),
+                Some(AutoindentMode::EachLine),
                 cx,
             );
             assert_eq!(

--- a/crates/zed/src/languages/python.rs
+++ b/crates/zed/src/languages/python.rs
@@ -147,7 +147,7 @@ impl LspAdapter for PythonLspAdapter {
 #[cfg(test)]
 mod tests {
     use gpui::{ModelContext, MutableAppContext};
-    use language::Buffer;
+    use language::{AutoindentMode, Buffer};
     use settings::Settings;
     use std::sync::Arc;
 
@@ -163,7 +163,7 @@ mod tests {
             let mut buffer = Buffer::new(0, "", cx).with_language(Arc::new(language), cx);
             let append = |buffer: &mut Buffer, text: &str, cx: &mut ModelContext<Buffer>| {
                 let ix = buffer.len();
-                buffer.edit_with_autoindent([(ix..ix, text)], cx);
+                buffer.edit([(ix..ix, text)], Some(AutoindentMode::Independent), cx);
             };
 
             // indent after "def():"
@@ -207,7 +207,11 @@ mod tests {
 
             // dedent the closing paren if it is shifted to the beginning of the line
             let argument_ix = buffer.text().find("1").unwrap();
-            buffer.edit_with_autoindent([(argument_ix..argument_ix + 1, "")], cx);
+            buffer.edit(
+                [(argument_ix..argument_ix + 1, "")],
+                Some(AutoindentMode::Independent),
+                cx,
+            );
             assert_eq!(
                 buffer.text(),
                 "def a():\n  \n  if a:\n    b()\n  else:\n    foo(\n    )"
@@ -222,7 +226,11 @@ mod tests {
 
             // manually outdent the last line
             let end_whitespace_ix = buffer.len() - 4;
-            buffer.edit_with_autoindent([(end_whitespace_ix..buffer.len(), "")], cx);
+            buffer.edit(
+                [(end_whitespace_ix..buffer.len(), "")],
+                Some(AutoindentMode::Independent),
+                cx,
+            );
             assert_eq!(
                 buffer.text(),
                 "def a():\n  \n  if a:\n    b()\n  else:\n    foo(\n    )\n"
@@ -236,7 +244,7 @@ mod tests {
             );
 
             // reset to a simple if statement
-            buffer.edit([(0..buffer.len(), "if a:\n  b(\n  )")], cx);
+            buffer.edit([(0..buffer.len(), "if a:\n  b(\n  )")], None, cx);
 
             // dedent "else" on the line after a closing paren
             append(&mut buffer, "\n  else:\n", cx);

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -444,29 +444,29 @@ mod tests {
             // indent between braces
             buffer.set_text("fn a() {}", cx);
             let ix = buffer.len() - 1;
-            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "fn a() {\n  \n}");
 
             // indent between braces, even after empty lines
             buffer.set_text("fn a() {\n\n\n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "fn a() {\n\n\n  \n}");
 
             // indent a line that continues a field expression
             buffer.set_text("fn a() {\n  \n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "b\n.c")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "b\n.c")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n}");
 
             // indent further lines that continue the field expression, even after empty lines
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "\n\n.d")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n\n.d")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n    \n    .d\n}");
 
             // dedent the line after the field expression
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, ";\ne")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, ";\ne")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(
                 buffer.text(),
                 "fn a() {\n  b\n    .c\n    \n    .d;\n  e\n}"
@@ -475,21 +475,17 @@ mod tests {
             // indent inside a struct within a call
             buffer.set_text("const a: B = c(D {});", cx);
             let ix = buffer.len() - 3;
-            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "const a: B = c(D {\n  \n});");
 
             // indent further inside a nested call
             let ix = buffer.len() - 4;
-            buffer.edit(
-                [(ix..ix, "e: f(\n\n)")],
-                Some(AutoindentMode::Independent),
-                cx,
-            );
+            buffer.edit([(ix..ix, "e: f(\n\n)")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(buffer.text(), "const a: B = c(D {\n  e: f(\n    \n  )\n});");
 
             // keep that indent after an empty line
             let ix = buffer.len() - 8;
-            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::Independent), cx);
+            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::EachLine), cx);
             assert_eq!(
                 buffer.text(),
                 "const a: B = c(D {\n  e: f(\n    \n    \n  )\n});"

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -444,29 +444,29 @@ mod tests {
             // indent between braces
             buffer.set_text("fn a() {}", cx);
             let ix = buffer.len() - 1;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n")], cx);
+            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "fn a() {\n  \n}");
 
             // indent between braces, even after empty lines
             buffer.set_text("fn a() {\n\n\n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "\n")], cx);
+            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "fn a() {\n\n\n  \n}");
 
             // indent a line that continues a field expression
             buffer.set_text("fn a() {\n  \n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "b\n.c")], cx);
+            buffer.edit([(ix..ix, "b\n.c")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n}");
 
             // indent further lines that continue the field expression, even after empty lines
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n.d")], cx);
+            buffer.edit([(ix..ix, "\n\n.d")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n    \n    .d\n}");
 
             // dedent the line after the field expression
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, ";\ne")], cx);
+            buffer.edit([(ix..ix, ";\ne")], Some(AutoindentMode::Independent), cx);
             assert_eq!(
                 buffer.text(),
                 "fn a() {\n  b\n    .c\n    \n    .d;\n  e\n}"
@@ -475,17 +475,21 @@ mod tests {
             // indent inside a struct within a call
             buffer.set_text("const a: B = c(D {});", cx);
             let ix = buffer.len() - 3;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n")], cx);
+            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::Independent), cx);
             assert_eq!(buffer.text(), "const a: B = c(D {\n  \n});");
 
             // indent further inside a nested call
             let ix = buffer.len() - 4;
-            buffer.edit_with_autoindent([(ix..ix, "e: f(\n\n)")], cx);
+            buffer.edit(
+                [(ix..ix, "e: f(\n\n)")],
+                Some(AutoindentMode::Independent),
+                cx,
+            );
             assert_eq!(buffer.text(), "const a: B = c(D {\n  e: f(\n    \n  )\n});");
 
             // keep that indent after an empty line
             let ix = buffer.len() - 8;
-            buffer.edit_with_autoindent([(ix..ix, "\n")], cx);
+            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::Independent), cx);
             assert_eq!(
                 buffer.text(),
                 "const a: B = c(D {\n  e: f(\n    \n    \n  )\n});"

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -257,6 +257,7 @@ mod tests {
     use super::*;
     use crate::languages::{language, CachedLspAdapter};
     use gpui::{color::Color, MutableAppContext};
+    use settings::Settings;
     use theme::SyntaxTheme;
 
     #[gpui::test]
@@ -433,37 +434,39 @@ mod tests {
     fn test_rust_autoindent(cx: &mut MutableAppContext) {
         cx.foreground().set_block_on_ticks(usize::MAX..=usize::MAX);
         let language = crate::languages::language("rust", tree_sitter_rust::language(), None);
+        let mut settings = Settings::test(cx);
+        settings.editor_overrides.tab_size = Some(2.try_into().unwrap());
+        cx.set_global(settings);
 
         cx.add_model(|cx| {
             let mut buffer = Buffer::new(0, "", cx).with_language(Arc::new(language), cx);
-            let size = IndentSize::spaces(2);
 
             // indent between braces
             buffer.set_text("fn a() {}", cx);
             let ix = buffer.len() - 1;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n\n")], cx);
             assert_eq!(buffer.text(), "fn a() {\n  \n}");
 
             // indent between braces, even after empty lines
             buffer.set_text("fn a() {\n\n\n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "\n")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n")], cx);
             assert_eq!(buffer.text(), "fn a() {\n\n\n  \n}");
 
             // indent a line that continues a field expression
             buffer.set_text("fn a() {\n  \n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "b\n.c")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "b\n.c")], cx);
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n}");
 
             // indent further lines that continue the field expression, even after empty lines
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n.d")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n\n.d")], cx);
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n    \n    .d\n}");
 
             // dedent the line after the field expression
             let ix = buffer.len() - 2;
-            buffer.edit_with_autoindent([(ix..ix, ";\ne")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, ";\ne")], cx);
             assert_eq!(
                 buffer.text(),
                 "fn a() {\n  b\n    .c\n    \n    .d;\n  e\n}"
@@ -472,17 +475,17 @@ mod tests {
             // indent inside a struct within a call
             buffer.set_text("const a: B = c(D {});", cx);
             let ix = buffer.len() - 3;
-            buffer.edit_with_autoindent([(ix..ix, "\n\n")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n\n")], cx);
             assert_eq!(buffer.text(), "const a: B = c(D {\n  \n});");
 
             // indent further inside a nested call
             let ix = buffer.len() - 4;
-            buffer.edit_with_autoindent([(ix..ix, "e: f(\n\n)")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "e: f(\n\n)")], cx);
             assert_eq!(buffer.text(), "const a: B = c(D {\n  e: f(\n    \n  )\n});");
 
             // keep that indent after an empty line
             let ix = buffer.len() - 8;
-            buffer.edit_with_autoindent([(ix..ix, "\n")], size, cx);
+            buffer.edit_with_autoindent([(ix..ix, "\n")], cx);
             assert_eq!(
                 buffer.text(),
                 "const a: B = c(D {\n  e: f(\n    \n    \n  )\n});"


### PR DESCRIPTION
### Description of feature or change

Previously, when inserting multiple lines of text, we would auto-indent each of those lines according to the current language's indentation rules. But when pasting text, people generally expect the text's *relative* indentation to be preserved. This PR restructures auto-indent accordingly. We now calculate the indentation suggestion for the *first line* of an insertion, and then adjust the entire insertion's indentation uniformly.

Aside from this problem, there were several bugs in how we decided which text to indent, which this PR also fixes.


### Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/321

### Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
