### PR TITLE
Fix bug where absolute paths of worktrees were not being stored on the server

### DIFF
--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -5988,6 +5988,13 @@ async fn test_random_collaboration(
                                 id
                             );
                             assert_eq!(
+                                guest_snapshot.abs_path(),
+                                host_snapshot.abs_path(),
+                                "{} has different abs path than the host for worktree {}",
+                                guest_client.username,
+                                id
+                            );
+                            assert_eq!(
                                 guest_snapshot.entries(false).collect::<Vec<_>>(),
                                 host_snapshot.entries(false).collect::<Vec<_>>(),
                                 "{} has different snapshot than the host for worktree {}",

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -42,7 +42,6 @@ use std::{
     marker::PhantomData,
     net::SocketAddr,
     ops::{Deref, DerefMut},
-    os::unix::prelude::OsStrExt,
     rc::Rc,
     sync::{
         atomic::{AtomicBool, Ordering::SeqCst},
@@ -1024,7 +1023,7 @@ impl Server {
                 id: *id,
                 root_name: worktree.root_name.clone(),
                 visible: worktree.visible,
-                abs_path: worktree.abs_path.as_os_str().as_bytes().to_vec(),
+                abs_path: worktree.abs_path.clone(),
             })
             .collect::<Vec<_>>();
 
@@ -1075,7 +1074,7 @@ impl Server {
             let message = proto::UpdateWorktree {
                 project_id: project_id.to_proto(),
                 worktree_id: *worktree_id,
-                abs_path: worktree.abs_path.as_os_str().as_bytes().to_vec(),
+                abs_path: worktree.abs_path.clone(),
                 root_name: worktree.root_name.clone(),
                 updated_entries: worktree.entries.values().cloned().collect(),
                 removed_entries: Default::default(),
@@ -1195,6 +1194,7 @@ impl Server {
             project_id,
             worktree_id,
             &request.payload.root_name,
+            &request.payload.abs_path,
             &request.payload.removed_entries,
             &request.payload.updated_entries,
             request.payload.scan_id,

--- a/crates/collab/src/rpc/store.rs
+++ b/crates/collab/src/rpc/store.rs
@@ -67,7 +67,7 @@ pub struct Collaborator {
 
 #[derive(Default, Serialize)]
 pub struct Worktree {
-    pub abs_path: PathBuf,
+    pub abs_path: Vec<u8>,
     pub root_name: String,
     pub visible: bool,
     #[serde(skip)]
@@ -773,7 +773,11 @@ impl Store {
                             Worktree {
                                 root_name: worktree.root_name,
                                 visible: worktree.visible,
-                                ..Default::default()
+                                abs_path: worktree.abs_path.clone(),
+                                entries: Default::default(),
+                                diagnostic_summaries: Default::default(),
+                                scan_id: Default::default(),
+                                is_complete: Default::default(),
                             },
                         )
                     })
@@ -852,7 +856,11 @@ impl Store {
                         Worktree {
                             root_name: worktree.root_name.clone(),
                             visible: worktree.visible,
-                            ..Default::default()
+                            abs_path: worktree.abs_path.clone(),
+                            entries: Default::default(),
+                            diagnostic_summaries: Default::default(),
+                            scan_id: Default::default(),
+                            is_complete: false,
                         },
                     );
                 }
@@ -1006,6 +1014,7 @@ impl Store {
         project_id: ProjectId,
         worktree_id: u64,
         worktree_root_name: &str,
+        worktree_abs_path: &[u8],
         removed_entries: &[u64],
         updated_entries: &[proto::Entry],
         scan_id: u64,
@@ -1016,6 +1025,7 @@ impl Store {
         let connection_ids = project.connection_ids();
         let mut worktree = project.worktrees.entry(worktree_id).or_default();
         worktree.root_name = worktree_root_name.to_string();
+        worktree.abs_path = worktree_abs_path.to_vec();
 
         for entry_id in removed_entries {
             worktree.entries.remove(entry_id);

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1179,6 +1179,10 @@ impl Snapshot {
         self.id
     }
 
+    pub fn abs_path(&self) -> &Arc<Path> {
+        &self.abs_path
+    }
+
     pub fn contains_entry(&self, entry_id: ProjectEntryId) -> bool {
         self.entries_by_id.get(&entry_id, &()).is_some()
     }
@@ -1370,10 +1374,6 @@ impl Snapshot {
 }
 
 impl LocalSnapshot {
-    pub fn abs_path(&self) -> &Arc<Path> {
-        &self.abs_path
-    }
-
     pub fn extension_counts(&self) -> &HashMap<OsString, usize> {
         &self.extension_counts
     }


### PR DESCRIPTION
When we added absolute paths to the worktrees, we forgot to include an assertion in the randomized test, which would have revealed that we weren't correctly storing the absolute paths on the server. This meant that any worktrees that were already shared upon a guest joining had no absolute paths. This was masked at compile time by the use of `..Default::default()`, which we should probably use more conservatively in the future.

We also need to cherry-pick this to stable and preview and redeploy the server, since the bug was introduced in 0.61.x.

/cc @mikayla-maki 