### PR TITLE
Use One Dark as the default theme.

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1,6 +1,6 @@
 {
     // The name of the Zed theme to use for the UI
-    "theme": "cave-dark",
+    "theme": "one-dark",
     // The name of a font to use for rendering text in the editor
     "buffer_font_family": "Zed Mono",
     // The default font size for text in the editor


### PR DESCRIPTION
## Description of feature or change
Use One Dark as the default theme.

Launch Screenshot:

![CleanShot - 2022-08-05 at 12 46 01@2x](https://user-images.githubusercontent.com/1714999/183123498-617bf404-859f-466a-9f04-e57c67cd54d1.png)

## Link to related issues from zed or insiders

https://github.com/zed-industries/zed/issues/1475

Closes #1475 

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
  - No functional changes
- [x] Have you added the necessary settings to configure this feature?
  - Setting already exists
- [x] Has documentation been created or updated (including above changes to settings)?
  - Updated the default value in "Configuring Zed" on zed.dev 
