### PR TITLE
Fix error on clangd when `compile-commands.json` is present

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -56,7 +56,7 @@ pub struct Subscription {
 
 #[derive(Serialize, Deserialize)]
 struct Request<'a, T> {
-    jsonrpc: &'a str,
+    jsonrpc: &'static str,
     id: usize,
     method: &'a str,
     params: T,
@@ -73,6 +73,7 @@ struct AnyResponse<'a> {
 
 #[derive(Serialize)]
 struct Response<T> {
+    jsonrpc: &'static str,
     id: usize,
     result: Option<T>,
     error: Option<Error>,
@@ -80,8 +81,7 @@ struct Response<T> {
 
 #[derive(Serialize, Deserialize)]
 struct Notification<'a, T> {
-    #[serde(borrow)]
-    jsonrpc: &'a str,
+    jsonrpc: &'static str,
     #[serde(borrow)]
     method: &'a str,
     params: T,
@@ -453,11 +453,13 @@ impl LanguageServer {
                                 async move {
                                     let response = match response.await {
                                         Ok(result) => Response {
+                                            jsonrpc: JSON_RPC_VERSION,
                                             id,
                                             result: Some(result),
                                             error: None,
                                         },
                                         Err(error) => Response {
+                                            jsonrpc: JSON_RPC_VERSION,
                                             id,
                                             result: None,
                                             error: Some(Error {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/524

The language server was failing because we were forgetting to provide a `jsonrpc` field for responses to requests coming from the lsp.