### PR TITLE
Clear any stale go-to-definition link when resizing the buffer font

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -42,7 +42,7 @@ use language::{
     DiagnosticSeverity, IndentKind, IndentSize, Language, OffsetRangeExt, OffsetUtf16, Point,
     Selection, SelectionGoal, TransactionId,
 };
-use link_go_to_definition::LinkGoToDefinitionState;
+use link_go_to_definition::{hide_link_definition, LinkGoToDefinitionState};
 pub use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot, ToOffset,
     ToPoint,
@@ -6010,6 +6010,7 @@ impl View for Editor {
                 if let Some(editor) = handle.upgrade(cx) {
                     editor.update(cx, |editor, cx| {
                         hide_hover(editor, cx);
+                        hide_link_definition(editor, cx);
                     })
                 }
             });

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Anchor, Autoscroll, Editor, Event, ExcerptId, MultiBuffer, NavigationData, ToPoint as _,
+    link_go_to_definition::hide_link_definition, Anchor, Autoscroll, Editor, Event, ExcerptId,
+    MultiBuffer, NavigationData, ToPoint as _,
 };
 use anyhow::{anyhow, Result};
 use futures::FutureExt;
@@ -374,6 +375,11 @@ impl Item for Editor {
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
         let selection = self.selections.newest_anchor();
         self.push_to_nav_history(selection.head(), None, cx);
+    }
+
+    fn workspace_deactivated(&mut self, cx: &mut ViewContext<Self>) {
+        hide_link_definition(self, cx);
+        self.link_go_to_definition_state.last_mouse_location = None;
     }
 
     fn is_dirty(&self, cx: &AppContext) -> bool {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -261,6 +261,7 @@ pub struct AppState {
 
 pub trait Item: View {
     fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
+    fn workspace_deactivated(&mut self, _: &mut ViewContext<Self>) {}
     fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) -> bool {
         false
     }
@@ -433,6 +434,7 @@ pub trait ItemHandle: 'static + fmt::Debug {
         cx: &mut ViewContext<Workspace>,
     );
     fn deactivated(&self, cx: &mut MutableAppContext);
+    fn workspace_deactivated(&self, cx: &mut MutableAppContext);
     fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext) -> bool;
     fn id(&self) -> usize;
     fn to_any(&self) -> AnyViewHandle;
@@ -627,6 +629,10 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
 
     fn deactivated(&self, cx: &mut MutableAppContext) {
         self.update(cx, |this, cx| this.deactivated(cx));
+    }
+
+    fn workspace_deactivated(&self, cx: &mut MutableAppContext) {
+        self.update(cx, |this, cx| this.workspace_deactivated(cx));
     }
 
     fn navigate(&self, data: Box<dyn Any>, cx: &mut MutableAppContext) -> bool {
@@ -2383,18 +2389,21 @@ impl Workspace {
         None
     }
 
-    fn on_window_activation_changed(&mut self, active: bool, cx: &mut ViewContext<Self>) {
-        if !active
-            && matches!(
-                cx.global::<Settings>().autosave,
-                Autosave::OnWindowChange | Autosave::OnFocusChange
-            )
-        {
+    pub fn on_window_activation_changed(&mut self, active: bool, cx: &mut ViewContext<Self>) {
+        if !active {
             for pane in &self.panes {
                 pane.update(cx, |pane, cx| {
-                    for item in pane.items() {
-                        Pane::autosave_item(item.as_ref(), self.project.clone(), cx)
-                            .detach_and_log_err(cx);
+                    if let Some(item) = pane.active_item() {
+                        item.workspace_deactivated(cx);
+                    }
+                    if matches!(
+                        cx.global::<Settings>().autosave,
+                        Autosave::OnWindowChange | Autosave::OnFocusChange
+                    ) {
+                        for item in pane.items() {
+                            Pane::autosave_item(item.as_ref(), self.project.clone(), cx)
+                                .detach_and_log_err(cx);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
This PR fixes two minor bugs with the *go-to-definition* link.

1. Previously, when resizing the font (and then possibly scrolling arbitrarily far) and then holding down the `cmd` key, it was possible to get a go-to-def link appearing far away from the mouse cursor. This PR fixes that bug in the same way that we fixed a similar behavior with the hover popover.
1. Previously, when using `cmd-tab` to navigate away from Zed (then moving the mouse) then using `cmd-tab` to come *back* to Zed, the go-to-def link would still be present at its initial location (arbitrarily far from the mouse cursor).