### PR TITLE
Fix IME regressions

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -14,30 +14,30 @@
             "k": "vim::Up",
             "l": "vim::Right",
             "0": "vim::StartOfLine",
-            "shift-$": "vim::EndOfLine",
-            "shift-G": "vim::EndOfDocument",
+            "$": "vim::EndOfLine",
+            "shift-g": "vim::EndOfDocument",
             "w": "vim::NextWordStart",
-            "shift-W": [
+            "shift-w": [
                 "vim::NextWordStart",
                 {
                     "ignorePunctuation": true
                 }
             ],
             "e": "vim::NextWordEnd",
-            "shift-E": [
+            "shift-e": [
                 "vim::NextWordEnd",
                 {
                     "ignorePunctuation": true
                 }
             ],
             "b": "vim::PreviousWordStart",
-            "shift-B": [
+            "shift-b": [
                 "vim::PreviousWordStart",
                 {
                     "ignorePunctuation": true
                 }
             ],
-            "shift-%": "vim::Matching",
+            "%": "vim::Matching",
             "escape": "editor::Cancel"
         }
     },
@@ -48,12 +48,12 @@
                 "vim::PushOperator",
                 "Change"
             ],
-            "shift-C": "vim::ChangeToEndOfLine",
+            "shift-c": "vim::ChangeToEndOfLine",
             "d": [
                 "vim::PushOperator",
                 "Delete"
             ],
-            "shift-D": "vim::DeleteToEndOfLine",
+            "shift-d": "vim::DeleteToEndOfLine",
             "y": [
                 "vim::PushOperator",
                 "Yank"
@@ -62,14 +62,14 @@
                 "vim::SwitchMode",
                 "Insert"
             ],
-            "shift-I": "vim::InsertFirstNonWhitespace",
+            "shift-i": "vim::InsertFirstNonWhitespace",
             "a": "vim::InsertAfter",
-            "shift-A": "vim::InsertEndOfLine",
+            "shift-a": "vim::InsertEndOfLine",
             "x": "vim::DeleteRight",
-            "shift-X": "vim::DeleteLeft",
-            "shift-^": "vim::FirstNonWhitespace",
+            "shift-x": "vim::DeleteLeft",
+            "^": "vim::FirstNonWhitespace",
             "o": "vim::InsertLineBelow",
-            "shift-O": "vim::InsertLineAbove",
+            "shift-o": "vim::InsertLineAbove",
             "v": [
                 "vim::SwitchMode",
                 {
@@ -78,7 +78,7 @@
                     }
                 }
             ],
