### PR TITLE
Do not announce preview releases to discord channel

### DIFF
--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -1,7 +1,9 @@
 on:
   release:
     types: [published]
-
+  tags:
+    "!**-pre"
+    
 jobs:
   discord_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of feature or change

This has a side effect of not sending Amplitude information about preview releases.  I considered splitting the workflow file up into two files, so I could still allow preview release info to be sent to amplitude and skip preview releases from being announced in Discord, but since we are going to be removing Amplitude in the near future (probably after we get a few weeks of data in mixpanel), I figure its ok to skip.

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
