### PR TITLE
Adds the ability to disable cursor blinking and replicates cursor shape to collaborators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,6 +5828,7 @@ dependencies = [
  "futures 0.3.24",
  "gpui",
  "itertools",
+ "language",
  "lazy_static",
  "libc",
  "mio-extras",

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: cd ../zed.dev && PORT=3000 npx next dev
+web: cd ../zed.dev && PORT=3000 npx vercel dev
 collab: cd crates/collab && cargo run

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -69,6 +69,8 @@
     // The column at which to soft-wrap lines, for buffers where soft-wrap
     // is enabled.
     "preferred_line_length": 80,
+    // Whether the cursor blinks in the editor.
+    "cursor_blink": true,
     // Whether to indent lines using tab characters, as opposed to multiple
     // spaces.
     "hard_tabs": false,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -10,6 +10,8 @@
     // Whether to show the informational hover box when moving the mouse
     // over symbols in the editor.
     "hover_popover_enabled": true,
+    // Whether the cursor blinks in the editor.
+    "cursor_blink": true,
     // Whether to pop the completions menu while typing in an editor without
     // explicitly requesting it.
     "show_completions_on_input": true,
@@ -69,8 +71,6 @@
     // The column at which to soft-wrap lines, for buffers where soft-wrap
     // is enabled.
     "preferred_line_length": 80,
-    // Whether the cursor blinks in the editor.
-    "cursor_blink": true,
     // Whether to indent lines using tab characters, as opposed to multiple
     // spaces.
     "hard_tabs": false,

--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use gpui::{Entity, ModelContext};
+use settings::Settings;
+use smol::Timer;
+
+pub struct BlinkManager {
+    blink_interval: Duration,
+
+    blink_epoch: usize,
+    blinking_paused: bool,
+    visible: bool,
+    enabled: bool,
+}
+
+impl BlinkManager {
+    pub fn new(blink_interval: Duration, cx: &mut ModelContext<Self>) -> Self {
+        let weak_handle = cx.weak_handle();
+        cx.observe_global::<Settings, _>(move |_, cx| {
+            if let Some(this) = weak_handle.upgrade(cx) {
+                // Make sure we blink the cursors if the setting is re-enabled
+                this.update(cx, |this, cx| this.blink_cursors(this.blink_epoch, cx));
+            }
+        })
+        .detach();
+
+        Self {
+            blink_interval,
+
+            blink_epoch: 0,
+            blinking_paused: false,
+            visible: true,
+            enabled: true,
+        }
+    }
+
+    fn next_blink_epoch(&mut self) -> usize {
+        self.blink_epoch += 1;
+        self.blink_epoch
+    }
+
+    pub fn pause_blinking(&mut self, cx: &mut ModelContext<Self>) {
+        if !self.visible {
+            self.visible = true;
+            cx.notify();
+        }
+
+        let epoch = self.next_blink_epoch();
+        let interval = self.blink_interval;
+        cx.spawn(|this, mut cx| {
+            let this = this.downgrade();
+            async move {
+                Timer::after(interval).await;
+                if let Some(this) = this.upgrade(&cx) {
+                    this.update(&mut cx, |this, cx| this.resume_cursor_blinking(epoch, cx))
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn resume_cursor_blinking(&mut self, epoch: usize, cx: &mut ModelContext<Self>) {
+        if epoch == self.blink_epoch {
+            self.blinking_paused = false;
+            self.blink_cursors(epoch, cx);
+        }
+    }
+
+    fn blink_cursors(&mut self, epoch: usize, cx: &mut ModelContext<Self>) {
+        if cx.global::<Settings>().cursor_blink {
+            if epoch == self.blink_epoch && self.enabled && !self.blinking_paused {
+                self.visible = !self.visible;
+                cx.notify();
+
+                let epoch = self.next_blink_epoch();
+                let interval = self.blink_interval;
+                cx.spawn(|this, mut cx| {
+                    let this = this.downgrade();
+                    async move {
+                        Timer::after(interval).await;
+                        if let Some(this) = this.upgrade(&cx) {
+                            this.update(&mut cx, |this, cx| this.blink_cursors(epoch, cx));
+                        }
+                    }
+                })
+                .detach();
+            }
+        } else if !self.visible {
+            self.visible = true;
+            cx.notify();
+        }
+    }
+
+    pub fn enable(&mut self, cx: &mut ModelContext<Self>) {
+        self.enabled = true;
+        self.blink_cursors(self.blink_epoch, cx);
+    }
+
+    pub fn disable(&mut self, _: &mut ModelContext<Self>) {
+        self.enabled = true;
+    }
+
+    pub fn visible(&self) -> bool {
+        self.visible
+    }
+}
+
+impl Entity for BlinkManager {
+    type Event = ();
+}

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -705,7 +705,7 @@ impl EditorElement {
                     cx,
                 );
 
-                if view.show_local_cursors() || *replica_id != local_replica_id {
+                if view.show_local_cursors(cx) || *replica_id != local_replica_id {
                     let cursor_position = selection.head;
                     if layout
                         .visible_display_row_range

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -35,7 +35,7 @@ use gpui::{
     WeakViewHandle,
 };
 use json::json;
-use language::{Bias, DiagnosticSeverity, OffsetUtf16, Point, Selection};
+use language::{Bias, CursorShape, DiagnosticSeverity, OffsetUtf16, Point, Selection};
 use project::ProjectPath;
 use settings::{GitGutter, Settings};
 use smallvec::SmallVec;
@@ -56,6 +56,7 @@ struct DiffHunkLayout {
 
 struct SelectionLayout {
     head: DisplayPoint,
+    cursor_shape: CursorShape,
     range: Range<DisplayPoint>,
 }
 
@@ -63,6 +64,7 @@ impl SelectionLayout {
     fn new<T: ToPoint + ToDisplayPoint + Clone>(
         selection: Selection<T>,
         line_mode: bool,
+        cursor_shape: CursorShape,
         map: &DisplaySnapshot,
     ) -> Self {
         if line_mode {
@@ -70,6 +72,7 @@ impl SelectionLayout {
             let point_range = map.expand_to_line(selection.range());
             Self {
                 head: selection.head().to_display_point(map),
+                cursor_shape,
                 range: point_range.start.to_display_point(map)
                     ..point_range.end.to_display_point(map),
             }
@@ -77,6 +80,7 @@ impl SelectionLayout {
             let selection = selection.map(|p| p.to_display_point(map));
             Self {
                 head: selection.head(),
+                cursor_shape,
                 range: selection.range(),
             }
         }
@@ -87,19 +91,13 @@ impl SelectionLayout {
 pub struct EditorElement {
     view: WeakViewHandle<Editor>,
     style: Arc<EditorStyle>,
-    cursor_shape: CursorShape,
 }
 
 impl EditorElement {
-    pub fn new(
-        view: WeakViewHandle<Editor>,
-        style: EditorStyle,
-        cursor_shape: CursorShape,
-    ) -> Self {
+    pub fn new(view: WeakViewHandle<Editor>, style: EditorStyle) -> Self {
         Self {
             view,
             style: Arc::new(style),
-            cursor_shape,
         }
     }
 
@@ -723,7 +721,7 @@ impl EditorElement {
                         if block_width == 0.0 {
                             block_width = layout.position_map.em_width;
                         }
-                        let block_text = if let CursorShape::Block = self.cursor_shape {
+                        let block_text = if let CursorShape::Block = selection.cursor_shape {
                             layout
                                 .position_map
                                 .snapshot
@@ -759,7 +757,7 @@ impl EditorElement {
                             block_width,
                             origin: vec2f(x, y),
                             line_height: layout.position_map.line_height,
-                            shape: self.cursor_shape,
+                            shape: selection.cursor_shape,
                             block_text,
                         });
                     }
@@ -1648,7 +1646,7 @@ impl Element for EditorElement {
             );
 
             let mut remote_selections = HashMap::default();
-            for (replica_id, line_mode, selection) in display_map
+            for (replica_id, line_mode, cursor_shape, selection) in display_map
                 .buffer_snapshot
                 .remote_selections_in_range(&(start_anchor.clone()..end_anchor.clone()))
             {
@@ -1659,7 +1657,12 @@ impl Element for EditorElement {
                 remote_selections
                     .entry(replica_id)
                     .or_insert(Vec::new())
-                    .push(SelectionLayout::new(selection, line_mode, &display_map));
+                    .push(SelectionLayout::new(
+                        selection,
+                        line_mode,
+                        cursor_shape,
+                        &display_map,
+                    ));
             }
             selections.extend(remote_selections);
 
@@ -1691,7 +1694,12 @@ impl Element for EditorElement {
                     local_selections
                         .into_iter()
                         .map(|selection| {
-                            SelectionLayout::new(selection, view.selections.line_mode, &display_map)
+                            SelectionLayout::new(
+                                selection,
+                                view.selections.line_mode,
+                                view.cursor_shape,
+                                &display_map,
+                            )
                         })
                         .collect(),
                 ));
@@ -2094,20 +2102,6 @@ fn layout_line(
     )
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum CursorShape {
-    Bar,
-    Block,
-    Underscore,
-    Hollow,
-}
-
-impl Default for CursorShape {
-    fn default() -> Self {
-        CursorShape::Bar
-    }
-}
-
 #[derive(Debug)]
 pub struct Cursor {
     origin: Vector2F,
@@ -2348,11 +2342,7 @@ mod tests {
         let (window_id, editor) = cx.add_window(Default::default(), |cx| {
             Editor::new(EditorMode::Full, buffer, None, None, cx)
         });
-        let element = EditorElement::new(
-            editor.downgrade(),
-            editor.read(cx).style(cx),
-            CursorShape::Bar,
-        );
+        let element = EditorElement::new(editor.downgrade(), editor.read(cx).style(cx));
 
         let layouts = editor.update(cx, |editor, cx| {
             let snapshot = editor.snapshot(cx);
@@ -2388,11 +2378,7 @@ mod tests {
             cx.blur();
         });
 
-        let mut element = EditorElement::new(
-            editor.downgrade(),
-            editor.read(cx).style(cx),
-            CursorShape::Bar,
-        );
+        let mut element = EditorElement::new(editor.downgrade(), editor.read(cx).style(cx));
 
         let mut scene = Scene::new(1.0);
         let mut presenter = cx.build_presenter(window_id, 30., Default::default());

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -120,6 +120,7 @@ impl FollowableItem for Editor {
                     buffer.set_active_selections(
                         &self.selections.disjoint_anchors(),
                         self.selections.line_mode,
+                        self.cursor_shape,
                         cx,
                     );
                 }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1283,7 +1283,7 @@ fn test_random_collaboration(cx: &mut MutableAppContext, mut rng: StdRng) {
                         selections
                     );
                     active_selections.insert(replica_id, selections.clone());
-                    buffer.set_active_selections(selections, false, cx);
+                    buffer.set_active_selections(selections, false, Default::default(), cx);
                 });
                 mutation_count -= 1;
             }
@@ -1448,7 +1448,7 @@ fn test_random_collaboration(cx: &mut MutableAppContext, mut rng: StdRng) {
         let buffer = buffer.read(cx).snapshot();
         let actual_remote_selections = buffer
             .remote_selections_in_range(Anchor::MIN..Anchor::MAX)
-            .map(|(replica_id, _, selections)| (replica_id, selections.collect::<Vec<_>>()))
+            .map(|(replica_id, _, _, selections)| (replica_id, selections.collect::<Vec<_>>()))
             .collect::<Vec<_>>();
         let expected_remote_selections = active_selections
             .iter()

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -908,6 +908,7 @@ message SelectionSet {
     repeated Selection selections = 2;
     uint32 lamport_timestamp = 3;
     bool line_mode = 4;
+    CursorShape cursor_shape = 5;
 }
 
 message Selection {
@@ -915,6 +916,13 @@ message Selection {
     Anchor start = 2;
     Anchor end = 3;
     bool reversed = 4;
+}
+
+enum CursorShape {
+    CursorBar = 0;
+    CursorBlock = 1;
+    CursorUnderscore = 2;
+    CursorHollow = 3;
 }
 
 message Anchor {
@@ -982,6 +990,7 @@ message Operation {
         uint32 lamport_timestamp = 2;
         repeated Selection selections = 3;
         bool line_mode = 4;
+        CursorShape cursor_shape = 5;
     }
 
     message UpdateCompletionTriggers {

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 35;
+pub const PROTOCOL_VERSION: u32 = 36;

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub buffer_font_family: FamilyId,
     pub default_buffer_font_size: f32,
     pub buffer_font_size: f32,
+    pub cursor_blink: bool,
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
     pub vim_mode: bool,
@@ -79,7 +80,6 @@ pub struct GitGutterConfig {}
 pub struct EditorSettings {
     pub tab_size: Option<NonZeroU32>,
     pub hard_tabs: Option<bool>,
-    pub cursor_blink: Option<bool>,
     pub soft_wrap: Option<SoftWrap>,
     pub preferred_line_length: Option<u32>,
     pub format_on_save: Option<FormatOnSave>,
@@ -235,6 +235,8 @@ pub struct SettingsFileContent {
     #[serde(default)]
     pub buffer_font_size: Option<f32>,
     #[serde(default)]
+    pub cursor_blink: Option<bool>,
+    #[serde(default)]
     pub hover_popover_enabled: Option<bool>,
     #[serde(default)]
     pub show_completions_on_input: Option<bool>,
@@ -293,6 +295,7 @@ impl Settings {
                 .unwrap(),
             buffer_font_size: defaults.buffer_font_size.unwrap(),
             default_buffer_font_size: defaults.buffer_font_size.unwrap(),
+            cursor_blink: defaults.cursor_blink.unwrap(),
             hover_popover_enabled: defaults.hover_popover_enabled.unwrap(),
             show_completions_on_input: defaults.show_completions_on_input.unwrap(),
             projects_online_by_default: defaults.projects_online_by_default.unwrap(),
@@ -302,7 +305,6 @@ impl Settings {
             editor_defaults: EditorSettings {
                 tab_size: required(defaults.editor.tab_size),
                 hard_tabs: required(defaults.editor.hard_tabs),
-                cursor_blink: required(defaults.editor.cursor_blink),
                 soft_wrap: required(defaults.editor.soft_wrap),
                 preferred_line_length: required(defaults.editor.preferred_line_length),
                 format_on_save: required(defaults.editor.format_on_save),
@@ -348,6 +350,7 @@ impl Settings {
         );
         merge(&mut self.buffer_font_size, data.buffer_font_size);
         merge(&mut self.default_buffer_font_size, data.buffer_font_size);
+        merge(&mut self.cursor_blink, data.cursor_blink);
         merge(&mut self.hover_popover_enabled, data.hover_popover_enabled);
         merge(
             &mut self.show_completions_on_input,
@@ -390,10 +393,6 @@ impl Settings {
 
     pub fn hard_tabs(&self, language: Option<&str>) -> bool {
         self.language_setting(language, |settings| settings.hard_tabs)
-    }
-
-    pub fn cursor_blink(&self, language: Option<&str>) -> bool {
-        self.language_setting(language, |settings| settings.cursor_blink)
     }
 
     pub fn soft_wrap(&self, language: Option<&str>) -> SoftWrap {
@@ -442,6 +441,7 @@ impl Settings {
             buffer_font_family: cx.font_cache().load_family(&["Monaco"]).unwrap(),
             buffer_font_size: 14.,
             default_buffer_font_size: 14.,
+            cursor_blink: true,
             hover_popover_enabled: true,
             show_completions_on_input: true,
             vim_mode: false,
@@ -450,7 +450,6 @@ impl Settings {
             editor_defaults: EditorSettings {
                 tab_size: Some(4.try_into().unwrap()),
                 hard_tabs: Some(false),
-                cursor_blink: Some(true),
                 soft_wrap: Some(SoftWrap::None),
                 preferred_line_length: Some(80),
                 format_on_save: Some(FormatOnSave::On),

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -79,6 +79,7 @@ pub struct GitGutterConfig {}
 pub struct EditorSettings {
     pub tab_size: Option<NonZeroU32>,
     pub hard_tabs: Option<bool>,
+    pub cursor_blink: Option<bool>,
     pub soft_wrap: Option<SoftWrap>,
     pub preferred_line_length: Option<u32>,
     pub format_on_save: Option<FormatOnSave>,
@@ -301,6 +302,7 @@ impl Settings {
             editor_defaults: EditorSettings {
                 tab_size: required(defaults.editor.tab_size),
                 hard_tabs: required(defaults.editor.hard_tabs),
+                cursor_blink: required(defaults.editor.cursor_blink),
                 soft_wrap: required(defaults.editor.soft_wrap),
                 preferred_line_length: required(defaults.editor.preferred_line_length),
                 format_on_save: required(defaults.editor.format_on_save),
@@ -390,6 +392,10 @@ impl Settings {
         self.language_setting(language, |settings| settings.hard_tabs)
     }
 
+    pub fn cursor_blink(&self, language: Option<&str>) -> bool {
+        self.language_setting(language, |settings| settings.cursor_blink)
+    }
+
     pub fn soft_wrap(&self, language: Option<&str>) -> SoftWrap {
         self.language_setting(language, |settings| settings.soft_wrap)
     }
@@ -444,6 +450,7 @@ impl Settings {
             editor_defaults: EditorSettings {
                 tab_size: Some(4.try_into().unwrap()),
                 hard_tabs: Some(false),
+                cursor_blink: Some(true),
                 soft_wrap: Some(SoftWrap::None),
                 preferred_line_length: Some(80),
                 format_on_save: Some(FormatOnSave::On),

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -8,16 +8,17 @@ path = "src/terminal.rs"
 doctest = false
 
 [dependencies]
+context_menu = { path = "../context_menu" }
+editor = { path = "../editor" }
+language = { path = "../language" }
+gpui = { path = "../gpui" }
+project = { path = "../project" }
+settings = { path = "../settings" }
+theme = { path = "../theme" }
+util = { path = "../util" }
+workspace = { path = "../workspace" }
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "a51dbe25d67e84d6ed4261e640d3954fbdd9be45" }
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
-editor = { path = "../editor" }
-util = { path = "../util" }
-gpui = { path = "../gpui" }
-theme = { path = "../theme" }
-settings = { path = "../settings" }
-workspace = { path = "../workspace" }
-project = { path = "../project" }
-context_menu = { path = "../context_menu" }
 smallvec = { version = "1.6", features = ["union"] }
 smol = "1.2.5"
 mio-extras = "2.0.6"

--- a/crates/terminal/src/terminal_element.rs
+++ b/crates/terminal/src/terminal_element.rs
@@ -4,7 +4,7 @@ use alacritty_terminal::{
     index::Point,
     term::{cell::Flags, TermMode},
 };
-use editor::{Cursor, CursorShape, HighlightedRange, HighlightedRangeLine};
+use editor::{Cursor, HighlightedRange, HighlightedRangeLine};
 use gpui::{
     color::Color,
     elements::{Empty, Overlay},
@@ -20,6 +20,7 @@ use gpui::{
     WeakViewHandle,
 };
 use itertools::Itertools;
+use language::CursorShape;
 use ordered_float::OrderedFloat;
 use settings::Settings;
 use theme::TerminalStyle;

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1,5 +1,5 @@
-use editor::CursorShape;
 use gpui::keymap::Context;
+use language::CursorShape;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -12,8 +12,9 @@ mod visual;
 
 use collections::HashMap;
 use command_palette::CommandPaletteFilter;
-use editor::{Bias, Cancel, CursorShape, Editor};
+use editor::{Bias, Cancel, Editor};
 use gpui::{impl_actions, MutableAppContext, Subscription, ViewContext, WeakViewHandle};
+use language::CursorShape;
 use serde::Deserialize;
 
 use settings::Settings;


### PR DESCRIPTION
## Description of feature or change
Previously all cursors in an editor with a set cursor shape were rendered the same including remote cursors. Now the shape of a cursor is a property of the cursor set so if a user is using vim mode, their cursor will properly reflect the mode they are in.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
