### PR TITLE
Added channel to database directories

### DIFF
--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -25,9 +25,9 @@ pub struct RealDb {
 
 impl Db {
     /// Open or create a database at the given directory path.
-    pub fn open(db_dir: &Path) -> Self {
+    pub fn open(db_dir: &Path, channel: &'static str) -> Self {
         // Use 0 for now. Will implement incrementing and clearing of old db files soon TM
-        let current_db_dir = db_dir.join(Path::new("0"));
+        let current_db_dir = db_dir.join(Path::new(&format!("0-{}", channel)));
         fs::create_dir_all(&current_db_dir)
             .expect("Should be able to create the database directory");
         let db_path = current_db_dir.join(Path::new("db.sqlite"));

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -39,7 +39,10 @@ use settings::watched_json::{watch_keymap_file, watch_settings_file, WatchedJson
 use theme::ThemeRegistry;
 use util::{ResultExt, TryFutureExt};
 use workspace::{self, AppState, ItemHandle, NewFile, OpenPaths, Workspace};
-use zed::{self, build_window_options, initialize_workspace, languages, menus, RELEASE_CHANNEL};
+use zed::{
+    self, build_window_options, initialize_workspace, languages, menus, RELEASE_CHANNEL,
+    RELEASE_CHANNEL_NAME,
+};
 
 fn main() {
     let http = http::client();
@@ -52,9 +55,10 @@ fn main() {
         .or_else(|| app.platform().app_version().ok())
         .map_or("dev".to_string(), |v| v.to_string());
     init_panic_hook(app_version, http.clone(), app.background());
-    let db = app
-        .background()
-        .spawn(async move { project::Db::open(&*zed::paths::DB_DIR) });
+
+    let db = app.background().spawn(async move {
+        project::Db::open(&*zed::paths::DB_DIR, RELEASE_CHANNEL_NAME.as_str())
+    });
 
     load_embedded_fonts(&app);
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -71,7 +71,7 @@ actions!(
 const MIN_FONT_SIZE: f32 = 6.0;
 
 lazy_static! {
-    static ref RELEASE_CHANNEL_NAME: String =
+    pub static ref RELEASE_CHANNEL_NAME: String =
         env::var("ZED_RELEASE_CHANNEL").unwrap_or(include_str!("../RELEASE_CHANNEL").to_string());
     pub static ref RELEASE_CHANNEL: ReleaseChannel = match RELEASE_CHANNEL_NAME.as_str() {
         "dev" => ReleaseChannel::Dev,


### PR DESCRIPTION
## Description of feature or change

After the previous PR, I realized that we still have issues with clobbering a whole database when moving between channels. This adds a channel tag to the DB file structure so that we can mess around without destroying the global data.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
