### PR TITLE
Remove terminal integration test

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -389,23 +389,13 @@ mod tests {
 
     mod terminal_test_context;
 
-    ///Basic integration test, can we get the terminal to show up, execute a command,
-    //and produce noticable output?
-    #[gpui::test(retries = 5)]
-    async fn test_terminal(cx: &mut TestAppContext) {
-        let mut cx = TerminalTestContext::new(cx, true);
-
-        cx.execute_and_wait("expr 3 + 4", |content, _cx| content.contains("7"))
-            .await;
-    }
-
     ///Working directory calculation tests
 
     ///No Worktrees in project -> home_dir()
     #[gpui::test]
     async fn no_worktree(cx: &mut TestAppContext) {
         //Setup variables
-        let mut cx = TerminalTestContext::new(cx, true);
+        let mut cx = TerminalTestContext::new(cx);
         let (project, workspace) = cx.blank_workspace().await;
         //Test
         cx.cx.read(|cx| {
@@ -428,7 +418,7 @@ mod tests {
     async fn no_active_entry_worktree_is_file(cx: &mut TestAppContext) {
         //Setup variables
 
-        let mut cx = TerminalTestContext::new(cx, true);
+        let mut cx = TerminalTestContext::new(cx);
         let (project, workspace) = cx.blank_workspace().await;
         cx.create_file_wt(project.clone(), "/root.txt").await;
 
@@ -451,7 +441,7 @@ mod tests {
     #[gpui::test]
     async fn no_active_entry_worktree_is_dir(cx: &mut TestAppContext) {
         //Setup variables
-        let mut cx = TerminalTestContext::new(cx, true);
+        let mut cx = TerminalTestContext::new(cx);
         let (project, workspace) = cx.blank_workspace().await;
         let (_wt, _entry) = cx.create_folder_wt(project.clone(), "/root/").await;
 
@@ -474,7 +464,7 @@ mod tests {
     #[gpui::test]
     async fn active_entry_worktree_is_file(cx: &mut TestAppContext) {
         //Setup variables
-        let mut cx = TerminalTestContext::new(cx, true);
+        let mut cx = TerminalTestContext::new(cx);
         let (project, workspace) = cx.blank_workspace().await;
         let (_wt, _entry) = cx.create_folder_wt(project.clone(), "/root1/").await;
         let (wt2, entry2) = cx.create_file_wt(project.clone(), "/root2.txt").await;
@@ -498,7 +488,7 @@ mod tests {
     #[gpui::test]
     async fn active_entry_worktree_is_dir(cx: &mut TestAppContext) {
         //Setup variables
-        let mut cx = TerminalTestContext::new(cx, true);
+        let mut cx = TerminalTestContext::new(cx);
         let (project, workspace) = cx.blank_workspace().await;
         let (_wt, _entry) = cx.create_folder_wt(project.clone(), "/root1/").await;
         let (wt2, entry2) = cx.create_folder_wt(project.clone(), "/root2/").await;
@@ -522,7 +512,7 @@ mod tests {
     #[gpui::test]
     async fn active_entry_worktree_is_file_int(cx: &mut TestAppContext) {
         //Setup variables
-        let mut cx = TerminalTestContext::new(cx, true);
+        let mut cx = TerminalTestContext::new(cx);
         let (project, workspace) = cx.blank_workspace().await;
         let (_wt, _entry) = cx.create_folder_wt(project.clone(), "/root1/").await;
         let (wt2, entry2) = cx.create_file_wt(project.clone(), "/root2.txt").await;

--- a/crates/terminal/src/tests/terminal_test_context.rs
+++ b/crates/terminal/src/tests/terminal_test_context.rs
@@ -1,72 +1,16 @@
-use std::{path::Path, time::Duration};
-
-use gpui::{
-    geometry::vector::vec2f, AppContext, ModelHandle, ReadModelWith, TestAppContext, ViewHandle,
-};
-use itertools::Itertools;
+use gpui::{ModelHandle, TestAppContext, ViewHandle};
 use project::{Entry, Project, ProjectPath, Worktree};
+use std::{path::Path, time::Duration};
 use workspace::{AppState, Workspace};
-
-use crate::{
-    connected_el::TermDimensions,
-    model::{Terminal, TerminalBuilder},
-    DEBUG_CELL_WIDTH, DEBUG_LINE_HEIGHT, DEBUG_TERMINAL_HEIGHT, DEBUG_TERMINAL_WIDTH,
-};
 
 pub struct TerminalTestContext<'a> {
     pub cx: &'a mut TestAppContext,
-    pub connection: Option<ModelHandle<Terminal>>,
 }
 
 impl<'a> TerminalTestContext<'a> {
-    pub fn new(cx: &'a mut TestAppContext, term: bool) -> Self {
+    pub fn new(cx: &'a mut TestAppContext) -> Self {
         cx.set_condition_duration(Some(Duration::from_secs(5)));
-
-        let size_info = TermDimensions::new(
-            DEBUG_CELL_WIDTH,
-            DEBUG_LINE_HEIGHT,
-            vec2f(DEBUG_TERMINAL_WIDTH, DEBUG_TERMINAL_HEIGHT),
-        );
-
-        let connection = term.then(|| {
-            cx.add_model(|cx| {
-                TerminalBuilder::new(None, None, None, size_info)
-                    .unwrap()
-                    .subscribe(cx)
-            })
-        });
-
-        TerminalTestContext { cx, connection }
-    }
-
-    pub async fn execute_and_wait<F>(&mut self, command: &str, f: F) -> String
-    where
-        F: Fn(String, &AppContext) -> bool,
-    {
-        let connection = self.connection.take().unwrap();
-
-        let command = command.to_string();
-        connection.update(self.cx, |connection, _| {
-            connection.write_to_pty(command);
-            connection.write_to_pty("\r".to_string());
-        });
-
-        connection
-            .condition(self.cx, |conn, cx| {
-                let content = Self::grid_as_str(conn);
-                f(content, cx)
-            })
-            .await;
-
-        let res = self
-            .cx
-            .read_model_with(&connection, &mut |conn, _: &AppContext| {
-                Self::grid_as_str(conn)
-            });
-
-        self.connection = Some(connection);
-
-        res
+        TerminalTestContext { cx }
     }
 
     ///Creates a worktree with 1 file: /root.txt
@@ -138,17 +82,6 @@ impl<'a> TerminalTestContext<'a> {
             };
             project.update(cx, |project, cx| project.set_active_path(Some(p), cx));
         });
-    }
-
-    fn grid_as_str(connection: &Terminal) -> String {
-        connection.render_lock(None, |content, _| {
-            let lines = content.display_iter.group_by(|i| i.point.line.0);
-            lines
-                .into_iter()
-                .map(|(_, line)| line.map(|i| i.c).collect::<String>())
-                .collect::<Vec<String>>()
-                .join("\n")
-        })
     }
 }
 


### PR DESCRIPTION
## Description of feature or change

Creating a full-fledged terminal is flaky and causes tests to either hang or outright panic. The only test that requires creating a terminal was `test_terminal` but we think the value added by that test is not worth the flakiness, so we're removing it.

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
