### PR TITLE
Propagate mouse move event through dragged-item-receiver if not dragging

### DIFF
--- a/crates/workspace/src/pane/dragged_item_receiver.rs
+++ b/crates/workspace/src/pane/dragged_item_receiver.rs
@@ -76,6 +76,8 @@ where
             .is_some()
         {
             cx.notify();
+        } else {
+            cx.propagate_event();
         }
     })
 }


### PR DESCRIPTION
## Description of feature or change

Fixes an issue introduced with the tab dragging changes that prevented editor hover and other mouse move related stuff from working

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
