### PR TITLE
Don't use 'on' background color for projects in the contact list

### DIFF
--- a/styles/src/styleTree/contactList.ts
+++ b/styles/src/styleTree/contactList.ts
@@ -63,7 +63,7 @@ export default function contactsPanel(colorScheme: ColorScheme) {
         top: 4,
       },
       margin: {
-        left: 6
+        left: 6,
       },
     },
     userQueryEditorHeight: 33,
@@ -151,7 +151,7 @@ export default function contactsPanel(colorScheme: ColorScheme) {
       color: foreground(layer, "on"),
     },
     callingIndicator: {
-      ...text(layer, "mono", "variant", { size: "xs" })
+      ...text(layer, "mono", "variant", { size: "xs" }),
     },
     treeBranch: {
       color: borderColor(layer),
@@ -165,7 +165,7 @@ export default function contactsPanel(colorScheme: ColorScheme) {
     },
     projectRow: {
       ...projectRow,
-      background: background(layer, "on"),
+      background: background(layer),
       icon: {
         margin: { left: nameMargin },
         color: foreground(layer, "variant"),
@@ -176,11 +176,11 @@ export default function contactsPanel(colorScheme: ColorScheme) {
         ...text(layer, "mono", { size: "sm" }),
       },
       hover: {
-        background: background(layer, "on", "hovered"),
+        background: background(layer, "hovered"),
       },
       active: {
-        background: background(layer, "on", "active"),
+        background: background(layer, "active"),
       },
     },
-  }
+  };
 }


### PR DESCRIPTION
This PR changes the background color of participants' projects in the contacts panel.

Previously, all projects had a distinct background color from the outer list. But when hovered, the background color would change to match the outer list:
![Screen Shot 2022-10-31 at 12 32 18 PM](https://user-images.githubusercontent.com/326587/199094080-684132f7-e499-4a1d-b65f-dad416441ba8.png)

Now, the projects normally have the same background color as the list, but when you hover them, they are highlighted.

![Screen Shot 2022-10-31 at 12 31 51 PM](https://user-images.githubusercontent.com/326587/199094063-f5b23af3-f7f4-4798-bbe5-e3cbe9124be6.png)
