### PR TITLE
Fix crash when closing a window while in full-screen mode

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -458,9 +458,15 @@ impl Window {
 
 impl Drop for Window {
     fn drop(&mut self) {
-        unsafe {
-            self.0.as_ref().borrow().native_window.close();
-        }
+        let this = self.0.borrow();
+        let window = this.native_window;
+        this.executor
+            .spawn(async move {
+                unsafe {
+                    window.close();
+                }
+            })
+            .detach();
     }
 }
 


### PR DESCRIPTION
## Description of feature or change

This commit delays closing the native window to the next tick to avoid borrowing either `WindowState` or `MutableAppContext` twice.

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/453

## Before Merging 

- ~~Does this have tests or have existing tests been updated to cover this change?~~
- ~~Have you added the necessary settings to configure this feature?~~
- ~~Has documentation been created or updated (including above changes to settings)?~~