-            "shift-V": [
+            "shift-v": [
                 "vim::SwitchMode",
                 {
                     "Visual": {
@@ -113,7 +113,7 @@
         "context": "Editor && vim_operator == c",
         "bindings": {
             "w": "vim::ChangeWord",
-            "shift-W": [
+            "shift-w": [
                 "vim::ChangeWord",
                 {
                     "ignorePunctuation": true

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -41,6 +41,7 @@ pub struct Keystroke {
     pub alt: bool,
     pub shift: bool,
     pub cmd: bool,
+    pub function: bool,
     pub key: String,
 }
 
@@ -277,6 +278,7 @@ impl Keystroke {
         let mut alt = false;
         let mut shift = false;
         let mut cmd = false;
+        let mut function = false;
         let mut key = None;
 
         let mut components = source.split("-").peekable();
@@ -286,6 +288,7 @@ impl Keystroke {
                 "alt" => alt = true,
                 "shift" => shift = true,
                 "cmd" => cmd = true,
+                "fn" => function = true,
                 _ => {
                     if let Some(component) = components.peek() {
                         if component.is_empty() && source.ends_with('-') {
@@ -306,6 +309,7 @@ impl Keystroke {
             alt,
             shift,
             cmd,
+            function,
             key: key.unwrap(),
         })
     }
@@ -464,6 +468,7 @@ mod tests {
                 alt: false,
                 shift: false,
                 cmd: false,
+                function: false,
             }
         );
 
@@ -475,6 +480,7 @@ mod tests {
                 alt: true,
                 shift: true,
                 cmd: false,
+                function: false,
             }
         );
 
@@ -486,6 +492,7 @@ mod tests {
                 alt: false,
                 shift: true,
                 cmd: true,
+                function: false,
             }
         );
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -184,6 +184,7 @@ impl MacForegroundPlatform {
                             (keystroke.cmd, NSEventModifierFlags::NSCommandKeyMask),
                             (keystroke.ctrl, NSEventModifierFlags::NSControlKeyMask),
                             (keystroke.alt, NSEventModifierFlags::NSAlternateKeyMask),
+                            (keystroke.shift, NSEventModifierFlags::NSShiftKeyMask),
                         ] {
                             if *modifier {
                                 mask |= *flag;

--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -311,6 +311,7 @@ mod test {
             alt: false,
             shift: false,
             cmd: false,
+            function: false,
             key: "🖖🏻".to_string(), //2 char string
         };
         assert_eq!(to_esc_str(&ks, &TermMode::NONE), None);

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -427,7 +427,7 @@ mod test {
     #[gpui::test]
     async fn test_jump_to_line_boundaries(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-$"]);
+        let mut cx = cx.binding(["$"]);
         cx.assert("T|est test", "Test tes|t");
         cx.assert("Test tes|t", "Test tes|t");
         cx.assert(
@@ -471,7 +471,7 @@ mod test {
     #[gpui::test]
     async fn test_jump_to_end(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-G"]);
+        let mut cx = cx.binding(["shift-g"]);
 
         cx.assert(
             indoc! {"
@@ -561,7 +561,7 @@ mod test {
         );
 
         for cursor_offset in cursor_offsets {
-            cx.simulate_keystroke("shift-W");
+            cx.simulate_keystroke("shift-w");
             cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
     }
@@ -607,7 +607,7 @@ mod test {
             Mode::Normal,
         );
         for cursor_offset in cursor_offsets {
-            cx.simulate_keystroke("shift-E");
+            cx.simulate_keystroke("shift-e");
             cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
     }
@@ -653,7 +653,7 @@ mod test {
             Mode::Normal,
         );
         for cursor_offset in cursor_offsets.into_iter().rev() {
-            cx.simulate_keystroke("shift-B");
+            cx.simulate_keystroke("shift-b");
             cx.assert_editor_selections(vec![Selection::from_offset(cursor_offset)]);
         }
     }
@@ -740,7 +740,7 @@ mod test {
     #[gpui::test]
     async fn test_insert_end_of_line(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-A"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["shift-a"]).mode_after(Mode::Insert);
         cx.assert("The q|uick", "The quick|");
         cx.assert("The q|uick ", "The quick |");
         cx.assert("|", "|");
@@ -765,7 +765,7 @@ mod test {
     #[gpui::test]
     async fn test_jump_to_first_non_whitespace(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-^"]);
+        let mut cx = cx.binding(["^"]);
         cx.assert("The q|uick", "|The quick");
         cx.assert(" The q|uick", " |The quick");
         cx.assert("|", "|");
@@ -792,7 +792,7 @@ mod test {
     #[gpui::test]
     async fn test_insert_first_non_whitespace(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-I"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["shift-i"]).mode_after(Mode::Insert);
         cx.assert("The q|uick", "|The quick");
         cx.assert(" The q|uick", " |The quick");
         cx.assert("|", "|");
@@ -817,7 +817,7 @@ mod test {
     #[gpui::test]
     async fn test_delete_to_end_of_line(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-D"]);
+        let mut cx = cx.binding(["shift-d"]);
         cx.assert(
             indoc! {"
                 The q|uick
@@ -858,7 +858,7 @@ mod test {
     #[gpui::test]
     async fn test_delete_left(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-X"]);
+        let mut cx = cx.binding(["shift-x"]);
         cx.assert("Te|st", "T|st");
         cx.assert("T|est", "|est");
         cx.assert("|Test", "|Test");
@@ -956,7 +956,7 @@ mod test {
     #[gpui::test]
     async fn test_insert_line_above(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-O"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["shift-o"]).mode_after(Mode::Insert);
 
         cx.assert(
             "|",

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -139,7 +139,7 @@ mod test {
                 test"},
         );
 
-        let mut cx = cx.binding(["c", "shift-W"]);
+        let mut cx = cx.binding(["c", "shift-w"]);
         cx.assert("Test te|st-test test", "Test te| test");
     }
 
@@ -174,7 +174,7 @@ mod test {
                 test"},
         );
 
-        let mut cx = cx.binding(["c", "shift-E"]);
+        let mut cx = cx.binding(["c", "shift-e"]);
         cx.assert("Test te|st-test test", "Test te| test");
     }
 
@@ -204,14 +204,14 @@ mod test {
                 test"},
         );
 
-        let mut cx = cx.binding(["c", "shift-B"]);
+        let mut cx = cx.binding(["c", "shift-b"]);
         cx.assert("Test test-test |test", "Test |test");
     }
 
     #[gpui::test]
     async fn test_change_end_of_line(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["c", "shift-$"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["c", "$"]).mode_after(Mode::Insert);
         cx.assert(
             indoc! {"
                 The q|uick
@@ -347,7 +347,7 @@ mod test {
     #[gpui::test]
     async fn test_change_end_of_document(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["c", "shift-G"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["c", "shift-g"]).mode_after(Mode::Insert);
         cx.assert(
             indoc! {"
                 The quick

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -109,7 +109,7 @@ mod test {
                 test"},
         );
 
-        let mut cx = cx.binding(["d", "shift-W"]);
+        let mut cx = cx.binding(["d", "shift-w"]);
         cx.assert("Test te|st-test test", "Test te|test");
     }
 
@@ -144,7 +144,7 @@ mod test {
                 test"},
         );
 
-        let mut cx = cx.binding(["d", "shift-E"]);
+        let mut cx = cx.binding(["d", "shift-e"]);
         cx.assert("Test te|st-test test", "Test te| test");
     }
 
@@ -176,14 +176,14 @@ mod test {
                 test"},
         );
 
-        let mut cx = cx.binding(["d", "shift-B"]);
+        let mut cx = cx.binding(["d", "shift-b"]);
         cx.assert("Test test-test |test", "Test |test");
     }
 
     #[gpui::test]
     async fn test_delete_end_of_line(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["d", "shift-$"]);
+        let mut cx = cx.binding(["d", "$"]);
         cx.assert(
             indoc! {"
                 The q|uick
@@ -304,7 +304,7 @@ mod test {
     #[gpui::test]
     async fn test_delete_end_of_document(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["d", "shift-G"]);
+        let mut cx = cx.binding(["d", "shift-g"]);
         cx.assert(
             indoc! {"
                 The quick

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -422,7 +422,7 @@ mod test {
     #[gpui::test]
     async fn test_visual_line_delete(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-V", "x"]);
+        let mut cx = cx.binding(["shift-v", "x"]);
         cx.assert(
             indoc! {"
                 The qu|ick brown
@@ -457,7 +457,7 @@ mod test {
                 The quick brown
                 fox ju|mps over"},
         );
-        let mut cx = cx.binding(["shift-V", "j", "x"]);
+        let mut cx = cx.binding(["shift-v", "j", "x"]);
         cx.assert(
             indoc! {"
                 The qu|ick brown
@@ -558,7 +558,7 @@ mod test {
     #[gpui::test]
     async fn test_visual_line_change(cx: &mut gpui::TestAppContext) {
         let cx = VimTestContext::new(cx, true).await;
-        let mut cx = cx.binding(["shift-V", "c"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["shift-v", "c"]).mode_after(Mode::Insert);
         cx.assert(
             indoc! {"
                 The qu|ick brown
@@ -597,7 +597,7 @@ mod test {
                 fox jumps over
                 |"},
         );
-        let mut cx = cx.binding(["shift-V", "j", "c"]).mode_after(Mode::Insert);
+        let mut cx = cx.binding(["shift-v", "j", "c"]).mode_after(Mode::Insert);
         cx.assert(
             indoc! {"
                 The qu|ick brown


### PR DESCRIPTION
## Description of feature or change

This pull request addresses several regressions that occurred as a result of #1395:

- Shift wasn't being shown in the application menu shortcuts (fe7ba09d528221c67adf7532f800638c0f2e2d6a)
- Some vim bindings were not updated and still used uppercase letters or their shift variants when `shift` was pressed (5c5e7db587864e7e48a79f21c521247802b918f4)
- System key bindings such as ``Cmd-` `` were not being honored because we would always report `performKeyEquivalent` as handled. We will now dispatch application menu events if a custom key equivalent wasn't found (d3f14fb1c21a927338d2405d4d63f76a78df69d0 and 6a718dc4da4f6bd1bf5cfea95956b454a951205f)

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/391

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
