### PR TITLE
Basic feature flag implementation

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -425,12 +425,5 @@
             "cmd-v": "terminal::Paste",
             "cmd-k": "terminal::Clear"
         }
-    },
-    {
-        "context": "ModalTerminal",
-        "bindings": {
-            "ctrl-cmd-space": "terminal::ShowCharacterPalette",
-            "shift-escape": "terminal::DeployModal"
-        }
     }
 ]

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -20,7 +20,7 @@ pub use keymap_file::{keymap_file_json_schema, KeymapFileContent};
 
 #[derive(Clone)]
 pub struct Settings {
-    pub nightly: FeatureFlags,
+    pub experiments: FeatureFlags,
     pub projects_online_by_default: bool,
     pub buffer_font_family: FamilyId,
     pub default_buffer_font_size: f32,
@@ -197,7 +197,7 @@ impl Settings {
         .unwrap();
 
         Self {
-            nightly: FeatureFlags::default(),
+            experiments: FeatureFlags::default(),
             buffer_font_family: font_cache
                 .load_family(&[defaults.buffer_font_family.as_ref().unwrap()])
                 .unwrap(),
@@ -256,7 +256,7 @@ impl Settings {
         );
         merge(&mut self.vim_mode, data.vim_mode);
         merge(&mut self.autosave, data.autosave);
-        merge(&mut self.nightly, data.nightly);
+        merge(&mut self.experiments, data.nightly);
         // Ensure terminal font is loaded, so we can request it in terminal_element layout
         if let Some(terminal_font) = &data.terminal.font_family {
             font_cache.load_family(&[terminal_font]).log_err();
@@ -317,7 +317,7 @@ impl Settings {
     #[cfg(any(test, feature = "test-support"))]
     pub fn test(cx: &gpui::AppContext) -> Settings {
         Settings {
-            nightly: FeatureFlags::default(),
+            experiments: FeatureFlags::default(),
             buffer_font_family: cx.font_cache().load_family(&["Monaco"]).unwrap(),
             buffer_font_size: 14.,
             default_buffer_font_size: 14.,

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -146,7 +146,7 @@ pub enum WorkingDirectory {
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
 pub struct SettingsFileContent {
     #[serde(default)]
-    pub nightly: Option<FeatureFlags>,
+    pub experiments: Option<FeatureFlags>,
     #[serde(default)]
     pub projects_online_by_default: Option<bool>,
     #[serde(default)]
@@ -256,7 +256,7 @@ impl Settings {
         );
         merge(&mut self.vim_mode, data.vim_mode);
         merge(&mut self.autosave, data.autosave);
-        merge(&mut self.experiments, data.nightly);
+        merge(&mut self.experiments, data.experiments);
         // Ensure terminal font is loaded, so we can request it in terminal_element layout
         if let Some(terminal_font) = &data.terminal.font_family {
             font_cache.load_family(&[terminal_font]).log_err();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -46,7 +46,10 @@ use crate::mappings::{
 
 ///Initialize and register all of our action handlers
 pub fn init(cx: &mut MutableAppContext) {
-    cx.add_action(deploy_modal);
+    let settings = cx.global::<Settings>();
+    if settings.nightly.modal_terminal {
+        cx.add_action(deploy_modal);
+    }
 
     terminal_view::init(cx);
     connected_view::init(cx);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -47,7 +47,7 @@ use crate::mappings::{
 ///Initialize and register all of our action handlers
 pub fn init(cx: &mut MutableAppContext) {
     let settings = cx.global::<Settings>();
-    if settings.nightly.modal_terminal {
+    if settings.experiments.modal_terminal {
         cx.add_action(deploy_modal);
     }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -95,6 +95,12 @@ fn main() {
             .spawn(languages::init(languages.clone(), cx.background().clone()));
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
 
+        let (settings_file, keymap_file) = cx.background().block(config_files).unwrap();
+
+        //Make sure to load settings before initialization, so we know what features to toggle
+        watch_settings_file(default_settings, settings_file, themes.clone(), cx);
+        watch_keymap_file(keymap_file, cx);
+
         context_menu::init(cx);
         project::Project::init(&client);
         client::Channel::init(&client);
@@ -114,10 +120,7 @@ fn main() {
         terminal::init(cx);
 
         let db = cx.background().block(db);
-        let (settings_file, keymap_file) = cx.background().block(config_files).unwrap();
 
-        watch_settings_file(default_settings, settings_file, themes.clone(), cx);
-        watch_keymap_file(keymap_file, cx);
         cx.spawn(|cx| watch_themes(fs.clone(), themes.clone(), cx))
             .detach();
 


### PR DESCRIPTION
## Description of feature or change

This PR adds a feature flags system to Zed and puts the Modal terminal behind it. 

When publishing this update, people's existing workflows may fail. To restore the modal terminal behavior, user's should:

* add this field to their settings.json:

```json
"experiments": {
        "modal_terminal": true
}
```

Note the lack of `"` around the value, this is a JSON boolean. 

* Add or merge this into their keymaps.json file:

```json
{
        "context": "ModalTerminal",
        "bindings": {
            "ctrl-cmd-space": "terminal::ShowCharacterPalette",
            "shift-escape": "terminal::DeployModal"
        }
}
```

* Restart Zed. Experimental features require a full Zed restart to take effect.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
