### PR TITLE
Don't drop `unregistered` column in reconnection support migration

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -44,7 +44,8 @@ CREATE TABLE "projects" (
     "room_id" INTEGER REFERENCES rooms (id) NOT NULL,
     "host_user_id" INTEGER REFERENCES users (id) NOT NULL,
     "host_connection_id" INTEGER NOT NULL,
-    "host_connection_epoch" TEXT NOT NULL
+    "host_connection_epoch" TEXT NOT NULL,
+    "unregistered" BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX "index_projects_on_host_connection_epoch" ON "projects" ("host_connection_epoch");
 

--- a/crates/collab/migrations/20221111092550_reconnection_support.sql
+++ b/crates/collab/migrations/20221111092550_reconnection_support.sql
@@ -6,8 +6,7 @@ CREATE TABLE IF NOT EXISTS "rooms" (
 ALTER TABLE "projects"
     ADD "room_id" INTEGER REFERENCES rooms (id),
     ADD "host_connection_id" INTEGER,
-    ADD "host_connection_epoch" UUID,
-    DROP COLUMN "unregistered";
+    ADD "host_connection_epoch" UUID;
 CREATE INDEX "index_projects_on_host_connection_epoch" ON "projects" ("host_connection_epoch");
 
 CREATE TABLE "worktrees" (


### PR DESCRIPTION
We don't use this column anymore because, when a project is unshared, we simply remove it from the `projects` table. However, this column is expected in the stable version of the server and the database is shared between stable and preview. If we dropped it, stable would start throwing errors.