### PR TITLE
Fix divergence bug in undo/redo

### DIFF
--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -39,7 +39,6 @@ pub fn serialize_operation(operation: &Operation) -> proto::Operation {
                 local_timestamp: undo.id.value,
                 lamport_timestamp: lamport_timestamp.value,
                 version: serialize_version(&undo.version),
-                transaction_version: serialize_version(&undo.transaction_version),
                 counts: undo
                     .counts
                     .iter()
@@ -199,7 +198,6 @@ pub fn deserialize_operation(message: proto::Operation) -> Result<Operation> {
                             )
                         })
                         .collect(),
-                    transaction_version: deserialize_version(undo.transaction_version),
                 },
             }),
             proto::operation::Variant::UpdateSelections(message) => {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -901,8 +901,7 @@ message Operation {
         uint32 local_timestamp = 2;
         uint32 lamport_timestamp = 3;
         repeated VectorClockEntry version = 4;
-        repeated VectorClockEntry transaction_version = 6;
-        repeated UndoCount counts = 7;
+        repeated UndoCount counts = 5;
     }
 
     message UpdateSelections {

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 29;
+pub const PROTOCOL_VERSION: u32 = 30;


### PR DESCRIPTION
## Description of feature or change

As part of #1405, we changed the way we performed undo and redo to support combining transactions that were not temporally adjacent for IME purposes.

We introduced a bug with that release that caused divergence when performing undo: the bug was caused by only changing the visibility of fragments whose insertion id was contained in the undo operation. However, an undo operation also affects deletions which we were mistakenly not considering. Randomized tests caught this but I guess we didn't run enough of them.

## Link to related issues from zed or insiders

Fixes #1528 

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- ~~Have you added the necessary settings to configure this feature?~~
- ~~Has documentation been created or updated (including above changes to settings)?~~
