### PR TITLE
Remove unconditional invalidation when calling mouse region handlers

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -354,7 +354,7 @@ impl InfoPopover {
                 .with_style(style.hover_popover.container)
                 .boxed()
         })
-        .on_move(|_, _| {})
+        .on_move(|_, _| {}) // Consume move events so they don't reach regions underneath.
         .with_cursor_style(CursorStyle::Arrow)
         .with_padding(Padding {
             bottom: HOVER_POPOVER_GAP,
@@ -400,7 +400,7 @@ impl DiagnosticPopover {
             bottom: HOVER_POPOVER_GAP,
             ..Default::default()
         })
-        .on_move(|_, _| {})
+        .on_move(|_, _| {}) // Consume move events so they don't reach regions underneath.
         .on_click(MouseButton::Left, |_, cx| {
             cx.dispatch_action(GoToDiagnostic)
         })

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -558,6 +558,8 @@ impl StateInner {
             let visible_range = self.visible_range(height, scroll_top);
             self.scroll_handler.as_mut().unwrap()(visible_range, cx);
         }
+
+        cx.notify();
     }
 
     fn scroll_top(&self, logical_scroll_top: &ListOffset) -> f32 {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -482,9 +482,6 @@ impl Presenter {
 
                     if let Some(callback) = valid_region.handlers.get(&region_event.handler_key()) {
                         event_cx.handled = true;
-                        event_cx
-                            .invalidated_views
-                            .insert(valid_region.id().view_id());
                         event_cx.with_current_view(valid_region.id().view_id(), {
                             let region_event = region_event.clone();
                             |cx| {


### PR DESCRIPTION
We want invalidation to opt-in as much as possible. If you want a view to re-render, you need to call `cx.notify`.

@Kethku, I talked to @as-cii and @maxbrunsfeld about this. Antonio feels strongly that view invalidation should be opt in, and Max is on board. Our experience in Atom is that poor performance can sometimes be the result of a lot of tiny grains of sand rather than one big thing, making it very tough to optimize once slowness has accreted. Since this is framework level, we want to give the element / view author full control over invalidation.