### PR TITLE
Don't select on copy by default in the terminal

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -148,6 +148,9 @@
         //  2. Make the option keys behave as a 'meta' key, e.g. for emacs
         //         "option_to_meta": true,
         "option_as_meta": false,
+        // Whether or not selecting text in the terminal will automatically
+        // copy to the system clipboard.
+        "copy_on_select": false,
         // Any key-value pairs added to this list will be added to the terminal's
         // enviroment. Use `:` to seperate multiple values.
         "env": {

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -129,6 +129,7 @@ pub struct TerminalSettings {
     pub blinking: Option<TerminalBlink>,
     pub alternate_scroll: Option<AlternateScroll>,
     pub option_as_meta: Option<bool>,
+    pub copy_on_select: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -274,7 +275,7 @@ impl Settings {
             editor_overrides: Default::default(),
             git: defaults.git.unwrap(),
             git_overrides: Default::default(),
-            terminal_defaults: Default::default(),
+            terminal_defaults: defaults.terminal,
             terminal_overrides: Default::default(),
             language_defaults: defaults.languages,
             language_overrides: Default::default(),
@@ -327,6 +328,7 @@ impl Settings {
         self.editor_overrides = data.editor;
         self.git_overrides = data.git.unwrap_or_default();
         self.terminal_defaults.font_size = data.terminal.font_size;
+        self.terminal_overrides.copy_on_select = data.terminal.copy_on_select;
         self.terminal_overrides = data.terminal;
         self.language_overrides = data.languages;
         self.lsp = data.lsp;

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1045,7 +1045,18 @@ impl Terminal {
         }
     }
 
-    pub fn mouse_up(&mut self, e: &UpRegionEvent, origin: Vector2F) {
+    pub fn mouse_up(&mut self, e: &UpRegionEvent, origin: Vector2F, cx: &mut ModelContext<Self>) {
+        let settings = cx.global::<Settings>();
+        let copy_on_select = settings
+            .terminal_overrides
+            .copy_on_select
+            .unwrap_or_else(|| {
+                settings
+                    .terminal_defaults
+                    .copy_on_select
+                    .expect("Should be set in defaults")
+            });
+
         let position = e.position.sub(origin);
         if self.mouse_mode(e.shift) {
             let point = grid_point(
@@ -1057,11 +1068,10 @@ impl Terminal {
             if let Some(bytes) = mouse_button_report(point, e, false, self.last_content.mode) {
                 self.pty_tx.notify(bytes);
             }
-        } else if e.button == MouseButton::Left {
-            // Seems pretty standard to automatically copy on mouse_up for terminals,
-            // so let's do that here
+        } else if e.button == MouseButton::Left && copy_on_select {
             self.copy();
         }
+
         self.selection_phase = SelectionPhase::Ended;
         self.last_mouse = None;
     }

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -424,8 +424,8 @@ impl TerminalElement {
                 TerminalElement::generic_button_handler(
                     connection,
                     origin,
-                    move |terminal, origin, e, _cx| {
-                        terminal.mouse_up(&e, origin);
+                    move |terminal, origin, e, cx| {
+                        terminal.mouse_up(&e, origin, cx);
                     },
                 ),
             )
@@ -492,8 +492,8 @@ impl TerminalElement {
                     TerminalElement::generic_button_handler(
                         connection,
                         origin,
-                        move |terminal, origin, e, _cx| {
-                            terminal.mouse_up(&e, origin);
+                        move |terminal, origin, e, cx| {
+                            terminal.mouse_up(&e, origin, cx);
                         },
                     ),
                 )
@@ -502,8 +502,8 @@ impl TerminalElement {
                     TerminalElement::generic_button_handler(
                         connection,
                         origin,
-                        move |terminal, origin, e, _cx| {
-                            terminal.mouse_up(&e, origin);
+                        move |terminal, origin, e, cx| {
+                            terminal.mouse_up(&e, origin, cx);
                         },
                     ),
                 )


### PR DESCRIPTION
## Description of feature or change

Adds setting to enable/disable copy on select in the terminal, disabled by default.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
 - https://github.com/zed-industries/zed.dev/pull/157
