### PR TITLE
Added more autoscroll behaviors

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -75,7 +75,7 @@
             "ctrl-n": "editor::MoveDown",
             "ctrl-b": "editor::MoveLeft",
             "ctrl-f": "editor::MoveRight",
-            "ctrl-l": "editor::CenterScreen",
+            "ctrl-l": "editor::NextScreen",
             "alt-left": "editor::MoveToPreviousWordStart",
             "alt-b": "editor::MoveToPreviousWordStart",
             "alt-right": "editor::MoveToNextWordEnd",

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -452,7 +452,7 @@ impl ProjectDiagnosticsEditor {
             } else {
                 groups = self.path_states.get(path_ix)?.diagnostic_groups.as_slice();
                 new_excerpt_ids_by_selection_id =
-                    editor.change_selections(Some(Autoscroll::Fit), cx, |s| s.refresh());
+                    editor.change_selections(Some(Autoscroll::fit()), cx, |s| s.refresh());
                 selections = editor.selections.all::<usize>(cx);
             }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -408,23 +408,42 @@ pub enum SelectMode {
     All,
 }
 
-#[derive(PartialEq, Eq, Default)]
+#[derive(PartialEq, Eq)]
 pub enum Autoscroll {
+    Next,
+    Strategy(AutoscrollStrategy),
+}
+
+impl Autoscroll {
+    pub fn fit() -> Self {
+        Self::Strategy(AutoscrollStrategy::Fit)
+    }
+
+    pub fn newest() -> Self {
+        Self::Strategy(AutoscrollStrategy::Newest)
+    }
+
+    pub fn center() -> Self {
+        Self::Strategy(AutoscrollStrategy::Center)
+    }
+}
+
+#[derive(PartialEq, Eq, Default)]
+pub enum AutoscrollStrategy {
     Fit,
     Newest,
     #[default]
     Center,
     Top,
     Bottom,
-    Next,
 }
 
