### PR TITLE
Automatically trigger project search to occur when deploying

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -477,6 +477,7 @@ impl ProjectSearchView {
         search.update(cx, |search, cx| {
             if let Some(query) = query {
                 search.set_query(&query, cx);
+                search.search(cx);
             }
             search.focus_query_editor(cx)
         });


### PR DESCRIPTION
## Description of feature or change

When deploying project search automatically trigger a search to occur immediately

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
