### PR TITLE
Make project panel more compact

### DIFF
--- a/styles/src/styleTree/projectPanel.ts
+++ b/styles/src/styleTree/projectPanel.ts
@@ -6,7 +6,7 @@ export default function projectPanel(theme: Theme) {
   return {
     ...panel,
     padding: { left: 12, right: 12, top: 6, bottom: 6 },
-    indentWidth: 20,
+    indentWidth: 8,
     entry: {
       height: 24,
       iconColor: iconColor(theme, "muted"),


### PR DESCRIPTION
## Description of feature or change

This ensures more deeply-nested entries can be displayed without needing to show scrollbars. Adding scrollbars introduces UX issues when creating/renaming files because there are two scroll layers: the outer project panel AND the editor.

Sublime Text and Atom dodged this issue by not displaying an inline editor and showing it as a modal instead. VS Code shows the editor inline but has a much more compact visualization. I think we should copy VS Code.

Before:

<img width="1028" alt="Screen Shot 2022-08-05 at 16 42 12" src="https://user-images.githubusercontent.com/482957/183101040-49145200-aae5-42a3-a645-5eb1eef9e22a.png">

After:

<img width="1028" alt="Screen Shot 2022-08-05 at 16 42 08" src="https://user-images.githubusercontent.com/482957/183101068-8b08201b-5a67-486f-9836-c35a2e6cfac9.png">

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/feedback/issues/241

## Before Merging 

- ~~Does this have tests or have existing tests been updated to cover this change?~~
- ~~Have you added the necessary settings to configure this feature?~~
- ~~Has documentation been created or updated (including above changes to settings)?~~
