### PR TITLE
Automatically re-join call when server is restarted

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -94,12 +94,18 @@ impl ActiveCall {
 
     async fn handle_call_canceled(
         this: ModelHandle<Self>,
-        _: TypedEnvelope<proto::CallCanceled>,
+        envelope: TypedEnvelope<proto::CallCanceled>,
         _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {
-            *this.incoming_call.0.borrow_mut() = None;
+            let mut incoming_call = this.incoming_call.0.borrow_mut();
+            if incoming_call
+                .as_ref()
+                .map_or(false, |call| call.room_id == envelope.payload.room_id)
+            {
+                incoming_call.take();
+            }
         });
         Ok(())
     }

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -264,45 +264,52 @@ impl Room {
                     });
 
                 // Wait for client to re-establish a connection to the server.
-                let mut reconnection_timeout = cx.background().timer(RECONNECT_TIMEOUT).fuse();
-                let client_reconnection = async {
-                    loop {
-                        if let Some(status) = client_status.next().await {
-                            if status.is_connected() {
-                                return true;
+                {
+                    let mut reconnection_timeout = cx.background().timer(RECONNECT_TIMEOUT).fuse();
+                    let client_reconnection = async {
+                        let mut remaining_attempts = 3;
+                        while remaining_attempts > 0 {
+                            if let Some(status) = client_status.next().await {
+                                if status.is_connected() {
+                                    let rejoin_room = async {
+                                        let response =
+                                            client.request(proto::JoinRoom { id: room_id }).await?;
+                                        let room_proto =
+                                            response.room.ok_or_else(|| anyhow!("invalid room"))?;
+                                        this.upgrade(&cx)
+                                            .ok_or_else(|| anyhow!("room was dropped"))?
+                                            .update(&mut cx, |this, cx| {
+                                                this.status = RoomStatus::Online;
+                                                this.apply_room_update(room_proto, cx)
+                                            })?;
+                                        anyhow::Ok(())
+                                    };
+
+                                    if rejoin_room.await.is_ok() {
+                                        return true;
+                                    } else {
+                                        remaining_attempts -= 1;
+                                    }
+                                }
+                            } else {
+                                return false;
                             }
-                        } else {
-                            return false;
                         }
+                        false
                     }
-                }
-                .fuse();
-                futures::pin_mut!(client_reconnection);
+                    .fuse();
+                    futures::pin_mut!(client_reconnection);
 
-                futures::select_biased! {
-                    reconnected = client_reconnection => {
-                        if reconnected {
-                            // Client managed to reconnect to the server. Now attempt to join the room.
-                            let rejoin_room = async {
-                                let response = client.request(proto::JoinRoom { id: room_id }).await?;
-                                let room_proto = response.room.ok_or_else(|| anyhow!("invalid room"))?;
-                                this.upgrade(&cx)
-                                    .ok_or_else(|| anyhow!("room was dropped"))?
-                                    .update(&mut cx, |this, cx| {
-                                        this.status = RoomStatus::Online;
-                                        this.apply_room_update(room_proto, cx)
-                                    })?;
-                                anyhow::Ok(())
-                            };
-
-                            // If we successfully joined the room, go back around the loop
-                            // waiting for future connection status changes.
-                            if rejoin_room.await.log_err().is_some() {
+                    futures::select_biased! {
+                        reconnected = client_reconnection => {
+                            if reconnected {
+                                // If we successfully joined the room, go back around the loop
+                                // waiting for future connection status changes.
                                 continue;
                             }
                         }
+                        _ = reconnection_timeout => {}
                     }
-                    _ = reconnection_timeout => {}
                 }
 
                 // The client failed to re-establish a connection to the server

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -15,7 +15,7 @@ use project::Project;
 use std::{mem, sync::Arc, time::Duration};
 use util::{post_inc, ResultExt};
 
-pub const RECONNECTION_TIMEOUT: Duration = client::RECEIVE_TIMEOUT;
+pub const RECONNECT_TIMEOUT: Duration = client::RECEIVE_TIMEOUT;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
@@ -262,7 +262,7 @@ impl Room {
                     });
 
                 // Wait for client to re-establish a connection to the server.
-                let mut reconnection_timeout = cx.background().timer(RECONNECTION_TIMEOUT).fuse();
+                let mut reconnection_timeout = cx.background().timer(RECONNECT_TIMEOUT).fuse();
                 let client_reconnection = async {
                     loop {
                         if let Some(status) = client_status.next().await {

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -129,6 +129,7 @@ CREATE TABLE "room_participants" (
     "calling_connection_epoch" TEXT NOT NULL
 );
 CREATE UNIQUE INDEX "index_room_participants_on_user_id" ON "room_participants" ("user_id");
+CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");
 CREATE INDEX "index_room_participants_on_answering_connection_epoch" ON "room_participants" ("answering_connection_epoch");
 CREATE INDEX "index_room_participants_on_calling_connection_epoch" ON "room_participants" ("calling_connection_epoch");
 CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_participants" ("answering_connection_id");

--- a/crates/collab/migrations/20221207165001_add_connection_lost_to_room_participants.sql
+++ b/crates/collab/migrations/20221207165001_add_connection_lost_to_room_participants.sql
@@ -3,6 +3,6 @@ ALTER TABLE "room_participants"
 
 CREATE INDEX "index_project_collaborators_on_connection_id" ON "project_collaborators" ("connection_id");
 CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_connection_id_and_epoch" ON "project_collaborators" ("project_id", "connection_id", "connection_epoch");
-CREATE INDEX "index_room_participants_on_room_id_id" ON "room_participants" ("room_id");
+CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");
 CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_participants" ("answering_connection_id");
 CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_epoch" ON "room_participants" ("answering_connection_id", "answering_connection_epoch");

--- a/crates/collab/migrations/20221207165001_add_connection_lost_to_room_participants.sql
+++ b/crates/collab/migrations/20221207165001_add_connection_lost_to_room_participants.sql
@@ -3,5 +3,6 @@ ALTER TABLE "room_participants"
 
 CREATE INDEX "index_project_collaborators_on_connection_id" ON "project_collaborators" ("connection_id");
 CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_connection_id_and_epoch" ON "project_collaborators" ("project_id", "connection_id", "connection_epoch");
+CREATE INDEX "index_room_participants_on_room_id_id" ON "room_participants" ("room_id");
 CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_participants" ("answering_connection_id");
 CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_epoch" ON "room_participants" ("answering_connection_id", "answering_connection_epoch");

--- a/crates/collab/migrations/20221207165001_add_connection_lost_to_room_participants.sql
+++ b/crates/collab/migrations/20221207165001_add_connection_lost_to_room_participants.sql
@@ -3,6 +3,5 @@ ALTER TABLE "room_participants"
 
 CREATE INDEX "index_project_collaborators_on_connection_id" ON "project_collaborators" ("connection_id");
 CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_connection_id_and_epoch" ON "project_collaborators" ("project_id", "connection_id", "connection_epoch");
-CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");
 CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_participants" ("answering_connection_id");
 CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_epoch" ON "room_participants" ("answering_connection_id", "answering_connection_epoch");

--- a/crates/collab/migrations/20221213125710_index_room_participants_on_room_id.sql
+++ b/crates/collab/migrations/20221213125710_index_room_participants_on_room_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -6062,7 +6062,6 @@ async fn test_random_collaboration(
                 let user_connection_ids = server
                     .connection_pool
                     .lock()
-                    .await
                     .user_connection_ids(removed_guest_id)
                     .collect::<Vec<_>>();
                 assert_eq!(user_connection_ids.len(), 1);
@@ -6083,7 +6082,7 @@ async fn test_random_collaboration(
                 }
                 for user_id in &user_ids {
                     let contacts = server.app_state.db.get_contacts(*user_id).await.unwrap();
-                    let pool = server.connection_pool.lock().await;
+                    let pool = server.connection_pool.lock();
                     for contact in contacts {
                         if let db::Contact::Accepted { user_id, .. } = contact {
                             if pool.is_user_online(user_id) {
@@ -6112,7 +6111,6 @@ async fn test_random_collaboration(
                 let user_connection_ids = server
                     .connection_pool
                     .lock()
-                    .await
                     .user_connection_ids(user_id)
                     .collect::<Vec<_>>();
                 assert_eq!(user_connection_ids.len(), 1);

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -641,6 +641,7 @@ async fn test_server_restarts(
         .update(cx_d, |call, cx| call.accept_incoming(cx))
         .await
         .unwrap();
+    deterministic.run_until_parked();
     let room_d = active_call_d.read_with(cx_d, |call, _| call.room().unwrap().clone());
     assert_eq!(
         room_participants(&room_a, cx_a),

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -6121,6 +6121,13 @@ async fn test_random_collaboration(
                 deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
                 operations += 1;
             }
+            30..=34 => {
+                log::info!("Simulating server restart");
+                server.teardown();
+                deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
+                server.start().await.unwrap();
+                deterministic.advance_clock(RECONNECT_TIMEOUT);
+            }
             _ if !op_start_signals.is_empty() => {
                 while operations < max_operations && rng.lock().gen_bool(0.7) {
                     op_start_signals

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -2,7 +2,7 @@ pub mod api;
 pub mod auth;
 pub mod db;
 pub mod env;
-mod executor;
+pub mod executor;
 #[cfg(test)]
 mod integration_tests;
 pub mod rpc;

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -52,12 +52,12 @@ async fn main() -> Result<()> {
             init_tracing(&config);
 
             let state = AppState::new(config).await?;
-            state.db.clear_stale_data().await?;
 
             let listener = TcpListener::bind(&format!("0.0.0.0:{}", state.config.http_port))
                 .expect("failed to bind TCP listener");
 
             let rpc_server = collab::rpc::Server::new(state.clone());
+            rpc_server.start().await?;
 
             let app = collab::api::routes(rpc_server.clone(), state.clone())
                 .merge(collab::rpc::routes(rpc_server.clone()))

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use axum::{routing::get, Router};
-use collab::{db, env, AppState, Config, MigrateConfig, Result};
+use collab::{db, env, executor::Executor, AppState, Config, MigrateConfig, Result};
 use db::Database;
 use std::{
     env::args,
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
             let listener = TcpListener::bind(&format!("0.0.0.0:{}", state.config.http_port))
                 .expect("failed to bind TCP listener");
 
-            let rpc_server = collab::rpc::Server::new(state.clone());
+            let rpc_server = collab::rpc::Server::new(state.clone(), Executor::Production);
             rpc_server.start().await?;
 
             let app = collab::api::routes(rpc_server.clone(), state.clone())

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -323,8 +323,10 @@ impl Server {
         Ok(())
     }
 
+    #[cfg(test)]
     pub fn teardown(&self) {
         self.peer.reset();
+        self.connection_pool.lock().reset();
         let _ = self.teardown.send(());
     }
 

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -263,7 +263,6 @@ impl Server {
                             .extend(refreshed_room.canceled_calls_to_user_ids.iter().copied());
                         canceled_calls_to_user_ids =
                             mem::take(&mut refreshed_room.canceled_calls_to_user_ids);
-                        dbg!(&canceled_calls_to_user_ids);
                         live_kit_room = mem::take(&mut refreshed_room.room.live_kit_room);
                         delete_live_kit_room = refreshed_room.room.participants.is_empty();
                     }

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -277,12 +277,9 @@ impl Server {
                     }
 
                     for user_id in contacts_to_update {
-                        if let Some((busy, contacts)) = db
-                            .is_user_busy(user_id)
-                            .await
-                            .trace_err()
-                            .zip(db.get_contacts(user_id).await.trace_err())
-                        {
+                        let busy = db.is_user_busy(user_id).await.trace_err();
+                        let contacts = db.get_contacts(user_id).await.trace_err();
+                        if let Some((busy, contacts)) = busy.zip(contacts) {
                             let pool = pool.lock().await;
                             let updated_contact = contact_for_user(user_id, false, busy, &pool);
                             for contact in contacts {

--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -23,6 +23,11 @@ pub struct Connection {
 }
 
 impl ConnectionPool {
+    pub fn reset(&mut self) {
+        self.connections.clear();
+        self.connected_users.clear();
+    }
+
     #[instrument(skip(self))]
     pub fn add_connection(&mut self, connection_id: ConnectionId, user_id: UserId, admin: bool) {
         self.connections

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -212,7 +212,9 @@ message IncomingCall {
     optional ParticipantProject initial_project = 4;
 }
 
-message CallCanceled {}
+message CallCanceled {
+    uint64 room_id = 1;
+}
 
 message CancelCall {
     uint64 room_id = 1;

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 40;
+pub const PROTOCOL_VERSION: u32 = 41;


### PR DESCRIPTION
Closes #1956

This pull request enhances the server to support re-establishing calls after a restart (either due to a crash or a deploy) occurs. As before, if clients detect a disconnection they will try to re-connect. When the new instance of the server is spun up, it will allow up to 5 seconds for clients to re-establish their connection and re-join a call. After that grace period, it will iteratively go through each stale room and delete participants that were unable to reconnect. 

The above is achieved by assigning a new, random epoch (a UUID) to every new server instance and associating every connection to that epoch. When re-joining a room the old epoch is updated with the new one. This makes it pretty easy to identify stale connections by querying participants that are associated with an epoch that doesn't correspond to the current one.