### PR TITLE
Avoid skipping over a different closing bracket in autoclose

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1938,9 +1938,10 @@ impl Editor {
                             }
                         } else if let Some(region) = autoclose_region {
                             // If the selection is followed by an auto-inserted closing bracket,
-                            // then don't insert anything else; just move the selection past the
-                            // closing bracket.
-                            let should_skip = selection.end == region.range.end.to_point(&snapshot);
+                            // then don't insert that closing bracket again; just move the selection
+                            // past the closing bracket.
+                            let should_skip = selection.end == region.range.end.to_point(&snapshot)
+                                && text.as_ref() == region.pair.end.as_str();
                             if should_skip {
                                 let anchor = snapshot.anchor_after(selection.end);
                                 new_selections.push((

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2908,6 +2908,12 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
                     newline: true,
                 },
                 BracketPair {
+                    start: "(".to_string(),
+                    end: ")".to_string(),
+                    close: true,
+                    newline: true,
+                },
+                BracketPair {
                     start: "/*".to_string(),
                     end: " */".to_string(),
                     close: true,
@@ -2957,6 +2963,19 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
         .unindent(),
     );
 
+    // insert a different closing bracket
+    cx.update_editor(|view, cx| {
+        view.handle_input(")", cx);
+    });
+    cx.assert_editor_state(
+        &"
+            🏀{{{)ˇ}}}
+            ε{{{)ˇ}}}
+            ❤️{{{)ˇ}}}
+        "
+        .unindent(),
+    );
+
     // skip over the auto-closed brackets when typing a closing bracket
     cx.update_editor(|view, cx| {
         view.move_right(&MoveRight, cx);
@@ -2966,9 +2985,9 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
     });
     cx.assert_editor_state(
         &"
-            🏀{{{}}}}ˇ
-            ε{{{}}}}ˇ
-            ❤️{{{}}}}ˇ
+            🏀{{{)}}}}ˇ
+            ε{{{)}}}}ˇ
+            ❤️{{{)}}}}ˇ
         "
         .unindent(),
     );


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/588