### PR TITLE
Handle RPC requests for type definitions on server and host

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -165,6 +165,7 @@ impl Server {
             .add_message_handler(Server::update_diagnostic_summary)
             .add_request_handler(Server::forward_project_request::<proto::GetHover>)
             .add_request_handler(Server::forward_project_request::<proto::GetDefinition>)
+            .add_request_handler(Server::forward_project_request::<proto::GetTypeDefinition>)
             .add_request_handler(Server::forward_project_request::<proto::GetReferences>)
             .add_request_handler(Server::forward_project_request::<proto::SearchProject>)
             .add_request_handler(Server::forward_project_request::<proto::GetDocumentHighlights>)

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -389,6 +389,7 @@ impl Project {
         client.add_model_request_handler(Self::handle_get_completions);
         client.add_model_request_handler(Self::handle_lsp_command::<GetHover>);
         client.add_model_request_handler(Self::handle_lsp_command::<GetDefinition>);
+        client.add_model_request_handler(Self::handle_lsp_command::<GetTypeDefinition>);
         client.add_model_request_handler(Self::handle_lsp_command::<GetDocumentHighlights>);
         client.add_model_request_handler(Self::handle_lsp_command::<GetReferences>);
         client.add_model_request_handler(Self::handle_lsp_command::<PrepareRename>);


### PR DESCRIPTION
This adds  two missing lines of implementation code that set up RPC handlers for the `GetTypeDefinition` on the host and on the collaboration server.