### PR TITLE
Allow overwriting signup data if a user signs up more than once with the same email address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "lsp",
  "nanoid",
  "parking_lot 0.11.2",
+ "pretty_assertions",
  "project",
  "prometheus",
  "rand 0.8.5",
@@ -1729,6 +1730,12 @@ dependencies = [
  "util",
  "workspace",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -4006,6 +4013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4361,18 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -8064,6 +8092,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zed"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -64,6 +64,7 @@ fs = { path = "../fs", features = ["test-support"] }
 git = { path = "../git", features = ["test-support"] }
 live_kit_client = { path = "../live_kit_client", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
+pretty_assertions = "1.3.0"
 project = { path = "../project", features = ["test-support"] }
 rpc = { path = "../rpc", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }

--- a/crates/collab/src/db/signup.rs
+++ b/crates/collab/src/db/signup.rs
@@ -34,7 +34,7 @@ pub struct Invite {
     pub email_confirmation_code: String,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct NewSignup {
     pub email_address: String,
     pub platform_mac: bool,

--- a/crates/collab/src/db/signup.rs
+++ b/crates/collab/src/db/signup.rs
@@ -44,6 +44,7 @@ pub struct NewSignup {
     pub programming_languages: Vec<String>,
     pub device_id: Option<String>,
     pub added_to_mailing_list: bool,
+    pub created_at: Option<DateTime>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, FromQueryResult)]

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -737,7 +737,7 @@ async fn test_multiple_signup_overwrite() {
 
     let email_address = "user_1@example.com".to_string();
 
-    let signup = NewSignup {
+    let initial_signup = NewSignup {
         email_address: email_address.clone(),
         platform_mac: false,
         platform_linux: true,
@@ -748,26 +748,26 @@ async fn test_multiple_signup_overwrite() {
         added_to_mailing_list: false,
     };
 
-    db.create_signup(&signup).await.unwrap();
+    db.create_signup(&initial_signup).await.unwrap();
 
-    let signup_from_db = db.get_signup(&signup.email_address).await.unwrap();
+    let initial_signup_from_db = db.get_signup(&email_address).await.unwrap();
 
     assert_eq!(
-        signup_from_db.clone(),
+        initial_signup_from_db.clone(),
         signup::Model {
-            email_address: signup.email_address,
-            platform_mac: signup.platform_mac,
-            platform_linux: signup.platform_linux,
-            platform_windows: signup.platform_windows,
-            editor_features: Some(signup.editor_features),
-            programming_languages: Some(signup.programming_languages),
-            added_to_mailing_list: signup.added_to_mailing_list,
-            ..signup_from_db
+            email_address: initial_signup.email_address,
+            platform_mac: initial_signup.platform_mac,
+            platform_linux: initial_signup.platform_linux,
+            platform_windows: initial_signup.platform_windows,
+            editor_features: Some(initial_signup.editor_features),
+            programming_languages: Some(initial_signup.programming_languages),
+            added_to_mailing_list: initial_signup.added_to_mailing_list,
+            ..initial_signup_from_db
         }
     );
 
-    let signup_overwrite = NewSignup {
-        email_address,
+    let subsequent_signup = NewSignup {
+        email_address: email_address.clone(),
         platform_mac: true,
         platform_linux: false,
         platform_windows: true,
@@ -777,26 +777,23 @@ async fn test_multiple_signup_overwrite() {
         added_to_mailing_list: true,
     };
 
-    db.create_signup(&signup_overwrite).await.unwrap();
+    db.create_signup(&subsequent_signup).await.unwrap();
 
-    let signup_overwrite_from_db = db
-        .get_signup(&signup_overwrite.email_address)
-        .await
-        .unwrap();
+    let subsequent_signup_from_db = db.get_signup(&email_address).await.unwrap();
 
     assert_eq!(
-        signup_overwrite_from_db.clone(),
+        subsequent_signup_from_db.clone(),
         signup::Model {
-            platform_mac: signup_overwrite.platform_mac,
-            platform_linux: signup_overwrite.platform_linux,
-            platform_windows: signup_overwrite.platform_windows,
-            editor_features: Some(signup_overwrite.editor_features),
-            programming_languages: Some(signup_overwrite.programming_languages),
-            device_id: signup_overwrite.device_id,
-            added_to_mailing_list: signup_overwrite.added_to_mailing_list,
+            platform_mac: subsequent_signup.platform_mac,
+            platform_linux: subsequent_signup.platform_linux,
+            platform_windows: subsequent_signup.platform_windows,
+            editor_features: Some(subsequent_signup.editor_features),
+            programming_languages: Some(subsequent_signup.programming_languages),
+            device_id: subsequent_signup.device_id,
+            added_to_mailing_list: subsequent_signup.added_to_mailing_list,
             // shouldn't overwrite their creation Datetime - user shouldn't lose their spot in line
-            created_at: signup_from_db.created_at,
-            ..signup_overwrite_from_db
+            created_at: initial_signup_from_db.created_at,
+            ..subsequent_signup_from_db
         }
     );
 }

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -737,6 +737,8 @@ async fn test_multiple_signup_overwrite() {
 
     let email_address = "user_1@example.com".to_string();
 
+    let initial_signup_created_at_milliseconds = 0;
+
     let initial_signup = NewSignup {
         email_address: email_address.clone(),
         platform_mac: false,
@@ -746,6 +748,9 @@ async fn test_multiple_signup_overwrite() {
         programming_languages: vec!["rust".into(), "c".into()],
         device_id: Some(format!("device_id")),
         added_to_mailing_list: false,
+        created_at: Some(
+            DateTime::from_timestamp_millis(initial_signup_created_at_milliseconds).unwrap(),
+        ),
     };
 
     db.create_signup(&initial_signup).await.unwrap();
@@ -775,6 +780,13 @@ async fn test_multiple_signup_overwrite() {
         programming_languages: vec!["d".into(), "elm".into()],
         device_id: Some(format!("different_device_id")),
         added_to_mailing_list: true,
+        // subsequent signup happens next day
+        created_at: Some(
+            DateTime::from_timestamp_millis(
+                initial_signup_created_at_milliseconds + (1000 * 60 * 60 * 24),
+            )
+            .unwrap(),
+        ),
     };
 
     db.create_signup(&subsequent_signup).await.unwrap();
@@ -817,6 +829,7 @@ async fn test_signups() {
             programming_languages: vec!["rust".into(), "c".into()],
             device_id: Some(format!("device_id_{i}")),
             added_to_mailing_list: i != 0, // One user failed to subscribe
+            created_at: Some(DateTime::from_timestamp_millis(i as i64).unwrap()), // Signups are consecutive
         })
         .collect::<Vec<NewSignup>>();
 

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -750,7 +750,6 @@ async fn test_multiple_signup_overwrite() {
 
     db.create_signup(&signup).await.unwrap();
 
-    // TODO: Remove this method and just have create_signup return an instance?
     let signup_from_db = db.get_signup(&signup.email_address).await.unwrap();
 
     assert_eq!(


### PR DESCRIPTION
## Description of feature or change

A user originally signed up as a Linux-only user.  Later down the line, their employer gave them a Mac, so they re-enrolled, which was successful, but we didn't overwrite the original fields, so we continued to consider them as a Linux-only user, which means they were being skipped when we did invites.  This PR allows a user to signup again and overwrite those fields.

It makes more sense to have a UI to edit signup / profile data, but this is a quick fix in the meantime and users would likely still try to enroll multiple times even if once we supply them with a place to edit their signup / profile data.

I omitted certain fields from being overwritten, such as `created_at`, so that we don't push a user to the back of the line if they enroll multiple times.

## Link to related issues from zed or insiders

## Before Merging 

- [X] Does this have tests or have existing tests been updated to cover this change?
- [NA] Have you added the necessary settings to configure this feature?
- [NA] Has documentation been created or updated (including above changes to settings)?
