### PR TITLE
Update release urls to match new zed.dev url format

### DIFF
--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -14,7 +14,7 @@ jobs:
         content: |
           📣 Zed ${{ github.event.release.tag_name }} was just released!
           
-          Restart your Zed or head to https://zed.dev/releases to grab it.
+          Restart your Zed or head to https://zed.dev/releases/latest to grab it.
         
           ```md
           ### Changelog

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -70,7 +70,14 @@ pub fn init(db: project::Db, http_client: Arc<dyn HttpClient>, cx: &mut MutableA
             }
         });
         cx.add_global_action(move |_: &ViewReleaseNotes, cx| {
-            cx.platform().open_url(&format!("{server_url}/releases"));
+            let latest_release_url = if cx.has_global::<ReleaseChannel>()
+                && *cx.global::<ReleaseChannel>() == ReleaseChannel::Preview
+            {
+                format!("{server_url}/releases/preview/latest")
+            } else {
+                format!("{server_url}/releases/latest")
+            };
+            cx.platform().open_url(&latest_release_url);
         });
         cx.add_action(UpdateNotification::dismiss);
     }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -213,21 +213,6 @@ fn init_paths() {
     std::fs::create_dir_all(&*zed::paths::LANGUAGES_DIR).expect("could not create languages path");
     std::fs::create_dir_all(&*zed::paths::DB_DIR).expect("could not create database path");
     std::fs::create_dir_all(&*zed::paths::LOGS_DIR).expect("could not create logs path");
-
-    // Copy setting files from legacy locations. TODO: remove this after a few releases.
-    thread::spawn(|| {
-        if std::fs::metadata(&*zed::paths::legacy::SETTINGS).is_ok()
-            && std::fs::metadata(&*zed::paths::SETTINGS).is_err()
-        {
-            std::fs::copy(&*zed::paths::legacy::SETTINGS, &*zed::paths::SETTINGS).log_err();
-        }
-
-        if std::fs::metadata(&*zed::paths::legacy::KEYMAP).is_ok()
-            && std::fs::metadata(&*zed::paths::KEYMAP).is_err()
-        {
-            std::fs::copy(&*zed::paths::legacy::KEYMAP, &*zed::paths::KEYMAP).log_err();
-        }
-    });
 }
 
 fn init_logger() {


### PR DESCRIPTION
## Description of feature or change

Note: Do not merge this until [this PR](https://github.com/zed-industries/zed.dev/issues/198) lands.  This PR updates the release urls in Zed to match the new url format in zed.dev.

One thing to note is that we don't need to change the urls for apis related to download releases - those apis were not changed in the zed.dev changes, only the urls for navigating to releases on the website were changed.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
