### PR TITLE
Remove restart to update zed icon

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -17,7 +17,6 @@ actions!(lsp_status, [ShowErrorMessage]);
 
 const DOWNLOAD_ICON: &str = "icons/download_12.svg";
 const WARNING_ICON: &str = "icons/triangle_exclamation_12.svg";
-const DONE_ICON: &str = "icons/circle_check_12.svg";
 
 pub enum Event {
     ShowError { lsp_name: Arc<str>, error: String },

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -237,7 +237,6 @@ impl ActivityIndicator {
 
         // Show any application auto-update info.
         if let Some(updater) = &self.auto_updater {
-            // let theme = &cx.global::<Settings>().theme.workspace.status_bar;
             match &updater.read(cx).status() {
                 AutoUpdateStatus::Checking => (
                     Some(DOWNLOAD_ICON),

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -254,9 +254,7 @@ impl ActivityIndicator {
                     "Installing Zed update…".to_string(),
                     None,
                 ),
-                AutoUpdateStatus::Updated => {
-                    (Some(DONE_ICON), "Restart to update Zed".to_string(), None)
-                }
+                AutoUpdateStatus::Updated => (None, "Restart to update Zed".to_string(), None),
                 AutoUpdateStatus::Errored => (
                     Some(WARNING_ICON),
                     "Auto update failed".to_string(),


### PR DESCRIPTION
## Description of feature or change

Addresses a repeated icon in from the diagnostics indicator
![image](https://user-images.githubusercontent.com/3323631/200688726-151d46b2-b938-4ba3-a8a8-0b910fe317af.png)

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