-impl Autoscroll {
+impl AutoscrollStrategy {
     fn next(&self) -> Self {
         match self {
-            Autoscroll::Center => Autoscroll::Top,
-            Autoscroll::Top => Autoscroll::Bottom,
-            _ => Autoscroll::Center,
+            AutoscrollStrategy::Center => AutoscrollStrategy::Top,
+            AutoscrollStrategy::Top => AutoscrollStrategy::Bottom,
+            _ => AutoscrollStrategy::Center,
         }
     }
 }
@@ -568,7 +587,7 @@ pub struct Editor {
     hover_state: HoverState,
     link_go_to_definition_state: LinkGoToDefinitionState,
     visible_line_count: Option<f32>,
-    last_autoscroll: Option<(Vector2F, f32, f32, Autoscroll)>,
+    last_autoscroll: Option<(Vector2F, f32, f32, AutoscrollStrategy)>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -1441,7 +1460,7 @@ impl Editor {
             self.set_scroll_position(scroll_position, cx);
         }
 
-        let (mut autoscroll, local) = if let Some(autoscroll) = self.autoscroll_request.take() {
+        let (autoscroll, local) = if let Some(autoscroll) = self.autoscroll_request.take() {
             autoscroll
         } else {
             return false;
@@ -1452,7 +1471,7 @@ impl Editor {
         if let Some(highlighted_rows) = &self.highlighted_rows {
             first_cursor_top = highlighted_rows.start as f32;
             last_cursor_bottom = first_cursor_top + 1.;
-        } else if autoscroll == Autoscroll::Newest {
+        } else if autoscroll == Autoscroll::newest() {
             let newest_selection = self.selections.newest::<Point>(cx);
             first_cursor_top = newest_selection.head().to_display_point(&display_map).row() as f32;
             last_cursor_bottom = first_cursor_top + 1.;
@@ -1482,24 +1501,27 @@ impl Editor {
             return false;
         }
 
-        if matches!(autoscroll, Autoscroll::Next) {
-            let last_autoscroll = &self.last_autoscroll;
-            autoscroll = if let Some(last_autoscroll) = last_autoscroll {
-                if self.scroll_position == last_autoscroll.0
-                    && first_cursor_top == last_autoscroll.1
-                    && last_cursor_bottom == last_autoscroll.2
-                {
-                    last_autoscroll.3.next()
+        let strategy = match autoscroll {
+            Autoscroll::Strategy(strategy) => strategy,
+            Autoscroll::Next => {
+                let last_autoscroll = &self.last_autoscroll;
+                if let Some(last_autoscroll) = last_autoscroll {
+                    if self.scroll_position == last_autoscroll.0
+                        && first_cursor_top == last_autoscroll.1
+                        && last_cursor_bottom == last_autoscroll.2
+                    {
+                        last_autoscroll.3.next()
+                    } else {
+                        AutoscrollStrategy::default()
+                    }
                 } else {
-                    Autoscroll::default()
+                    AutoscrollStrategy::default()
                 }
-            } else {
-                Autoscroll::default()
             }
-        }
+        };
 
-        match autoscroll {
-            Autoscroll::Fit | Autoscroll::Newest => {
+        match strategy {
+            AutoscrollStrategy::Fit | AutoscrollStrategy::Newest => {
                 let margin = margin.min(self.vertical_scroll_margin);
                 let target_top = (first_cursor_top - margin).max(0.0);
                 let target_bottom = last_cursor_bottom + margin;
@@ -1514,18 +1536,15 @@ impl Editor {
                     self.set_scroll_position_internal(scroll_position, local, cx);
                 }
             }
-            Autoscroll::Center => {
+            AutoscrollStrategy::Center => {
                 scroll_position.set_y((first_cursor_top - margin).max(0.0));
                 self.set_scroll_position_internal(scroll_position, local, cx);
             }
-            Autoscroll::Next => {
-                unreachable!("This should be handled above")
-            }
-            Autoscroll::Top => {
+            AutoscrollStrategy::Top => {
                 scroll_position.set_y((first_cursor_top).max(0.0));
                 self.set_scroll_position_internal(scroll_position, local, cx);
             }
-            Autoscroll::Bottom => {
+            AutoscrollStrategy::Bottom => {
                 scroll_position.set_y((last_cursor_bottom - visible_lines).max(0.0));
                 self.set_scroll_position_internal(scroll_position, local, cx);
             }
@@ -1535,7 +1554,7 @@ impl Editor {
             self.scroll_position,
             first_cursor_top,
             last_cursor_bottom,
-            autoscroll,
+            strategy,
         ));
 
         true
@@ -1785,7 +1804,7 @@ impl Editor {
             _ => {}
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.set_pending(pending_selection, pending_mode)
         });
     }
@@ -1846,7 +1865,7 @@ impl Editor {
             }
         }
 
-        self.change_selections(auto_scroll.then(|| Autoscroll::Newest), cx, |s| {
+        self.change_selections(auto_scroll.then(|| Autoscroll::newest()), cx, |s| {
             if !add {
                 s.clear_disjoint();
             } else if click_count > 1 {
@@ -2063,7 +2082,7 @@ impl Editor {
                 return;
             }
 
-            if self.change_selections(Some(Autoscroll::Fit), cx, |s| s.try_cancel()) {
+            if self.change_selections(Some(Autoscroll::fit()), cx, |s| s.try_cancel()) {
                 return;
             }
         }
@@ -2229,7 +2248,7 @@ impl Editor {
             }
 
             drop(snapshot);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(new_selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(new_selections));
             this.trigger_completion_on_input(&text, cx);
         });
     }
@@ -2309,7 +2328,7 @@ impl Editor {
                 })
                 .collect();
 
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(new_selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(new_selections));
         });
     }
 
@@ -2339,7 +2358,7 @@ impl Editor {
         self.transact(cx, |editor, cx| {
             editor.edit_with_autoindent(edits, cx);
 
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 let mut index = 0;
                 s.move_cursors_with(|map, _, _| {
                     let row = rows[index];
@@ -2380,7 +2399,7 @@ impl Editor {
                 anchors
             });
 
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select_anchors(selection_anchors);
             })
         });
@@ -3076,7 +3095,7 @@ impl Editor {
         });
 
         if let Some(tabstop) = tabstops.first() {
-            self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            self.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select_ranges(tabstop.iter().cloned());
             });
             self.snippet_stack.push(SnippetState {
@@ -3117,7 +3136,7 @@ impl Editor {
                 }
             }
             if let Some(current_ranges) = snippet.ranges.get(snippet.active_index) {
-                self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                self.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.select_anchor_ranges(current_ranges.iter().cloned())
                 });
                 // If snippet state is not at the last tabstop, push it back on the stack
@@ -3182,14 +3201,14 @@ impl Editor {
                 }
             }
 
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(selections));
             this.insert("", cx);
         });
     }
 
     pub fn delete(&mut self, _: &Delete, cx: &mut ViewContext<Self>) {
         self.transact(cx, |this, cx| {
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 let line_mode = s.line_mode;
                 s.move_with(|map, selection| {
                     if selection.is_empty() && !line_mode {
@@ -3283,7 +3302,7 @@ impl Editor {
 
         self.transact(cx, |this, cx| {
             this.buffer.update(cx, |b, cx| b.edit(edits, None, cx));
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(selections))
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(selections))
         });
     }
 
@@ -3306,7 +3325,7 @@ impl Editor {
 
         self.transact(cx, |this, cx| {
             this.buffer.update(cx, |b, cx| b.edit(edits, None, cx));
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(selections));
         });
     }
 
@@ -3438,7 +3457,7 @@ impl Editor {
                 );
             });
             let selections = this.selections.all::<usize>(cx);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(selections));
         });
     }
 
@@ -3518,7 +3537,7 @@ impl Editor {
                 })
                 .collect();
 
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(new_selections);
             });
         });
@@ -3560,7 +3579,7 @@ impl Editor {
                 buffer.edit(edits, None, cx);
             });
 
-            this.request_autoscroll(Autoscroll::Fit, cx);
+            this.request_autoscroll(Autoscroll::fit(), cx);
         });
     }
 
@@ -3670,7 +3689,7 @@ impl Editor {
                 }
             });
             this.fold_ranges(refold_ranges, cx);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(new_selections);
             })
         });
