### PR TITLE
Prevent Zed from hanging when changing tab size

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1351,6 +1351,39 @@ pub mod tests {
         )
     }
 
+    #[gpui::test]
+    fn test_changing_tab_size(cx: &mut gpui::MutableAppContext) {
+        cx.set_global({
+            let mut settings = Settings::test(cx);
+            settings.editor_overrides.tab_size = Some(NonZeroU32::new(4).unwrap());
+            settings
+        });
+        let buffer = MultiBuffer::build_simple("\ta\n\tb\n\tc", cx);
+        let font_cache = cx.font_cache();
+        let family_id = font_cache.load_family(&["Helvetica"]).unwrap();
+        let font_id = font_cache
+            .select_font(family_id, &Default::default())
+            .unwrap();
+        let font_size = 14.0;
+
+        let map =
+            cx.add_model(|cx| DisplayMap::new(buffer.clone(), font_id, font_size, None, 1, 1, cx));
+        assert_eq!(
+            map.update(cx, |map, cx| map.snapshot(cx)).text(),
+            "    a\n    b\n    c"
+        );
+
+        cx.set_global({
+            let mut settings = Settings::test(cx);
+            settings.editor_overrides.tab_size = Some(NonZeroU32::new(2).unwrap());
+            settings
+        });
+        assert_eq!(
+            map.update(cx, |map, cx| map.snapshot(cx)).text(),
+            "  a\n  b\n  c"
+        );
+    }
+
     fn syntax_chunks<'a>(
         rows: Range<u32>,
         map: &ModelHandle<DisplayMap>,

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -34,64 +34,64 @@ impl TabMap {
             version: old_snapshot.version,
         };
 
-        if old_snapshot.tab_size != new_snapshot.tab_size {
-            new_snapshot.version += 1;
-            let edits = vec![TabEdit {
-                old: TabPoint::zero()..old_snapshot.max_point(),
-                new: TabPoint::zero()..new_snapshot.max_point(),
-            }];
-            return (new_snapshot, edits);
-        }
-
         if old_snapshot.fold_snapshot.version != new_snapshot.fold_snapshot.version {
             new_snapshot.version += 1;
         }
 
         let old_max_offset = old_snapshot.fold_snapshot.len();
         let mut tab_edits = Vec::with_capacity(fold_edits.len());
-        for fold_edit in &mut fold_edits {
-            let mut delta = 0;
-            for chunk in
-                old_snapshot
-                    .fold_snapshot
-                    .chunks(fold_edit.old.end..old_max_offset, false, None)
-            {
-                let patterns: &[_] = &['\t', '\n'];
-                if let Some(ix) = chunk.text.find(patterns) {
-                    if &chunk.text[ix..ix + 1] == "\t" {
-                        fold_edit.old.end.0 += delta + ix + 1;
-                        fold_edit.new.end.0 += delta + ix + 1;
+
+        if old_snapshot.tab_size == new_snapshot.tab_size {
+            for fold_edit in &mut fold_edits {
+                let mut delta = 0;
+                for chunk in old_snapshot.fold_snapshot.chunks(
+                    fold_edit.old.end..old_max_offset,
+                    false,
+                    None,
+                ) {
+                    let patterns: &[_] = &['\t', '\n'];
+                    if let Some(ix) = chunk.text.find(patterns) {
+                        if &chunk.text[ix..ix + 1] == "\t" {
+                            fold_edit.old.end.0 += delta + ix + 1;
+                            fold_edit.new.end.0 += delta + ix + 1;
+                        }
+
+                        break;
                     }
 
-                    break;
+                    delta += chunk.text.len();
                 }
-
-                delta += chunk.text.len();
             }
-        }
 
-        let mut ix = 1;
-        while ix < fold_edits.len() {
-            let (prev_edits, next_edits) = fold_edits.split_at_mut(ix);
-            let prev_edit = prev_edits.last_mut().unwrap();
-            let edit = &next_edits[0];
-            if prev_edit.old.end >= edit.old.start {
-                prev_edit.old.end = edit.old.end;
-                prev_edit.new.end = edit.new.end;
-                fold_edits.remove(ix);
-            } else {
-                ix += 1;
+            let mut ix = 1;
+            while ix < fold_edits.len() {
+                let (prev_edits, next_edits) = fold_edits.split_at_mut(ix);
+                let prev_edit = prev_edits.last_mut().unwrap();
+                let edit = &next_edits[0];
+                if prev_edit.old.end >= edit.old.start {
+                    prev_edit.old.end = edit.old.end;
+                    prev_edit.new.end = edit.new.end;
+                    fold_edits.remove(ix);
+                } else {
+                    ix += 1;
+                }
             }
-        }
 
-        for fold_edit in fold_edits {
-            let old_start = fold_edit.old.start.to_point(&old_snapshot.fold_snapshot);
-            let old_end = fold_edit.old.end.to_point(&old_snapshot.fold_snapshot);
-            let new_start = fold_edit.new.start.to_point(&new_snapshot.fold_snapshot);
-            let new_end = fold_edit.new.end.to_point(&new_snapshot.fold_snapshot);
+            for fold_edit in fold_edits {
+                let old_start = fold_edit.old.start.to_point(&old_snapshot.fold_snapshot);
+                let old_end = fold_edit.old.end.to_point(&old_snapshot.fold_snapshot);
+                let new_start = fold_edit.new.start.to_point(&new_snapshot.fold_snapshot);
+                let new_end = fold_edit.new.end.to_point(&new_snapshot.fold_snapshot);
+                tab_edits.push(TabEdit {
+                    old: old_snapshot.to_tab_point(old_start)..old_snapshot.to_tab_point(old_end),
+                    new: new_snapshot.to_tab_point(new_start)..new_snapshot.to_tab_point(new_end),
+                });
+            }
+        } else {
+            new_snapshot.version += 1;
             tab_edits.push(TabEdit {
-                old: old_snapshot.to_tab_point(old_start)..old_snapshot.to_tab_point(old_end),
-                new: new_snapshot.to_tab_point(new_start)..new_snapshot.to_tab_point(new_end),
+                old: TabPoint::zero()..old_snapshot.max_point(),
+                new: TabPoint::zero()..new_snapshot.max_point(),
             });
         }
 

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -220,7 +220,7 @@ impl WrapMap {
         if !self.snapshot.interpolated {
             let mut to_remove_len = 0;
             for (tab_snapshot, _) in &self.pending_edits {
-                if tab_snapshot.version() <= self.snapshot.tab_snapshot.version() {
+                if tab_snapshot.version <= self.snapshot.tab_snapshot.version {
                     to_remove_len += 1;
                 } else {
                     break;
@@ -282,7 +282,7 @@ impl WrapMap {
         let was_interpolated = self.snapshot.interpolated;
         let mut to_remove_len = 0;
         for (tab_snapshot, edits) in &self.pending_edits {
-            if tab_snapshot.version() <= self.snapshot.tab_snapshot.version() {
+            if tab_snapshot.version <= self.snapshot.tab_snapshot.version {
                 to_remove_len += 1;
             } else {
                 let interpolated_edits = self.snapshot.interpolate(tab_snapshot.clone(), &edits);


### PR DESCRIPTION
## Description of feature or change

Previously, we wouldn't generate any `TabEdit` when the tab size changed, causing coordinate spaces in `WrapMap` and `BlockMap` to become outdated and out of sync compared to the `TabMap`.

This pull request generates a synthetic edit that covers the entire `TabMap` to ensure layers above are correctly synchronized.

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/387

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- ~~Have you added the necessary settings to configure this feature?~~
- ~~Has documentation been created or updated (including above changes to settings)?~~
