### PR TITLE
Set `MACOSX_DEPLOYMENT_TARGET` when running `script/bundle`

### DIFF
--- a/script/bundle
+++ b/script/bundle
@@ -3,6 +3,7 @@
 set -e
 
 export ZED_BUNDLE=true
+export MACOSX_DEPLOYMENT_TARGET=10.14
 
 echo "Installing cargo bundle"
 cargo install cargo-bundle --version 0.5.0


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/520

This ensures that every library and binary we build doesn't assume that it's going to run on the same machine that created it.
