### PR TITLE
Touch ups

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -27,7 +27,8 @@
             "cmd-q": "zed::Quit",
             "cmd-n": "workspace::NewFile",
             "cmd-shift-n": "workspace::NewWindow",
-            "cmd-o": "workspace::Open"
+            "cmd-o": "workspace::Open",
+            "ctrl-`": "terminal::Deploy"
         }
     },
     {

--- a/crates/terminal/src/connected_el.rs
+++ b/crates/terminal/src/connected_el.rs
@@ -368,14 +368,7 @@ impl TerminalEl {
         let fg = convert_color(&fg, &style.colors, modal);
 
         let underline = flags
-            .contains(
-                Flags::UNDERLINE
-                    | Flags::DOUBLE_UNDERLINE
-                    | Flags::DOTTED_UNDERLINE
-                    | Flags::DASHED_UNDERLINE
-                    | Flags::UNDERCURL
-                    | Flags::ALL_UNDERLINES,
-            )
+            .intersects(Flags::ALL_UNDERLINES)
             .then(|| Underline {
                 color: Some(fg),
                 squiggly: flags.contains(Flags::UNDERCURL),
@@ -386,11 +379,11 @@ impl TerminalEl {
         let mut properties = Properties::new();
         if indexed
             .flags
-            .contains(Flags::BOLD | Flags::BOLD_ITALIC | Flags::DIM_BOLD)
+            .intersects(Flags::BOLD | Flags::BOLD_ITALIC | Flags::DIM_BOLD)
         {
             properties = *properties.weight(Weight::BOLD);
         }
-        if indexed.flags.contains(Flags::ITALIC | Flags::BOLD_ITALIC) {
+        if indexed.flags.intersects(Flags::ITALIC | Flags::BOLD_ITALIC) {
             properties = *properties.style(Italic);
         }
 
@@ -598,12 +591,13 @@ impl Element for TerminalEl {
                     cells.extend(
                         content
                             .display_iter
-                            .filter(|ic| {
-                                !ic.flags.contains(Flags::HIDDEN)
-                                    && !(ic.bg == Named(NamedColor::Background)
-                                        && ic.c == ' '
-                                        && !ic.flags.contains(Flags::INVERSE))
-                            })
+                            //TODO: Add this once there's a way to retain empty lines
+                            // .filter(|ic| {
+                            //     !ic.flags.contains(Flags::HIDDEN)
+                            //         && !(ic.bg == Named(NamedColor::Background)
+                            //             && ic.c == ' '
+                            //             && !ic.flags.contains(Flags::INVERSE))
+                            // })
                             .map(|ic| IndexedCell {
                                 point: ic.point.clone(),
                                 cell: ic.cell.clone(),


### PR DESCRIPTION
## Description of feature or change

This adds:

* Respects bold, italics, and inverse flags.
* Adds a key binding to launch the terminal (ctrl-`)

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/259

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
  - N/A 
- [x] Have you added the necessary settings to configure this feature?
  - N/A 
- [x] Has documentation been created or updated (including above changes to settings)?
  - N/A 
