### PR TITLE
Prevent guest disconnection when opening buffers with many operations

### DIFF
--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -3304,8 +3304,16 @@ mod tests {
     fn test_remote_multibuffer(cx: &mut MutableAppContext) {
         let host_buffer = cx.add_model(|cx| Buffer::new(0, "a", cx));
         let guest_buffer = cx.add_model(|cx| {
-            let message = host_buffer.read(cx).to_proto();
-            Buffer::from_proto(1, message, None, cx).unwrap()
+            let (state, ops) = host_buffer.read(cx).to_proto();
+            let mut buffer = Buffer::from_proto(1, state, None).unwrap();
+            buffer
+                .apply_ops(
+                    ops.into_iter()
+                        .map(|op| language::proto::deserialize_operation(op).unwrap()),
+                    cx,
+                )
+                .unwrap();
+            buffer
         });
         let multibuffer = cx.add_model(|cx| MultiBuffer::singleton(guest_buffer.clone(), cx));
         let snapshot = multibuffer.read(cx).snapshot(cx);

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -3304,7 +3304,10 @@ mod tests {
     fn test_remote_multibuffer(cx: &mut MutableAppContext) {
         let host_buffer = cx.add_model(|cx| Buffer::new(0, "a", cx));
         let guest_buffer = cx.add_model(|cx| {
-            let (state, ops) = host_buffer.read(cx).to_proto();
+            let state = host_buffer.read(cx).to_proto();
+            let ops = cx
+                .background()
+                .block(host_buffer.read(cx).serialize_ops(cx));
             let mut buffer = Buffer::from_proto(1, state, None).unwrap();
             buffer
                 .apply_ops(

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -1048,7 +1048,8 @@ fn test_serialization(cx: &mut gpui::MutableAppContext) {
     });
     assert_eq!(buffer1.read(cx).text(), "abcDF");
 
-    let (state, ops) = buffer1.read(cx).to_proto();
+    let state = buffer1.read(cx).to_proto();
+    let ops = cx.background().block(buffer1.read(cx).serialize_ops(cx));
     let buffer2 = cx.add_model(|cx| {
         let mut buffer = Buffer::from_proto(1, state, None).unwrap();
         buffer
@@ -1086,7 +1087,10 @@ fn test_random_collaboration(cx: &mut MutableAppContext, mut rng: StdRng) {
 
     for i in 0..rng.gen_range(min_peers..=max_peers) {
         let buffer = cx.add_model(|cx| {
-            let (state, ops) = base_buffer.read(cx).to_proto();
+            let state = base_buffer.read(cx).to_proto();
+            let ops = cx
+                .background()
+                .block(base_buffer.read(cx).serialize_ops(cx));
             let mut buffer = Buffer::from_proto(i as ReplicaId, state, None).unwrap();
             buffer
                 .apply_ops(
@@ -1181,7 +1185,8 @@ fn test_random_collaboration(cx: &mut MutableAppContext, mut rng: StdRng) {
                 mutation_count -= 1;
             }
             50..=59 if replica_ids.len() < max_peers => {
-                let (old_buffer_state, old_buffer_ops) = buffer.read(cx).to_proto();
+                let old_buffer_state = buffer.read(cx).to_proto();
+                let old_buffer_ops = cx.background().block(buffer.read(cx).serialize_ops(cx));
                 let new_replica_id = (0..=replica_ids.len() as ReplicaId)
                     .filter(|replica_id| *replica_id != buffer.read(cx).replica_id())
                     .choose(&mut rng)

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -370,7 +370,10 @@ message OpenBufferResponse {
 message CreateBufferForPeer {
     uint64 project_id = 1;
     uint32 peer_id = 2;
-    Buffer buffer = 3;
+    oneof variant {
+        BufferState state = 3;
+        BufferChunk chunk = 4;
+    }
 }
 
 message UpdateBuffer {
@@ -808,12 +811,17 @@ message Entry {
     bool is_ignored = 7;
 }
 
-message Buffer {
+message BufferState {
     uint64 id = 1;
     optional File file = 2;
     string base_text = 3;
-    repeated Operation operations = 4;
-    LineEnding line_ending = 5;
+    LineEnding line_ending = 4;
+}
+
+message BufferChunk {
+    uint64 buffer_id = 1;
+    repeated Operation operations = 2;
+    bool is_last = 3;
 }
 
 enum LineEnding {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -813,11 +813,7 @@ message Buffer {
     optional File file = 2;
     string base_text = 3;
     repeated Operation operations = 4;
-    repeated SelectionSet selections = 5;
-    repeated Diagnostic diagnostics = 6;
-    uint32 diagnostics_timestamp = 7;
-    repeated string completion_triggers = 8;
-    LineEnding line_ending = 9;
+    LineEnding line_ending = 5;
 }
 
 enum LineEnding {

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 30;
+pub const PROTOCOL_VERSION: u32 = 31;

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -45,7 +45,7 @@ use std::{
 };
 pub use subscription::*;
 pub use sum_tree::Bias;
-use sum_tree::{FilterCursor, SumTree};
+use sum_tree::{FilterCursor, SumTree, TreeMap};
 
 lazy_static! {
     static ref CARRIAGE_RETURNS_REGEX: Regex = Regex::new("\r\n|\r").unwrap();
@@ -109,7 +109,7 @@ impl HistoryEntry {
 struct History {
     // TODO: Turn this into a String or Rope, maybe.
     base_text: Arc<str>,
-    operations: HashMap<clock::Local, Operation>,
+    operations: TreeMap<clock::Local, Operation>,
     insertion_slices: HashMap<clock::Local, Vec<InsertionSlice>>,
     undo_stack: Vec<HistoryEntry>,
     redo_stack: Vec<HistoryEntry>,
@@ -1213,8 +1213,8 @@ impl Buffer {
         &self.history.base_text
     }
 
-    pub fn history(&self) -> impl Iterator<Item = &Operation> {
-        self.history.operations.values()
+    pub fn operations(&self) -> &TreeMap<clock::Local, Operation> {
+        &self.history.operations
     }
 
     pub fn undo_history(&self) -> impl Iterator<Item = (&clock::Local, &[(clock::Local, u32)])> {


### PR DESCRIPTION
Fixes #1540 

Previously, sending a buffer with many operations could cause connections to drop because we would serialize the buffer into a single payload and send it as a whole. This was problematic because it meant that all the connection bookkeeping that Zed does at the `Peer` level would pause until that message was sent. Similarly, if the host succeeded in sending the message and the guest managed to receive it, deserialization would take place on the main thread: this was once again problematic, because deserializing lots of operations at once would stall the UI.

With this pull request, we are changing buffer serialization to occur in two steps:

1. First, the buffer's fundamental state (id, base text, etc.) is sent as its own message (`proto::BufferState`). This lets the guest create a corresponding `Buffer` model locally, which is inserted into a `incomplete_buffers` map on the `Project`2. 
2. Second, the buffer's operations are serialized off the main thread into proto-buffers and then streamed 100 at a time to the guest (`proto::BufferChunk`). This prevents the host from sending too big of a payload and the guest from being overwhelmed by too many operations at once. When the last chunk is received on the guest, we make the buffer available to the `Project` as before.

TODO:

- [ ] Manual end-to-end test