### PR TITLE
Handle Cmd/Shift + Click go-to action on mouse-up instead of mouse-down

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1787,6 +1787,14 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn are_selections_empty(&self) -> bool {
+        let pending_empty = match self.selections.pending_anchor() {
+            Some(Selection { start, end, .. }) => start == end,
+            None => true,
+        };
+        pending_empty && self.columnar_selection_tail.is_none()
+    }
+
     pub fn is_selecting(&self) -> bool {
         self.selections.pending_anchor().is_some() || self.columnar_selection_tail.is_some()
     }


### PR DESCRIPTION
## Description of feature or change

See title

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/feedback/issues/416

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
