### PR TITLE
Upgraded migration library to remove panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,8 +4839,7 @@ dependencies = [
 [[package]]
 name = "rusqlite_migration"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda44233be97aea786691f9f6f7ef230bcf905061f4012e90f4f39e6dcf31163"
+source = "git+https://github.com/cljoly/rusqlite_migration?rev=c433555d7c1b41b103426e35756eb3144d0ebbc6#c433555d7c1b41b103426e35756eb3144d0ebbc6"
 dependencies = [
  "log",
  "rusqlite",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 parking_lot = "0.11.1"
 rusqlite = { version = "0.28.0", features = ["bundled", "serde_json"] }
-rusqlite_migration = "1.0.0"
+rusqlite_migration = { git = "https://github.com/cljoly/rusqlite_migration", rev = "c433555d7c1b41b103426e35756eb3144d0ebbc6" }
 serde = { workspace = true }
 serde_rusqlite = "0.31.0"
 


### PR DESCRIPTION
## Description of feature or change

There is currently a panic when developing database migrations locally and then switching to an unmigrated branch. This suppresses that panic.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
