### PR TITLE
allow users to sign up multiple times without throwing a 500

### DIFF
--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -338,7 +338,7 @@ async fn create_signup(
     Json(params): Json<Signup>,
     Extension(app): Extension<Arc<AppState>>,
 ) -> Result<()> {
-    app.db.create_signup(params).await?;
+    app.db.create_signup(&params).await?;
     Ok(())
 }
 

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -157,7 +157,7 @@ impl Db<sqlx::Sqlite> {
         unimplemented!()
     }
 
-    pub async fn create_signup(&self, _signup: Signup) -> Result<()> {
+    pub async fn create_signup(&self, _signup: &Signup) -> Result<()> {
         unimplemented!()
     }
 
@@ -375,7 +375,7 @@ impl Db<sqlx::Postgres> {
         })
     }
 
-    pub async fn create_signup(&self, signup: Signup) -> Result<()> {
+    pub async fn create_signup(&self, signup: &Signup) -> Result<()> {
         test_support!(self, {
             sqlx::query(
                 "
@@ -394,6 +394,8 @@ impl Db<sqlx::Postgres> {
                 )
                 VALUES
                     ($1, $2, FALSE, $3, $4, $5, FALSE, $6, $7, $8)
+                ON CONFLICT (email_address) DO UPDATE SET
+                    email_address = excluded.email_address
                 RETURNING id
                 ",
             )
@@ -1259,7 +1261,7 @@ pub struct IncomingContactRequest {
     pub should_notify: bool,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Default)]
 pub struct Signup {
     pub email_address: String,
     pub platform_mac: bool,
@@ -1284,7 +1286,7 @@ pub struct WaitlistSummary {
     pub unknown_count: i64,
 }
 
-#[derive(FromRow, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, FromRow, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Invite {
     pub email_address: String,
     pub email_confirmation_code: String,


### PR DESCRIPTION
## Description of feature or change

Adds a test to make sure users can sign up multiple times and the associated fix
Also did a bit of refactoring on the test

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
