### PR TITLE
Drag project entry to pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,6 +4265,7 @@ name = "project_panel"
 version = "0.1.0"
 dependencies = [
  "context_menu",
+ "drag_and_drop",
  "editor",
  "futures 0.3.24",
  "gpui",

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -908,7 +908,7 @@ async fn test_host_disconnect(
         cx_b.add_window(|cx| Workspace::new(project_b.clone(), |_, _| unimplemented!(), cx));
     let editor_b = workspace_b
         .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "b.txt"), true, cx)
+            workspace.open_path((worktree_id, "b.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -3704,7 +3704,7 @@ async fn test_collaborating_with_code_actions(
         cx_b.add_window(|cx| Workspace::new(project_b.clone(), |_, _| unimplemented!(), cx));
     let editor_b = workspace_b
         .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "main.rs"), true, cx)
+            workspace.open_path((worktree_id, "main.rs"), None, true, cx)
         })
         .await
         .unwrap()
@@ -3925,7 +3925,7 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
         cx_b.add_window(|cx| Workspace::new(project_b.clone(), |_, _| unimplemented!(), cx));
     let editor_b = workspace_b
         .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "one.rs"), true, cx)
+            workspace.open_path((worktree_id, "one.rs"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5134,7 +5134,7 @@ async fn test_following(
     let pane_a = workspace_a.read_with(cx_a, |workspace, _| workspace.active_pane().clone());
     let editor_a1 = workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace.open_path((worktree_id, "1.txt"), true, cx)
+            workspace.open_path((worktree_id, "1.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5142,7 +5142,7 @@ async fn test_following(
         .unwrap();
     let editor_a2 = workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace.open_path((worktree_id, "2.txt"), true, cx)
+            workspace.open_path((worktree_id, "2.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5153,7 +5153,7 @@ async fn test_following(
     let workspace_b = client_b.build_workspace(&project_b, cx_b);
     let editor_b1 = workspace_b
         .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "1.txt"), true, cx)
+            workspace.open_path((worktree_id, "1.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5411,7 +5411,7 @@ async fn test_peers_following_each_other(cx_a: &mut TestAppContext, cx_b: &mut T
     let pane_a1 = workspace_a.read_with(cx_a, |workspace, _| workspace.active_pane().clone());
     let _editor_a1 = workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace.open_path((worktree_id, "1.txt"), true, cx)
+            workspace.open_path((worktree_id, "1.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5423,7 +5423,7 @@ async fn test_peers_following_each_other(cx_a: &mut TestAppContext, cx_b: &mut T
     let pane_b1 = workspace_b.read_with(cx_b, |workspace, _| workspace.active_pane().clone());
     let _editor_b1 = workspace_b
         .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "2.txt"), true, cx)
+            workspace.open_path((worktree_id, "2.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5474,7 +5474,7 @@ async fn test_peers_following_each_other(cx_a: &mut TestAppContext, cx_b: &mut T
 
     workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace.open_path((worktree_id, "3.txt"), true, cx)
+            workspace.open_path((worktree_id, "3.txt"), None, true, cx)
         })
         .await
         .unwrap();
@@ -5485,7 +5485,7 @@ async fn test_peers_following_each_other(cx_a: &mut TestAppContext, cx_b: &mut T
     workspace_b
         .update(cx_b, |workspace, cx| {
             assert_eq!(*workspace.active_pane(), pane_b1);
-            workspace.open_path((worktree_id, "4.txt"), true, cx)
+            workspace.open_path((worktree_id, "4.txt"), None, true, cx)
         })
         .await
         .unwrap();
@@ -5586,7 +5586,7 @@ async fn test_auto_unfollowing(cx_a: &mut TestAppContext, cx_b: &mut TestAppCont
     let workspace_a = client_a.build_workspace(&project_a, cx_a);
     let _editor_a1 = workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace.open_path((worktree_id, "1.txt"), true, cx)
+            workspace.open_path((worktree_id, "1.txt"), None, true, cx)
         })
         .await
         .unwrap()
@@ -5699,7 +5699,7 @@ async fn test_auto_unfollowing(cx_a: &mut TestAppContext, cx_b: &mut TestAppCont
     // When client B activates a different item in the original pane, it automatically stops following client A.
     workspace_b
         .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "2.txt"), true, cx)
+            workspace.open_path((worktree_id, "2.txt"), None, true, cx)
         })
         .await
         .unwrap();

--- a/crates/drag_and_drop/src/drag_and_drop.rs
+++ b/crates/drag_and_drop/src/drag_and_drop.rs
@@ -1,5 +1,3 @@
-pub mod shared_payloads;
-
 use std::{any::Any, rc::Rc};
 
 use collections::HashSet;
@@ -149,7 +147,6 @@ impl<V: View> DragAndDrop<V> {
                             return None;
                         }
 
-                        dbg!("Rendered dragging state");
                         let position = position + region_offset;
                         Some(
                             Overlay::new(
@@ -160,7 +157,6 @@ impl<V: View> DragAndDrop<V> {
                                 .on_up(MouseButton::Left, |_, cx| {
                                     cx.defer(|cx| {
                                         cx.update_global::<Self, _, _>(|this, cx| {
-                                            dbg!("Up with dragging state");
                                             this.finish_dragging(cx)
                                         });
                                     });
@@ -169,7 +165,6 @@ impl<V: View> DragAndDrop<V> {
                                 .on_up_out(MouseButton::Left, |_, cx| {
                                     cx.defer(|cx| {
                                         cx.update_global::<Self, _, _>(|this, cx| {
-                                            dbg!("Up out with dragging state");
                                             this.finish_dragging(cx)
                                         });
                                     });
@@ -186,35 +181,30 @@ impl<V: View> DragAndDrop<V> {
                         )
                     }
 
-                    State::Canceled => {
-                        dbg!("Rendered canceled state");
-                        Some(
-                            MouseEventHandler::<DraggedElementHandler>::new(0, cx, |_, _| {
-                                Empty::new()
-                                    .constrained()
-                                    .with_width(0.)
-                                    .with_height(0.)
-                                    .boxed()
-                            })
-                            .on_up(MouseButton::Left, |_, cx| {
-                                cx.defer(|cx| {
-                                    cx.update_global::<Self, _, _>(|this, _| {
-                                        dbg!("Up with canceled state");
-                                        this.currently_dragged = None;
-                                    });
+                    State::Canceled => Some(
+                        MouseEventHandler::<DraggedElementHandler>::new(0, cx, |_, _| {
+                            Empty::new()
+                                .constrained()
+                                .with_width(0.)
+                                .with_height(0.)
+                                .boxed()
+                        })
+                        .on_up(MouseButton::Left, |_, cx| {
+                            cx.defer(|cx| {
+                                cx.update_global::<Self, _, _>(|this, _| {
+                                    this.currently_dragged = None;
                                 });
-                            })
-                            .on_up_out(MouseButton::Left, |_, cx| {
-                                cx.defer(|cx| {
-                                    cx.update_global::<Self, _, _>(|this, _| {
-                                        dbg!("Up out with canceled state");
-                                        this.currently_dragged = None;
-                                    });
+                            });
+                        })
+                        .on_up_out(MouseButton::Left, |_, cx| {
+                            cx.defer(|cx| {
+                                cx.update_global::<Self, _, _>(|this, _| {
+                                    this.currently_dragged = None;
                                 });
-                            })
-                            .boxed(),
-                        )
-                    }
+                            });
+                        })
+                        .boxed(),
+                    ),
                 }
             })
     }
@@ -227,7 +217,6 @@ impl<V: View> DragAndDrop<V> {
             if payload.is::<P>() {
                 let window_id = *window_id;
                 self.currently_dragged = Some(State::Canceled);
-                dbg!("Canceled");
                 self.notify_containers_for_window(window_id, cx);
             }
         }

--- a/crates/drag_and_drop/src/shared_payloads.rs
+++ b/crates/drag_and_drop/src/shared_payloads.rs
@@ -1,0 +1,6 @@
+use std::{path::Path, sync::Arc};
+
+#[derive(Debug, Clone)]
+pub struct DraggedProjectEntry {
+    pub path: Arc<Path>,
+}

--- a/crates/drag_and_drop/src/shared_payloads.rs
+++ b/crates/drag_and_drop/src/shared_payloads.rs
@@ -1,6 +1,0 @@
-use std::{path::Path, sync::Arc};
-
-#[derive(Debug, Clone)]
-pub struct DraggedProjectEntry {
-    pub path: Arc<Path>,
-}

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6394,7 +6394,7 @@ impl Editor {
     }
 
     fn jump(workspace: &mut Workspace, action: &Jump, cx: &mut ViewContext<Workspace>) {
-        let editor = workspace.open_path(action.path.clone(), true, cx);
+        let editor = workspace.open_path(action.path.clone(), None, true, cx);
         let position = action.position;
         let anchor = action.anchor;
         cx.spawn_weak(|_, mut cx| async move {

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -76,7 +76,9 @@ impl<'a> EditorLspTestContext<'a> {
 
         let file = cx.read(|cx| workspace.file_project_paths(cx)[0].clone());
         let item = workspace
-            .update(cx, |workspace, cx| workspace.open_path(file, true, cx))
+            .update(cx, |workspace, cx| {
+                workspace.open_path(file, None, true, cx)
+            })
             .await
             .expect("Could not open test file");
 

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -104,7 +104,7 @@ impl FileFinder {
         match event {
             Event::Selected(project_path) => {
                 workspace
-                    .open_path(project_path.clone(), true, cx)
+                    .open_path(project_path.clone(), None, true, cx)
                     .detach_and_log_err(cx);
                 workspace.dismiss_modal(cx);
             }

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 context_menu = { path = "../context_menu" }
+drag_and_drop = { path = "../drag_and_drop" }
 editor = { path = "../editor" }
 gpui = { path = "../gpui" }
 menu = { path = "../menu" }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1,5 +1,5 @@
 use context_menu::{ContextMenu, ContextMenuItem};
-use drag_and_drop::{shared_payloads::DraggedProjectEntry, DragAndDrop, Draggable};
+use drag_and_drop::{DragAndDrop, Draggable};
 use editor::{Cancel, Editor};
 use futures::stream::StreamExt;
 use gpui::{
@@ -239,6 +239,7 @@ impl ProjectPanel {
                                         worktree_id: worktree.read(cx).id(),
                                         path: entry.path.clone(),
                                     },
+                                    None,
                                     focus_opened_item,
                                     cx,
                                 )
@@ -607,7 +608,7 @@ impl ProjectPanel {
             }
 
             cx.update_global(|drag_and_drop: &mut DragAndDrop<Workspace>, cx| {
-                drag_and_drop.cancel_dragging::<DraggedProjectEntry>(cx);
+                drag_and_drop.cancel_dragging::<ProjectEntryId>(cx);
             })
         }
     }
@@ -1127,26 +1128,21 @@ impl ProjectPanel {
                 position: e.position,
             })
         })
-        .as_draggable(
-            DraggedProjectEntry {
-                path: details.path.clone(),
-            },
-            {
-                let row_container_style = theme.dragged_entry.container;
+        .as_draggable(entry_id, {
+            let row_container_style = theme.dragged_entry.container;
 
-                move |_, cx: &mut RenderContext<Workspace>| {
-                    let theme = cx.global::<Settings>().theme.clone();
-                    Self::render_entry_visual_element(
-                        &details,
-                        None,
-                        padding,
-                        row_container_style,
-                        &theme.project_panel.dragged_entry,
-                        cx,
-                    )
-                }
-            },
-        )
+            move |_, cx: &mut RenderContext<Workspace>| {
+                let theme = cx.global::<Settings>().theme.clone();
+                Self::render_entry_visual_element(
+                    &details,
+                    None,
+                    padding,
+                    row_container_style,
+                    &theme.project_panel.dragged_entry,
+                    cx,
+                )
+            }
+        })
         .with_cursor_style(CursorStyle::PointingHand)
         .boxed()
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1,12 +1,13 @@
 use context_menu::{ContextMenu, ContextMenuItem};
+use drag_and_drop::Draggable;
 use editor::{Cancel, Editor};
 use futures::stream::StreamExt;
 use gpui::{
     actions,
     anyhow::{anyhow, Result},
     elements::{
-        AnchorCorner, ChildView, ConstrainedBox, Empty, Flex, Label, MouseEventHandler,
-        ParentElement, ScrollTarget, Stack, Svg, UniformList, UniformListState,
+        AnchorCorner, ChildView, ConstrainedBox, ContainerStyle, Empty, Flex, Label,
+        MouseEventHandler, ParentElement, ScrollTarget, Stack, Svg, UniformList, UniformListState,
     },
     geometry::vector::Vector2F,
     impl_internal_actions, keymap,
@@ -25,6 +26,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use theme::ProjectPanelEntry;
 use unicase::UniCase;
 use workspace::Workspace;
 
@@ -70,9 +72,10 @@ pub enum ClipboardEntry {
     },
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 struct EntryDetails {
     filename: String,
+    path: Arc<Path>,
     depth: usize,
     kind: EntryKind,
     is_ignored: bool,
@@ -220,6 +223,7 @@ impl ProjectPanel {
             this.update_visible_entries(None, cx);
             this
         });
+
         cx.subscribe(&project_panel, {
             let project_panel = project_panel.downgrade();
             move |workspace, _, event, cx| match event {
@@ -950,14 +954,15 @@ impl ProjectPanel {
             let end_ix = range.end.min(ix + visible_worktree_entries.len());
             if let Some(worktree) = self.project.read(cx).worktree_for_id(*worktree_id, cx) {
                 let snapshot = worktree.read(cx).snapshot();
+                let root_name = OsStr::new(snapshot.root_name());
                 let expanded_entry_ids = self
                     .expanded_dir_ids
                     .get(&snapshot.id())
                     .map(Vec::as_slice)
                     .unwrap_or(&[]);
-                let root_name = OsStr::new(snapshot.root_name());
-                for entry in &visible_worktree_entries[range.start.saturating_sub(ix)..end_ix - ix]
-                {
+
+                let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
+                for entry in &visible_worktree_entries[entry_range] {
                     let mut details = EntryDetails {
                         filename: entry
                             .path
@@ -965,6 +970,7 @@ impl ProjectPanel {
                             .unwrap_or(root_name)
                             .to_string_lossy()
                             .to_string(),
+                        path: entry.path.clone(),
                         depth: entry.path.components().count(),
                         kind: entry.kind,
                         is_ignored: entry.is_ignored,
@@ -978,12 +984,14 @@ impl ProjectPanel {
                             .clipboard_entry
                             .map_or(false, |e| e.is_cut() && e.entry_id() == entry.id),
                     };
+
                     if let Some(edit_state) = &self.edit_state {
                         let is_edited_entry = if edit_state.is_new_entry {
                             entry.id == NEW_ENTRY_ID
                         } else {
                             entry.id == edit_state.entry_id
                         };
+
                         if is_edited_entry {
                             if let Some(processing_filename) = &edit_state.processing_filename {
                                 details.is_processing = true;
@@ -1005,6 +1013,63 @@ impl ProjectPanel {
         }
     }
 
+    fn render_entry_visual_element<V: View>(
+        details: EntryDetails,
+        editor: &ViewHandle<Editor>,
+        padding: f32,
+        row_container_style: ContainerStyle,
+        style: &ProjectPanelEntry,
+        cx: &mut RenderContext<V>,
+    ) -> ElementBox {
+        let kind = details.kind;
+        let show_editor = details.is_editing && !details.is_processing;
+
+        Flex::row()
+            .with_child(
+                ConstrainedBox::new(if kind == EntryKind::Dir {
+                    if details.is_expanded {
+                        Svg::new("icons/chevron_down_8.svg")
+                            .with_color(style.icon_color)
+                            .boxed()
+                    } else {
+                        Svg::new("icons/chevron_right_8.svg")
+                            .with_color(style.icon_color)
+                            .boxed()
+                    }
+                } else {
+                    Empty::new().boxed()
+                })
+                .with_max_width(style.icon_size)
+                .with_max_height(style.icon_size)
+                .aligned()
+                .constrained()
+                .with_width(style.icon_size)
+                .boxed(),
+            )
+            .with_child(if show_editor {
+                ChildView::new(editor.clone(), cx)
+                    .contained()
+                    .with_margin_left(style.icon_spacing)
+                    .aligned()
+                    .left()
+                    .flex(1.0, true)
+                    .boxed()
+            } else {
+                Label::new(details.filename.clone(), style.text.clone())
+                    .contained()
+                    .with_margin_left(style.icon_spacing)
+                    .aligned()
+                    .left()
+                    .boxed()
+            })
+            .constrained()
+            .with_height(style.height)
+            .contained()
+            .with_style(row_container_style)
+            .with_padding_left(padding)
+            .boxed()
+    }
+
     fn render_entry(
         entry_id: ProjectEntryId,
         details: EntryDetails,
@@ -1013,69 +1078,34 @@ impl ProjectPanel {
         cx: &mut RenderContext<Self>,
     ) -> ElementBox {
         let kind = details.kind;
+        let padding = theme.container.padding.left + details.depth as f32 * theme.indent_width;
+
+        let entry_style = if details.is_cut {
+            &theme.cut_entry
+        } else if details.is_ignored {
+            &theme.ignored_entry
+        } else {
+            &theme.entry
+        };
+
         let show_editor = details.is_editing && !details.is_processing;
+
         MouseEventHandler::<Self>::new(entry_id.to_usize(), cx, |state, cx| {
-            let padding = theme.container.padding.left + details.depth as f32 * theme.indent_width;
-
-            let entry_style = if details.is_cut {
-                &theme.cut_entry
-            } else if details.is_ignored {
-                &theme.ignored_entry
-            } else {
-                &theme.entry
-            };
-
             let style = entry_style.style_for(state, details.is_selected).clone();
-
             let row_container_style = if show_editor {
                 theme.filename_editor.container
             } else {
                 style.container
             };
-            Flex::row()
-                .with_child(
-                    ConstrainedBox::new(if kind == EntryKind::Dir {
-                        if details.is_expanded {
-                            Svg::new("icons/chevron_down_8.svg")
-                                .with_color(style.icon_color)
-                                .boxed()
-                        } else {
-                            Svg::new("icons/chevron_right_8.svg")
-                                .with_color(style.icon_color)
-                                .boxed()
-                        }
-                    } else {
-                        Empty::new().boxed()
-                    })
-                    .with_max_width(style.icon_size)
-                    .with_max_height(style.icon_size)
-                    .aligned()
-                    .constrained()
-                    .with_width(style.icon_size)
-                    .boxed(),
-                )
-                .with_child(if show_editor {
-                    ChildView::new(editor.clone(), cx)
-                        .contained()
-                        .with_margin_left(theme.entry.default.icon_spacing)
-                        .aligned()
-                        .left()
-                        .flex(1.0, true)
-                        .boxed()
-                } else {
-                    Label::new(details.filename, style.text.clone())
-                        .contained()
-                        .with_margin_left(style.icon_spacing)
-                        .aligned()
-                        .left()
-                        .boxed()
-                })
-                .constrained()
-                .with_height(theme.entry.default.height)
-                .contained()
-                .with_style(row_container_style)
-                .with_padding_left(padding)
-                .boxed()
+
+            Self::render_entry_visual_element(
+                details.clone(),
+                editor,
+                padding,
+                row_container_style,
+                &style,
+                cx,
+            )
         })
         .on_click(MouseButton::Left, move |e, cx| {
             if kind == EntryKind::Dir {
@@ -1092,6 +1122,22 @@ impl ProjectPanel {
                 entry_id,
                 position: e.position,
             })
+        })
+        .as_draggable(details.clone(), {
+            let editor = editor.clone();
+            let row_container_style = theme.dragged_entry.container;
+
+            move |payload, cx: &mut RenderContext<Workspace>| {
+                let theme = cx.global::<Settings>().theme.clone();
+                Self::render_entry_visual_element(
+                    payload.clone(),
+                    &editor,
+                    padding,
+                    row_container_style,
+                    &theme.project_panel.dragged_entry,
+                    cx,
+                )
+            }
         })
         .with_cursor_style(CursorStyle::PointingHand)
         .boxed()

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -326,6 +326,7 @@ pub struct ProjectPanel {
     #[serde(flatten)]
     pub container: ContainerStyle,
     pub entry: Interactive<ProjectPanelEntry>,
+    pub dragged_entry: ProjectPanelEntry,
     pub ignored_entry: Interactive<ProjectPanelEntry>,
     pub cut_entry: Interactive<ProjectPanelEntry>,
     pub filename_editor: FieldEditor,

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -67,7 +67,9 @@ impl<'a> VimTestContext<'a> {
 
         let file = cx.read(|cx| workspace.file_project_paths(cx)[0].clone());
         let item = workspace
-            .update(cx, |workspace, cx| workspace.open_path(file, true, cx))
+            .update(cx, |workspace, cx| {
+                workspace.open_path(file, None, true, cx)
+            })
             .await
             .expect("Could not open test file");
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -818,7 +818,7 @@ mod tests {
 
         // Open the first entry
         let entry_1 = workspace
-            .update(cx, |w, cx| w.open_path(file1.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file1.clone(), None, true, cx))
             .await
             .unwrap();
         cx.read(|cx| {
@@ -832,7 +832,7 @@ mod tests {
 
         // Open the second entry
         workspace
-            .update(cx, |w, cx| w.open_path(file2.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file2.clone(), None, true, cx))
             .await
             .unwrap();
         cx.read(|cx| {
@@ -846,7 +846,7 @@ mod tests {
 
         // Open the first entry again. The existing pane item is activated.
         let entry_1b = workspace
-            .update(cx, |w, cx| w.open_path(file1.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file1.clone(), None, true, cx))
             .await
             .unwrap();
         assert_eq!(entry_1.id(), entry_1b.id());
@@ -864,7 +864,7 @@ mod tests {
         workspace
             .update(cx, |w, cx| {
                 w.split_pane(w.active_pane().clone(), SplitDirection::Right, cx);
-                w.open_path(file2.clone(), true, cx)
+                w.open_path(file2.clone(), None, true, cx)
             })
             .await
             .unwrap();
@@ -883,8 +883,8 @@ mod tests {
         // Open the third entry twice concurrently. Only one pane item is added.
         let (t1, t2) = workspace.update(cx, |w, cx| {
             (
-                w.open_path(file3.clone(), true, cx),
-                w.open_path(file3.clone(), true, cx),
+                w.open_path(file3.clone(), None, true, cx),
+                w.open_path(file3.clone(), None, true, cx),
             )
         });
         t1.await.unwrap();
@@ -1195,7 +1195,7 @@ mod tests {
         workspace
             .update(cx, |workspace, cx| {
                 workspace.split_pane(workspace.active_pane().clone(), SplitDirection::Right, cx);
-                workspace.open_path((worktree.read(cx).id(), "the-new-name.rs"), true, cx)
+                workspace.open_path((worktree.read(cx).id(), "the-new-name.rs"), None, true, cx)
             })
             .await
             .unwrap();
@@ -1284,7 +1284,7 @@ mod tests {
         let pane_1 = cx.read(|cx| workspace.read(cx).active_pane().clone());
 
         workspace
-            .update(cx, |w, cx| w.open_path(file1.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file1.clone(), None, true, cx))
             .await
             .unwrap();
 
@@ -1359,7 +1359,7 @@ mod tests {
         let file3 = entries[2].clone();
 
         let editor1 = workspace
-            .update(cx, |w, cx| w.open_path(file1.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file1.clone(), None, true, cx))
             .await
             .unwrap()
             .downcast::<Editor>()
@@ -1370,13 +1370,13 @@ mod tests {
             });
         });
         let editor2 = workspace
-            .update(cx, |w, cx| w.open_path(file2.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file2.clone(), None, true, cx))
             .await
             .unwrap()
             .downcast::<Editor>()
             .unwrap();
         let editor3 = workspace
-            .update(cx, |w, cx| w.open_path(file3.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file3.clone(), None, true, cx))
             .await
             .unwrap()
             .downcast::<Editor>()
@@ -1626,22 +1626,22 @@ mod tests {
         let file4 = entries[3].clone();
 
         let file1_item_id = workspace
-            .update(cx, |w, cx| w.open_path(file1.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file1.clone(), None, true, cx))
             .await
             .unwrap()
             .id();
         let file2_item_id = workspace
-            .update(cx, |w, cx| w.open_path(file2.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file2.clone(), None, true, cx))
             .await
             .unwrap()
             .id();
         let file3_item_id = workspace
-            .update(cx, |w, cx| w.open_path(file3.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file3.clone(), None, true, cx))
             .await
             .unwrap()
             .id();
         let file4_item_id = workspace
-            .update(cx, |w, cx| w.open_path(file4.clone(), true, cx))
+            .update(cx, |w, cx| w.open_path(file4.clone(), None, true, cx))
             .await
             .unwrap()
             .id();

--- a/styles/src/styleTree/projectPanel.ts
+++ b/styles/src/styleTree/projectPanel.ts
@@ -1,14 +1,19 @@
 import { ColorScheme } from "../themes/common/colorScheme";
-import { background, foreground, text } from "./components";
+import { withOpacity } from "../utils/color";
+import { background, border, foreground, text } from "./components";
 
 export default function projectPanel(colorScheme: ColorScheme) {
   let layer = colorScheme.middle;
-
-  let entry = {
+  
+  let baseEntry = {
     height: 24,
     iconColor: foreground(layer, "variant"),
     iconSize: 8,
     iconSpacing: 8,
+  }
+
+  let entry = {
+    ...baseEntry,
     text: text(layer, "mono", "variant", { size: "sm" }),
     hover: {
       background: background(layer, "variant", "hovered"),
@@ -28,6 +33,12 @@ export default function projectPanel(colorScheme: ColorScheme) {
     padding: { left: 12, right: 12, top: 6, bottom: 6 },
     indentWidth: 8,
     entry,
+    draggedEntry: {
+      ...baseEntry,
+      text: text(layer, "mono", "on", { size: "sm" }),
+      background: withOpacity(background(layer, "on"), 0.9),
+      border: border(layer),
+    },
     ignoredEntry: {
       ...entry,
       text: text(layer, "mono", "disabled"),

--- a/styles/src/styleTree/tabBar.ts
+++ b/styles/src/styleTree/tabBar.ts
@@ -67,7 +67,7 @@ export default function tabBar(colorScheme: ColorScheme) {
 
   const draggedTab = {
     ...activePaneActiveTab,
-    background: withOpacity(tab.background, 0.95),
+    background: withOpacity(tab.background, 0.9),
     border: undefined as any,
     shadow: colorScheme.popoverShadow,
   };


### PR DESCRIPTION
## Description of feature or change
Allows dragging project panel entries over panes to open it in that pane or a new split.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
