### PR TITLE
Fix opening a buffer after leaving and joining the same project

### DIFF
--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -1205,7 +1205,7 @@ impl Store {
                 let guest_connection = self.connections.get(guest_connection_id).unwrap();
                 assert!(guest_connection.projects.contains(project_id));
             }
-            assert_eq!(project.active_replica_ids.len(), project.guests.len(),);
+            assert_eq!(project.active_replica_ids.len(), project.guests.len());
             assert_eq!(
                 project.active_replica_ids,
                 project

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4561,6 +4561,7 @@ impl Project {
                     buffer.update(cx, |buffer, cx| buffer.remove_peer(replica_id, cx));
                 }
             }
+            this.shared_buffers.remove(&peer_id);
 
             cx.emit(Event::CollaboratorLeft(peer_id));
             cx.notify();


### PR DESCRIPTION
Fixes #1725 

This bug existed prior to #1700 and was caused by not clearing the buffers that were already shared with a peer that left and opened a project using the same connection. When such peer would re-join the project and open a buffer that it had opened previously, the host assumed the peer had already seen that buffer and wouldn't bother sending it again.