### PR TITLE
Match progress token's prefix to detect disk-based diagnostic progress

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2262,8 +2262,11 @@ impl Project {
             return;
         }
 
-        let is_disk_based_diagnostics_progress =
-            Some(token.as_ref()) == disk_based_diagnostics_progress_token.as_deref();
+        let is_disk_based_diagnostics_progress = disk_based_diagnostics_progress_token
+            .as_ref()
+            .map_or(false, |disk_based_token| {
+                token.starts_with(disk_based_token)
+            });
 
         match progress {
             lsp::WorkDoneProgress::Begin(report) => {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -644,7 +644,9 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     let mut events = subscribe(&project, cx);
 
     let fake_server = fake_servers.next().await.unwrap();
-    fake_server.start_progress(progress_token).await;
+    fake_server
+        .start_progress(format!("{}/0", progress_token))
+        .await;
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsStarted {
@@ -670,7 +672,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
         }
     );
 
-    fake_server.end_progress(progress_token);
+    fake_server.end_progress(format!("{}/0", progress_token));
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsFinished {

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -93,7 +93,7 @@ impl LspAdapter for RustLspAdapter {
     }
 
     async fn disk_based_diagnostics_progress_token(&self) -> Option<String> {
-        Some("rustAnalyzer/cargo check".into())
+        Some("rust-analyzer/checkOnSave".into())
     }
 
     async fn process_diagnostics(&self, params: &mut lsp::PublishDiagnosticsParams) {


### PR DESCRIPTION
Fixes #1807 

The new version of rust-analyzer changed the disk-based diagnostic token to `rust-analyzer/checkOnSave/0`. The trailing number could be different from 0 when there are multiple Rust projects open using the same rust-analyzer instance.

As such, with this pull request we will perform a prefix match as opposed to a strict equality check when detecting a disk-based diagnostics progress token.
