### PR TITLE
Terminal mouse mode

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -102,27 +102,37 @@
         //
         //
         "working_directory": "current_project_directory",
-        //Set the cursor blinking behavior in the terminal.
-        //May take 4 values:
-        // 1. Never blink the cursor, ignoring the terminal mode
-        //        "blinking": "off",
-        // 2. Default the cursor blink to off, but allow the terminal to 
-        //    set blinking
-        //        "blinking": "terminal_controlled",
-        // 3. Always blink the cursor, ignoring the terminal mode
-        //        "blinking": "on",
+        // Set the cursor blinking behavior in the terminal.
+        // May take 4 values:
+        //  1. Never blink the cursor, ignoring the terminal mode
+        //         "blinking": "off",
+        //  2. Default the cursor blink to off, but allow the terminal to 
+        //     set blinking
+        //         "blinking": "terminal_controlled",
+        //  3. Always blink the cursor, ignoring the terminal mode
+        //         "blinking": "on",
         "blinking": "terminal_controlled",
-        //Any key-value pairs added to this list will be added to the terminal's
-        //enviroment. Use `:` to seperate multiple values.
+        // Set whether Alternate Scroll mode (code: ?1007) is active by default.
+        // Alternate Scroll mode converts mouse scroll events into up / down key
+        // presses when in the alternate screen (e.g. when running applications 
+        // like vim or  less). The terminal can still set and unset this mode.
+        // May take 2 values:
+        //  1. Default alternate scroll mode to on
+        //         "alternate_scroll": "on",
+        //  2. Default alternate scroll mode to off
+        //         "alternate_scroll": "off",
+        "alternate_scroll": "off",
+        // Any key-value pairs added to this list will be added to the terminal's
+        // enviroment. Use `:` to seperate multiple values.
         "env": {
-            //"KEY": "value1:value2"
+            // "KEY": "value1:value2"
         }
-        //Set the terminal's font size. If this option is not included,
-        //the terminal will default to matching the buffer's font size.
-        //"font_size": "15"
-        //Set the terminal's font family. If this option is not included,
-        //the terminal will default to matching the buffer's font family.
-        //"font_family": "Zed Mono"
+        // Set the terminal's font size. If this option is not included,
+        // the terminal will default to matching the buffer's font size.
+        // "font_size": "15"
+        // Set the terminal's font family. If this option is not included,
+        // the terminal will default to matching the buffer's font family.
+        // "font_family": "Zed Mono"
     },
     // Different settings for specific languages.
     "languages": {
@@ -155,15 +165,15 @@
             "tab_size": 2
         }
     },
