### PR TITLE
Add language injection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.8"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=1f1b1eb4501ed0a2d195d37f7de15f72aa10acd0#1f1b1eb4501ed0a2d195d37f7de15f72aa10acd0"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=477b6677537e89c7bdff14ce84dad6d23a6415bb#477b6677537e89c7bdff14ce84dad6d23a6415bb"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.8"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=477b6677537e89c7bdff14ce84dad6d23a6415bb#477b6677537e89c7bdff14ce84dad6d23a6415bb"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=366210ae925d7ea0891bc7a0c738f60c77c04d7b#366210ae925d7ea0891bc7a0c738f60c77c04d7b"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/zed"]
 resolver = "2"
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "1f1b1eb4501ed0a2d195d37f7de15f72aa10acd0" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "477b6677537e89c7bdff14ce84dad6d23a6415bb" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/zed"]
 resolver = "2"
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "477b6677537e89c7bdff14ce84dad6d23a6415bb" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "366210ae925d7ea0891bc7a0c738f60c77c04d7b" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1953,8 +1953,10 @@ impl BufferSnapshot {
         theme: Option<&SyntaxTheme>,
     ) -> Option<Vec<OutlineItem<Anchor>>> {
         let position = position.to_offset(self);
-        let mut items =
-            self.outline_items_containing(position.saturating_sub(1)..position + 1, theme)?;
+        let mut items = self.outline_items_containing(
+            position.saturating_sub(1)..self.len().min(position + 1),
+            theme,
+        )?;
         let mut prev_depth = None;
         items.retain(|item| {
             let result = prev_depth.map_or(true, |prev_depth| item.depth > prev_depth);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2496,7 +2496,7 @@ impl Drop for QueryCursorHandle {
     }
 }
 
-trait ToTreeSitterPoint {
+pub(crate) trait ToTreeSitterPoint {
     fn to_ts_point(self) -> tree_sitter::Point;
     fn from_ts_point(point: tree_sitter::Point) -> Self;
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -30,8 +30,12 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     str,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        Arc,
+    },
 };
+use syntax_map::SyntaxSnapshot;
 use theme::{SyntaxTheme, Theme};
 use tree_sitter::{self, Query};
 use util::ResultExt;
@@ -50,6 +54,7 @@ thread_local! {
 }
 
 lazy_static! {
+    pub static ref NEXT_GRAMMAR_ID: AtomicUsize = Default::default();
     pub static ref PLAIN_TEXT: Arc<Language> = Arc::new(Language::new(
         LanguageConfig {
             name: "Plain Text".into(),
@@ -286,13 +291,27 @@ pub struct Language {
 }
 
 pub struct Grammar {
+    id: usize,
     pub(crate) ts_language: tree_sitter::Language,
     pub(crate) highlights_query: Option<Query>,
-    pub(crate) brackets_query: Option<Query>,
-    pub(crate) indents_query: Option<Query>,
-    pub(crate) outline_query: Option<Query>,
+    pub(crate) brackets_config: Option<BracketConfig>,
+    pub(crate) indents_config: Option<IndentConfig>,
+    pub(crate) outline_config: Option<OutlineConfig>,
     pub(crate) injection_config: Option<InjectionConfig>,
     pub(crate) highlight_map: Mutex<HighlightMap>,
+}
+
+struct IndentConfig {
+    query: Query,
+    indent_capture_ix: u32,
+    end_capture_ix: Option<u32>,
+}
+
+struct OutlineConfig {
+    query: Query,
+    item_capture_ix: u32,
+    name_capture_ix: u32,
+    context_capture_ix: Option<u32>,
 }
 
 struct InjectionConfig {
@@ -300,6 +319,12 @@ struct InjectionConfig {
     content_capture_ix: u32,
     language_capture_ix: Option<u32>,
     languages_by_pattern_ix: Vec<Option<Box<str>>>,
+}
+
+struct BracketConfig {
+    query: Query,
+    open_capture_ix: u32,
+    close_capture_ix: u32,
 }
 
 #[derive(Clone)]
@@ -499,6 +524,13 @@ impl LanguageRegistry {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
+impl Default for LanguageRegistry {
+    fn default() -> Self {
+        Self::test()
+    }
+}
+
 async fn get_server_binary_path(
     adapter: Arc<CachedLspAdapter>,
     language: Arc<Language>,
@@ -576,10 +608,11 @@ impl Language {
             config,
             grammar: ts_language.map(|ts_language| {
                 Arc::new(Grammar {
+                    id: NEXT_GRAMMAR_ID.fetch_add(1, SeqCst),
                     highlights_query: None,
-                    brackets_query: None,
-                    indents_query: None,
-                    outline_query: None,
+                    brackets_config: None,
+                    outline_config: None,
+                    indents_config: None,
                     injection_config: None,
                     ts_language,
                     highlight_map: Default::default(),
@@ -604,19 +637,70 @@ impl Language {
 
     pub fn with_brackets_query(mut self, source: &str) -> Result<Self> {
         let grammar = self.grammar_mut();
-        grammar.brackets_query = Some(Query::new(grammar.ts_language, source)?);
+        let query = Query::new(grammar.ts_language, source)?;
+        let mut open_capture_ix = None;
+        let mut close_capture_ix = None;
+        get_capture_indices(
+            &query,
+            &mut [
+                ("open", &mut open_capture_ix),
+                ("close", &mut close_capture_ix),
+            ],
+        );
+        if let Some((open_capture_ix, close_capture_ix)) = open_capture_ix.zip(close_capture_ix) {
+            grammar.brackets_config = Some(BracketConfig {
+                query,
+                open_capture_ix,
+                close_capture_ix,
+            });
+        }
         Ok(self)
     }
 
     pub fn with_indents_query(mut self, source: &str) -> Result<Self> {
         let grammar = self.grammar_mut();
-        grammar.indents_query = Some(Query::new(grammar.ts_language, source)?);
+        let query = Query::new(grammar.ts_language, source)?;
+        let mut indent_capture_ix = None;
+        let mut end_capture_ix = None;
+        get_capture_indices(
+            &query,
+            &mut [
+                ("indent", &mut indent_capture_ix),
+                ("end", &mut end_capture_ix),
+            ],
+        );
+        if let Some(indent_capture_ix) = indent_capture_ix {
+            grammar.indents_config = Some(IndentConfig {
+                query,
+                indent_capture_ix,
+                end_capture_ix,
+            });
+        }
         Ok(self)
     }
 
     pub fn with_outline_query(mut self, source: &str) -> Result<Self> {
         let grammar = self.grammar_mut();
-        grammar.outline_query = Some(Query::new(grammar.ts_language, source)?);
+        let query = Query::new(grammar.ts_language, source)?;
+        let mut item_capture_ix = None;
+        let mut name_capture_ix = None;
+        let mut context_capture_ix = None;
+        get_capture_indices(
+            &query,
+            &mut [
+                ("item", &mut item_capture_ix),
+                ("name", &mut name_capture_ix),
+                ("context", &mut context_capture_ix),
+            ],
+        );
+        if let Some((item_capture_ix, name_capture_ix)) = item_capture_ix.zip(name_capture_ix) {
+            grammar.outline_config = Some(OutlineConfig {
+                query,
+                item_capture_ix,
+                name_capture_ix,
+                context_capture_ix,
+            });
+        }
         Ok(self)
     }
 
@@ -625,13 +709,13 @@ impl Language {
         let query = Query::new(grammar.ts_language, source)?;
         let mut language_capture_ix = None;
         let mut content_capture_ix = None;
-        for (ix, name) in query.capture_names().iter().enumerate() {
-            *match name.as_str() {
-                "language" => &mut language_capture_ix,
-                "content" => &mut content_capture_ix,
-                _ => continue,
-            } = Some(ix as u32);
-        }
+        get_capture_indices(
+            &query,
+            &mut [
+                ("language", &mut language_capture_ix),
+                ("content", &mut content_capture_ix),
+            ],
+        );
         let languages_by_pattern_ix = (0..query.pattern_count())
             .map(|ix| {
                 query.property_settings(ix).iter().find_map(|setting| {
@@ -729,9 +813,16 @@ impl Language {
         let mut result = Vec::new();
         if let Some(grammar) = &self.grammar {
             let tree = grammar.parse_text(text, None);
+            let captures = SyntaxSnapshot::single_tree_captures(
+                range.clone(),
+                text,
+                &tree,
+                grammar,
+                |grammar| grammar.highlights_query.as_ref(),
+            );
+            let highlight_maps = vec![grammar.highlight_map()];
             let mut offset = 0;
-            for chunk in BufferChunks::new(text, range, Some(&tree), self.grammar.as_ref(), vec![])
-            {
+            for chunk in BufferChunks::new(text, range, Some((captures, highlight_maps)), vec![]) {
                 let end_offset = offset + chunk.text.len();
                 if let Some(highlight_id) = chunk.syntax_highlight_id {
                     if !highlight_id.is_default() {
@@ -771,6 +862,10 @@ impl Language {
 }
 
 impl Grammar {
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
     fn parse_text(&self, text: &Rope, old_tree: Option<Tree>) -> Tree {
         PARSER.with(|parser| {
             let mut parser = parser.borrow_mut();
@@ -867,6 +962,17 @@ impl LspAdapter for Arc<FakeLspAdapter> {
 
     async fn disk_based_diagnostics_progress_token(&self) -> Option<String> {
         self.disk_based_diagnostics_progress_token.clone()
+    }
+}
+
+fn get_capture_indices(query: &Query, captures: &mut [(&str, &mut Option<u32>)]) {
+    for (ix, name) in query.capture_names().iter().enumerate() {
+        for (capture_name, index) in captures.iter_mut() {
+            if capture_name == name {
+                **index = Some(ix as u32);
+                break;
+            }
+        }
     }
 }
 

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1,0 +1,418 @@
+use crate::{
+    Grammar, Language, LanguageRegistry, QueryCursorHandle, TextProvider, ToTreeSitterPoint,
+};
+use collections::VecDeque;
+use gpui::executor::Background;
+use std::{borrow::Cow, cell::RefCell, cmp::Ordering, ops::Range, sync::Arc};
+use sum_tree::{SeekTarget, SumTree};
+use text::{Anchor, BufferSnapshot, Point, Rope, ToOffset};
+use tree_sitter::{Parser, Tree};
+use util::post_inc;
+
+thread_local! {
+    static PARSER: RefCell<Parser> = RefCell::new(Parser::new());
+}
+
+#[derive(Default)]
+pub struct SyntaxMap {
+    next_layer_id: usize,
+    snapshot: SyntaxMapSnapshot,
+}
+
+#[derive(Clone, Default)]
+pub struct SyntaxMapSnapshot {
+    version: clock::Global,
+    layers: SumTree<SyntaxLayer>,
+}
+
+#[derive(Clone)]
+struct SyntaxLayer {
+    id: usize,
+    parent_id: Option<usize>,
+    range: SyntaxLayerRange,
+    tree: tree_sitter::Tree,
+    language: Arc<Language>,
+}
+
+#[derive(Debug, Clone)]
+struct SyntaxLayerSummary {
+    range: Range<Anchor>,
+    last_layer_range: Range<Anchor>,
+}
+
+#[derive(Clone, Debug)]
+struct SyntaxLayerRange(Range<Anchor>);
+
+impl SyntaxMap {
+    pub fn new(
+        executor: Arc<Background>,
+        registry: Arc<LanguageRegistry>,
+        language: Arc<Language>,
+        text: BufferSnapshot,
+        prev_set: Option<Self>,
+    ) -> Self {
+        let mut next_layer_id = 0;
+        let mut layers = Vec::new();
+        let mut injections = VecDeque::<(Option<usize>, _, Vec<tree_sitter::Range>)>::new();
+
+        injections.push_back((None, language, vec![]));
+        while let Some((parent_id, language, ranges)) = injections.pop_front() {
+            if let Some(grammar) = &language.grammar.as_deref() {
+                let id = post_inc(&mut next_layer_id);
+                let range = if let Some((first, last)) = ranges.first().zip(ranges.last()) {
+                    text.anchor_before(first.start_byte)..text.anchor_after(last.end_byte)
+                } else {
+                    Anchor::MIN..Anchor::MAX
+                };
+                let tree = Self::parse_text(grammar, text.as_rope(), None, ranges);
+                Self::get_injections(grammar, &text, &tree, id, &registry, &mut injections);
+                layers.push(SyntaxLayer {
+                    id,
+                    parent_id,
+                    range: SyntaxLayerRange(range),
+                    tree,
+                    language,
+                });
+            }
+        }
+
+        layers.sort_unstable_by(|a, b| SeekTarget::cmp(&a.range, &b.range, &text));
+
+        Self {
+            next_layer_id,
+            snapshot: SyntaxMapSnapshot {
+                layers: SumTree::from_iter(layers, &text),
+                version: text.version,
+            },
+        }
+    }
+
+    pub fn snapshot(&self) -> SyntaxMapSnapshot {
+        self.snapshot.clone()
+    }
+
+    fn interpolate(&mut self, text: &BufferSnapshot) {
+        let edits = text
+            .edits_since::<(Point, usize)>(&self.version)
+            .map(|edit| {
+                let (lines, bytes) = edit.flatten();
+                tree_sitter::InputEdit {
+                    start_byte: bytes.new.start,
+                    old_end_byte: bytes.new.start + bytes.old.len(),
+                    new_end_byte: bytes.new.end,
+                    start_position: lines.new.start.to_ts_point(),
+                    old_end_position: (lines.new.start + (lines.old.end - lines.old.start))
+                        .to_ts_point(),
+                    new_end_position: lines.new.end.to_ts_point(),
+                }
+            })
+            .collect::<Vec<_>>();
+        if edits.is_empty() {
+            return;
+        }
+    }
+
+    fn get_injections(
+        grammar: &Grammar,
+        text: &BufferSnapshot,
+        tree: &Tree,
+        id: usize,
+        registry: &Arc<LanguageRegistry>,
+        output: &mut VecDeque<(Option<usize>, Arc<Language>, Vec<tree_sitter::Range>)>,
+    ) {
+        let config = if let Some(config) = &grammar.injection_config {
+            config
+        } else {
+            return;
+        };
+
+        let mut query_cursor = QueryCursorHandle::new();
+        for mat in query_cursor.matches(
+            &config.query,
+            tree.root_node(),
+            TextProvider(text.as_rope()),
+        ) {
+            let content_ranges = mat
+                .nodes_for_capture_index(config.content_capture_ix)
+                .map(|node| node.range())
+                .collect::<Vec<_>>();
+            if content_ranges.is_empty() {
+                continue;
+            }
+            let language_name = config.languages_by_pattern_ix[mat.pattern_index]
+                .as_ref()
+                .map(|s| Cow::Borrowed(s.as_ref()))
+                .or_else(|| {
+                    let ix = config.language_capture_ix?;
+                    let node = mat.nodes_for_capture_index(ix).next()?;
+                    Some(Cow::Owned(text.text_for_range(node.byte_range()).collect()))
+                });
+            if let Some(language_name) = language_name {
+                if let Some(language) = registry.get_language(language_name.as_ref()) {
+                    output.push_back((Some(id), language, content_ranges))
+                }
+            }
+        }
+    }
+
+    fn parse_text(
+        grammar: &Grammar,
+        text: &Rope,
+        old_tree: Option<Tree>,
+        ranges: Vec<tree_sitter::Range>,
+    ) -> Tree {
+        PARSER.with(|parser| {
+            let mut parser = parser.borrow_mut();
+            let mut chunks = text.chunks_in_range(0..text.len());
+            parser
+                .set_included_ranges(&ranges)
+                .expect("overlapping ranges");
+            parser
+                .set_language(grammar.ts_language)
+                .expect("incompatible grammar");
+            parser
+                .parse_with(
+                    &mut move |offset, _| {
+                        chunks.seek(offset);
+                        chunks.next().unwrap_or("").as_bytes()
+                    },
+                    old_tree.as_ref(),
+                )
+                .expect("invalid language")
+        })
+    }
+}
+
+impl SyntaxMapSnapshot {
+    pub fn layers_for_range<'a, T: ToOffset>(
+        &self,
+        range: Range<T>,
+        buffer: &BufferSnapshot,
+    ) -> Vec<(Tree, &Grammar)> {
+        let start = buffer.anchor_before(range.start.to_offset(buffer));
+        let end = buffer.anchor_after(range.end.to_offset(buffer));
+
+        let mut cursor = self.layers.filter::<_, ()>(|summary| {
+            let is_before_start = summary.range.end.cmp(&start, buffer).is_lt();
+            let is_after_end = summary.range.start.cmp(&end, buffer).is_gt();
+            !is_before_start && !is_after_end
+        });
+
+        let mut result = Vec::new();
+        cursor.next(buffer);
+        while let Some(item) = cursor.item() {
+            if let Some(grammar) = &item.language.grammar {
+                result.push((item.tree.clone(), grammar.as_ref()));
+            }
+            cursor.next(buffer)
+        }
+
+        result
+    }
+}
+
+impl std::ops::Deref for SyntaxMap {
+    type Target = SyntaxMapSnapshot;
+
+    fn deref(&self) -> &Self::Target {
+        &self.snapshot
+    }
+}
+
+impl Default for SyntaxLayerSummary {
+    fn default() -> Self {
+        Self {
+            range: Anchor::MAX..Anchor::MIN,
+            last_layer_range: Anchor::MIN..Anchor::MAX,
+        }
+    }
+}
+
+impl sum_tree::Summary for SyntaxLayerSummary {
+    type Context = BufferSnapshot;
+
+    fn add_summary(&mut self, other: &Self, buffer: &Self::Context) {
+        if other.range.start.cmp(&self.range.start, buffer).is_lt() {
+            self.range.start = other.range.start;
+        }
+        if other.range.end.cmp(&self.range.end, buffer).is_gt() {
+            self.range.end = other.range.end;
+        }
+        self.last_layer_range = other.last_layer_range.clone();
+    }
+}
+
+impl Default for SyntaxLayerRange {
+    fn default() -> Self {
+        Self(Anchor::MIN..Anchor::MAX)
+    }
+}
+
+impl<'a> SeekTarget<'a, SyntaxLayerSummary, SyntaxLayerRange> for SyntaxLayerRange {
+    fn cmp(&self, cursor_location: &Self, buffer: &BufferSnapshot) -> Ordering {
+        self.0
+            .start
+            .cmp(&cursor_location.0.start, buffer)
+            .then_with(|| cursor_location.0.end.cmp(&self.0.end, buffer))
+    }
+}
+
+impl<'a> sum_tree::Dimension<'a, SyntaxLayerSummary> for SyntaxLayerRange {
+    fn add_summary(
+        &mut self,
+        summary: &'a SyntaxLayerSummary,
+        _: &<SyntaxLayerSummary as sum_tree::Summary>::Context,
+    ) {
+        self.0 = summary.last_layer_range.clone();
+    }
+}
+
+impl sum_tree::Item for SyntaxLayer {
+    type Summary = SyntaxLayerSummary;
+
+    fn summary(&self) -> Self::Summary {
+        SyntaxLayerSummary {
+            range: self.range.0.clone(),
+            last_layer_range: self.range.0.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for SyntaxLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyntaxLayer")
+            .field("id", &self.id)
+            .field("parent_id", &self.parent_id)
+            .field("range", &self.range)
+            .field("tree", &self.tree)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LanguageConfig;
+    use gpui::MutableAppContext;
+    use text::{Buffer, Point};
+    use unindent::Unindent as _;
+
+    #[gpui::test]
+    fn test_syntax_map(cx: &mut MutableAppContext) {
+        let buffer = Buffer::new(
+            0,
+            0,
+            r#"
+                fn a() {
+                    assert_eq!(
+                        b(vec![C {}]),
+                        vec![d.e],
+                    );
+                    println!("{}", f(|_| true));
+                }
+            "#
+            .unindent(),
+        );
+
+        let executor = cx.background().clone();
+        let registry = Arc::new(LanguageRegistry::test());
+        let language = Arc::new(rust_lang());
+        let snapshot = buffer.snapshot();
+        registry.add(language.clone());
+
+        let syntax_map = SyntaxMap::new(executor, registry, language, snapshot.clone(), None);
+
+        let layers = syntax_map.layers_for_range(Point::new(0, 0)..Point::new(0, 1), &snapshot);
+        assert_layers(
+            &layers,
+            &["(source_file (function_item name: (identifier)..."],
+        );
+
+        let layers = syntax_map.layers_for_range(Point::new(2, 0)..Point::new(2, 0), &snapshot);
+        assert_layers(
+            &layers,
+            &[
+                "...(function_item ... (block (expression_statement (macro_invocation...",
+                "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
+            ],
+        );
+
+        let layers = syntax_map.layers_for_range(Point::new(2, 14)..Point::new(2, 16), &snapshot);
+        assert_layers(
+            &layers,
+            &[
+                "...(function_item ...",
+                "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
+                "...(array_expression (struct_expression ...",
+            ],
+        );
+
+        let layers = syntax_map.layers_for_range(Point::new(3, 14)..Point::new(3, 16), &snapshot);
+        assert_layers(
+            &layers,
+            &[
+                "...(function_item ...",
+                "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
+                "...(array_expression (field_expression ...",
+            ],
+        );
+
+        let layers = syntax_map.layers_for_range(Point::new(5, 12)..Point::new(5, 16), &snapshot);
+        assert_layers(
+            &layers,
+            &[
+                "...(function_item ...",
+                "...(call_expression ... (arguments (closure_expression ...",
+            ],
+        );
+    }
+
+    fn rust_lang() -> Language {
+        Language::new(
+            LanguageConfig {
+                name: "Rust".into(),
+                path_suffixes: vec!["rs".to_string()],
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::language()),
+        )
+        .with_injection_query(
+            r#"
+                (macro_invocation
+                    (token_tree) @content
+                    (#set! "language" "rust"))
+            "#,
+        )
+        .unwrap()
+    }
+
+    fn assert_layers(layers: &[(Tree, &Grammar)], expected_layers: &[&str]) {
+        assert_eq!(
+            layers.len(),
+            expected_layers.len(),
+            "wrong number of layers"
+        );
+        for (i, (layer, expected_s_exp)) in layers.iter().zip(expected_layers.iter()).enumerate() {
+            let actual_s_exp = layer.0.root_node().to_sexp();
+            assert!(
+                string_contains_sequence(
+                    &actual_s_exp,
+                    &expected_s_exp.split("...").collect::<Vec<_>>()
+                ),
+                "layer {i}:\n\nexpected: {expected_s_exp}\nactual:   {actual_s_exp}",
+            );
+        }
+    }
+
+    pub fn string_contains_sequence(text: &str, parts: &[&str]) -> bool {
+        let mut last_part_end = 0;
+        for part in parts {
+            if let Some(start_ix) = text[last_part_end..].find(part) {
+                last_part_end = start_ix + part.len();
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -306,10 +306,6 @@ impl SyntaxSnapshot {
         language: Arc<Language>,
     ) {
         let edits = text.edits_since::<usize>(from_version).collect::<Vec<_>>();
-        if edits.is_empty() {
-            return;
-        }
-
         let max_depth = self.layers.summary().max_depth;
         let mut cursor = self.layers.cursor::<SyntaxLayerSummary>();
         cursor.next(&text);

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -284,10 +284,18 @@ impl SyntaxSnapshot {
                 };
 
                 layer.tree.edit(&tree_edit);
+
                 if edit.new.start.0 < start_byte {
                     break;
                 }
             }
+
+            debug_assert!(
+                layer.tree.root_node().end_byte() <= text.len(),
+                "tree's size {}, is larger than text size {}",
+                layer.tree.root_node().end_byte(),
+                text.len(),
+            );
 
             layers.push(layer, text);
             cursor.next(text);

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -173,6 +173,7 @@ impl SyntaxMap {
     }
 
     pub fn did_parse(&mut self, snapshot: SyntaxSnapshot, version: clock::Global) {
+        self.interpolated_version = version.clone();
         self.parsed_version = version;
         self.snapshot = snapshot;
     }

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1,11 +1,13 @@
 use crate::{
-    Grammar, Language, LanguageRegistry, QueryCursorHandle, TextProvider, ToTreeSitterPoint,
+    Grammar, InjectionConfig, Language, LanguageRegistry, QueryCursorHandle, TextProvider,
+    ToTreeSitterPoint,
 };
-use collections::VecDeque;
-use gpui::executor::Background;
-use std::{borrow::Cow, cell::RefCell, cmp::Ordering, ops::Range, sync::Arc};
-use sum_tree::{SeekTarget, SumTree};
-use text::{Anchor, BufferSnapshot, Point, Rope, ToOffset};
+use collections::HashMap;
+use std::{
+    borrow::Cow, cell::RefCell, cmp::Ordering, collections::BinaryHeap, ops::Range, sync::Arc,
+};
+use sum_tree::{Bias, SeekTarget, SumTree};
+use text::{Anchor, BufferSnapshot, OffsetRangeExt, Point, Rope, ToOffset};
 use tree_sitter::{Parser, Tree};
 use util::post_inc;
 
@@ -15,175 +17,399 @@ thread_local! {
 
 #[derive(Default)]
 pub struct SyntaxMap {
-    next_layer_id: usize,
-    snapshot: SyntaxMapSnapshot,
+    version: clock::Global,
+    snapshot: SyntaxSnapshot,
+    language_registry: Option<Arc<LanguageRegistry>>,
 }
 
 #[derive(Clone, Default)]
-pub struct SyntaxMapSnapshot {
-    version: clock::Global,
+pub struct SyntaxSnapshot {
     layers: SumTree<SyntaxLayer>,
 }
 
 #[derive(Clone)]
 struct SyntaxLayer {
-    id: usize,
-    parent_id: Option<usize>,
-    range: SyntaxLayerRange,
+    depth: usize,
+    range: Range<Anchor>,
     tree: tree_sitter::Tree,
     language: Arc<Language>,
 }
 
 #[derive(Debug, Clone)]
 struct SyntaxLayerSummary {
+    max_depth: usize,
     range: Range<Anchor>,
     last_layer_range: Range<Anchor>,
 }
 
 #[derive(Clone, Debug)]
-struct SyntaxLayerRange(Range<Anchor>);
+struct Depth(usize);
+
+#[derive(Clone, Debug)]
+struct MaxPosition(Anchor);
+
+enum ReparseStep {
+    CreateLayer {
+        depth: usize,
+        language: Arc<Language>,
+        ranges: Vec<tree_sitter::Range>,
+    },
+    EnterChangedRange {
+        id: usize,
+        depth: usize,
+        range: Range<usize>,
+    },
+    LeaveChangedRange {
+        id: usize,
+        depth: usize,
+        range: Range<usize>,
+    },
+}
 
 impl SyntaxMap {
-    pub fn new(
-        executor: Arc<Background>,
-        registry: Arc<LanguageRegistry>,
-        language: Arc<Language>,
-        text: BufferSnapshot,
-        prev_set: Option<Self>,
-    ) -> Self {
-        let mut next_layer_id = 0;
-        let mut layers = Vec::new();
-        let mut injections = VecDeque::<(Option<usize>, _, Vec<tree_sitter::Range>)>::new();
-
-        injections.push_back((None, language, vec![]));
-        while let Some((parent_id, language, ranges)) = injections.pop_front() {
-            if let Some(grammar) = &language.grammar.as_deref() {
-                let id = post_inc(&mut next_layer_id);
-                let range = if let Some((first, last)) = ranges.first().zip(ranges.last()) {
-                    text.anchor_before(first.start_byte)..text.anchor_after(last.end_byte)
-                } else {
-                    Anchor::MIN..Anchor::MAX
-                };
-                let tree = Self::parse_text(grammar, text.as_rope(), None, ranges);
-                Self::get_injections(grammar, &text, &tree, id, &registry, &mut injections);
-                layers.push(SyntaxLayer {
-                    id,
-                    parent_id,
-                    range: SyntaxLayerRange(range),
-                    tree,
-                    language,
-                });
-            }
-        }
-
-        layers.sort_unstable_by(|a, b| SeekTarget::cmp(&a.range, &b.range, &text));
-
-        Self {
-            next_layer_id,
-            snapshot: SyntaxMapSnapshot {
-                layers: SumTree::from_iter(layers, &text),
-                version: text.version,
-            },
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub fn snapshot(&self) -> SyntaxMapSnapshot {
+    pub fn set_language_registry(&mut self, registry: Arc<LanguageRegistry>) {
+        self.language_registry = Some(registry);
+    }
+
+    pub fn snapshot(&self) -> SyntaxSnapshot {
         self.snapshot.clone()
     }
 
-    fn interpolate(&mut self, text: &BufferSnapshot) {
+    pub fn interpolate(&mut self, text: &BufferSnapshot) {
+        self.snapshot.interpolate(&self.version, text);
+        self.version = text.version.clone();
+    }
+
+    pub fn reparse(&mut self, language: Arc<Language>, text: &BufferSnapshot) {
+        self.version = text.version.clone();
+        self.snapshot
+            .reparse(self.language_registry.clone(), language, text);
+    }
+}
+
+// Assumptions:
+// * The maximum depth is small (< 5)
+// * For a given depth, the number of layers that touch a given range
+//   is small (usually only 1)
+
+//                                  |change|
+// 0 (............................................................)
+// 1  (...............................................)
+// 1                         (................)
+// 1                                                    (.......)
+// 2      (....)
+// 2       (....)
+// 2              (.......)
+// 2                        (...)
+// 2                               (.........)
+// 2                                           (...)
+// 3       (.)
+// 3              (.)
+// 3                  (..)
+// 3                               (..)
+// 3                                   (..)
+// 3                                       (.)
+
+impl SyntaxSnapshot {
+    pub fn interpolate(&mut self, current_version: &clock::Global, text: &BufferSnapshot) {
         let edits = text
-            .edits_since::<(Point, usize)>(&self.version)
-            .map(|edit| {
-                let (lines, bytes) = edit.flatten();
-                tree_sitter::InputEdit {
-                    start_byte: bytes.new.start,
-                    old_end_byte: bytes.new.start + bytes.old.len(),
-                    new_end_byte: bytes.new.end,
-                    start_position: lines.new.start.to_ts_point(),
-                    old_end_position: (lines.new.start + (lines.old.end - lines.old.start))
-                        .to_ts_point(),
-                    new_end_position: lines.new.end.to_ts_point(),
-                }
-            })
+            .edits_since::<(usize, Point)>(&current_version)
             .collect::<Vec<_>>();
         if edits.is_empty() {
             return;
         }
+
+        let mut layers = SumTree::new();
+        let max_depth = self.layers.summary().max_depth;
+        let mut cursor = self.layers.cursor::<SyntaxLayerSummary>();
+        cursor.next(&text);
+
+        for depth in 0..max_depth {
+            let mut edits = &edits[..];
+            layers.push_tree(cursor.slice(&Depth(depth), Bias::Left, text), text);
+
+            while let Some(layer) = cursor.item() {
+                let mut endpoints = text.summaries_for_anchors::<(usize, Point), _>([
+                    &layer.range.start,
+                    &layer.range.end,
+                ]);
+                let layer_range = endpoints.next().unwrap()..endpoints.next().unwrap();
+                let start_byte = layer_range.start.0;
+                let start_point = layer_range.start.1;
+
+                // Preserve any layers at this depth that precede the first edit.
+                let first_edit = if let Some(edit) = edits.first() {
+                    edit
+                } else {
+                    break;
+                };
+                if first_edit.new.start.0 > layer_range.end.0 {
+                    layers.push_tree(
+                        cursor.slice(
+                            &(
+                                Depth(depth),
+                                MaxPosition(text.anchor_before(first_edit.new.start.0)),
+                            ),
+                            Bias::Left,
+                            text,
+                        ),
+                        text,
+                    );
+                    continue;
+                }
+
+                // Preserve any layers at this depth that follow the last edit.
+                let last_edit = edits.last().unwrap();
+                if last_edit.new.end.0 < layer_range.start.0 {
+                    break;
+                }
+
+                let mut layer = layer.clone();
+                for (i, edit) in edits.iter().enumerate().rev() {
+                    // Ignore any edits that start after the end of this layer.
+                    if edit.new.start.0 > layer_range.end.0 {
+                        continue;
+                    }
+
+                    // Ignore edits that end before the start of this layer, and don't consider them
+                    // for any subsequent layers at this same depth.
+                    if edit.new.end.0 <= start_byte {
+                        edits = &edits[i + 1..];
+                        break;
+                    }
+
+                    // Apply any edits that intersect this layer to the layer's syntax tree.
+                    if edit.new.start.0 >= start_byte {
+                        layer.tree.edit(&tree_sitter::InputEdit {
+                            start_byte: edit.new.start.0 - start_byte,
+                            old_end_byte: edit.new.start.0 - start_byte
+                                + (edit.old.end.0 - edit.old.start.0),
+                            new_end_byte: edit.new.end.0 - start_byte,
+                            start_position: (edit.new.start.1 - start_point).to_ts_point(),
+                            old_end_position: (edit.new.start.1 - start_point
+                                + (edit.old.end.1 - edit.old.start.1))
+                                .to_ts_point(),
+                            new_end_position: (edit.new.end.1 - start_point).to_ts_point(),
+                        });
+                    } else {
+                        layer.tree.edit(&tree_sitter::InputEdit {
+                            start_byte: 0,
+                            old_end_byte: edit.new.end.0 - start_byte,
+                            new_end_byte: 0,
+                            start_position: Default::default(),
+                            old_end_position: (edit.new.end.1 - start_point).to_ts_point(),
+                            new_end_position: Default::default(),
+                        });
+                        break;
+                    }
+                }
+
+                layers.push(layer, text);
+                cursor.next(text);
+            }
+        }
+
+        layers.push_tree(cursor.suffix(&text), &text);
+        drop(cursor);
+        self.layers = layers;
     }
 
-    fn get_injections(
-        grammar: &Grammar,
+    pub fn reparse(
+        &mut self,
+        registry: Option<Arc<LanguageRegistry>>,
+        language: Arc<Language>,
         text: &BufferSnapshot,
-        tree: &Tree,
-        id: usize,
-        registry: &Arc<LanguageRegistry>,
-        output: &mut VecDeque<(Option<usize>, Arc<Language>, Vec<tree_sitter::Range>)>,
     ) {
-        let config = if let Some(config) = &grammar.injection_config {
-            config
-        } else {
-            return;
-        };
+        let mut cursor = self.layers.cursor::<SyntaxLayerSummary>();
+        cursor.next(&text);
+        let mut layers = SumTree::new();
 
-        let mut query_cursor = QueryCursorHandle::new();
-        for mat in query_cursor.matches(
-            &config.query,
-            tree.root_node(),
-            TextProvider(text.as_rope()),
-        ) {
-            let content_ranges = mat
-                .nodes_for_capture_index(config.content_capture_ix)
-                .map(|node| node.range())
-                .collect::<Vec<_>>();
-            if content_ranges.is_empty() {
-                continue;
-            }
-            let language_name = config.languages_by_pattern_ix[mat.pattern_index]
-                .as_ref()
-                .map(|s| Cow::Borrowed(s.as_ref()))
-                .or_else(|| {
-                    let ix = config.language_capture_ix?;
-                    let node = mat.nodes_for_capture_index(ix).next()?;
-                    Some(Cow::Owned(text.text_for_range(node.byte_range()).collect()))
-                });
-            if let Some(language_name) = language_name {
-                if let Some(language) = registry.get_language(language_name.as_ref()) {
-                    output.push_back((Some(id), language, content_ranges))
+        let mut next_change_id = 0;
+        let mut current_changes = HashMap::default();
+        let mut queue = BinaryHeap::new();
+        queue.push(ReparseStep::CreateLayer {
+            depth: 0,
+            language: language.clone(),
+            ranges: Vec::new(),
+        });
+
+        while let Some(step) = queue.pop() {
+            match step {
+                ReparseStep::CreateLayer {
+                    depth,
+                    language,
+                    ranges,
+                } => {
+                    let range;
+                    let start_point;
+                    let start_byte;
+                    let end_byte;
+                    if let Some((first, last)) = ranges.first().zip(ranges.last()) {
+                        start_point = first.start_point;
+                        start_byte = first.start_byte;
+                        end_byte = last.end_byte;
+                        range = text.anchor_before(start_byte)..text.anchor_after(end_byte);
+                    } else {
+                        start_point = Point::zero().to_ts_point();
+                        start_byte = 0;
+                        end_byte = text.len();
+                        range = Anchor::MIN..Anchor::MAX;
+                    };
+
+                    let target = (Depth(depth), range.clone());
+                    if target.cmp(cursor.start(), &text).is_gt() {
+                        if current_changes.is_empty() {
+                            let slice = cursor.slice(&target, Bias::Left, text);
+                            layers.push_tree(slice, &text);
+                        } else {
+                            while let Some(layer) = cursor.item() {
+                                if layer.depth > depth
+                                    || layer.depth == depth
+                                        && layer.range.start.cmp(&range.end, text).is_ge()
+                                {
+                                    break;
+                                }
+                                if !layer_is_changed(layer, text, &current_changes) {
+                                    layers.push(layer.clone(), text);
+                                }
+                                cursor.next(text);
+                            }
+                        }
+                    }
+
+                    let mut old_layer = cursor.item();
+                    if let Some(layer) = old_layer {
+                        if layer.range.to_offset(text) == (start_byte..end_byte) {
+                            cursor.next(&text);
+                        } else {
+                            old_layer = None;
+                        }
+                    }
+
+                    let grammar = if let Some(grammar) = language.grammar.as_deref() {
+                        grammar
+                    } else {
+                        continue;
+                    };
+
+                    let tree;
+                    let changed_ranges;
+                    if let Some(old_layer) = old_layer {
+                        tree = parse_text(
+                            grammar,
+                            text.as_rope(),
+                            Some(old_layer.tree.clone()),
+                            ranges,
+                        );
+
+                        changed_ranges = old_layer
+                            .tree
+                            .changed_ranges(&tree)
+                            .map(|r| r.start_byte..r.end_byte)
+                            .collect();
+                    } else {
+                        tree = parse_text(grammar, text.as_rope(), None, ranges);
+                        changed_ranges = vec![0..end_byte - start_byte];
+                    }
+
+                    layers.push(
+                        SyntaxLayer {
+                            depth,
+                            range,
+                            tree: tree.clone(),
+                            language: language.clone(),
+                        },
+                        &text,
+                    );
+
+                    if let (Some((config, registry)), false) = (
+                        grammar.injection_config.as_ref().zip(registry.as_ref()),
+                        changed_ranges.is_empty(),
+                    ) {
+                        let depth = depth + 1;
+                        queue.extend(changed_ranges.iter().flat_map(|range| {
+                            let id = post_inc(&mut next_change_id);
+                            let range = start_byte + range.start..start_byte + range.end;
+                            [
+                                ReparseStep::EnterChangedRange {
+                                    id,
+                                    depth,
+                                    range: range.clone(),
+                                },
+                                ReparseStep::LeaveChangedRange {
+                                    id,
+                                    depth,
+                                    range: range.clone(),
+                                },
+                            ]
+                        }));
+
+                        get_injections(
+                            config,
+                            text,
+                            &tree,
+                            registry,
+                            depth,
+                            start_byte,
+                            Point::from_ts_point(start_point),
+                            &changed_ranges,
+                            &mut queue,
+                        );
+                    }
+                }
+                ReparseStep::EnterChangedRange { id, depth, range } => {
+                    let range = text.anchor_before(range.start)..text.anchor_after(range.end);
+                    if current_changes.is_empty() {
+                        let target = (Depth(depth), range.start..Anchor::MAX);
+                        let slice = cursor.slice(&target, Bias::Left, text);
+                        layers.push_tree(slice, text);
+                    } else {
+                        while let Some(layer) = cursor.item() {
+                            if layer.depth > depth
+                                || layer.depth == depth
+                                    && layer.range.end.cmp(&range.start, text).is_gt()
+                            {
+                                break;
+                            }
+                            if !layer_is_changed(layer, text, &current_changes) {
+                                layers.push(layer.clone(), text);
+                            }
+                            cursor.next(text);
+                        }
+                    }
+
+                    current_changes.insert(id, range);
+                }
+                ReparseStep::LeaveChangedRange { id, depth, range } => {
+                    let range = text.anchor_before(range.start)..text.anchor_after(range.end);
+                    while let Some(layer) = cursor.item() {
+                        if layer.depth > depth
+                            || layer.depth == depth
+                                && layer.range.start.cmp(&range.end, text).is_ge()
+                        {
+                            break;
+                        }
+                        if !layer_is_changed(layer, text, &current_changes) {
+                            layers.push(layer.clone(), text);
+                        }
+                        cursor.next(text);
+                    }
+
+                    current_changes.remove(&id);
                 }
             }
         }
+
+        let slice = cursor.suffix(&text);
+        layers.push_tree(slice, &text);
+        drop(cursor);
+        self.layers = layers;
     }
 
-    fn parse_text(
-        grammar: &Grammar,
-        text: &Rope,
-        old_tree: Option<Tree>,
-        ranges: Vec<tree_sitter::Range>,
-    ) -> Tree {
-        PARSER.with(|parser| {
-            let mut parser = parser.borrow_mut();
-            let mut chunks = text.chunks_in_range(0..text.len());
-            parser
-                .set_included_ranges(&ranges)
-                .expect("overlapping ranges");
-            parser
-                .set_language(grammar.ts_language)
-                .expect("incompatible grammar");
-            parser
-                .parse_with(
-                    &mut move |offset, _| {
-                        chunks.seek(offset);
-                        chunks.next().unwrap_or("").as_bytes()
-                    },
-                    old_tree.as_ref(),
-                )
-                .expect("invalid language")
-        })
-    }
-}
-
-impl SyntaxMapSnapshot {
     pub fn layers_for_range<'a, T: ToOffset>(
         &self,
         range: Range<T>,
@@ -211,17 +437,184 @@ impl SyntaxMapSnapshot {
     }
 }
 
+fn parse_text(
+    grammar: &Grammar,
+    text: &Rope,
+    old_tree: Option<Tree>,
+    mut ranges: Vec<tree_sitter::Range>,
+) -> Tree {
+    let (start_byte, start_point) = ranges
+        .first()
+        .map(|range| (range.start_byte, Point::from_ts_point(range.start_point)))
+        .unwrap_or_default();
+
+    for range in &mut ranges {
+        range.start_byte -= start_byte;
+        range.end_byte -= start_byte;
+        range.start_point = (Point::from_ts_point(range.start_point) - start_point).to_ts_point();
+        range.end_point = (Point::from_ts_point(range.end_point) - start_point).to_ts_point();
+    }
+
+    PARSER.with(|parser| {
+        let mut parser = parser.borrow_mut();
+        let mut chunks = text.chunks_in_range(start_byte..text.len());
+        parser
+            .set_included_ranges(&ranges)
+            .expect("overlapping ranges");
+        parser
+            .set_language(grammar.ts_language)
+            .expect("incompatible grammar");
+        parser
+            .parse_with(
+                &mut move |offset, _| {
+                    chunks.seek(start_byte + offset);
+                    chunks.next().unwrap_or("").as_bytes()
+                },
+                old_tree.as_ref(),
+            )
+            .expect("invalid language")
+    })
+}
+
+fn get_injections(
+    config: &InjectionConfig,
+    text: &BufferSnapshot,
+    tree: &Tree,
+    language_registry: &LanguageRegistry,
+    depth: usize,
+    start_byte: usize,
+    start_point: Point,
+    query_ranges: &[Range<usize>],
+    stack: &mut BinaryHeap<ReparseStep>,
+) -> bool {
+    let mut result = false;
+    let mut query_cursor = QueryCursorHandle::new();
+    let mut prev_match = None;
+    for query_range in query_ranges {
+        query_cursor.set_byte_range(query_range.start..query_range.end);
+        for mat in query_cursor.matches(
+            &config.query,
+            tree.root_node(),
+            TextProvider(text.as_rope()),
+        ) {
+            let content_ranges = mat
+                .nodes_for_capture_index(config.content_capture_ix)
+                .map(|node| tree_sitter::Range {
+                    start_byte: start_byte + node.start_byte(),
+                    end_byte: start_byte + node.end_byte(),
+                    start_point: (start_point + Point::from_ts_point(node.start_position()))
+                        .to_ts_point(),
+                    end_point: (start_point + Point::from_ts_point(node.end_position()))
+                        .to_ts_point(),
+                })
+                .collect::<Vec<_>>();
+            if content_ranges.is_empty() {
+                continue;
+            }
+
+            // Avoid duplicate matches if two changed ranges intersect the same injection.
+            let content_range =
+                content_ranges.first().unwrap().start_byte..content_ranges.last().unwrap().end_byte;
+            if let Some((last_pattern_ix, last_range)) = &prev_match {
+                if mat.pattern_index == *last_pattern_ix && content_range == *last_range {
+                    continue;
+                }
+            }
+            prev_match = Some((mat.pattern_index, content_range));
+
+            let language_name = config.languages_by_pattern_ix[mat.pattern_index]
+                .as_ref()
+                .map(|s| Cow::Borrowed(s.as_ref()))
+                .or_else(|| {
+                    let ix = config.language_capture_ix?;
+                    let node = mat.nodes_for_capture_index(ix).next()?;
+                    Some(Cow::Owned(
+                        text.text_for_range(
+                            start_byte + node.start_byte()..start_byte + node.end_byte(),
+                        )
+                        .collect(),
+                    ))
+                });
+
+            if let Some(language_name) = language_name {
+                if let Some(language) = language_registry.get_language(language_name.as_ref()) {
+                    result = true;
+                    stack.push(ReparseStep::CreateLayer {
+                        depth,
+                        language,
+                        ranges: content_ranges,
+                    })
+                }
+            }
+        }
+    }
+    result
+}
+
+fn layer_is_changed(
+    layer: &SyntaxLayer,
+    text: &BufferSnapshot,
+    changed_ranges: &HashMap<usize, Range<Anchor>>,
+) -> bool {
+    changed_ranges.values().any(|range| {
+        let is_before_layer = range.end.cmp(&layer.range.start, text).is_le();
+        let is_after_layer = range.start.cmp(&layer.range.end, text).is_ge();
+        !is_before_layer && !is_after_layer
+    })
+}
+
 impl std::ops::Deref for SyntaxMap {
-    type Target = SyntaxMapSnapshot;
+    type Target = SyntaxSnapshot;
 
     fn deref(&self) -> &Self::Target {
         &self.snapshot
     }
 }
 
+impl ReparseStep {
+    fn sort_key(&self) -> (usize, Range<usize>) {
+        match self {
+            ReparseStep::CreateLayer { depth, ranges, .. } => (
+                *depth,
+                ranges.first().map_or(0, |r| r.start_byte)
+                    ..ranges.last().map_or(usize::MAX, |r| r.end_byte),
+            ),
+            ReparseStep::EnterChangedRange { depth, range, .. } => {
+                (*depth, range.start..usize::MAX)
+            }
+            ReparseStep::LeaveChangedRange { depth, range, .. } => (*depth, range.end..usize::MAX),
+        }
+    }
+}
+
+impl PartialEq for ReparseStep {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+
+impl Eq for ReparseStep {}
+
+impl PartialOrd for ReparseStep {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl Ord for ReparseStep {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let (depth_a, range_a) = self.sort_key();
+        let (depth_b, range_b) = other.sort_key();
+        Ord::cmp(&depth_b, &depth_a)
+            .then_with(|| Ord::cmp(&range_b.start, &range_a.start))
+            .then_with(|| Ord::cmp(&range_a.end, &range_b.end))
+    }
+}
+
 impl Default for SyntaxLayerSummary {
     fn default() -> Self {
         Self {
+            max_depth: 0,
             range: Anchor::MAX..Anchor::MIN,
             last_layer_range: Anchor::MIN..Anchor::MAX,
         }
@@ -232,38 +625,49 @@ impl sum_tree::Summary for SyntaxLayerSummary {
     type Context = BufferSnapshot;
 
     fn add_summary(&mut self, other: &Self, buffer: &Self::Context) {
-        if other.range.start.cmp(&self.range.start, buffer).is_lt() {
-            self.range.start = other.range.start;
+        if other.max_depth > self.max_depth {
+            *self = other.clone();
+        } else {
+            if other.range.start.cmp(&self.range.start, buffer).is_lt() {
+                self.range.start = other.range.start;
+            }
+            if other.range.end.cmp(&self.range.end, buffer).is_gt() {
+                self.range.end = other.range.end;
+            }
+            self.last_layer_range = other.last_layer_range.clone();
         }
-        if other.range.end.cmp(&self.range.end, buffer).is_gt() {
-            self.range.end = other.range.end;
-        }
-        self.last_layer_range = other.last_layer_range.clone();
     }
 }
 
-impl Default for SyntaxLayerRange {
-    fn default() -> Self {
-        Self(Anchor::MIN..Anchor::MAX)
+impl<'a> SeekTarget<'a, SyntaxLayerSummary, SyntaxLayerSummary> for Depth {
+    fn cmp(&self, cursor_location: &SyntaxLayerSummary, _: &BufferSnapshot) -> Ordering {
+        Ord::cmp(&self.0, &cursor_location.max_depth)
     }
 }
 
-impl<'a> SeekTarget<'a, SyntaxLayerSummary, SyntaxLayerRange> for SyntaxLayerRange {
-    fn cmp(&self, cursor_location: &Self, buffer: &BufferSnapshot) -> Ordering {
+impl<'a> SeekTarget<'a, SyntaxLayerSummary, SyntaxLayerSummary> for (Depth, MaxPosition) {
+    fn cmp(&self, cursor_location: &SyntaxLayerSummary, text: &BufferSnapshot) -> Ordering {
         self.0
-            .start
-            .cmp(&cursor_location.0.start, buffer)
-            .then_with(|| cursor_location.0.end.cmp(&self.0.end, buffer))
+            .cmp(&cursor_location, text)
+            .then_with(|| (self.1).0.cmp(&cursor_location.range.end, text))
     }
 }
 
-impl<'a> sum_tree::Dimension<'a, SyntaxLayerSummary> for SyntaxLayerRange {
-    fn add_summary(
-        &mut self,
-        summary: &'a SyntaxLayerSummary,
-        _: &<SyntaxLayerSummary as sum_tree::Summary>::Context,
-    ) {
-        self.0 = summary.last_layer_range.clone();
+impl<'a> SeekTarget<'a, SyntaxLayerSummary, SyntaxLayerSummary> for (Depth, Range<Anchor>) {
+    fn cmp(&self, cursor_location: &SyntaxLayerSummary, buffer: &BufferSnapshot) -> Ordering {
+        self.0
+            .cmp(&cursor_location, buffer)
+            .then_with(|| {
+                self.1
+                    .start
+                    .cmp(&cursor_location.last_layer_range.start, buffer)
+            })
+            .then_with(|| {
+                cursor_location
+                    .last_layer_range
+                    .end
+                    .cmp(&self.1.end, buffer)
+            })
     }
 }
 
@@ -272,8 +676,9 @@ impl sum_tree::Item for SyntaxLayer {
 
     fn summary(&self) -> Self::Summary {
         SyntaxLayerSummary {
-            range: self.range.0.clone(),
-            last_layer_range: self.range.0.clone(),
+            max_depth: self.depth,
+            range: self.range.clone(),
+            last_layer_range: self.range.clone(),
         }
     }
 }
@@ -281,8 +686,7 @@ impl sum_tree::Item for SyntaxLayer {
 impl std::fmt::Debug for SyntaxLayer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SyntaxLayer")
-            .field("id", &self.id)
-            .field("parent_id", &self.parent_id)
+            .field("depth", &self.depth)
             .field("range", &self.range)
             .field("tree", &self.tree)
             .finish()
@@ -293,13 +697,16 @@ impl std::fmt::Debug for SyntaxLayer {
 mod tests {
     use super::*;
     use crate::LanguageConfig;
-    use gpui::MutableAppContext;
     use text::{Buffer, Point};
     use unindent::Unindent as _;
 
     #[gpui::test]
-    fn test_syntax_map(cx: &mut MutableAppContext) {
-        let buffer = Buffer::new(
+    fn test_syntax_map_layers_for_range() {
+        let registry = Arc::new(LanguageRegistry::test());
+        let language = Arc::new(rust_lang());
+        registry.add(language.clone());
+
+        let mut buffer = Buffer::new(
             0,
             0,
             r#"
@@ -314,55 +721,78 @@ mod tests {
             .unindent(),
         );
 
-        let executor = cx.background().clone();
-        let registry = Arc::new(LanguageRegistry::test());
-        let language = Arc::new(rust_lang());
-        let snapshot = buffer.snapshot();
-        registry.add(language.clone());
+        let mut syntax_map = SyntaxMap::new();
+        syntax_map.set_language_registry(registry.clone());
+        syntax_map.reparse(language.clone(), &buffer);
 
-        let syntax_map = SyntaxMap::new(executor, registry, language, snapshot.clone(), None);
-
-        let layers = syntax_map.layers_for_range(Point::new(0, 0)..Point::new(0, 1), &snapshot);
-        assert_layers(
-            &layers,
-            &["(source_file (function_item name: (identifier)..."],
-        );
-
-        let layers = syntax_map.layers_for_range(Point::new(2, 0)..Point::new(2, 0), &snapshot);
-        assert_layers(
-            &layers,
+        assert_layers_for_range(
+            &syntax_map,
+            &buffer,
+            Point::new(2, 0)..Point::new(2, 0),
             &[
                 "...(function_item ... (block (expression_statement (macro_invocation...",
                 "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
             ],
         );
-
-        let layers = syntax_map.layers_for_range(Point::new(2, 14)..Point::new(2, 16), &snapshot);
-        assert_layers(
-            &layers,
+        assert_layers_for_range(
+            &syntax_map,
+            &buffer,
+            Point::new(2, 14)..Point::new(2, 16),
             &[
                 "...(function_item ...",
                 "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
                 "...(array_expression (struct_expression ...",
             ],
         );
-
-        let layers = syntax_map.layers_for_range(Point::new(3, 14)..Point::new(3, 16), &snapshot);
-        assert_layers(
-            &layers,
+        assert_layers_for_range(
+            &syntax_map,
+            &buffer,
+            Point::new(3, 14)..Point::new(3, 16),
             &[
                 "...(function_item ...",
                 "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
                 "...(array_expression (field_expression ...",
             ],
         );
-
-        let layers = syntax_map.layers_for_range(Point::new(5, 12)..Point::new(5, 16), &snapshot);
-        assert_layers(
-            &layers,
+        assert_layers_for_range(
+            &syntax_map,
+            &buffer,
+            Point::new(5, 12)..Point::new(5, 16),
             &[
                 "...(function_item ...",
                 "...(call_expression ... (arguments (closure_expression ...",
+            ],
+        );
+
+        // Replace a vec! macro invocation with a plain slice, removing a syntactic layer.
+        let macro_name_range = range_for_text(&buffer, "vec!");
+        buffer.edit([(macro_name_range, "&")]);
+        syntax_map.interpolate(&buffer);
+        syntax_map.reparse(language.clone(), &buffer);
+
+        assert_layers_for_range(
+            &syntax_map,
+            &buffer,
+            Point::new(2, 14)..Point::new(2, 16),
+            &[
+                "...(function_item ...",
+                "...(tuple_expression (call_expression ... arguments: (arguments (reference_expression value: (array_expression...",
+            ],
+        );
+
+        // Put the vec! macro back, adding back the syntactic layer.
+        buffer.undo();
+        syntax_map.interpolate(&buffer);
+        syntax_map.reparse(language.clone(), &buffer);
+
+        assert_layers_for_range(
+            &syntax_map,
+            &buffer,
+            Point::new(2, 14)..Point::new(2, 16),
+            &[
+                "...(function_item ...",
+                "...(tuple_expression (call_expression ... arguments: (arguments (macro_invocation...",
+                "...(array_expression (struct_expression ...",
             ],
         );
     }
@@ -386,7 +816,18 @@ mod tests {
         .unwrap()
     }
 
-    fn assert_layers(layers: &[(Tree, &Grammar)], expected_layers: &[&str]) {
+    fn range_for_text(buffer: &Buffer, text: &str) -> Range<usize> {
+        let start = buffer.as_rope().to_string().find(text).unwrap();
+        start..start + text.len()
+    }
+
+    fn assert_layers_for_range(
+        syntax_map: &SyntaxMap,
+        buffer: &BufferSnapshot,
+        range: Range<Point>,
+        expected_layers: &[&str],
+    ) {
+        let layers = syntax_map.layers_for_range(range, &buffer);
         assert_eq!(
             layers.len(),
             expected_layers.len(),

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -1407,7 +1407,9 @@ fn json_lang() -> Language {
 
 fn get_tree_sexp(buffer: &ModelHandle<Buffer>, cx: &gpui::TestAppContext) -> String {
     buffer.read_with(cx, |buffer, _| {
-        buffer.syntax_tree().unwrap().root_node().to_sexp()
+        let syntax_map = buffer.syntax_map();
+        let layers = syntax_map.layers(buffer.as_text_snapshot());
+        layers[0].2.to_sexp()
     })
 }
 

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -998,6 +998,7 @@ fn test_autoindent_language_without_indents_query(cx: &mut MutableAppContext) {
             Arc::new(Language::new(
                 LanguageConfig {
                     name: "Markdown".into(),
+                    auto_indent_using_last_non_empty_line: false,
                     ..Default::default()
                 },
                 Some(tree_sitter_json::language()),

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -1407,8 +1407,8 @@ fn json_lang() -> Language {
 
 fn get_tree_sexp(buffer: &ModelHandle<Buffer>, cx: &gpui::TestAppContext) -> String {
     buffer.read_with(cx, |buffer, _| {
-        let syntax_map = buffer.syntax_map();
-        let layers = syntax_map.layers(buffer.as_text_snapshot());
+        let snapshot = buffer.snapshot();
+        let layers = snapshot.syntax.layers(buffer.as_text_snapshot());
         layers[0].2.to_sexp()
     })
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2056,6 +2056,7 @@ impl Project {
         let full_path = buffer.read(cx).file()?.full_path(cx);
         let language = self.languages.select_language(&full_path)?;
         buffer.update(cx, |buffer, cx| {
+            buffer.set_language_registry(self.languages.clone());
             buffer.set_language(Some(language.clone()), cx);
         });
 

--- a/crates/sum_tree/src/cursor.rs
+++ b/crates/sum_tree/src/cursor.rs
@@ -608,9 +608,9 @@ where
 
 impl<'a, F, T, S, U> Iterator for FilterCursor<'a, F, T, U>
 where
-    F: Fn(&T::Summary) -> bool,
+    F: FnMut(&T::Summary) -> bool,
     T: Item<Summary = S>,
-    S: Summary<Context = ()>,
+    S: Summary<Context = ()>, //Context for the summary must be unit type, as .next() doesn't take arguments
     U: Dimension<'a, T::Summary>,
 {
     type Item = &'a T;
@@ -621,7 +621,7 @@ where
         }
 
         if let Some(item) = self.item() {
-            self.cursor.next_internal(&self.filter_node, &());
+            self.cursor.next_internal(&mut self.filter_node, &());
             Some(item)
         } else {
             None

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -168,6 +168,8 @@ impl<T: Item> SumTree<T> {
         Cursor::new(self)
     }
 
+    /// Note: If the summary type requires a non `()` context, then the filter cursor
+    /// that is returned cannot be used with Rust's iterators.
     pub fn filter<'a, F, U>(&'a self, filter_node: F) -> FilterCursor<F, T, U>
     where
         F: FnMut(&T::Summary) -> bool,

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2435,7 +2435,7 @@ impl ToOffset for PointUtf16 {
 
 impl ToOffset for usize {
     fn to_offset<'a>(&self, snapshot: &BufferSnapshot) -> usize {
-        assert!(*self <= snapshot.len(), "offset is out of range");
+        assert!(*self <= snapshot.len(), "offset {self} is out of range");
         *self
     }
 }

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -128,6 +128,11 @@ pub(crate) fn language(
             .with_outline_query(query.as_ref())
             .expect("failed to load outline query");
     }
+    if let Some(query) = load_query(name, "/injections") {
+        language = language
+            .with_injection_query(query.as_ref())
+            .expect("failed to load injection query");
+    }
     if let Some(lsp_adapter) = lsp_adapter {
         language = language.with_lsp_adapter(lsp_adapter)
     }

--- a/crates/zed/src/languages/c/injections.scm
+++ b/crates/zed/src/languages/c/injections.scm
@@ -1,0 +1,7 @@
+(preproc_def
+    value: (preproc_arg) @content
+    (#set! "language" "c"))
+
+(preproc_function_def
+    value: (preproc_arg) @content
+    (#set! "language" "c"))

--- a/crates/zed/src/languages/cpp/highlights.scm
+++ b/crates/zed/src/languages/cpp/highlights.scm
@@ -1,3 +1,5 @@
+(identifier) @variable
+
 (call_expression
   function: (qualified_identifier
     name: (identifier) @function))
@@ -33,8 +35,6 @@
 
 (auto) @type
 (type_identifier) @type
-
-(identifier) @variable
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]*$"))

--- a/crates/zed/src/languages/cpp/injections.scm
+++ b/crates/zed/src/languages/cpp/injections.scm
@@ -1,0 +1,7 @@
+(preproc_def
+    value: (preproc_arg) @content
+    (#set! "language" "c++"))
+
+(preproc_function_def
+    value: (preproc_arg) @content
+    (#set! "language" "c++"))

--- a/crates/zed/src/languages/rust/highlights.scm
+++ b/crates/zed/src/languages/rust/highlights.scm
@@ -1,6 +1,6 @@
 (type_identifier) @type
 (primitive_type) @type.builtin
-
+(self) @variable.builtin
 (field_identifier) @property
 
 (call_expression
@@ -14,6 +14,16 @@
 
 (function_item name: (identifier) @function.definition)
 (function_signature_item name: (identifier) @function.definition)
+
+(macro_invocation
+  macro: [
+    (identifier) @function.special
+    (scoped_identifier
+      name: (identifier) @function.special)
+  ])
+
+(macro_definition
+  name: (identifier) @function.special.definition)
 
 ; Identifier conventions
 
@@ -71,6 +81,7 @@
   "mod"
   "move"
   "pub"
+  "ref"
   "return"
   "static"
   "struct"
@@ -90,6 +101,13 @@
   (raw_string_literal)
   (char_literal)
 ] @string
+
+[
+  (integer_literal)
+  (float_literal)
+] @number
+
+(boolean_literal) @constant
 
 [
   (line_comment)

--- a/crates/zed/src/languages/rust/injections.scm
+++ b/crates/zed/src/languages/rust/injections.scm
@@ -1,0 +1,3 @@
+(macro_invocation
+  (token_tree) @content)
+  (#set! "language" "rust"))

--- a/crates/zed/src/languages/rust/injections.scm
+++ b/crates/zed/src/languages/rust/injections.scm
@@ -1,3 +1,7 @@
 (macro_invocation
-  (token_tree) @content)
+  (token_tree) @content
+  (#set! "language" "rust"))
+
+(macro_rule
+  (token_tree) @content
   (#set! "language" "rust"))


### PR DESCRIPTION
### Description of feature or change

This PR adds the concept of *language injection* to Zed. If a language has an *injection query*, then that query will be used to find syntax nodes whose content should be parsed in another pass, creating another syntax tree in an arbitrary language. All syntax-related features of the `Buffer` now account for *multiple* syntax trees:
* syntax highlighting
* auto-indent
* breadcrumbs / outline
* bracket matching
* select {larger,smaller} syntax node

### Examples

Syntax highlighting and breadcrumbs for definitions inside a macro rule:
<img width="921" alt="Screen Shot 2022-08-24 at 3 40 22 PM" src="https://user-images.githubusercontent.com/326587/186536220-70bd8a49-b44a-46d8-91b3-3160190b7c59.png">

Syntax highlighting inside of macro invocations like `assert_eq!`
<img width="927" alt="Screen Shot 2022-08-24 at 3 41 22 PM" src="https://user-images.githubusercontent.com/326587/186536216-364892a0-7141-4872-8816-6598d43f237a.png">

Syntax highlighting of macro bodies in C:

<img width="1021" alt="Screen Shot 2022-08-24 at 4 39 39 PM" src="https://user-images.githubusercontent.com/326587/186542243-934e040e-ac02-46ea-afc7-67493ea4804a.png">

### Tasks

* [x] Parse rust token trees as rust
* [x] Parse C macro bodies as C
* [x] Test more thoroughly
* ~Parse markdown code blocks as the language indicated at the top of the block~

### Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/153

### Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
