### PR TITLE
notify views when hover finishes in tooltip wrapper

### DIFF
--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -115,6 +115,7 @@ impl Tooltip {
                     } else {
                         state.visible.set(false);
                         state.debounce.take();
+                        cx.notify();
                     }
                 }
             })


### PR DESCRIPTION
## Description of feature or change

fixes tooltips that stick around for disabled buttons

## Link to related issues from zed or insiders

https://github.com/zed-industries/feedback/issues/643

## Before Merging 

- [N/A] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
