### PR TITLE
Don't allow drag event to fall through context menu

### DIFF
--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -315,13 +315,16 @@ impl ContextMenu {
     fn render_menu(&self, cx: &mut RenderContext<Self>) -> impl Element {
         enum Menu {}
         enum MenuItem {}
+
         let style = cx.global::<Settings>().theme.context_menu.clone();
+
         MouseEventHandler::<Menu>::new(0, cx, |_, cx| {
             Flex::column()
                 .with_children(self.items.iter().enumerate().map(|(ix, item)| {
                     match item {
                         ContextMenuItem::Item { label, action } => {
                             let action = action.boxed_clone();
+
                             MouseEventHandler::<MenuItem>::new(ix, cx, |state, _| {
                                 let style =
                                     style.item.style_for(state, Some(ix) == self.selected_index);
@@ -350,6 +353,7 @@ impl ContextMenu {
                                 cx.dispatch_action(Clicked);
                                 cx.dispatch_any_action(action.boxed_clone());
                             })
+                            .on_drag(MouseButton::Left, |_, _| {})
                             .boxed()
                         }
                         ContextMenuItem::Separator => Empty::new()


### PR DESCRIPTION
## Description of feature or change

Fixes drag causing text to be selected behind context menu

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/559

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
