### PR TITLE
Move page up down

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -3,8 +3,12 @@
     {
         "bindings": {
             "up": "menu::SelectPrev",
+            "pageup": "menu::SelectFirst",
+            "shift-pageup": "menu::SelectFirst",
             "ctrl-p": "menu::SelectPrev",
             "down": "menu::SelectNext",
+            "pagedown": "menu::SelectLast",
+            "shift-pagedown": "menu::SelectFirst",
             "ctrl-n": "menu::SelectNext",
             "cmd-up": "menu::SelectFirst",
             "cmd-down": "menu::SelectLast",
@@ -60,13 +64,18 @@
             "cmd-z": "editor::Undo",
             "cmd-shift-z": "editor::Redo",
             "up": "editor::MoveUp",
+            "pageup": "editor::PageUp",
+            "shift-pageup": "editor::MovePageUp",
             "down": "editor::MoveDown",
+            "pagedown": "editor::PageDown",
+            "shift-pagedown": "editor::MovePageDown",
             "left": "editor::MoveLeft",
             "right": "editor::MoveRight",
             "ctrl-p": "editor::MoveUp",
             "ctrl-n": "editor::MoveDown",
             "ctrl-b": "editor::MoveLeft",
             "ctrl-f": "editor::MoveRight",
+            "ctrl-l": "editor::CenterScreen",
             "alt-left": "editor::MoveToPreviousWordStart",
             "alt-b": "editor::MoveToPreviousWordStart",
             "alt-right": "editor::MoveToNextWordEnd",
@@ -118,8 +127,18 @@
                     "stop_at_soft_wraps": true
                 }
             ],
-            "pageup": "editor::PageUp",
-            "pagedown": "editor::PageDown",
+            "ctrl-v": [
+                "editor::MovePageDown",
+                {
+                    "center_cursor": true
+                }
+            ],
+            "alt-v": [
+                "editor::MovePageUp",
+                {
+                    "center_cursor": true
+                }
+            ],
             "ctrl-cmd-space": "editor::ShowCharacterPalette"
         }
     },
@@ -451,9 +470,17 @@
                 "terminal::SendKeystroke",
                 "up"
             ],
