### PR TITLE
Preserve buffer identity when underlying entry temporarily disappears

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4298,34 +4298,35 @@ impl Project {
                             return;
                         }
 
-                        let new_file = if let Some(entry) = old_file
-                            .entry_id
-                            .and_then(|entry_id| snapshot.entry_for_id(entry_id))
+                        let new_file = if let Some(entry) = snapshot.entry_for_id(old_file.entry_id)
                         {
                             File {
                                 is_local: true,
-                                entry_id: Some(entry.id),
+                                entry_id: entry.id,
                                 mtime: entry.mtime,
                                 path: entry.path.clone(),
                                 worktree: worktree_handle.clone(),
+                                is_deleted: false,
                             }
                         } else if let Some(entry) =
                             snapshot.entry_for_path(old_file.path().as_ref())
                         {
                             File {
                                 is_local: true,
-                                entry_id: Some(entry.id),
+                                entry_id: entry.id,
                                 mtime: entry.mtime,
                                 path: entry.path.clone(),
                                 worktree: worktree_handle.clone(),
+                                is_deleted: false,
                             }
                         } else {
                             File {
                                 is_local: true,
-                                entry_id: None,
+                                entry_id: old_file.entry_id,
                                 path: old_file.path().clone(),
                                 mtime: old_file.mtime(),
                                 worktree: worktree_handle.clone(),
+                                is_deleted: true,
                             }
                         };
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2457,6 +2457,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
         .await
         .unwrap();
     cx.foreground().run_until_parked();
+    buffer2.read_with(cx, |buffer, _| assert!(buffer.is_dirty()));
     assert_eq!(
         *events.borrow(),
         &[

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -868,9 +868,10 @@ message User {
 
 message File {
     uint64 worktree_id = 1;
-    optional uint64 entry_id = 2;
+    uint64 entry_id = 2;
     string path = 3;
     Timestamp mtime = 4;
+    bool is_deleted = 5;
 }
 
 message Entry {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/543

This pull request addresses a problem that would cause buffers to appear as deleted after renaming an ancestor directory. Renaming a folder (either via Zed or the file-system) is a pretty coarse-grained action: we delete the directory at the old location and re-scan the directory at the new location. In practice, this means that for a brief moment in time, Zed thinks descendants of such folder are deleted.

Previously, when detecting a deletion, we would treat the buffer as deleted forever by forgetting its entry id. This meant that, if the buffer re-appeared as in the case of a rename, we would still treat it as deleted and fail to detect the rename.

With this pull request, buffers always retain their identity independently of whether they were deleted or not. This lets us detect the rename if we can find an entry in the snapshot with the same id as the temporarily-deleted buffer. We should probably be more fine-grained with respect to renames, but fundamentally I think there's always a possibility of buffers temporarily disappearing when processing file-system events and therefore this change seems good no matter what.