### PR TITLE
Implemented page up and page down for the editor

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -451,7 +451,7 @@ pub struct Editor {
     leader_replica_id: Option<u16>,
     hover_state: HoverState,
     link_go_to_definition_state: LinkGoToDefinitionState,
-    lines: Option<f32>,
+    visible_line_count: Option<f32>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -1053,7 +1053,7 @@ impl Editor {
             leader_replica_id: None,
             hover_state: Default::default(),
             link_go_to_definition_state: Default::default(),
-            lines: None,
+            visible_line_count: None,
             _subscriptions: vec![
                 cx.observe(&buffer, Self::on_buffer_changed),
                 cx.subscribe(&buffer, Self::on_buffer_event),
@@ -1188,8 +1188,8 @@ impl Editor {
         cx.notify();
     }
 
-    fn set_lines(&mut self, lines: f32) {
-        self.lines = Some(lines)
+    fn set_visible_line_count(&mut self, lines: f32) {
+        self.visible_line_count = Some(lines)
     }
 
     fn set_scroll_top_anchor(
@@ -5521,8 +5521,7 @@ impl Editor {
     }
 
     pub fn page_up(&mut self, _: &PageUp, cx: &mut ViewContext<Self>) {
-        log::info!("Editor::page_up");
-        let lines = match self.lines {
+        let lines = match self.visible_line_count {
             Some(lines) => lines,
             None => return,
         };
@@ -5533,8 +5532,7 @@ impl Editor {
     }
 
     pub fn page_down(&mut self, _: &PageDown, cx: &mut ViewContext<Self>) {
-        log::info!("Editor::page_up");
-        let lines = match self.lines {
+        let lines = match self.visible_line_count {
             Some(lines) => lines,
             None => return,
         };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1422,6 +1422,8 @@ impl Element for EditorElement {
         let em_advance = style.text.em_advance(cx.font_cache);
         let overscroll = vec2f(em_width, 0.);
         let snapshot = self.update_view(cx.app, |view, cx| {
+            view.set_visible_line_count(size.y() / line_height);
+
             let wrap_width = match view.soft_wrap_mode(cx) {
                 SoftWrap::None => Some((MAX_LINE_LEN / 2) as f32 * em_advance),
                 SoftWrap::EditorWidth => {
@@ -1495,8 +1497,6 @@ impl Element for EditorElement {
         let mut highlighted_rows = None;
         let mut highlighted_ranges = Vec::new();
         self.update_view(cx.app, |view, cx| {
-            view.set_lines(size.y() / line_height);
-
             let display_map = view.display_map.update(cx, |map, cx| map.snapshot(cx));
 
             highlighted_rows = view.highlighted_rows();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1495,6 +1495,8 @@ impl Element for EditorElement {
         let mut highlighted_rows = None;
         let mut highlighted_ranges = Vec::new();
         self.update_view(cx.app, |view, cx| {
+            view.set_lines(size.y() / line_height);
+
             let display_map = view.display_map.update(cx, |map, cx| map.snapshot(cx));
 
             highlighted_rows = view.highlighted_rows();


### PR DESCRIPTION
## Description of feature or change

This fills out the stubs for the 'page up' and 'page down' that where in the editor. 

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/191

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
