### PR TITLE
Include outline items for c/c++ functions returning pointers

### DIFF
--- a/crates/zed/src/languages/c/outline.scm
+++ b/crates/zed/src/languages/c/outline.scm
@@ -14,17 +14,57 @@
     declarator: (_) @name) @item
 
 (declaration
-    type: (_) @context
-    declarator: (function_declarator
-        declarator: (_) @name
-        parameters: (parameter_list
-            "(" @context
-            ")" @context))) @item
+    (type_qualifier)? @context
+    type: (_)? @context
+    declarator: [
+        (function_declarator
+            declarator: (_) @name
+            parameters: (parameter_list
+                "(" @context
+                ")" @context))
+        (pointer_declarator
+            "*" @context
+            declarator: (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+    ]
+) @item
 
 (function_definition
-    type: (_) @context
-    declarator: (function_declarator
-        declarator: (_) @name
-        parameters: (parameter_list
-            "(" @context
-            ")" @context))) @item
+    (type_qualifier)? @context
+    type: (_)? @context
+    declarator: [
+        (function_declarator
+            declarator: (_) @name
+            parameters: (parameter_list
+                "(" @context
+                ")" @context))
+        (pointer_declarator
+            "*" @context
+            declarator: (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+    ]
+) @item

--- a/crates/zed/src/languages/cpp/outline.scm
+++ b/crates/zed/src/languages/cpp/outline.scm
@@ -51,6 +51,22 @@
                 parameters: (parameter_list
                     "(" @context
                     ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+        (reference_declarator
+            ["&" "&&"] @context
+            (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
     ]
     (type_qualifier)? @context) @item
 
@@ -74,6 +90,22 @@
                 parameters: (parameter_list
                     "(" @context
                     ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+        (reference_declarator
+            ["&" "&&"] @context
+            (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
     ]
     (type_qualifier)? @context) @item
 
@@ -93,6 +125,22 @@
         (pointer_declarator
             "*" @context
             declarator: (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+        (reference_declarator
+            ["&" "&&"] @context
+            (function_declarator
                 declarator: (_) @name
                 parameters: (parameter_list
                     "(" @context


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/754

There are still obscure forms of functions in these languages that *won't* show up in the outline (such as functions that return pointers to pointers to pointers), but these changes make it so that 99% of functions will be picked up. To make it work in the general case, we may need to add features to Tree-sitter's query language (such some kind "descendent" operator) to deal with the arbitrarily-nested structure of C's definition syntax.

🍐 'd with @ForLoveOfCats 