### PR TITLE
Fix some git gutter bugs

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -630,9 +630,7 @@ impl EditorElement {
                     let new_hunk = get_hunk(diff_layout.buffer_row, &layout.diff_hunks);
 
                     let (is_ending, is_starting) = match (diff_layout.last_diff, new_hunk) {
-                        (Some(old_hunk), Some(new_hunk)) if new_hunk == old_hunk => {
-                            (false, false)
-                        }
+                        (Some(old_hunk), Some(new_hunk)) if new_hunk == old_hunk => (false, false),
                         (a, b) => (a.is_some(), b.is_some()),
                     };
 

--- a/crates/project/src/fs.rs
+++ b/crates/project/src/fs.rs
@@ -491,7 +491,6 @@ impl FakeFs {
     }
 
     pub async fn set_index_for_repo(&self, dot_git: &Path, head_state: &[(&Path, String)]) {
-        let content_path = dot_git.parent().unwrap();
         let mut state = self.state.lock().await;
         let entry = state.read_path(dot_git).await.unwrap();
         let mut entry = entry.lock().await;
@@ -504,7 +503,7 @@ impl FakeFs {
             repo_state.index_contents.extend(
                 head_state
                     .iter()
-                    .map(|(path, content)| (content_path.join(path), content.clone())),
+                    .map(|(path, content)| (path.to_path_buf(), content.clone())),
             );
 
             state.emit_event([dot_git]);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4684,7 +4684,7 @@ impl Project {
                 cx.spawn(|_, mut cx| async move {
                     let diff_base = cx
                         .background()
-                        .spawn(async move { repo.repo.lock().load_index(&relative_repo) })
+                        .spawn(async move { repo.repo.lock().load_index_text(&relative_repo) })
                         .await;
 
                     let buffer_id = buffer.update(&mut cx, |buffer, cx| {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4673,13 +4673,18 @@ impl Project {
                     None => return,
                 };
 
+                let relative_repo = match path.strip_prefix(repo.content_path) {
+                    Ok(relative_repo) => relative_repo.to_owned(),
+                    Err(_) => return,
+                };
+
                 let shared_remote_id = self.shared_remote_id();
                 let client = self.client.clone();
 
                 cx.spawn(|_, mut cx| async move {
                     let diff_base = cx
                         .background()
-                        .spawn(async move { repo.repo.lock().load_index(&path) })
+                        .spawn(async move { repo.repo.lock().load_index(&relative_repo) })
                         .await;
 
                     let buffer_id = buffer.update(&mut cx, |buffer, cx| {

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -671,7 +671,7 @@ impl LocalWorktree {
                 if let Ok(repo_relative) = path.strip_prefix(repo.content_path) {
                     let repo_relative = repo_relative.to_owned();
                     cx.background()
-                        .spawn(async move { repo.repo.lock().load_index(&repo_relative) })
+                        .spawn(async move { repo.repo.lock().load_index_text(&repo_relative) })
                         .await
                 } else {
                     None
@@ -2505,6 +2505,7 @@ impl BackgroundScanner {
 
                         let scan_id = snapshot.scan_id;
                         if let Some(repo) = snapshot.in_dot_git(&path) {
+                            repo.repo.lock().reload_index();
                             repo.scan_id = scan_id;
                         }
 


### PR DESCRIPTION
## Description of feature or change

Fixes issue(s) with repositories which are not located at worktree root and once again reopen repos when file events fire so that we get updated index contents

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
