### PR TITLE
Bump tree-sitter-rust for let-else, let-chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6493,9 +6493,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13470fafb7327a3acf96f5bc1013b5539a899a182f01c59b5af53f6b93195717"
+checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -97,7 +97,7 @@ tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev 
 tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "05e3631c6a0701c1fa518b0fee7be95a2ceef5e2" }
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
-tree-sitter-rust = "0.20.1"
+tree-sitter-rust = "0.20.3"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 tree-sitter-python = "0.20.2"
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }

--- a/crates/zed/src/languages/rust/indents.scm
+++ b/crates/zed/src/languages/rust/indents.scm
@@ -4,6 +4,7 @@
     (call_expression)
     (assignment_expression)
     (let_declaration)
+    (let_chain)
 ] @indent
 
 (_ "[" "]" @end) @indent


### PR DESCRIPTION
Rust 1.65 came out today and stabilized let-else. This PR upgrades Tree-sitter-rust to a version that has [these](https://github.com/tree-sitter/tree-sitter-rust/pull/162) [PRs](https://github.com/tree-sitter/tree-sitter-rust/pull/152), which add support for let-else, and for let-chains, respectively.