### PR TITLE
Prevent mouse down from falling through context menu

### DIFF
--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -349,6 +349,7 @@ impl ContextMenu {
                                     .boxed()
                             })
                             .with_cursor_style(CursorStyle::PointingHand)
+                            .on_down(MouseButton::Left, |_, _| {})
                             .on_click(MouseButton::Left, move |_, cx| {
                                 cx.dispatch_action(Clicked);
                                 cx.dispatch_any_action(action.boxed_clone());


### PR DESCRIPTION
## Description of feature or change

Fixes the context menu click issue that arose after https://github.com/zed-industries/zed/pull/1902. I haven't yet fully figured out how this wasn't broken before as this behavior seems to match my understanding of how mouse handlers should function.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
 - N/A
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
