### PR TITLE
Generate themes before compiling the 'assets' crate

### DIFF
--- a/crates/assets/build.rs
+++ b/crates/assets/build.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("npm")
+        .current_dir("../../styles")
+        .args(["install", "--no-save"])
+        .output()
+        .expect("failed to run npm");
+    if !output.status.success() {
+        panic!(
+            "failed to install theme dependencies {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = Command::new("npm")
+        .current_dir("../../styles")
+        .args(["run", "build"])
+        .output()
+        .expect("failed to run npm");
+    if !output.status.success() {
+        panic!(
+            "build script failed {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    println!("cargo:rerun-if-changed=../../styles/src");
+}

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -1,5 +1,3 @@
-use std::process::Command;
-
 fn main() {
     println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.15.7");
 
@@ -26,30 +24,4 @@ fn main() {
 
     // Register exported Objective-C selectors, protocols, etc
     println!("cargo:rustc-link-arg=-Wl,-ObjC");
-
-    let output = Command::new("npm")
-        .current_dir("../../styles")
-        .args(["install", "--no-save"])
-        .output()
-        .expect("failed to run npm");
-    if !output.status.success() {
-        panic!(
-            "failed to install theme dependencies {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let output = Command::new("npm")
-        .current_dir("../../styles")
-        .args(["run", "build"])
-        .output()
-        .expect("failed to run npm");
-    if !output.status.success() {
-        panic!(
-            "build script failed {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    println!("cargo:rerun-if-changed=../../styles/src");
 }


### PR DESCRIPTION
I believe this fixes an intermittent compile error that we have been seeing in CI, when compiling the app in release mode.

Examples:
* https://github.com/zed-industries/zed/actions/runs/3364376307/jobs/5578721035
* https://github.com/zed-industries/zed/actions/runs/3363673136/jobs/5577122241

I think the issue was that the `zed` crate's build script was running *while* the `assets` crate was being compiled. But the `zed` crate's build script *wrote* to the `assets/themes` directory (generating the theme JSON files from their TypeScript sources).

My fix is to  move that theme-generation logic out of the `zed.rs` build script and into a separate build script in the `assets` crate.