### PR TITLE
WIP: Add some mnemonic bindings and the leader action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "binding_helper"
+version = "0.1.0"
+dependencies = [
+ "collections",
+ "gpui",
+ "itertools",
+ "settings",
+ "smallvec",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7568,6 +7579,7 @@ name = "workspace"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "binding_helper",
  "call",
  "client",
  "collections",

--- a/assets/keymaps/experiments/mnemonic.json
+++ b/assets/keymaps/experiments/mnemonic.json
@@ -1,0 +1,117 @@
+[
+    // Leader Key. The first binding which triggers the mnemonic bindings
+    {
+        "context": "Workspace",
+        "bindings": {
+            "cmd-shift-space": "zed::Leader"
+        }
+    },
+    {
+        "context": "Workspace && vim_mode == normal && vim_operator == none",
+        "bindings": {
+            "space": "zed::Leader"
+        }
+    },
+    // Top Level. All behind <Leader>
+    {
+        "context": "Leader && Workspace",
+        "bindings": {
+            "1": [
+                "workspace::ActivatePane",
+                0
+            ],
+            "2": [
+                "workspace::ActivatePane",
+                1
+            ],
+            "3": [
+                "workspace::ActivatePane",
+                2
+            ],
+            "4": [
+                "workspace::ActivatePane",
+                3
+            ],
+            "5": [
+                "workspace::ActivatePane",
+                4
+            ],
+            "6": [
+                "workspace::ActivatePane",
+                5
+            ],
+            "7": [
+                "workspace::ActivatePane",
+                6
+            ],
+            "8": [
+                "workspace::ActivatePane",
+                7
+            ],
+            "9": [
+                "workspace::ActivatePane",
+                8
+            ],
+            "space": "command_palette::Toggle",
+            "q q": "zed::Quit"
+        }
+    },
+    // File bindings. All behind <Leader> f
+    {
+        "context": "Leader",
+        "bindings": {
+            "f s": "workspace::Save",
+            "f shift-s": "workspace::SaveAs",
+            "f a": "workspace::SaveAll"
+        }
+    },
+    {
+        "context": "Leader && Workspace",
+        "bindings": {
+            "f f": "file_finder::Toggle",
+            "f e k": "zed::OpenKeymap",
+            "f e K": "zed::OpenDefaultKeymap",
+            "f e s": "zed::OpenSettings",
+            "f e S": "zed::OpenDefaultSettings"
+        }
+    },
+    // Window Bindings. All behind <Leader> w
+    {
+        "context": "Leader",
+        "bindings": {
+            "w q": "workspace::CloseWindow",
+            "w =": "zed::IncreaseBufferFontSize",
+            "w -": "zed::DecreaseBufferFontSize",
+            "w 0": "zed::ResetBufferFontSize",
+            "w h": "zed::Hide",
+            "w H": "zed::HideOthers",
+            "w m": "zed::Minimize",
+            "w f": "zed::ToggleFullScreen"
+        }
+    },
+    {
+        "context": "Leader && Pane",
+        "bindings": {
+            "w s left": "pane::SplitLeft",
+            "w s down": "pane::SplitDown",
+            "w s up": "pane::SplitUp",
+            "w s right": "pane::SplitRight",
+            "w y": "pane::SplitLeft",
+            "w u": "pane::SplitDown",
+            "w i": "pane::SplitUp",
+            "w o": "pane::SplitRight"
+        }
+    },
+    // Tab Bindings. All behind <Leader> t
+    {
+        "context": "Leader && Pane",
+        "bindings": {
+            "t n": "pane::ActivateNextItem",
+            "t p": "pane::ActivatePrevItem",
+            "t d": "pane::CloseActiveItem",
+            "t D": "pane::CloseInactiveItems",
+            "t t": "workspace::NewTerminal",
+            "t e": "workspace::NewFile"
+        }
+    }
+]

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,13 +1,7 @@
 [
     {
-        "context": "Editor && VimControl",
+        "context": "!Leader && Editor && VimControl",
         "bindings": {
-            "g": [
-                "vim::PushOperator",
-                {
-                    "Namespace": "G"
-                }
-            ],
             "h": "vim::Left",
             "backspace": "vim::Backspace",
             "j": "vim::Down",
@@ -38,22 +32,6 @@
             ],
             "%": "vim::Matching",
             "escape": "editor::Cancel",
-            "i": [
-                "vim::PushOperator",
-                {
-                    "Object": {
-                        "around": false
-                    }
-                }
-            ],
-            "a": [
-                "vim::PushOperator",
-                {
-                    "Object": {
-                        "around": true
-                    }
-                }
-            ],
             "0": "vim::StartOfLine", // When no number operator present, use start of line motion
             "1": [
                 "vim::Number",
@@ -90,6 +68,34 @@
             "9": [
                 "vim::Number",
                 9
+            ]
+        }
+    },
+    {
+        // Operators
+        "context": "Editor && VimControl && vim_operator == none",
+        "bindings": {
+            "g": [
+                "vim::PushOperator",
+                {
+                    "Namespace": "G"
+                }
+            ],
+            "i": [
+                "vim::PushOperator",
+                {
+                    "Object": {
+                        "around": false
+                    }
+                }
+            ],
+            "a": [
+                "vim::PushOperator",
+                {
+                    "Object": {
+                        "around": true
+                    }
+                }
             ]
         }
     },

--- a/crates/binding_helper/Cargo.toml
+++ b/crates/binding_helper/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "binding_helper"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/binding_helper.rs"
+doctest = false
+
+[dependencies]
+collections = { path = "../collections" }
+gpui = { path = "../gpui" }
+settings = { path = "../settings" }
+smallvec = { version = "1.6", features = ["union"] }
+itertools = "0.10"

--- a/crates/binding_helper/src/binding_helper.rs
+++ b/crates/binding_helper/src/binding_helper.rs
@@ -32,7 +32,7 @@ impl BindingHelper {
                             })
                             .collect();
                     }
