### PR TITLE
Prevent expanded dock from hiding contacts popover

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -247,6 +247,7 @@ impl CollabTitlebarItem {
                 )
                 .with_fit_mode(OverlayFitMode::SwitchAnchor)
                 .with_anchor_corner(AnchorCorner::BottomLeft)
+                .with_z_index(999)
                 .boxed()
             }))
             .boxed()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -791,7 +791,7 @@ impl EditorElement {
         cx.scene.pop_layer();
 
         if let Some((position, context_menu)) = layout.context_menu.as_mut() {
-            cx.scene.push_stacking_context(None);
+            cx.scene.push_stacking_context(None, None);
             let cursor_row_layout =
                 &layout.position_map.line_layouts[(position.row() - start_row) as usize];
             let x = cursor_row_layout.x_for_index(position.column() as usize) - scroll_left;
@@ -820,7 +820,7 @@ impl EditorElement {
         }
 
         if let Some((position, hover_popovers)) = layout.hover_popovers.as_mut() {
-            cx.scene.push_stacking_context(None);
+            cx.scene.push_stacking_context(None, None);
 
             // This is safe because we check on layout whether the required row is available
             let hovered_row_layout =

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -31,7 +31,7 @@ use gpui::{
     text_layout::{self, Line, RunStyle, TextLayoutCache},
     AppContext, Axis, Border, CursorRegion, Element, ElementBox, EventContext, LayoutContext,
     Modifiers, MouseButton, MouseButtonEvent, MouseMovedEvent, MouseRegion, MutableAppContext,
-    PaintContext, Quad, Scene, SizeConstraint, ViewContext, WeakViewHandle,
+    PaintContext, Quad, SceneBuilder, SizeConstraint, ViewContext, WeakViewHandle,
 };
 use json::json;
 use language::{Bias, CursorShape, DiagnosticSeverity, OffsetUtf16, Point, Selection};
@@ -2189,7 +2189,7 @@ pub struct HighlightedRangeLine {
 }
 
 impl HighlightedRange {
-    pub fn paint(&self, bounds: RectF, scene: &mut Scene) {
+    pub fn paint(&self, bounds: RectF, scene: &mut SceneBuilder) {
         if self.lines.len() >= 2 && self.lines[0].start_x > self.lines[1].end_x {
             self.paint_lines(self.start_y, &self.lines[0..1], bounds, scene);
             self.paint_lines(
@@ -2208,7 +2208,7 @@ impl HighlightedRange {
         start_y: f32,
         lines: &[HighlightedRangeLine],
         bounds: RectF,
-        scene: &mut Scene,
+        scene: &mut SceneBuilder,
     ) {
         if lines.is_empty() {
             return;
@@ -2375,7 +2375,7 @@ mod tests {
 
         let mut element = EditorElement::new(editor.downgrade(), editor.read(cx).style(cx));
 
-        let mut scene = Scene::new(1.0);
+        let mut scene = SceneBuilder::new(1.0);
         let mut presenter = cx.build_presenter(window_id, 30., Default::default());
         let mut layout_cx = presenter.build_layout_context(Vector2F::zero(), false, cx);
         let (size, mut state) = element.layout(

--- a/crates/gpui/src/elements/overlay.rs
+++ b/crates/gpui/src/elements/overlay.rs
@@ -16,7 +16,7 @@ pub struct Overlay {
     fit_mode: OverlayFitMode,
     position_mode: OverlayPositionMode,
     hoverable: bool,
-    height: Option<usize>,
+    z_index: Option<usize>,
 }
 
 #[derive(Copy, Clone)]
@@ -83,7 +83,7 @@ impl Overlay {
             fit_mode: OverlayFitMode::None,
             position_mode: OverlayPositionMode::Window,
             hoverable: false,
-            height: None,
+            z_index: None,
         }
     }
 
@@ -112,8 +112,8 @@ impl Overlay {
         self
     }
 
-    pub fn with_height(mut self, height: usize) -> Self {
-        self.height = Some(height);
+    pub fn with_z_index(mut self, z_index: usize) -> Self {
+        self.z_index = Some(z_index);
         self
     }
 }
@@ -211,7 +211,7 @@ impl Element for Overlay {
             OverlayFitMode::None => {}
         }
 
-        cx.paint_stacking_context(None, self.height, |cx| {
+        cx.paint_stacking_context(None, self.z_index, |cx| {
             if self.hoverable {
                 enum OverlayHoverCapture {}
                 // Block hovers in lower stacking contexts

--- a/crates/gpui/src/elements/overlay.rs
+++ b/crates/gpui/src/elements/overlay.rs
@@ -16,6 +16,7 @@ pub struct Overlay {
     fit_mode: OverlayFitMode,
     position_mode: OverlayPositionMode,
     hoverable: bool,
+    height: Option<usize>,
 }
 
 #[derive(Copy, Clone)]
@@ -82,6 +83,7 @@ impl Overlay {
             fit_mode: OverlayFitMode::None,
             position_mode: OverlayPositionMode::Window,
             hoverable: false,
+            height: None,
         }
     }
 
@@ -107,6 +109,11 @@ impl Overlay {
 
     pub fn with_hoverable(mut self, hoverable: bool) -> Self {
         self.hoverable = hoverable;
+        self
+    }
+
+    pub fn with_height(mut self, height: usize) -> Self {
+        self.height = Some(height);
         self
     }
 }
@@ -204,7 +211,7 @@ impl Element for Overlay {
             OverlayFitMode::None => {}
         }
 
-        cx.paint_stacking_context(None, |cx| {
+        cx.paint_stacking_context(None, self.height, |cx| {
             if self.hoverable {
                 enum OverlayHoverCapture {}
                 // Block hovers in lower stacking contexts

--- a/crates/gpui/src/elements/resizable.rs
+++ b/crates/gpui/src/elements/resizable.rs
@@ -149,7 +149,7 @@ impl Element for Resizable {
         _child_size: &mut Self::LayoutState,
         cx: &mut crate::PaintContext,
     ) -> Self::PaintState {
-        cx.scene.push_stacking_context(None);
+        cx.scene.push_stacking_context(None, None);
 
         let handle_region = self.side.of_rect(bounds, self.handle_size);
 

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -16,7 +16,7 @@ pub mod fonts;
 pub mod geometry;
 mod presenter;
 pub mod scene;
-pub use scene::{Border, CursorRegion, MouseRegion, MouseRegionId, Quad, Scene};
+pub use scene::{Border, CursorRegion, MouseRegion, MouseRegionId, Quad, Scene, SceneBuilder};
 pub mod text_layout;
 pub use text_layout::TextLayoutCache;
 mod util;

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -360,14 +360,14 @@ impl Presenter {
         for mut mouse_event in mouse_events {
             let mut valid_regions = Vec::new();
 
-            // GPUI elements are arranged by depth but sibling elements can register overlapping
+            // GPUI elements are arranged by height but sibling elements can register overlapping
             // mouse regions. As such, hover events are only fired on overlapping elements which
-            // are at the same depth as the topmost element which overlaps with the mouse.
+            // are at the same height as the topmost element which overlaps with the mouse.
             match &mouse_event {
                 MouseEvent::Hover(_) => {
-                    let mut top_most_depth = None;
+                    let mut top_most_height = None;
                     let mouse_position = self.mouse_position.clone();
-                    for (region, depth) in self.mouse_regions.iter().rev() {
+                    for (region, height) in self.mouse_regions.iter().rev() {
                         // Allow mouse regions to appear transparent to hovers
                         if !region.hoverable {
                             continue;
@@ -375,15 +375,15 @@ impl Presenter {
 
                         let contains_mouse = region.bounds.contains_point(mouse_position);
 
-                        if contains_mouse && top_most_depth.is_none() {
-                            top_most_depth = Some(depth);
+                        if contains_mouse && top_most_height.is_none() {
+                            top_most_height = Some(height);
                         }
 
                         // This unwrap relies on short circuiting boolean expressions
                         // The right side of the && is only executed when contains_mouse
                         // is true, and we know above that when contains_mouse is true
-                        // top_most_depth is set
-                        if contains_mouse && depth == top_most_depth.unwrap() {
+                        // top_most_height is set
+                        if contains_mouse && height == top_most_height.unwrap() {
                             //Ensure that hover entrance events aren't sent twice
                             if self.hovered_region_ids.insert(region.id()) {
                                 valid_regions.push(region.clone());

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -360,14 +360,14 @@ impl Presenter {
         for mut mouse_event in mouse_events {
             let mut valid_regions = Vec::new();
 
-            // GPUI elements are arranged by height but sibling elements can register overlapping
+            // GPUI elements are arranged by z_index but sibling elements can register overlapping
             // mouse regions. As such, hover events are only fired on overlapping elements which
-            // are at the same height as the topmost element which overlaps with the mouse.
+            // are at the same z-index as the topmost element which overlaps with the mouse.
             match &mouse_event {
                 MouseEvent::Hover(_) => {
-                    let mut top_most_height = None;
+                    let mut highest_z_index = None;
                     let mouse_position = self.mouse_position.clone();
-                    for (region, height) in self.mouse_regions.iter().rev() {
+                    for (region, z_index) in self.mouse_regions.iter().rev() {
                         // Allow mouse regions to appear transparent to hovers
                         if !region.hoverable {
                             continue;
@@ -375,15 +375,15 @@ impl Presenter {
 
                         let contains_mouse = region.bounds.contains_point(mouse_position);
 
-                        if contains_mouse && top_most_height.is_none() {
-                            top_most_height = Some(height);
+                        if contains_mouse && highest_z_index.is_none() {
+                            highest_z_index = Some(z_index);
                         }
 
                         // This unwrap relies on short circuiting boolean expressions
                         // The right side of the && is only executed when contains_mouse
                         // is true, and we know above that when contains_mouse is true
-                        // top_most_height is set
-                        if contains_mouse && height == top_most_height.unwrap() {
+                        // highest_z_index is set.
+                        if contains_mouse && z_index == highest_z_index.unwrap() {
                             //Ensure that hover entrance events aren't sent twice
                             if self.hovered_region_ids.insert(region.id()) {
                                 valid_regions.push(region.clone());
@@ -712,12 +712,12 @@ impl<'a> PaintContext<'a> {
     pub fn paint_stacking_context<F>(
         &mut self,
         clip_bounds: Option<RectF>,
-        height: Option<usize>,
+        z_index: Option<usize>,
         f: F,
     ) where
         F: FnOnce(&mut Self),
     {
-        self.scene.push_stacking_context(clip_bounds, height);
+        self.scene.push_stacking_context(clip_bounds, z_index);
         f(self);
         self.scene.pop_stacking_context();
     }

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -709,11 +709,15 @@ impl<'a> PaintContext<'a> {
     }
 
     #[inline]
-    pub fn paint_stacking_context<F>(&mut self, clip_bounds: Option<RectF>, f: F)
-    where
+    pub fn paint_stacking_context<F>(
+        &mut self,
+        clip_bounds: Option<RectF>,
+        height: Option<usize>,
+        f: F,
+    ) where
         F: FnOnce(&mut Self),
     {
-        self.scene.push_stacking_context(clip_bounds);
+        self.scene.push_stacking_context(clip_bounds, height);
         f(self);
         self.scene.pop_stacking_context();
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -29,7 +29,7 @@ pub struct SceneBuilder {
 struct StackingContext {
     layers: Vec<Layer>,
     active_layer_stack: Vec<usize>,
-    depth: usize,
+    height: usize,
 }
 
 #[derive(Default)]
@@ -205,7 +205,7 @@ impl Scene {
                     .layers
                     .iter()
                     .flat_map(|layer| &layer.mouse_regions)
-                    .map(|region| (region.clone(), context.depth))
+                    .map(|region| (region.clone(), context.height))
             })
             .collect()
     }
@@ -224,7 +224,7 @@ impl SceneBuilder {
     }
 
     pub fn build(mut self) -> Scene {
-        self.stacking_contexts.sort_by_key(|context| context.depth);
+        self.stacking_contexts.sort_by_key(|context| context.height);
         Scene {
             scale_factor: self.scale_factor,
             stacking_contexts: self.stacking_contexts,
@@ -236,11 +236,11 @@ impl SceneBuilder {
     }
 
     pub fn push_stacking_context(&mut self, clip_bounds: Option<RectF>) {
-        let depth = self.active_stacking_context().depth + 1;
+        let height = self.active_stacking_context().height + 1;
         self.active_stacking_context_stack
             .push(self.stacking_contexts.len());
         self.stacking_contexts
-            .push(StackingContext::new(depth, clip_bounds))
+            .push(StackingContext::new(height, clip_bounds))
     }
 
     pub fn pop_stacking_context(&mut self) {
@@ -332,11 +332,11 @@ impl SceneBuilder {
 }
 
 impl StackingContext {
-    fn new(depth: usize, clip_bounds: Option<RectF>) -> Self {
+    fn new(height: usize, clip_bounds: Option<RectF>) -> Self {
         Self {
             layers: vec![Layer::new(clip_bounds)],
             active_layer_stack: vec![0],
-            depth,
+            height,
         }
     }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -235,8 +235,8 @@ impl SceneBuilder {
         self.scale_factor
     }
 
-    pub fn push_stacking_context(&mut self, clip_bounds: Option<RectF>) {
-        let height = self.active_stacking_context().height + 1;
+    pub fn push_stacking_context(&mut self, clip_bounds: Option<RectF>, height: Option<usize>) {
+        let height = height.unwrap_or_else(|| self.active_stacking_context().height + 1);
         self.active_stacking_context_stack
             .push(self.stacking_contexts.len());
         self.stacking_contexts

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -26,6 +26,11 @@ pub struct SceneBuilder {
     mouse_region_ids: HashSet<MouseRegionId>,
 }
 
+pub struct Scene {
+    scale_factor: f32,
+    stacking_contexts: Vec<StackingContext>,
+}
+
 struct StackingContext {
     layers: Vec<Layer>,
     active_layer_stack: Vec<usize>,
@@ -174,11 +179,6 @@ pub struct Image {
     pub corner_radius: f32,
     pub grayscale: bool,
     pub data: Arc<ImageData>,
-}
-
-pub struct Scene {
-    scale_factor: f32,
-    stacking_contexts: Vec<StackingContext>,
 }
 
 impl Scene {

--- a/crates/workspace/src/pane/dragged_item_receiver.rs
+++ b/crates/workspace/src/pane/dragged_item_receiver.rs
@@ -48,7 +48,7 @@ where
                             .map(|(dir, margin)| dir.along_edge(bounds, margin))
                             .unwrap_or(bounds);
 
-                        cx.paint_stacking_context(None, |cx| {
+                        cx.paint_stacking_context(None, None, |cx| {
                             cx.scene.push_quad(Quad {
                                 bounds: overlay_region,
                                 background: Some(overlay_color(cx)),


### PR DESCRIPTION
Fixes #1795 

This pull request introduces the ability to supply a custom `z-index` when pushing stacking contexts. This was needed to allow elements such as the contacts popover to be painted on top of e.g. the expanded dock, even when the dock was _temporally_ painted after the popover.

To achieve this, I extracted `SceneBuilder`: this new struct will sort the stacking contexts by their `z-index` when calling `SceneBuilder::build` and return a `Scene` struct as before.

@Kethku @nathansobo: this shouldn't affect the mouse region stuff y'all worked on, but I did touch some of those code paths and so I'd love to get your input in case I missed anything there.