### PR TITLE
Don't bundle the app on CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on:
       - self-hosted
       - bundle
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: tests
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
       MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
Bundling the app takes a very long time, and for most PRs, it doesn't catch any problems that aren't already caught by the `tests` job. I think it might be worth the tradeoff to just do it when changes land on `main` and of course for release builds.

I also added a serialization step so that we won't even bother with the bundling if the tests don't pass. This seems like it will reduce contention on the bundling runner, since the tests are much faster than bundling.