### PR TITLE
Reduce Cursor Blink CPU Load

### DIFF
--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -97,7 +97,7 @@ impl BlinkManager {
         self.blink_cursors(self.blink_epoch, cx);
     }
 
-    pub fn disable(&mut self, cx: &mut ModelContext<Self>) {
+    pub fn disable(&mut self, _cx: &mut ModelContext<Self>) {
         self.enabled = false;
     }
 

--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -30,7 +30,7 @@ impl BlinkManager {
             blink_epoch: 0,
             blinking_paused: false,
             visible: true,
-            enabled: true,
+            enabled: false,
         }
     }
 
@@ -71,6 +71,7 @@ impl BlinkManager {
             if epoch == self.blink_epoch && self.enabled && !self.blinking_paused {
                 self.visible = !self.visible;
                 cx.notify();
+                dbg!(cx.handle());
 
                 let epoch = self.next_blink_epoch();
                 let interval = self.blink_interval;
@@ -96,8 +97,8 @@ impl BlinkManager {
         self.blink_cursors(self.blink_epoch, cx);
     }
 
-    pub fn disable(&mut self, _: &mut ModelContext<Self>) {
-        self.enabled = true;
+    pub fn disable(&mut self, cx: &mut ModelContext<Self>) {
+        self.enabled = false;
     }
 
     pub fn visible(&self) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6511,8 +6511,10 @@ impl View for Editor {
         if let Some(rename) = self.pending_rename.as_ref() {
             cx.focus(&rename.editor);
         } else {
+            if !self.focused {
+                self.blink_manager.update(cx, BlinkManager::enable);
+            }
             self.focused = true;
-            self.blink_manager.update(cx, BlinkManager::enable);
             self.buffer.update(cx, |buffer, cx| {
                 buffer.finalize_last_transaction(cx);
                 if self.leader_replica_id.is_none() {


### PR DESCRIPTION
## Description of feature or change

Before this change, non visible editors (such as the rename editor) would have cursor blink notifications queued. This meant that as the number of splits went up, the zed would get slower.

This fixes that issue along with a typo preventing editors from properly disabling their cursor blinks when not focused.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