+            "pageup": [
+                "terminal::SendKeystroke",
+                "pageup"
+            ],
             "down": [
                 "terminal::SendKeystroke",
                 "down"
+            ],
+            "pagedown": [
+                "terminal::SendKeystroke",
+                "pagedown"
             ],
             "escape": [
                 "terminal::SendKeystroke",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -173,8 +173,11 @@ actions!(
         Paste,
         Undo,
         Redo,
+        CenterScreen,
         MoveUp,
+        PageUp,
         MoveDown,
+        PageDown,
         MoveLeft,
         MoveRight,
         MoveToPreviousWordStart,
@@ -214,8 +217,6 @@ actions!(
         FindAllReferences,
         Rename,
         ConfirmRename,
-        PageUp,
-        PageDown,
         Fold,
         UnfoldLines,
         FoldSelectedRanges,
@@ -287,7 +288,12 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::undo);
     cx.add_action(Editor::redo);
     cx.add_action(Editor::move_up);
+    cx.add_action(Editor::move_page_up);
+    cx.add_action(Editor::page_up);
     cx.add_action(Editor::move_down);
+    cx.add_action(Editor::move_page_down);
+    cx.add_action(Editor::page_down);
+    cx.add_action(Editor::center_screen);
     cx.add_action(Editor::move_left);
     cx.add_action(Editor::move_right);
     cx.add_action(Editor::move_to_previous_word_start);
@@ -326,8 +332,6 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::go_to_prev_diagnostic);
     cx.add_action(Editor::go_to_definition);
     cx.add_action(Editor::go_to_type_definition);
-    cx.add_action(Editor::page_up);
-    cx.add_action(Editor::page_down);
     cx.add_action(Editor::fold);
     cx.add_action(Editor::unfold_lines);
     cx.add_action(Editor::fold_selected_ranges);
@@ -620,6 +624,18 @@ enum ContextMenu {
 }
 
 impl ContextMenu {
+    fn select_first(&mut self, cx: &mut ViewContext<Editor>) -> bool {
+        if self.visible() {
+            match self {
+                ContextMenu::Completions(menu) => menu.select_first(cx),
+                ContextMenu::CodeActions(menu) => menu.select_first(cx),
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     fn select_prev(&mut self, cx: &mut ViewContext<Editor>) -> bool {
         if self.visible() {
             match self {
@@ -637,6 +653,18 @@ impl ContextMenu {
             match self {
                 ContextMenu::Completions(menu) => menu.select_next(cx),
                 ContextMenu::CodeActions(menu) => menu.select_next(cx),
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn select_last(&mut self, cx: &mut ViewContext<Editor>) -> bool {
+        if self.visible() {
+            match self {
+                ContextMenu::Completions(menu) => menu.select_last(cx),
+                ContextMenu::CodeActions(menu) => menu.select_last(cx),
             }
             true
         } else {
@@ -676,6 +704,12 @@ struct CompletionsMenu {
 }
 
 impl CompletionsMenu {
+    fn select_first(&mut self, cx: &mut ViewContext<Editor>) {
+        self.selected_item = 0;
+        self.list.scroll_to(ScrollTarget::Show(self.selected_item));
+        cx.notify();
+    }
+
     fn select_prev(&mut self, cx: &mut ViewContext<Editor>) {
         if self.selected_item > 0 {
             self.selected_item -= 1;
@@ -689,6 +723,12 @@ impl CompletionsMenu {
             self.selected_item += 1;
             self.list.scroll_to(ScrollTarget::Show(self.selected_item));
         }
+        cx.notify();
+    }
+
+    fn select_last(&mut self, cx: &mut ViewContext<Editor>) {
+        self.selected_item = self.matches.len() - 1;
+        self.list.scroll_to(ScrollTarget::Show(self.selected_item));
         cx.notify();
     }
 
@@ -823,6 +863,11 @@ struct CodeActionsMenu {
 }
 
 impl CodeActionsMenu {
+    fn select_first(&mut self, cx: &mut ViewContext<Editor>) {
+        self.selected_item = 0;
+        cx.notify()
+    }
+
     fn select_prev(&mut self, cx: &mut ViewContext<Editor>) {
         if self.selected_item > 0 {
             self.selected_item -= 1;
@@ -835,6 +880,11 @@ impl CodeActionsMenu {
             self.selected_item += 1;
             cx.notify()
         }
+    }
+
+    fn select_last(&mut self, cx: &mut ViewContext<Editor>) {
+        self.selected_item = self.actions.len() - 1;
+        cx.notify()
     }
 
     fn visible(&self) -> bool {
@@ -3863,6 +3913,23 @@ impl Editor {
         })
     }
 
+    pub fn center_screen(&mut self, _: &CenterScreen, cx: &mut ViewContext<Self>) {
+        if self.take_rename(true, cx).is_some() {
+            return;
+        }
+
+        if let Some(_) = self.context_menu.as_mut() {
+            return;
+        }
+
+        if matches!(self.mode, EditorMode::SingleLine) {
+            cx.propagate_action();
+            return;
+        }
+
+        self.request_autoscroll(Autoscroll::Center, cx);
+    }
+
     pub fn move_up(&mut self, _: &MoveUp, cx: &mut ViewContext<Self>) {
         if self.take_rename(true, cx).is_some() {
             return;
@@ -3889,6 +3956,72 @@ impl Editor {
                 selection.collapse_to(cursor, goal);
             });
         })
+    }
+
+    pub fn move_page_up(&mut self, action: &MovePageUp, cx: &mut ViewContext<Self>) {
+        if self.take_rename(true, cx).is_some() {
+            return;
+        }
+
+        if let Some(context_menu) = self.context_menu.as_mut() {
+            if context_menu.select_first(cx) {
+                return;
+            }
+        }
+
+        if matches!(self.mode, EditorMode::SingleLine) {
+            cx.propagate_action();
+            return;
+        }
+
+        let row_count = match self.visible_line_count {
+            Some(row_count) => row_count as u32 - 1,
+            None => return,
+        };
+
+        let autoscroll = if action.center_cursor {
+            Autoscroll::Center
+        } else {
+            Autoscroll::Fit
+        };
+
+        self.change_selections(Some(autoscroll), cx, |s| {
+            let line_mode = s.line_mode;
+            s.move_with(|map, selection| {
+                if !selection.is_empty() && !line_mode {
+                    selection.goal = SelectionGoal::None;
+                }
+                let (cursor, goal) =
+                    movement::up_by_rows(map, selection.end, row_count, selection.goal, false);
+                selection.collapse_to(cursor, goal);
+            });
+        });
+    }
+
+    pub fn page_up(&mut self, _: &PageUp, cx: &mut ViewContext<Self>) {
+        if self.take_rename(true, cx).is_some() {
+            return;
+        }
+
+        if let Some(context_menu) = self.context_menu.as_mut() {
+            if context_menu.select_first(cx) {
+                return;
+            }
+        }
+
+        if matches!(self.mode, EditorMode::SingleLine) {
+            cx.propagate_action();
+            return;
+        }
+
+        let lines = match self.visible_line_count {
+            Some(lines) => lines,
+            None => return,
+        };
+
+        let cur_position = self.scroll_position(cx);
+        let new_pos = cur_position - vec2f(0., lines + 1.);
+        self.set_scroll_position(new_pos, cx);
     }
 
     pub fn select_up(&mut self, _: &SelectUp, cx: &mut ViewContext<Self>) {
@@ -3921,6 +4054,72 @@ impl Editor {
                 selection.collapse_to(cursor, goal);
             });
         });
+    }
+
+    pub fn move_page_down(&mut self, action: &MovePageDown, cx: &mut ViewContext<Self>) {
+        if self.take_rename(true, cx).is_some() {
+            return;
+        }
+
+        if let Some(context_menu) = self.context_menu.as_mut() {
+            if context_menu.select_last(cx) {
+                return;
+            }
+        }
+
+        if matches!(self.mode, EditorMode::SingleLine) {
+            cx.propagate_action();
+            return;
+        }
+
+        let row_count = match self.visible_line_count {
+            Some(row_count) => row_count as u32 - 1,
+            None => return,
+        };
+
+        let autoscroll = if action.center_cursor {
+            Autoscroll::Center
+        } else {
+            Autoscroll::Fit
+        };
+
+        self.change_selections(Some(autoscroll), cx, |s| {
+            let line_mode = s.line_mode;
+            s.move_with(|map, selection| {
+                if !selection.is_empty() && !line_mode {
+                    selection.goal = SelectionGoal::None;
+                }
+                let (cursor, goal) =
+                    movement::down_by_rows(map, selection.end, row_count, selection.goal, false);
+                selection.collapse_to(cursor, goal);
+            });
+        });
+    }
+
+    pub fn page_down(&mut self, _: &PageDown, cx: &mut ViewContext<Self>) {
+        if self.take_rename(true, cx).is_some() {
+            return;
+        }
+
+        if let Some(context_menu) = self.context_menu.as_mut() {
+            if context_menu.select_last(cx) {
+                return;
+            }
+        }
+
+        if matches!(self.mode, EditorMode::SingleLine) {
+            cx.propagate_action();
+            return;
+        }
+
+        let lines = match self.visible_line_count {
+            Some(lines) => lines,
+            None => return,
+        };
+
+        let cur_position = self.scroll_position(cx);
+        let new_pos = cur_position + vec2f(0., lines - 1.);
+        self.set_scroll_position(new_pos, cx);
     }
 
     pub fn select_down(&mut self, _: &SelectDown, cx: &mut ViewContext<Self>) {
@@ -5548,71 +5747,6 @@ impl Editor {
         } else {
             None
         }
-    }
-
-    // Vscode style + emacs style
-    pub fn move_page_down(&mut self, _: &MovePageDown, cx: &mut ViewContext<Self>) {
-        let row_count = match self.visible_line_count {
-            Some(row_count) => row_count as u32 - 1,
-            None => return,
-        };
-
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
-            let line_mode = s.line_mode;
-            s.move_with(|map, selection| {
-                if !selection.is_empty() && !line_mode {
-                    selection.goal = SelectionGoal::None;
-                }
-                let (cursor, goal) =
-                    movement::down_by_rows(map, selection.end, row_count, selection.goal, false);
-                eprintln!(
-                    "{:?} down by rows {} = {:?}",
-                    selection.end, row_count, cursor
-                );
-                selection.collapse_to(cursor, goal);
-            });
-        });
-    }
-
-    pub fn move_page_up(&mut self, _: &MovePageUp, cx: &mut ViewContext<Self>) {
-        let row_count = match self.visible_line_count {
-            Some(row_count) => row_count as u32 - 1,
-            None => return,
-        };
-
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
-            let line_mode = s.line_mode;
-            s.move_with(|map, selection| {
-                if !selection.is_empty() && !line_mode {
-                    selection.goal = SelectionGoal::None;
-                }
-                let (cursor, goal) =
-                    movement::up_by_rows(map, selection.end, row_count, selection.goal, false);
-                selection.collapse_to(cursor, goal);
-            });
-        });
-    }
-
-    pub fn page_up(&mut self, _: &PageUp, cx: &mut ViewContext<Self>) {
-        let lines = match self.visible_line_count {
-            Some(lines) => lines,
-            None => return,
-        };
-
-        let cur_position = self.scroll_position(cx);
-        let new_pos = cur_position - vec2f(0., lines + 1.);
-        self.set_scroll_position(new_pos, cx);
-    }
-
-    pub fn page_down(&mut self, _: &PageDown, cx: &mut ViewContext<Self>) {
-        let lines = match self.visible_line_count {
-            Some(lines) => lines,
-            None => return,
-        };
-
-        let cur_position = self.scroll_position(cx);
-        let new_pos = cur_position + vec2f(0., lines - 1.);
-        self.set_scroll_position(new_pos, cx);
     }
 
     pub fn fold(&mut self, _: &Fold, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1229,7 +1229,7 @@ async fn test_move_page_up_page_down(cx: &mut gpui::TestAppContext) {
         seven
         eight
         nine
-        tenx
+        ten
         "#
         .unindent(),
     );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1195,6 +1195,120 @@ fn test_prev_next_word_bounds_with_soft_wrap(cx: &mut gpui::MutableAppContext) {
 }
 
 #[gpui::test]
+async fn test_move_page_up_page_down(cx: &mut gpui::TestAppContext) {
+    let mut cx = EditorTestContext::new(cx);
+
+    let line_height = cx.editor(|editor, cx| editor.style(cx).text.line_height(cx.font_cache()));
+    cx.simulate_window_resize(cx.window_id, vec2f(100., 4. * line_height));
+
+    cx.set_state(
+        &r#"
+        ˇone
+        two
+        threeˇ
+        four
+        five
+        six
+        seven
+        eight
+        nine
+        ten
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, cx| editor.move_page_down(&MovePageDown::default(), cx));
+    cx.assert_editor_state(
+        &r#"
+        one
+        two
+        three
+        ˇfour
+        five
+        sixˇ
+        seven
+        eight
+        nine
+        tenx
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, cx| editor.move_page_down(&MovePageDown::default(), cx));
+    cx.assert_editor_state(
+        &r#"
+        one
+        two
+        three
+        four
+        five
+        six
+        ˇseven
+        eight
+        nineˇ
+        ten
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, cx| editor.move_page_up(&MovePageUp::default(), cx));
+    cx.assert_editor_state(
+        &r#"
+        one
+        two
+        three
+        ˇfour
+        five
+        sixˇ
+        seven
+        eight
+        nine
+        ten
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, cx| editor.move_page_up(&MovePageUp::default(), cx));
+    cx.assert_editor_state(
+        &r#"
+        ˇone
+        two
+        threeˇ
+        four
+        five
+        six
+        seven
+        eight
+        nine
+        ten
+        "#
+        .unindent(),
+    );
+
+    // Test select collapsing
+    cx.update_editor(|editor, cx| {
+        editor.move_page_down(&MovePageDown::default(), cx);
+        editor.move_page_down(&MovePageDown::default(), cx);
+        editor.move_page_down(&MovePageDown::default(), cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+        one
+        two
+        three
+        four
+        five
+        six
+        seven
+        eight
+        nine
+        ˇten
+        ˇ"#
+        .unindent(),
+    );
+}
+
+#[gpui::test]
 async fn test_delete_to_beginning_of_line(cx: &mut gpui::TestAppContext) {
     let mut cx = EditorTestContext::new(cx);
     cx.set_state("one «two threeˇ» four");

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -30,13 +30,32 @@ pub fn up(
     goal: SelectionGoal,
     preserve_column_at_start: bool,
 ) -> (DisplayPoint, SelectionGoal) {
+    up_by_rows(map, start, 1, goal, preserve_column_at_start)
+}
+
+pub fn down(
+    map: &DisplaySnapshot,
+    start: DisplayPoint,
+    goal: SelectionGoal,
+    preserve_column_at_end: bool,
+) -> (DisplayPoint, SelectionGoal) {
+    down_by_rows(map, start, 1, goal, preserve_column_at_end)
+}
+
+pub fn up_by_rows(
+    map: &DisplaySnapshot,
+    start: DisplayPoint,
+    row_count: u32,
+    goal: SelectionGoal,
+    preserve_column_at_start: bool,
+) -> (DisplayPoint, SelectionGoal) {
     let mut goal_column = if let SelectionGoal::Column(column) = goal {
         column
     } else {
         map.column_to_chars(start.row(), start.column())
     };
 
-    let prev_row = start.row().saturating_sub(1);
+    let prev_row = start.row().saturating_sub(row_count);
     let mut point = map.clip_point(
         DisplayPoint::new(prev_row, map.line_len(prev_row)),
         Bias::Left,
@@ -62,9 +81,10 @@ pub fn up(
     )
 }
 
-pub fn down(
+pub fn down_by_rows(
     map: &DisplaySnapshot,
     start: DisplayPoint,
+    row_count: u32,
     goal: SelectionGoal,
     preserve_column_at_end: bool,
 ) -> (DisplayPoint, SelectionGoal) {
@@ -74,8 +94,8 @@ pub fn down(
         map.column_to_chars(start.row(), start.column())
     };
 
-    let next_row = start.row() + 1;
-    let mut point = map.clip_point(DisplayPoint::new(next_row, 0), Bias::Right);
+    let new_row = start.row() + row_count;
+    let mut point = map.clip_point(DisplayPoint::new(new_row, 0), Bias::Right);
     if point.row() > start.row() {
         *point.column_mut() = map.column_from_chars(point.row(), goal_column);
     } else if preserve_column_at_end {

--- a/crates/gpui/src/app/test_app_context.rs
+++ b/crates/gpui/src/app/test_app_context.rs
@@ -17,10 +17,11 @@ use parking_lot::{Mutex, RwLock};
 use smol::stream::StreamExt;
 
 use crate::{
-    executor, keymap::Keystroke, platform, Action, AnyViewHandle, AppContext, Appearance, Entity,
-    Event, FontCache, InputHandler, KeyDownEvent, LeakDetector, ModelContext, ModelHandle,
-    MutableAppContext, Platform, ReadModelWith, ReadViewWith, RenderContext, Task, UpdateModel,
-    UpdateView, View, ViewContext, ViewHandle, WeakHandle, WindowInputHandler,
+    executor, geometry::vector::Vector2F, keymap::Keystroke, platform, Action, AnyViewHandle,
+    AppContext, Appearance, Entity, Event, FontCache, InputHandler, KeyDownEvent, LeakDetector,
+    ModelContext, ModelHandle, MutableAppContext, Platform, ReadModelWith, ReadViewWith,
+    RenderContext, Task, UpdateModel, UpdateView, View, ViewContext, ViewHandle, WeakHandle,
+    WindowInputHandler,
 };
 use collections::BTreeMap;
 
@@ -273,6 +274,17 @@ impl TestAppContext {
         } else {
             false
         }
+    }
+
+    pub fn simulate_window_resize(&self, window_id: usize, size: Vector2F) {
+        let mut window = self.window_mut(window_id);
+        window.size = size;
+        let mut handlers = mem::take(&mut window.resize_handlers);
+        drop(window);
+        for handler in &mut handlers {
+            handler();
+        }
+        self.window_mut(window_id).resize_handlers = handlers;
     }
 
     pub fn simulate_window_activation(&self, to_activate: Option<usize>) {

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -34,11 +34,11 @@ pub struct ForegroundPlatform {
 struct Dispatcher;
 
 pub struct Window {
-    size: Vector2F,
+    pub(crate) size: Vector2F,
     scale_factor: f32,
     current_scene: Option<crate::Scene>,
     event_handlers: Vec<Box<dyn FnMut(super::Event) -> bool>>,
-    resize_handlers: Vec<Box<dyn FnMut()>>,
+    pub(crate) resize_handlers: Vec<Box<dyn FnMut()>>,
     close_handlers: Vec<Box<dyn FnOnce()>>,
     fullscreen_handlers: Vec<Box<dyn FnMut(bool)>>,
     pub(crate) active_status_change_handlers: Vec<Box<dyn FnMut(bool)>>,

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -142,8 +142,8 @@ impl TerminalView {
 
     pub fn deploy_context_menu(&mut self, action: &DeployContextMenu, cx: &mut ViewContext<Self>) {
         let menu_entries = vec![
-            ContextMenuItem::item("Clear Buffer", Clear),
-            ContextMenuItem::item("Close Terminal", pane::CloseActiveItem),
+            ContextMenuItem::item("Clear", Clear),
+            ContextMenuItem::item("Close", pane::CloseActiveItem),
         ];
 
         self.context_menu.update(cx, |menu, cx| {


### PR DESCRIPTION
## Description of feature or change

Adds 2 variations of page up and page down:

1. `editor::MovePageUp` and `editor::MovePageDown`, which move the cursors along with the screen. These are bound to `shift-pageup` and `shift-pagedown`
2. `editor::MovePageUp/Down { center_cursor: true }`, which moves as well as centers the screen on the moved cursors

As well as a new command: `editor::CenterScreen` which autoscrolls the buffer to center it on the cursor. 

This also improves the existing implementation of `pageup` and `pagedown` to work with context menus and renames.

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/447#issuecomment-1279182997

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
