### PR TITLE
Make Workspace item search generic

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4938,6 +4938,14 @@ impl Clone for AnyViewHandle {
     }
 }
 
+impl PartialEq for AnyViewHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.window_id == other.window_id
+            && self.view_id == other.view_id
+            && self.view_type == other.view_type
+    }
+}
+
 impl From<&AnyViewHandle> for AnyViewHandle {
     fn from(handle: &AnyViewHandle) -> Self {
         handle.clone()
@@ -5163,6 +5171,7 @@ impl<T> Hash for WeakViewHandle<T> {
     }
 }
 
+#[derive(Eq, PartialEq, Hash)]
 pub struct AnyWeakViewHandle {
     window_id: usize,
     view_id: usize,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4938,14 +4938,6 @@ impl Clone for AnyViewHandle {
     }
 }
 
-impl PartialEq for AnyViewHandle {
-    fn eq(&self, other: &Self) -> bool {
-        self.window_id == other.window_id
-            && self.view_id == other.view_id
-            && self.view_type == other.view_type
-    }
-}
-
 impl From<&AnyViewHandle> for AnyViewHandle {
     fn from(handle: &AnyViewHandle) -> Self {
         handle.clone()
@@ -5171,7 +5163,6 @@ impl<T> Hash for WeakViewHandle<T> {
     }
 }
 
-#[derive(Eq, PartialEq, Hash)]
 pub struct AnyWeakViewHandle {
     window_id: usize,
     view_id: usize,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1,10 +1,12 @@
 use crate::{
-    active_match_index, match_index_for_direction, query_suggestion_for_editor, Direction,
     SearchOption, SelectNextMatch, SelectPrevMatch, ToggleCaseSensitive, ToggleRegex,
     ToggleWholeWord,
 };
 use collections::HashMap;
-use editor::{Anchor, Autoscroll, Editor, MultiBuffer, SelectAll, MAX_TAB_TITLE_LEN};
+use editor::{
+    items::{active_match_index, match_index_for_direction},
+    Anchor, Autoscroll, Editor, MultiBuffer, SelectAll, MAX_TAB_TITLE_LEN,
+};
 use gpui::{
     actions, elements::*, platform::CursorStyle, Action, AnyViewHandle, AppContext, ElementBox,
     Entity, ModelContext, ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription,
@@ -21,6 +23,7 @@ use std::{
 };
 use util::ResultExt as _;
 use workspace::{
+    searchable::{Direction, SearchableItemHandle},
     Item, ItemHandle, ItemNavHistory, Pane, ToolbarItemLocation, ToolbarItemView, Workspace,
 };
 
@@ -429,7 +432,7 @@ impl ProjectSearchView {
 
         let query = workspace.active_item(cx).and_then(|item| {
             let editor = item.act_as::<Editor>(cx)?;
-            let query = query_suggestion_for_editor(&editor, cx);
+            let query = editor.query_suggestion(cx);
             if query.is_empty() {
                 None
             } else {

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -1,11 +1,6 @@
 pub use buffer_search::BufferSearchBar;
-use editor::{display_map::ToDisplayPoint, Anchor, Bias, Editor, MultiBufferSnapshot};
-use gpui::{actions, Action, MutableAppContext, ViewHandle};
+use gpui::{actions, Action, MutableAppContext};
 pub use project_search::{ProjectSearchBar, ProjectSearchView};
-use std::{
-    cmp::{self, Ordering},
-    ops::Range,
-};
 
 pub mod buffer_search;
 pub mod project_search;
@@ -48,95 +43,5 @@ impl SearchOption {
             SearchOption::CaseSensitive => Box::new(ToggleCaseSensitive),
             SearchOption::Regex => Box::new(ToggleRegex),
         }
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum Direction {
-    Prev,
-    Next,
-}
-
-pub(crate) fn active_match_index(
-    ranges: &[Range<Anchor>],
-    cursor: &Anchor,
-    buffer: &MultiBufferSnapshot,
-) -> Option<usize> {
-    if ranges.is_empty() {
-        None
-    } else {
-        match ranges.binary_search_by(|probe| {
-            if probe.end.cmp(cursor, &*buffer).is_lt() {
-                Ordering::Less
-            } else if probe.start.cmp(cursor, &*buffer).is_gt() {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        }) {
-            Ok(i) | Err(i) => Some(cmp::min(i, ranges.len() - 1)),
-        }
-    }
-}
-
-pub(crate) fn match_index_for_direction(
-    ranges: &[Range<Anchor>],
-    cursor: &Anchor,
-    mut index: usize,
-    direction: Direction,
-    buffer: &MultiBufferSnapshot,
-) -> usize {
-    if ranges[index].start.cmp(cursor, buffer).is_gt() {
-        if direction == Direction::Prev {
-            if index == 0 {
-                index = ranges.len() - 1;
-            } else {
-                index -= 1;
-            }
-        }
-    } else if ranges[index].end.cmp(cursor, buffer).is_lt() {
-        if direction == Direction::Next {
-            index = 0;
-        }
-    } else if direction == Direction::Prev {
-        if index == 0 {
-            index = ranges.len() - 1;
-        } else {
-            index -= 1;
-        }
-    } else if direction == Direction::Next {
-        if index == ranges.len() - 1 {
-            index = 0
-        } else {
-            index += 1;
-        }
-    };
-    index
-}
-
-pub(crate) fn query_suggestion_for_editor(
-    editor: &ViewHandle<Editor>,
-    cx: &mut MutableAppContext,
-) -> String {
-    let display_map = editor
-        .update(cx, |editor, cx| editor.snapshot(cx))
-        .display_snapshot;
-    let selection = editor.read(cx).selections.newest::<usize>(cx);
-    if selection.start == selection.end {
-        let point = selection.start.to_display_point(&display_map);
-        let range = editor::movement::surrounding_word(&display_map, point);
-        let range = range.start.to_offset(&display_map, Bias::Left)
-            ..range.end.to_offset(&display_map, Bias::Right);
-        let text: String = display_map.buffer_snapshot.text_for_range(range).collect();
-        if text.trim().is_empty() {
-            String::new()
-        } else {
-            text
-        }
-    } else {
-        display_map
-            .buffer_snapshot
-            .text_for_range(selection.start..selection.end)
-            .collect()
     }
 }


### PR DESCRIPTION
## Description of feature or change
Before this change, buffer search was very specific to editor workspace items which made integration with other types of items impossible. This PR pulls the editor specific methods out into a SearchableItem trait, SearchableItemHandle and WeakSearchableItemHandle. This should enable us to implement consistent search in the terminal and any future workspace items.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
