### PR TITLE
Fix focus regression in contact finder

### DIFF
--- a/crates/contacts_panel/src/contact_finder.rs
+++ b/crates/contacts_panel/src/contact_finder.rs
@@ -43,7 +43,9 @@ impl View for ContactFinder {
     }
 
     fn on_focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.focus(&self.picker);
+        if cx.is_self_focused() {
+            cx.focus(&self.picker);
+        }
     }
 }
 


### PR DESCRIPTION
It looks like our `focus_in` changes in #1441 broke the management of focus in the contacts finder. This fixes it.