### PR TITLE
Fix crash when querying for enclosing brackets at EOF

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2059,7 +2059,8 @@ impl BufferSnapshot {
         range: Range<T>,
     ) -> Option<(Range<usize>, Range<usize>)> {
         // Find bracket pairs that *inclusively* contain the given range.
-        let range = range.start.to_offset(self).saturating_sub(1)..range.end.to_offset(self) + 1;
+        let range = range.start.to_offset(self).saturating_sub(1)
+            ..self.len().min(range.end.to_offset(self) + 1);
         let mut matches = self.syntax.matches(range, &self.text, |grammar| {
             grammar.brackets_config.as_ref().map(|c| &c.query)
         });

--- a/crates/language/src/tests.rs
+++ b/crates/language/src/tests.rs
@@ -571,6 +571,15 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
             Point::new(3, 4)..Point::new(3, 5)
         ))
     );
+
+    // Regression test: avoid crash when querying at the end of the buffer.
+    assert_eq!(
+        buffer.enclosing_bracket_point_ranges(buffer.len() - 1..buffer.len()),
+        Some((
+            Point::new(0, 6)..Point::new(0, 7),
+            Point::new(4, 0)..Point::new(4, 1)
+        ))
+    );
 }
 
 #[gpui::test]


### PR DESCRIPTION
This fixes a crash that I observed in v0.53.