### PR TITLE
Correctly handle disconnect when a different client for the same user is on a call

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -319,6 +319,14 @@ impl Client {
             .map(|credentials| credentials.user_id)
     }
 
+    pub fn peer_id(&self) -> Option<PeerId> {
+        if let Status::Connected { peer_id, .. } = &*self.status().borrow() {
+            Some(*peer_id)
+        } else {
+            None
+        }
+    }
+
     pub fn status(&self) -> watch::Receiver<Status> {
         self.state.read().status.1.clone()
     }

--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -84,9 +84,19 @@ impl FakeServer {
                         let (connection_id, io, incoming) =
                             peer.add_test_connection(server_conn, cx.background());
                         cx.background().spawn(io).detach();
-                        let mut state = state.lock();
-                        state.connection_id = Some(connection_id);
-                        state.incoming = Some(incoming);
+                        {
+                            let mut state = state.lock();
+                            state.connection_id = Some(connection_id);
+                            state.incoming = Some(incoming);
+                        }
+                        peer.send(
+                            connection_id,
+                            proto::Hello {
+                                peer_id: connection_id.0,
+                            },
+                        )
+                        .unwrap();
+
                         Ok(client_conn)
                     })
                 }

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -418,7 +418,7 @@ async fn test_calls_on_multiple_connections(
     let mut server = TestServer::start(cx_a.foreground(), cx_a.background()).await;
     let client_a = server.create_client(cx_a, "user_a").await;
     let client_b1 = server.create_client(cx_b1, "user_b").await;
-    let _client_b2 = server.create_client(cx_b2, "user_b").await;
+    let client_b2 = server.create_client(cx_b2, "user_b").await;
     server
         .make_contacts(&mut [(&client_a, cx_a), (&client_b1, cx_b1)])
         .await;
@@ -548,8 +548,9 @@ async fn test_calls_on_multiple_connections(
     assert!(incoming_call_b2.next().await.unwrap().is_some());
 
     // User B disconnects all clients, causing user A to no longer see a pending call for them.
-    println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    server.forbid_connections();
     server.disconnect_client(client_b1.peer_id().unwrap());
+    server.disconnect_client(client_b2.peer_id().unwrap());
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     active_call_a.read_with(cx_a, |call, _| assert!(call.room().is_none()));
 }

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 use call::{room, ActiveCall, ParticipantLocation, Room};
 use client::{
     self, test::FakeHttpClient, Channel, ChannelDetails, ChannelList, Client, Connection,
-    Credentials, EstablishConnectionError, User, UserStore, RECEIVE_TIMEOUT,
+    Credentials, EstablishConnectionError, PeerId, User, UserStore, RECEIVE_TIMEOUT,
 };
 use collections::{BTreeMap, HashMap, HashSet};
 use editor::{
@@ -16,7 +16,10 @@ use editor::{
     ToggleCodeActions, Undo,
 };
 use fs::{FakeFs, Fs as _, HomeDir, LineEnding};
-use futures::{channel::mpsc, Future, StreamExt as _};
+use futures::{
+    channel::{mpsc, oneshot},
+    Future, StreamExt as _,
+};
 use gpui::{
     executor::{self, Deterministic},
     geometry::vector::vec2f,
@@ -34,7 +37,6 @@ use project::{
     ProjectStore, WorktreeId,
 };
 use rand::prelude::*;
-use rpc::PeerId;
 use serde_json::json;
 use settings::{Formatter, Settings};
 use sqlx::types::time::OffsetDateTime;
@@ -385,7 +387,7 @@ async fn test_leaving_room_on_disconnection(
     );
 
     // When user A disconnects, both client A and B clear their room on the active call.
-    server.disconnect_client(client_a.current_user_id(cx_a));
+    server.disconnect_client(client_a.peer_id().unwrap());
     cx_a.foreground().advance_clock(rpc::RECEIVE_TIMEOUT);
     active_call_a.read_with(cx_a, |call, _| assert!(call.room().is_none()));
     active_call_b.read_with(cx_b, |call, _| assert!(call.room().is_none()));
@@ -529,7 +531,7 @@ async fn test_calls_on_multiple_connections(
     assert!(incoming_call_b2.next().await.unwrap().is_some());
 
     // User A disconnects, causing both connections to stop ringing.
-    server.disconnect_client(client_a.current_user_id(cx_a));
+    server.disconnect_client(client_a.peer_id().unwrap());
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     assert!(incoming_call_b1.next().await.unwrap().is_none());
     assert!(incoming_call_b2.next().await.unwrap().is_none());
@@ -547,7 +549,7 @@ async fn test_calls_on_multiple_connections(
 
     // User B disconnects all clients, causing user A to no longer see a pending call for them.
     println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-    server.disconnect_client(client_b1.current_user_id(cx_b1));
+    server.disconnect_client(client_b1.peer_id().unwrap());
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     active_call_a.read_with(cx_a, |call, _| assert!(call.room().is_none()));
 }
@@ -607,7 +609,7 @@ async fn test_share_project(
         .update(cx_b, |call, cx| call.accept_incoming(cx))
         .await
         .unwrap();
-    let client_b_peer_id = client_b.peer_id;
+    let client_b_peer_id = client_b.peer_id().unwrap();
     let project_b = client_b
         .build_remote_project(initial_project.id, cx_b)
         .await;
@@ -831,7 +833,7 @@ async fn test_host_disconnect(
     assert!(cx_b.is_window_edited(workspace_b.window_id()));
 
     // Drop client A's connection. Collaborators should disappear and the project should not be shown as shared.
-    server.disconnect_client(client_a.current_user_id(cx_a));
+    server.disconnect_client(client_a.peer_id().unwrap());
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     project_a
         .condition(cx_a, |project, _| project.collaborators().is_empty())
@@ -874,7 +876,7 @@ async fn test_host_disconnect(
         .unwrap();
 
     // Drop client A's connection again. We should still unshare it successfully.
-    server.disconnect_client(client_a.current_user_id(cx_a));
+    server.disconnect_client(client_a.peer_id().unwrap());
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     project_a.read_with(cx_a, |project, _| assert!(!project.is_shared()));
 }
@@ -2175,7 +2177,7 @@ async fn test_leaving_project(
 
     // Simulate connection loss for client C and ensure client A observes client C leaving the project.
     client_c.wait_for_current_user(cx_c).await;
-    server.disconnect_client(client_c.current_user_id(cx_c));
+    server.disconnect_client(client_c.peer_id().unwrap());
     cx_a.foreground().advance_clock(rpc::RECEIVE_TIMEOUT);
     deterministic.run_until_parked();
     project_a.read_with(cx_a, |project, _| {
@@ -4338,7 +4340,7 @@ async fn test_chat_reconnection(cx_a: &mut TestAppContext, cx_b: &mut TestAppCon
 
     // Disconnect client B, ensuring we can still access its cached channel data.
     server.forbid_connections();
-    server.disconnect_client(client_b.current_user_id(cx_b));
+    server.disconnect_client(client_b.peer_id().unwrap());
     cx_b.foreground().advance_clock(rpc::RECEIVE_TIMEOUT);
     while !matches!(
         status_b.next().await,
@@ -4501,7 +4503,7 @@ async fn test_contacts(
         ]
     );
 
-    server.disconnect_client(client_c.current_user_id(cx_c));
+    server.disconnect_client(client_c.peer_id().unwrap());
     server.forbid_connections();
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     assert_eq!(
@@ -4741,7 +4743,7 @@ async fn test_contacts(
     );
 
     server.forbid_connections();
-    server.disconnect_client(client_a.current_user_id(cx_a));
+    server.disconnect_client(client_a.peer_id().unwrap());
     deterministic.advance_clock(rpc::RECEIVE_TIMEOUT);
     assert_eq!(contacts(&client_a, cx_a), []);
     assert_eq!(
@@ -5651,6 +5653,7 @@ async fn test_random_collaboration(
 
     let mut clients = Vec::new();
     let mut user_ids = Vec::new();
+    let mut peer_ids = Vec::new();
     let mut op_start_signals = Vec::new();
 
     let mut next_entity_id = 100000;
@@ -5839,6 +5842,7 @@ async fn test_random_collaboration(
 
     let op_start_signal = futures::channel::mpsc::unbounded();
     user_ids.push(host_user_id);
+    peer_ids.push(host.peer_id().unwrap());
     op_start_signals.push(op_start_signal.0);
     clients.push(host_cx.foreground().spawn(host.simulate_host(
         host_project,
@@ -5856,7 +5860,7 @@ async fn test_random_collaboration(
     let mut operations = 0;
     while operations < max_operations {
         if operations == disconnect_host_at {
-            server.disconnect_client(user_ids[0]);
+            server.disconnect_client(peer_ids[0]);
             deterministic.advance_clock(RECEIVE_TIMEOUT);
             drop(op_start_signals);
 
@@ -5939,6 +5943,7 @@ async fn test_random_collaboration(
 
                 let op_start_signal = futures::channel::mpsc::unbounded();
                 user_ids.push(guest_user_id);
+                peer_ids.push(guest.peer_id().unwrap());
                 op_start_signals.push(op_start_signal.0);
                 clients.push(guest_cx.foreground().spawn(guest.simulate_guest(
                     guest_username.clone(),
@@ -5955,10 +5960,11 @@ async fn test_random_collaboration(
                 let guest_ix = rng.lock().gen_range(1..clients.len());
                 log::info!("Removing guest {}", user_ids[guest_ix]);
                 let removed_guest_id = user_ids.remove(guest_ix);
+                let removed_peer_id = peer_ids.remove(guest_ix);
                 let guest = clients.remove(guest_ix);
                 op_start_signals.remove(guest_ix);
                 server.forbid_connections();
-                server.disconnect_client(removed_guest_id);
+                server.disconnect_client(removed_peer_id);
                 deterministic.advance_clock(RECEIVE_TIMEOUT);
                 deterministic.start_waiting();
                 log::info!("Waiting for guest {} to exit...", removed_guest_id);
@@ -6082,8 +6088,10 @@ async fn test_random_collaboration(
             let host_buffer = host_project.read_with(&host_cx, |project, cx| {
                 project.buffer_for_id(buffer_id, cx).unwrap_or_else(|| {
                     panic!(
-                        "host does not have buffer for guest:{}, peer:{}, id:{}",
-                        guest_client.username, guest_client.peer_id, buffer_id
+                        "host does not have buffer for guest:{}, peer:{:?}, id:{}",
+                        guest_client.username,
+                        guest_client.peer_id(),
+                        buffer_id
                     )
                 })
             });
@@ -6126,7 +6134,7 @@ struct TestServer {
     server: Arc<Server>,
     foreground: Rc<executor::Foreground>,
     notifications: mpsc::UnboundedReceiver<()>,
-    connection_killers: Arc<Mutex<HashMap<UserId, Arc<AtomicBool>>>>,
+    connection_killers: Arc<Mutex<HashMap<PeerId, Arc<AtomicBool>>>>,
     forbid_connections: Arc<AtomicBool>,
     _test_db: TestDb,
 }
@@ -6192,7 +6200,6 @@ impl TestServer {
         let db = self.app_state.db.clone();
         let connection_killers = self.connection_killers.clone();
         let forbid_connections = self.forbid_connections.clone();
-        let (connection_id_tx, mut connection_id_rx) = mpsc::channel(16);
 
         Arc::get_mut(&mut client)
             .unwrap()
@@ -6215,7 +6222,6 @@ impl TestServer {
                 let connection_killers = connection_killers.clone();
                 let forbid_connections = forbid_connections.clone();
                 let client_name = client_name.clone();
-                let connection_id_tx = connection_id_tx.clone();
                 cx.spawn(move |cx| async move {
                     if forbid_connections.load(SeqCst) {
                         Err(EstablishConnectionError::other(anyhow!(
@@ -6224,7 +6230,7 @@ impl TestServer {
                     } else {
                         let (client_conn, server_conn, killed) =
                             Connection::in_memory(cx.background());
-                        connection_killers.lock().insert(user_id, killed);
+                        let (connection_id_tx, connection_id_rx) = oneshot::channel();
                         let user = db.get_user_by_id(user_id).await.unwrap().unwrap();
                         cx.background()
                             .spawn(server.handle_connection(
@@ -6235,6 +6241,10 @@ impl TestServer {
                                 cx.background(),
                             ))
                             .detach();
+                        let connection_id = connection_id_rx.await.unwrap();
+                        connection_killers
+                            .lock()
+                            .insert(PeerId(connection_id.0), killed);
                         Ok(client_conn)
                     }
                 })
@@ -6266,11 +6276,9 @@ impl TestServer {
             .authenticate_and_connect(false, &cx.to_async())
             .await
             .unwrap();
-        let peer_id = PeerId(connection_id_rx.next().await.unwrap().0);
 
         let client = TestClient {
             client,
-            peer_id,
             username: name.to_string(),
             user_store,
             project_store,
@@ -6282,10 +6290,10 @@ impl TestServer {
         client
     }
 
-    fn disconnect_client(&self, user_id: UserId) {
+    fn disconnect_client(&self, peer_id: PeerId) {
         self.connection_killers
             .lock()
-            .remove(&user_id)
+            .remove(&peer_id)
             .unwrap()
             .store(true, SeqCst);
     }
@@ -6386,7 +6394,6 @@ impl Drop for TestServer {
 struct TestClient {
     client: Arc<Client>,
     username: String,
-    pub peer_id: PeerId,
     pub user_store: ModelHandle<UserStore>,
     pub project_store: ModelHandle<ProjectStore>,
     language_registry: Arc<LanguageRegistry>,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -477,6 +477,10 @@ impl Server {
         let mut contacts_to_update = HashSet::default();
         {
             let mut store = self.store().await;
+
+            #[cfg(test)]
+            let removed_connection = store.remove_connection(connection_id).unwrap();
+            #[cfg(not(test))]
             let removed_connection = store.remove_connection(connection_id)?;
 
             for project in removed_connection.hosted_projects {

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -369,6 +369,8 @@ impl Server {
                 });
 
             tracing::info!(%user_id, %login, %connection_id, %address, "connection opened");
+            this.peer.send(connection_id, proto::Hello { peer_id: connection_id.0 })?;
+            tracing::info!(%user_id, %login, %connection_id, %address, "sent hello message");
 
             if let Some(send_connection_id) = send_connection_id.as_mut() {
                 let _ = send_connection_id.send(connection_id).await;

--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -221,6 +221,9 @@ impl Store {
                 result.guest_projects = left_room.left_projects;
                 result.room_id = Some(room_id);
                 result.canceled_call_connection_ids = left_room.canceled_call_connection_ids;
+            } else if connected_user.connection_ids.len() == 1 {
+                self.decline_call(room_id, connection_id)?;
+                result.room_id = Some(room_id);
             }
         }
 

--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -215,11 +215,13 @@ impl Store {
         let connected_user = self.connected_users.get(&user_id).unwrap();
         if let Some(active_call) = connected_user.active_call.as_ref() {
             let room_id = active_call.room_id;
-            let left_room = self.leave_room(room_id, connection_id)?;
-            result.hosted_projects = left_room.unshared_projects;
-            result.guest_projects = left_room.left_projects;
-            result.room_id = Some(room_id);
-            result.canceled_call_connection_ids = left_room.canceled_call_connection_ids;
+            if active_call.connection_id == Some(connection_id) {
+                let left_room = self.leave_room(room_id, connection_id)?;
+                result.hosted_projects = left_room.unshared_projects;
+                result.guest_projects = left_room.left_projects;
+                result.room_id = Some(room_id);
+                result.canceled_call_connection_ids = left_room.canceled_call_connection_ids;
+            }
         }
 
         let connected_user = self.connected_users.get_mut(&user_id).unwrap();

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -6,124 +6,129 @@ message Envelope {
     optional uint32 responding_to = 2;
     optional uint32 original_sender_id = 3;
     oneof payload {
-        Ack ack = 4;
-        Error error = 5;
-        Ping ping = 6;
-        Test test = 7;
+        Hello hello = 4;
+        Ack ack = 5;
+        Error error = 6;
+        Ping ping = 7;
+        Test test = 8;
         
-        CreateRoom create_room = 8;
-        CreateRoomResponse create_room_response = 9;
-        JoinRoom join_room = 10;
-        JoinRoomResponse join_room_response = 11;
-        LeaveRoom leave_room = 12;
-        Call call = 13;
-        IncomingCall incoming_call = 14;
-        CallCanceled call_canceled = 15;
-        CancelCall cancel_call = 16;
-        DeclineCall decline_call = 17;
-        UpdateParticipantLocation update_participant_location = 18;
-        RoomUpdated room_updated = 19;
+        CreateRoom create_room = 9;
+        CreateRoomResponse create_room_response = 10;
+        JoinRoom join_room = 11;
+        JoinRoomResponse join_room_response = 12;
+        LeaveRoom leave_room = 13;
+        Call call = 14;
+        IncomingCall incoming_call = 15;
+        CallCanceled call_canceled = 16;
+        CancelCall cancel_call = 17;
+        DeclineCall decline_call = 18;
+        UpdateParticipantLocation update_participant_location = 19;
+        RoomUpdated room_updated = 20;
 
-        ShareProject share_project = 20;
-        ShareProjectResponse share_project_response = 21;
-        UnshareProject unshare_project = 22;
-        JoinProject join_project = 23;
-        JoinProjectResponse join_project_response = 24;
-        LeaveProject leave_project = 25;
-        AddProjectCollaborator add_project_collaborator = 26;
-        RemoveProjectCollaborator remove_project_collaborator = 27;
+        ShareProject share_project = 21;
+        ShareProjectResponse share_project_response = 22;
+        UnshareProject unshare_project = 23;
+        JoinProject join_project = 24;
+        JoinProjectResponse join_project_response = 25;
+        LeaveProject leave_project = 26;
+        AddProjectCollaborator add_project_collaborator = 27;
+        RemoveProjectCollaborator remove_project_collaborator = 28;
 
-        GetDefinition get_definition = 28;
-        GetDefinitionResponse get_definition_response = 29;
-        GetTypeDefinition get_type_definition = 30;
-        GetTypeDefinitionResponse get_type_definition_response = 31;
-        GetReferences get_references = 32;
-        GetReferencesResponse get_references_response = 33;
-        GetDocumentHighlights get_document_highlights = 34;
-        GetDocumentHighlightsResponse get_document_highlights_response = 35;
-        GetProjectSymbols get_project_symbols = 36;
-        GetProjectSymbolsResponse get_project_symbols_response = 37;
-        OpenBufferForSymbol open_buffer_for_symbol = 38;
-        OpenBufferForSymbolResponse open_buffer_for_symbol_response = 39;
+        GetDefinition get_definition = 29;
+        GetDefinitionResponse get_definition_response = 30;
+        GetTypeDefinition get_type_definition = 31;
+        GetTypeDefinitionResponse get_type_definition_response = 32;
+        GetReferences get_references = 33;
+        GetReferencesResponse get_references_response = 34;
+        GetDocumentHighlights get_document_highlights = 35;
+        GetDocumentHighlightsResponse get_document_highlights_response = 36;
+        GetProjectSymbols get_project_symbols = 37;
+        GetProjectSymbolsResponse get_project_symbols_response = 38;
+        OpenBufferForSymbol open_buffer_for_symbol = 39;
+        OpenBufferForSymbolResponse open_buffer_for_symbol_response = 40;
 
-        UpdateProject update_project = 40;
-        RegisterProjectActivity register_project_activity = 41;
-        UpdateWorktree update_worktree = 42;
-        UpdateWorktreeExtensions update_worktree_extensions = 43;
+        UpdateProject update_project = 41;
+        RegisterProjectActivity register_project_activity = 42;
+        UpdateWorktree update_worktree = 43;
+        UpdateWorktreeExtensions update_worktree_extensions = 44;
 
-        CreateProjectEntry create_project_entry = 44;
-        RenameProjectEntry rename_project_entry = 45;
-        CopyProjectEntry copy_project_entry = 46;
-        DeleteProjectEntry delete_project_entry = 47;
-        ProjectEntryResponse project_entry_response = 48;
+        CreateProjectEntry create_project_entry = 45;
+        RenameProjectEntry rename_project_entry = 46;
+        CopyProjectEntry copy_project_entry = 47;
+        DeleteProjectEntry delete_project_entry = 48;
+        ProjectEntryResponse project_entry_response = 49;
 
-        UpdateDiagnosticSummary update_diagnostic_summary = 49;
-        StartLanguageServer start_language_server = 50;
-        UpdateLanguageServer update_language_server = 51;
+        UpdateDiagnosticSummary update_diagnostic_summary = 50;
+        StartLanguageServer start_language_server = 51;
+        UpdateLanguageServer update_language_server = 52;
 
-        OpenBufferById open_buffer_by_id = 52;
-        OpenBufferByPath open_buffer_by_path = 53;
-        OpenBufferResponse open_buffer_response = 54;
-        CreateBufferForPeer create_buffer_for_peer = 55;
-        UpdateBuffer update_buffer = 56;
-        UpdateBufferFile update_buffer_file = 57;
-        SaveBuffer save_buffer = 58;
-        BufferSaved buffer_saved = 59;
-        BufferReloaded buffer_reloaded = 60;
-        ReloadBuffers reload_buffers = 61;
-        ReloadBuffersResponse reload_buffers_response = 62;
-        FormatBuffers format_buffers = 63;
-        FormatBuffersResponse format_buffers_response = 64;
-        GetCompletions get_completions = 65;
-        GetCompletionsResponse get_completions_response = 66;
-        ApplyCompletionAdditionalEdits apply_completion_additional_edits = 67;
-        ApplyCompletionAdditionalEditsResponse apply_completion_additional_edits_response = 68;
-        GetCodeActions get_code_actions = 69;
-        GetCodeActionsResponse get_code_actions_response = 70;
-        GetHover get_hover = 71;
-        GetHoverResponse get_hover_response = 72;
-        ApplyCodeAction apply_code_action = 73;
-        ApplyCodeActionResponse apply_code_action_response = 74;
-        PrepareRename prepare_rename = 75;
-        PrepareRenameResponse prepare_rename_response = 76;
-        PerformRename perform_rename = 77;
-        PerformRenameResponse perform_rename_response = 78;
-        SearchProject search_project = 79;
-        SearchProjectResponse search_project_response = 80;
+        OpenBufferById open_buffer_by_id = 53;
+        OpenBufferByPath open_buffer_by_path = 54;
+        OpenBufferResponse open_buffer_response = 55;
+        CreateBufferForPeer create_buffer_for_peer = 56;
+        UpdateBuffer update_buffer = 57;
+        UpdateBufferFile update_buffer_file = 58;
+        SaveBuffer save_buffer = 59;
+        BufferSaved buffer_saved = 60;
+        BufferReloaded buffer_reloaded = 61;
+        ReloadBuffers reload_buffers = 62;
+        ReloadBuffersResponse reload_buffers_response = 63;
+        FormatBuffers format_buffers = 64;
+        FormatBuffersResponse format_buffers_response = 65;
+        GetCompletions get_completions = 66;
+        GetCompletionsResponse get_completions_response = 67;
+        ApplyCompletionAdditionalEdits apply_completion_additional_edits = 68;
+        ApplyCompletionAdditionalEditsResponse apply_completion_additional_edits_response = 69;
+        GetCodeActions get_code_actions = 70;
+        GetCodeActionsResponse get_code_actions_response = 71;
+        GetHover get_hover = 72;
+        GetHoverResponse get_hover_response = 73;
+        ApplyCodeAction apply_code_action = 74;
+        ApplyCodeActionResponse apply_code_action_response = 75;
+        PrepareRename prepare_rename = 76;
+        PrepareRenameResponse prepare_rename_response = 77;
+        PerformRename perform_rename = 78;
+        PerformRenameResponse perform_rename_response = 79;
+        SearchProject search_project = 80;
+        SearchProjectResponse search_project_response = 81;
 
-        GetChannels get_channels = 81;
-        GetChannelsResponse get_channels_response = 82;
-        JoinChannel join_channel = 83;
-        JoinChannelResponse join_channel_response = 84;
-        LeaveChannel leave_channel = 85;
-        SendChannelMessage send_channel_message = 86;
-        SendChannelMessageResponse send_channel_message_response = 87;
-        ChannelMessageSent channel_message_sent = 88;
-        GetChannelMessages get_channel_messages = 89;
-        GetChannelMessagesResponse get_channel_messages_response = 90;
+        GetChannels get_channels = 82;
+        GetChannelsResponse get_channels_response = 83;
+        JoinChannel join_channel = 84;
+        JoinChannelResponse join_channel_response = 85;
+        LeaveChannel leave_channel = 86;
+        SendChannelMessage send_channel_message = 87;
+        SendChannelMessageResponse send_channel_message_response = 88;
+        ChannelMessageSent channel_message_sent = 89;
+        GetChannelMessages get_channel_messages = 90;
+        GetChannelMessagesResponse get_channel_messages_response = 91;
 
-        UpdateContacts update_contacts = 91;
-        UpdateInviteInfo update_invite_info = 92;
-        ShowContacts show_contacts = 93;
+        UpdateContacts update_contacts = 92;
+        UpdateInviteInfo update_invite_info = 93;
+        ShowContacts show_contacts = 94;
 
-        GetUsers get_users = 94;
-        FuzzySearchUsers fuzzy_search_users = 95;
-        UsersResponse users_response = 96;
-        RequestContact request_contact = 97;
-        RespondToContactRequest respond_to_contact_request = 98;
-        RemoveContact remove_contact = 99;
+        GetUsers get_users = 95;
+        FuzzySearchUsers fuzzy_search_users = 96;
+        UsersResponse users_response = 97;
+        RequestContact request_contact = 98;
+        RespondToContactRequest respond_to_contact_request = 99;
+        RemoveContact remove_contact = 100;
 
-        Follow follow = 100;
-        FollowResponse follow_response = 101;
-        UpdateFollowers update_followers = 102;
-        Unfollow unfollow = 103;
-        GetPrivateUserInfo get_private_user_info = 104;
-        GetPrivateUserInfoResponse get_private_user_info_response = 105;
-        UpdateDiffBase update_diff_base = 106;
+        Follow follow = 101;
+        FollowResponse follow_response = 102;
+        UpdateFollowers update_followers = 103;
+        Unfollow unfollow = 104;
+        GetPrivateUserInfo get_private_user_info = 105;
+        GetPrivateUserInfoResponse get_private_user_info_response = 106;
+        UpdateDiffBase update_diff_base = 107;
     }
 }
 
 // Messages
+
+message Hello {
+    uint32 peer_id = 1;
+}
 
 message Ping {}
 

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -121,6 +121,7 @@ messages!(
     (GetProjectSymbols, Background),
     (GetProjectSymbolsResponse, Background),
     (GetUsers, Foreground),
+    (Hello, Foreground),
     (IncomingCall, Foreground),
     (UsersResponse, Foreground),
     (JoinChannel, Foreground),

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 37;
+pub const PROTOCOL_VERSION: u32 = 38;


### PR DESCRIPTION
A user is only allowed to have one active call, even if they have multiple connections. This pull request fixes a bug where we would try to leave the call upon terminating *any* of their connections. This caused an error, which would prevent us from cleaning up the remaining state associated with the connection.

We also changed the protocol to inform each client of their assigned peer id on the server, which simplifies obtaining this information in tests.