### PR TITLE
Scroll horizontal flex lists by whichever scroll delta dimension is g…

### DIFF
--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -259,7 +259,7 @@ impl Element for Flex {
                             if remaining_space < 0. {
                                 let mut delta = match axis {
                                     Axis::Horizontal => {
-                                        if e.delta.x() != 0. {
+                                        if e.delta.x().abs() >= e.delta.y().abs() {
                                             e.delta.x()
                                         } else {
                                             e.delta.y()


### PR DESCRIPTION
This fixes a janky experience when scrolling the tab-bar (a horizontal flex element) with vertical trackpad motions. Previously, if any scroll event had a tiny but non-zero horizontal component, then the tab bar would abruptly switch scrolling directions.