### PR TITLE
Fix autoclose skipping when start and end are the same character

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2080,7 +2080,9 @@ impl Editor {
                                 ));
                                 continue;
                             }
-                        } else if let Some(region) = autoclose_region {
+                        }
+
+                        if let Some(region) = autoclose_region {
                             // If the selection is followed by an auto-inserted closing bracket,
                             // then don't insert that closing bracket again; just move the selection
                             // past the closing bracket.

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3039,6 +3039,12 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
                     close: false,
                     newline: true,
                 },
+                BracketPair {
+                    start: "\"".to_string(),
+                    end: "\"".to_string(),
+                    close: true,
+                    newline: false,
+                },
             ],
             autoclose_before: "})]".to_string(),
             ..Default::default()
@@ -3159,6 +3165,13 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
     cx.set_state("«aˇ» b");
     cx.update_editor(|view, cx| view.handle_input("{", cx));
     cx.assert_editor_state("{«aˇ»} b");
+
+    // Autclose pair where the start and end characters are the same
+    cx.set_state("aˇ");
+    cx.update_editor(|view, cx| view.handle_input("\"", cx));
+    cx.assert_editor_state("a\"ˇ\"");
+    cx.update_editor(|view, cx| view.handle_input("\"", cx));
+    cx.assert_editor_state("a\"\"ˇ");
 }
 
 #[gpui::test]


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/624