### PR TITLE
Add scrollbars

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -330,10 +330,6 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_async_action(Editor::confirm_rename);
     cx.add_async_action(Editor::find_all_references);
 
-    cx.set_global(ScrollbarAutoHide(
-        cx.platform().should_auto_hide_scrollbars(),
-    ));
-
     hover_popover::init(cx);
     link_go_to_definition::init(cx);
     mouse_context_menu::init(cx);
@@ -1075,6 +1071,11 @@ impl Editor {
 
         let editor_created_event = EditorCreated(cx.handle());
         cx.emit_global(editor_created_event);
+
+        if mode == EditorMode::Full {
+            let should_auto_hide_scrollbars = cx.platform().should_auto_hide_scrollbars();
+            cx.set_global(ScrollbarAutoHide(should_auto_hide_scrollbars));
+        }
 
         this.report_event("open editor", cx);
         this

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -931,13 +931,13 @@ impl EditorElement {
         let track_bounds = RectF::from_points(vec2f(left, top), vec2f(right, bottom));
         let thumb_bounds = RectF::from_points(vec2f(left, thumb_top), vec2f(right, thumb_bottom));
 
-        cx.scene.push_quad(Quad {
-            bounds: track_bounds,
-            border: style.track.border,
-            background: style.track.background_color,
-            ..Default::default()
-        });
         if layout.show_scrollbars {
+            cx.scene.push_quad(Quad {
+                bounds: track_bounds,
+                border: style.track.border,
+                background: style.track.background_color,
+                ..Default::default()
+            });
             cx.scene.push_quad(Quad {
                 bounds: thumb_bounds,
                 border: style.thumb.border,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -916,6 +916,9 @@ impl EditorElement {
 
         let view = self.view.clone();
         let style = &self.style.theme.scrollbar;
+        let min_thumb_height =
+            style.min_height_factor * cx.font_cache.line_height(self.style.text.font_size);
+
         let top = bounds.min_y();
         let bottom = bounds.max_y();
         let right = bounds.max_x();
@@ -925,8 +928,23 @@ impl EditorElement {
         let max_row = layout.max_row + ((row_range.end - row_range.start) as u32);
         let scrollbar_start = row_range.start as f32 / max_row as f32;
         let scrollbar_end = row_range.end as f32 / max_row as f32;
-        let thumb_top = top + scrollbar_start * height;
-        let thumb_bottom = top + scrollbar_end * height;
+
+        let mut thumb_top = top + scrollbar_start * height;
+        let mut thumb_bottom = top + scrollbar_end * height;
+        let thumb_center = (thumb_top + thumb_bottom) / 2.0;
+
+        if thumb_bottom - thumb_top < min_thumb_height {
+            thumb_top = thumb_center - min_thumb_height / 2.0;
+            thumb_bottom = thumb_center + min_thumb_height / 2.0;
+            if thumb_top < top {
+                thumb_top = top;
+                thumb_bottom = top + min_thumb_height;
+            }
+            if thumb_bottom > bottom {
+                thumb_bottom = bottom;
+                thumb_top = bottom - min_thumb_height;
+            }
+        }
 
         let track_bounds = RectF::from_points(vec2f(left, top), vec2f(right, bottom));
         let thumb_bounds = RectF::from_points(vec2f(left, thumb_top), vec2f(right, thumb_bottom));

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -922,7 +922,7 @@ impl EditorElement {
         let bottom = bounds.max_y();
         let height = bounds.height();
 
-        let max_row = layout.max_row + row_range.len() as u32;
+        let max_row = layout.max_row + ((row_range.end - row_range.start) as u32);
         let scrollbar_start = row_range.start as f32 / max_row as f32;
         let scrollbar_end = row_range.end as f32 / max_row as f32;
 
@@ -959,7 +959,7 @@ impl EditorElement {
             )
             .on_down(MouseButton::Left, {
                 let view = view.clone();
-                let row_range_len = row_range.len();
+                let row_range_len = row_range.end - row_range.start;
                 move |e, cx| {
                     let y = e.position.y();
                     if y < thumb_top || thumb_bottom < y {
@@ -1653,7 +1653,7 @@ impl Element for EditorElement {
             .collect();
 
         let scrollbar_row_range = if snapshot.mode == EditorMode::Full {
-            Some(start_row..(start_row + visible_row_count))
+            Some(scroll_position.y()..(scroll_position.y() + visible_row_count as f32))
         } else {
             None
         };
@@ -1945,7 +1945,7 @@ pub struct LayoutState {
     blocks: Vec<BlockLayout>,
     highlighted_ranges: Vec<(Range<DisplayPoint>, Color)>,
     selections: Vec<(ReplicaId, Vec<SelectionLayout>)>,
-    scrollbar_row_range: Option<Range<u32>>,
+    scrollbar_row_range: Option<Range<f32>>,
     max_row: u32,
     context_menu: Option<(DisplayPoint, ElementBox)>,
     diff_hunks: Vec<DiffHunk<u32>>,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -63,6 +63,7 @@ pub trait Platform: Send + Sync {
     fn delete_credentials(&self, url: &str) -> Result<()>;
 
     fn set_cursor_style(&self, style: CursorStyle);
+    fn should_auto_hide_scrollbars(&self) -> bool;
 
     fn local_timezone(&self) -> UtcOffset;
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -699,6 +699,16 @@ impl platform::Platform for MacPlatform {
         }
     }
 
+    fn should_auto_hide_scrollbars(&self) -> bool {
+        #[allow(non_upper_case_globals)]
+        const NSScrollerStyleOverlay: NSInteger = 1;
+
+        unsafe {
+            let style: NSInteger = msg_send![class!(NSScroller), preferredScrollerStyle];
+            style == NSScrollerStyleOverlay
+        }
+    }
+
     fn local_timezone(&self) -> UtcOffset {
         unsafe {
             let local_timezone: id = msg_send![class!(NSTimeZone), localTimeZone];

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -177,6 +177,10 @@ impl super::Platform for Platform {
         *self.cursor.lock() = style;
     }
 
+    fn should_auto_hide_scrollbars(&self) -> bool {
+        false
+    }
+
     fn local_timezone(&self) -> UtcOffset {
         UtcOffset::UTC
     }

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -510,6 +510,14 @@ pub struct Editor {
     pub link_definition: HighlightStyle,
     pub composition_mark: HighlightStyle,
     pub jump_icon: Interactive<IconButton>,
+    pub scrollbar: Scrollbar,
+}
+
+#[derive(Clone, Deserialize, Default)]
+pub struct Scrollbar {
+    pub track: ContainerStyle,
+    pub thumb: ContainerStyle,
+    pub width: f32,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -518,6 +518,7 @@ pub struct Scrollbar {
     pub track: ContainerStyle,
     pub thumb: ContainerStyle,
     pub width: f32,
+    pub min_height_factor: f32,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -1,4 +1,5 @@
 import Theme from "../themes/common/theme";
+import { withOpacity } from "../utils/color";
 import {
   backgroundColor,
   border,
@@ -169,6 +170,19 @@ export default function editor(theme: Theme) {
         color: iconColor(theme, "active"),
         background: backgroundColor(theme, "on500"),
       },
+    },
+    scrollbar: {
+      width: 12,
+      track: {
+        border: {
+          left: true,
+          width: 1,
+          color: borderColor(theme, "secondary"),
+        },
+      },
+      thumb: {
+        background: borderColor(theme, "secondary"),
+      }
     },
     compositionMark: {
       underline: {

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -173,6 +173,7 @@ export default function editor(theme: Theme) {
     },
     scrollbar: {
       width: 12,
+      minHeightFactor: 1.0,
       track: {
         border: {
           left: true,

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -172,7 +172,7 @@ export default function editor(theme: Theme) {
       },
     },
     scrollbar: {
-      width: 12,
+      width: 14,
       track: {
         border: {
           left: true,
@@ -181,7 +181,11 @@ export default function editor(theme: Theme) {
         },
       },
       thumb: {
-        background: borderColor(theme, "secondary"),
+        background: withOpacity(borderColor(theme, "secondary"), 0.5),
+        border: {
+          width: 1,
+          color: withOpacity(borderColor(theme, 'muted'), 0.5),
+        }
       }
     },
     compositionMark: {

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -172,7 +172,7 @@ export default function editor(theme: Theme) {
       },
     },
     scrollbar: {
-      width: 14,
+      width: 12,
       track: {
         border: {
           left: true,

--- a/styles/src/themes/common/base16.ts
+++ b/styles/src/themes/common/base16.ts
@@ -123,7 +123,7 @@ export function createTheme(
   const borderColor = {
     primary: sample(ramps.neutral, isLight ? 1.5 : 0),
     secondary: sample(ramps.neutral, isLight ? 1.25 : 1),
-    muted: sample(ramps.neutral, isLight ? 1 : 3),
+    muted: sample(ramps.neutral, isLight ? 1.25 : 3),
     active: sample(ramps.neutral, isLight ? 4 : 3),
     onMedia: withOpacity(darkest, 0.1),
     ok: sample(ramps.green, 0.3),


### PR DESCRIPTION
### Description of feature or change

This PR adds scrollbars to all full-sized editors.

![scrollbars-3](https://user-images.githubusercontent.com/326587/194968706-6cf184bc-1489-40f0-93e3-f3c8d21279d4.gif)

In a light theme, with a multi-buffer:
<img width="972" alt="Screen Shot 2022-10-10 at 4 49 17 PM" src="https://user-images.githubusercontent.com/326587/194968848-7f2f6fa1-7774-4e71-86f0-c6128d4e6dfe.png">

* [x] Auto-hide scrollbars when scrolling has stopped for a certain amount of time

## Link to related issues from zed or insiders

Closes zed-industries/feedback#165

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
