### PR TITLE
Added focus-in and focus-out behavior to terminal

### DIFF
--- a/crates/terminal/src/connected_el.rs
+++ b/crates/terminal/src/connected_el.rs
@@ -647,6 +647,13 @@ impl Element for TerminalEl {
             let cursor_point = DisplayCursor::from(cursor.point, display_offset);
             let cursor_text = {
                 let str_trxt = cursor_text.to_string();
+
+                let color = if self.focused {
+                    terminal_theme.colors.background
+                } else {
+                    terminal_theme.colors.foreground
+                };
+
                 cx.text_layout_cache.layout_str(
                     &str_trxt,
                     text_style.font_size,
@@ -654,7 +661,7 @@ impl Element for TerminalEl {
                         str_trxt.len(),
                         RunStyle {
                             font_id: text_style.font_id,
-                            color: terminal_theme.colors.background,
+                            color,
                             underline: Default::default(),
                         },
                     )],

--- a/crates/terminal/src/connected_el.rs
+++ b/crates/terminal/src/connected_el.rs
@@ -200,6 +200,7 @@ pub struct TerminalEl {
     terminal: WeakModelHandle<Terminal>,
     view: WeakViewHandle<ConnectedView>,
     modal: bool,
+    focused: bool,
 }
 
 impl TerminalEl {
@@ -207,11 +208,13 @@ impl TerminalEl {
         view: WeakViewHandle<ConnectedView>,
         terminal: WeakModelHandle<Terminal>,
         modal: bool,
+        focused: bool,
     ) -> TerminalEl {
         TerminalEl {
             view,
             terminal,
             modal,
+            focused,
         }
     }
 
@@ -660,12 +663,18 @@ impl Element for TerminalEl {
 
             TerminalEl::shape_cursor(cursor_point, dimensions, &cursor_text).map(
                 move |(cursor_position, block_width)| {
+                    let (shape, color) = if self.focused {
+                        (CursorShape::Block, terminal_theme.colors.cursor)
+                    } else {
+                        (CursorShape::Underscore, terminal_theme.colors.foreground)
+                    };
+
                     Cursor::new(
                         cursor_position,
                         block_width,
                         dimensions.line_height,
-                        terminal_theme.colors.cursor,
-                        CursorShape::Block,
+                        color,
+                        shape,
                         Some(cursor_text),
                     )
                 },

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -601,16 +601,21 @@ impl Terminal {
         f(content, cursor_text)
     }
 
-    // fn estimate_utilization(last_processed: usize) -> f32 {
-    //     let buffer_utilization = (last_processed as f32 / (READ_BUFFER_SIZE as f32)).clamp(0., 1.);
-
-    //     //Scale result to bias low, then high
-    //     buffer_utilization * buffer_utilization
-    // }
-
     ///Scroll the terminal
     pub fn scroll(&mut self, scroll: Scroll) {
         self.events.push(InternalEvent::Scroll(scroll));
+    }
+
+    pub fn focus_in(&self) {
+        if self.last_mode.contains(TermMode::FOCUS_IN_OUT) {
+            self.notify_pty("\x1b[I".to_string());
+        }
+    }
+
+    pub fn focus_out(&self) {
+        if self.last_mode.contains(TermMode::FOCUS_IN_OUT) {
+            self.notify_pty("\x1b[O".to_string());
+        }
     }
 
     pub fn click(&mut self, point: Point, side: Direction, clicks: usize) {


### PR DESCRIPTION
## Description of feature or change

This both prints to the pty if the associated terminal mode is activated, and changes the cursor styling based on focus

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
