### PR TITLE
Fix panic on main

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1169,22 +1169,17 @@ extern "C" fn insert_text(this: &Object, _: Sel, text: id, replacement_range: NS
                 .flatten()
                 .is_some();
 
-        match pending_key_down {
-            None | Some(_) if is_composing || text.chars().count() > 1 => {
-                with_input_handler(this, |input_handler| {
-                    input_handler.replace_text_in_range(replacement_range, text)
-                });
-            }
-
-            Some(mut pending_key_down) => {
-                pending_key_down.1 = Some(InsertText {
-                    replacement_range,
-                    text: text.to_string(),
-                });
-                window_state.borrow_mut().pending_key_down = Some(pending_key_down);
-            }
-
-            _ => unreachable!(),
+        if is_composing || text.chars().count() > 1 || pending_key_down.is_none() {
+            with_input_handler(this, |input_handler| {
+                input_handler.replace_text_in_range(replacement_range, text)
+            });
+        } else {
+            let mut pending_key_down = pending_key_down.unwrap();
+            pending_key_down.1 = Some(InsertText {
+                replacement_range,
+                text: text.to_string(),
+            });
+            window_state.borrow_mut().pending_key_down = Some(pending_key_down);
         }
     }
 }

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "styles",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Description of feature or change

This fixes a panic that was introduced to main during the clippy cleanup. I'm still not sure exactly why this if works and the match statement doesn't, but restoring the old behavior seems important.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
