### PR TITLE
Feature flag

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -425,12 +425,5 @@
             "cmd-v": "terminal::Paste",
             "cmd-k": "terminal::Clear"
         }
-    },
-    {
-        "context": "ModalTerminal",
-        "bindings": {
-            "ctrl-cmd-space": "terminal::ShowCharacterPalette",
-            "shift-escape": "terminal::DeployModal"
-        }
     }
 ]

--- a/assets/keymaps/experiments/modal_terminal.json
+++ b/assets/keymaps/experiments/modal_terminal.json
@@ -1,0 +1,9 @@
+[
+    {
+        "context": "ModalTerminal",
+        "bindings": {
+            "ctrl-cmd-space": "terminal::ShowCharacterPalette",
+            "shift-escape": "terminal::DeployModal"
+        }
+    }
+]

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -1,4 +1,4 @@
-use crate::parse_json_with_comments;
+use crate::{parse_json_with_comments, Settings};
 use anyhow::{Context, Result};
 use assets::Assets;
 use collections::BTreeMap;
@@ -10,6 +10,7 @@ use schemars::{
 };
 use serde::Deserialize;
 use serde_json::{value::RawValue, Value};
+use util::ResultExt;
 
 #[derive(Deserialize, Default, Clone, JsonSchema)]
 #[serde(transparent)]
@@ -41,7 +42,9 @@ struct ActionWithData(Box<str>, Box<RawValue>);
 
 impl KeymapFileContent {
     pub fn load_defaults(cx: &mut MutableAppContext) {
-        for path in ["keymaps/default.json", "keymaps/vim.json"] {
+        let mut paths = vec!["keymaps/default.json", "keymaps/vim.json"];
+        paths.extend(cx.global::<Settings>().experiments.keymap_files());
+        for path in paths {
             Self::load(path, cx).unwrap();
         }
     }
@@ -56,26 +59,27 @@ impl KeymapFileContent {
         for KeymapBlock { context, bindings } in self.0 {
             let bindings = bindings
                 .into_iter()
-                .map(|(keystroke, action)| {
+                .filter_map(|(keystroke, action)| {
                     let action = action.0.get();
 
                     // This is a workaround for a limitation in serde: serde-rs/json#497
                     // We want to deserialize the action data as a `RawValue` so that we can
                     // deserialize the action itself dynamically directly from the JSON
                     // string. But `RawValue` currently does not work inside of an untagged enum.
-                    let action = if action.starts_with('[') {
-                        let ActionWithData(name, data) = serde_json::from_str(action)?;
+                    if action.starts_with('[') {
+                        let ActionWithData(name, data) = serde_json::from_str(action).log_err()?;
                         cx.deserialize_action(&name, Some(data.get()))
                     } else {
-                        let name = serde_json::from_str(action)?;
+                        let name = serde_json::from_str(action).log_err()?;
                         cx.deserialize_action(name, None)
                     }
                     .with_context(|| {
                         format!(
                             "invalid binding value for keystroke {keystroke}, context {context:?}"
                         )
-                    })?;
-                    Binding::load(&keystroke, action, context.as_deref())
+                    })
+                    .log_err()
+                    .map(|action| Binding::load(&keystroke, action, context.as_deref()))
                 })
                 .collect::<Result<Vec<_>>>()?;
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -46,7 +46,10 @@ use crate::mappings::{
 
 ///Initialize and register all of our action handlers
 pub fn init(cx: &mut MutableAppContext) {
-    cx.add_action(deploy_modal);
+    let settings = cx.global::<Settings>();
+    if settings.experiments.modal_terminal() {
+        cx.add_action(deploy_modal);
+    }
 
     terminal_view::init(cx);
     connected_view::init(cx);

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -97,6 +97,7 @@ fn main() {
 
         let (settings_file, keymap_file) = cx.background().block(config_files).unwrap();
 
+        //Setup settings global before binding actions
         watch_settings_file(default_settings, settings_file, themes.clone(), cx);
         watch_keymap_file(keymap_file, cx);
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -95,6 +95,11 @@ fn main() {
             .spawn(languages::init(languages.clone(), cx.background().clone()));
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
 
+        let (settings_file, keymap_file) = cx.background().block(config_files).unwrap();
+
+        watch_settings_file(default_settings, settings_file, themes.clone(), cx);
+        watch_keymap_file(keymap_file, cx);
+
         context_menu::init(cx);
         project::Project::init(&client);
         client::Channel::init(&client);
@@ -114,10 +119,6 @@ fn main() {
         terminal::init(cx);
 
         let db = cx.background().block(db);
-        let (settings_file, keymap_file) = cx.background().block(config_files).unwrap();
-
-        watch_settings_file(default_settings, settings_file, themes.clone(), cx);
-        watch_keymap_file(keymap_file, cx);
         cx.spawn(|cx| watch_themes(fs.clone(), themes.clone(), cx))
             .detach();
 


### PR DESCRIPTION
## Description of feature or change

This is a redo of the feature flag changes, to create a mechanism for adding an experimental default keymaps file. 

Some users may experience a regression in their workflow now that the modal terminal is behind a flag. To fix this, users will need to add:

```json
"experiments": {
    "modal_terminal": true
}
```

To their settings.json file. 

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
