### PR TITLE
Don't panic if a tab isn't present in a from tab when dragged

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -910,13 +910,18 @@ impl Pane {
         destination_index: usize,
         cx: &mut ViewContext<Workspace>,
     ) {
-        let (item_ix, item_handle) = from
+        let item_to_move = from
             .read(cx)
             .items()
             .enumerate()
-            .find(|(_, item_handle)| item_handle.id() == item_to_move)
-            .expect("Tried to move item handle which was not in from pane");
+            .find(|(_, item_handle)| item_handle.id() == item_to_move);
 
+        if item_to_move.is_none() {
+            log::warn!("Tried to move item handle which was not in `from` pane. Maybe tab was closed during drop");
+            return;
+        }
+
+        let (item_ix, item_handle) = item_to_move.unwrap();
         // This automatically removes duplicate items in the pane
         Pane::add_item(
             workspace,


### PR DESCRIPTION
## Description of feature or change
It is possible to close a tab item while it is being dragged. This PR causes that to be a no-op instead of panicing.

## Link to related issues from zed or insiders
- FIxes https://github.com/zed-industries/feedback/issues/490

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
