### PR TITLE
Add on_child_focus and on_child_blur to View trait

### DIFF
--- a/crates/chat_panel/src/chat_panel.rs
+++ b/crates/chat_panel/src/chat_panel.rs
@@ -8,8 +8,8 @@ use gpui::{
     elements::*,
     platform::CursorStyle,
     views::{ItemType, Select, SelectStyle},
-    AppContext, Entity, ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription,
-    Task, View, ViewContext, ViewHandle,
+    AnyViewHandle, AppContext, Entity, ModelHandle, MouseButton, MutableAppContext, RenderContext,
+    Subscription, Task, View, ViewContext, ViewHandle,
 };
 use menu::Confirm;
 use postage::prelude::Stream;
@@ -397,7 +397,7 @@ impl View for ChatPanel {
         .boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         if matches!(
             *self.rpc.status().borrow(),
             client::Status::Connected { .. }

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -86,8 +86,8 @@ impl CommandPalette {
         let focused_view_id = cx.focused_view_id(window_id).unwrap_or(workspace.id());
 
         cx.as_mut().defer(move |cx| {
+            let this = cx.add_view(workspace.clone(), |cx| Self::new(focused_view_id, cx));
             workspace.update(cx, |workspace, cx| {
-                let this = cx.add_view(|cx| Self::new(focused_view_id, cx));
                 workspace.toggle_modal(cx, |_, cx| {
                     cx.subscribe(&this, Self::on_event).detach();
                     this

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -4,7 +4,8 @@ use gpui::{
     actions,
     elements::{ChildView, Flex, Label, ParentElement},
     keymap::Keystroke,
-    Action, Element, Entity, MouseState, MutableAppContext, View, ViewContext, ViewHandle,
+    Action, AnyViewHandle, Element, Entity, MouseState, MutableAppContext, View, ViewContext,
+    ViewHandle,
 };
 use picker::{Picker, PickerDelegate};
 use settings::Settings;
@@ -132,7 +133,7 @@ impl View for CommandPalette {
         ChildView::new(self.picker.clone()).boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.picker);
     }
 }

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -134,7 +134,9 @@ impl View for CommandPalette {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.picker);
+        if cx.is_self_focused() {
+            cx.focus(&self.picker);
+        }
     }
 }
 

--- a/crates/contacts_panel/src/contact_finder.rs
+++ b/crates/contacts_panel/src/contact_finder.rs
@@ -1,7 +1,7 @@
 use client::{ContactRequestStatus, User, UserStore};
 use gpui::{
-    actions, elements::*, Entity, ModelHandle, MouseState, MutableAppContext, RenderContext, Task,
-    View, ViewContext, ViewHandle,
+    actions, elements::*, AnyViewHandle, Entity, ModelHandle, MouseState, MutableAppContext,
+    RenderContext, Task, View, ViewContext, ViewHandle,
 };
 use picker::{Picker, PickerDelegate};
 use settings::Settings;
@@ -42,7 +42,7 @@ impl View for ContactFinder {
         ChildView::new(self.picker.clone()).boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.picker);
     }
 }

--- a/crates/contacts_panel/src/contacts_panel.rs
+++ b/crates/contacts_panel/src/contacts_panel.rs
@@ -1248,8 +1248,8 @@ mod tests {
             .0
             .read_with(cx, |worktree, _| worktree.id().to_proto());
 
-        let workspace = cx.add_view(0, |cx| Workspace::new(project.clone(), cx));
-        let panel = cx.add_view(0, |cx| {
+        let (_, workspace) = cx.add_window(|cx| Workspace::new(project.clone(), cx));
+        let panel = cx.add_view(&workspace, |cx| {
             ContactsPanel::new(
                 user_store.clone(),
                 project_store.clone(),

--- a/crates/contacts_panel/src/contacts_panel.rs
+++ b/crates/contacts_panel/src/contacts_panel.rs
@@ -13,9 +13,9 @@ use gpui::{
     geometry::{rect::RectF, vector::vec2f},
     impl_actions, impl_internal_actions,
     platform::CursorStyle,
-    AppContext, ClipboardItem, Element, ElementBox, Entity, ModelHandle, MouseButton,
-    MutableAppContext, RenderContext, Subscription, View, ViewContext, ViewHandle, WeakModelHandle,
-    WeakViewHandle,
+    AnyViewHandle, AppContext, ClipboardItem, Element, ElementBox, Entity, ModelHandle,
+    MouseButton, MutableAppContext, RenderContext, Subscription, View, ViewContext, ViewHandle,
+    WeakModelHandle, WeakViewHandle,
 };
 use join_project_notification::JoinProjectNotification;
 use menu::{Confirm, SelectNext, SelectPrev};
@@ -1152,7 +1152,7 @@ impl View for ContactsPanel {
         .boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.filter_editor);
     }
 

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -1,6 +1,6 @@
 use gpui::{
     elements::*, geometry::vector::Vector2F, impl_internal_actions, keymap, platform::CursorStyle,
-    Action, AppContext, Axis, Entity, MouseButton, MutableAppContext, RenderContext,
+    Action, AnyViewHandle, AppContext, Axis, Entity, MouseButton, MutableAppContext, RenderContext,
     SizeConstraint, Subscription, View, ViewContext,
 };
 use menu::*;
@@ -106,7 +106,7 @@ impl View for ContextMenu {
             .boxed()
     }
 
-    fn on_blur(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_out(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         self.reset(cx);
     }
 }

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -156,9 +156,7 @@ impl ContextMenu {
     fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
         if let Some(ix) = self.selected_index {
             if let Some(ContextMenuItem::Item { action, .. }) = self.items.get(ix) {
-                let window_id = cx.window_id();
-                let view_id = cx.view_id();
-                cx.dispatch_action_at(window_id, view_id, action.as_ref());
+                cx.dispatch_any_action(action.boxed_clone());
                 self.reset(cx);
             }
         }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -786,7 +786,7 @@ mod tests {
             .await;
 
         let project = Project::test(app_state.fs.clone(), ["/test".as_ref()], cx).await;
-        let workspace = cx.add_view(0, |cx| Workspace::new(project.clone(), cx));
+        let (_, workspace) = cx.add_window(|cx| Workspace::new(project.clone(), cx));
 
         // Create some diagnostics
         project.update(cx, |project, cx| {
@@ -873,7 +873,7 @@ mod tests {
         });
 
         // Open the project diagnostics view while there are already diagnostics.
-        let view = cx.add_view(0, |cx| {
+        let view = cx.add_view(&workspace, |cx| {
             ProjectDiagnosticsEditor::new(project.clone(), workspace.downgrade(), cx)
         });
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -568,10 +568,6 @@ impl workspace::Item for ProjectDiagnosticsEditor {
         unreachable!()
     }
 
-    fn should_activate_item_on_event(event: &Self::Event) -> bool {
-        Editor::should_activate_item_on_event(event)
-    }
-
     fn should_update_tab_on_event(event: &Event) -> bool {
         Editor::should_update_tab_on_event(event)
     }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -99,7 +99,7 @@ impl View for ProjectDiagnosticsEditor {
         }
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         if !self.path_states.is_empty() {
             cx.focus(&self.editor);
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1561,7 +1561,6 @@ impl Editor {
     ) {
         if !self.focused {
             cx.focus_self();
-            cx.emit(Event::Activate);
         }
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
@@ -1623,7 +1622,6 @@ impl Editor {
     ) {
         if !self.focused {
             cx.focus_self();
-            cx.emit(Event::Activate);
         }
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
@@ -5969,7 +5967,6 @@ fn compute_scroll_position(
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Event {
-    Activate,
     BufferEdited,
     Edited,
     Reparsed,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -29,8 +29,8 @@ use gpui::{
     geometry::vector::{vec2f, Vector2F},
     impl_actions, impl_internal_actions,
     platform::CursorStyle,
-    text_layout, AppContext, AsyncAppContext, ClipboardItem, Element, ElementBox, Entity,
-    ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription, Task, View,
+    text_layout, AnyViewHandle, AppContext, AsyncAppContext, ClipboardItem, Element, ElementBox,
+    Entity, ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription, Task, View,
     ViewContext, ViewHandle, WeakViewHandle,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
@@ -6025,7 +6025,7 @@ impl View for Editor {
         "Editor"
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         let focused_event = EditorFocused(cx.handle());
         cx.emit_global(focused_event);
         if let Some(rename) = self.pending_rename.as_ref() {
@@ -6046,7 +6046,7 @@ impl View for Editor {
         }
     }
 
-    fn on_blur(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_out(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         let blurred_event = EditorBlurred(cx.handle());
         cx.emit_global(blurred_event);
         self.focused = false;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7099,10 +7099,10 @@ mod tests {
     fn test_navigation_history(cx: &mut gpui::MutableAppContext) {
         cx.set_global(Settings::test(cx));
         use workspace::Item;
-        let pane = cx.add_view(Default::default(), |cx| Pane::new(cx));
+        let (_, pane) = cx.add_window(Default::default(), |cx| Pane::new(cx));
         let buffer = MultiBuffer::build_simple(&sample_text(300, 5, 'a'), cx);
 
-        cx.add_window(Default::default(), |cx| {
+        cx.add_view(&pane, |cx| {
             let mut editor = build_editor(buffer.clone(), cx);
             let handle = cx.handle();
             editor.set_nav_history(Some(pane.read(cx).nav_history_for_item(&handle)));

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -469,10 +469,6 @@ impl Item for Editor {
         })
     }
 
-    fn should_activate_item_on_event(event: &Event) -> bool {
-        matches!(event, Event::Activate)
-    }
-
     fn should_close_item_on_event(event: &Event) -> bool {
         matches!(event, Event::Closed)
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -54,8 +54,8 @@ impl FollowableItem for Editor {
                     })
                 })
                 .unwrap_or_else(|| {
-                    cx.add_view(pane.window_id(), |cx| {
-                        Editor::for_buffer(buffer, Some(project), cx)
+                    pane.update(&mut cx, |_, cx| {
+                        cx.add_view(|cx| Editor::for_buffer(buffer, Some(project), cx))
                     })
                 });
             editor.update(&mut cx, |editor, cx| {

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -8,8 +8,8 @@ use util::TryFutureExt;
 use workspace::Workspace;
 
 use crate::{
-    Anchor, DisplayPoint, Editor, EditorSnapshot, Event, GoToDefinition, GoToTypeDefinition,
-    Select, SelectPhase,
+    Anchor, DisplayPoint, Editor, EditorSnapshot, GoToDefinition, GoToTypeDefinition, Select,
+    SelectPhase,
 };
 
 #[derive(Clone, PartialEq)]
@@ -355,7 +355,6 @@ fn go_to_fetched_definition_of_kind(
         editor_handle.update(cx, |editor, cx| {
             if !editor.focused {
                 cx.focus_self();
-                cx.emit(Event::Activate);
             }
         });
 

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -2,7 +2,7 @@ use context_menu::ContextMenuItem;
 use gpui::{geometry::vector::Vector2F, impl_internal_actions, MutableAppContext, ViewContext};
 
 use crate::{
-    DisplayPoint, Editor, EditorMode, Event, FindAllReferences, GoToDefinition, GoToTypeDefinition,
+    DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition, GoToTypeDefinition,
     Rename, SelectMode, ToggleCodeActions,
 };
 
@@ -25,7 +25,6 @@ pub fn deploy_context_menu(
 ) {
     if !editor.focused {
         cx.focus_self();
-        cx.emit(Event::Activate);
     }
 
     // Don't show context menu for inline editors

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -54,7 +54,9 @@ impl View for FileFinder {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.picker);
+        if cx.is_self_focused() {
+            cx.focus(&self.picker);
+        }
     }
 }
 

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1,7 +1,7 @@
 use fuzzy::PathMatch;
 use gpui::{
-    actions, elements::*, AppContext, Entity, ModelHandle, MouseState, MutableAppContext,
-    RenderContext, Task, View, ViewContext, ViewHandle,
+    actions, elements::*, AnyViewHandle, AppContext, Entity, ModelHandle, MouseState,
+    MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle,
 };
 use picker::{Picker, PickerDelegate};
 use project::{PathMatchCandidateSet, Project, ProjectPath, WorktreeId};
@@ -53,7 +53,7 @@ impl View for FileFinder {
         ChildView::new(self.picker.clone()).boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.picker);
     }
 }

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -1,7 +1,7 @@
 use editor::{display_map::ToDisplayPoint, Autoscroll, DisplayPoint, Editor};
 use gpui::{
-    actions, elements::*, geometry::vector::Vector2F, Axis, Entity, MutableAppContext,
-    RenderContext, View, ViewContext, ViewHandle,
+    actions, elements::*, geometry::vector::Vector2F, AnyViewHandle, Axis, Entity,
+    MutableAppContext, RenderContext, View, ViewContext, ViewHandle,
 };
 use menu::{Cancel, Confirm};
 use settings::Settings;
@@ -183,7 +183,7 @@ impl View for GoToLine {
         .named("go to line")
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.line_editor);
     }
 }

--- a/crates/gpui/grammars/context-predicate/src/parser.c
+++ b/crates/gpui/grammars/context-predicate/src/parser.c
@@ -35,115 +35,132 @@ enum {
   sym_parenthesized = 16,
 };
 
-static const char * const ts_symbol_names[] = {
-  [ts_builtin_sym_end] = "end",
-  [sym_identifier] = "identifier",
-  [anon_sym_BANG] = "!",
-  [anon_sym_AMP_AMP] = "&&",
-  [anon_sym_PIPE_PIPE] = "||",
-  [anon_sym_EQ_EQ] = "==",
-  [anon_sym_BANG_EQ] = "!=",
-  [anon_sym_LPAREN] = "(",
-  [anon_sym_RPAREN] = ")",
-  [sym_source] = "source",
-  [sym__expression] = "_expression",
-  [sym_not] = "not",
-  [sym_and] = "and",
-  [sym_or] = "or",
-  [sym_equal] = "equal",
-  [sym_not_equal] = "not_equal",
-  [sym_parenthesized] = "parenthesized",
+static const char *const ts_symbol_names[] = {
+    [ts_builtin_sym_end] = "end",
+    [sym_identifier] = "identifier",
+    [anon_sym_BANG] = "!",
+    [anon_sym_AMP_AMP] = "&&",
+    [anon_sym_PIPE_PIPE] = "||",
+    [anon_sym_EQ_EQ] = "==",
+    [anon_sym_BANG_EQ] = "!=",
+    [anon_sym_LPAREN] = "(",
+    [anon_sym_RPAREN] = ")",
+    [sym_source] = "source",
+    [sym__expression] = "_expression",
+    [sym_not] = "not",
+    [sym_and] = "and",
+    [sym_or] = "or",
+    [sym_equal] = "equal",
+    [sym_not_equal] = "not_equal",
+    [sym_parenthesized] = "parenthesized",
 };
 
 static const TSSymbol ts_symbol_map[] = {
-  [ts_builtin_sym_end] = ts_builtin_sym_end,
-  [sym_identifier] = sym_identifier,
-  [anon_sym_BANG] = anon_sym_BANG,
-  [anon_sym_AMP_AMP] = anon_sym_AMP_AMP,
-  [anon_sym_PIPE_PIPE] = anon_sym_PIPE_PIPE,
-  [anon_sym_EQ_EQ] = anon_sym_EQ_EQ,
-  [anon_sym_BANG_EQ] = anon_sym_BANG_EQ,
-  [anon_sym_LPAREN] = anon_sym_LPAREN,
-  [anon_sym_RPAREN] = anon_sym_RPAREN,
-  [sym_source] = sym_source,
-  [sym__expression] = sym__expression,
-  [sym_not] = sym_not,
-  [sym_and] = sym_and,
-  [sym_or] = sym_or,
-  [sym_equal] = sym_equal,
-  [sym_not_equal] = sym_not_equal,
-  [sym_parenthesized] = sym_parenthesized,
+    [ts_builtin_sym_end] = ts_builtin_sym_end,
+    [sym_identifier] = sym_identifier,
+    [anon_sym_BANG] = anon_sym_BANG,
+    [anon_sym_AMP_AMP] = anon_sym_AMP_AMP,
+    [anon_sym_PIPE_PIPE] = anon_sym_PIPE_PIPE,
+    [anon_sym_EQ_EQ] = anon_sym_EQ_EQ,
+    [anon_sym_BANG_EQ] = anon_sym_BANG_EQ,
+    [anon_sym_LPAREN] = anon_sym_LPAREN,
+    [anon_sym_RPAREN] = anon_sym_RPAREN,
+    [sym_source] = sym_source,
+    [sym__expression] = sym__expression,
+    [sym_not] = sym_not,
+    [sym_and] = sym_and,
+    [sym_or] = sym_or,
+    [sym_equal] = sym_equal,
+    [sym_not_equal] = sym_not_equal,
+    [sym_parenthesized] = sym_parenthesized,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
-  [ts_builtin_sym_end] = {
-    .visible = false,
-    .named = true,
-  },
-  [sym_identifier] = {
-    .visible = true,
-    .named = true,
-  },
-  [anon_sym_BANG] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_AMP_AMP] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_PIPE_PIPE] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_EQ_EQ] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_BANG_EQ] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_LPAREN] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_RPAREN] = {
-    .visible = true,
-    .named = false,
-  },
-  [sym_source] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym__expression] = {
-    .visible = false,
-    .named = true,
-  },
-  [sym_not] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_and] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_or] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_equal] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_not_equal] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_parenthesized] = {
-    .visible = true,
-    .named = true,
-  },
+    [ts_builtin_sym_end] =
+        {
+            .visible = false,
+            .named = true,
+        },
+    [sym_identifier] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [anon_sym_BANG] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [anon_sym_AMP_AMP] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [anon_sym_PIPE_PIPE] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [anon_sym_EQ_EQ] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [anon_sym_BANG_EQ] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [anon_sym_LPAREN] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [anon_sym_RPAREN] =
+        {
+            .visible = true,
+            .named = false,
+        },
+    [sym_source] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [sym__expression] =
+        {
+            .visible = false,
+            .named = true,
+        },
+    [sym_not] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [sym_and] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [sym_or] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [sym_equal] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [sym_not_equal] =
+        {
+            .visible = true,
+            .named = true,
+        },
+    [sym_parenthesized] =
+        {
+            .visible = true,
+            .named = true,
+        },
 };
 
 enum {
@@ -152,340 +169,378 @@ enum {
   field_right = 3,
 };
 
-static const char * const ts_field_names[] = {
-  [0] = NULL,
-  [field_expression] = "expression",
-  [field_left] = "left",
-  [field_right] = "right",
+static const char *const ts_field_names[] = {
+    [0] = NULL,
+    [field_expression] = "expression",
+    [field_left] = "left",
+    [field_right] = "right",
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
-  [1] = {.index = 0, .length = 1},
-  [2] = {.index = 1, .length = 2},
+    [1] = {.index = 0, .length = 1},
+    [2] = {.index = 1, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
-  [0] =
-    {field_expression, 1},
-  [1] =
-    {field_left, 0},
+    [0] = {field_expression, 1},
+    [1] = {field_left, 0},
     {field_right, 2},
 };
 
-static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
-  [0] = {0},
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT]
+                                        [MAX_ALIAS_SEQUENCE_LENGTH] = {
+                                            [0] = {0},
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
-  0,
+    0,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
   eof = lexer->eof(lexer);
   switch (state) {
-    case 0:
-      if (eof) ADVANCE(7);
-      if (lookahead == '!') ADVANCE(10);
-      if (lookahead == '&') ADVANCE(2);
-      if (lookahead == '(') ADVANCE(15);
-      if (lookahead == ')') ADVANCE(16);
-      if (lookahead == '=') ADVANCE(4);
-      if (lookahead == '|') ADVANCE(5);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(0)
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(8);
-      END_STATE();
-    case 1:
-      if (lookahead == '!') ADVANCE(9);
-      if (lookahead == '(') ADVANCE(15);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(1)
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(8);
-      END_STATE();
-    case 2:
-      if (lookahead == '&') ADVANCE(11);
-      END_STATE();
-    case 3:
-      if (lookahead == '=') ADVANCE(14);
-      END_STATE();
-    case 4:
-      if (lookahead == '=') ADVANCE(13);
-      END_STATE();
-    case 5:
-      if (lookahead == '|') ADVANCE(12);
-      END_STATE();
-    case 6:
-      if (eof) ADVANCE(7);
-      if (lookahead == '!') ADVANCE(3);
-      if (lookahead == '&') ADVANCE(2);
-      if (lookahead == ')') ADVANCE(16);
-      if (lookahead == '=') ADVANCE(4);
-      if (lookahead == '|') ADVANCE(5);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(6)
-      END_STATE();
-    case 7:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 8:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(8);
-      END_STATE();
-    case 9:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      END_STATE();
-    case 10:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(14);
-      END_STATE();
-    case 11:
-      ACCEPT_TOKEN(anon_sym_AMP_AMP);
-      END_STATE();
-    case 12:
-      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
-      END_STATE();
-    case 13:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ);
-      END_STATE();
-    case 14:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
-      END_STATE();
-    case 15:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 16:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    default:
-      return false;
+  case 0:
+    if (eof)
+      ADVANCE(7);
+    if (lookahead == '!')
+      ADVANCE(10);
+    if (lookahead == '&')
+      ADVANCE(2);
+    if (lookahead == '(')
+      ADVANCE(15);
+    if (lookahead == ')')
+      ADVANCE(16);
+    if (lookahead == '=')
+      ADVANCE(4);
+    if (lookahead == '|')
+      ADVANCE(5);
+    if (lookahead == '\t' || lookahead == '\n' || lookahead == '\r' ||
+        lookahead == ' ')
+      SKIP(0)
+    if (lookahead == '-' || ('0' <= lookahead && lookahead <= '9') ||
+        ('A' <= lookahead && lookahead <= 'Z') || lookahead == '_' ||
+        ('a' <= lookahead && lookahead <= 'z'))
+      ADVANCE(8);
+    END_STATE();
+  case 1:
+    if (lookahead == '!')
+      ADVANCE(9);
+    if (lookahead == '(')
+      ADVANCE(15);
+    if (lookahead == '\t' || lookahead == '\n' || lookahead == '\r' ||
+        lookahead == ' ')
+      SKIP(1)
+    if (lookahead == '-' || ('0' <= lookahead && lookahead <= '9') ||
+        ('A' <= lookahead && lookahead <= 'Z') || lookahead == '_' ||
+        ('a' <= lookahead && lookahead <= 'z'))
+      ADVANCE(8);
+    END_STATE();
+  case 2:
+    if (lookahead == '&')
+      ADVANCE(11);
+    END_STATE();
+  case 3:
+    if (lookahead == '=')
+      ADVANCE(14);
+    END_STATE();
+  case 4:
+    if (lookahead == '=')
+      ADVANCE(13);
+    END_STATE();
+  case 5:
+    if (lookahead == '|')
+      ADVANCE(12);
+    END_STATE();
+  case 6:
+    if (eof)
+      ADVANCE(7);
+    if (lookahead == '!')
+      ADVANCE(3);
+    if (lookahead == '&')
+      ADVANCE(2);
+    if (lookahead == ')')
+      ADVANCE(16);
+    if (lookahead == '=')
+      ADVANCE(4);
+    if (lookahead == '|')
+      ADVANCE(5);
+    if (lookahead == '\t' || lookahead == '\n' || lookahead == '\r' ||
+        lookahead == ' ')
+      SKIP(6)
+    END_STATE();
+  case 7:
+    ACCEPT_TOKEN(ts_builtin_sym_end);
+    END_STATE();
+  case 8:
+    ACCEPT_TOKEN(sym_identifier);
+    if (lookahead == '-' || ('0' <= lookahead && lookahead <= '9') ||
+        ('A' <= lookahead && lookahead <= 'Z') || lookahead == '_' ||
+        ('a' <= lookahead && lookahead <= 'z'))
+      ADVANCE(8);
+    END_STATE();
+  case 9:
+    ACCEPT_TOKEN(anon_sym_BANG);
+    END_STATE();
+  case 10:
+    ACCEPT_TOKEN(anon_sym_BANG);
+    if (lookahead == '=')
+      ADVANCE(14);
+    END_STATE();
+  case 11:
+    ACCEPT_TOKEN(anon_sym_AMP_AMP);
+    END_STATE();
+  case 12:
+    ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
+    END_STATE();
+  case 13:
+    ACCEPT_TOKEN(anon_sym_EQ_EQ);
+    END_STATE();
+  case 14:
+    ACCEPT_TOKEN(anon_sym_BANG_EQ);
+    END_STATE();
+  case 15:
+    ACCEPT_TOKEN(anon_sym_LPAREN);
+    END_STATE();
+  case 16:
+    ACCEPT_TOKEN(anon_sym_RPAREN);
+    END_STATE();
+  default:
+    return false;
   }
 }
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
-  [0] = {.lex_state = 0},
-  [1] = {.lex_state = 1},
-  [2] = {.lex_state = 1},
-  [3] = {.lex_state = 1},
-  [4] = {.lex_state = 1},
-  [5] = {.lex_state = 1},
-  [6] = {.lex_state = 6},
-  [7] = {.lex_state = 0},
-  [8] = {.lex_state = 0},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 0},
-  [11] = {.lex_state = 0},
-  [12] = {.lex_state = 0},
-  [13] = {.lex_state = 0},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 0},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 0},
+    [0] = {.lex_state = 0},  [1] = {.lex_state = 1},  [2] = {.lex_state = 1},
+    [3] = {.lex_state = 1},  [4] = {.lex_state = 1},  [5] = {.lex_state = 1},
+    [6] = {.lex_state = 6},  [7] = {.lex_state = 0},  [8] = {.lex_state = 0},
+    [9] = {.lex_state = 0},  [10] = {.lex_state = 0}, [11] = {.lex_state = 0},
+    [12] = {.lex_state = 0}, [13] = {.lex_state = 0}, [14] = {.lex_state = 0},
+    [15] = {.lex_state = 0}, [16] = {.lex_state = 0}, [17] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
-  [0] = {
-    [ts_builtin_sym_end] = ACTIONS(1),
-    [sym_identifier] = ACTIONS(1),
-    [anon_sym_BANG] = ACTIONS(1),
-    [anon_sym_AMP_AMP] = ACTIONS(1),
-    [anon_sym_PIPE_PIPE] = ACTIONS(1),
-    [anon_sym_EQ_EQ] = ACTIONS(1),
-    [anon_sym_BANG_EQ] = ACTIONS(1),
-    [anon_sym_LPAREN] = ACTIONS(1),
-    [anon_sym_RPAREN] = ACTIONS(1),
-  },
-  [1] = {
-    [sym_source] = STATE(15),
-    [sym__expression] = STATE(13),
-    [sym_not] = STATE(13),
-    [sym_and] = STATE(13),
-    [sym_or] = STATE(13),
-    [sym_equal] = STATE(13),
-    [sym_not_equal] = STATE(13),
-    [sym_parenthesized] = STATE(13),
-    [sym_identifier] = ACTIONS(3),
-    [anon_sym_BANG] = ACTIONS(5),
-    [anon_sym_LPAREN] = ACTIONS(7),
-  },
-  [2] = {
-    [sym__expression] = STATE(7),
-    [sym_not] = STATE(7),
-    [sym_and] = STATE(7),
-    [sym_or] = STATE(7),
-    [sym_equal] = STATE(7),
-    [sym_not_equal] = STATE(7),
-    [sym_parenthesized] = STATE(7),
-    [sym_identifier] = ACTIONS(3),
-    [anon_sym_BANG] = ACTIONS(5),
-    [anon_sym_LPAREN] = ACTIONS(7),
-  },
-  [3] = {
-    [sym__expression] = STATE(14),
-    [sym_not] = STATE(14),
-    [sym_and] = STATE(14),
-    [sym_or] = STATE(14),
-    [sym_equal] = STATE(14),
-    [sym_not_equal] = STATE(14),
-    [sym_parenthesized] = STATE(14),
-    [sym_identifier] = ACTIONS(3),
-    [anon_sym_BANG] = ACTIONS(5),
-    [anon_sym_LPAREN] = ACTIONS(7),
-  },
-  [4] = {
-    [sym__expression] = STATE(11),
-    [sym_not] = STATE(11),
-    [sym_and] = STATE(11),
-    [sym_or] = STATE(11),
-    [sym_equal] = STATE(11),
-    [sym_not_equal] = STATE(11),
-    [sym_parenthesized] = STATE(11),
-    [sym_identifier] = ACTIONS(3),
-    [anon_sym_BANG] = ACTIONS(5),
-    [anon_sym_LPAREN] = ACTIONS(7),
-  },
-  [5] = {
-    [sym__expression] = STATE(12),
-    [sym_not] = STATE(12),
-    [sym_and] = STATE(12),
-    [sym_or] = STATE(12),
-    [sym_equal] = STATE(12),
-    [sym_not_equal] = STATE(12),
-    [sym_parenthesized] = STATE(12),
-    [sym_identifier] = ACTIONS(3),
-    [anon_sym_BANG] = ACTIONS(5),
-    [anon_sym_LPAREN] = ACTIONS(7),
-  },
+    [0] =
+        {
+            [ts_builtin_sym_end] = ACTIONS(1),
+            [sym_identifier] = ACTIONS(1),
+            [anon_sym_BANG] = ACTIONS(1),
+            [anon_sym_AMP_AMP] = ACTIONS(1),
+            [anon_sym_PIPE_PIPE] = ACTIONS(1),
+            [anon_sym_EQ_EQ] = ACTIONS(1),
+            [anon_sym_BANG_EQ] = ACTIONS(1),
+            [anon_sym_LPAREN] = ACTIONS(1),
+            [anon_sym_RPAREN] = ACTIONS(1),
+        },
+    [1] =
+        {
+            [sym_source] = STATE(15),
+            [sym__expression] = STATE(13),
+            [sym_not] = STATE(13),
+            [sym_and] = STATE(13),
+            [sym_or] = STATE(13),
+            [sym_equal] = STATE(13),
+            [sym_not_equal] = STATE(13),
+            [sym_parenthesized] = STATE(13),
+            [sym_identifier] = ACTIONS(3),
+            [anon_sym_BANG] = ACTIONS(5),
+            [anon_sym_LPAREN] = ACTIONS(7),
+        },
+    [2] =
+        {
+            [sym__expression] = STATE(7),
+            [sym_not] = STATE(7),
+            [sym_and] = STATE(7),
+            [sym_or] = STATE(7),
+            [sym_equal] = STATE(7),
+            [sym_not_equal] = STATE(7),
+            [sym_parenthesized] = STATE(7),
+            [sym_identifier] = ACTIONS(3),
+            [anon_sym_BANG] = ACTIONS(5),
+            [anon_sym_LPAREN] = ACTIONS(7),
+        },
+    [3] =
+        {
+            [sym__expression] = STATE(14),
+            [sym_not] = STATE(14),
+            [sym_and] = STATE(14),
+            [sym_or] = STATE(14),
+            [sym_equal] = STATE(14),
+            [sym_not_equal] = STATE(14),
+            [sym_parenthesized] = STATE(14),
+            [sym_identifier] = ACTIONS(3),
+            [anon_sym_BANG] = ACTIONS(5),
+            [anon_sym_LPAREN] = ACTIONS(7),
+        },
+    [4] =
+        {
+            [sym__expression] = STATE(11),
+            [sym_not] = STATE(11),
+            [sym_and] = STATE(11),
+            [sym_or] = STATE(11),
+            [sym_equal] = STATE(11),
+            [sym_not_equal] = STATE(11),
+            [sym_parenthesized] = STATE(11),
+            [sym_identifier] = ACTIONS(3),
+            [anon_sym_BANG] = ACTIONS(5),
+            [anon_sym_LPAREN] = ACTIONS(7),
+        },
+    [5] =
+        {
+            [sym__expression] = STATE(12),
+            [sym_not] = STATE(12),
+            [sym_and] = STATE(12),
+            [sym_or] = STATE(12),
+            [sym_equal] = STATE(12),
+            [sym_not_equal] = STATE(12),
+            [sym_parenthesized] = STATE(12),
+            [sym_identifier] = ACTIONS(3),
+            [anon_sym_BANG] = ACTIONS(5),
+            [anon_sym_LPAREN] = ACTIONS(7),
+        },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 3,
-    ACTIONS(11), 1,
-      anon_sym_EQ_EQ,
-    ACTIONS(13), 1,
-      anon_sym_BANG_EQ,
-    ACTIONS(9), 4,
-      ts_builtin_sym_end,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [13] = 1,
-    ACTIONS(15), 4,
-      ts_builtin_sym_end,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [20] = 1,
-    ACTIONS(17), 4,
-      ts_builtin_sym_end,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [27] = 1,
-    ACTIONS(19), 4,
-      ts_builtin_sym_end,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [34] = 1,
-    ACTIONS(21), 4,
-      ts_builtin_sym_end,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [41] = 1,
-    ACTIONS(23), 4,
-      ts_builtin_sym_end,
-      anon_sym_AMP_AMP,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [48] = 2,
-    ACTIONS(27), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(25), 3,
-      ts_builtin_sym_end,
-      anon_sym_PIPE_PIPE,
-      anon_sym_RPAREN,
-  [57] = 3,
-    ACTIONS(27), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(29), 1,
-      ts_builtin_sym_end,
-    ACTIONS(31), 1,
-      anon_sym_PIPE_PIPE,
-  [67] = 3,
-    ACTIONS(27), 1,
-      anon_sym_AMP_AMP,
-    ACTIONS(31), 1,
-      anon_sym_PIPE_PIPE,
-    ACTIONS(33), 1,
-      anon_sym_RPAREN,
-  [77] = 1,
-    ACTIONS(35), 1,
-      ts_builtin_sym_end,
-  [81] = 1,
-    ACTIONS(37), 1,
-      sym_identifier,
-  [85] = 1,
-    ACTIONS(39), 1,
-      sym_identifier,
+    [0] = 3,
+    ACTIONS(11),
+    1,
+    anon_sym_EQ_EQ,
+    ACTIONS(13),
+    1,
+    anon_sym_BANG_EQ,
+    ACTIONS(9),
+    4,
+    ts_builtin_sym_end,
+    anon_sym_AMP_AMP,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [13] = 1,
+    ACTIONS(15),
+    4,
+    ts_builtin_sym_end,
+    anon_sym_AMP_AMP,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [20] = 1,
+    ACTIONS(17),
+    4,
+    ts_builtin_sym_end,
+    anon_sym_AMP_AMP,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [27] = 1,
+    ACTIONS(19),
+    4,
+    ts_builtin_sym_end,
+    anon_sym_AMP_AMP,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [34] = 1,
+    ACTIONS(21),
+    4,
+    ts_builtin_sym_end,
+    anon_sym_AMP_AMP,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [41] = 1,
+    ACTIONS(23),
+    4,
+    ts_builtin_sym_end,
+    anon_sym_AMP_AMP,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [48] = 2,
+    ACTIONS(27),
+    1,
+    anon_sym_AMP_AMP,
+    ACTIONS(25),
+    3,
+    ts_builtin_sym_end,
+    anon_sym_PIPE_PIPE,
+    anon_sym_RPAREN,
+    [57] = 3,
+    ACTIONS(27),
+    1,
+    anon_sym_AMP_AMP,
+    ACTIONS(29),
+    1,
+    ts_builtin_sym_end,
+    ACTIONS(31),
+    1,
+    anon_sym_PIPE_PIPE,
+    [67] = 3,
+    ACTIONS(27),
+    1,
+    anon_sym_AMP_AMP,
+    ACTIONS(31),
+    1,
+    anon_sym_PIPE_PIPE,
+    ACTIONS(33),
+    1,
+    anon_sym_RPAREN,
+    [77] = 1,
+    ACTIONS(35),
+    1,
+    ts_builtin_sym_end,
+    [81] = 1,
+    ACTIONS(37),
+    1,
+    sym_identifier,
+    [85] = 1,
+    ACTIONS(39),
+    1,
+    sym_identifier,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(6)] = 0,
-  [SMALL_STATE(7)] = 13,
-  [SMALL_STATE(8)] = 20,
-  [SMALL_STATE(9)] = 27,
-  [SMALL_STATE(10)] = 34,
-  [SMALL_STATE(11)] = 41,
-  [SMALL_STATE(12)] = 48,
-  [SMALL_STATE(13)] = 57,
-  [SMALL_STATE(14)] = 67,
-  [SMALL_STATE(15)] = 77,
-  [SMALL_STATE(16)] = 81,
-  [SMALL_STATE(17)] = 85,
+    [SMALL_STATE(6)] = 0,   [SMALL_STATE(7)] = 13,  [SMALL_STATE(8)] = 20,
+    [SMALL_STATE(9)] = 27,  [SMALL_STATE(10)] = 34, [SMALL_STATE(11)] = 41,
+    [SMALL_STATE(12)] = 48, [SMALL_STATE(13)] = 57, [SMALL_STATE(14)] = 67,
+    [SMALL_STATE(15)] = 77, [SMALL_STATE(16)] = 81, [SMALL_STATE(17)] = 85,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
-  [0] = {.entry = {.count = 0, .reusable = false}},
-  [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_not, 2, .production_id = 1),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_equal, 3, .production_id = 2),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_not_equal, 3, .production_id = 2),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized, 3, .production_id = 1),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_and, 3, .production_id = 2),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_or, 3, .production_id = 2),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source, 1),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [35] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+    [0] = {.entry = {.count = 0, .reusable = false}},
+    [1] = {.entry = {.count = 1, .reusable = false}},
+    RECOVER(),
+    [3] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(6),
+    [5] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(2),
+    [7] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(3),
+    [9] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym__expression, 1),
+    [11] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(16),
+    [13] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(17),
+    [15] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_not, 2, .production_id = 1),
+    [17] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_equal, 3, .production_id = 2),
+    [19] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_not_equal, 3, .production_id = 2),
+    [21] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_parenthesized, 3, .production_id = 1),
+    [23] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_and, 3, .production_id = 2),
+    [25] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_or, 3, .production_id = 2),
+    [27] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(4),
+    [29] = {.entry = {.count = 1, .reusable = true}},
+    REDUCE(sym_source, 1),
+    [31] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(5),
+    [33] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(10),
+    [35] = {.entry = {.count = 1, .reusable = true}},
+    ACCEPT_INPUT(),
+    [37] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(8),
+    [39] = {.entry = {.count = 1, .reusable = true}},
+    SHIFT(9),
 };
 
 #ifdef __cplusplus
