### PR TITLE
Fix vim mode panic when backspace is used in a change operation

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -145,8 +145,12 @@ impl Motion {
 
         match self {
             EndOfLine | NextWordEnd { .. } | Matching => true,
-            Left | Right | StartOfLine | NextWordStart { .. } | PreviousWordStart { .. } => false,
-            _ => panic!("Exclusivity not defined for {self:?}"),
+            Left
+            | Backspace
+            | Right
+            | StartOfLine
+            | NextWordStart { .. }
+            | PreviousWordStart { .. } => false,
         }
     }
 


### PR DESCRIPTION


## Description of feature or change

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
