### PR TITLE
Fix busy status when accepting a contact request

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1616,7 +1616,8 @@ async fn respond_to_contact_request(
 
         db.respond_to_contact_request(responder_id, requester_id, accept)
             .await?;
-        let busy = db.is_user_busy(requester_id).await?;
+        let requester_busy = db.is_user_busy(requester_id).await?;
+        let responder_busy = db.is_user_busy(responder_id).await?;
 
         let pool = session.connection_pool().await;
         // Update responder with new contact
@@ -1624,7 +1625,7 @@ async fn respond_to_contact_request(
         if accept {
             update
                 .contacts
-                .push(contact_for_user(requester_id, false, busy, &pool));
+                .push(contact_for_user(requester_id, false, requester_busy, &pool));
         }
         update
             .remove_incoming_requests
@@ -1638,7 +1639,7 @@ async fn respond_to_contact_request(
         if accept {
             update
                 .contacts
-                .push(contact_for_user(responder_id, true, busy, &pool));
+                .push(contact_for_user(responder_id, true, responder_busy, &pool));
         }
         update
             .remove_outgoing_requests


### PR DESCRIPTION
Previously, we would send an contact update when accepting a request using the same `busy` status for both the requester and the responder. This was obviously wrong and caused the requester to see their own busy status as the newly-added responder contact's status.