### PR TITLE
Backward compat format settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -43,7 +43,7 @@
     //     "default_dock_anchor": "expanded"
     "default_dock_anchor": "right",
     // Whether or not to perform a buffer format before saving
-    "format_on_save": true,
+    "format_on_save": "off",
     // How to perform a buffer format. This setting can take two values:
     //
     // 1. Format code using the current language server:

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -58,7 +58,7 @@ pub struct EditorSettings {
     pub hard_tabs: Option<bool>,
     pub soft_wrap: Option<SoftWrap>,
     pub preferred_line_length: Option<u32>,
-    pub format_on_save: Option<bool>,
+    pub format_on_save: Option<FormatOnSave>,
     pub formatter: Option<Formatter>,
     pub enable_language_server: Option<bool>,
 }
@@ -69,6 +69,17 @@ pub enum SoftWrap {
     None,
     EditorWidth,
     PreferredLineLength,
+}
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FormatOnSave {
+    On,
+    Off,
+    LanguageServer,
+    External {
+        command: String,
+        arguments: Vec<String>,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -324,8 +335,8 @@ impl Settings {
         self.language_setting(language, |settings| settings.preferred_line_length)
     }
 
-    pub fn format_on_save(&self, language: Option<&str>) -> bool {
-        self.language_setting(language, |settings| settings.format_on_save)
+    pub fn format_on_save(&self, language: Option<&str>) -> FormatOnSave {
+        self.language_setting(language, |settings| settings.format_on_save.clone())
     }
 
     pub fn formatter(&self, language: Option<&str>) -> Formatter {
@@ -364,7 +375,7 @@ impl Settings {
                 hard_tabs: Some(false),
                 soft_wrap: Some(SoftWrap::None),
                 preferred_line_length: Some(80),
-                format_on_save: Some(true),
+                format_on_save: Some(FormatOnSave::On),
                 formatter: Some(Formatter::LanguageServer),
                 enable_language_server: Some(true),
             },


### PR DESCRIPTION
## Description of feature or change

Makes settings from https://github.com/zed-industries/zed/pull/1647 backwards compatible (for now?), fixes https://github.com/zed-industries/zed/issues/1649

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
