### PR TITLE
Re-add Abruzzo theme to experimental themes

### DIFF
--- a/styles/src/themes/experiments/abruzzo.ts
+++ b/styles/src/themes/experiments/abruzzo.ts
@@ -1,0 +1,31 @@
+import chroma from "chroma-js";
+import { colorRamp, createColorScheme } from "../common/ramps";
+
+const name = "Abruzzo";
+const author = "slightknack <hey@isaac.sh>";
+const url = "https://github.com/slightknack";
+const license = {
+  type: "",
+  url: ""
+}
+
+export const dark = createColorScheme(`${name}`, false, {
+  neutral: chroma.scale([
+    "#1b0d05",
+    "#2c1e18",
+    "#654035",
+    "#9d5e4a",
+    "#b37354",
+    "#c1825a",
+    "#dda66e",
+    "#fbf3e2",
+  ]),
+  red: colorRamp(chroma("#e594c4")),
+  orange: colorRamp(chroma("#d9e87e")),
+  yellow: colorRamp(chroma("#fd9d83")),
+  green: colorRamp(chroma("#96adf7")),
+  cyan: colorRamp(chroma("#fc798f")),
+  blue: colorRamp(chroma("#BCD0F5")),
+  violet: colorRamp(chroma("#dac5eb")),
+  magenta: colorRamp(chroma("#c1a3ef")),
+});


### PR DESCRIPTION
## Description of feature or change

Abruzzo was removed during the elevations work. For the moment we'll re-add it in `/experimental` so that people can continue to use it for now until we choose a list of themes to continue with.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
