### PR TITLE
Terminal Breadcrumbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "collections",
  "editor",
  "gpui",
+ "itertools",
  "language",
  "project",
  "search",

--- a/crates/breadcrumbs/Cargo.toml
+++ b/crates/breadcrumbs/Cargo.toml
@@ -17,6 +17,7 @@ search = { path = "../search" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
 workspace = { path = "../workspace" }
+itertools = "0.10"
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -566,12 +566,8 @@ impl workspace::Item for ProjectDiagnosticsEditor {
         unreachable!()
     }
 
-    fn should_update_tab_on_event(event: &Event) -> bool {
-        Editor::should_update_tab_on_event(event)
-    }
-
-    fn is_edit_event(event: &Self::Event) -> bool {
-        Editor::is_edit_event(event)
+    fn to_item_events(event: &Self::Event) -> Vec<workspace::ItemEvent> {
+        Editor::to_item_events(event)
     }
 
     fn set_nav_history(&mut self, nav_history: ItemNavHistory, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -26,7 +26,7 @@ use text::{Point, Selection};
 use util::TryFutureExt;
 use workspace::{
     searchable::{Direction, SearchEvent, SearchableItem, SearchableItemHandle},
-    FollowableItem, Item, ItemHandle, ItemNavHistory, ProjectItem, StatusItemView,
+    FollowableItem, Item, ItemEvent, ItemHandle, ItemNavHistory, ProjectItem, StatusItemView,
 };
 
 pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -475,19 +475,13 @@ impl Item for Editor {
         })
     }
 
-    fn should_close_item_on_event(event: &Event) -> bool {
-        matches!(event, Event::Closed)
-    }
-
-    fn should_update_tab_on_event(event: &Event) -> bool {
-        matches!(
-            event,
-            Event::Saved | Event::DirtyChanged | Event::TitleChanged
-        )
-    }
-
-    fn is_edit_event(event: &Self::Event) -> bool {
-        matches!(event, Event::BufferEdited)
+    fn to_item_events(event: &Self::Event) -> Vec<workspace::ItemEvent> {
+        match event {
+            Event::Closed => vec![ItemEvent::CloseItem],
+            Event::Saved | Event::DirtyChanged | Event::TitleChanged => vec![ItemEvent::UpdateTab],
+            Event::BufferEdited => vec![ItemEvent::Edit],
+            _ => Vec::new(),
+        }
     }
 
     fn as_searchable(&self, handle: &ViewHandle<Self>) -> Option<Box<dyn SearchableItemHandle>> {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -191,16 +191,17 @@ impl ToolbarItemView for BufferSearchBar {
 
         if let Some(searchable_item_handle) = item.and_then(|item| item.as_searchable(cx)) {
             let handle = cx.weak_handle();
-            self.active_searchable_item_subscription = Some(searchable_item_handle.subscribe(
-                cx,
-                Box::new(move |search_event, cx| {
-                    if let Some(this) = handle.upgrade(cx) {
-                        this.update(cx, |this, cx| {
-                            this.on_active_searchable_item_event(search_event, cx)
-                        });
-                    }
-                }),
-            ));
+            self.active_searchable_item_subscription =
+                Some(searchable_item_handle.subscribe_to_search_events(
+                    cx,
+                    Box::new(move |search_event, cx| {
+                        if let Some(this) = handle.upgrade(cx) {
+                            this.update(cx, |this, cx| {
+                                this.on_active_searchable_item_event(search_event, cx)
+                            });
+                        }
+                    }),
+                ));
 
             self.active_searchable_item = Some(searchable_item_handle);
             self.update_matches(false, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -189,7 +189,9 @@ impl ToolbarItemView for BufferSearchBar {
         self.active_searchable_item.take();
         self.pending_search.take();
 
-        if let Some(searchable_item_handle) = item.and_then(|item| item.as_searchable(cx)) {
+        if let Some(searchable_item_handle) =
+            item.and_then(|item| item.to_searchable_item_handle(cx))
+        {
             let handle = cx.weak_handle();
             self.active_searchable_item_subscription =
                 Some(searchable_item_handle.subscribe_to_search_events(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -24,7 +24,8 @@ use std::{
 use util::ResultExt as _;
 use workspace::{
     searchable::{Direction, SearchableItem, SearchableItemHandle},
-    Item, ItemHandle, ItemNavHistory, Pane, ToolbarItemLocation, ToolbarItemView, Workspace,
+    Item, ItemEvent, ItemHandle, ItemNavHistory, Pane, ToolbarItemLocation, ToolbarItemView,
+    Workspace,
 };
 
 actions!(project_search, [SearchInNew, ToggleFocus]);
@@ -326,15 +327,11 @@ impl Item for ProjectSearchView {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn should_update_tab_on_event(event: &ViewEvent) -> bool {
-        matches!(event, ViewEvent::UpdateTab)
-    }
-
-    fn is_edit_event(event: &Self::Event) -> bool {
-        if let ViewEvent::EditorEvent(editor_event) = event {
-            Editor::is_edit_event(editor_event)
-        } else {
-            false
+    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
+        match event {
+            ViewEvent::UpdateTab => vec![ItemEvent::UpdateTab],
+            ViewEvent::EditorEvent(editor_event) => Editor::to_item_events(editor_event),
+            _ => Vec::new(),
         }
     }
 }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -329,10 +329,22 @@ impl Item for ProjectSearchView {
 
     fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
         match event {
-            ViewEvent::UpdateTab => vec![ItemEvent::UpdateTab],
+            ViewEvent::UpdateTab => vec![ItemEvent::UpdateBreadcrumbs, ItemEvent::UpdateTab],
             ViewEvent::EditorEvent(editor_event) => Editor::to_item_events(editor_event),
             _ => Vec::new(),
         }
+    }
+
+    fn breadcrumb_location(&self) -> ToolbarItemLocation {
+        if self.has_matches() {
+            ToolbarItemLocation::Secondary
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+
+    fn breadcrumbs(&self, theme: &theme::Theme, cx: &AppContext) -> Option<Vec<ElementBox>> {
+        self.results_editor.breadcrumbs(theme, cx)
     }
 }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -83,6 +83,7 @@ const DEBUG_LINE_HEIGHT: f32 = 5.;
 #[derive(Clone, Copy, Debug)]
 pub enum Event {
     TitleChanged,
+    BreadcrumbsChanged,
     CloseTerminal,
     Bell,
     Wakeup,
@@ -494,9 +495,11 @@ impl Terminal {
         match event {
             AlacTermEvent::Title(title) => {
                 self.breadcrumb_text = title.to_string();
+                cx.emit(Event::BreadcrumbsChanged);
             }
             AlacTermEvent::ResetTitle => {
                 self.breadcrumb_text = String::new();
+                cx.emit(Event::BreadcrumbsChanged);
             }
             AlacTermEvent::ClipboardStore(_, data) => {
                 cx.write_to_clipboard(ClipboardItem::new(data.to_string()))

--- a/crates/terminal/src/terminal_container_view.rs
+++ b/crates/terminal/src/terminal_container_view.rs
@@ -9,7 +9,7 @@ use gpui::{
 };
 use util::truncate_and_trailoff;
 use workspace::searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle};
-use workspace::{Item, Workspace};
+use workspace::{Item, ItemEvent, Workspace};
 
 use crate::TerminalSize;
 use project::{LocalWorktree, Project, ProjectPath};
@@ -359,16 +359,16 @@ impl Item for TerminalContainer {
         false
     }
 
-    fn should_update_tab_on_event(event: &Self::Event) -> bool {
-        matches!(event, &Event::TitleChanged | &Event::Wakeup)
-    }
-
-    fn should_close_item_on_event(event: &Self::Event) -> bool {
-        matches!(event, &Event::CloseTerminal)
-    }
-
     fn as_searchable(&self, handle: &ViewHandle<Self>) -> Option<Box<dyn SearchableItemHandle>> {
         Some(Box::new(handle.clone()))
+    }
+
+    fn to_item_events(event: &Self::Event) -> Vec<workspace::ItemEvent> {
+        match event {
+            Event::TitleChanged | Event::Wakeup => vec![ItemEvent::UpdateTab],
+            Event::CloseTerminal => vec![ItemEvent::CloseItem],
+            _ => vec![],
+        }
     }
 }
 

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -88,7 +88,7 @@ pub trait SearchableItemHandle: ItemHandle {
     fn downgrade(&self) -> Box<dyn WeakSearchableItemHandle>;
     fn boxed_clone(&self) -> Box<dyn SearchableItemHandle>;
     fn supported_options(&self) -> SearchOptions;
-    fn subscribe(
+    fn subscribe_to_search_events(
         &self,
         cx: &mut MutableAppContext,
         handler: Box<dyn Fn(SearchEvent, &mut MutableAppContext)>,
@@ -134,7 +134,7 @@ impl<T: SearchableItem> SearchableItemHandle for ViewHandle<T> {
         T::supported_options()
     }
 
-    fn subscribe(
+    fn subscribe_to_search_events(
         &self,
         cx: &mut MutableAppContext,
         handler: Box<dyn Fn(SearchEvent, &mut MutableAppContext)>,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -267,6 +267,14 @@ pub struct AppState {
     pub initialize_workspace: fn(&mut Workspace, &Arc<AppState>, &mut ViewContext<Workspace>),
 }
 
+#[derive(Eq, PartialEq, Hash)]
+pub enum ItemEvent {
+    CloseItem,
+    UpdateTab,
+    UpdateBreadcrumbs,
+    Edit,
+}
+
 pub trait Item: View {
     fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
     fn workspace_deactivated(&mut self, _: &mut ViewContext<Self>) {}
@@ -311,15 +319,7 @@ pub trait Item: View {
         project: ModelHandle<Project>,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<()>>;
-    fn should_close_item_on_event(_: &Self::Event) -> bool {
-        false
-    }
-    fn should_update_tab_on_event(_: &Self::Event) -> bool {
-        false
-    }
-    fn is_edit_event(_: &Self::Event) -> bool {
-        false
-    }
+    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent>;
     fn act_as_type(
         &self,
         type_id: TypeId,
@@ -333,6 +333,13 @@ pub trait Item: View {
         }
     }
     fn as_searchable(&self, _: &ViewHandle<Self>) -> Option<Box<dyn SearchableItemHandle>> {
+        None
+    }
+
+    fn breadcrumb_location(&self) -> ToolbarItemLocation {
+        ToolbarItemLocation::Hidden
+    }
+    fn breadcrumbs(&self, _theme: &Theme) -> Option<Vec<ElementBox>> {
         None
     }
 }
@@ -470,6 +477,9 @@ pub trait ItemHandle: 'static + fmt::Debug {
         callback: Box<dyn FnOnce(&mut MutableAppContext)>,
     ) -> gpui::Subscription;
     fn as_searchable(&self, cx: &AppContext) -> Option<Box<dyn SearchableItemHandle>>;
+
+    fn breadcrumb_location(&self, cx: &AppContext) -> ToolbarItemLocation;
+    fn breadcrumbs(&self, theme: &Theme, cx: &AppContext) -> Option<Vec<ElementBox>>;
 }
 
 pub trait WeakItemHandle {
@@ -605,47 +615,53 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
                         }
                     }
 
-                    if T::should_close_item_on_event(event) {
-                        Pane::close_item(workspace, pane, item.id(), cx).detach_and_log_err(cx);
-                        return;
-                    }
+                    for item_event in T::to_item_events(event).into_iter() {
+                        match item_event {
+                            ItemEvent::CloseItem => {
+                                Pane::close_item(workspace, pane, item.id(), cx)
+                                    .detach_and_log_err(cx);
+                                return;
+                            }
+                            ItemEvent::UpdateTab => {
+                                pane.update(cx, |_, cx| {
+                                    cx.emit(pane::Event::ChangeItemTitle);
+                                    cx.notify();
+                                });
+                            }
+                            ItemEvent::Edit => {
+                                if let Autosave::AfterDelay { milliseconds } =
+                                    cx.global::<Settings>().autosave
+                                {
+                                    let prev_autosave = pending_autosave
+                                        .take()
+                                        .unwrap_or_else(|| Task::ready(Some(())));
+                                    let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+                                    let prev_cancel_tx =
+                                        mem::replace(&mut cancel_pending_autosave, cancel_tx);
+                                    let project = workspace.project.downgrade();
+                                    let _ = prev_cancel_tx.send(());
+                                    let item = item.clone();
+                                    pending_autosave =
+                                        Some(cx.spawn_weak(|_, mut cx| async move {
+                                            let mut timer = cx
+                                                .background()
+                                                .timer(Duration::from_millis(milliseconds))
+                                                .fuse();
+                                            prev_autosave.await;
+                                            futures::select_biased! {
+                                                _ = cancel_rx => return None,
+                                                    _ = timer => {}
+                                            }
 
-                    if T::should_update_tab_on_event(event) {
-                        pane.update(cx, |_, cx| {
-                            cx.emit(pane::Event::ChangeItemTitle);
-                            cx.notify();
-                        });
-                    }
-
-                    if T::is_edit_event(event) {
-                        if let Autosave::AfterDelay { milliseconds } =
-                            cx.global::<Settings>().autosave
-                        {
-                            let prev_autosave = pending_autosave
-                                .take()
-                                .unwrap_or_else(|| Task::ready(Some(())));
-                            let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
-                            let prev_cancel_tx =
-                                mem::replace(&mut cancel_pending_autosave, cancel_tx);
-                            let project = workspace.project.downgrade();
-                            let _ = prev_cancel_tx.send(());
-                            pending_autosave = Some(cx.spawn_weak(|_, mut cx| async move {
-                                let mut timer = cx
-                                    .background()
-                                    .timer(Duration::from_millis(milliseconds))
-                                    .fuse();
-                                prev_autosave.await;
-                                futures::select_biased! {
-                                    _ = cancel_rx => return None,
-                                    _ = timer => {}
+                                            let project = project.upgrade(&cx)?;
+                                            cx.update(|cx| Pane::autosave_item(&item, project, cx))
+                                                .await
+                                                .log_err();
+                                            None
+                                        }));
                                 }
-
-                                let project = project.upgrade(&cx)?;
-                                cx.update(|cx| Pane::autosave_item(&item, project, cx))
-                                    .await
-                                    .log_err();
-                                None
-                            }));
+                            }
+                            _ => {}
                         }
                     }
                 }));
@@ -748,6 +764,14 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
 
     fn as_searchable(&self, cx: &AppContext) -> Option<Box<dyn SearchableItemHandle>> {
         self.read(cx).as_searchable(self)
+    }
+
+    fn breadcrumb_location(&self, cx: &AppContext) -> ToolbarItemLocation {
+        self.read(cx).breadcrumb_location()
+    }
+
+    fn breadcrumbs(&self, theme: &Theme, cx: &AppContext) -> Option<Vec<ElementBox>> {
+        self.read(cx).breadcrumbs(theme)
     }
 }
 
@@ -3590,12 +3614,8 @@ mod tests {
             Task::ready(Ok(()))
         }
 
-        fn should_update_tab_on_event(_: &Self::Event) -> bool {
-            true
-        }
-
-        fn is_edit_event(event: &Self::Event) -> bool {
-            matches!(event, TestItemEvent::Edit)
+        fn to_item_events(_: &Self::Event) -> Vec<ItemEvent> {
+            vec![ItemEvent::UpdateTab, ItemEvent::Edit]
         }
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -225,12 +225,11 @@ pub fn initialize_workspace(
     cx: &mut ViewContext<Workspace>,
 ) {
     cx.subscribe(&cx.handle(), {
-        let project = workspace.project().clone();
         move |_, _, event, cx| {
             if let workspace::Event::PaneAdded(pane) = event {
                 pane.update(cx, |pane, cx| {
                     pane.toolbar().update(cx, |toolbar, cx| {
-                        let breadcrumbs = cx.add_view(|_| Breadcrumbs::new(project.clone()));
+                        let breadcrumbs = cx.add_view(|_| Breadcrumbs::new());
                         toolbar.add_item(breadcrumbs, cx);
                         let buffer_search_bar = cx.add_view(BufferSearchBar::new);
                         toolbar.add_item(buffer_search_bar, cx);


### PR DESCRIPTION
## Description of feature or change
Refactors item event handling to use a to_item_events rather than individual query functions
Make breadcrumbs toolbar generic over any active item rather than having hard coded logic
Implement breadcrumb rendering of the user's terminal title for terminal tabs

## Link to related issues from zed or insiders
- Fixes https://github.com/zed-industries/zed/issues/1575

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
