### PR TITLE
Reduce unnecessary view invalidations related to mouse events

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -285,7 +285,7 @@ impl View for ActivityIndicator {
                 .workspace
                 .status_bar
                 .lsp_status;
-            let style = if state.hovered && action.is_some() {
+            let style = if state.hovered() && action.is_some() {
                 theme.hover.as_ref().unwrap_or(&theme.default)
             } else {
                 &theme.default

--- a/crates/chat_panel/src/chat_panel.rs
+++ b/crates/chat_panel/src/chat_panel.rs
@@ -311,7 +311,7 @@ impl ChatPanel {
             MouseEventHandler::<SignInPromptLabel>::new(0, cx, |mouse_state, _| {
                 Label::new(
                     "Sign in to use chat".to_string(),
-                    if mouse_state.hovered {
+                    if mouse_state.hovered() {
                         theme.chat_panel.hovered_sign_in_prompt.clone()
                     } else {
                         theme.chat_panel.sign_in_prompt.clone()

--- a/crates/collab_ui/src/contact_finder.rs
+++ b/crates/collab_ui/src/contact_finder.rs
@@ -101,7 +101,7 @@ impl PickerDelegate for ContactFinder {
     fn render_match(
         &self,
         ix: usize,
-        mouse_state: MouseState,
+        mouse_state: &mut MouseState,
         selected: bool,
         cx: &gpui::AppContext,
     ) -> ElementBox {

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -653,7 +653,11 @@ impl ContactList {
             .constrained()
             .with_height(theme.row_height)
             .contained()
-            .with_style(*theme.contact_row.style_for(Default::default(), is_selected))
+            .with_style(
+                *theme
+                    .contact_row
+                    .style_for(&mut Default::default(), is_selected),
+            )
             .boxed()
     }
 
@@ -768,7 +772,9 @@ impl ContactList {
     ) -> ElementBox {
         enum Header {}
 
-        let header_style = theme.header_row.style_for(Default::default(), is_selected);
+        let header_style = theme
+            .header_row
+            .style_for(&mut Default::default(), is_selected);
         let text = match section {
             Section::ActiveCall => "Collaborators",
             Section::Requests => "Contact Requests",
@@ -890,7 +896,11 @@ impl ContactList {
                     .constrained()
                     .with_height(theme.row_height)
                     .contained()
-                    .with_style(*theme.contact_row.style_for(Default::default(), is_selected))
+                    .with_style(
+                        *theme
+                            .contact_row
+                            .style_for(&mut Default::default(), is_selected),
+                    )
                     .boxed()
             })
             .on_click(MouseButton::Left, move |_, cx| {
@@ -1014,7 +1024,11 @@ impl ContactList {
         row.constrained()
             .with_height(theme.row_height)
             .contained()
-            .with_style(*theme.contact_row.style_for(Default::default(), is_selected))
+            .with_style(
+                *theme
+                    .contact_row
+                    .style_for(&mut Default::default(), is_selected),
+            )
             .boxed()
     }
 

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -224,7 +224,7 @@ impl PickerDelegate for CommandPalette {
     fn render_match(
         &self,
         ix: usize,
-        mouse_state: MouseState,
+        mouse_state: &mut MouseState,
         selected: bool,
         cx: &gpui::AppContext,
     ) -> gpui::ElementBox {

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -258,9 +258,10 @@ impl ContextMenu {
                     .with_children(self.items.iter().enumerate().map(|(ix, item)| {
                         match item {
                             ContextMenuItem::Item { label, .. } => {
-                                let style = style
-                                    .item
-                                    .style_for(Default::default(), Some(ix) == self.selected_index);
+                                let style = style.item.style_for(
+                                    &mut Default::default(),
+                                    Some(ix) == self.selected_index,
+                                );
 
                                 Label::new(label.to_string(), style.label.clone())
                                     .contained()
@@ -283,9 +284,10 @@ impl ContextMenu {
                     .with_children(self.items.iter().enumerate().map(|(ix, item)| {
                         match item {
                             ContextMenuItem::Item { action, .. } => {
-                                let style = style
-                                    .item
-                                    .style_for(Default::default(), Some(ix) == self.selected_index);
+                                let style = style.item.style_for(
+                                    &mut Default::default(),
+                                    Some(ix) == self.selected_index,
+                                );
                                 KeystrokeLabel::new(
                                     action.boxed_clone(),
                                     style.keystroke.container,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -705,7 +705,7 @@ impl CompletionsMenu {
                             |state, _| {
                                 let item_style = if item_ix == selected_item {
                                     style.autocomplete.selected_item
-                                } else if state.hovered {
+                                } else if state.hovered() {
                                     style.autocomplete.hovered_item
                                 } else {
                                     style.autocomplete.item
@@ -850,7 +850,7 @@ impl CodeActionsMenu {
                         MouseEventHandler::<ActionTag>::new(item_ix, cx, |state, _| {
                             let item_style = if item_ix == selected_item {
                                 style.autocomplete.selected_item
-                            } else if state.hovered {
+                            } else if state.hovered() {
                                 style.autocomplete.hovered_item
                             } else {
                                 style.autocomplete.item

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5792,8 +5792,11 @@ impl Editor {
         &mut self,
         cx: &mut ViewContext<Self>,
     ) -> Option<(fn(&Theme) -> Color, Vec<Range<Anchor>>)> {
-        cx.notify();
-        self.background_highlights.remove(&TypeId::of::<T>())
+        let highlights = self.background_highlights.remove(&TypeId::of::<T>());
+        if highlights.is_some() {
+            cx.notify();
+        }
+        highlights
     }
 
     #[cfg(feature = "test-support")]
@@ -5907,9 +5910,13 @@ impl Editor {
         &mut self,
         cx: &mut ViewContext<Self>,
     ) -> Option<Arc<(HighlightStyle, Vec<Range<Anchor>>)>> {
-        cx.notify();
-        self.display_map
-            .update(cx, |map, _| map.clear_text_highlights(TypeId::of::<T>()))
+        let highlights = self
+            .display_map
+            .update(cx, |map, _| map.clear_text_highlights(TypeId::of::<T>()));
+        if highlights.is_some() {
+            cx.notify();
+        }
+        highlights
     }
 
     fn next_blink_epoch(&mut self) -> usize {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -354,7 +354,7 @@ impl InfoPopover {
                 .with_style(style.hover_popover.container)
                 .boxed()
         })
-        .on_move(|_, _| {})
+        .on_move(|_, _| {}) // Consume move events so they don't reach regions underneath.
         .with_cursor_style(CursorStyle::Arrow)
         .with_padding(Padding {
             bottom: HOVER_POPOVER_GAP,
@@ -400,7 +400,7 @@ impl DiagnosticPopover {
             bottom: HOVER_POPOVER_GAP,
             ..Default::default()
         })
-        .on_move(|_, _| {})
+        .on_move(|_, _| {}) // Consume move events so they don't reach regions underneath.
         .on_click(MouseButton::Left, |_, cx| {
             cx.dispatch_action(GoToDiagnostic)
         })

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -251,7 +251,7 @@ impl PickerDelegate for FileFinder {
     fn render_match(
         &self,
         ix: usize,
-        mouse_state: MouseState,
+        mouse_state: &mut MouseState,
         selected: bool,
         cx: &AppContext,
     ) -> ElementBox {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -3774,10 +3774,32 @@ pub struct RenderContext<'a, T: View> {
     pub refreshing: bool,
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct MouseState {
-    pub hovered: bool,
-    pub clicked: Option<MouseButton>,
+    hovered: bool,
+    clicked: Option<MouseButton>,
+    accessed_hovered: bool,
+    accessed_clicked: bool,
+}
+
+impl MouseState {
+    pub fn hovered(&mut self) -> bool {
+        self.accessed_hovered = true;
+        self.hovered
+    }
+
+    pub fn clicked(&mut self) -> Option<MouseButton> {
+        self.accessed_clicked = true;
+        self.clicked
+    }
+
+    pub fn accessed_hovered(&self) -> bool {
+        self.accessed_hovered
+    }
+
+    pub fn accessed_clicked(&self) -> bool {
+        self.accessed_clicked
+    }
 }
 
 impl<'a, V: View> RenderContext<'a, V> {
@@ -3818,6 +3840,8 @@ impl<'a, V: View> RenderContext<'a, V> {
                     None
                 }
             }),
+            accessed_hovered: false,
+            accessed_clicked: false,
         }
     }
 

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -558,6 +558,8 @@ impl StateInner {
             let visible_range = self.visible_range(height, scroll_top);
             self.scroll_handler.as_mut().unwrap()(visible_range, cx);
         }
+
+        cx.notify();
     }
 
     fn scroll_top(&self, logical_scroll_top: &ListOffset) -> f32 {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -482,9 +482,6 @@ impl Presenter {
 
                     if let Some(callback) = valid_region.handlers.get(&region_event.handler_key()) {
                         event_cx.handled = true;
-                        event_cx
-                            .invalidated_views
-                            .insert(valid_region.id().view_id());
                         event_cx.with_current_view(valid_region.id().view_id(), {
                             let region_event = region_event.clone();
                             |cx| {

--- a/crates/gpui/src/scene/mouse_region.rs
+++ b/crates/gpui/src/scene/mouse_region.rs
@@ -20,6 +20,8 @@ pub struct MouseRegion {
     pub bounds: RectF,
     pub handlers: HandlerSet,
     pub hoverable: bool,
+    pub notify_on_hover: bool,
+    pub notify_on_click: bool,
 }
 
 impl MouseRegion {
@@ -52,6 +54,8 @@ impl MouseRegion {
             bounds,
             handlers,
             hoverable: true,
+            notify_on_hover: false,
+            notify_on_click: false,
         }
     }
 
@@ -135,6 +139,16 @@ impl MouseRegion {
 
     pub fn with_hoverable(mut self, is_hoverable: bool) -> Self {
         self.hoverable = is_hoverable;
+        self
+    }
+
+    pub fn with_notify_on_hover(mut self, notify: bool) -> Self {
+        self.notify_on_hover = notify;
+        self
+    }
+
+    pub fn with_notify_on_click(mut self, notify: bool) -> Self {
+        self.notify_on_click = notify;
         self
     }
 }

--- a/crates/gpui/src/views/select.rs
+++ b/crates/gpui/src/views/select.rs
@@ -113,7 +113,7 @@ impl View for Select {
                 Container::new((self.render_item)(
                     self.selected_item_ix,
                     ItemType::Header,
-                    mouse_state.hovered,
+                    mouse_state.hovered(),
                     cx,
                 ))
                 .with_style(style.header)
@@ -145,7 +145,7 @@ impl View for Select {
                                                 } else {
                                                     ItemType::Unselected
                                                 },
-                                                mouse_state.hovered,
+                                                mouse_state.hovered(),
                                                 cx,
                                             )
                                         })

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -233,7 +233,7 @@ impl PickerDelegate for OutlineView {
     fn render_match(
         &self,
         ix: usize,
-        mouse_state: MouseState,
+        mouse_state: &mut MouseState,
         selected: bool,
         cx: &AppContext,
     ) -> ElementBox {

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -33,7 +33,7 @@ pub trait PickerDelegate: View {
     fn render_match(
         &self,
         ix: usize,
-        state: MouseState,
+        state: &mut MouseState,
         selected: bool,
         cx: &AppContext,
     ) -> ElementBox;

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -234,7 +234,7 @@ impl PickerDelegate for ProjectSymbolsView {
     fn render_match(
         &self,
         ix: usize,
-        mouse_state: MouseState,
+        mouse_state: &mut MouseState,
         selected: bool,
         cx: &AppContext,
     ) -> ElementBox {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -645,12 +645,12 @@ pub struct Interactive<T> {
 }
 
 impl<T> Interactive<T> {
-    pub fn style_for(&self, state: MouseState, active: bool) -> &T {
+    pub fn style_for(&self, state: &mut MouseState, active: bool) -> &T {
         if active {
             self.active.as_ref().unwrap_or(&self.default)
-        } else if state.clicked == Some(gpui::MouseButton::Left) && self.clicked.is_some() {
+        } else if state.clicked() == Some(gpui::MouseButton::Left) && self.clicked.is_some() {
             self.clicked.as_ref().unwrap()
-        } else if state.hovered {
+        } else if state.hovered() {
             self.hover.as_ref().unwrap_or(&self.default)
         } else {
             &self.default

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -230,7 +230,7 @@ impl PickerDelegate for ThemeSelector {
     fn render_match(
         &self,
         ix: usize,
-        mouse_state: MouseState,
+        mouse_state: &mut MouseState,
         selected: bool,
         cx: &AppContext,
     ) -> ElementBox {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1088,7 +1088,7 @@ impl Pane {
                         move |mouse_state, cx| {
                             let tab_style =
                                 theme.workspace.tab_bar.tab_style(pane_active, tab_active);
-                            let hovered = mouse_state.hovered;
+                            let hovered = mouse_state.hovered();
                             Self::render_tab(
                                 &item,
                                 pane,
@@ -1161,7 +1161,8 @@ impl Pane {
                         .with_style(filler_style.container)
                         .with_border(filler_style.container.border);
 
-                    if let Some(overlay) = Self::tab_overlay_color(mouse_state.hovered, &theme, cx)
+                    if let Some(overlay) =
+                        Self::tab_overlay_color(mouse_state.hovered(), &theme, cx)
                     {
                         filler = filler.with_overlay_color(overlay);
                     }
@@ -1283,7 +1284,7 @@ impl Pane {
                         enum TabCloseButton {}
                         let icon = Svg::new("icons/x_mark_thin_8.svg");
                         MouseEventHandler::<TabCloseButton>::new(item_id, cx, |mouse_state, _| {
-                            if mouse_state.hovered {
+                            if mouse_state.hovered() {
                                 icon.with_color(tab_style.icon_close_active).boxed()
                             } else {
                                 icon.with_color(tab_style.icon_close).boxed()


### PR DESCRIPTION
- Detect when a mouse event handler's child element actually cares about `hovered` and `clicked` states, and only invalidate the view when needed.
- Avoid editor rerenders on every mouse move by only notifying the editor when clearing highlights if some highlights existed before clearing.

This dramatically reduces CPU overhead when moving the mouse over an editor.