### PR TITLE
Dock Tweaks

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -309,8 +309,7 @@
             "cmd-shift-p": "command_palette::Toggle",
             "cmd-shift-m": "diagnostics::Deploy",
             "cmd-shift-e": "project_panel::ToggleFocus",
-            "cmd-alt-s": "workspace::SaveAll",
-            "shift-escape": "workspace::ActivateOrHideDock"
+            "cmd-alt-s": "workspace::SaveAll"
         }
     },
     // Bindings from Sublime Text
@@ -395,7 +394,17 @@
         "context": "Workspace",
         "bindings": {
             "cmd-shift-c": "contacts_panel::ToggleFocus",
-            "cmd-shift-b": "workspace::ToggleRightSidebar"
+            "cmd-shift-b": "workspace::ToggleRightSidebar",
+            "shift-escape": "dock::FocusDock",
+            "cmd-shift-k cmd-shift-right": "dock::AnchorDockRight",
+            "cmd-shift-k cmd-shift-down": "dock::AnchorDockBottom",
+            "cmd-shift-k cmd-shift-up": "dock::ExpandDock"
+        }
+    },
+    {
+        "context": "Dock",
+        "bindings": {
+            "shift-escape": "dock::HideDock"
         }
     },
     {

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -393,9 +393,13 @@
     {
         "context": "Workspace",
         "bindings": {
-            "cmd-shift-c": "contacts_panel::ToggleFocus",
-            "cmd-shift-b": "workspace::ToggleRightSidebar",
             "shift-escape": "dock::FocusDock",
+            "cmd-shift-c": "contacts_panel::ToggleFocus",
+            "cmd-shift-b": "workspace::ToggleRightSidebar"
+        }
+    },
+    {
+        "bindings": {
             "cmd-shift-k cmd-shift-right": "dock::AnchorDockRight",
             "cmd-shift-k cmd-shift-down": "dock::AnchorDockBottom",
             "cmd-shift-k cmd-shift-up": "dock::ExpandDock"

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -755,35 +755,34 @@ impl Element for TerminalElement {
         _paint: &mut Self::PaintState,
         cx: &mut gpui::EventContext,
     ) -> bool {
-        match event {
-            Event::KeyDown(KeyDownEvent { keystroke, .. }) => {
-                if !cx.is_parent_view_focused() {
-                    return false;
-                }
-
-                if let Some(view) = self.view.upgrade(cx.app) {
-                    view.update(cx.app, |view, cx| {
-                        view.clear_bel(cx);
-                        view.pause_cursor_blinking(cx);
-                    })
-                }
-
-                self.terminal
-                    .upgrade(cx.app)
-                    .map(|model_handle| {
-                        model_handle.update(cx.app, |term, cx| {
-                            term.try_keystroke(
-                                keystroke,
-                                cx.global::<Settings>()
-                                    .terminal_overrides
-                                    .option_as_meta
-                                    .unwrap_or(false),
-                            )
-                        })
-                    })
-                    .unwrap_or(false)
+        if let Event::KeyDown(KeyDownEvent { keystroke, .. }) = event {
+            if !cx.is_parent_view_focused() {
+                return false;
             }
-            _ => false,
+
+            if let Some(view) = self.view.upgrade(cx.app) {
+                view.update(cx.app, |view, cx| {
+                    view.clear_bel(cx);
+                    view.pause_cursor_blinking(cx);
+                })
+            }
+
+            self.terminal
+                .upgrade(cx.app)
+                .map(|model_handle| {
+                    model_handle.update(cx.app, |term, cx| {
+                        term.try_keystroke(
+                            keystroke,
+                            cx.global::<Settings>()
+                                .terminal_overrides
+                                .option_as_meta
+                                .unwrap_or(false),
+                        )
+                    })
+                })
+                .unwrap_or(false)
+        } else {
+            false
         }
     }
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -80,6 +80,7 @@ pub struct TabBar {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub pane_button: Interactive<IconButton>,
+    pub pane_button_container: ContainerStyle,
     pub active_pane: TabStyles,
     pub inactive_pane: TabStyles,
     pub dragged_tab: Tab,
@@ -155,7 +156,6 @@ pub struct Dock {
     pub initial_size_right: f32,
     pub initial_size_bottom: f32,
     pub wash_color: Color,
-    pub flex: f32,
     pub panel: ContainerStyle,
     pub maximized: ContainerStyle,
 }

--- a/styles/src/styleTree/tabBar.ts
+++ b/styles/src/styleTree/tabBar.ts
@@ -59,13 +59,7 @@ export default function tabBar(theme: Theme) {
   const draggedTab = {
     ...activePaneActiveTab,
     background: withOpacity(tab.background, 0.8),
-    border: {
-      ...tab.border,
-      top: false,
-      left: false,
-      right: false,
-      bottom: false,
-    },
+    border: undefined as any, // Remove border
     shadow: draggedShadow(theme),
   }
 
@@ -74,7 +68,6 @@ export default function tabBar(theme: Theme) {
     background: backgroundColor(theme, 300),
     dropTargetOverlayColor: withOpacity(theme.textColor.muted, 0.6),
     border: border(theme, "primary", {
-      left: true,
       bottom: true,
       overlay: true,
     }),
@@ -89,14 +82,18 @@ export default function tabBar(theme: Theme) {
     draggedTab,
     paneButton: {
       color: iconColor(theme, "secondary"),
-      border: {
-        ...tab.border,
-      },
       iconWidth: 12,
       buttonWidth: activePaneActiveTab.height,
       hover: {
         color: iconColor(theme, "active"),
       },
     },
+    paneButtonContainer: {
+      background: tab.background,
+      border: {
+        ...tab.border,
+        right: false,
+      }
+    }
   }
 }

--- a/styles/src/styleTree/workspace.ts
+++ b/styles/src/styleTree/workspace.ts
@@ -163,13 +163,16 @@ export default function workspace(theme: Theme) {
       initialSizeRight: 640,
       initialSizeBottom: 480,
       wash_color: withOpacity(theme.backgroundColor[500].base, 0.5),
-      flex: 0.5,
       panel: {
-        margin: 4,
+        border: {
+          ...border(theme, "secondary"),
+          width: 1
+        },
       },
       maximized: {
-        margin: 32,
-        border: border(theme, "secondary"),
+        cornerRadius: 10,
+        margin: 24,
+        border: border(theme, "secondary", { "overlay": true }),
         shadow: modalShadow(theme),
       }
     }

--- a/styles/src/styleTree/workspace.ts
+++ b/styles/src/styleTree/workspace.ts
@@ -170,7 +170,6 @@ export default function workspace(theme: Theme) {
         },
       },
       maximized: {
-        cornerRadius: 10,
         margin: 24,
         border: border(theme, "secondary", { "overlay": true }),
         shadow: modalShadow(theme),


### PR DESCRIPTION
## Description of feature or change
Address some issues that cropped up from the dock PR below.
Adds keybindings for moving the dock to a given location via `cmd-shift-k cmd-shift-{direction}`.
Also tweaks the themes for the dock as per nate's suggestions.

## Link to related issues from zed or insiders
Fixes https://github.com/zed-industries/zed/issues/1631
Fixes https://github.com/zed-industries/zed/issues/1629
Fixes https://github.com/zed-industries/zed/issues/1628
Fixes https://github.com/zed-industries/zed/issues/1627
Fixes https://github.com/zed-industries/zed/issues/1626

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
