### PR TITLE
Misc drag and drop issue fixes

### DIFF
--- a/crates/drag_and_drop/src/drag_and_drop.rs
+++ b/crates/drag_and_drop/src/drag_and_drop.rs
@@ -4,7 +4,7 @@ use gpui::{
     elements::{Container, MouseEventHandler},
     geometry::vector::Vector2F,
     scene::DragRegionEvent,
-    Element, ElementBox, EventContext, MouseButton, RenderContext, View, ViewContext,
+    CursorStyle, Element, ElementBox, EventContext, MouseButton, RenderContext, View, ViewContext,
     WeakViewHandle,
 };
 
@@ -33,7 +33,6 @@ pub struct DragAndDrop<V: View> {
 
 impl<V: View> DragAndDrop<V> {
     pub fn new(parent: WeakViewHandle<V>, cx: &mut ViewContext<V>) -> Self {
-        // TODO: Figure out if detaching here would result in a memory leak
         cx.observe_global::<Self, _>(|cx| {
             if let Some(parent) = cx.global::<Self>().parent.upgrade(cx) {
                 parent.update(cx, |_, cx| cx.notify())
@@ -110,6 +109,7 @@ impl<V: View> DragAndDrop<V> {
                         .left()
                         .boxed()
                 })
+                .with_cursor_style(CursorStyle::Arrow)
                 .on_up(MouseButton::Left, |_, cx| {
                     cx.defer(|cx| {
                         cx.update_global::<Self, _, _>(|this, _| this.currently_dragged.take());

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -5103,6 +5103,7 @@ impl<T: Entity> From<WeakModelHandle<T>> for AnyWeakModelHandle {
     }
 }
 
+#[derive(Debug)]
 pub struct WeakViewHandle<T> {
     window_id: usize,
     view_id: usize,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -381,7 +381,12 @@ impl Presenter {
                         }
                     }
                     MouseRegionEvent::Click(e) => {
-                        if e.button == self.clicked_button.unwrap() {
+                        // Only raise click events if the released button is the same as the one stored
+                        if self
+                            .clicked_button
+                            .map(|clicked_button| clicked_button == e.button)
+                            .unwrap_or(false)
+                        {
                             // Clear clicked regions and clicked button
                             let clicked_regions =
                                 std::mem::replace(&mut self.clicked_regions, Vec::new());

--- a/crates/gpui/src/scene/mouse_region_event.rs
+++ b/crates/gpui/src/scene/mouse_region_event.rs
@@ -169,7 +169,7 @@ impl MouseRegionEvent {
         match self {
             MouseRegionEvent::Move(_) => true,
             MouseRegionEvent::Drag(_) => false,
-            MouseRegionEvent::Hover(_) => true,
+            MouseRegionEvent::Hover(_) => false,
             MouseRegionEvent::Down(_) => true,
             MouseRegionEvent::Up(_) => true,
             MouseRegionEvent::Click(_) => true,

--- a/styles/src/styleTree/tabBar.ts
+++ b/styles/src/styleTree/tabBar.ts
@@ -72,7 +72,7 @@ export default function tabBar(theme: Theme) {
   return {
     height,
     background: backgroundColor(theme, 300),
-    dropTargetOverlayColor: withOpacity(theme.textColor.muted, 0.8),
+    dropTargetOverlayColor: withOpacity(theme.textColor.muted, 0.6),
     border: border(theme, "primary", {
       left: true,
       bottom: true,


### PR DESCRIPTION
## Description of feature or change
Locks the mouse cursor to the pointer when dragging
Address tooltips getting stuck when dragging over buttons
Fix editor subscription leaks when a tab item is moved between panes

The last one required storing a mapping between item ids and `WeakViewHandle<Pane>` in the workspace so that the correct pane can be retrieved when handling item events. This is updated in AddedToPane and is cleared when an item is released.

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/zed/issues/1570
Fixes https://github.com/zed-industries/zed/issues/1571
Fixes https://github.com/zed-industries/zed/issues/1569

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
