### PR TITLE
Reset buffer git diff when setting diff base to None

### DIFF
--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -104,6 +104,11 @@ impl BufferDiff {
         })
     }
 
+    pub fn clear(&mut self, buffer: &text::BufferSnapshot) {
+        self.last_buffer_version = Some(buffer.version().clone());
+        self.tree = SumTree::new();
+    }
+
     pub fn needs_update(&self, buffer: &text::BufferSnapshot) -> bool {
         match &self.last_buffer_version {
             Some(last) => buffer.version().changed_since(last),
@@ -296,6 +301,9 @@ mod tests {
             &diff_base,
             &[(0..1, "", "point five\n"), (2..3, "two\n", "HELLO\n")],
         );
+
+        diff.clear(&buffer);
+        assert_hunks(diff.hunks(&buffer), &buffer, &diff_base, &[]);
     }
 
     #[test]

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -707,6 +707,11 @@ impl Buffer {
                 }
             })
             .detach()
+        } else {
+            let snapshot = self.snapshot();
+            self.git_diff_status.diff.clear(&snapshot);
+            self.git_diff_update_count += 1;
+            cx.notify();
         }
     }
 


### PR DESCRIPTION
## Description of feature or change

See title, fixes situations where a file becomes untracked but we didn't otherwise clear the diff

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A