### PR TITLE
Added drag-to-edge.

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2006,7 +2006,7 @@ impl HighlightedRange {
     }
 }
 
-fn scale_vertical_mouse_autoscroll_delta(delta: f32) -> f32 {
+pub fn scale_vertical_mouse_autoscroll_delta(delta: f32) -> f32 {
     delta.powf(1.5) / 100.0
 }
 

--- a/crates/terminal/src/mappings/mouse.rs
+++ b/crates/terminal/src/mappings/mouse.rs
@@ -33,12 +33,11 @@ impl Modifiers {
         }
     }
 
-    //TODO: Determine if I should add modifiers into the ScrollWheelEvent type
-    fn from_scroll() -> Self {
+    fn from_scroll(scroll: &ScrollWheelEvent) -> Self {
         Modifiers {
-            ctrl: false,
-            shift: false,
-            alt: false,
+            ctrl: scroll.ctrl,
+            shift: scroll.shift,
+            alt: scroll.alt,
         }
     }
 }
@@ -123,7 +122,7 @@ pub fn scroll_report(
             point,
             MouseButton::from_scroll(e),
             true,
-            Modifiers::from_scroll(),
+            Modifiers::from_scroll(e),
             MouseFormat::from_mode(mode),
         )
         .map(|report| repeat(report).take(max(scroll_lines, 1) as usize))

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -457,7 +457,7 @@ impl TerminalElement {
                 if cx.is_parent_view_focused() {
                     if let Some(conn_handle) = connection.upgrade(cx.app) {
                         conn_handle.update(cx.app, |terminal, cx| {
-                            terminal.mouse_drag(event, origin);
+                            terminal.mouse_drag(event, origin, visible_bounds);
                             cx.notify();
                         })
                     }

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -830,7 +830,7 @@ impl Element for TerminalElement {
                     let origin = bounds.origin() + vec2f(layout.size.cell_width, 0.);
 
                     if let Some(terminal) = self.terminal.upgrade(cx.app) {
-                        terminal.update(cx.app, |term, _| term.scroll(e, origin));
+                        terminal.update(cx.app, |term, _| term.scroll_wheel(e, origin));
                         cx.notify();
                     }
                 })


### PR DESCRIPTION
## Description of feature or change

Adds the ability to scroll a terminal by dragging a selection to the edge, and fixes scrolling desyncing with the mouse

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/436.

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
