### PR TITLE
Skip LSP additional completion edits which fall within primary edit

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3481,6 +3481,8 @@ impl Project {
                             let end_within = range.start.cmp(&primary.end, buffer).is_le()
                                 && range.end.cmp(&primary.end, buffer).is_ge();
 
+                            //Skip addtional edits which overlap with the primary completion edit
+                            //https://github.com/zed-industries/zed/pull/1871
                             if !start_within && !end_within {
                                 buffer.edit([(range, text)], None, cx);
                             }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3476,12 +3476,12 @@ impl Project {
 
                         for (range, text) in edits {
                             let primary = &completion.old_range;
-                            let within_primary = primary.start.cmp(&range.start, buffer).is_ge()
-                                && primary.end.cmp(&range.end, buffer).is_le();
-                            let within_additional = range.start.cmp(&primary.start, buffer).is_ge()
-                                && range.end.cmp(&primary.end, buffer).is_le();
+                            let start_within = primary.start.cmp(&range.start, buffer).is_le()
+                                && primary.end.cmp(&range.start, buffer).is_ge();
+                            let end_within = range.start.cmp(&primary.end, buffer).is_le()
+                                && range.end.cmp(&primary.end, buffer).is_ge();
 
-                            if !within_primary && !within_additional {
+                            if !start_within && !end_within {
                                 buffer.edit([(range, text)], None, cx);
                             }
                         }


### PR DESCRIPTION
## Description of feature or change

Works around an apparent bug in tsserver where resolving a completion returns an `additionalTextEdits` array containing an item(s?) which overlap with the primary completion edit (both the original completion's edit and resolved completion's edit).

This presented itself when completing an import within JS files. The primary edit was a snippet expanding out and placing the cursor after the completed name but within the expanded snippet, but then the resolved completion would provide an additional edit which completed just the name, causing that to be inserted as well, resulting in a double import within the braces.

This is in apparent conflict with the LSP spec which states that the additional edits `[...] must not overlap (including the same insert position) with the main edit nor with themselves.` ([spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem))

Interestingly this issue only presented itself within JS files but not TS files as when requesting a completion to be resolved in a TS file tsserver throws an exception and so Zed never gets the faulty `additionalTextEdits` array.

This patch works around this issue by skipping any additional edits which overlap in any way with the primary completion edit which has already been applied. It may be useful to also check for overlap between additional edits but that seems needless at this moment.

TODO: Confirm that this is faulty behavior in tsserver and report upstream?

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/zed/issues/5444

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
