### PR TITLE
Fix duplicate key error that occurs when a user joins that is already in the db

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -567,6 +567,10 @@ impl Db for PostgresDb {
             (email_address, github_login, github_user_id, admin, invite_count, invite_code)
             VALUES
             ($1, $2, $3, 'f', $4, $5)
+            ON CONFLICT (github_login) DO UPDATE SET
+                email_address = excluded.email_address,
+                github_user_id = excluded.github_user_id,
+                admin = excluded.admin
             RETURNING id, metrics_id::text
             ",
         )
@@ -616,6 +620,7 @@ impl Db for PostgresDb {
                     (user_id_a, user_id_b, a_to_b, should_notify, accepted)
                 VALUES
                     ($1, $2, 't', 't', 't')
+                ON CONFLICT DO NOTHING
                 ",
             )
             .bind(inviting_user_id)


### PR DESCRIPTION
## Description of feature or change

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
