### PR TITLE
Fixed issue where the NextScreen action would never have an effect

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -184,7 +184,6 @@ actions!(
         Paste,
         Undo,
         Redo,
-        NextScreen,
         MoveUp,
         PageUp,
         MoveDown,

--- a/crates/editor/src/scroll/actions.rs
+++ b/crates/editor/src/scroll/actions.rs
@@ -64,15 +64,15 @@ impl Editor {
             return None;
         }
 
-        self.context_menu.as_mut()?;
+        if self.mouse_context_menu.read(cx).visible() {
+            return None;
+        }
 
         if matches!(self.mode, EditorMode::SingleLine) {
             cx.propagate_action();
             return None;
         }
-
         self.request_autoscroll(Autoscroll::Next, cx);
-
         Some(())
     }
 


### PR DESCRIPTION
## Description of feature or change

The NextScreen action would never successfully execute. This changes it to only be blocked when the right-click mouse menu is open.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
