### PR TITLE
Make MouseRegion Click handlers, also handle Down events by default.

### DIFF
--- a/crates/gpui/src/scene/mouse_region.rs
+++ b/crates/gpui/src/scene/mouse_region.rs
@@ -196,6 +196,14 @@ impl HandlerSet {
         self.set.get(key).cloned()
     }
 
+    pub fn contains_handler(
+        &self,
+        event: Discriminant<MouseRegionEvent>,
+        button: Option<MouseButton>,
+    ) -> bool {
+        self.set.contains_key(&(event, button))
+    }
+
     pub fn on_move(
         mut self,
         handler: impl Fn(MoveRegionEvent, &mut EventContext) + 'static,


### PR DESCRIPTION
## Description of feature or change
This fixes the issue where context menus in the editor would move the selection and then dispatch the menu action causing it to be triggered from the wrong location.

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/feedback/issues/487

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
Testing this would require a geometric testing feature where we can send mouse events by position. I have some thoughts about what this should look like but it is out of scope for this hot fix.
- [x] Have you added the necessary settings to configure this feature?
N/A
- [x] Has documentation been created or updated (including above changes to settings)?
N/A
