### PR TITLE
WIP: Implement text manipulation commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "ordered-float",
  "parking_lot 0.11.2",
  "postage",
+ "pretty_assertions",
  "project",
  "rand 0.8.5",
  "rpc",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -140,7 +140,8 @@
                     "center_cursor": true
                 }
             ],
-            "ctrl-cmd-space": "editor::ShowCharacterPalette"
+            "ctrl-cmd-space": "editor::ShowCharacterPalette",
+            "ctrl-'": "editor::SortLines"
         }
     },
     {

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -69,6 +69,7 @@ settings = { path = "../settings", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
 ctor = "0.1"
 env_logger = "0.9"
+pretty_assertions = "1.3.0"
 rand = "0.8"
 unindent = "0.1.7"
 tree-sitter = "0.20"

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5439,6 +5439,43 @@ async fn go_to_hunk(deterministic: Arc<Deterministic>, cx: &mut gpui::TestAppCon
     );
 }
 
+#[gpui::test]
+async fn test_sort_lines(cx: &mut gpui::TestAppContext) {
+    let mut cx = EditorTestContext::new(cx);
+
+    //cargo test -p editor
+
+    let start_text = r#"
+        «bb
+        dddd
+        ccc
+        aˇ»
+        "#
+    .unindent();
+
+    let end_text = r#"
+        «a
+        bb
+        ccc
+        ddddˇ»
+        "#
+    .unindent();
+
+    // Things to test:
+    // 1) Make sure we're clipping to the right range (not deleting the line after the selections)
+    // 2) Make sure that we move the selections, associated with the line that gets moved
+
+    // 3) Support folds
+    // 4) Support excerpts
+
+    cx.set_state(&start_text);
+    cx.update_editor(|editor, cx| {
+        editor.sort_lines(&SortLines, cx);
+    });
+
+    cx.assert_editor_state(&end_text);
+}
+
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {
     let point = DisplayPoint::new(row as u32, column as u32);
     point..point

--- a/crates/editor/src/editor_util.rs
+++ b/crates/editor/src/editor_util.rs
@@ -7,34 +7,27 @@ use crate::display_map::DisplaySnapshot;
 type RowIndex = u32;
 
 pub fn end_row_for(selection: &Selection<Point>, display_map: &DisplaySnapshot) -> RowIndex {
-    let mut end_row = if selection.end.column > 0 || selection.is_empty() {
+    if selection.end.column > 0 || selection.is_empty() {
         display_map.next_line_boundary(selection.end).0.row + 1
     } else {
         selection.end.row
-    };
-    end_row
+    }
 }
 
-struct ContiguousRowRanges<'snapshot, I: Iterator> {
+pub struct ContiguousRowRanges<'snapshot, I: Iterator> {
     selections: Peekable<I>,
     display_map: &'snapshot DisplaySnapshot,
 }
 
-impl<'snapshot, I: Iterator> ContiguousRowRanges<'snapshot, I> {
-    fn new(selections: I, display_map: &DisplaySnapshot) -> Self {
-        Self {
-            selections: selections.peekable(),
-            display_map,
-        }
-    }
-}
-
 pub trait IteratorExtension {
-    fn by_contiguous_rows<I>(self, display_map: &DisplaySnapshot) -> ContiguousRowRanges<Self>
+    fn by_contiguous_rows(self, display_map: &DisplaySnapshot) -> ContiguousRowRanges<Self>
     where
         Self: Sized + Iterator<Item = Selection<Point>>,
     {
-        ContiguousRowRanges::new(self, display_map)
+        ContiguousRowRanges {
+            selections: self.peekable(),
+            display_map,
+        }
     }
 }
 
@@ -47,13 +40,13 @@ impl<'snapshot, I: Iterator<Item = Selection<Point>>> Iterator
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.selections.next();
-        let selections = Vec::new();
+        let mut selections = Vec::new();
 
         if let Some(selection) = next {
             selections.push(selection.clone());
             let start_row = selection.start.row;
 
-            let end_row = end_row_for(&selection, self.display_map);
+            let mut end_row = end_row_for(&selection, self.display_map);
 
             while let Some(next_selection) = self.selections.peek() {
                 if next_selection.start.row <= end_row {

--- a/crates/editor/src/editor_util.rs
+++ b/crates/editor/src/editor_util.rs
@@ -1,0 +1,71 @@
+use std::{iter::Peekable, ops::Range};
+
+use language::{Point, Selection};
+
+use crate::display_map::DisplaySnapshot;
+
+type RowIndex = u32;
+
+pub fn end_row_for(selection: &Selection<Point>, display_map: &DisplaySnapshot) -> RowIndex {
+    let mut end_row = if selection.end.column > 0 || selection.is_empty() {
+        display_map.next_line_boundary(selection.end).0.row + 1
+    } else {
+        selection.end.row
+    };
+    end_row
+}
+
+struct ContiguousRowRanges<'snapshot, I: Iterator> {
+    selections: Peekable<I>,
+    display_map: &'snapshot DisplaySnapshot,
+}
+
+impl<'snapshot, I: Iterator> ContiguousRowRanges<'snapshot, I> {
+    fn new(selections: I, display_map: &DisplaySnapshot) -> Self {
+        Self {
+            selections: selections.peekable(),
+            display_map,
+        }
+    }
+}
+
+pub trait IteratorExtension {
+    fn by_contiguous_rows<I>(self, display_map: &DisplaySnapshot) -> ContiguousRowRanges<Self>
+    where
+        Self: Sized + Iterator<Item = Selection<Point>>,
+    {
+        ContiguousRowRanges::new(self, display_map)
+    }
+}
+
+impl<I> IteratorExtension for I where I: Iterator {}
+
+impl<'snapshot, I: Iterator<Item = Selection<Point>>> Iterator
+    for ContiguousRowRanges<'snapshot, I>
+{
+    type Item = (Range<u32>, Vec<Selection<Point>>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.selections.next();
+        let selections = Vec::new();
+
+        if let Some(selection) = next {
+            selections.push(selection.clone());
+            let start_row = selection.start.row;
+
+            let end_row = end_row_for(&selection, self.display_map);
+
+            while let Some(next_selection) = self.selections.peek() {
+                if next_selection.start.row <= end_row {
+                    end_row = end_row_for(next_selection, self.display_map);
+                    selections.push(self.selections.next().unwrap().clone());
+                } else {
+                    break;
+                }
+            }
+            Some((start_row..end_row, selections))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/editor/src/editor_util.rs
+++ b/crates/editor/src/editor_util.rs
@@ -1,4 +1,4 @@
-use std::{iter::Peekable, ops::Range};
+use std::{iter::Peekable, ops::RangeInclusive};
 
 use language::{Point, Selection};
 
@@ -8,7 +8,7 @@ type RowIndex = u32;
 
 pub fn end_row_for(selection: &Selection<Point>, display_map: &DisplaySnapshot) -> RowIndex {
     if selection.end.column > 0 || selection.is_empty() {
-        display_map.next_line_boundary(selection.end).0.row + 1
+        display_map.next_line_boundary(selection.end).0.row
     } else {
         selection.end.row
     }
@@ -36,7 +36,7 @@ impl<I> IteratorExtension for I where I: Iterator {}
 impl<'snapshot, I: Iterator<Item = Selection<Point>>> Iterator
     for ContiguousRowRanges<'snapshot, I>
 {
-    type Item = (Range<u32>, Vec<Selection<Point>>);
+    type Item = (RangeInclusive<u32>, Vec<Selection<Point>>);
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.selections.next();
@@ -56,7 +56,7 @@ impl<'snapshot, I: Iterator<Item = Selection<Point>>> Iterator
                     break;
                 }
             }
-            Some((start_row..end_row, selections))
+            Some((start_row..=end_row, selections))
         } else {
             None
         }

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -17,6 +17,9 @@ use util::{
     test::{generate_marked_text, marked_text_ranges},
 };
 
+#[cfg(test)]
+use pretty_assertions::assert_eq;
+
 use super::build_editor;
 
 pub struct EditorTestContext<'a> {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -98,6 +98,12 @@ pub struct BufferSnapshot {
     parse_count: usize,
 }
 
+impl std::fmt::Debug for BufferSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<BufferSnapshot>")
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct IndentSize {
     pub len: u32,

--- a/crates/util/src/test.rs
+++ b/crates/util/src/test.rs
@@ -51,6 +51,7 @@ fn write_tree(path: &Path, tree: serde_json::Value) {
     }
 }
 
+// Returns a square string, where each row is filled with the ascii character (start_char + row)
 pub fn sample_text(rows: usize, cols: usize, start_char: char) -> String {
     let mut text = String::new();
     for row in 0..rows {


### PR DESCRIPTION
May eventually add commands for manipulating the order/content of text under selections

## Description of feature or change

https://github.com/zed-industries/feedback/issues/57

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
