### PR TITLE
Git gutter meets code folding (and word wrap fixes)

### DIFF
--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -157,6 +157,7 @@ pub struct BlockChunks<'a> {
     max_output_row: u32,
 }
 
+#[derive(Clone)]
 pub struct BlockBufferRows<'a> {
     transforms: sum_tree::Cursor<'a, Transform, (BlockRow, WrapRow)>,
     input_buffer_rows: wrap_map::WrapBufferRows<'a>,

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -987,6 +987,7 @@ impl<'a> sum_tree::Dimension<'a, FoldSummary> for usize {
     }
 }
 
+#[derive(Clone)]
 pub struct FoldBufferRows<'a> {
     cursor: Cursor<'a, Transform, (FoldPoint, Point)>,
     input_buffer_rows: MultiBufferRows<'a>,

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -62,6 +62,7 @@ pub struct WrapChunks<'a> {
     transforms: Cursor<'a, Transform, (WrapPoint, TabPoint)>,
 }
 
+#[derive(Clone)]
 pub struct WrapBufferRows<'a> {
     input_buffer_rows: fold_map::FoldBufferRows<'a>,
     input_buffer_row: Option<u32>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1023,6 +1023,8 @@ impl EditorElement {
                     break;
                 }
                 visual_count += 1;
+            } else {
+                visual_count += 1;
             }
 
             buffer_rows.next();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -539,11 +539,6 @@ impl EditorElement {
             bounds: RectF,
         }
 
-        struct DiffLayout<'a> {
-            buffer_row: u32,
-            last_diff: Option<&'a DiffHunk<u32>>,
-        }
-
         fn diff_quad(
             hunk: &DiffHunkLayout,
             gutter_layout: &GutterLayout,
@@ -603,11 +598,6 @@ impl EditorElement {
                 line_height,
                 bounds,
             }
-        };
-
-        let mut diff_layout = DiffLayout {
-            buffer_row: scroll_position.y() as u32,
-            last_diff: None,
         };
 
         let diff_style = &cx.global::<Settings>().theme.editor.diff.clone();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1017,7 +1017,7 @@ impl EditorElement {
         let visual_end = DisplayPoint::new(rows.end, 0).to_point(snapshot).row;
         let hunks = buffer_snapshot.git_diff_hunks_in_range(visual_start..visual_end);
 
-        let mut layouts = Vec::new();
+        let mut layouts = Vec::<DiffHunkLayout>::new();
 
         for hunk in hunks {
             let hunk_start_point = Point::new(hunk.buffer_range.start, 0);
@@ -1049,11 +1049,18 @@ impl EditorElement {
                 start..end
             };
 
-            layouts.push(DiffHunkLayout {
-                visual_range,
-                status: hunk.status(),
-                is_folded: containing_fold.is_some(),
-            });
+            let has_existing_layout = match layouts.last() {
+                Some(e) => visual_range == e.visual_range && e.status == hunk.status(),
+                None => false,
+            };
+
+            if !has_existing_layout {
+                layouts.push(DiffHunkLayout {
+                    visual_range,
+                    status: hunk.status(),
+                    is_folded: containing_fold.is_some(),
+                });
+            }
         }
 
         layouts

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -143,6 +143,7 @@ struct ExcerptSummary {
     text: TextSummary,
 }
 
+#[derive(Clone)]
 pub struct MultiBufferRows<'a> {
     buffer_row_range: Range<u32>,
     excerpts: Cursor<'a, Excerpt, Point>,

--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -191,7 +191,6 @@ impl BufferDiff {
             }
 
             if kind == GitDiffLineType::Deletion {
-                *buffer_row_divergence -= 1;
                 let end = content_offset + content_len;
 
                 match &mut head_byte_range {
@@ -204,6 +203,8 @@ impl BufferDiff {
                     let row = old_row as i64 + *buffer_row_divergence;
                     first_deletion_buffer_row = Some(row as u32);
                 }
+
+                *buffer_row_divergence -= 1;
             }
         }
 


### PR DESCRIPTION
## Description of feature or change

Handle code folding and word wrap when layout out gutter diff hunks

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/zed/issues/1711

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
