### PR TITLE
Allow having multiple mouse event handlers of the same kind

### DIFF
--- a/crates/gpui/src/scene/mouse_event.rs
+++ b/crates/gpui/src/scene/mouse_event.rs
@@ -5,7 +5,7 @@ use std::{
 
 use pathfinder_geometry::{rect::RectF, vector::Vector2F};
 
-use crate::{MouseButton, MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent};
+use crate::{scene::mouse_region::HandlerKey, MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent};
 
 #[derive(Debug, Default, Clone)]
 pub struct MouseMove {
@@ -217,17 +217,17 @@ impl MouseEvent {
         discriminant(&MouseEvent::ScrollWheel(Default::default()))
     }
 
-    pub fn handler_key(&self) -> (Discriminant<MouseEvent>, Option<MouseButton>) {
+    pub fn handler_key(&self) -> HandlerKey {
         match self {
-            MouseEvent::Move(_) => (Self::move_disc(), None),
-            MouseEvent::Drag(e) => (Self::drag_disc(), e.pressed_button),
-            MouseEvent::Hover(_) => (Self::hover_disc(), None),
-            MouseEvent::Down(e) => (Self::down_disc(), Some(e.button)),
-            MouseEvent::Up(e) => (Self::up_disc(), Some(e.button)),
-            MouseEvent::Click(e) => (Self::click_disc(), Some(e.button)),
-            MouseEvent::UpOut(e) => (Self::up_out_disc(), Some(e.button)),
-            MouseEvent::DownOut(e) => (Self::down_out_disc(), Some(e.button)),
-            MouseEvent::ScrollWheel(_) => (Self::scroll_wheel_disc(), None),
+            MouseEvent::Move(_) => HandlerKey::new(Self::move_disc(), None),
+            MouseEvent::Drag(e) => HandlerKey::new(Self::drag_disc(), e.pressed_button),
+            MouseEvent::Hover(_) => HandlerKey::new(Self::hover_disc(), None),
+            MouseEvent::Down(e) => HandlerKey::new(Self::down_disc(), Some(e.button)),
+            MouseEvent::Up(e) => HandlerKey::new(Self::up_disc(), Some(e.button)),
+            MouseEvent::Click(e) => HandlerKey::new(Self::click_disc(), Some(e.button)),
+            MouseEvent::UpOut(e) => HandlerKey::new(Self::up_out_disc(), Some(e.button)),
+            MouseEvent::DownOut(e) => HandlerKey::new(Self::down_out_disc(), Some(e.button)),
+            MouseEvent::ScrollWheel(_) => HandlerKey::new(Self::scroll_wheel_disc(), None),
         }
     }
 }


### PR DESCRIPTION
## Description of feature or change

Previously we only allowed a single mouse handler per handler region of a specific mouse event kind and button. This meant that any API which added additional functionality to a region could potentially stop over an existing handler causing it's logic to never fire. Instead now we will store all of them and fire in order of adding to the region. If any one handler calls propagate then the region will propagate the event.

Fixes issue where click on a tab would not change tab focus.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
