### PR TITLE
Fix two crashes related to diagnostics and bugs in mouse-based columnar selection

### DIFF
--- a/crates/gpui/src/text_layout.rs
+++ b/crates/gpui/src/text_layout.rs
@@ -238,8 +238,10 @@ impl Line {
         None
     }
 
-    // If round_to_closest, find the closest index to the given x position
-    // If !round_to_closest, find the largest index before the given x position
+    pub fn len(&self) -> usize {
+        self.layout.len
+    }
+
     pub fn index_for_x(&self, x: f32) -> Option<usize> {
         if x >= self.layout.width {
             None


### PR DESCRIPTION
### Description of feature or change

This PR fixes two crashes that @ForLoveOfCats and I discovered yesterday when pairing, both somewhat related to diagnostics.

The first crash occurred when the diagnostic popover was active, but the underlying diagnostic had been *removed* from the buffer since the popover was opened. Clicking the popover (to view the diagnostic blocks) would perform an `unwrap()`, assuming that the diagnostic still existed.

The second crash occurred when mousing over a diagnostic block. There was a logic error in `editor::Element` method called `point_for_position` that caused a subtraction with overflow.

While doing that, I noticed some errors in the way that we attempt to identify the *column* being clicked when creating columnar selections with the mouse and the `alt-shift` modifiers. We represented the column as the combination of a *clipped* display point plus an *overshoot* point. But sometimes (for example, when clicking on a block line or below the end of the buffer), clipping a display point changes its *row* in addition to its column, such that the nearest valid position has a *greater* column than the clicked position.

I've changed all of the logic for detecting the clicked column to use two independent points: one clipped (which we use for most purposes), and one that is *unclipped*. We use the latter point to represent the clicked column when creating a columnar selection. We can also test the *equality* of the two points to check if a valid position was clicked.

### Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/zed/issues/1450
Fixes https://github.com/zed-industries/zed/issues/1456

### Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
