### PR TITLE
Patch for beachball on disconnected overlay

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2189,8 +2189,9 @@ impl Workspace {
 
     fn render_disconnected_overlay(&self, cx: &mut RenderContext<Workspace>) -> Option<ElementBox> {
         if self.project.read(cx).is_read_only() {
+            enum DisconnectedOverlay {};
             Some(
-                MouseEventHandler::new::<Workspace, _, _>(0, cx, |_, cx| {
+                MouseEventHandler::new::<DisconnectedOverlay, _, _>(0, cx, |_, cx| {
                     let theme = &cx.global::<Settings>().theme;
                     Label::new(
                         "Your connection to the remote project has been lost.".to_string(),


### PR DESCRIPTION
Permanent fix to MouseRegion API is a part of the Dock PR.

Co-Authored-By: Keith <keith@zed.dev>

## Description of feature or change

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
