### PR TITLE
Do not reorder tab opened by follower to end of item list

### DIFF
--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -5040,14 +5040,6 @@ async fn test_following_tab_order(
     //Verify that the tabs opened in the order we expect
     assert_eq!(&pane_paths(&pane_a, cx_a), &["1.txt", "3.txt"]);
 
-    //Open just 2 on client B
-    workspace_b
-        .update(cx_b, |workspace, cx| {
-            workspace.open_path((worktree_id, "2.txt"), None, true, cx)
-        })
-        .await
-        .unwrap();
-
     //Follow client B as client A
     workspace_a
         .update(cx_a, |workspace, cx| {
@@ -5057,6 +5049,15 @@ async fn test_following_tab_order(
         })
         .await
         .unwrap();
+
+    //Open just 2 on client B
+    workspace_b
+        .update(cx_b, |workspace, cx| {
+            workspace.open_path((worktree_id, "2.txt"), None, true, cx)
+        })
+        .await
+        .unwrap();
+    deterministic.run_until_parked();
 
     // Verify that newly opened followed file is at the end
     assert_eq!(&pane_paths(&pane_a, cx_a), &["1.txt", "3.txt", "2.txt"]);
@@ -5069,6 +5070,7 @@ async fn test_following_tab_order(
         .await
         .unwrap();
     assert_eq!(&pane_paths(&pane_b, cx_b), &["2.txt", "1.txt"]);
+    deterministic.run_until_parked();
 
     // Verify that following into 1 did not reorder
     assert_eq!(&pane_paths(&pane_a, cx_a), &["1.txt", "3.txt", "2.txt"]);

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -55,9 +55,11 @@ impl FollowableItem for Editor {
             let buffer = buffer.await?;
             let editor = pane
                 .read_with(&cx, |pane, cx| {
-                    pane.items_of_type::<Self>().find(|editor| {
+                    let existing = pane.items_of_type::<Self>().find(|editor| {
                         editor.read(cx).buffer.read(cx).as_singleton().as_ref() == Some(&buffer)
-                    })
+                    });
+                    dbg!(&existing);
+                    existing
                 })
                 .unwrap_or_else(|| {
                     pane.update(&mut cx, |_, cx| {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -55,11 +55,9 @@ impl FollowableItem for Editor {
             let buffer = buffer.await?;
             let editor = pane
                 .read_with(&cx, |pane, cx| {
-                    let existing = pane.items_of_type::<Self>().find(|editor| {
+                    pane.items_of_type::<Self>().find(|editor| {
                         editor.read(cx).buffer.read(cx).as_singleton().as_ref() == Some(&buffer)
-                    });
-                    dbg!(&existing);
-                    existing
+                    })
                 })
                 .unwrap_or_else(|| {
                     pane.update(&mut cx, |_, cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2676,7 +2676,12 @@ impl Workspace {
         }
 
         for (pane, item) in items_to_add {
-            Pane::add_item(self, &pane, item.boxed_clone(), false, false, None, cx);
+            if let Some(index) = pane.update(cx, |pane, _| pane.index_for_item(item.as_ref())) {
+                pane.update(cx, |pane, cx| pane.activate_item(index, false, false, cx));
+            } else {
+                Pane::add_item(self, &pane, item.boxed_clone(), false, false, None, cx);
+            }
+
             if pane == self.active_pane {
                 pane.update(cx, |pane, cx| pane.focus_active_item(cx));
             }


### PR DESCRIPTION
## Description of feature or change

Yet another cause of tab rearranging down

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
 - N/A
- [ ] Has documentation been created or updated (including above changes to settings)?
 - N/A
