### PR TITLE
Propagate mouse up event through drop receiver in early return

### DIFF
--- a/crates/workspace/src/pane/dragged_item_receiver.rs
+++ b/crates/workspace/src/pane/dragged_item_receiver.rs
@@ -118,6 +118,7 @@ pub fn handle_dropped_item(
     {
         Action::Open(*project_entry)
     } else {
+        cx.propagate_event();
         return;
     };
 


### PR DESCRIPTION
## Description of feature or change

Fixes an oversight in the project panel entry drag to panel PR which prevented cmd-click from functioning in the editor

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