@@ -497,30 +552,30 @@ extern "C" {
 
 extern const TSLanguage *tree_sitter_context_predicate(void) {
   static const TSLanguage language = {
-    .version = LANGUAGE_VERSION,
-    .symbol_count = SYMBOL_COUNT,
-    .alias_count = ALIAS_COUNT,
-    .token_count = TOKEN_COUNT,
-    .external_token_count = EXTERNAL_TOKEN_COUNT,
-    .state_count = STATE_COUNT,
-    .large_state_count = LARGE_STATE_COUNT,
-    .production_id_count = PRODUCTION_ID_COUNT,
-    .field_count = FIELD_COUNT,
-    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
-    .parse_table = &ts_parse_table[0][0],
-    .small_parse_table = ts_small_parse_table,
-    .small_parse_table_map = ts_small_parse_table_map,
-    .parse_actions = ts_parse_actions,
-    .symbol_names = ts_symbol_names,
-    .field_names = ts_field_names,
-    .field_map_slices = ts_field_map_slices,
-    .field_map_entries = ts_field_map_entries,
-    .symbol_metadata = ts_symbol_metadata,
-    .public_symbol_map = ts_symbol_map,
-    .alias_map = ts_non_terminal_alias_map,
-    .alias_sequences = &ts_alias_sequences[0][0],
-    .lex_modes = ts_lex_modes,
-    .lex_fn = ts_lex,
+      .version = LANGUAGE_VERSION,
+      .symbol_count = SYMBOL_COUNT,
+      .alias_count = ALIAS_COUNT,
+      .token_count = TOKEN_COUNT,
+      .external_token_count = EXTERNAL_TOKEN_COUNT,
+      .state_count = STATE_COUNT,
+      .large_state_count = LARGE_STATE_COUNT,
+      .production_id_count = PRODUCTION_ID_COUNT,
+      .field_count = FIELD_COUNT,
+      .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
+      .parse_table = &ts_parse_table[0][0],
+      .small_parse_table = ts_small_parse_table,
+      .small_parse_table_map = ts_small_parse_table_map,
+      .parse_actions = ts_parse_actions,
+      .symbol_names = ts_symbol_names,
+      .field_names = ts_field_names,
+      .field_map_slices = ts_field_map_slices,
+      .field_map_entries = ts_field_map_entries,
+      .symbol_metadata = ts_symbol_metadata,
+      .public_symbol_map = ts_symbol_map,
+      .alias_map = ts_non_terminal_alias_map,
+      .alias_sequences = &ts_alias_sequences[0][0],
+      .lex_modes = ts_lex_modes,
+      .lex_fn = ts_lex,
   };
   return &language;
 }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1239,7 +1239,7 @@ impl MutableAppContext {
         let mut view = self
             .cx
             .views
-            .remove(&(params.window_id, params.view_id))
+            .remove(&(window_id, view_id))
             .ok_or(anyhow!("view not found"))?;
         let element = view.render(params, self);
         self.cx.views.insert((window_id, view_id), view);
@@ -1781,7 +1781,7 @@ impl MutableAppContext {
                     .cx
                     .views
                     .get(&(window_id, view_id))
-                    .expect("View passed to visit does not exist")
+                    .unwrap()
                     .keymap_context(self.as_ref());
 
                 match self.keystroke_matcher.push_keystroke(
@@ -2548,11 +2548,6 @@ impl MutableAppContext {
 
             if let Some(blurred_id) = blurred_id {
                 for view_id in blurred_parents.iter().copied() {
-                    // We've reached a common anscestor. Break.
-                    if focused_parents.contains(&view_id) {
-                        break;
-                    }
-
                     if let Some(mut view) = this.cx.views.remove(&(window_id, view_id)) {
                         view.on_focus_out(this, window_id, view_id, blurred_id);
                         this.cx.views.insert((window_id, view_id), view);
@@ -2566,12 +2561,9 @@ impl MutableAppContext {
 
             if let Some(focused_id) = focused_id {
                 for view_id in focused_parents {
-                    if blurred_parents.contains(&view_id) {
-                        break;
-                    }
                     if let Some(mut view) = this.cx.views.remove(&(window_id, view_id)) {
                         view.on_focus_in(this, window_id, view_id, focused_id);
-                        this.cx.views.insert((window_id, focused_id), view);
+                        this.cx.views.insert((window_id, view_id), view);
                     }
                 }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -7089,7 +7089,7 @@ mod tests {
 
         let (window_id, view_1) = cx.add_window(Default::default(), |_| view_1);
         let view_2 = cx.add_view(&view_1, |_| view_2);
-        cx.add_view(&view_2, |cx| {
+        let _view_3 = cx.add_view(&view_2, |cx| {
             cx.focus_self();
             view_3
         });
@@ -7135,6 +7135,7 @@ mod tests {
         assert_eq!(&*actions.borrow(), &["2 a"]);
 
         actions.borrow_mut().clear();
+
         cx.dispatch_keystroke(window_id, &Keystroke::parse("b").unwrap());
 
         assert_eq!(&*actions.borrow(), &["3 b", "2 b", "1 b", "global b"]);

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -26,7 +26,6 @@ use std::{
 pub struct Presenter {
     window_id: usize,
     pub(crate) rendered_views: HashMap<usize, ElementBox>,
-    parents: HashMap<usize, usize>,
     cursor_regions: Vec<CursorRegion>,
     mouse_regions: Vec<(MouseRegion, usize)>,
     font_cache: Arc<FontCache>,
@@ -52,7 +51,6 @@ impl Presenter {
         Self {
             window_id,
             rendered_views: cx.render_views(window_id, titlebar_height),
-            parents: Default::default(),
             cursor_regions: Default::default(),
             mouse_regions: Default::default(),
             font_cache,
@@ -67,22 +65,22 @@ impl Presenter {
         }
     }
 
-    pub fn dispatch_path(&self, app: &AppContext) -> Vec<usize> {
-        let mut path = Vec::new();
-        if let Some(view_id) = app.focused_view_id(self.window_id) {
-            self.compute_dispatch_path_from(view_id, &mut path)
-        }
-        path
-    }
+    // pub fn dispatch_path(&self, app: &AppContext) -> Vec<usize> {
+    //     let mut path = Vec::new();
+    //     if let Some(view_id) = app.focused_view_id(self.window_id) {
+    //         self.compute_dispatch_path_from(view_id, &mut path)
+    //     }
+    //     path
+    // }
 
-    pub(crate) fn compute_dispatch_path_from(&self, mut view_id: usize, path: &mut Vec<usize>) {
-        path.push(view_id);
-        while let Some(parent_id) = self.parents.get(&view_id).copied() {
-            path.push(parent_id);
-            view_id = parent_id;
-        }
-        path.reverse();
-    }
+    // pub(crate) fn compute_dispatch_path_from(&self, mut view_id: usize, path: &mut Vec<usize>) {
+    //     path.push(view_id);
+    //     while let Some(parent_id) = self.parents.get(&view_id).copied() {
+    //         path.push(parent_id);
+    //         view_id = parent_id;
+    //     }
+    //     path.reverse();
+    // }
 
     pub fn invalidate(
         &mut self,
@@ -93,7 +91,6 @@ impl Presenter {
         for view_id in &invalidation.removed {
             invalidation.updated.remove(&view_id);
             self.rendered_views.remove(&view_id);
-            self.parents.remove(&view_id);
         }
         for view_id in &invalidation.updated {
             self.rendered_views.insert(
@@ -191,7 +188,6 @@ impl Presenter {
         LayoutContext {
             window_id: self.window_id,
             rendered_views: &mut self.rendered_views,
-            parents: &mut self.parents,
             font_cache: &self.font_cache,
             font_system: cx.platform().fonts(),
             text_layout_cache: &self.text_layout_cache,
@@ -344,19 +340,9 @@ impl Presenter {
             }
 
             invalidated_views.extend(event_cx.invalidated_views);
-            let dispatch_directives = event_cx.dispatched_actions;
 
             for view_id in invalidated_views {
                 cx.notify_view(self.window_id, view_id);
-            }
-
-            let mut dispatch_path = Vec::new();
-            for directive in dispatch_directives {
-                dispatch_path.clear();
-                if let Some(view_id) = directive.dispatcher_view_id {
-                    self.compute_dispatch_path_from(view_id, &mut dispatch_path);
-                }
-                cx.dispatch_action_any(self.window_id, &dispatch_path, directive.action.as_ref());
             }
 
             handled
@@ -372,9 +358,6 @@ impl Presenter {
         cx: &'a mut MutableAppContext,
     ) -> (bool, EventContext<'a>) {
         let mut hover_regions = Vec::new();
-        // let mut unhovered_regions = Vec::new();
-        // let mut hovered_regions = Vec::new();
-
         if let Event::MouseMoved(
             e @ MouseMovedEvent {
                 position,
@@ -446,7 +429,6 @@ impl Presenter {
     ) -> EventContext<'a> {
         EventContext {
             rendered_views: &mut self.rendered_views,
-            dispatched_actions: Default::default(),
             font_cache: &self.font_cache,
             text_layout_cache: &self.text_layout_cache,
             view_stack: Default::default(),
@@ -473,15 +455,9 @@ impl Presenter {
     }
 }
 
-pub struct DispatchDirective {
-    pub dispatcher_view_id: Option<usize>,
-    pub action: Box<dyn Action>,
-}
-
 pub struct LayoutContext<'a> {
     window_id: usize,
     rendered_views: &'a mut HashMap<usize, ElementBox>,
-    parents: &'a mut HashMap<usize, usize>,
     view_stack: Vec<usize>,
     pub font_cache: &'a Arc<FontCache>,
     pub font_system: Arc<dyn FontSystem>,
@@ -506,9 +482,6 @@ impl<'a> LayoutContext<'a> {
     }
 
     fn layout(&mut self, view_id: usize, constraint: SizeConstraint) -> Vector2F {
-        if let Some(parent_id) = self.view_stack.last() {
-            self.parents.insert(view_id, *parent_id);
-        }
         self.view_stack.push(view_id);
         let mut rendered_view = self.rendered_views.remove(&view_id).unwrap();
         let size = rendered_view.layout(constraint, self);
@@ -637,7 +610,6 @@ impl<'a> Deref for PaintContext<'a> {
 
 pub struct EventContext<'a> {
     rendered_views: &'a mut HashMap<usize, ElementBox>,
-    dispatched_actions: Vec<DispatchDirective>,
     pub font_cache: &'a FontCache,
     pub text_layout_cache: &'a TextLayoutCache,
     pub app: &'a mut MutableAppContext,
@@ -692,10 +664,8 @@ impl<'a> EventContext<'a> {
     }
 
     pub fn dispatch_any_action(&mut self, action: Box<dyn Action>) {
-        self.dispatched_actions.push(DispatchDirective {
-            dispatcher_view_id: self.view_stack.last().copied(),
-            action,
-        });
+        self.app
+            .dispatch_any_action_at(self.window_id, *self.view_stack.last().unwrap(), action)
     }
 
     pub fn dispatch_action<A: Action>(&mut self, action: A) {

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -1,6 +1,6 @@
 use crate::{
-    executor, platform, Entity, FontCache, Handle, LeakDetector, MutableAppContext, Platform,
-    Subscription, TestAppContext,
+    elements::Empty, executor, platform, Element, ElementBox, Entity, FontCache, Handle,
+    LeakDetector, MutableAppContext, Platform, RenderContext, Subscription, TestAppContext, View,
 };
 use futures::StreamExt;
 use parking_lot::Mutex;
@@ -161,4 +161,20 @@ where
     });
 
     Observation { rx, _subscription }
+}
+
+pub struct EmptyView;
+
+impl Entity for EmptyView {
+    type Event = ();
+}
+
+impl View for EmptyView {
+    fn ui_name() -> &'static str {
+        "empty view"
+    }
+
+    fn render(&mut self, _: &mut RenderContext<Self>) -> ElementBox {
+        Element::boxed(Empty::new())
+    }
 }

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -4,8 +4,8 @@ use editor::{
 };
 use fuzzy::StringMatch;
 use gpui::{
-    actions, elements::*, geometry::vector::Vector2F, AppContext, Entity, MouseState,
-    MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle,
+    actions, elements::*, geometry::vector::Vector2F, AnyViewHandle, AppContext, Entity,
+    MouseState, MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle,
 };
 use language::Outline;
 use ordered_float::OrderedFloat;
@@ -52,7 +52,7 @@ impl View for OutlineView {
         ChildView::new(self.picker.clone()).boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.picker);
     }
 }

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -53,7 +53,9 @@ impl View for OutlineView {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.picker);
+        if cx.is_self_focused() {
+            cx.focus(&self.picker);
+        }
     }
 }
 

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -7,8 +7,8 @@ use gpui::{
     geometry::vector::{vec2f, Vector2F},
     keymap,
     platform::CursorStyle,
-    AppContext, Axis, Element, ElementBox, Entity, MouseButton, MouseState, MutableAppContext,
-    RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
+    AnyViewHandle, AppContext, Axis, Element, ElementBox, Entity, MouseButton, MouseState,
+    MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use menu::{Cancel, Confirm, SelectFirst, SelectIndex, SelectLast, SelectNext, SelectPrev};
 use settings::Settings;
@@ -118,7 +118,7 @@ impl<D: PickerDelegate> View for Picker<D> {
         cx
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.query_editor);
     }
 }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -119,7 +119,9 @@ impl<D: PickerDelegate> View for Picker<D> {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.query_editor);
+        if cx.is_self_focused() {
+            cx.focus(&self.query_editor);
+        }
     }
 }
 

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -52,7 +52,9 @@ impl View for ProjectSymbolsView {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.picker);
+        if cx.is_self_focused() {
+            cx.focus(&self.picker);
+        }
     }
 }
 

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -3,8 +3,8 @@ use editor::{
 };
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, elements::*, AppContext, Entity, ModelHandle, MouseState, MutableAppContext,
-    RenderContext, Task, View, ViewContext, ViewHandle,
+    actions, elements::*, AnyViewHandle, AppContext, Entity, ModelHandle, MouseState,
+    MutableAppContext, RenderContext, Task, View, ViewContext, ViewHandle,
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
@@ -51,7 +51,7 @@ impl View for ProjectSymbolsView {
         ChildView::new(self.picker.clone()).boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.picker);
     }
 }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -6,8 +6,8 @@ use crate::{
 use collections::HashMap;
 use editor::{Anchor, Autoscroll, Editor};
 use gpui::{
-    actions, elements::*, impl_actions, platform::CursorStyle, Action, AppContext, Entity,
-    MouseButton, MutableAppContext, RenderContext, Subscription, Task, View, ViewContext,
+    actions, elements::*, impl_actions, platform::CursorStyle, Action, AnyViewHandle, AppContext,
+    Entity, MouseButton, MutableAppContext, RenderContext, Subscription, Task, View, ViewContext,
     ViewHandle, WeakViewHandle,
 };
 use language::OffsetRangeExt;
@@ -80,7 +80,7 @@ impl View for BufferSearchBar {
         "BufferSearchBar"
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.query_editor);
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -600,7 +600,7 @@ impl BufferSearchBar {
 mod tests {
     use super::*;
     use editor::{DisplayPoint, Editor};
-    use gpui::{color::Color, TestAppContext};
+    use gpui::{color::Color, test::EmptyView, TestAppContext};
     use language::Buffer;
     use std::sync::Arc;
     use unindent::Unindent as _;
@@ -629,11 +629,13 @@ mod tests {
                 cx,
             )
         });
-        let editor = cx.add_view(Default::default(), |cx| {
+        let (_, root_view) = cx.add_window(|_| EmptyView);
+
+        let editor = cx.add_view(&root_view, |cx| {
             Editor::for_buffer(buffer.clone(), None, cx)
         });
 
-        let search_bar = cx.add_view(Default::default(), |cx| {
+        let search_bar = cx.add_view(&root_view, |cx| {
             let mut search_bar = BufferSearchBar::new(cx);
             search_bar.set_active_pane_item(Some(&editor), cx);
             search_bar.show(false, true, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -81,7 +81,9 @@ impl View for BufferSearchBar {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.query_editor);
+        if cx.is_self_focused() {
+            cx.focus(&self.query_editor);
+        }
     }
 
     fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -6,9 +6,9 @@ use crate::{
 use collections::HashMap;
 use editor::{Anchor, Autoscroll, Editor, MultiBuffer, SelectAll, MAX_TAB_TITLE_LEN};
 use gpui::{
-    actions, elements::*, platform::CursorStyle, Action, AppContext, ElementBox, Entity,
-    ModelContext, ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription, Task,
-    View, ViewContext, ViewHandle, WeakModelHandle, WeakViewHandle,
+    actions, elements::*, platform::CursorStyle, Action, AnyViewHandle, AppContext, ElementBox,
+    Entity, ModelContext, ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription,
+    Task, View, ViewContext, ViewHandle, WeakModelHandle, WeakViewHandle,
 };
 use menu::Confirm;
 use project::{search::SearchQuery, Project};
@@ -190,7 +190,7 @@ impl View for ProjectSearchView {
         }
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         let handle = cx.weak_handle();
         cx.update_global(|state: &mut ActiveSearches, cx| {
             state

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -933,7 +933,8 @@ mod tests {
         cx.update(|cx| {
             let mut settings = Settings::test(cx);
             settings.theme = Arc::new(theme);
-            cx.set_global(settings)
+            cx.set_global(settings);
+            cx.set_global(ActiveSearches::default());
         });
 
         let fs = FakeFs::new(cx.background());
@@ -949,9 +950,7 @@ mod tests {
         .await;
         let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let search = cx.add_model(|cx| ProjectSearch::new(project, cx));
-        let search_view = cx.add_view(Default::default(), |cx| {
-            ProjectSearchView::new(search.clone(), cx)
-        });
+        let (_, search_view) = cx.add_window(|cx| ProjectSearchView::new(search.clone(), cx));
 
         search_view.update(cx, |search_view, cx| {
             search_view

--- a/crates/terminal/src/connected_view.rs
+++ b/crates/terminal/src/connected_view.rs
@@ -6,7 +6,8 @@ use gpui::{
     geometry::vector::Vector2F,
     impl_internal_actions,
     keymap::Keystroke,
-    AppContext, Element, ElementBox, ModelHandle, MutableAppContext, View, ViewContext, ViewHandle,
+    AnyViewHandle, AppContext, Element, ElementBox, ModelHandle, MutableAppContext, View,
+    ViewContext, ViewHandle,
 };
 use workspace::pane;
 
@@ -190,7 +191,7 @@ impl View for ConnectedView {
             .boxed()
     }
 
-    fn on_focus(&mut self, _cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, _cx: &mut ViewContext<Self>) {
         self.has_new_content = false;
     }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -161,13 +161,6 @@ impl Dimensions for TerminalSize {
     fn columns(&self) -> usize {
         self.num_columns()
     }
-
-    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.emit(Event::Activate);
-        cx.defer(|view, cx| {
-            cx.focus(view.content.handle());
-        });
-    }
 }
 
 #[derive(Error, Debug)]

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -60,7 +60,6 @@ const DEBUG_LINE_HEIGHT: f32 = 5.;
 pub enum Event {
     TitleChanged,
     CloseTerminal,
-    Activate,
     Bell,
     Wakeup,
 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -161,6 +161,13 @@ impl Dimensions for TerminalSize {
     fn columns(&self) -> usize {
         self.num_columns()
     }
+
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::Activate);
+        cx.defer(|view, cx| {
+            cx.focus(view.content.handle());
+        });
+    }
 }
 
 #[derive(Error, Debug)]

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -153,10 +153,7 @@ impl View for TerminalView {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.emit(Event::Activate);
-        cx.defer(|view, cx| {
-            cx.focus(view.content.handle());
-        });
+        cx.focus(self.content.handle());
     }
 
     fn keymap_context(&self, _: &gpui::AppContext) -> gpui::keymap::Context {
@@ -313,10 +310,6 @@ impl Item for TerminalView {
 
     fn should_close_item_on_event(event: &Self::Event) -> bool {
         matches!(event, &Event::CloseTerminal)
-    }
-
-    fn should_activate_item_on_event(event: &Self::Event) -> bool {
-        matches!(event, &Event::Activate)
     }
 }
 

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -153,7 +153,9 @@ impl View for TerminalView {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(self.content.handle());
+        if cx.is_self_focused() {
+            cx.focus(self.content.handle());
+        }
     }
 
     fn keymap_context(&self, _: &gpui::AppContext) -> gpui::keymap::Context {

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -152,7 +152,7 @@ impl View for TerminalView {
         }
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.emit(Event::Activate);
         cx.defer(|view, cx| {
             cx.focus(view.content.handle());

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -1,7 +1,7 @@
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, elements::*, AppContext, Element, ElementBox, Entity, MouseState, MutableAppContext,
-    RenderContext, View, ViewContext, ViewHandle,
+    actions, elements::*, AnyViewHandle, AppContext, Element, ElementBox, Entity, MouseState,
+    MutableAppContext, RenderContext, View, ViewContext, ViewHandle,
 };
 use picker::{Picker, PickerDelegate};
 use settings::Settings;
@@ -249,7 +249,7 @@ impl View for ThemeSelector {
         ChildView::new(self.picker.clone()).boxed()
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.picker);
     }
 }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -250,6 +250,8 @@ impl View for ThemeSelector {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.picker);
+        if cx.is_self_focused() {
+            cx.focus(&self.picker);
+        }
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -13,9 +13,9 @@ use gpui::{
     },
     impl_actions, impl_internal_actions,
     platform::{CursorStyle, NavigationDirection},
-    AppContext, AsyncAppContext, Entity, EventContext, ModelHandle, MouseButton, MouseButtonEvent,
-    MutableAppContext, PromptLevel, Quad, RenderContext, Task, View, ViewContext, ViewHandle,
-    WeakViewHandle,
+    AnyViewHandle, AppContext, AsyncAppContext, Entity, EventContext, ModelHandle, MouseButton,
+    MouseButtonEvent, MutableAppContext, PromptLevel, Quad, RenderContext, Task, View, ViewContext,
+    ViewHandle, WeakViewHandle,
 };
 use project::{Project, ProjectEntryId, ProjectPath};
 use serde::Deserialize;
@@ -830,6 +830,7 @@ impl Pane {
     pub fn focus_active_item(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(active_item) = self.active_item() {
             cx.focus(active_item);
+            self.activate(cx);
         }
     }
 
@@ -1210,8 +1211,12 @@ impl View for Pane {
             .named("pane")
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
-        self.focus_active_item(cx);
+    fn on_focus_in(&mut self, focused: AnyViewHandle, cx: &mut ViewContext<Self>) {
+        if cx.handle().id() == focused.id() {
+            self.focus_active_item(cx);
+        } else {
+            self.activate(cx);
+        }
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -441,6 +441,7 @@ impl Pane {
                 pane.active_item_index = usize::MAX;
             };
 
+            cx.reparent(&item);
             pane.items.insert(item_ix, item);
             pane.activate_item(item_ix, activate_pane, focus_item, false, cx);
             cx.notify();

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -386,7 +386,7 @@ impl Pane {
         project_entry_id: ProjectEntryId,
         focus_item: bool,
         cx: &mut ViewContext<Workspace>,
-        build_item: impl FnOnce(&mut MutableAppContext) -> Box<dyn ItemHandle>,
+        build_item: impl FnOnce(&mut ViewContext<Pane>) -> Box<dyn ItemHandle>,
     ) -> Box<dyn ItemHandle> {
         let existing_item = pane.update(cx, |pane, cx| {
             for (ix, item) in pane.items.iter().enumerate() {
@@ -403,7 +403,7 @@ impl Pane {
         if let Some(existing_item) = existing_item {
             existing_item
         } else {
-            let item = build_item(cx);
+            let item = pane.update(cx, |_, cx| build_item(cx));
             Self::add_item(workspace, pane, item.boxed_clone(), true, focus_item, cx);
             item
         }

--- a/crates/workspace/src/sidebar.rs
+++ b/crates/workspace/src/sidebar.rs
@@ -140,6 +140,7 @@ impl Sidebar {
                 }
             }),
         ];
+        cx.reparent(&view);
         self.items.push(Item {
             icon_path,
             tooltip,

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -81,6 +81,7 @@ impl StatusBar {
     where
         T: 'static + StatusItemView,
     {
+        cx.reparent(&item);
         self.left_items.push(Box::new(item));
         cx.notify();
     }
@@ -89,6 +90,7 @@ impl StatusBar {
     where
         T: 'static + StatusItemView,
     {
+        cx.reparent(&item);
         self.right_items.push(Box::new(item));
         cx.notify();
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2489,7 +2489,7 @@ impl View for Workspace {
             .named("workspace")
     }
 
-    fn on_focus(&mut self, cx: &mut ViewContext<Self>) {
+    fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         cx.focus(&self.active_pane);
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1,5 +1,6 @@
 /// NOTE: Focus only 'takes' after an update has flushed_effects. Pane sends an event in on_focus_in
 /// which the workspace uses to change the activated pane.
+///
 /// This may cause issues when you're trying to write tests that use workspace focus to add items at
 /// specific locations.
 pub mod pane;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -708,6 +708,12 @@ impl Into<AnyViewHandle> for Box<dyn ItemHandle> {
     }
 }
 
+impl Into<AnyViewHandle> for &Box<dyn ItemHandle> {
+    fn into(self) -> AnyViewHandle {
+        self.to_any()
+    }
+}
+
 impl Clone for Box<dyn ItemHandle> {
     fn clone(&self) -> Box<dyn ItemHandle> {
         self.boxed_clone()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2476,7 +2476,6 @@ impl View for Workspace {
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         if cx.is_self_focused() {
-            println!("Active Pane Focused");
             cx.focus(&self.active_pane);
         }
     }

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "styles",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Description of feature or change
Introduces focus callbacks on the view trait which are raised any time a descendant of a given view is focused.
Moves event dispatch into flush_effects making the order of operations when dispatching events more explicit. For example, before this PR, calling focus in an event callback and dispatching an event. Would dispatch the event first and then handle the focus regardless of call order. This acts as expected now.

Before this PR, actions were dispatched immediately when running event callbacks. This was possible because the presenter right before sending events, would render and layout the tree in order to build up the view hierarchy. This PR makes the parent hierarchy explicit and requires a parent to construct a view. This way the AppContext has enough information to bubble events itself, and to send focus events based on that hierarchy.

Move parent hierarchy out of presenter and into MutableAppContext. Require that every view must have a parent.
Change event dispatch to be handled in flush_effects so that it is handled in order in event callbacks.
Update event dispatch to use common visit_parents function.
Add parents function which returns an iterator of the parent ids (this replaces the presenter's build_dispatch_path function).
Update add_view and add_window constructors to require a parent handle or to use the context handle to setup parent relationship.
Add reparent function to MutableAppContext which will swap the parent to another view at runtime. 
Add on_focus_in and on_focus_out callbacks to View which are raised any time a descendant view is focused.
Change pane to trigger activation based on a focus notification rather than a custom activate event.
Update pane to keep track of last focused child view in order to refocus that view when the pane is made active again.
Remove manual refocusing from project search.

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/zed/issues/1441
Fixes https://github.com/zed-industries/feedback/issues/428
Fixes https://github.com/zed-industries/feedback/issues/398
Fixes https://github.com/zed-industries/feedback/issues/394
Fixes https://github.com/zed-industries/zed/issues/966

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
