### PR TITLE
Store config files under `~/.config/zed` and data files under `~/Library/Application Support/Zed`

### DIFF
--- a/crates/project/src/db.rs
+++ b/crates/project/src/db.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 pub struct Db(DbStore);
@@ -16,8 +16,8 @@ enum DbStore {
 
 impl Db {
     /// Open or create a database at the given file path.
-    pub fn open(path: PathBuf) -> Result<Arc<Self>> {
-        let db = rocksdb::DB::open_default(&path)?;
+    pub fn open(path: &Path) -> Result<Arc<Self>> {
+        let db = rocksdb::DB::open_default(path)?;
         Ok(Arc::new(Self(DbStore::Real(db))))
     }
 
@@ -125,7 +125,7 @@ mod tests {
     fn test_db() {
         let dir = TempDir::new("db-test").unwrap();
         let fake_db = Db::open_fake();
-        let real_db = Db::open(dir.path().join("test.db")).unwrap();
+        let real_db = Db::open(&dir.path().join("test.db")).unwrap();
 
         for db in [&real_db, &fake_db] {
             assert_eq!(
@@ -152,7 +152,7 @@ mod tests {
 
         drop(real_db);
 
-        let real_db = Db::open(dir.path().join("test.db")).unwrap();
+        let real_db = Db::open(&dir.path().join("test.db")).unwrap();
         assert_eq!(
             real_db.read(["key-1", "key-2", "key-3"]).unwrap(),
             &[Some("one".as_bytes().to_vec()), None, None,]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -28,15 +28,7 @@ use project::{Fs, ProjectStore};
 use serde_json::json;
 use settings::{self, KeymapFileContent, Settings, SettingsFileContent};
 use smol::process::Command;
-use std::{
-    env,
-    ffi::OsStr,
-    fs, panic,
-    path::{Path, PathBuf},
-    sync::Arc,
-    thread,
-    time::Duration,
-};
+use std::{env, ffi::OsStr, fs, panic, path::PathBuf, sync::Arc, thread, time::Duration};
 use terminal;
 use theme::ThemeRegistry;
 use util::{ResultExt, TryFutureExt};
@@ -50,21 +42,19 @@ use zed::{
 
 fn main() {
     let http = http::client();
-    let home_dir = dirs::home_dir().expect("could not find home dir");
-    let db_dir_path = home_dir.join("Library/Application Support/Zed");
-    let logs_dir_path = home_dir.join("Library/Logs/Zed");
-    fs::create_dir_all(&db_dir_path).expect("could not create database path");
-    fs::create_dir_all(&logs_dir_path).expect("could not create logs path");
-    init_logger(&logs_dir_path);
+    fs::create_dir_all(&*zed::LANGUAGES_DIR_PATH).expect("could not create languages path");
+    fs::create_dir_all(&*zed::DB_DIR_PATH).expect("could not create database path");
+    fs::create_dir_all(&*zed::LOGS_DIR_PATH).expect("could not create logs path");
+    init_logger();
 
     log::info!("========== starting zed ==========");
     let mut app = gpui::App::new(Assets).unwrap();
     let app_version = ZED_APP_VERSION
         .or_else(|| app.platform().app_version().ok())
         .map_or("dev".to_string(), |v| v.to_string());
-    init_panic_hook(logs_dir_path, app_version, http.clone(), app.background());
+    init_panic_hook(app_version, http.clone(), app.background());
     let db = app.background().spawn(async move {
-        project::Db::open(db_dir_path.join("zed.db"))
+        project::Db::open(&*zed::DB_PATH)
             .log_err()
             .unwrap_or(project::Db::null())
     });
@@ -100,7 +90,7 @@ fn main() {
     app.run(move |cx| {
         let client = client::Client::new(http.clone());
         let mut languages = LanguageRegistry::new(login_shell_env_loaded);
-        languages.set_language_server_download_dir(zed::ROOT_PATH.clone());
+        languages.set_language_server_download_dir(zed::LANGUAGES_DIR_PATH.clone());
         let languages = Arc::new(languages);
         let init_languages = cx
             .background()
@@ -205,42 +195,34 @@ fn main() {
     });
 }
 
-fn init_logger(logs_dir_path: &Path) {
+fn init_logger() {
     if stdout_is_a_pty() {
         env_logger::init();
     } else {
         let level = LevelFilter::Info;
-        let log_file_path = logs_dir_path.join("Zed.log");
 
         // Prevent log file from becoming too large.
         const MAX_LOG_BYTES: u64 = 1 * 1024 * 1024;
-        if fs::metadata(&log_file_path).map_or(false, |metadata| metadata.len() > MAX_LOG_BYTES) {
-            let _ = fs::rename(&log_file_path, logs_dir_path.join("Zed.log.old"));
+        if fs::metadata(&*zed::LOG_PATH).map_or(false, |metadata| metadata.len() > MAX_LOG_BYTES) {
+            let _ = fs::rename(&*zed::LOG_PATH, &*zed::OLD_LOG_PATH);
         }
 
         let log_file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(log_file_path)
+            .open(&*zed::LOG_PATH)
             .expect("could not open logfile");
         simplelog::WriteLogger::init(level, simplelog::Config::default(), log_file)
             .expect("could not initialize logger");
     }
 }
 
-fn init_panic_hook(
-    logs_dir_path: PathBuf,
-    app_version: String,
-    http: Arc<dyn HttpClient>,
-    background: Arc<Background>,
-) {
+fn init_panic_hook(app_version: String, http: Arc<dyn HttpClient>, background: Arc<Background>) {
     background
         .spawn({
-            let logs_dir_path = logs_dir_path.clone();
-
             async move {
                 let panic_report_url = format!("{}/api/panic", &*client::ZED_SERVER_URL);
-                let mut children = smol::fs::read_dir(&logs_dir_path).await?;
+                let mut children = smol::fs::read_dir(&*zed::LOGS_DIR_PATH).await?;
                 while let Some(child) = children.next().await {
                     let child = child?;
                     let child_path = child.path();
@@ -330,7 +312,7 @@ fn init_panic_hook(
 
         let panic_filename = chrono::Utc::now().format("%Y_%m_%d %H_%M_%S").to_string();
         fs::write(
-            logs_dir_path.join(format!("zed-{}-{}.panic", app_version, panic_filename)),
+            zed::LOGS_DIR_PATH.join(format!("zed-{}-{}.panic", app_version, panic_filename)),
             &message,
         )
         .context("error writing panic to disk")

--- a/crates/zed/src/paths.rs
+++ b/crates/zed/src/paths.rs
@@ -1,22 +1,24 @@
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
-use lazy_static::lazy_static;
-
-lazy_static! {
+lazy_static::lazy_static! {
     static ref HOME: PathBuf = dirs::home_dir().expect("failed to determine home directory");
-    static ref CACHE_DIR: PathBuf = dirs::cache_dir()
-        .expect("failed to determine cache directory")
-        .join("Zed");
-    pub static ref CONFIG_DIR: PathBuf = env::var_os("XDG_CONFIG_HOME")
-        .map(|home| home.into())
-        .unwrap_or_else(|| HOME.join(".config"))
-        .join("zed");
+    pub static ref CONFIG_DIR: PathBuf = HOME.join(".config").join("zed");
     pub static ref LOGS_DIR: PathBuf = HOME.join("Library/Logs/Zed");
-    pub static ref LANGUAGES_DIR: PathBuf = CACHE_DIR.join("languages");
-    pub static ref DB_DIR: PathBuf = CACHE_DIR.join("db");
+    pub static ref LANGUAGES_DIR: PathBuf = HOME.join("Library/Application Support/Zed/languages");
+    pub static ref DB_DIR: PathBuf = HOME.join("Library/Application Support/Zed/db");
     pub static ref DB: PathBuf = DB_DIR.join("zed.db");
     pub static ref SETTINGS: PathBuf = CONFIG_DIR.join("settings.json");
     pub static ref KEYMAP: PathBuf = CONFIG_DIR.join("keymap.json");
     pub static ref LOG: PathBuf = LOGS_DIR.join("Zed.log");
     pub static ref OLD_LOG: PathBuf = LOGS_DIR.join("Zed.log.old");
+}
+
+pub mod legacy {
+    use std::path::PathBuf;
+
+    lazy_static::lazy_static! {
+        static ref CONFIG_DIR: PathBuf = super::HOME.join(".zed");
+        pub static ref SETTINGS: PathBuf = CONFIG_DIR.join("settings.json");
+        pub static ref KEYMAP: PathBuf = CONFIG_DIR.join("keymap.json");
+    }
 }

--- a/crates/zed/src/paths.rs
+++ b/crates/zed/src/paths.rs
@@ -1,0 +1,22 @@
+use std::{env, path::PathBuf};
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref HOME: PathBuf = dirs::home_dir().expect("failed to determine home directory");
+    static ref CACHE_DIR: PathBuf = dirs::cache_dir()
+        .expect("failed to determine cache directory")
+        .join("Zed");
+    pub static ref CONFIG_DIR: PathBuf = env::var_os("XDG_CONFIG_HOME")
+        .map(|home| home.into())
+        .unwrap_or_else(|| HOME.join(".config"))
+        .join("zed");
+    pub static ref LOGS_DIR: PathBuf = HOME.join("Library/Logs/Zed");
+    pub static ref LANGUAGES_DIR: PathBuf = CACHE_DIR.join("languages");
+    pub static ref DB_DIR: PathBuf = CACHE_DIR.join("db");
+    pub static ref DB: PathBuf = DB_DIR.join("zed.db");
+    pub static ref SETTINGS: PathBuf = CONFIG_DIR.join("settings.json");
+    pub static ref KEYMAP: PathBuf = CONFIG_DIR.join("keymap.json");
+    pub static ref LOG: PathBuf = LOGS_DIR.join("Zed.log");
+    pub static ref OLD_LOG: PathBuf = LOGS_DIR.join("Zed.log.old");
+}

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -223,11 +223,11 @@ pub fn initialize_workspace(
                 },
                 "schemas": [
                     {
-                        "fileMatch": [".zed/settings.json"],
+                        "fileMatch": [schema_file_match(&*paths::SETTINGS)],
                         "schema": settings_file_json_schema(theme_names, language_names),
                     },
                     {
-                        "fileMatch": [".zed/keymap.json"],
+                        "fileMatch": [schema_file_match(&*paths::KEYMAP)],
                         "schema": keymap_file_json_schema(&action_names),
                     }
                 ]
@@ -385,7 +385,6 @@ fn open_config_file(
     cx.spawn(|workspace, mut cx| async move {
         let fs = &app_state.fs;
         if !fs.is_file(path).await {
-            fs.create_dir(&paths::CONFIG_DIR).await?;
             fs.create_file(path, Default::default()).await?;
             fs.save(path, &default_content(), Default::default())
                 .await?;
@@ -479,6 +478,11 @@ fn open_bundled_config_file(
             cx,
         );
     });
+}
+
+fn schema_file_match(path: &Path) -> &Path {
+    path.strip_prefix(path.parent().unwrap().parent().unwrap())
+        .unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of feature or change

This pull request switches to using `~/.config/zed` for configuration files such as `settings.json` and `keymap.json`. Data files (the local database and the downloaded language servers) will be stored under `~/Library/Application Support/Zed`. The database was already being stored there and I think it makes sense to move servers under that directory as well. In theory, macOS guideline say we should put those configuration files under `Application Support`, but I've never liked because it feels like a pretty obscure location that users have a hard time locating.

Note that this also takes care of copying the old `~/.zed/settings.json` and `~/.zed/keymap.json` to the new locations on startup, if those files don't already exist. This is done on a separate thread to avoid delaying startup: still, we should probably remove this migration code path after a few releases.

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/feedback/issues/154

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