@@ -3775,13 +3794,13 @@ impl Editor {
                 }
             });
             this.fold_ranges(refold_ranges, cx);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(new_selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(new_selections));
         });
     }
 
     pub fn transpose(&mut self, _: &Transpose, cx: &mut ViewContext<Self>) {
         self.transact(cx, |this, cx| {
-            let edits = this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            let edits = this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 let mut edits: Vec<(Range<usize>, String)> = Default::default();
                 let line_mode = s.line_mode;
                 s.move_with(|display_map, selection| {
@@ -3825,7 +3844,7 @@ impl Editor {
             this.buffer
                 .update(cx, |buffer, cx| buffer.edit(edits, None, cx));
             let selections = this.selections.all::<usize>(cx);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(selections);
             });
         });
@@ -3859,7 +3878,7 @@ impl Editor {
         }
 
         self.transact(cx, |this, cx| {
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(selections);
             });
             this.insert("", cx);
@@ -3974,7 +3993,7 @@ impl Editor {
                     });
 
                     let selections = this.selections.all::<usize>(cx);
-                    this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(selections));
+                    this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(selections));
                 } else {
                     this.insert(&clipboard_text, cx);
                 }
@@ -3989,7 +4008,7 @@ impl Editor {
                     s.select_anchors(selections.to_vec());
                 });
             }
-            self.request_autoscroll(Autoscroll::Fit, cx);
+            self.request_autoscroll(Autoscroll::fit(), cx);
             self.unmark_text(cx);
             cx.emit(Event::Edited);
         }
@@ -4003,7 +4022,7 @@ impl Editor {
                     s.select_anchors(selections.to_vec());
                 });
             }
-            self.request_autoscroll(Autoscroll::Fit, cx);
+            self.request_autoscroll(Autoscroll::fit(), cx);
             self.unmark_text(cx);
             cx.emit(Event::Edited);
         }
