### PR TITLE
Add `newline_below` action

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -124,6 +124,7 @@
         "context": "Editor && mode == full",
         "bindings": {
             "enter": "editor::Newline",
+            "cmd-enter": "editor::NewlineBelow",
             "cmd-f": [
                 "buffer_search::Deploy",
                 {
@@ -141,7 +142,8 @@
     {
         "context": "Editor && mode == auto_height",
         "bindings": {
-            "alt-enter": "editor::Newline"
+            "alt-enter": "editor::Newline",
+            "cmd-alt-enter": "editor::NewlineBelow"
         }
     },
     {


### PR DESCRIPTION
## Description of feature or change

Insert a newline below all cursors, indent correctly, and move cursors onto their respective new lines

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
