### PR TITLE
Clear auto-indent requests if they couldn't be computed

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -866,6 +866,8 @@ impl Buffer {
                     }));
                 }
             }
+        } else {
+            self.autoindent_requests.clear();
         }
     }
 


### PR DESCRIPTION
Fixes #1727 
Closes #1669 