### PR TITLE
Query project count as `i64` instead of `i32` when gathering metrics

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -1472,7 +1472,7 @@ impl Database {
                 .into_values::<_, QueryAs>()
                 .one(&*tx)
                 .await?
-                .unwrap_or(0) as usize)
+                .unwrap_or(0i64) as usize)
         })
         .await
     }


### PR DESCRIPTION
Using the latter would cause a type mismatch when performing the query.