### PR TITLE
Avoid undesirable pane item deduping with multibuffers

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3451,6 +3451,21 @@ mod tests {
             self
         }
 
+        pub fn with_singleton(mut self, singleton: bool) -> Self {
+            self.is_singleton = singleton;
+            self
+        }
+
+        pub fn with_project_entry_ids(mut self, project_entry_ids: &[u64]) -> Self {
+            self.project_entry_ids.extend(
+                project_entry_ids
+                    .iter()
+                    .copied()
+                    .map(ProjectEntryId::from_proto),
+            );
+            self
+        }
+
         fn set_state(&mut self, state: String, cx: &mut ViewContext<Self>) {
             self.push_to_nav_history(cx);
             self.state = state;

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -5,7 +5,7 @@ fn main() {
 
     let output = Command::new("npm")
         .current_dir("../../styles")
-        .args(["install"])
+        .args(["install", "--no-save"])
         .output()
         .expect("failed to run npm");
     if !output.status.success() {


### PR DESCRIPTION
This fixes a regression introduced in #1515, which prevented you from opening a single-file multibuffer when you already had that file open, and vise versa.