### PR TITLE
Compute diffs based on characters rather than lines

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1006,7 +1006,7 @@ impl Buffer {
             let old_text = old_text.to_string();
             let line_ending = LineEnding::detect(&new_text);
             LineEnding::normalize(&mut new_text);
-            let changes = TextDiff::from_lines(old_text.as_str(), new_text.as_str())
+            let changes = TextDiff::from_chars(old_text.as_str(), new_text.as_str())
                 .iter_all_changes()
                 .map(|c| (c.tag(), c.value().len()))
                 .collect::<Vec<_>>();

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -183,20 +183,23 @@ fn test_edit_events(cx: &mut gpui::MutableAppContext) {
 async fn test_apply_diff(cx: &mut gpui::TestAppContext) {
     let text = "a\nbb\nccc\ndddd\neeeee\nffffff\n";
     let buffer = cx.add_model(|cx| Buffer::new(0, text, cx));
+    let anchor = buffer.read_with(cx, |buffer, _| buffer.anchor_before(Point::new(3, 3)));
 
     let text = "a\nccc\ndddd\nffffff\n";
     let diff = buffer.read_with(cx, |b, cx| b.diff(text.into(), cx)).await;
     buffer.update(cx, |buffer, cx| {
         buffer.apply_diff(diff, cx).unwrap();
+        assert_eq!(buffer.text(), text);
+        assert_eq!(anchor.to_point(&buffer), Point::new(2, 3));
     });
-    cx.read(|cx| assert_eq!(buffer.read(cx).text(), text));
 
     let text = "a\n1\n\nccc\ndd2dd\nffffff\n";
     let diff = buffer.read_with(cx, |b, cx| b.diff(text.into(), cx)).await;
     buffer.update(cx, |buffer, cx| {
         buffer.apply_diff(diff, cx).unwrap();
+        assert_eq!(buffer.text(), text);
+        assert_eq!(anchor.to_point(&buffer), Point::new(4, 4));
     });
-    cx.read(|cx| assert_eq!(buffer.read(cx).text(), text));
 }
 
 #[gpui::test]

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2498,7 +2498,7 @@ async fn test_buffer_file_changes_on_disk(cx: &mut gpui::TestAppContext) {
             .collect::<Vec<_>>();
         assert_eq!(
             anchor_positions,
-            [Point::new(1, 1), Point::new(3, 1), Point::new(4, 0)]
+            [Point::new(1, 1), Point::new(3, 1), Point::new(3, 5)]
         );
     });
 


### PR DESCRIPTION
## Description of feature or change

Previously, a change on a given line would cause that whole line to be replaced when applying a diff. In turn, this caused anchors on that line to go to the start of that line because they would lie inside of a deleted region.

By switching to a character-wise diff, we perform smaller edits to the buffer which stabilizes anchor positions.

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/400

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
