### PR TITLE
Don't autoclose brackets when `close` is false

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1874,7 +1874,7 @@ impl Editor {
                 let mut bracket_pair = None;
                 let mut is_bracket_pair_start = false;
                 for pair in language.brackets() {
-                    if pair.start.ends_with(text.as_ref()) {
+                    if pair.close && pair.start.ends_with(text.as_ref()) {
                         bracket_pair = Some(pair.clone());
                         is_bracket_pair_start = true;
                         break;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3016,6 +3016,11 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
     cx.update_editor(|view, cx| view.handle_input("{", cx));
     cx.assert_editor_state("{ˇa b");
 
+    // Don't autoclose if `close` is false for the bracket pair
+    cx.set_state("ˇ");
+    cx.update_editor(|view, cx| view.handle_input("[", cx));
+    cx.assert_editor_state("[ˇ");
+
     // Surround with brackets if text is selected
     cx.set_state("«aˇ» b");
     cx.update_editor(|view, cx| view.handle_input("{", cx));

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3039,16 +3039,19 @@ async fn test_autoclose_with_embedded_language(cx: &mut gpui::TestAppContext) {
                     BracketPair {
                         start: "<".into(),
                         end: ">".into(),
+                        close: true,
                         ..Default::default()
                     },
                     BracketPair {
                         start: "{".into(),
                         end: "}".into(),
+                        close: true,
                         ..Default::default()
                     },
                     BracketPair {
                         start: "(".into(),
                         end: ")".into(),
+                        close: true,
                         ..Default::default()
                     },
                 ],
@@ -3074,16 +3077,19 @@ async fn test_autoclose_with_embedded_language(cx: &mut gpui::TestAppContext) {
                 BracketPair {
                     start: "/*".into(),
                     end: " */".into(),
+                    close: true,
                     ..Default::default()
                 },
                 BracketPair {
                     start: "{".into(),
                     end: "}".into(),
+                    close: true,
                     ..Default::default()
                 },
                 BracketPair {
                     start: "(".into(),
                     end: ")".into(),
+                    close: true,
                     ..Default::default()
                 },
             ],


### PR DESCRIPTION
It looks like we accidentally stopped checking the `close` property on bracket pairs when updating auto-close logic to be multi-language aware. This restores that check.