### PR TITLE
Allow toggling collaboration menu from the keyboard

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -376,6 +376,7 @@
     {
         "bindings": {
             "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
+            "cmd-shift-c": "collab::ToggleCollaborationMenu",
             "cmd-alt-i": "zed::DebugElements"
         }
     },

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -17,10 +17,7 @@ use std::ops::Range;
 use theme::Theme;
 use workspace::{FollowNextCollaborator, JoinProject, ToggleFollow, Workspace};
 
-actions!(
-    contacts_titlebar_item,
-    [ToggleContactsPopover, ShareProject]
-);
+actions!(collab, [ToggleCollaborationMenu, ShareProject]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(CollabTitlebarItem::toggle_contacts_popover);
@@ -143,7 +140,11 @@ impl CollabTitlebarItem {
         }
     }
 
-    fn toggle_contacts_popover(&mut self, _: &ToggleContactsPopover, cx: &mut ViewContext<Self>) {
+    pub fn toggle_contacts_popover(
+        &mut self,
+        _: &ToggleCollaborationMenu,
+        cx: &mut ViewContext<Self>,
+    ) {
         match self.contacts_popover.take() {
             Some(_) => {}
             None => {
@@ -197,7 +198,7 @@ impl CollabTitlebarItem {
         };
         Stack::new()
             .with_child(
-                MouseEventHandler::<ToggleContactsPopover>::new(0, cx, |state, _| {
+                MouseEventHandler::<ToggleCollaborationMenu>::new(0, cx, |state, _| {
                     let style = titlebar
                         .toggle_contacts_button
                         .style_for(state, self.contacts_popover.is_some());
@@ -214,8 +215,8 @@ impl CollabTitlebarItem {
                         .boxed()
                 })
                 .with_cursor_style(CursorStyle::PointingHand)
-                .on_click(MouseButton::Left, |_, cx| {
-                    cx.dispatch_action(ToggleContactsPopover);
+                .on_click(MouseButton::Left, move |_, cx| {
+                    cx.dispatch_action(ToggleCollaborationMenu);
                 })
                 .aligned()
                 .boxed(),

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -8,7 +8,7 @@ mod notifications;
 mod project_shared_notification;
 
 use call::ActiveCall;
-pub use collab_titlebar_item::CollabTitlebarItem;
+pub use collab_titlebar_item::{CollabTitlebarItem, ToggleCollaborationMenu};
 use gpui::MutableAppContext;
 use project::Project;
 use std::sync::Arc;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1173,6 +1173,10 @@ impl Workspace {
         cx.notify();
     }
 
+    pub fn titlebar_item(&self) -> Option<AnyViewHandle> {
+        self.titlebar_item.clone()
+    }
+
     /// Call the given callback with a workspace whose project is local.
     ///
     /// If the given workspace has a local project, then it will be passed

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use assets::Assets;
 use breadcrumbs::Breadcrumbs;
 pub use client;
-use collab_ui::CollabTitlebarItem;
+use collab_ui::{CollabTitlebarItem, ToggleCollaborationMenu};
 use collections::VecDeque;
 pub use editor;
 use editor::{Editor, MultiBuffer};
@@ -92,6 +92,22 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     cx.add_action(
         |_: &mut Workspace, _: &ToggleFullScreen, cx: &mut ViewContext<Workspace>| {
             cx.toggle_full_screen();
+        },
+    );
+    cx.add_action(
+        |workspace: &mut Workspace,
+         _: &ToggleCollaborationMenu,
+         cx: &mut ViewContext<Workspace>| {
+            if let Some(item) = workspace
+                .titlebar_item()
+                .and_then(|item| item.downcast::<CollabTitlebarItem>())
+            {
+                cx.as_mut().defer(move |cx| {
+                    item.update(cx, |item, cx| {
+                        item.toggle_contacts_popover(&Default::default(), cx);
+                    });
+                });
+            }
         },
     );
     cx.add_global_action(quit);


### PR DESCRIPTION
This adds back the `cmd-shift-c` key binding that used to toggle the contacts panel. The action it is bound to is now called `collab: Toggle Collaboration Menu`.