@@ -4015,7 +4034,7 @@ impl Editor {
     }
 
     pub fn move_left(&mut self, _: &MoveLeft, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             let line_mode = s.line_mode;
             s.move_with(|map, selection| {
                 let cursor = if selection.is_empty() && !line_mode {
@@ -4029,13 +4048,13 @@ impl Editor {
     }
 
     pub fn select_left(&mut self, _: &SelectLeft, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| (movement::left(map, head), SelectionGoal::None));
         })
     }
 
     pub fn move_right(&mut self, _: &MoveRight, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             let line_mode = s.line_mode;
             s.move_with(|map, selection| {
                 let cursor = if selection.is_empty() && !line_mode {
@@ -4049,7 +4068,7 @@ impl Editor {
     }
 
     pub fn select_right(&mut self, _: &SelectRight, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| (movement::right(map, head), SelectionGoal::None));
         })
     }
@@ -4087,7 +4106,7 @@ impl Editor {
             return;
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             let line_mode = s.line_mode;
             s.move_with(|map, selection| {
                 if !selection.is_empty() && !line_mode {
@@ -4121,9 +4140,9 @@ impl Editor {
         };
 
         let autoscroll = if action.center_cursor {
-            Autoscroll::Center
+            Autoscroll::center()
         } else {
-            Autoscroll::Fit
+            Autoscroll::fit()
         };
 
         self.change_selections(Some(autoscroll), cx, |s| {
@@ -4166,7 +4185,7 @@ impl Editor {
     }
 
     pub fn select_up(&mut self, _: &SelectUp, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, goal| movement::up(map, head, goal, false))
         })
     }
@@ -4185,7 +4204,7 @@ impl Editor {
             return;
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             let line_mode = s.line_mode;
             s.move_with(|map, selection| {
                 if !selection.is_empty() && !line_mode {
@@ -4219,9 +4238,9 @@ impl Editor {
         };
 
         let autoscroll = if action.center_cursor {
-            Autoscroll::Center
+            Autoscroll::center()
         } else {
-            Autoscroll::Fit
+            Autoscroll::fit()
         };
 
         self.change_selections(Some(autoscroll), cx, |s| {
@@ -4264,7 +4283,7 @@ impl Editor {
     }
 
     pub fn select_down(&mut self, _: &SelectDown, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, goal| movement::down(map, head, goal, false))
         });
     }
@@ -4274,7 +4293,7 @@ impl Editor {
         _: &MoveToPreviousWordStart,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
                     movement::previous_word_start(map, head),
@@ -4289,7 +4308,7 @@ impl Editor {
         _: &MoveToPreviousSubwordStart,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
                     movement::previous_subword_start(map, head),
@@ -4304,7 +4323,7 @@ impl Editor {
         _: &SelectToPreviousWordStart,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
                     movement::previous_word_start(map, head),
@@ -4319,7 +4338,7 @@ impl Editor {
         _: &SelectToPreviousSubwordStart,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
                     movement::previous_subword_start(map, head),
@@ -4336,7 +4355,7 @@ impl Editor {
     ) {
         self.transact(cx, |this, cx| {
             this.select_autoclose_pair(cx);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 let line_mode = s.line_mode;
                 s.move_with(|map, selection| {
                     if selection.is_empty() && !line_mode {
@@ -4356,7 +4375,7 @@ impl Editor {
     ) {
         self.transact(cx, |this, cx| {
             this.select_autoclose_pair(cx);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 let line_mode = s.line_mode;
                 s.move_with(|map, selection| {
                     if selection.is_empty() && !line_mode {
@@ -4370,7 +4389,7 @@ impl Editor {
     }
 
     pub fn move_to_next_word_end(&mut self, _: &MoveToNextWordEnd, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (movement::next_word_end(map, head), SelectionGoal::None)
             });
@@ -4382,7 +4401,7 @@ impl Editor {
         _: &MoveToNextSubwordEnd,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (movement::next_subword_end(map, head), SelectionGoal::None)
             });
@@ -4390,7 +4409,7 @@ impl Editor {
     }
 
     pub fn select_to_next_word_end(&mut self, _: &SelectToNextWordEnd, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (movement::next_word_end(map, head), SelectionGoal::None)
             });
@@ -4402,7 +4421,7 @@ impl Editor {
         _: &SelectToNextSubwordEnd,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (movement::next_subword_end(map, head), SelectionGoal::None)
             });
@@ -4411,7 +4430,7 @@ impl Editor {
 
     pub fn delete_to_next_word_end(&mut self, _: &DeleteToNextWordEnd, cx: &mut ViewContext<Self>) {
         self.transact(cx, |this, cx| {
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 let line_mode = s.line_mode;
                 s.move_with(|map, selection| {
                     if selection.is_empty() && !line_mode {
@@ -4430,7 +4449,7 @@ impl Editor {
         cx: &mut ViewContext<Self>,
     ) {
         self.transact(cx, |this, cx| {
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     if selection.is_empty() {
                         let cursor = movement::next_subword_end(map, selection.head());
@@ -4447,7 +4466,7 @@ impl Editor {
         _: &MoveToBeginningOfLine,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
                     movement::indented_line_beginning(map, head, true),
@@ -4462,7 +4481,7 @@ impl Editor {
         action: &SelectToBeginningOfLine,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
                     movement::indented_line_beginning(map, head, action.stop_at_soft_wraps),
@@ -4478,7 +4497,7 @@ impl Editor {
         cx: &mut ViewContext<Self>,
     ) {
         self.transact(cx, |this, cx| {
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|_, selection| {
                     selection.reversed = true;
                 });
@@ -4495,7 +4514,7 @@ impl Editor {
     }
 
     pub fn move_to_end_of_line(&mut self, _: &MoveToEndOfLine, cx: &mut ViewContext<Self>) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (movement::line_end(map, head, true), SelectionGoal::None)
             });
@@ -4507,7 +4526,7 @@ impl Editor {
         action: &SelectToEndOfLine,
         cx: &mut ViewContext<Self>,
     ) {
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
                     movement::line_end(map, head, action.stop_at_soft_wraps),
@@ -4547,7 +4566,7 @@ impl Editor {
             return;
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select_ranges(vec![0..0]);
         });
     }
@@ -4556,7 +4575,7 @@ impl Editor {
         let mut selection = self.selections.last::<Point>(cx);
         selection.set_head(Point::zero(), SelectionGoal::None);
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select(vec![selection]);
         });
     }
@@ -4568,7 +4587,7 @@ impl Editor {
         }
 
         let cursor = self.buffer.read(cx).read(cx).len();
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select_ranges(vec![cursor..cursor])
         });
     }
@@ -4617,14 +4636,14 @@ impl Editor {
         let buffer = self.buffer.read(cx).snapshot(cx);
         let mut selection = self.selections.first::<usize>(cx);
         selection.set_head(buffer.len(), SelectionGoal::None);
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select(vec![selection]);
         });
     }
 
     pub fn select_all(&mut self, _: &SelectAll, cx: &mut ViewContext<Self>) {
         let end = self.buffer.read(cx).read(cx).len();
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select_ranges(vec![0..end]);
         });
     }
@@ -4639,7 +4658,7 @@ impl Editor {
             selection.end = cmp::min(max_point, Point::new(rows.end, 0));
             selection.reversed = false;
         }
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select(selections);
         });
     }
@@ -4664,7 +4683,7 @@ impl Editor {
             }
         }
         self.unfold_ranges(to_unfold, true, cx);
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select_ranges(new_selection_ranges);
         });
     }
@@ -4764,7 +4783,7 @@ impl Editor {
             state.stack.pop();
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select(new_selections);
         });
         if state.stack.len() > 1 {
@@ -4813,7 +4832,7 @@ impl Editor {
 
                 if let Some(next_selected_range) = next_selected_range {
                     self.unfold_ranges([next_selected_range.clone()], false, cx);
-                    self.change_selections(Some(Autoscroll::Newest), cx, |s| {
+                    self.change_selections(Some(Autoscroll::newest()), cx, |s| {
                         if action.replace_newest {
                             s.delete(s.newest_anchor().id);
                         }
@@ -4846,7 +4865,7 @@ impl Editor {
                     done: false,
                 };
                 self.unfold_ranges([selection.start..selection.end], false, cx);
-                self.change_selections(Some(Autoscroll::Newest), cx, |s| {
+                self.change_selections(Some(Autoscroll::newest()), cx, |s| {
                     s.select(selections);
                 });
                 self.select_next_state = Some(select_state);
@@ -5079,7 +5098,7 @@ impl Editor {
             }
 
             drop(snapshot);
-            this.change_selections(Some(Autoscroll::Fit), cx, |s| s.select(selections));
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(selections));
         });
     }
 
@@ -5123,7 +5142,7 @@ impl Editor {
 
         if selected_larger_node {
             stack.push(old_selections);
-            self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            self.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(new_selections);
             });
         }
@@ -5137,7 +5156,7 @@ impl Editor {
     ) {
         let mut stack = mem::take(&mut self.select_larger_syntax_node_stack);
         if let Some(selections) = stack.pop() {
-            self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            self.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(selections.to_vec());
             });
         }
@@ -5168,7 +5187,7 @@ impl Editor {
             }
         }
 
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select(selections);
         });
     }
@@ -5180,7 +5199,7 @@ impl Editor {
             self.change_selections(None, cx, |s| s.select_anchors(entry.selections.to_vec()));
             self.select_next_state = entry.select_next_state;
             self.add_selections_state = entry.add_selections_state;
-            self.request_autoscroll(Autoscroll::Newest, cx);
+            self.request_autoscroll(Autoscroll::newest(), cx);
         }
         self.selection_history.mode = SelectionHistoryMode::Normal;
     }
@@ -5192,7 +5211,7 @@ impl Editor {
             self.change_selections(None, cx, |s| s.select_anchors(entry.selections.to_vec()));
             self.select_next_state = entry.select_next_state;
             self.add_selections_state = entry.add_selections_state;
-            self.request_autoscroll(Autoscroll::Newest, cx);
+            self.request_autoscroll(Autoscroll::newest(), cx);
         }
         self.selection_history.mode = SelectionHistoryMode::Normal;
     }
@@ -5214,7 +5233,7 @@ impl Editor {
             if let Some(popover) = self.hover_state.diagnostic_popover.as_ref() {
                 let (group_id, jump_to) = popover.activation_info();
                 if self.activate_diagnostics(group_id, cx) {
-                    self.change_selections(Some(Autoscroll::Center), cx, |s| {
+                    self.change_selections(Some(Autoscroll::center()), cx, |s| {
                         let mut new_selection = s.newest_anchor().clone();
                         new_selection.collapse_to(jump_to, SelectionGoal::None);
                         s.select_anchors(vec![new_selection.clone()]);
@@ -5260,7 +5279,7 @@ impl Editor {
 
             if let Some((primary_range, group_id)) = group {
                 if self.activate_diagnostics(group_id, cx) {
-                    self.change_selections(Some(Autoscroll::Center), cx, |s| {
+                    self.change_selections(Some(Autoscroll::center()), cx, |s| {
                         s.select(vec![Selection {
                             id: selection.id,
                             start: primary_range.start,
@@ -5335,7 +5354,7 @@ impl Editor {
                 .dedup();
 
             if let Some(hunk) = hunks.next() {
-                this.change_selections(Some(Autoscroll::Center), cx, |s| {
+                this.change_selections(Some(Autoscroll::center()), cx, |s| {
                     let row = hunk.start_display_row();
                     let point = DisplayPoint::new(row, 0);
                     s.select_display_ranges([point..point]);
@@ -5433,7 +5452,7 @@ impl Editor {
                 if editor_handle != target_editor_handle {
                     pane.update(cx, |pane, _| pane.disable_history());
                 }
-                target_editor.change_selections(Some(Autoscroll::Center), cx, |s| {
+                target_editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                     s.select_ranges([range]);
                 });
 
@@ -6055,7 +6074,7 @@ impl Editor {
         let mut ranges = ranges.into_iter().peekable();
         if ranges.peek().is_some() {
             self.display_map.update(cx, |map, cx| map.fold(ranges, cx));
-            self.request_autoscroll(Autoscroll::Fit, cx);
+            self.request_autoscroll(Autoscroll::fit(), cx);
             cx.notify();
         }
     }
@@ -6070,7 +6089,7 @@ impl Editor {
         if ranges.peek().is_some() {
             self.display_map
                 .update(cx, |map, cx| map.unfold(ranges, inclusive, cx));
-            self.request_autoscroll(Autoscroll::Fit, cx);
+            self.request_autoscroll(Autoscroll::fit(), cx);
             cx.notify();
         }
     }
@@ -6083,7 +6102,7 @@ impl Editor {
         let blocks = self
             .display_map
             .update(cx, |display_map, cx| display_map.insert_blocks(blocks, cx));
-        self.request_autoscroll(Autoscroll::Fit, cx);
+        self.request_autoscroll(Autoscroll::fit(), cx);
         blocks
     }
 
@@ -6094,7 +6113,7 @@ impl Editor {
     ) {
         self.display_map
             .update(cx, |display_map, _| display_map.replace_blocks(blocks));
-        self.request_autoscroll(Autoscroll::Fit, cx);
+        self.request_autoscroll(Autoscroll::fit(), cx);
     }
 
     pub fn remove_blocks(&mut self, block_ids: HashSet<BlockId>, cx: &mut ViewContext<Self>) {
@@ -6434,7 +6453,7 @@ impl Editor {
             for (buffer, ranges) in new_selections_by_buffer.into_iter() {
                 let editor = workspace.open_project_item::<Self>(buffer, cx);
                 editor.update(cx, |editor, cx| {
-                    editor.change_selections(Some(Autoscroll::Newest), cx, |s| {
+                    editor.change_selections(Some(Autoscroll::newest()), cx, |s| {
                         s.select_ranges(ranges);
                     });
                 });
@@ -6460,7 +6479,7 @@ impl Editor {
                 };
 
                 let nav_history = editor.nav_history.take();
-                editor.change_selections(Some(Autoscroll::Newest), cx, |s| {
+                editor.change_selections(Some(Autoscroll::newest()), cx, |s| {
                     s.select_ranges([cursor..cursor]);
                 });
                 editor.nav_history = nav_history;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5011,7 +5011,7 @@ fn test_following(cx: &mut gpui::MutableAppContext) {
     // Update the selections and scroll position
     leader.update(cx, |leader, cx| {
         leader.change_selections(None, cx, |s| s.select_ranges([0..0]));
-        leader.request_autoscroll(Autoscroll::Newest, cx);
+        leader.request_autoscroll(Autoscroll::newest(), cx);
         leader.set_scroll_position(vec2f(1.5, 3.5), cx);
     });
     follower.update(cx, |follower, cx| {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -204,7 +204,7 @@ impl FollowableItem for Editor {
 
                 if !selections.is_empty() {
                     self.set_selections_from_remote(selections, cx);
-                    self.request_autoscroll_remotely(Autoscroll::Newest, cx);
+                    self.request_autoscroll_remotely(Autoscroll::newest(), cx);
                 } else if let Some(anchor) = message.scroll_top_anchor {
                     self.set_scroll_top_anchor(
                         Anchor {
@@ -294,7 +294,7 @@ impl Item for Editor {
                 let nav_history = self.nav_history.take();
                 self.scroll_position = data.scroll_position;
                 self.scroll_top_anchor = scroll_top_anchor;
-                self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                self.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.select_ranges([offset..offset])
                 });
                 self.nav_history = nav_history;
@@ -466,7 +466,7 @@ impl Item for Editor {
         cx.spawn(|this, mut cx| async move {
             let transaction = reload_buffers.log_err().await;
             this.update(&mut cx, |editor, cx| {
-                editor.request_autoscroll(Autoscroll::Fit, cx)
+                editor.request_autoscroll(Autoscroll::fit(), cx)
             });
             buffer.update(&mut cx, |buffer, _| {
                 if let Some(transaction) = transaction {
@@ -619,7 +619,7 @@ impl SearchableItem for Editor {
         cx: &mut ViewContext<Self>,
     ) {
         self.unfold_ranges([matches[index].clone()], false, cx);
-        self.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.select_ranges([matches[index].clone()])
         });
     }

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -811,7 +811,7 @@ mod tests {
             let snapshot = editor.buffer().read(cx).snapshot(cx);
             let anchor_range = snapshot.anchor_before(selection_range.start)
                 ..snapshot.anchor_after(selection_range.end);
-            editor.change_selections(Some(crate::Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(crate::Autoscroll::fit()), cx, |s| {
                 s.set_pending_anchor_range(anchor_range, crate::SelectMode::Character)
             });
         });

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -169,7 +169,7 @@ impl<'a> EditorTestContext<'a> {
         let (unmarked_text, selection_ranges) = marked_text_ranges(marked_text, true);
         self.editor.update(self.cx, |editor, cx| {
             editor.set_text(unmarked_text, cx);
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select_ranges(selection_ranges)
             })
         });

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -83,7 +83,7 @@ impl GoToLine {
             if let Some(rows) = active_editor.highlighted_rows() {
                 let snapshot = active_editor.snapshot(cx).display_snapshot;
                 let position = DisplayPoint::new(rows.start, 0).to_point(&snapshot);
-                active_editor.change_selections(Some(Autoscroll::Center), cx, |s| {
+                active_editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                     s.select_ranges([position..position])
                 });
             }
@@ -127,7 +127,7 @@ impl GoToLine {
                         let display_point = point.to_display_point(&snapshot);
                         let row = display_point.row();
                         active_editor.highlight_rows(Some(row..row + 1));
-                        active_editor.request_autoscroll(Autoscroll::Center, cx);
+                        active_editor.request_autoscroll(Autoscroll::center(), cx);
                     });
                     cx.notify();
                 }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -61,7 +61,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                 if let Some(editor) = item.downcast::<Editor>() {
                     editor.update(&mut cx, |editor, cx| {
                         let len = editor.buffer().read(cx).len(cx);
-                        editor.change_selections(Some(Autoscroll::Center), cx, |s| {
+                        editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                             s.select_ranges([len..len])
                         });
                         if len > 0 {

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -122,7 +122,7 @@ impl OutlineView {
                 let display_rows = start.to_display_point(&snapshot).row()
                     ..end.to_display_point(&snapshot).row() + 1;
                 active_editor.highlight_rows(Some(display_rows));
-                active_editor.request_autoscroll(Autoscroll::Center, cx);
+                active_editor.request_autoscroll(Autoscroll::center(), cx);
             });
         }
         cx.notify();
@@ -219,7 +219,7 @@ impl PickerDelegate for OutlineView {
             if let Some(rows) = active_editor.highlighted_rows() {
                 let snapshot = active_editor.snapshot(cx).display_snapshot;
                 let position = DisplayPoint::new(rows.start, 0).to_point(&snapshot);
-                active_editor.change_selections(Some(Autoscroll::Center), cx, |s| {
+                active_editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                     s.select_ranges([position..position])
                 });
             }

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -150,7 +150,7 @@ impl ProjectSymbolsView {
 
                         let editor = workspace.open_project_item::<Editor>(buffer, cx);
                         editor.update(cx, |editor, cx| {
-                            editor.change_selections(Some(Autoscroll::Center), cx, |s| {
+                            editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                                 s.select_ranges([position..position])
                             });
                         });

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -512,7 +512,7 @@ impl ProjectSearchView {
             let range_to_select = match_ranges[new_index].clone();
             self.results_editor.update(cx, |editor, cx| {
                 editor.unfold_ranges([range_to_select.clone()], false, cx);
-                editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.select_ranges([range_to_select])
                 });
             });
@@ -546,7 +546,7 @@ impl ProjectSearchView {
         } else {
             self.results_editor.update(cx, |editor, cx| {
                 if reset_selections {
-                    editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                    editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                         s.select_ranges(match_ranges.first().cloned())
                     });
                 }

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -13,7 +13,7 @@ pub fn init(cx: &mut MutableAppContext) {
 fn normal_before(_: &mut Workspace, _: &NormalBefore, cx: &mut ViewContext<Workspace>) {
     Vim::update(cx, |state, cx| {
         state.update_active_editor(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_cursors_with(|map, mut cursor, _| {
                     *cursor.column_mut() = cursor.column().saturating_sub(1);
                     (map.clip_point(cursor, Bias::Left), SelectionGoal::None)

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -114,7 +114,7 @@ pub fn normal_object(object: Object, cx: &mut MutableAppContext) {
 
 fn move_cursor(vim: &mut Vim, motion: Motion, times: usize, cx: &mut MutableAppContext) {
     vim.update_active_editor(cx, |editor, cx| {
-        editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+        editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, cursor, goal| {
                 motion
                     .move_point(map, cursor, goal, times)
@@ -128,7 +128,7 @@ fn insert_after(_: &mut Workspace, _: &InsertAfter, cx: &mut ViewContext<Workspa
     Vim::update(cx, |vim, cx| {
         vim.switch_mode(Mode::Insert, false, cx);
         vim.update_active_editor(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.maybe_move_cursors_with(|map, cursor, goal| {
                     Motion::Right.move_point(map, cursor, goal, 1)
                 });
@@ -145,7 +145,7 @@ fn insert_first_non_whitespace(
     Vim::update(cx, |vim, cx| {
         vim.switch_mode(Mode::Insert, false, cx);
         vim.update_active_editor(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.maybe_move_cursors_with(|map, cursor, goal| {
                     Motion::FirstNonWhitespace.move_point(map, cursor, goal, 1)
                 });
@@ -158,7 +158,7 @@ fn insert_end_of_line(_: &mut Workspace, _: &InsertEndOfLine, cx: &mut ViewConte
     Vim::update(cx, |vim, cx| {
         vim.switch_mode(Mode::Insert, false, cx);
         vim.update_active_editor(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.maybe_move_cursors_with(|map, cursor, goal| {
                     Motion::EndOfLine.move_point(map, cursor, goal, 1)
                 });
@@ -187,7 +187,7 @@ fn insert_line_above(_: &mut Workspace, _: &InsertLineAbove, cx: &mut ViewContex
                     (start_of_line..start_of_line, new_text)
                 });
                 editor.edit_with_autoindent(edits, cx);
-                editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.move_cursors_with(|map, mut cursor, _| {
                         *cursor.row_mut() -= 1;
                         *cursor.column_mut() = map.line_len(cursor.row());
@@ -218,7 +218,7 @@ fn insert_line_below(_: &mut Workspace, _: &InsertLineBelow, cx: &mut ViewContex
                     new_text.push_str(&" ".repeat(indent as usize));
                     (end_of_line..end_of_line, new_text)
                 });
-                editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.maybe_move_cursors_with(|map, cursor, goal| {
                         Motion::EndOfLine.move_point(map, cursor, goal, 1)
                     });
@@ -336,7 +336,7 @@ fn paste(_: &mut Workspace, _: &Paste, cx: &mut ViewContext<Workspace>) {
                             buffer.edit(edits, Some(AutoindentMode::EachLine), cx);
                         });
 
-                        editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                        editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                             s.move_with(|map, selection| {
                                 if let Some(new_position) = new_selections.get(&selection.id) {
                                     match new_position {

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -15,7 +15,7 @@ pub fn change_motion(vim: &mut Vim, motion: Motion, times: usize, cx: &mut Mutab
         editor.transact(cx, |editor, cx| {
             // We are swapping to insert mode anyway. Just set the line end clipping behavior now
             editor.set_clip_at_line_ends(false, cx);
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     motion_succeeded |= if let Motion::NextWordStart { ignore_punctuation } = motion
                     {
@@ -43,7 +43,7 @@ pub fn change_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Mutab
         // We are swapping to insert mode anyway. Just set the line end clipping behavior now
         editor.set_clip_at_line_ends(false, cx);
         editor.transact(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     objects_found |= object.expand_selection(map, selection, around);
                 });

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -8,7 +8,7 @@ pub fn delete_motion(vim: &mut Vim, motion: Motion, times: usize, cx: &mut Mutab
         editor.transact(cx, |editor, cx| {
             editor.set_clip_at_line_ends(false, cx);
             let mut original_columns: HashMap<_, _> = Default::default();
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     let original_head = selection.head();
                     original_columns.insert(selection.id, original_head.column());
@@ -20,7 +20,7 @@ pub fn delete_motion(vim: &mut Vim, motion: Motion, times: usize, cx: &mut Mutab
 
             // Fixup cursor position after the deletion
             editor.set_clip_at_line_ends(true, cx);
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     let mut cursor = selection.head();
                     if motion.linewise() {
@@ -43,7 +43,7 @@ pub fn delete_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Mutab
             // Emulates behavior in vim where if we expanded backwards to include a newline
             // the cursor gets set back to the start of the line
             let mut should_move_to_start: HashSet<_> = Default::default();
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     object.expand_selection(map, selection, around);
                     let offset_range = selection.map(|p| p.to_offset(map, Bias::Left)).range();
@@ -78,7 +78,7 @@ pub fn delete_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Mutab
 
             // Fixup cursor position after the deletion
             editor.set_clip_at_line_ends(true, cx);
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     let mut cursor = selection.head();
                     if should_move_to_start.contains(&selection.id) {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -26,7 +26,7 @@ pub fn init(cx: &mut MutableAppContext) {
 pub fn visual_motion(motion: Motion, times: usize, cx: &mut MutableAppContext) {
     Vim::update(cx, |vim, cx| {
         vim.update_active_editor(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     let was_reversed = selection.reversed;
 
@@ -58,7 +58,7 @@ pub fn visual_object(object: Object, cx: &mut MutableAppContext) {
     Vim::update(cx, |vim, cx| {
         if let Operator::Object { around } = vim.pop_operator(cx) {
             vim.update_active_editor(cx, |editor, cx| {
-                editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.move_with(|map, selection| {
                         let head = selection.head();
                         if let Some(mut range) = object.range(map, head, around) {
@@ -126,7 +126,7 @@ pub fn change(_: &mut Workspace, _: &VisualChange, cx: &mut ViewContext<Workspac
             });
             copy_selections_content(editor, editor.selections.line_mode, cx);
             editor.edit_with_autoindent(edits, cx);
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select_anchors(new_selections);
             });
         });
@@ -140,7 +140,7 @@ pub fn delete(_: &mut Workspace, _: &VisualDelete, cx: &mut ViewContext<Workspac
             editor.set_clip_at_line_ends(false, cx);
             let mut original_columns: HashMap<_, _> = Default::default();
             let line_mode = editor.selections.line_mode;
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     if line_mode {
                         original_columns
@@ -159,7 +159,7 @@ pub fn delete(_: &mut Workspace, _: &VisualDelete, cx: &mut ViewContext<Workspac
 
             // Fixup cursor position after the deletion
             editor.set_clip_at_line_ends(true, cx);
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
                     let mut cursor = selection.head().to_point(map);
 
@@ -298,7 +298,7 @@ pub fn paste(_: &mut Workspace, _: &VisualPaste, cx: &mut ViewContext<Workspace>
                             buffer.edit(edits, Some(AutoindentMode::EachLine), cx);
                         });
 
-                        editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                        editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                             s.select(new_selections)
                         });
                     } else {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1365,7 +1365,7 @@ mod tests {
             .downcast::<Editor>()
             .unwrap();
         editor1.update(cx, |editor, cx| {
-            editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select_display_ranges([DisplayPoint::new(10, 0)..DisplayPoint::new(10, 0)])
             });
         });
@@ -1384,7 +1384,7 @@ mod tests {
 
         editor3
             .update(cx, |editor, cx| {
-                editor.change_selections(Some(Autoscroll::Fit), cx, |s| {
+                editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.select_display_ranges([DisplayPoint::new(12, 0)..DisplayPoint::new(12, 0)])
                 });
                 editor.newline(&Default::default(), cx);


### PR DESCRIPTION
## Description of feature or change

This changes the behavior of `ctrl-l` to alternate between centering the screen, aligning the cursor to the top of the screen, or aligning the cursor to the bottom of the screen. 

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/546

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
