### PR TITLE
Fix inviting existing users via a different email address

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -878,10 +878,16 @@ impl Database {
             let signup = signup.update(&*tx).await?;
 
             if let Some(inviting_user_id) = signup.inviting_user_id {
+                let (user_id_a, user_id_b, a_to_b) = if inviting_user_id < user.id {
+                    (inviting_user_id, user.id, true)
+                } else {
+                    (user.id, inviting_user_id, false)
+                };
+
                 contact::Entity::insert(contact::ActiveModel {
-                    user_id_a: ActiveValue::set(inviting_user_id),
-                    user_id_b: ActiveValue::set(user.id),
-                    a_to_b: ActiveValue::set(true),
+                    user_id_a: ActiveValue::set(user_id_a),
+                    user_id_b: ActiveValue::set(user_id_b),
+                    a_to_b: ActiveValue::set(a_to_b),
                     should_notify: ActiveValue::set(true),
                     accepted: ActiveValue::set(true),
                     ..Default::default()

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -595,6 +595,8 @@ async fn test_invite_codes() {
             busy: false,
         }]
     );
+    assert!(db.has_contact(user1, user2).await.unwrap());
+    assert!(db.has_contact(user2, user1).await.unwrap());
     assert_eq!(
         db.get_invite_code_for_user(user2).await.unwrap().unwrap().1,
         7
@@ -649,6 +651,8 @@ async fn test_invite_codes() {
             busy: false,
         }]
     );
+    assert!(db.has_contact(user1, user3).await.unwrap());
+    assert!(db.has_contact(user3, user1).await.unwrap());
     assert_eq!(
         db.get_invite_code_for_user(user3).await.unwrap().unwrap().1,
         3
@@ -714,6 +718,8 @@ async fn test_invite_codes() {
             busy: false,
         }]
     );
+    assert!(db.has_contact(user1, user4).await.unwrap());
+    assert!(db.has_contact(user4, user1).await.unwrap());
     assert_eq!(
         db.get_invite_code_for_user(user4).await.unwrap().unwrap().1,
         5
@@ -725,6 +731,77 @@ async fn test_invite_codes() {
         .unwrap_err();
     let (_, invite_count) = db.get_invite_code_for_user(user1).await.unwrap().unwrap();
     assert_eq!(invite_count, 1);
+
+    // A newer user can invite an existing one via a different email address
+    // than the one they used to sign up.
+    let user5 = db
+        .create_user(
+            "user5@example.com",
+            false,
+            NewUserParams {
+                github_login: "user5".into(),
+                github_user_id: 5,
+                invite_count: 0,
+            },
+        )
+        .await
+        .unwrap()
+        .user_id;
+    db.set_invite_count_for_user(user5, 5).await.unwrap();
+    let (user5_invite_code, _) = db.get_invite_code_for_user(user5).await.unwrap().unwrap();
+    let user5_invite_to_user1 = db
+        .create_invite_from_code(&user5_invite_code, "user1@different.com", None)
+        .await
+        .unwrap();
+    let user1_2 = db
+        .create_user_from_invite(
+            &user5_invite_to_user1,
+            NewUserParams {
+                github_login: "user1".into(),
+                github_user_id: 1,
+                invite_count: 5,
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .user_id;
+    assert_eq!(user1_2, user1);
+    assert_eq!(
+        db.get_contacts(user1).await.unwrap(),
+        [
+            Contact::Accepted {
+                user_id: user2,
+                should_notify: true,
+                busy: false,
+            },
+            Contact::Accepted {
+                user_id: user3,
+                should_notify: true,
+                busy: false,
+            },
+            Contact::Accepted {
+                user_id: user4,
+                should_notify: true,
+                busy: false,
+            },
+            Contact::Accepted {
+                user_id: user5,
+                should_notify: false,
+                busy: false,
+            }
+        ]
+    );
+    assert_eq!(
+        db.get_contacts(user5).await.unwrap(),
+        [Contact::Accepted {
+            user_id: user1,
+            should_notify: true,
+            busy: false,
+        }]
+    );
+    assert!(db.has_contact(user1, user5).await.unwrap());
+    assert!(db.has_contact(user5, user1).await.unwrap());
 }
 
 #[gpui::test]


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/758

Previously, when a newer user invited an existing one using a different email address than the one they originally signed up with, we would correctly create a contact but it would violate the `contacts` table invariant of `user_id_a` always being less than `user_id_b`. That caused issues in the `Database::has_contact` method, because we would fail to correctly determine whether two users were contacts or not, which would in turn cause the bug illustrated in the issue linked above.

This pull request doesn't make any assumption about the invited user id and, before inserting the new contact, orders user ids such that the aforementioned invariant isn't violated.

I ran this query in the production database to see how often the invariant was violated:

```sql
SELECT * FROM contacts
WHERE user_id_a > user_id_b
```

And it returned 3 instances of it happening:

id|user_id_a|user_id_b|a_to_b|should_notify|accepted
-- | -- | -- | -- | -- | --
1393 | 46624 | 43593 | TRUE | TRUE | TRUE
1551 | 56932 | 46118 | TRUE | TRUE | TRUE
1554 | 55026 | 44541 | TRUE | TRUE | TRUE

I went ahead and fixed those manually to solve the problem for those users. I'll work on backporting this change to production to ensure it doesn't happen again.