-                    MatchResult::Action(action) => {
+                    MatchResult::Match { action, .. } => {
                         if action.namespace() == "zed" && action.name() == "Leader" {
                             this.next_bindings = cx
                                 .available_bindings(cx.window_id(), focused_view)

--- a/crates/binding_helper/src/binding_helper.rs
+++ b/crates/binding_helper/src/binding_helper.rs
@@ -1,0 +1,124 @@
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+use settings::Settings;
+use smallvec::SmallVec;
+
+use gpui::{
+    elements::{Empty, Flex, Label, Overlay, ParentElement},
+    keymap::{Keystroke, MatchResult},
+    Element, Entity, View, ViewContext,
+};
+
+pub struct BindingHelper {
+    next_bindings: BTreeMap<SmallVec<[Keystroke; 2]>, (&'static str, &'static str)>,
+}
+
+impl BindingHelper {
+    pub fn new(cx: &mut ViewContext<Self>) -> Self {
+        cx.observe_keystrokes(|this, _keystroke, result, cx| {
+            if let Some(focused_view) = cx.focused_view_id(cx.window_id()) {
+                match result {
+                    MatchResult::None => this.next_bindings.clear(),
+                    MatchResult::Pending => {
+                        this.next_bindings = cx
+                            .available_bindings(cx.window_id(), focused_view)
+                            .into_iter()
+                            .map(|(keys, binding)| {
+                                (
+                                    keys,
+                                    (binding.action().namespace(), binding.action().name()),
+                                )
+                            })
+                            .collect();
+                    }
+                    MatchResult::Action(action) => {
+                        if action.namespace() == "zed" && action.name() == "Leader" {
+                            this.next_bindings = cx
+                                .available_bindings(cx.window_id(), focused_view)
+                                .into_iter()
+                                .filter(|(_, binding)| {
+                                    binding.context_contains_identifier("Leader")
+                                })
+                                .map(|(keys, binding)| {
+                                    (
+                                        keys,
+                                        (binding.action().namespace(), binding.action().name()),
+                                    )
+                                })
+                                .collect();
+                        } else {
+                            this.next_bindings.clear();
+                        }
+                    }
+                }
+            }
+
+            cx.notify();
+            true
+        })
+        .detach();
+
+        Self {
+            next_bindings: Default::default(),
+        }
+    }
+}
+
+impl Entity for BindingHelper {
+    type Event = ();
+}
+
+impl View for BindingHelper {
+    fn ui_name() -> &'static str {
+        "Binding Helper"
+    }
+
+    fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
+        if self.next_bindings.is_empty() {
+            return Empty::new().boxed();
+        }
+
+        let style = cx.global::<Settings>().theme.context_menu.clone();
+        let next_keys = Flex::row()
+            .with_children(
+                self.next_bindings
+                    .iter()
+                    .chunks(7)
+                    .into_iter()
+                    .map(|chunk| {
+                        Flex::column()
+                            .with_children(chunk.into_iter().map(|(keys, action)| {
+                                let style = style.item.default.clone();
+
+                                Flex::row()
+                                    .with_children(keys.iter().map(|keystroke| {
+                                        Label::new(
+                                            keystroke.to_string(),
+                                            style.keystroke.text.clone(),
+                                        )
+                                        .contained()
+                                        .with_style(style.keystroke.container.clone())
+                                        .boxed()
+                                    }))
+                                    .with_child({
+                                        Label::new(
+                                            format!("{}::{}", action.0, action.1),
+                                            style.label.clone(),
+                                        )
+                                        .contained()
+                                        .boxed()
+                                    })
+                                    .boxed()
+                            }))
+                            .boxed()
+                    }),
+            )
+            .aligned()
+            .bottom()
+            .contained()
+            .boxed();
+
+        Overlay::new(next_keys).boxed()
+    }
+}

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -1262,8 +1262,8 @@ impl View for ContactList {
         "ContactList"
     }
 
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
+    fn keymap_context(&self, cx: &AppContext) -> keymap::Context {
+        let mut cx = Self::default_keymap_context(cx);
         cx.set.insert("menu".into());
         cx
     }

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -75,8 +75,8 @@ impl View for ContextMenu {
         "ContextMenu"
     }
 
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
+    fn keymap_context(&self, cx: &AppContext) -> keymap::Context {
+        let mut cx = Self::default_keymap_context(cx);
         cx.set.insert("menu".into());
         cx
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6461,7 +6461,6 @@ pub enum Event {
     SelectionsChanged { local: bool },
     ScrollPositionChanged { local: bool },
     Closed,
-    IgnoredInput,
 }
 
 pub struct EditorFocused(pub ViewHandle<Editor>);
@@ -6578,8 +6577,8 @@ impl View for Editor {
         false
     }
 
-    fn keymap_context(&self, _: &AppContext) -> gpui::keymap::Context {
-        let mut context = Self::default_keymap_context();
+    fn keymap_context(&self, cx: &AppContext) -> gpui::keymap::Context {
+        let mut context = Self::default_keymap_context(cx);
         let mode = match self.mode {
             EditorMode::SingleLine => "single_line",
             EditorMode::AutoHeight { .. } => "auto_height",
@@ -6645,7 +6644,6 @@ impl View for Editor {
         cx: &mut ViewContext<Self>,
     ) {
         if !self.input_enabled {
-            cx.emit(Event::IgnoredInput);
             return;
         }
 
@@ -6682,7 +6680,6 @@ impl View for Editor {
         cx: &mut ViewContext<Self>,
     ) {
         if !self.input_enabled {
-            cx.emit(Event::IgnoredInput);
             return;
         }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1357,7 +1357,7 @@ impl MutableAppContext {
     ) -> BTreeMap<SmallVec<[Keystroke; 2]>, &Binding> {
         let mut result: BTreeMap<SmallVec<[Keystroke; 2]>, &Binding> = Default::default();
 
-        for parent_view_id in self.parents(window_id, view_id) {
+        for parent_view_id in self.ancestors(window_id, view_id) {
             let keymap_context = self
                 .cx
                 .views

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -110,8 +110,8 @@ impl<D: PickerDelegate> View for Picker<D> {
             .named("picker")
     }
 
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
+    fn keymap_context(&self, cx: &AppContext) -> keymap::Context {
+        let mut cx = Self::default_keymap_context(cx);
         cx.set.insert("menu".into());
         cx
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1152,8 +1152,8 @@ impl View for ProjectPanel {
             .boxed()
     }
 
-    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
-        let mut cx = Self::default_keymap_context();
+    fn keymap_context(&self, cx: &AppContext) -> keymap::Context {
+        let mut cx = Self::default_keymap_context(cx);
         cx.set.insert("menu".into());
         cx
     }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -52,6 +52,7 @@ pub struct Settings {
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct FeatureFlags {
     pub experimental_themes: bool,
+    pub mnemonic_keybindings: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -64,7 +65,13 @@ pub enum ReleaseChannel {
 
 impl FeatureFlags {
     pub fn keymap_files(&self) -> Vec<&'static str> {
-        vec![]
+        let mut experimental_keymaps = Vec::new();
+
+        if self.mnemonic_keybindings {
+            experimental_keymaps.push("keymaps/experiments/mnemonic.json");
+        }
+
+        experimental_keymaps
     }
 }
 

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -387,7 +387,7 @@ impl View for TerminalView {
     }
 
     fn keymap_context(&self, cx: &gpui::AppContext) -> gpui::keymap::Context {
-        let mut context = Self::default_keymap_context();
+        let mut context = Self::default_keymap_context(cx);
         if self.modal {
             context.set.insert("ModalTerminal".into());
         }

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -22,20 +22,9 @@ fn editor_focused(EditorFocused(editor): &EditorFocused, cx: &mut MutableAppCont
         vim.active_editor = Some(editor.downgrade());
         vim.selection_subscription = Some(cx.subscribe(editor, |editor, event, cx| {
             if editor.read(cx).leader_replica_id().is_none() {
-                match event {
-                    editor::Event::SelectionsChanged { local: true } => {
-                        let newest_empty =
-                            editor.read(cx).selections.newest::<usize>(cx).is_empty();
-                        editor_local_selections_changed(newest_empty, cx);
-                    }
-                    editor::Event::IgnoredInput => {
-                        Vim::update(cx, |vim, cx| {
-                            if vim.active_operator().is_some() {
-                                vim.clear_operator(cx);
-                            }
-                        });
-                    }
-                    _ => (),
+                if let editor::Event::SelectionsChanged { local: true } = event {
+                    let newest_empty = editor.read(cx).selections.newest::<usize>(cx).is_empty();
+                    editor_local_selections_changed(newest_empty, cx);
                 }
             }
         }));

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -63,50 +63,52 @@ impl VimState {
         !matches!(self.mode, Mode::Visual { .. })
     }
 
-    pub fn keymap_context_layer(&self) -> Context {
-        let mut context = Context::default();
-        context.map.insert(
-            "vim_mode".to_string(),
-            match self.mode {
-                Mode::Normal => "normal",
-                Mode::Visual { .. } => "visual",
-                Mode::Insert => "insert",
+    pub fn update_global_keymap_context(&self, context: &mut Context, enabled: bool) {
+        if enabled {
+            context.map.insert(
+                "vim_mode".to_string(),
+                match self.mode {
+                    Mode::Normal => "normal",
+                    Mode::Visual { .. } => "visual",
+                    Mode::Insert => "insert",
+                }
+                .to_string(),
+            );
+
+            if self.vim_controlled() {
+                context.set.insert("VimControl".to_string());
+            } else {
+                context.set.remove("VimControl");
             }
-            .to_string(),
-        );
 
-        if self.vim_controlled() {
-            context.set.insert("VimControl".to_string());
+            let active_operator = self.operator_stack.last();
+            if matches!(active_operator, Some(Operator::Object { .. })) {
+                context.set.insert("VimObject".to_string());
+            } else {
+                context.set.remove("VimObject");
+            }
+
+            let operator_context = match active_operator {
+                Some(Operator::Number(_)) => "n",
+                Some(Operator::Namespace(Namespace::G)) => "g",
+                Some(Operator::Object { around: false }) => "i",
+                Some(Operator::Object { around: true }) => "a",
+                Some(Operator::Change) => "c",
+                Some(Operator::Delete) => "d",
+                Some(Operator::Yank) => "y",
+
+                None => "none",
+            }
+            .to_owned();
+
+            context
+                .map
+                .insert("vim_operator".to_string(), operator_context);
+        } else {
+            context.set.remove("VimControl");
+            context.set.remove("VimObject");
+            context.map.remove("vim_mode");
+            context.map.remove("vim_operator");
         }
-
-        let active_operator = self.operator_stack.last();
-        if matches!(active_operator, Some(Operator::Object { .. })) {
-            context.set.insert("VimObject".to_string());
-        }
-
-        Operator::set_context(active_operator, &mut context);
-
-        context
-    }
-}
-
-impl Operator {
-    pub fn set_context(operator: Option<&Operator>, context: &mut Context) {
-        let operator_context = match operator {
-            Some(Operator::Number(_)) => "n",
-            Some(Operator::Namespace(Namespace::G)) => "g",
-            Some(Operator::Object { around: false }) => "i",
-            Some(Operator::Object { around: true }) => "a",
-            Some(Operator::Change) => "c",
-            Some(Operator::Delete) => "d",
-            Some(Operator::Yank) => "y",
-
-            None => "none",
-        }
-        .to_owned();
-
-        context
-            .map
-            .insert("vim_operator".to_string(), operator_context);
     }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -12,7 +12,7 @@ mod visual;
 
 use collections::HashMap;
 use command_palette::CommandPaletteFilter;
-use editor::{Bias, Cancel, CursorShape, Editor};
+use editor::{Bias, Cancel, Editor};
 use gpui::{
     impl_actions, keymap::MatchResult, MutableAppContext, Subscription, ViewContext, WeakViewHandle,
 };

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -18,6 +18,7 @@ test-support = [
 ]
 
 [dependencies]
+binding_helper = { path = "../binding_helper" }
 call = { path = "../call" }
 client = { path = "../client" }
 collections = { path = "../collections" }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -352,7 +352,7 @@ pub fn initialize_workspace(
     if cx.global::<Settings>().experiments.mnemonic_keybindings {
         cx.observe_keystrokes(|_this, _key, result, cx| {
             let clear_leader = match result {
-                MatchResult::Action(action) => {
+                MatchResult::Match { action, .. } => {
                     action.namespace() != "zed" || action.name() != "Leader"
                 }
                 MatchResult::None => true,


### PR DESCRIPTION
## Description of feature or change

Adds a hook to gpui which gives a notification when a key is received with possible actions associated with it
Adds a popover which shows what keys can be pressed next to input an action
Adds a <Leader> key (bound to cmd+shift+space by default) which is used for mnemonic bindings and can be rebound by the user
Adds an experimental set of keybindings which use deeply nested mnemonic keys to expose actions in zed with some structure. For example, file actions are all <Leader> f <Something> and tab related actions are all <Leader> t <Something>

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
