### PR TITLE
Telemetry fixes

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -15,11 +15,9 @@ use async_tungstenite::tungstenite::{
 use db::Db;
 use futures::{future::LocalBoxFuture, FutureExt, SinkExt, StreamExt, TryStreamExt};
 use gpui::{
-    actions,
-    serde_json::{json, Value},
-    AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle, AppContext,
-    AsyncAppContext, Entity, ModelContext, ModelHandle, MutableAppContext, Task, View, ViewContext,
-    ViewHandle,
+    actions, serde_json::Value, AnyModelHandle, AnyViewHandle, AnyWeakModelHandle,
+    AnyWeakViewHandle, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle,
+    MutableAppContext, Task, View, ViewContext, ViewHandle,
 };
 use http::HttpClient;
 use lazy_static::lazy_static;
@@ -56,7 +54,7 @@ lazy_static! {
 
 pub const ZED_SECRET_CLIENT_TOKEN: &str = "618033988749894";
 
-actions!(client, [Authenticate, TestTelemetry]);
+actions!(client, [Authenticate]);
 
 pub fn init(client: Arc<Client>, cx: &mut MutableAppContext) {
     cx.add_global_action({
@@ -67,17 +65,6 @@ pub fn init(client: Arc<Client>, cx: &mut MutableAppContext) {
                 |cx| async move { client.authenticate_and_connect(true, &cx).log_err().await },
             )
             .detach();
-        }
-    });
-    cx.add_global_action({
-        let client = client.clone();
-        move |_: &TestTelemetry, _| {
-            client.report_event(
-                "test_telemetry",
-                json!({
-                    "test_property": "test_value"
-                }),
-            )
         }
     });
 }

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -52,6 +52,12 @@ lazy_static! {
 struct AmplitudeEventBatch {
     api_key: &'static str,
     events: Vec<AmplitudeEvent>,
+    options: AmplitudeEventBatchOptions,
+}
+
+#[derive(Serialize)]
+struct AmplitudeEventBatchOptions {
+    min_id_length: usize,
 }
 
 #[derive(Serialize)]
@@ -239,7 +245,11 @@ impl Telemetry {
                             }
                         }
 
-                        let batch = AmplitudeEventBatch { api_key, events };
+                        let batch = AmplitudeEventBatch {
+                            api_key,
+                            events,
+                            options: AmplitudeEventBatchOptions { min_id_length: 1 },
+                        };
                         json_bytes.clear();
                         serde_json::to_writer(&mut json_bytes, &batch)?;
                         let request =


### PR DESCRIPTION
### Description of feature or change

In-app telemetry events from early users aren't getting reported because of Amplitude's default minimum user id length of 5. This updates our Amplitude API calls from Zed to set the `min_id_length` to 1.

### Link to related issues from zed or insiders

### Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
