### PR TITLE
Pass the current view id when painting List's mouse region instead of 10

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -264,8 +264,8 @@ impl Element for List {
         let visible_bounds = visible_bounds.intersection(bounds).unwrap_or_default();
         cx.scene.push_layer(Some(visible_bounds));
 
-        cx.scene
-            .push_mouse_region(MouseRegion::new::<Self>(10, 0, bounds).on_scroll({
+        cx.scene.push_mouse_region(
+            MouseRegion::new::<Self>(cx.current_view_id(), 0, bounds).on_scroll({
                 let state = self.state.clone();
                 let height = bounds.height();
                 let scroll_top = scroll_top.clone();
@@ -278,7 +278,8 @@ impl Element for List {
                         cx,
                     )
                 }
-            }));
+            }),
+        );
 
         let state = &mut *self.state.0.borrow_mut();
         for (mut element, origin) in state.visible_elements(bounds, scroll_top) {


### PR DESCRIPTION
Previously, a dummy value was being passed. I think this slipped in accidentally. This was causing us not to be able to scroll the contacts panel in some cases because the view wasn't being notified correctly on scroll events. Using a view_id of 10 happened to magically work for the first window we created, but not subsequent windows. We were only showing the scroll update when the cursor blinked.

/cc @mikayla-maki 