### PR TITLE
Fix text size in notifications

### DIFF
--- a/crates/auto_update/src/update_notification.rs
+++ b/crates/auto_update/src/update_notification.rs
@@ -28,7 +28,7 @@ impl View for UpdateNotification {
 
     fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
         let theme = cx.global::<Settings>().theme.clone();
-        let theme = &theme.simple_message_notification;
+        let theme = &theme.update_notification;
 
         let app_name = cx.global::<ReleaseChannel>().display_name();
 

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -206,7 +206,7 @@ pub mod simple_message_notification {
 
         fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
             let theme = cx.global::<Settings>().theme.clone();
-            let theme = &theme.update_notification;
+            let theme = &theme.simple_message_notification;
 
             enum MessageNotificationTag {}
 

--- a/styles/src/styleTree/simpleMessageNotification.ts
+++ b/styles/src/styleTree/simpleMessageNotification.ts
@@ -7,11 +7,11 @@ export default function simpleMessageNotification(colorScheme: ColorScheme): Obj
   let layer = colorScheme.middle;
   return {
     message: {
-      ...text(layer, "sans", { size: "md" }),
+      ...text(layer, "sans", { size: "xs" }),
       margin: { left: headerPadding, right: headerPadding },
     },
     actionMessage: {
-      ...text(layer, "sans", { size: "md" }),
+      ...text(layer, "sans", { size: "xs" }),
       margin: { left: headerPadding, top: 6, bottom: 6 },
       hover: {
         color: foreground(layer, "hovered"),


### PR DESCRIPTION
## Description of feature or change

When refactoring notifications out of the workspace, I also built a 'generic notification' component. Somehow, this component and the update notification had their styling swapped. 

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
