### PR TITLE
Fix goto links with selections

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1789,15 +1789,15 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn are_selections_empty(&self) -> bool {
-        let pending_empty = match self.selections.pending_anchor() {
-            Some(Selection { start, end, .. }) => start == end,
-            None => true,
+    pub fn has_pending_nonempty_selection(&self) -> bool {
+        let pending_nonempty_selection = match self.selections.pending_anchor() {
+            Some(Selection { start, end, .. }) => start != end,
+            None => false,
         };
-        pending_empty && self.columnar_selection_tail.is_none()
+        pending_nonempty_selection || self.columnar_selection_tail.is_some()
     }
 
-    pub fn is_selecting(&self) -> bool {
+    pub fn has_pending_selection(&self) -> bool {
         self.selections.pending_anchor().is_some() || self.columnar_selection_tail.is_some()
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -179,14 +179,14 @@ impl EditorElement {
         cx: &mut EventContext,
     ) -> bool {
         let view = self.view(cx.app.as_ref());
-        let end_selection = view.is_selecting();
-        let selections_empty = view.are_selections_empty();
+        let end_selection = view.has_pending_selection();
+        let pending_nonempty_selections = view.has_pending_nonempty_selection();
 
         if end_selection {
             cx.dispatch_action(Select(SelectPhase::End));
         }
 
-        if selections_empty && cmd && paint.text_bounds.contains_point(position) {
+        if !pending_nonempty_selections && cmd && paint.text_bounds.contains_point(position) {
             let (point, target_point) =
                 paint.point_for_position(&self.snapshot(cx), layout, position);
 
@@ -206,14 +206,38 @@ impl EditorElement {
 
     fn mouse_dragged(
         &self,
-        position: Vector2F,
+        MouseMovedEvent {
+            cmd,
+            shift,
+            position,
+            ..
+        }: MouseMovedEvent,
         layout: &mut LayoutState,
         paint: &mut PaintState,
         cx: &mut EventContext,
     ) -> bool {
-        let view = self.view(cx.app.as_ref());
+        // This will be handled more correctly once https://github.com/zed-industries/zed/issues/1218 is completed
+        // Don't trigger hover popover if mouse is hovering over context menu
+        let point = if paint.text_bounds.contains_point(position) {
+            let (point, target_point) =
+                paint.point_for_position(&self.snapshot(cx), layout, position);
+            if point == target_point {
+                Some(point)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
-        if view.is_selecting() {
+        cx.dispatch_action(UpdateGoToDefinitionLink {
+            point,
+            cmd_held: cmd,
+            shift_held: shift,
+        });
+
+        let view = self.view(cx.app);
+        if view.has_pending_selection() {
             let rect = paint.text_bounds;
             let mut scroll_delta = Vector2F::zero();
 
@@ -250,8 +274,11 @@ impl EditorElement {
                 scroll_position: (snapshot.scroll_position() + scroll_delta)
                     .clamp(Vector2F::zero(), layout.scroll_max),
             }));
+
+            cx.dispatch_action(HoverAt { point });
             true
         } else {
+            cx.dispatch_action(HoverAt { point });
             false
         }
     }
@@ -1572,11 +1599,12 @@ impl Element for EditorElement {
                 ..
             }) => self.mouse_up(position, cmd, shift, layout, paint, cx),
 
-            Event::MouseMoved(MouseMovedEvent {
-                pressed_button: Some(MouseButton::Left),
-                position,
-                ..
-            }) => self.mouse_dragged(*position, layout, paint, cx),
+            Event::MouseMoved(
+                event @ MouseMovedEvent {
+                    pressed_button: Some(MouseButton::Left),
+                    ..
+                },
+            ) => self.mouse_dragged(*event, layout, paint, cx),
 
             Event::ScrollWheel(ScrollWheelEvent {
                 position,

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -183,7 +183,7 @@ impl<'a> EditorTestContext<'a> {
         }
     }
 
-    fn ranges(&self, marked_text: &str) -> Vec<Range<usize>> {
+    pub fn ranges(&self, marked_text: &str) -> Vec<Range<usize>> {
         let (unmarked_text, ranges) = marked_text_ranges(marked_text, false);
         assert_eq!(self.buffer_text(), unmarked_text);
         ranges

--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -64,7 +64,7 @@ impl Default for MouseButton {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct MouseButtonEvent {
     pub button: MouseButton,
     pub position: Vector2F,


### PR DESCRIPTION
## Description of feature or change

Prevents drawing go-to links while actively selecting text and as a result fixes an annoying event handling bug which prevented mouse cursor changes after a mouse move that had a button down even after the button was released. Also fixes an annoying issue where the link point used one of the ends of the selection rather than the mouse cursor... somehow (not going to question it at this point)

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/440

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
