### PR TITLE
Update search match highlight and occurrence style

### DIFF
--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -152,10 +152,10 @@ export default function editor(colorScheme: ColorScheme) {
       widthEm: 0.16,
       cornerRadius: 0.05,
     },
-    documentHighlightReadBackground: colorScheme.ramps
-      .neutral(0.5)
-      .alpha(0.2)
-      .hex(), // TODO: This was blend
+    /** Highlights matching occurences of what is under the cursor
+     * as well as matched brackets
+     */
+    documentHighlightReadBackground: withOpacity(foreground(layer, "accent"), 0.1),
     documentHighlightWriteBackground: colorScheme.ramps
       .neutral(0.5)
       .alpha(0.4)

--- a/styles/src/styleTree/search.ts
+++ b/styles/src/styleTree/search.ts
@@ -1,5 +1,6 @@
 import { ColorScheme } from "../themes/common/colorScheme";
-import { background, border, text } from "./components";
+import { withOpacity } from "../utils/color";
+import { background, border, foreground, text } from "./components";
 
 export default function search(colorScheme: ColorScheme) {
   let layer = colorScheme.highest;
@@ -26,7 +27,8 @@ export default function search(colorScheme: ColorScheme) {
   };
 
   return {
-    matchBackground: background(layer), // theme.editor.highlight.match,
+    // TODO: Add an activeMatchBackground on the rust side to differenciate between active and inactive
+    matchBackground: withOpacity(foreground(layer, "accent"), 0.4),
     tabIconSpacing: 8,
     tabIconWidth: 14,
     optionButton: {


### PR DESCRIPTION
## Description of feature or change

We won't be able to style active and inactive matches differently until we finish this task: https://github.com/zed-industries/zed/issues/1869

Before | After
![CleanShot - 2022-11-09 at 18 19 25@2x](https://user-images.githubusercontent.com/1714999/200962903-d4e2a9ef-6e85-4122-a531-95d8dc4ef4a6.png)
![CleanShot - 2022-11-09 at 18 19 54@2x](https://user-images.githubusercontent.com/1714999/200962956-e24fda25-af9e-423c-8a2b-12884a6529f2.png)
![CleanShot - 2022-11-09 at 18 20 17@2x](https://user-images.githubusercontent.com/1714999/200963004-11e46024-3086-4e81-acc2-fd260680eaa2.png)

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
