### PR TITLE
Added autocomplete to the file picker menu

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -11,6 +11,7 @@
             "enter": "menu::Confirm",
             "escape": "menu::Cancel",
             "ctrl-c": "menu::Cancel",
+            "tab": "menu::Autocomplete",
             "cmd-{": "pane::ActivatePrevItem",
             "cmd-}": "pane::ActivateNextItem",
             "alt-cmd-left": "pane::ActivatePrevItem",
@@ -446,6 +447,10 @@
             ],
             // There are conflicting bindings for these keys in the global context.
             // these bindings override them, remove at your own risk:
+            "tab": [
+                "terminal::SendKeystroke",
+                "tab"
+            ],
             "up": [
                 "terminal::SendKeystroke",
                 "up"

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3010,6 +3010,11 @@ impl Editor {
             return;
         }
 
+        if matches!(self.mode, EditorMode::SingleLine) {
+            cx.propagate_action();
+            return;
+        }
+
         let mut selections = self.selections.all_adjusted(cx);
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -276,6 +276,12 @@ impl PickerDelegate for FileFinder {
             .with_style(style.container)
             .named("match")
     }
+
+    fn get_selected_text(&self, _cx: &mut ViewContext<Self>) -> Option<String> {
+        self.matches
+            .get(self.selected_index())
+            .map(|path_match| path_match.path.to_string_lossy().to_string())
+    }
 }
 
 #[cfg(test)]

--- a/crates/menu/src/menu.rs
+++ b/crates/menu/src/menu.rs
@@ -9,7 +9,8 @@ gpui::actions!(
         SelectPrev,
         SelectNext,
         SelectFirst,
-        SelectLast
+        SelectLast,
+        Autocomplete
     ]
 );
 


### PR DESCRIPTION
## Description of feature or change

This PR adds tab completion to the Picker view, as preparation for handling https://github.com/zed-industries/feedback/issues/557

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/557

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
