### PR TITLE
Add `get-task-allow` entitlement to macOS app plist to allow attaching a debugger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
 
       - name: Upload app bundle to workflow run if main branch
         uses: actions/upload-artifact@v2
-        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           name: Zed.dmg
           path: target/release/Zed.dmg

--- a/crates/zed/resources/entitlements.plist
+++ b/crates/zed/resources/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>com.apple.security.get-task-allow</key>
+<true/>
+</dict>
+</plist>

--- a/script/bundle
+++ b/script/bundle
@@ -21,17 +21,23 @@ cargo build --release --package cli --target x86_64-apple-darwin
 echo "Creating application bundle"
 (cd crates/zed && cargo bundle --release --target x86_64-apple-darwin)
 
+echo "Updating application plist"
+BUNDLE_DIR=target/x86_64-apple-darwin/release/bundle/osx
+PLIST_PATH=${BUNDLE_DIR}/Zed.app/Contents/Info.plist
+sed -i.bak 's_<dict>_<dict>\n  <key>com.apple.security.get-task-allow</key><true/>_' $PLIST_PATH
+rm ${PLIST_PATH}.bak
+
 echo "Creating fat binaries"
 lipo \
     -create \
     target/{x86_64-apple-darwin,aarch64-apple-darwin}/release/Zed \
     -output \
-    target/x86_64-apple-darwin/release/bundle/osx/Zed.app/Contents/MacOS/zed
+    ${BUNDLE_DIR}/Zed.app/Contents/MacOS/zed
 lipo \
     -create \
     target/{x86_64-apple-darwin,aarch64-apple-darwin}/release/cli \
     -output \
-    target/x86_64-apple-darwin/release/bundle/osx/Zed.app/Contents/MacOS/cli
+    ${BUNDLE_DIR}/Zed.app/Contents/MacOS/cli
 
 if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then
     echo "Signing bundle with Apple-issued certificate"
@@ -42,17 +48,17 @@ if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTAR
     security import /tmp/zed-certificate.p12 -k zed.keychain -P $MACOS_CERTIFICATE_PASSWORD -T /usr/bin/codesign
     rm /tmp/zed-certificate.p12
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
-    /usr/bin/codesign --force --deep --timestamp --options runtime --sign "Zed Industries, Inc." target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+    /usr/bin/codesign --force --deep --timestamp --options runtime --sign "Zed Industries, Inc." ${BUNDLE_DIR}/Zed.app -v
     security default-keychain -s login.keychain
 else
     echo "One or more of the following variables are missing: MACOS_CERTIFICATE, MACOS_CERTIFICATE_PASSWORD, APPLE_NOTARIZATION_USERNAME, APPLE_NOTARIZATION_PASSWORD"
     echo "Performing an ad-hoc signature, but this bundle should not be distributed"
-    codesign --force --deep --sign - target/x86_64-apple-darwin/release/bundle/osx/Zed.app -v
+    codesign --force --deep --sign - ${BUNDLE_DIR}/Zed.app -v
 fi
 
 echo "Creating DMG"
 mkdir -p target/release
-hdiutil create -volname Zed -srcfolder target/x86_64-apple-darwin/release/bundle/osx -ov -format UDZO target/release/Zed.dmg
+hdiutil create -volname Zed -srcfolder ${BUNDLE_DIR} -ov -format UDZO target/release/Zed.dmg
 
 if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then
     echo "Notarizing DMG with Apple"

--- a/script/bundle
+++ b/script/bundle
@@ -17,15 +17,10 @@ cargo build --release --package zed --target aarch64-apple-darwin
 cargo build --release --package zed --target x86_64-apple-darwin
 cargo build --release --package cli --target aarch64-apple-darwin
 cargo build --release --package cli --target x86_64-apple-darwin
+BUNDLE_DIR=target/x86_64-apple-darwin/release/bundle/osx
 
 echo "Creating application bundle"
 (cd crates/zed && cargo bundle --release --target x86_64-apple-darwin)
-
-echo "Updating application plist"
-BUNDLE_DIR=target/x86_64-apple-darwin/release/bundle/osx
-PLIST_PATH=${BUNDLE_DIR}/Zed.app/Contents/Info.plist
-sed -i.bak 's_<dict>_<dict>\n  <key>com.apple.security.get-task-allow</key><true/>_' $PLIST_PATH
-rm ${PLIST_PATH}.bak
 
 echo "Creating fat binaries"
 lipo \
@@ -48,7 +43,14 @@ if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTAR
     security import /tmp/zed-certificate.p12 -k zed.keychain -P $MACOS_CERTIFICATE_PASSWORD -T /usr/bin/codesign
     rm /tmp/zed-certificate.p12
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CERTIFICATE_PASSWORD zed.keychain
-    /usr/bin/codesign --force --deep --timestamp --options runtime --sign "Zed Industries, Inc." ${BUNDLE_DIR}/Zed.app -v
+    /usr/bin/codesign \
+        --force \
+        --deep \
+        --timestamp \
+        --options runtime \
+        --entitlements crates/zed/resources/entitlements.plist \
+        --sign "Zed Industries, Inc." \
+        ${BUNDLE_DIR}/Zed.app -v
     security default-keychain -s login.keychain
 else
     echo "One or more of the following variables are missing: MACOS_CERTIFICATE, MACOS_CERTIFICATE_PASSWORD, APPLE_NOTARIZATION_USERNAME, APPLE_NOTARIZATION_PASSWORD"


### PR DESCRIPTION
### Description of feature or change

https://stackoverflow.com/questions/66575538/xcode-lldb-cant-attach-to-macos-system-program-bin-cp-not-allowed-to-attach

### Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
