### PR TITLE
Include empty selections in updating link logic on cmd/shift changed

### DIFF
--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -121,14 +121,14 @@ pub fn cmd_shift_changed(
     }: &CmdShiftChanged,
     cx: &mut ViewContext<Editor>,
 ) {
-    let pending_nonempty_selection = editor.has_pending_nonempty_selection();
+    let pending_selection = editor.has_pending_selection();
 
     if let Some(point) = editor
         .link_go_to_definition_state
         .last_mouse_location
         .clone()
     {
-        if cmd_down && !pending_nonempty_selection {
+        if cmd_down && !pending_selection {
             let snapshot = editor.snapshot(cx);
             let kind = if shift_down {
                 LinkDefinitionKind::Type


### PR DESCRIPTION
## Description of feature or change

Prevents an issue where pressing cmd while the mouse button is down
would create a link which would fire on mouse up if the selection was
still empty

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/zed/issues/1541

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
