### PR TITLE
Use `EMPTY` code action kind to get more RA actions without breaking TS

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3585,7 +3585,13 @@ impl Project {
                         partial_result_params: Default::default(),
                         context: lsp::CodeActionContext {
                             diagnostics: relevant_diagnostics,
-                            only: None,
+                            only: Some(vec![
+                                lsp::CodeActionKind::EMPTY,
+                                lsp::CodeActionKind::QUICKFIX,
+                                lsp::CodeActionKind::REFACTOR,
+                                lsp::CodeActionKind::REFACTOR_EXTRACT,
+                                lsp::CodeActionKind::SOURCE,
+                            ]),
                         },
                     })
                     .await?


### PR DESCRIPTION
## Description of feature or change

Fixes a regression with tsserver (of course) caused by https://github.com/zed-industries/zed/pull/1865 where tsserver would not give some of its code actions when asked not to filter by any action kinds. In experimentation adding `CodeAction::EMPTY` to the list of kinds gets rust-analyzer to still give us the actions we were missing without tripping up tsserver. This is something which in the future might be worth having server specific lists for, time will tell.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
