### PR TITLE
Add bootstrap script, avoid hard-coding zed team members

### DIFF
--- a/crates/collab/migrations/20210527024318_initial_schema.sql
+++ b/crates/collab/migrations/20210527024318_initial_schema.sql
@@ -18,9 +18,3 @@ CREATE TABLE IF NOT EXISTS "signups" (
     "email_address" VARCHAR,
     "about" TEXT
 );
-
-INSERT INTO users (github_login, admin)
-VALUES
-    ('nathansobo', true),
-    ('maxbrunsfeld', true),
-    ('as-cii', true);

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -709,7 +709,7 @@ impl Db for PostgresDb {
                 user_durations.user_id = project_durations.user_id AND
                 user_durations.user_id = users.id AND
                 project_durations.project_id = project_collaborators.project_id
-            ORDER BY total_duration DESC, user_id ASC
+            ORDER BY total_duration DESC, user_id ASC, project_id ASC
         ";
 
         let mut rows = sqlx::query_as::<_, (UserId, String, ProjectId, i64, i64)>(query)

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "installing foreman..."
+which foreman > /dev/null || brew install foreman
+
+echo "creating database..."
+script/sqlx database create
+
+echo "migrating database..."
+script/sqlx migrate run
+
+echo "seeding database..."
+script/seed-db

--- a/script/seed-db
+++ b/script/seed-db
@@ -4,6 +4,6 @@ set -e
 cd crates/collab
 
 # Export contents of .env.toml
-eval "$(cargo run --bin dotenv)"
+eval "$(cargo run --quiet --bin dotenv)"
 
-cargo run --package=collab --features seed-support --bin seed -- $@
+cargo run --quiet --package=collab --features seed-support --bin seed -- $@

--- a/script/sqlx
+++ b/script/sqlx
@@ -8,7 +8,7 @@ set -e
 cd crates/collab
 
 # Export contents of .env.toml
-eval "$(cargo run --bin dotenv)"
+eval "$(cargo run --quiet --bin dotenv)"
 
 # Run sqlx command
 sqlx $@


### PR DESCRIPTION
## Description of feature or change

This PR adds a `bootstrap` script that is intended to set up everything that you need for running the server locally, after cloning the repositories.

I've also updated the Seed script so that Zed team members are no longer hard-coded, but rather fetched from the GitHub API, and the *current* user is always set up as an admin.