### PR TITLE
Add Discord webhook for published releases

### DIFF
--- a/.github/workflows/discord_webhook.yml
+++ b/.github/workflows/discord_webhook.yml
@@ -1,0 +1,13 @@
+on:
+  release:
+    types: [published]
+    
+jobs:
+  message:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Discord Webhook Action
+      uses: tsickert/discord-webhook@v5.3.0
+      with:
+        webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        content: "Name: ${{ github.event.release.name }} Description: ${{ github.event.release.body }}"

--- a/.github/workflows/discord_webhook.yml
+++ b/.github/workflows/discord_webhook.yml
@@ -10,4 +10,11 @@ jobs:
       uses: tsickert/discord-webhook@v5.3.0
       with:
         webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        content: "Name: ${{ github.event.release.name }} Description: ${{ github.event.release.body }}"
+        content: |
+          ### 📣 Zed ${{ github.event.release.name }} was just released!
+          
+          Restart your Zed or head to https://zed.dev/releases to grab it.
+        
+          ### Changelog
+          
+          ${{ github.event.release.body }}"

--- a/.github/workflows/discord_webhook.yml
+++ b/.github/workflows/discord_webhook.yml
@@ -11,12 +11,12 @@ jobs:
       with:
         webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
         content: |
-          ```md
-          ### 📣 Zed ${{ github.event.release.name }} was just released!
+          📣 Zed ${{ github.event.release.name }} was just released!
           
           Restart your Zed or head to https://zed.dev/releases to grab it.
         
+          ```md
           ### Changelog
           
-          ${{ github.event.release.body }}"
+          ${{ github.event.release.body }}
           ```

--- a/.github/workflows/discord_webhook.yml
+++ b/.github/workflows/discord_webhook.yml
@@ -11,6 +11,7 @@ jobs:
       with:
         webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
         content: |
+          ```md
           ### 📣 Zed ${{ github.event.release.name }} was just released!
           
           Restart your Zed or head to https://zed.dev/releases to grab it.
@@ -18,3 +19,4 @@ jobs:
           ### Changelog
           
           ${{ github.event.release.body }}"
+          ```


### PR DESCRIPTION
## Description of feature or change

Adds a workflow to send the release information to our announcements discord channel.  I went with a workflow-based webhook because the [built-in support for webhooks](https://github.com/zed-industries/zed/settings/hooks) doesn't give you fine control over the type of release events we want to trigger on:

![SCR-20221005-om7](https://user-images.githubusercontent.com/19867440/194169612-0c872d41-9533-4b77-a8bc-9f98bf3c03b9.png)

Where in the workflow, we can pick "publish" only.  I haven't been able to test this yet.

## Link to related issues from zed or insiders

- https://github.com/zed-industries/zed/issues/1594
