### PR TITLE
Highlighting fixes

### DIFF
--- a/crates/zed/src/languages/c/highlights.scm
+++ b/crates/zed/src/languages/c/highlights.scm
@@ -86,7 +86,7 @@
 (identifier) @variable
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 (call_expression
   function: (identifier) @function)

--- a/crates/zed/src/languages/cpp/highlights.scm
+++ b/crates/zed/src/languages/cpp/highlights.scm
@@ -41,7 +41,7 @@
 
 (field_identifier) @property
 (statement_identifier) @label
-(this) @variable.builtin
+(this) @variable.special
 
 [
   "break"

--- a/crates/zed/src/languages/cpp/highlights.scm
+++ b/crates/zed/src/languages/cpp/highlights.scm
@@ -37,7 +37,7 @@
 (type_identifier) @type
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 (field_identifier) @property
 (statement_identifier) @label

--- a/crates/zed/src/languages/css/highlights.scm
+++ b/crates/zed/src/languages/css/highlights.scm
@@ -41,10 +41,13 @@
 
 (function_name) @function
 
-((property_name) @variable
- (#match? @variable "^--"))
-((plain_value) @variable
- (#match? @variable "^--"))
+(
+  [
+    (property_name)
+    (plain_value)
+  ] @variable.special
+  (#match? @variable.special "^--")
+)
 
 [
   "@media"

--- a/crates/zed/src/languages/css/highlights.scm
+++ b/crates/zed/src/languages/css/highlights.scm
@@ -73,7 +73,6 @@
 (unit) @type
 
 [
-  "#"
   ","
   ":"
 ] @punctuation.delimiter

--- a/crates/zed/src/languages/javascript/highlights.scm
+++ b/crates/zed/src/languages/javascript/highlights.scm
@@ -51,7 +51,7 @@
   (shorthand_property_identifier)
   (shorthand_property_identifier_pattern)
  ] @constant
- (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+ (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
 
 ; Literals
 

--- a/crates/zed/src/languages/javascript/highlights.scm
+++ b/crates/zed/src/languages/javascript/highlights.scm
@@ -55,8 +55,8 @@
 
 ; Literals
 
-(this) @variable.builtin
-(super) @variable.builtin
+(this) @variable.special
+(super) @variable.special
 
 [
   (true)

--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -21,7 +21,7 @@
  (#match? @type "^[A-Z]"))
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_]*$"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 ; Builtin functions
 

--- a/crates/zed/src/languages/rust/highlights.scm
+++ b/crates/zed/src/languages/rust/highlights.scm
@@ -1,6 +1,6 @@
 (type_identifier) @type
 (primitive_type) @type.builtin
-(self) @variable.builtin
+(self) @variable.special
 (field_identifier) @property
 
 (call_expression

--- a/crates/zed/src/languages/rust/highlights.scm
+++ b/crates/zed/src/languages/rust/highlights.scm
@@ -27,17 +27,8 @@
 
 ; Identifier conventions
 
-; Assume uppercase names are enum constructors
-((identifier) @variant
- (#match? @variant "^[A-Z]"))
-
-; Assume that uppercase names in paths are types
-((scoped_identifier
-  path: (identifier) @type)
- (#match? @type "^[A-Z]"))
-((scoped_identifier
-  path: (scoped_identifier
-    name: (identifier) @type))
+; Assume uppercase names are types/enum-constructors
+((identifier) @type
  (#match? @type "^[A-Z]"))
 
 ; Assume all-caps names are constants

--- a/crates/zed/src/languages/rust/highlights.scm
+++ b/crates/zed/src/languages/rust/highlights.scm
@@ -33,7 +33,7 @@
 
 ; Assume all-caps names are constants
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]+$"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 [
   "("

--- a/crates/zed/src/languages/typescript/highlights.scm
+++ b/crates/zed/src/languages/typescript/highlights.scm
@@ -51,7 +51,7 @@
   (shorthand_property_identifier)
   (shorthand_property_identifier_pattern)
  ] @constant
- (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+ (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
 
 ; Literals
 

--- a/crates/zed/src/languages/typescript/highlights.scm
+++ b/crates/zed/src/languages/typescript/highlights.scm
@@ -55,8 +55,8 @@
 
 ; Literals
 
-(this) @variable.builtin
-(super) @variable.builtin
+(this) @variable.special
+(super) @variable.special
 
 [
   (true)

--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -214,15 +214,11 @@ export function createTheme(
       weight: fontWeights.normal,
     },
     constructor: {
-      color: sample(ramps.blue, 0.5),
-      weight: fontWeights.normal,
-    },
-    variant: {
-      color: sample(ramps.blue, 0.5),
+      color: sample(ramps.cyan, 0.5),
       weight: fontWeights.normal,
     },
     property: {
-      color: sample(ramps.blue, 0.5),
+      color: sample(ramps.blue, 0.6),
       weight: fontWeights.normal,
     },
     enum: {

--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -185,6 +185,10 @@ export function createTheme(
       color: sample(ramps.neutral, 7),
       weight: fontWeights.normal,
     },
+    "variable.special": {
+      color: sample(ramps.blue, 0.80),
+      weight: fontWeights.normal,
+    },
     comment: {
       color: sample(ramps.neutral, 5),
       weight: fontWeights.normal,

--- a/styles/src/themes/common/theme.ts
+++ b/styles/src/themes/common/theme.ts
@@ -43,7 +43,7 @@ export interface Syntax {
   keyword: SyntaxHighlightStyle;
   function: SyntaxHighlightStyle;
   type: SyntaxHighlightStyle;
-  variant: SyntaxHighlightStyle;
+  constructor: SyntaxHighlightStyle;
   property: SyntaxHighlightStyle;
   enum: SyntaxHighlightStyle;
   operator: SyntaxHighlightStyle;


### PR DESCRIPTION
### Description of feature or change

This makes a few tweaks to some highlight queries and the syntax theme.

1. Add "special variable" highlight color. This is used for `self` in Rust, `this` in JavaScript and C++, and CSS variable (as in `var(--my-color)`)

For now, I've introduced a new color that is somewhere between the neutral color used for normal identifiers and the blue color used for keywords/properties. I didn't want to make too big a change  here, because I know that theme changes are in progress in zed-industries/zed#4674 .

2. Remove the distinction between `variant` and `type` in Rust, since it's not always possible to distinguish the two based on the syntax tree alone.3. 

3. Fix our regex for identifying a `SCREAMING_SNAKE_CASE` identifiers (which we highlight with the `constant` style).

### Link to related issues from zed or insiders

Fixes zed-industries/feedback#46
Fixes zed-industries/feedback#137

### Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
