### PR TITLE
Only extend selection with shift without other modifiers

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -110,13 +110,17 @@ impl EditorElement {
         self.update_view(cx, |view, cx| view.snapshot(cx))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn mouse_down(
         &self,
-        position: Vector2F,
-        alt: bool,
-        shift: bool,
-        mut click_count: usize,
+        MouseButtonEvent {
+            position,
+            ctrl,
+            alt,
+            shift,
+            cmd,
+            mut click_count,
+            ..
+        }: MouseButtonEvent,
         layout: &mut LayoutState,
         paint: &mut PaintState,
         cx: &mut EventContext,
@@ -135,7 +139,7 @@ impl EditorElement {
                 position,
                 goal_column: target_position.column(),
             }));
-        } else if shift {
+        } else if shift && !ctrl && !alt && !cmd {
             cx.dispatch_action(Select(SelectPhase::Extend {
                 position,
                 click_count,
@@ -1576,14 +1580,12 @@ impl Element for EditorElement {
         }
 
         match event {
-            &Event::MouseDown(MouseButtonEvent {
-                button: MouseButton::Left,
-                position,
-                alt,
-                shift,
-                click_count,
-                ..
-            }) => self.mouse_down(position, alt, shift, click_count, layout, paint, cx),
+            &Event::MouseDown(
+                event @ MouseButtonEvent {
+                    button: MouseButton::Left,
+                    ..
+                },
+            ) => self.mouse_down(event, layout, paint, cx),
 
             &Event::MouseDown(MouseButtonEvent {
                 button: MouseButton::Right,


### PR DESCRIPTION
## Description of feature or change

Don't shift extend selection if any other modifiers are pressed. With the new logic surrounding go-to links and selections this avoids an issue where cmd+shift+click to go-to-type-definition would extend the selection rather than performing the go-to if the edit cursor wasn't already at the click location. I figured it would make sense to also check for any other modifiers, so the extending only happens on shift+click with no other modifiers pressed

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
