### PR TITLE
Add check for if the user wants a blanks workspace when deserializing

### DIFF
--- a/crates/drag_and_drop/src/drag_and_drop.rs
+++ b/crates/drag_and_drop/src/drag_and_drop.rs
@@ -139,9 +139,7 @@ impl<V: View> DragAndDrop<V> {
                     region_offset,
                     region,
                 }) => {
-                    if (dbg!(event.position) - (dbg!(region.origin() + region_offset))).length()
-                        > DEAD_ZONE
-                    {
+                    if (event.position - (region.origin() + region_offset)).length() > DEAD_ZONE {
                         this.currently_dragged = Some(State::Dragging {
                             window_id,
                             region_offset,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use db::{define_connection, query, sqlez::connection::Connection, sqlez_macros::sql};
 use gpui::Axis;
 
-use util::{iife, unzip_option, ResultExt};
+use util::{ unzip_option, ResultExt};
 
 use crate::dock::DockPosition;
 use crate::WorkspaceId;
@@ -96,22 +96,16 @@ impl WorkspaceDb {
             WorkspaceLocation,
             bool,
             DockPosition,
-        ) = iife!({
-            if worktree_roots.len() == 0 {
-                self.select_row(sql!(
-                    SELECT workspace_id, workspace_location, left_sidebar_open, dock_visible, dock_anchor
-                    FROM workspaces
-                    ORDER BY timestamp DESC LIMIT 1))?()?
-            } else {
-                self.select_row_bound(sql!(
-                    SELECT workspace_id, workspace_location, left_sidebar_open, dock_visible, dock_anchor
-                    FROM workspaces 
-                    WHERE workspace_location = ?))?(&workspace_location)?
-            }
+        ) = 
+            self.select_row_bound(sql!{
+                SELECT workspace_id, workspace_location, left_sidebar_open, dock_visible, dock_anchor
+                FROM workspaces 
+                WHERE workspace_location = ?
+            })
+            .and_then(|mut prepared_statement| (prepared_statement)(&workspace_location))
             .context("No workspaces found")
-        })
-        .warn_on_err()
-        .flatten()?;
+            .warn_on_err()
+            .flatten()?;
 
         Some(SerializedWorkspace {
             id: workspace_id,
@@ -202,6 +196,16 @@ impl WorkspaceDb {
             WHERE workspace_location IS NOT NULL
             ORDER BY timestamp DESC 
             LIMIT ?
+        }
+    }
+
+    query! {
+        pub fn last_workspace() -> Result<Option<WorkspaceLocation>> {
+            SELECT workspace_location
+            FROM workspaces
+            WHERE workspace_location IS NOT NULL
+            ORDER BY timestamp DESC
+            LIMIT 1
         }
     }
 
@@ -371,9 +375,9 @@ impl WorkspaceDb {
 
         Ok(())
     }
-    
+
     query!{
-        fn update_timestamp(workspace_id: WorkspaceId) -> Result<()> {
+        pub async fn update_timestamp(workspace_id: WorkspaceId) -> Result<()> {
             UPDATE workspaces
             SET timestamp = CURRENT_TIMESTAMP
             WHERE workspace_id = ?

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -371,6 +371,15 @@ impl WorkspaceDb {
 
         Ok(())
     }
+    
+    query!{
+        fn update_timestamp(workspace_id: WorkspaceId) -> Result<()> {
+            UPDATE workspaces
+            SET timestamp = CURRENT_TIMESTAMP
+            WHERE workspace_id = ?
+        }
+    }
+    
 }
 
 #[cfg(test)]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -172,7 +172,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
         let app_state = Arc::downgrade(&app_state);
         move |_: &NewFile, cx: &mut MutableAppContext| {
             if let Some(app_state) = app_state.upgrade() {
-                open_new(&app_state, cx).detach();
+                open_new(&app_state, false, cx).detach();
             }
         }
     });
@@ -180,7 +180,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
         let app_state = Arc::downgrade(&app_state);
         move |_: &NewWindow, cx: &mut MutableAppContext| {
             if let Some(app_state) = app_state.upgrade() {
-                open_new(&app_state, cx).detach();
+                open_new(&app_state, true, cx).detach();
             }
         }
     });
@@ -652,6 +652,7 @@ impl Workspace {
     fn new_local(
         abs_paths: Vec<PathBuf>,
         app_state: Arc<AppState>,
+        blank: bool,
         cx: &mut MutableAppContext,
     ) -> Task<(
         ViewHandle<Workspace>,
@@ -666,7 +667,9 @@ impl Workspace {
         );
 
         cx.spawn(|mut cx| async move {
-            let serialized_workspace = persistence::DB.workspace_for_roots(&abs_paths.as_slice());
+            let serialized_workspace = (!blank)
+                .then(|| persistence::DB.workspace_for_roots(&abs_paths.as_slice()))
+                .flatten();
 
             let paths_to_open = serialized_workspace
                 .as_ref()
@@ -804,7 +807,7 @@ impl Workspace {
         if self.project.read(cx).is_local() {
             Task::Ready(Some(callback(self, cx)))
         } else {
-            let task = Self::new_local(Vec::new(), app_state.clone(), cx);
+            let task = Self::new_local(Vec::new(), app_state.clone(), true, cx);
             cx.spawn(|_vh, mut cx| async move {
                 let (workspace, _) = task.await;
                 workspace.update(&mut cx, callback)
@@ -2652,7 +2655,7 @@ pub fn open_paths(
                     .contains(&false);
 
             cx.update(|cx| {
-                let task = Workspace::new_local(abs_paths, app_state.clone(), cx);
+                let task = Workspace::new_local(abs_paths, app_state.clone(), false, cx);
 
                 cx.spawn(|mut cx| async move {
                     let (workspace, items) = task.await;
@@ -2671,8 +2674,8 @@ pub fn open_paths(
     })
 }
 
-pub fn open_new(app_state: &Arc<AppState>, cx: &mut MutableAppContext) -> Task<()> {
-    let task = Workspace::new_local(Vec::new(), app_state.clone(), cx);
+pub fn open_new(app_state: &Arc<AppState>, blank: bool, cx: &mut MutableAppContext) -> Task<()> {
+    let task = Workspace::new_local(Vec::new(), app_state.clone(), blank, cx);
     cx.spawn(|mut cx| async move {
         let (workspace, opened_paths) = task.await;
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -765,7 +765,7 @@ mod tests {
     #[gpui::test]
     async fn test_new_empty_workspace(cx: &mut TestAppContext) {
         let app_state = init(cx);
-        cx.update(|cx| open_new(&app_state, true, cx)).await;
+        cx.update(|cx| open_new(&app_state, cx)).await;
 
         let window_id = *cx.window_ids().first().unwrap();
         let workspace = cx.root_view::<Workspace>(window_id).unwrap();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -765,7 +765,7 @@ mod tests {
     #[gpui::test]
     async fn test_new_empty_workspace(cx: &mut TestAppContext) {
         let app_state = init(cx);
-        cx.update(|cx| open_new(&app_state, cx)).await;
+        cx.update(|cx| open_new(&app_state, true, cx)).await;
 
         let window_id = *cx.window_ids().first().unwrap();
         let workspace = cx.root_view::<Workspace>(window_id).unwrap();


### PR DESCRIPTION
## Description of feature or change

Bug fixes for workspace serialization

## Link to related issues from zed or insiders

https://github.com/zed-industries/zed/issues/1958

## Before Merging 

- [x] When Zed has no windows open, cmd-n should open a new workspace
- [x] Open new window should always open a blank zed
- [x] Update workspace timestamp based on window focus