### PR TITLE
Some more drag and drop fixes

### DIFF
--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -89,6 +89,20 @@ pub struct MouseMovedEvent {
     pub shift: bool,
 }
 
+impl MouseMovedEvent {
+    pub fn to_button_event(&self, button: MouseButton) -> MouseButtonEvent {
+        MouseButtonEvent {
+            position: self.position,
+            button: self.pressed_button.unwrap_or(button),
+            ctrl: self.ctrl,
+            alt: self.alt,
+            shift: self.shift,
+            cmd: self.cmd,
+            click_count: 0,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum Event {
     KeyDown(KeyDownEvent),

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -310,7 +310,23 @@ impl Presenter {
                                 prev_mouse_position: self.mouse_position,
                                 platform_event: e.clone(),
                             }));
+                        } else if let Some(clicked_button) = self.clicked_button {
+                            // Mouse up event happened outside the current window. Simulate mouse up button event
+                            let button_event = e.to_button_event(clicked_button);
+                            events_to_send.push(MouseRegionEvent::Up(UpRegionEvent {
+                                region: Default::default(),
+                                platform_event: button_event.clone(),
+                            }));
+                            events_to_send.push(MouseRegionEvent::UpOut(UpOutRegionEvent {
+                                region: Default::default(),
+                                platform_event: button_event.clone(),
+                            }));
+                            events_to_send.push(MouseRegionEvent::Click(ClickRegionEvent {
+                                region: Default::default(),
+                                platform_event: button_event.clone(),
+                            }));
                         }
+
                         events_to_send.push(MouseRegionEvent::Move(MoveRegionEvent {
                             region: Default::default(),
                             platform_event: e.clone(),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1256,7 +1256,7 @@ impl Pane {
     fn handle_dropped_item(pane: &WeakViewHandle<Pane>, index: usize, cx: &mut EventContext) {
         if let Some((_, dragged_item)) = cx
             .global::<DragAndDrop<Workspace>>()
-            .currently_dragged::<DraggedItem>()
+            .currently_dragged::<DraggedItem>(cx.window_id)
         {
             cx.dispatch_action(MoveItem {
                 item_id: dragged_item.item.id(),
@@ -1277,7 +1277,7 @@ impl Pane {
         if hovered
             && cx
                 .global::<DragAndDrop<Workspace>>()
-                .currently_dragged::<DraggedItem>()
+                .currently_dragged::<DraggedItem>(cx.window_id())
                 .is_some()
         {
             Some(theme.workspace.tab_bar.drop_target_overlay_color)


### PR DESCRIPTION
## Description of feature or change
- Prevents reporting a dragged payload if it was dragged from a different window
- Simulates mouse up events when the mouse re-enters the window if the mouse button was released outside of the window

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/zed/issues/1570

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