-    //LSP Specific settings.
+    // LSP Specific settings.
     "lsp": {
-        //Specify the LSP name as a key here.
-        //As of 8/10/22, supported LSPs are:
-        //pyright
-        //gopls
-        //rust-analyzer
-        //typescript-language-server
-        //vscode-json-languageserver
+        // Specify the LSP name as a key here.
+        // As of 8/10/22, supported LSPs are:
+        // pyright
+        // gopls
+        // rust-analyzer
+        // typescript-language-server
+        // vscode-json-languageserver
         // "rust_analyzer": {
         //     //These initialization options are merged into Zed's defaults
         //     "initialization_options": {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1582,6 +1582,7 @@ impl Element for EditorElement {
                 position,
                 delta,
                 precise,
+                ..
             }) => self.scroll(*position, *delta, *precise, layout, paint, cx),
 
             &Event::ModifiersChanged(event) => self.modifiers_changed(event, cx),

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -293,6 +293,7 @@ impl Element for Flex {
                 position,
                 delta,
                 precise,
+                ..
             }) = event
             {
                 if *remaining_space < 0. && bounds.contains_point(position) {

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -316,6 +316,7 @@ impl Element for List {
             position,
             delta,
             precise,
+            ..
         }) = event
         {
             if bounds.contains_point(*position)

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -315,6 +315,7 @@ impl Element for UniformList {
             position,
             delta,
             precise,
+            ..
         }) = event
         {
             if bounds.contains_point(*position)

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -24,6 +24,10 @@ pub struct ScrollWheelEvent {
     pub position: Vector2F,
     pub delta: Vector2F,
     pub precise: bool,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub cmd: bool,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug)]

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -148,6 +148,8 @@ impl Event {
                 })
             }
             NSEventType::NSScrollWheel => window_height.map(|window_height| {
+                let modifiers = native_event.modifierFlags();
+
                 Self::ScrollWheel(ScrollWheelEvent {
                     position: vec2f(
                         native_event.locationInWindow().x as f32,
@@ -158,6 +160,10 @@ impl Event {
                         native_event.scrollingDeltaY() as f32,
                     ),
                     precise: native_event.hasPreciseScrollingDeltas() == YES,
+                    ctrl: modifiers.contains(NSEventModifierFlags::NSControlKeyMask),
+                    alt: modifiers.contains(NSEventModifierFlags::NSAlternateKeyMask),
+                    shift: modifiers.contains(NSEventModifierFlags::NSShiftKeyMask),
+                    cmd: modifiers.contains(NSEventModifierFlags::NSCommandKeyMask),
                 })
             }),
             NSEventType::NSLeftMouseDragged

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -237,6 +237,7 @@ impl Presenter {
             let mut mouse_down_out_handlers = Vec::new();
             let mut mouse_moved_region = None;
             let mut mouse_down_region = None;
+            let mut mouse_up_region = None;
             let mut clicked_region = None;
             let mut dragged_region = None;
 
@@ -280,6 +281,15 @@ impl Presenter {
                         invalidated_views.push(region.view_id);
                         if region.bounds.contains_point(position) {
                             clicked_region = Some((region, MouseRegionEvent::Click(e.clone())));
+                        }
+                    }
+
+                    for (region, _) in self.mouse_regions.iter().rev() {
+                        if region.bounds.contains_point(position) {
+                            invalidated_views.push(region.view_id);
+                            mouse_up_region =
+                                Some((region.clone(), MouseRegionEvent::Up(e.clone())));
+                            break;
                         }
                     }
 
@@ -346,6 +356,17 @@ impl Presenter {
                 {
                     event_cx.with_current_view(move_moved_region.view_id, |event_cx| {
                         mouse_moved_callback(region_event, event_cx);
+                    })
+                }
+            }
+
+            if let Some((mouse_up_region, region_event)) = mouse_up_region {
+                handled = true;
+                if let Some(mouse_up_callback) =
+                    mouse_up_region.handlers.get(&region_event.handler_key())
+                {
+                    event_cx.with_current_view(mouse_up_region.view_id, |event_cx| {
+                        mouse_up_callback(region_event, event_cx);
                     })
                 }
             }

--- a/crates/gpui/src/scene/mouse_region.rs
+++ b/crates/gpui/src/scene/mouse_region.rs
@@ -1,6 +1,7 @@
 use std::{any::TypeId, mem::Discriminant, rc::Rc};
 
 use collections::HashMap;
+
 use pathfinder_geometry::{rect::RectF, vector::Vector2F};
 
 use crate::{EventContext, MouseButton, MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent};
@@ -95,6 +96,14 @@ impl MouseRegion {
         handler: impl Fn(bool, MouseMovedEvent, &mut EventContext) + 'static,
     ) -> Self {
         self.handlers = self.handlers.on_hover(handler);
+        self
+    }
+
+    pub fn on_move(
+        mut self,
+        handler: impl Fn(MouseMovedEvent, &mut EventContext) + 'static,
+    ) -> Self {
+        self.handlers = self.handlers.on_move(handler);
         self
     }
 }
@@ -262,6 +271,23 @@ impl HandlerSet {
                 } else {
                     panic!(
                         "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Hover, found {:?}", 
+                        region_event);
+                }
+            }));
+        self
+    }
+
+    pub fn on_move(
+        mut self,
+        handler: impl Fn(MouseMovedEvent, &mut EventContext) + 'static,
+    ) -> Self {
+        self.set.insert((MouseRegionEvent::move_disc(), None),
+            Rc::new(move |region_event, cx| {
+                if let MouseRegionEvent::Move(move_event)= region_event {
+                    handler(move_event, cx);
+                }  else {
+                    panic!(
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Move, found {:?}", 
                         region_event);
                 }
             }));

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -84,6 +84,7 @@ pub struct TerminalSettings {
     pub font_family: Option<String>,
     pub env: Option<HashMap<String, String>>,
     pub blinking: Option<TerminalBlink>,
+    pub alternate_scroll: Option<AlternateScroll>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -111,6 +112,19 @@ pub enum Shell {
 impl Default for Shell {
     fn default() -> Self {
         Shell::System
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AlternateScroll {
+    On,
+    Off,
+}
+
+impl Default for AlternateScroll {
+    fn default() -> Self {
+        AlternateScroll::On
     }
 }
 

--- a/crates/terminal/README.md
+++ b/crates/terminal/README.md
@@ -10,7 +10,7 @@ The TerminalView struct abstracts over failed and successful terminals, passing 
 
 #Input 
 
-There are currently 3 distinct paths for getting keystrokes to the terminal:
+There are currently many distinct paths for getting keystrokes to the terminal:
 
 1. Terminal specific characters and bindings. Things like ctrl-a mapping to ASCII control character 1, ANSI escape codes associated with the function keys, etc. These are caught with a raw key-down handler in the element and are processed immediately. This is done with the `try_keystroke()` method on Terminal
 
@@ -18,3 +18,6 @@ There are currently 3 distinct paths for getting keystrokes to the terminal:
 
 3. IME text. When the special character mappings fail, we pass the keystroke back to GPUI to hand it to the IME system. This comes back to us in the `View::replace_text_in_range()` method, and we then send that to the terminal directly, bypassing `try_keystroke()`.
 
+4. Pasted text has a seperate pathway. 
+
+Generally, there's a distinction between 'keystrokes that need to be mapped' and 'strings which need to be written'. I've attempted to unify these under the '.try_keystroke()' API and the `.input()` API (which try_keystroke uses) so we have consistent input handling across the terminal

--- a/crates/terminal/src/connected_el.rs
+++ b/crates/terminal/src/connected_el.rs
@@ -473,6 +473,22 @@ impl TerminalEl {
                         }
                     }
                 })
+                .on_drag(MouseButton::Left, move |_prev, event, cx| {
+                    if let Some(conn_handle) = connection.upgrade(cx.app) {
+                        conn_handle.update(cx.app, |terminal, cx| {
+                            let (point, side) = TerminalEl::mouse_to_cell_data(
+                                event.position,
+                                origin,
+                                cur_size,
+                                display_offset,
+                            );
+
+                            terminal.mouse_drag(point, side);
+
+                            cx.notify();
+                        })
+                    }
+                })
                 .on_down(
                     MouseButton::Left,
                     TerminalEl::generic_button_handler(
@@ -696,7 +712,7 @@ impl Element for TerminalEl {
 
                     (
                         cells,
-                        content.selection,
+                        dbg!(content.selection),
                         content.cursor,
                         content.display_offset,
                         cursor_text,

--- a/crates/terminal/src/connected_view.rs
+++ b/crates/terminal/src/connected_view.rs
@@ -251,7 +251,8 @@ impl ConnectedView {
     ///Attempt to paste the clipboard into the terminal
     fn paste(&mut self, _: &Paste, cx: &mut ViewContext<Self>) {
         if let Some(item) = cx.read_from_clipboard() {
-            self.terminal.read(cx).paste(item.text());
+            self.terminal
+                .update(cx, |terminal, _cx| terminal.paste(item.text()));
         }
     }
 
@@ -359,8 +360,7 @@ impl View for ConnectedView {
         cx: &mut ViewContext<Self>,
     ) {
         self.terminal.update(cx, |terminal, _| {
-            terminal.write_to_pty(text.into());
-            terminal.scroll(alacritty_terminal::grid::Scroll::Bottom);
+            terminal.input(text.into());
         });
     }
 

--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -1,3 +1,4 @@
+/// The mappings defined in this file where created from reading the alacritty source
 use alacritty_terminal::term::TermMode;
 use gpui::keymap::Keystroke;
 

--- a/crates/terminal/src/mappings/mod.rs
+++ b/crates/terminal/src/mappings/mod.rs
@@ -1,2 +1,3 @@
 pub mod colors;
 pub mod keys;
+pub mod mouse;

--- a/crates/terminal/src/mappings/mouse.rs
+++ b/crates/terminal/src/mappings/mouse.rs
@@ -134,8 +134,8 @@ pub fn scroll_report(
 pub fn alt_scroll(scroll_lines: i32) -> Vec<u8> {
     let cmd = if scroll_lines > 0 { b'A' } else { b'B' };
 
-    let mut content = Vec::with_capacity(scroll_lines as usize * 3);
-    for _ in 0..scroll_lines {
+    let mut content = Vec::with_capacity(scroll_lines.abs() as usize * 3);
+    for _ in 0..scroll_lines.abs() {
         content.push(0x1b);
         content.push(b'O');
         content.push(cmd);

--- a/crates/terminal/src/mappings/mouse.rs
+++ b/crates/terminal/src/mappings/mouse.rs
@@ -1,0 +1,248 @@
+/// Most of the code, and specifically the constants, in this are copied from Alacritty,
+/// with modifications for our circumstances
+use alacritty_terminal::{index::Point, term::TermMode};
+use gpui::{MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent};
+
+pub struct Modifiers {
+    ctrl: bool,
+    shift: bool,
+    alt: bool,
+}
+
+impl Modifiers {
+    pub fn from_moved(e: &MouseMovedEvent) -> Self {
+        Modifiers {
+            ctrl: e.ctrl,
+            shift: e.shift,
+            alt: e.alt,
+        }
+    }
+
+    pub fn from_button(e: &MouseButtonEvent) -> Self {
+        Modifiers {
+            ctrl: e.ctrl,
+            shift: e.shift,
+            alt: e.alt,
+        }
+    }
+
+    //TODO: Determine if I should add modifiers into the ScrollWheelEvent type
+    pub fn from_scroll() -> Self {
+        Modifiers {
+            ctrl: false,
+            shift: false,
+            alt: false,
+        }
+    }
+}
+
+pub enum MouseFormat {
+    SGR,
+    Normal(bool),
+}
+
+impl MouseFormat {
+    pub fn from_mode(mode: TermMode) -> Self {
+        if mode.contains(TermMode::SGR_MOUSE) {
+            MouseFormat::SGR
+        } else if mode.contains(TermMode::UTF8_MOUSE) {
+            MouseFormat::Normal(true)
+        } else {
+            MouseFormat::Normal(false)
+        }
+    }
+}
+
+pub enum MouseButton {
+    LeftButton = 0,
+    MiddleButton = 1,
+    RightButton = 2,
+    LeftMove = 32,
+    MiddleMove = 33,
+    RightMove = 34,
+    NoneMove = 35,
+    ScrollUp = 64,
+    ScrollDown = 65,
+    Other = 99,
+}
+
+impl MouseButton {
+    pub fn from_move(e: &MouseMovedEvent) -> Self {
+        match e.pressed_button {
+            Some(b) => match b {
+                gpui::MouseButton::Left => MouseButton::LeftMove,
+                gpui::MouseButton::Middle => MouseButton::MiddleMove,
+                gpui::MouseButton::Right => MouseButton::RightMove,
+                gpui::MouseButton::Navigate(_) => MouseButton::Other,
+            },
+            None => MouseButton::NoneMove,
+        }
+    }
+
+    pub fn from_button(e: &MouseButtonEvent) -> Self {
+        match e.button {
+            gpui::MouseButton::Left => MouseButton::LeftButton,
+            gpui::MouseButton::Right => MouseButton::MiddleButton,
+            gpui::MouseButton::Middle => MouseButton::RightButton,
+            gpui::MouseButton::Navigate(_) => MouseButton::Other,
+        }
+    }
+
+    pub fn from_scroll(e: &ScrollWheelEvent) -> Self {
+        if e.delta.y() > 0. {
+            MouseButton::ScrollUp
+        } else {
+            MouseButton::ScrollDown
+        }
+    }
+
+    pub fn is_other(&self) -> bool {
+        match self {
+            MouseButton::Other => true,
+            _ => false,
+        }
+    }
+}
+
+pub fn scroll_report(
+    point: Point,
+    scroll_lines: i32,
+    e: &ScrollWheelEvent,
+    mode: TermMode,
+) -> Option<Vec<Vec<u8>>> {
+    if mode.intersects(TermMode::MOUSE_MODE) && scroll_lines >= 1 {
+        if let Some(report) = mouse_report(
+            point,
+            MouseButton::from_scroll(e),
+            true,
+            Modifiers::from_scroll(),
+            MouseFormat::from_mode(mode),
+        ) {
+            let mut res = vec![];
+            for _ in 0..scroll_lines.abs() {
+                res.push(report.clone());
+            }
+            return Some(res);
+        }
+    }
+
+    None
+}
+
+pub fn mouse_button_report(
+    point: Point,
+    e: &MouseButtonEvent,
+    pressed: bool,
+    mode: TermMode,
+) -> Option<Vec<u8>> {
+    let button = MouseButton::from_button(e);
+    if !button.is_other() && mode.intersects(TermMode::MOUSE_MODE) {
+        mouse_report(
+            point,
+            button,
+            pressed,
+            Modifiers::from_button(e),
+            MouseFormat::from_mode(mode),
+        )
+    } else {
+        None
+    }
+}
+
+pub fn mouse_moved_report(point: Point, e: &MouseMovedEvent, mode: TermMode) -> Option<Vec<u8>> {
+    let button = MouseButton::from_move(e);
+    if !button.is_other() && mode.intersects(TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG) {
+        mouse_report(
+            point,
+            button,
+            true,
+            Modifiers::from_moved(e),
+            MouseFormat::from_mode(mode),
+        )
+    } else {
+        None
+    }
+}
+
+///Generate the bytes to send to the terminal, from the cell location, a mouse event, and the terminal mode
+fn mouse_report(
+    point: Point,
+    button: MouseButton,
+    pressed: bool,
+    modifiers: Modifiers,
+    format: MouseFormat,
+) -> Option<Vec<u8>> {
+    if point.line < 0 {
+        return None;
+    }
+
+    let mut mods = 0;
+    if modifiers.shift {
+        mods += 4;
+    }
+    if modifiers.alt {
+        mods += 8;
+    }
+    if modifiers.ctrl {
+        mods += 16;
+    }
+
+    match format {
+        MouseFormat::SGR => {
+            Some(sgr_mouse_report(point, button as u8 + mods, pressed).into_bytes())
+        }
+        MouseFormat::Normal(utf8) => {
+            if pressed {
+                normal_mouse_report(point, button as u8 + mods, utf8)
+            } else {
+                normal_mouse_report(point, 3 + mods, utf8)
+            }
+        }
+    }
+}
+
+fn normal_mouse_report(point: Point, button: u8, utf8: bool) -> Option<Vec<u8>> {
+    let Point { line, column } = point;
+    let max_point = if utf8 { 2015 } else { 223 };
+
+    if line >= max_point || column >= max_point {
+        return None;
+    }
+
+    let mut msg = vec![b'\x1b', b'[', b'M', 32 + button];
+
+    let mouse_pos_encode = |pos: usize| -> Vec<u8> {
+        let pos = 32 + 1 + pos;
+        let first = 0xC0 + pos / 64;
+        let second = 0x80 + (pos & 63);
+        vec![first as u8, second as u8]
+    };
+
+    if utf8 && column >= 95 {
+        msg.append(&mut mouse_pos_encode(column.0));
+    } else {
+        msg.push(32 + 1 + column.0 as u8);
+    }
+
+    if utf8 && line >= 95 {
+        msg.append(&mut mouse_pos_encode(line.0 as usize));
+    } else {
+        msg.push(32 + 1 + line.0 as u8);
+    }
+
+    Some(msg)
+}
+
+fn sgr_mouse_report(point: Point, button: u8, pressed: bool) -> String {
+    let c = if pressed { 'M' } else { 'm' };
+
+    let msg = format!(
+        "\x1b[<{};{};{}{}",
+        button,
+        point.column + 1,
+        point.line + 1,
+        c
+    );
+
+    msg
+}

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -607,11 +607,6 @@ impl Terminal {
         f(content, cursor_text)
     }
 
-    ///Scroll the terminal
-    pub fn scroll(&mut self, scroll: Scroll) {
-        self.events.push(InternalEvent::Scroll(scroll));
-    }
-
     pub fn focus_in(&self) {
         if self.last_mode.contains(TermMode::FOCUS_IN_OUT) {
             self.write_to_pty("\x1b[I".to_string());
@@ -624,34 +619,60 @@ impl Terminal {
         }
     }
 
+    ///Scroll the terminal
+    pub fn scroll(&mut self, scroll: Scroll) {
+        if self.last_mode.intersects(TermMode::MOUSE_MODE) {
+            //TODE: MOUSE MODE
+        }
+
+        self.events.push(InternalEvent::Scroll(scroll));
+    }
+
     pub fn click(&mut self, point: Point, side: Direction, clicks: usize) {
-        let selection_type = match clicks {
-            0 => return, //This is a release
-            1 => Some(SelectionType::Simple),
-            2 => Some(SelectionType::Semantic),
-            3 => Some(SelectionType::Lines),
-            _ => None,
-        };
+        if self.last_mode.intersects(TermMode::MOUSE_MODE) {
+            //TODE: MOUSE MODE
+        } else {
+            let selection_type = match clicks {
+                0 => return, //This is a release
+                1 => Some(SelectionType::Simple),
+                2 => Some(SelectionType::Semantic),
+                3 => Some(SelectionType::Lines),
+                _ => None,
+            };
 
-        let selection =
-            selection_type.map(|selection_type| Selection::new(selection_type, point, side));
+            let selection =
+                selection_type.map(|selection_type| Selection::new(selection_type, point, side));
 
-        self.events.push(InternalEvent::SetSelection(selection));
+            self.events.push(InternalEvent::SetSelection(selection));
+        }
+    }
+
+    pub fn mouse_move(&mut self, point: Point, side: Direction, clicks: usize) {
+        if self.last_mode.intersects(TermMode::MOUSE_MODE) {
+            //TODE: MOUSE MODE
+        }
     }
 
     pub fn drag(&mut self, point: Point, side: Direction) {
-        self.events
-            .push(InternalEvent::UpdateSelection((point, side)));
+        if self.last_mode.intersects(TermMode::MOUSE_MODE) {
+            //TODE: MOUSE MODE
+        } else {
+            self.events
+                .push(InternalEvent::UpdateSelection((point, side)));
+        }
     }
 
-    ///TODO: Check if the mouse_down-then-click assumption holds, so this code works as expected
     pub fn mouse_down(&mut self, point: Point, side: Direction) {
-        self.events
-            .push(InternalEvent::SetSelection(Some(Selection::new(
-                SelectionType::Simple,
-                point,
-                side,
-            ))));
+        if self.last_mode.intersects(TermMode::MOUSE_MODE) {
+            //TODE: MOUSE MODE
+        } else {
+            self.events
+                .push(InternalEvent::SetSelection(Some(Selection::new(
+                    SelectionType::Simple,
+                    point,
+                    side,
+                ))));
+        }
     }
 }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -28,7 +28,7 @@ use mappings::mouse::{
     alt_scroll, mouse_button_report, mouse_moved_report, mouse_point, mouse_side, scroll_report,
 };
 use modal::deploy_modal;
-use settings::{Settings, Shell, TerminalBlink};
+use settings::{AlternateScroll, Settings, Shell, TerminalBlink};
 use std::{collections::HashMap, fmt::Display, ops::Sub, path::PathBuf, sync::Arc, time::Duration};
 use thiserror::Error;
 
@@ -263,6 +263,7 @@ impl TerminalBuilder {
         env: Option<HashMap<String, String>>,
         initial_size: TerminalSize,
         blink_settings: Option<TerminalBlink>,
+        alternate_scroll: &AlternateScroll,
     ) -> Result<TerminalBuilder> {
         let pty_config = {
             let alac_shell = shell.clone().and_then(|shell| match shell {
@@ -304,6 +305,14 @@ impl TerminalBuilder {
         //Start off blinking if we need to
         if let Some(TerminalBlink::On) = blink_settings {
             term.set_mode(alacritty_terminal::ansi::Mode::BlinkingCursor)
+        }
+
+        //Start alternate_scroll if we need to
+        if let AlternateScroll::On = alternate_scroll {
+            term.set_mode(alacritty_terminal::ansi::Mode::AlternateScroll)
+        } else {
+            //Alacritty turns it on by default, so we need to turn it off.
+            term.unset_mode(alacritty_terminal::ansi::Mode::AlternateScroll)
         }
 
         let term = Arc::new(FairMutex::new(term));

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -664,7 +664,6 @@ impl Terminal {
 
     pub fn left_click(&mut self, e: &MouseButtonEvent, origin: Vector2F) {
         let position = e.position.sub(origin);
-        //TODO: Alt-click cursor position
 
         if !self.mouse_mode(e.shift) {
             let point = mouse_point(position, self.cur_size, self.last_offset);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -703,7 +703,7 @@ impl Terminal {
 
     ///Scroll the terminal
     pub fn scroll(&mut self, scroll: &ScrollWheelEvent, origin: Vector2F) {
-        if self.mouse_mode(false) {
+        if self.mouse_mode(scroll.shift) {
             //TODO: Currently this only sends the current scroll reports as they come in. Alacritty
             //Sends the *entire* scroll delta on *every* scroll event, only resetting it when
             //The scroll enters 'TouchPhase::Started'. Do I need to replicate this?
@@ -720,6 +720,7 @@ impl Terminal {
         } else if self
             .last_mode
             .contains(TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL)
+            && !scroll.shift
         {
             //TODO: See above TODO, also applies here.
             let scroll_lines = ((scroll.delta.y() * ALACRITTY_SCROLL_MULTIPLIER)

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -10,7 +10,7 @@ use workspace::{Item, Workspace};
 
 use crate::TerminalSize;
 use project::{LocalWorktree, Project, ProjectPath};
-use settings::{Settings, WorkingDirectory};
+use settings::{AlternateScroll, Settings, WorkingDirectory};
 use smallvec::SmallVec;
 use std::path::{Path, PathBuf};
 
@@ -94,12 +94,26 @@ impl TerminalView {
         let shell = settings.terminal_overrides.shell.clone();
         let envs = settings.terminal_overrides.env.clone(); //Should be short and cheap.
 
+        //TODO: move this pattern to settings
+        let scroll = settings
+            .terminal_overrides
+            .alternate_scroll
+            .as_ref()
+            .unwrap_or(
+                settings
+                    .terminal_defaults
+                    .alternate_scroll
+                    .as_ref()
+                    .unwrap_or_else(|| &AlternateScroll::On),
+            );
+
         let content = match TerminalBuilder::new(
             working_directory.clone(),
             shell,
             envs,
             size_info,
             settings.terminal_overrides.blinking.clone(),
+            scroll,
         ) {
             Ok(terminal) => {
                 let terminal = cx.add_model(|cx| terminal.subscribe(cx));

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "styles",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Description of feature or change

Forward mouse events to the terminal.

## Link to related issues from zed or insiders

## Before Merging 

TODO:
- [x] Events:
  - [x]  Moved,
  - [x]  Up,
  - [x]  Down,
  - [x]  scroll
- [x] Need to handle SGR vs. normal reporting
- [x] Make *all* input cancel selection and scroll
- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Make callbacks more efficient by only binding what's needed based on terminal mode
- [x] Add default alternate scroll setting
- [x] Add modifier keys to scroll
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
