### PR TITLE
Improve reconnections to server after it is redeployed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "futures 0.3.25",
  "gpui",
  "live_kit_client",
+ "log",
  "media",
  "postage",
  "project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "collab"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -21,6 +21,7 @@ test-support = [
 client = { path = "../client" }
 collections = { path = "../collections" }
 gpui = { path = "../gpui" }
+log = "0.4"
 live_kit_client = { path = "../live_kit_client" }
 media = { path = "../media" }
 project = { path = "../project" }

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -13,7 +13,7 @@ use live_kit_client::{LocalTrackPublication, LocalVideoTrack, RemoteVideoTrackUp
 use postage::stream::Stream;
 use project::Project;
 use std::{mem, sync::Arc, time::Duration};
-use util::{post_inc, ResultExt};
+use util::{post_inc, ResultExt, TryFutureExt};
 
 pub const RECONNECT_TIMEOUT: Duration = client::RECEIVE_TIMEOUT;
 
@@ -50,7 +50,7 @@ pub struct Room {
     user_store: ModelHandle<UserStore>,
     subscriptions: Vec<client::Subscription>,
     pending_room_update: Option<Task<()>>,
-    maintain_connection: Option<Task<Result<()>>>,
+    maintain_connection: Option<Task<Option<()>>>,
 }
 
 impl Entity for Room {
@@ -58,6 +58,7 @@ impl Entity for Room {
 
     fn release(&mut self, _: &mut MutableAppContext) {
         if self.status.is_online() {
+            log::info!("room was released, sending leave message");
             self.client.send(proto::LeaveRoom {}).log_err();
         }
     }
@@ -122,7 +123,7 @@ impl Room {
         };
 
         let maintain_connection =
-            cx.spawn_weak(|this, cx| Self::maintain_connection(this, client.clone(), cx));
+            cx.spawn_weak(|this, cx| Self::maintain_connection(this, client.clone(), cx).log_err());
 
         Self {
             id,
@@ -229,6 +230,7 @@ impl Room {
 
         cx.notify();
         cx.emit(Event::Left);
+        log::info!("leaving room");
         self.status = RoomStatus::Offline;
         self.remote_participants.clear();
         self.pending_participants.clear();
@@ -254,6 +256,7 @@ impl Room {
                 .map_or(false, |s| s.is_connected());
             // Even if we're initially connected, any future change of the status means we momentarily disconnected.
             if !is_connected || client_status.next().await.is_some() {
+                log::info!("detected client disconnection");
                 let room_id = this
                     .upgrade(&cx)
                     .ok_or_else(|| anyhow!("room was dropped"))?
@@ -269,8 +272,13 @@ impl Room {
                     let client_reconnection = async {
                         let mut remaining_attempts = 3;
                         while remaining_attempts > 0 {
+                            log::info!(
+                                "waiting for client status change, remaining attempts {}",
+                                remaining_attempts
+                            );
                             if let Some(status) = client_status.next().await {
                                 if status.is_connected() {
+                                    log::info!("client reconnected, attempting to rejoin room");
                                     let rejoin_room = async {
                                         let response =
                                             client.request(proto::JoinRoom { id: room_id }).await?;
@@ -285,7 +293,7 @@ impl Room {
                                         anyhow::Ok(())
                                     };
 
-                                    if rejoin_room.await.is_ok() {
+                                    if rejoin_room.await.log_err().is_some() {
                                         return true;
                                     } else {
                                         remaining_attempts -= 1;
@@ -303,12 +311,15 @@ impl Room {
                     futures::select_biased! {
                         reconnected = client_reconnection => {
                             if reconnected {
+                                log::info!("successfully reconnected to room");
                                 // If we successfully joined the room, go back around the loop
                                 // waiting for future connection status changes.
                                 continue;
                             }
                         }
-                        _ = reconnection_timeout => {}
+                        _ = reconnection_timeout => {
+                            log::info!("room reconnection timeout expired");
+                        }
                     }
                 }
 
@@ -316,6 +327,7 @@ impl Room {
                 // or an error occurred while trying to re-join the room. Either way
                 // we leave the room and return an error.
                 if let Some(this) = this.upgrade(&cx) {
+                    log::info!("reconnection failed, leaving room");
                     let _ = this.update(&mut cx, |this, cx| this.leave(cx));
                 }
                 return Err(anyhow!(
@@ -499,6 +511,7 @@ impl Room {
 
                 this.pending_room_update.take();
                 if this.should_leave() {
+                    log::info!("room is empty, leaving");
                     let _ = this.leave(cx);
                 }
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -333,14 +333,14 @@ impl Client {
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    pub fn tear_down(&self) {
+    pub fn teardown(&self) {
         let mut state = self.state.write();
         state._reconnect_task.take();
         state.message_handlers.clear();
         state.models_by_message_type.clear();
         state.entities_by_type_and_remote_id.clear();
         state.entity_id_extractors.clear();
-        self.peer.reset();
+        self.peer.teardown();
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -35,7 +35,7 @@ impl FakeServer {
         cx: &TestAppContext,
     ) -> Self {
         let server = Self {
-            peer: Peer::new(),
+            peer: Peer::new(0),
             state: Default::default(),
             user_id: client_user_id,
             executor: cx.foreground(),
@@ -92,7 +92,7 @@ impl FakeServer {
                         peer.send(
                             connection_id,
                             proto::Hello {
-                                peer_id: connection_id.0,
+                                peer_id: Some(connection_id.into()),
                             },
                         )
                         .unwrap();

--- a/crates/collab/.env.toml
+++ b/crates/collab/.env.toml
@@ -2,6 +2,7 @@ DATABASE_URL = "postgres://postgres@localhost/zed"
 HTTP_PORT = 8080
 API_TOKEN = "secret"
 INVITE_LINK_PREFIX = "http://localhost:3000/invites/"
+ZED_ENVIRONMENT = "development"
 LIVE_KIT_SERVER = "http://localhost:7880"
 LIVE_KIT_KEY = "devkey"
 LIVE_KIT_SECRET = "secret"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.9"
+version = "0.3.10"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.10"
+version = "0.3.11"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.4"
+version = "0.3.5"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.5"
+version = "0.3.6"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.11"
+version = "0.3.12"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.8"
+version = "0.3.9"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.13"
+version = "0.3.14"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.6"
+version = "0.3.7"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.12"
+version = "0.3.13"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
 edition = "2021"
 name = "collab"
-version = "0.3.7"
+version = "0.3.8"
 
 [[bin]]
 name = "collab"

--- a/crates/collab/k8s/environments/preview.sh
+++ b/crates/collab/k8s/environments/preview.sh
@@ -1,3 +1,3 @@
 ZED_ENVIRONMENT=preview
-RUST_LOG=debug
+RUST_LOG=info
 INVITE_LINK_PREFIX=https://zed.dev/invites/

--- a/crates/collab/k8s/environments/preview.sh
+++ b/crates/collab/k8s/environments/preview.sh
@@ -1,3 +1,3 @@
 ZED_ENVIRONMENT=preview
-RUST_LOG=info
+RUST_LOG=debug
 INVITE_LINK_PREFIX=https://zed.dev/invites/

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -99,6 +99,8 @@ spec:
               value: ${RUST_LOG}
             - name: LOG_JSON
               value: "true"
+            - name: ZED_ENVIRONMENT
+              value: ${ZED_ENVIRONMENT}
           securityContext:
             capabilities:
               # FIXME - Switch to the more restrictive `PERFMON` capability.

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -62,8 +62,9 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              initialDelaySeconds: 5
-              periodSeconds: 5
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
           env:
             - name: HTTP_PORT
               value: "8080"

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -59,6 +59,11 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              initialDelaySeconds: 5
+              periodSeconds: 5
           env:
             - name: HTTP_PORT
               value: "8080"

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -63,8 +63,8 @@ spec:
             httpGet:
               path: /
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 1
+            periodSeconds: 1
           env:
             - name: HTTP_PORT
               value: "8080"

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -110,9 +110,9 @@ CREATE TABLE "project_collaborators" (
 );
 CREATE INDEX "index_project_collaborators_on_project_id" ON "project_collaborators" ("project_id");
 CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_and_replica_id" ON "project_collaborators" ("project_id", "replica_id");
-CREATE INDEX "index_project_collaborators_on_connection_epoch" ON "project_collaborators" ("connection_epoch");
+CREATE INDEX "index_project_collaborators_on_connection_server_id" ON "project_collaborators" ("connection_server_id");
 CREATE INDEX "index_project_collaborators_on_connection_id" ON "project_collaborators" ("connection_id");
-CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_connection_id_and_epoch" ON "project_collaborators" ("project_id", "connection_id", "connection_epoch");
+CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_connection_id_and_server_id" ON "project_collaborators" ("project_id", "connection_id", "connection_server_id");
 
 CREATE TABLE "room_participants" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -130,10 +130,10 @@ CREATE TABLE "room_participants" (
 );
 CREATE UNIQUE INDEX "index_room_participants_on_user_id" ON "room_participants" ("user_id");
 CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");
-CREATE INDEX "index_room_participants_on_answering_connection_epoch" ON "room_participants" ("answering_connection_epoch");
-CREATE INDEX "index_room_participants_on_calling_connection_epoch" ON "room_participants" ("calling_connection_epoch");
+CREATE INDEX "index_room_participants_on_answering_connection_server_id" ON "room_participants" ("answering_connection_server_id");
+CREATE INDEX "index_room_participants_on_calling_connection_server_id" ON "room_participants" ("calling_connection_server_id");
 CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_participants" ("answering_connection_id");
-CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_epoch" ON "room_participants" ("answering_connection_id", "answering_connection_epoch");
+CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_server_id" ON "room_participants" ("answering_connection_id", "answering_connection_server_id");
 
 CREATE TABLE "servers" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -43,11 +43,12 @@ CREATE TABLE "projects" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "room_id" INTEGER REFERENCES rooms (id) NOT NULL,
     "host_user_id" INTEGER REFERENCES users (id) NOT NULL,
-    "host_connection_id" INTEGER NOT NULL,
-    "host_connection_server_id" INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE,
+    "host_connection_id" INTEGER,
+    "host_connection_server_id" INTEGER REFERENCES servers (id) ON DELETE CASCADE,
     "unregistered" BOOLEAN NOT NULL DEFAULT FALSE
 );
-CREATE INDEX "index_projects_on_host_connection_epoch" ON "projects" ("host_connection_epoch");
+CREATE INDEX "index_projects_on_host_connection_server_id" ON "projects" ("host_connection_server_id");
+CREATE INDEX "index_projects_on_host_connection_id_and_host_connection_server_id" ON "projects" ("host_connection_id", "host_connection_server_id");
 
 CREATE TABLE "worktrees" (
     "project_id" INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE "projects" (
     "room_id" INTEGER REFERENCES rooms (id) NOT NULL,
     "host_user_id" INTEGER REFERENCES users (id) NOT NULL,
     "host_connection_id" INTEGER NOT NULL,
-    "host_connection_epoch" INTEGER NOT NULL,
+    "host_connection_server_id" INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE,
     "unregistered" BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX "index_projects_on_host_connection_epoch" ON "projects" ("host_connection_epoch");
@@ -103,7 +103,7 @@ CREATE TABLE "project_collaborators" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "project_id" INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
     "connection_id" INTEGER NOT NULL,
-    "connection_epoch" INTEGER NOT NULL,
+    "connection_server_id" INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE,
     "user_id" INTEGER NOT NULL,
     "replica_id" INTEGER NOT NULL,
     "is_host" BOOLEAN NOT NULL
@@ -119,14 +119,14 @@ CREATE TABLE "room_participants" (
     "room_id" INTEGER NOT NULL REFERENCES rooms (id),
     "user_id" INTEGER NOT NULL REFERENCES users (id),
     "answering_connection_id" INTEGER,
-    "answering_connection_epoch" INTEGER,
+    "answering_connection_server_id" INTEGER REFERENCES servers (id) ON DELETE CASCADE,
     "answering_connection_lost" BOOLEAN NOT NULL,
     "location_kind" INTEGER,
     "location_project_id" INTEGER,
     "initial_project_id" INTEGER,
     "calling_user_id" INTEGER NOT NULL REFERENCES users (id),
     "calling_connection_id" INTEGER NOT NULL,
-    "calling_connection_epoch" INTEGER NOT NULL
+    "calling_connection_server_id" INTEGER REFERENCES servers (id) ON DELETE SET NULL
 );
 CREATE UNIQUE INDEX "index_room_participants_on_user_id" ON "room_participants" ("user_id");
 CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");
@@ -136,6 +136,6 @@ CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_parti
 CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_epoch" ON "room_participants" ("answering_connection_id", "answering_connection_epoch");
 
 CREATE TABLE "servers" (
-    "epoch" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "environment" VARCHAR NOT NULL
 );

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE "projects" (
     "room_id" INTEGER REFERENCES rooms (id) NOT NULL,
     "host_user_id" INTEGER REFERENCES users (id) NOT NULL,
     "host_connection_id" INTEGER NOT NULL,
-    "host_connection_epoch" TEXT NOT NULL,
+    "host_connection_epoch" INTEGER NOT NULL,
     "unregistered" BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX "index_projects_on_host_connection_epoch" ON "projects" ("host_connection_epoch");
@@ -103,7 +103,7 @@ CREATE TABLE "project_collaborators" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "project_id" INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
     "connection_id" INTEGER NOT NULL,
-    "connection_epoch" TEXT NOT NULL,
+    "connection_epoch" INTEGER NOT NULL,
     "user_id" INTEGER NOT NULL,
     "replica_id" INTEGER NOT NULL,
     "is_host" BOOLEAN NOT NULL
@@ -119,14 +119,14 @@ CREATE TABLE "room_participants" (
     "room_id" INTEGER NOT NULL REFERENCES rooms (id),
     "user_id" INTEGER NOT NULL REFERENCES users (id),
     "answering_connection_id" INTEGER,
-    "answering_connection_epoch" TEXT,
+    "answering_connection_epoch" INTEGER,
     "answering_connection_lost" BOOLEAN NOT NULL,
     "location_kind" INTEGER,
     "location_project_id" INTEGER,
     "initial_project_id" INTEGER,
     "calling_user_id" INTEGER NOT NULL REFERENCES users (id),
     "calling_connection_id" INTEGER NOT NULL,
-    "calling_connection_epoch" TEXT NOT NULL
+    "calling_connection_epoch" INTEGER NOT NULL
 );
 CREATE UNIQUE INDEX "index_room_participants_on_user_id" ON "room_participants" ("user_id");
 CREATE INDEX "index_room_participants_on_room_id" ON "room_participants" ("room_id");

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -134,3 +134,8 @@ CREATE INDEX "index_room_participants_on_answering_connection_epoch" ON "room_pa
 CREATE INDEX "index_room_participants_on_calling_connection_epoch" ON "room_participants" ("calling_connection_epoch");
 CREATE INDEX "index_room_participants_on_answering_connection_id" ON "room_participants" ("answering_connection_id");
 CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_epoch" ON "room_participants" ("answering_connection_id", "answering_connection_epoch");
+
+CREATE TABLE "servers" (
+    "epoch" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "environment" VARCHAR NOT NULL
+);

--- a/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
+++ b/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
@@ -12,6 +12,8 @@ DELETE FROM project_collaborators;
 ALTER TABLE project_collaborators
     DROP COLUMN connection_epoch,
     ADD COLUMN connection_server_id INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE;
+CREATE INDEX "index_project_collaborators_on_connection_server_id" ON "project_collaborators" ("connection_server_id");
+CREATE UNIQUE INDEX "index_project_collaborators_on_project_id_connection_id_and_server_id" ON "project_collaborators" ("project_id", "connection_id", "connection_server_id");
 
 DELETE FROM room_participants;
 ALTER TABLE room_participants
@@ -19,4 +21,6 @@ ALTER TABLE room_participants
     DROP COLUMN calling_connection_epoch,
     ADD COLUMN answering_connection_server_id INTEGER REFERENCES servers (id) ON DELETE CASCADE,
     ADD COLUMN calling_connection_server_id INTEGER REFERENCES servers (id) ON DELETE SET NULL;
-
+CREATE INDEX "index_room_participants_on_answering_connection_server_id" ON "room_participants" ("answering_connection_server_id");
+CREATE INDEX "index_room_participants_on_calling_connection_server_id" ON "room_participants" ("calling_connection_server_id");
+CREATE UNIQUE INDEX "index_room_participants_on_answering_connection_id_and_answering_connection_server_id" ON "room_participants" ("answering_connection_id", "answering_connection_server_id");

--- a/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
+++ b/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
@@ -3,10 +3,14 @@ CREATE TABLE servers (
     environment VARCHAR NOT NULL
 );
 
-DELETE FROM projects;
+DROP TABLE worktree_extensions;
+DROP TABLE project_activity_periods;
+DELETE from projects;
 ALTER TABLE projects
     DROP COLUMN host_connection_epoch,
-    ADD COLUMN host_connection_server_id INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE;
+    ADD COLUMN host_connection_server_id INTEGER REFERENCES servers (id) ON DELETE CASCADE;
+CREATE INDEX "index_projects_on_host_connection_server_id" ON "projects" ("host_connection_server_id");
+CREATE INDEX "index_projects_on_host_connection_id_and_host_connection_server_id" ON "projects" ("host_connection_id", "host_connection_server_id");
 
 DELETE FROM project_collaborators;
 ALTER TABLE project_collaborators

--- a/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
+++ b/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "projects"
+    ALTER COLUMN "host_connection_epoch" TYPE INTEGER USING 0;
+
+ALTER TABLE "project_collaborators"
+    ALTER COLUMN "connection_epoch" TYPE INTEGER USING 0;
+
+ALTER TABLE "room_participants"
+    ALTER COLUMN "answering_connection_epoch" TYPE INTEGER USING 0,
+    ALTER COLUMN "calling_connection_epoch" TYPE INTEGER USING 0;

--- a/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
+++ b/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
@@ -1,14 +1,22 @@
-ALTER TABLE "projects"
-    ALTER COLUMN "host_connection_epoch" TYPE INTEGER USING -1;
-
-ALTER TABLE "project_collaborators"
-    ALTER COLUMN "connection_epoch" TYPE INTEGER USING -1;
-
-ALTER TABLE "room_participants"
-    ALTER COLUMN "answering_connection_epoch" TYPE INTEGER USING -1,
-    ALTER COLUMN "calling_connection_epoch" TYPE INTEGER USING -1;
-
-CREATE TABLE "servers" (
-    "epoch" SERIAL PRIMARY KEY,
-    "environment" VARCHAR NOT NULL
+CREATE TABLE servers (
+    id SERIAL PRIMARY KEY,
+    environment VARCHAR NOT NULL
 );
+
+DELETE FROM projects;
+ALTER TABLE projects
+    DROP COLUMN host_connection_epoch,
+    ADD COLUMN host_connection_server_id INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE;
+
+DELETE FROM project_collaborators;
+ALTER TABLE project_collaborators
+    DROP COLUMN connection_epoch,
+    ADD COLUMN connection_server_id INTEGER NOT NULL REFERENCES servers (id) ON DELETE CASCADE;
+
+DELETE FROM room_participants;
+ALTER TABLE room_participants
+    DROP COLUMN answering_connection_epoch,
+    DROP COLUMN calling_connection_epoch,
+    ADD COLUMN answering_connection_server_id INTEGER REFERENCES servers (id) ON DELETE CASCADE,
+    ADD COLUMN calling_connection_server_id INTEGER REFERENCES servers (id) ON DELETE SET NULL;
+

--- a/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
+++ b/crates/collab/migrations/20221214144346_change_epoch_from_uuid_to_integer.sql
@@ -1,9 +1,14 @@
 ALTER TABLE "projects"
-    ALTER COLUMN "host_connection_epoch" TYPE INTEGER USING 0;
+    ALTER COLUMN "host_connection_epoch" TYPE INTEGER USING -1;
 
 ALTER TABLE "project_collaborators"
-    ALTER COLUMN "connection_epoch" TYPE INTEGER USING 0;
+    ALTER COLUMN "connection_epoch" TYPE INTEGER USING -1;
 
 ALTER TABLE "room_participants"
-    ALTER COLUMN "answering_connection_epoch" TYPE INTEGER USING 0,
-    ALTER COLUMN "calling_connection_epoch" TYPE INTEGER USING 0;
+    ALTER COLUMN "answering_connection_epoch" TYPE INTEGER USING -1,
+    ALTER COLUMN "calling_connection_epoch" TYPE INTEGER USING -1;
+
+CREATE TABLE "servers" (
+    "epoch" SERIAL PRIMARY KEY,
+    "environment" VARCHAR NOT NULL
+);

--- a/crates/collab/src/db/project.rs
+++ b/crates/collab/src/db/project.rs
@@ -9,7 +9,7 @@ pub struct Model {
     pub room_id: RoomId,
     pub host_user_id: UserId,
     pub host_connection_id: i32,
-    pub host_connection_epoch: Uuid,
+    pub host_connection_epoch: i32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/db/project.rs
+++ b/crates/collab/src/db/project.rs
@@ -1,4 +1,6 @@
-use super::{ProjectId, RoomId, ServerId, UserId};
+use super::{ProjectId, Result, RoomId, ServerId, UserId};
+use anyhow::anyhow;
+use rpc::ConnectionId;
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -8,8 +10,23 @@ pub struct Model {
     pub id: ProjectId,
     pub room_id: RoomId,
     pub host_user_id: UserId,
-    pub host_connection_id: i32,
-    pub host_connection_server_id: ServerId,
+    pub host_connection_id: Option<i32>,
+    pub host_connection_server_id: Option<ServerId>,
+}
+
+impl Model {
+    pub fn host_connection(&self) -> Result<ConnectionId> {
+        let host_connection_server_id = self
+            .host_connection_server_id
+            .ok_or_else(|| anyhow!("empty host_connection_server_id"))?;
+        let host_connection_id = self
+            .host_connection_id
+            .ok_or_else(|| anyhow!("empty host_connection_id"))?;
+        Ok(ConnectionId {
+            owner_id: host_connection_server_id.0 as u32,
+            id: host_connection_id as u32,
+        })
+    }
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/db/project.rs
+++ b/crates/collab/src/db/project.rs
@@ -1,4 +1,4 @@
-use super::{ProjectId, RoomId, UserId};
+use super::{ProjectId, RoomId, ServerId, UserId};
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -9,7 +9,7 @@ pub struct Model {
     pub room_id: RoomId,
     pub host_user_id: UserId,
     pub host_connection_id: i32,
-    pub host_connection_epoch: i32,
+    pub host_connection_server_id: ServerId,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/db/project_collaborator.rs
+++ b/crates/collab/src/db/project_collaborator.rs
@@ -8,7 +8,7 @@ pub struct Model {
     pub id: ProjectCollaboratorId,
     pub project_id: ProjectId,
     pub connection_id: i32,
-    pub connection_epoch: Uuid,
+    pub connection_epoch: i32,
     pub user_id: UserId,
     pub replica_id: ReplicaId,
     pub is_host: bool,

--- a/crates/collab/src/db/project_collaborator.rs
+++ b/crates/collab/src/db/project_collaborator.rs
@@ -1,4 +1,4 @@
-use super::{ProjectCollaboratorId, ProjectId, ReplicaId, UserId};
+use super::{ProjectCollaboratorId, ProjectId, ReplicaId, ServerId, UserId};
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -8,7 +8,7 @@ pub struct Model {
     pub id: ProjectCollaboratorId,
     pub project_id: ProjectId,
     pub connection_id: i32,
-    pub connection_epoch: i32,
+    pub connection_server_id: ServerId,
     pub user_id: UserId,
     pub replica_id: ReplicaId,
     pub is_host: bool,

--- a/crates/collab/src/db/room_participant.rs
+++ b/crates/collab/src/db/room_participant.rs
@@ -1,4 +1,4 @@
-use super::{ProjectId, RoomId, RoomParticipantId, UserId};
+use super::{ProjectId, RoomId, RoomParticipantId, ServerId, UserId};
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -9,14 +9,14 @@ pub struct Model {
     pub room_id: RoomId,
     pub user_id: UserId,
     pub answering_connection_id: Option<i32>,
-    pub answering_connection_epoch: Option<i32>,
+    pub answering_connection_server_id: Option<ServerId>,
     pub answering_connection_lost: bool,
     pub location_kind: Option<i32>,
     pub location_project_id: Option<ProjectId>,
     pub initial_project_id: Option<ProjectId>,
     pub calling_user_id: UserId,
     pub calling_connection_id: i32,
-    pub calling_connection_epoch: i32,
+    pub calling_connection_server_id: Option<ServerId>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/db/room_participant.rs
+++ b/crates/collab/src/db/room_participant.rs
@@ -9,14 +9,14 @@ pub struct Model {
     pub room_id: RoomId,
     pub user_id: UserId,
     pub answering_connection_id: Option<i32>,
-    pub answering_connection_epoch: Option<Uuid>,
+    pub answering_connection_epoch: Option<i32>,
     pub answering_connection_lost: bool,
     pub location_kind: Option<i32>,
     pub location_project_id: Option<ProjectId>,
     pub initial_project_id: Option<ProjectId>,
     pub calling_user_id: UserId,
     pub calling_connection_id: i32,
-    pub calling_connection_epoch: Uuid,
+    pub calling_connection_epoch: i32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/db/server.rs
+++ b/crates/collab/src/db/server.rs
@@ -1,0 +1,15 @@
+use super::ServerEpoch;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "servers")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub epoch: ServerEpoch,
+    pub environment: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/collab/src/db/server.rs
+++ b/crates/collab/src/db/server.rs
@@ -1,11 +1,11 @@
-use super::ServerEpoch;
+use super::ServerId;
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "servers")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub epoch: ServerEpoch,
+    pub id: ServerId,
     pub environment: String,
 }
 

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -410,6 +410,8 @@ test_both_dbs!(
     test_project_count_sqlite,
     db,
     {
+        let epoch = db.create_server("test").await.unwrap().0 as u32;
+
         let user1 = db
             .create_user(
                 &format!("admin@example.com"),
@@ -436,7 +438,7 @@ test_both_dbs!(
             .unwrap();
 
         let room_id = RoomId::from_proto(
-            db.create_room(user1.user_id, ConnectionId { epoch: 0, id: 0 }, "")
+            db.create_room(user1.user_id, ConnectionId { epoch, id: 0 }, "")
                 .await
                 .unwrap()
                 .id,
@@ -444,36 +446,34 @@ test_both_dbs!(
         db.call(
             room_id,
             user1.user_id,
-            ConnectionId { epoch: 0, id: 0 },
+            ConnectionId { epoch, id: 0 },
             user2.user_id,
             None,
         )
         .await
         .unwrap();
-        db.join_room(room_id, user2.user_id, ConnectionId { epoch: 0, id: 1 })
+        db.join_room(room_id, user2.user_id, ConnectionId { epoch, id: 1 })
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 0);
 
-        db.share_project(room_id, ConnectionId { epoch: 0, id: 1 }, &[])
+        db.share_project(room_id, ConnectionId { epoch, id: 1 }, &[])
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 1);
 
-        db.share_project(room_id, ConnectionId { epoch: 0, id: 1 }, &[])
+        db.share_project(room_id, ConnectionId { epoch, id: 1 }, &[])
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 2);
 
         // Projects shared by admins aren't counted.
-        db.share_project(room_id, ConnectionId { epoch: 0, id: 0 }, &[])
+        db.share_project(room_id, ConnectionId { epoch, id: 0 }, &[])
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 2);
 
-        db.leave_room(ConnectionId { epoch: 0, id: 1 })
-            .await
-            .unwrap();
+        db.leave_room(ConnectionId { epoch, id: 1 }).await.unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 0);
     }
 );

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -436,36 +436,44 @@ test_both_dbs!(
             .unwrap();
 
         let room_id = RoomId::from_proto(
-            db.create_room(user1.user_id, ConnectionId(0), "")
+            db.create_room(user1.user_id, ConnectionId { epoch: 0, id: 0 }, "")
                 .await
                 .unwrap()
                 .id,
         );
-        db.call(room_id, user1.user_id, ConnectionId(0), user2.user_id, None)
-            .await
-            .unwrap();
-        db.join_room(room_id, user2.user_id, ConnectionId(1))
+        db.call(
+            room_id,
+            user1.user_id,
+            ConnectionId { epoch: 0, id: 0 },
+            user2.user_id,
+            None,
+        )
+        .await
+        .unwrap();
+        db.join_room(room_id, user2.user_id, ConnectionId { epoch: 0, id: 1 })
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 0);
 
-        db.share_project(room_id, ConnectionId(1), &[])
+        db.share_project(room_id, ConnectionId { epoch: 0, id: 1 }, &[])
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 1);
 
-        db.share_project(room_id, ConnectionId(1), &[])
+        db.share_project(room_id, ConnectionId { epoch: 0, id: 1 }, &[])
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 2);
 
         // Projects shared by admins aren't counted.
-        db.share_project(room_id, ConnectionId(0), &[])
+        db.share_project(room_id, ConnectionId { epoch: 0, id: 0 }, &[])
             .await
             .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 2);
 
-        db.leave_room(ConnectionId(1)).await.unwrap();
+        db.leave_room(ConnectionId { epoch: 0, id: 1 })
+            .await
+            .unwrap();
         assert_eq!(db.project_count_excluding_admins().await.unwrap(), 0);
     }
 );

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -685,7 +685,7 @@ async fn test_server_restarts(
     );
 
     // The server finishes restarting, cleaning up stale connections.
-    server.start().await.unwrap();
+    server.start();
     deterministic.advance_clock(CLEANUP_TIMEOUT);
     assert_eq!(
         room_participants(&room_a, cx_a),
@@ -805,7 +805,7 @@ async fn test_server_restarts(
 
     // The server finishes restarting, cleaning up stale connections and canceling the
     // call to user D because the room has become empty.
-    server.start().await.unwrap();
+    server.start();
     deterministic.advance_clock(CLEANUP_TIMEOUT);
     assert!(incoming_call_d.next().await.unwrap().is_none());
 }
@@ -6124,7 +6124,7 @@ async fn test_random_collaboration(
                 log::info!("Simulating server restart");
                 server.teardown();
                 deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
-                server.start().await.unwrap();
+                server.start();
                 deterministic.advance_clock(CLEANUP_TIMEOUT);
             }
             _ if !op_start_signals.is_empty() => {
@@ -6324,7 +6324,7 @@ impl TestServer {
             app_state.clone(),
             Executor::Deterministic(deterministic.build_background()),
         );
-        server.start().await.unwrap();
+        server.start();
         // Advance clock to ensure the server's cleanup task is finished.
         deterministic.advance_clock(CLEANUP_TIMEOUT);
         Self {

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -6123,9 +6123,17 @@ async fn test_random_collaboration(
             30..=34 => {
                 log::info!("Simulating server restart");
                 server.reset().await;
-                deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
+                deterministic.advance_clock(RECEIVE_TIMEOUT);
                 server.start().await.unwrap();
                 deterministic.advance_clock(CLEANUP_TIMEOUT);
+                let environment = &server.app_state.config.zed_environment;
+                let stale_room_ids = server
+                    .app_state
+                    .db
+                    .stale_room_ids(environment, server.id())
+                    .await
+                    .unwrap();
+                assert_eq!(stale_room_ids, vec![]);
             }
             _ if !op_start_signals.is_empty() => {
                 while operations < max_operations && rng.lock().gen_bool(0.7) {

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -608,7 +608,7 @@ async fn test_server_restarts(
     );
 
     // The server is torn down.
-    server.teardown();
+    server.reset().await;
 
     // Users A and B reconnect to the call. User C has troubles reconnecting, so it leaves the room.
     client_c.override_establish_connection(|_, cx| cx.spawn(|_| future::pending()));
@@ -778,7 +778,7 @@ async fn test_server_restarts(
     );
 
     // The server is torn down.
-    server.teardown();
+    server.reset().await;
 
     // Users A and B have troubles reconnecting, so they leave the room.
     client_a.override_establish_connection(|_, cx| cx.spawn(|_| future::pending()));
@@ -6122,7 +6122,7 @@ async fn test_random_collaboration(
             }
             30..=34 => {
                 log::info!("Simulating server restart");
-                server.teardown();
+                server.reset().await;
                 deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
                 server.start().await.unwrap();
                 deterministic.advance_clock(CLEANUP_TIMEOUT);
@@ -6320,7 +6320,13 @@ impl TestServer {
         )
         .unwrap();
         let app_state = Self::build_app_state(&test_db, &live_kit_server).await;
+        let epoch = app_state
+            .db
+            .create_server(&app_state.config.zed_environment)
+            .await
+            .unwrap();
         let server = Server::new(
+            epoch,
             app_state.clone(),
             Executor::Deterministic(deterministic.build_background()),
         );
@@ -6337,9 +6343,15 @@ impl TestServer {
         }
     }
 
-    fn teardown(&self) {
-        self.server.teardown();
+    async fn reset(&self) {
         self.app_state.db.reset();
+        let epoch = self
+            .app_state
+            .db
+            .create_server(&self.app_state.config.zed_environment)
+            .await
+            .unwrap();
+        self.server.reset(epoch);
     }
 
     async fn create_client(&mut self, cx: &mut TestAppContext, name: &str) -> TestClient {
@@ -7251,7 +7263,7 @@ impl TestClient {
 
 impl Drop for TestClient {
     fn drop(&mut self) {
-        self.client.tear_down();
+        self.client.teardown();
     }
 }
 

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -7,8 +7,8 @@ use crate::{
 use anyhow::anyhow;
 use call::{room, ActiveCall, ParticipantLocation, Room};
 use client::{
-    self, test::FakeHttpClient, Client, Connection, Credentials, EstablishConnectionError, PeerId,
-    User, UserStore, RECEIVE_TIMEOUT,
+    self, proto::PeerId, test::FakeHttpClient, Client, Connection, Credentials,
+    EstablishConnectionError, User, UserStore, RECEIVE_TIMEOUT,
 };
 use collections::{BTreeMap, HashMap, HashSet};
 use editor::{
@@ -6066,7 +6066,7 @@ async fn test_random_collaboration(
                     .user_connection_ids(removed_guest_id)
                     .collect::<Vec<_>>();
                 assert_eq!(user_connection_ids.len(), 1);
-                let removed_peer_id = PeerId(user_connection_ids[0].0);
+                let removed_peer_id = user_connection_ids[0].into();
                 let guest = clients.remove(guest_ix);
                 op_start_signals.remove(guest_ix);
                 server.forbid_connections();
@@ -6115,7 +6115,7 @@ async fn test_random_collaboration(
                     .user_connection_ids(user_id)
                     .collect::<Vec<_>>();
                 assert_eq!(user_connection_ids.len(), 1);
-                let peer_id = PeerId(user_connection_ids[0].0);
+                let peer_id = user_connection_ids[0].into();
                 server.disconnect_client(peer_id);
                 deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
                 operations += 1;
@@ -6429,7 +6429,7 @@ impl TestServer {
                         let connection_id = connection_id_rx.await.unwrap();
                         connection_killers
                             .lock()
-                            .insert(PeerId(connection_id.0), killed);
+                            .insert(connection_id.into(), killed);
                         Ok(client_conn)
                     }
                 })

--- a/crates/collab/src/integration_tests.rs
+++ b/crates/collab/src/integration_tests.rs
@@ -685,7 +685,7 @@ async fn test_server_restarts(
     );
 
     // The server finishes restarting, cleaning up stale connections.
-    server.start();
+    server.start().await.unwrap();
     deterministic.advance_clock(CLEANUP_TIMEOUT);
     assert_eq!(
         room_participants(&room_a, cx_a),
@@ -805,7 +805,7 @@ async fn test_server_restarts(
 
     // The server finishes restarting, cleaning up stale connections and canceling the
     // call to user D because the room has become empty.
-    server.start();
+    server.start().await.unwrap();
     deterministic.advance_clock(CLEANUP_TIMEOUT);
     assert!(incoming_call_d.next().await.unwrap().is_none());
 }
@@ -6124,7 +6124,7 @@ async fn test_random_collaboration(
                 log::info!("Simulating server restart");
                 server.teardown();
                 deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
-                server.start();
+                server.start().await.unwrap();
                 deterministic.advance_clock(CLEANUP_TIMEOUT);
             }
             _ if !op_start_signals.is_empty() => {
@@ -6324,7 +6324,7 @@ impl TestServer {
             app_state.clone(),
             Executor::Deterministic(deterministic.build_background()),
         );
-        server.start();
+        server.start().await.unwrap();
         // Advance clock to ensure the server's cleanup task is finished.
         deterministic.advance_clock(CLEANUP_TIMEOUT);
         Self {

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -97,6 +97,7 @@ pub struct Config {
     pub live_kit_secret: Option<String>,
     pub rust_log: Option<String>,
     pub log_json: Option<bool>,
+    pub zed_environment: String,
 }
 
 #[derive(Default, Deserialize)]

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
                 .expect("failed to bind TCP listener");
 
             let rpc_server = collab::rpc::Server::new(state.clone(), Executor::Production);
-            rpc_server.start();
+            rpc_server.start().await?;
 
             let app = collab::api::routes(rpc_server.clone(), state.clone())
                 .merge(collab::rpc::routes(rpc_server.clone()))

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -57,7 +57,11 @@ async fn main() -> Result<()> {
             let listener = TcpListener::bind(&format!("0.0.0.0:{}", state.config.http_port))
                 .expect("failed to bind TCP listener");
 
-            let rpc_server = collab::rpc::Server::new(state.clone(), Executor::Production);
+            let epoch = state
+                .db
+                .create_server(&state.config.zed_environment)
+                .await?;
+            let rpc_server = collab::rpc::Server::new(epoch, state.clone(), Executor::Production);
             rpc_server.start().await?;
 
             let app = collab::api::routes(rpc_server.clone(), state.clone())

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<()> {
                     tokio::signal::ctrl_c()
                         .await
                         .expect("failed to listen for interrupt signal");
+                    tracing::info!("Received interrupt signal");
                     rpc_server.teardown();
                 })
                 .await?;

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -77,8 +77,7 @@ async fn main() -> Result<()> {
                         .expect("failed to listen for interrupt signal");
                     let sigterm = sigterm.recv();
                     let sigint = sigint.recv();
-                    futures::pin_mut!(sigterm);
-                    futures::pin_mut!(sigint);
+                    futures::pin_mut!(sigterm, sigint);
                     futures::future::select(sigterm, sigint).await;
                     tracing::info!("Received interrupt signal");
                     rpc_server.teardown();

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
                 .expect("failed to bind TCP listener");
 
             let rpc_server = collab::rpc::Server::new(state.clone(), Executor::Production);
-            rpc_server.start().await?;
+            rpc_server.start();
 
             let app = collab::api::routes(rpc_server.clone(), state.clone())
                 .merge(collab::rpc::routes(rpc_server.clone()))

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -238,14 +238,14 @@ impl Server {
         Arc::new(server)
     }
 
-    pub fn start(&self) {
+    pub async fn start(&self) -> Result<()> {
+        self.app_state.db.delete_stale_projects().await?;
         let db = self.app_state.db.clone();
         let peer = self.peer.clone();
+        let timeout = self.executor.sleep(CLEANUP_TIMEOUT);
         let pool = self.connection_pool.clone();
         let live_kit_client = self.app_state.live_kit_client.clone();
-        let timeout = self.executor.sleep(CLEANUP_TIMEOUT);
         self.executor.spawn_detached(async move {
-            db.delete_stale_projects().await.trace_err();
             timeout.await;
             if let Some(room_ids) = db.stale_room_ids().await.trace_err() {
                 for room_id in room_ids {
@@ -321,6 +321,7 @@ impl Server {
                 }
             }
         });
+        Ok(())
     }
 
     pub fn teardown(&self) {

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1506,7 +1506,6 @@ async fn update_buffer(
         .project_connection_ids(project_id, session.connection_id)
         .await?;
 
-    dbg!(session.connection_id, &*project_connection_ids);
     broadcast(
         session.connection_id,
         project_connection_ids.iter().copied(),

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -488,9 +488,9 @@ impl Server {
                     move |duration| executor.sleep(duration)
                 });
 
-            tracing::info!(%user_id, %login, ?connection_id, %address, "connection opened");
+            tracing::info!(%user_id, %login, %connection_id, %address, "connection opened");
             this.peer.send(connection_id, proto::Hello { peer_id: Some(connection_id.into()) })?;
-            tracing::info!(%user_id, %login, ?connection_id, %address, "sent hello message");
+            tracing::info!(%user_id, %login, %connection_id, %address, "sent hello message");
 
             if let Some(send_connection_id) = send_connection_id.take() {
                 let _ = send_connection_id.send(connection_id);
@@ -552,7 +552,7 @@ impl Server {
                     _ = teardown.changed().fuse() => return Ok(()),
                     result = handle_io => {
                         if let Err(error) = result {
-                            tracing::error!(?error, %user_id, %login, ?connection_id, %address, "error handling I/O");
+                            tracing::error!(?error, %user_id, %login, %connection_id, %address, "error handling I/O");
                         }
                         break;
                     }
@@ -560,7 +560,7 @@ impl Server {
                     message = next_message => {
                         if let Some(message) = message {
                             let type_name = message.payload_type_name();
-                            let span = tracing::info_span!("receive message", %user_id, %login, ?connection_id, %address, type_name);
+                            let span = tracing::info_span!("receive message", %user_id, %login, %connection_id, %address, type_name);
                             let span_enter = span.enter();
                             if let Some(handler) = this.handlers.get(&message.payload_type_id()) {
                                 let is_background = message.is_background();
@@ -574,10 +574,10 @@ impl Server {
                                     foreground_message_handlers.push(handle_message);
                                 }
                             } else {
-                                tracing::error!(%user_id, %login, ?connection_id, %address, "no message handler");
+                                tracing::error!(%user_id, %login, %connection_id, %address, "no message handler");
                             }
                         } else {
-                            tracing::info!(%user_id, %login, ?connection_id, %address, "connection closed");
+                            tracing::info!(%user_id, %login, %connection_id, %address, "connection closed");
                             break;
                         }
                     }
@@ -585,9 +585,9 @@ impl Server {
             }
 
             drop(foreground_message_handlers);
-            tracing::info!(%user_id, %login, ?connection_id, %address, "signing out");
+            tracing::info!(%user_id, %login, %connection_id, %address, "signing out");
             if let Err(error) = sign_out(session, teardown, executor).await {
-                tracing::error!(%user_id, %login, ?connection_id, %address, ?error, "error signing out");
+                tracing::error!(%user_id, %login, %connection_id, %address, ?error, "error signing out");
             }
 
             Ok(())

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -351,6 +351,12 @@ impl Server {
                         }
                     }
                 }
+
+                app_state
+                    .db
+                    .delete_stale_servers(epoch, &app_state.config.zed_environment)
+                    .await
+                    .trace_err();
             }
             .instrument(span),
         );

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -58,7 +58,7 @@ use tower::ServiceBuilder;
 use tracing::{info_span, instrument, Instrument};
 
 pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-pub const CLEANUP_TIMEOUT: Duration = Duration::from_secs(10);
+pub const CLEANUP_TIMEOUT: Duration = Duration::from_secs(20);
 
 lazy_static! {
     static ref METRIC_CONNECTIONS: IntGauge =

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -1,6 +1,6 @@
 use crate::{contact_notification::ContactNotification, contacts_popover};
 use call::{ActiveCall, ParticipantLocation};
-use client::{Authenticate, ContactEventKind, PeerId, User, UserStore};
+use client::{proto::PeerId, Authenticate, ContactEventKind, User, UserStore};
 use clock::ReplicaId;
 use contacts_popover::ContactsPopover;
 use gpui::{
@@ -474,7 +474,7 @@ impl CollabTitlebarItem {
                         cx.dispatch_action(ToggleFollow(peer_id))
                     })
                     .with_tooltip::<ToggleFollow, _>(
-                        peer_id.0 as usize,
+                        peer_id.as_u64() as usize,
                         if is_followed {
                             format!("Unfollow {}", peer_github_login)
                         } else {
@@ -487,22 +487,24 @@ impl CollabTitlebarItem {
                     .boxed()
             } else if let ParticipantLocation::SharedProject { project_id } = location {
                 let user_id = user.id;
-                MouseEventHandler::<JoinProject>::new(peer_id.0 as usize, cx, move |_, _| content)
-                    .with_cursor_style(CursorStyle::PointingHand)
-                    .on_click(MouseButton::Left, move |_, cx| {
-                        cx.dispatch_action(JoinProject {
-                            project_id,
-                            follow_user_id: user_id,
-                        })
+                MouseEventHandler::<JoinProject>::new(peer_id.as_u64() as usize, cx, move |_, _| {
+                    content
+                })
+                .with_cursor_style(CursorStyle::PointingHand)
+                .on_click(MouseButton::Left, move |_, cx| {
+                    cx.dispatch_action(JoinProject {
+                        project_id,
+                        follow_user_id: user_id,
                     })
-                    .with_tooltip::<JoinProject, _>(
-                        peer_id.0 as usize,
-                        format!("Follow {} into external project", peer_github_login),
-                        Some(Box::new(FollowNextCollaborator)),
-                        theme.tooltip.clone(),
-                        cx,
-                    )
-                    .boxed()
+                })
+                .with_tooltip::<JoinProject, _>(
+                    peer_id.as_u64() as usize,
+                    format!("Follow {} into external project", peer_github_login),
+                    Some(Box::new(FollowNextCollaborator)),
+                    theme.tooltip.clone(),
+                    cx,
+                )
+                .boxed()
             } else {
                 content
             }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use client::{proto, PeerId};
+use client::proto::{self, PeerId};
 use gpui::{AppContext, AsyncAppContext, ModelHandle};
 use language::{
     point_from_lsp, point_to_lsp,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7,7 +7,7 @@ pub mod worktree;
 mod project_tests;
 
 use anyhow::{anyhow, Context, Result};
-use client::{proto, Client, PeerId, TypedEnvelope, UserStore};
+use client::{proto, Client, TypedEnvelope, UserStore};
 use clock::ReplicaId;
 use collections::{hash_map, BTreeMap, HashMap, HashSet};
 use futures::{
@@ -15,7 +15,6 @@ use futures::{
     future::Shared,
     AsyncWriteExt, Future, FutureExt, StreamExt, TryFutureExt,
 };
-
 use gpui::{
     AnyModelHandle, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle,
     MutableAppContext, Task, UpgradeModelHandle, WeakModelHandle,
@@ -103,11 +102,11 @@ pub struct Project {
     user_store: ModelHandle<UserStore>,
     fs: Arc<dyn Fs>,
     client_state: Option<ProjectClientState>,
-    collaborators: HashMap<PeerId, Collaborator>,
+    collaborators: HashMap<proto::PeerId, Collaborator>,
     client_subscriptions: Vec<client::Subscription>,
     _subscriptions: Vec<gpui::Subscription>,
     opened_buffer: (watch::Sender<()>, watch::Receiver<()>),
-    shared_buffers: HashMap<PeerId, HashSet<u64>>,
+    shared_buffers: HashMap<proto::PeerId, HashSet<u64>>,
     #[allow(clippy::type_complexity)]
     loading_buffers: HashMap<
         ProjectPath,
@@ -164,7 +163,7 @@ enum ProjectClientState {
 
 #[derive(Clone, Debug)]
 pub struct Collaborator {
-    pub peer_id: PeerId,
+    pub peer_id: proto::PeerId,
     pub replica_id: ReplicaId,
 }
 
@@ -185,7 +184,7 @@ pub enum Event {
     },
     RemoteIdChanged(Option<u64>),
     DisconnectedFromHost,
-    CollaboratorLeft(PeerId),
+    CollaboratorLeft(proto::PeerId),
 }
 
 pub enum LanguageServerState {
@@ -555,7 +554,7 @@ impl Project {
             .await?;
         let mut collaborators = HashMap::default();
         for message in response.collaborators {
-            let collaborator = Collaborator::from_proto(message);
+            let collaborator = Collaborator::from_proto(message)?;
             collaborators.insert(collaborator.peer_id, collaborator);
         }
 
@@ -754,7 +753,7 @@ impl Project {
         }
     }
 
-    pub fn collaborators(&self) -> &HashMap<PeerId, Collaborator> {
+    pub fn collaborators(&self) -> &HashMap<proto::PeerId, Collaborator> {
         &self.collaborators
     }
 
@@ -4605,7 +4604,7 @@ impl Project {
             .take()
             .ok_or_else(|| anyhow!("empty collaborator"))?;
 
-        let collaborator = Collaborator::from_proto(collaborator);
+        let collaborator = Collaborator::from_proto(collaborator)?;
         this.update(&mut cx, |this, cx| {
             this.collaborators
                 .insert(collaborator.peer_id, collaborator);
@@ -4622,7 +4621,10 @@ impl Project {
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
-            let peer_id = PeerId(envelope.payload.peer_id);
+            let peer_id = envelope
+                .payload
+                .peer_id
+                .ok_or_else(|| anyhow!("invalid peer id"))?;
             let replica_id = this
                 .collaborators
                 .remove(&peer_id)
@@ -5489,7 +5491,7 @@ impl Project {
     fn serialize_project_transaction_for_peer(
         &mut self,
         project_transaction: ProjectTransaction,
-        peer_id: PeerId,
+        peer_id: proto::PeerId,
         cx: &AppContext,
     ) -> proto::ProjectTransaction {
         let mut serialized_transaction = proto::ProjectTransaction {
@@ -5545,7 +5547,7 @@ impl Project {
     fn create_buffer_for_peer(
         &mut self,
         buffer: &ModelHandle<Buffer>,
-        peer_id: PeerId,
+        peer_id: proto::PeerId,
         cx: &AppContext,
     ) -> u64 {
         let buffer_id = buffer.read(cx).remote_id();
@@ -5563,7 +5565,7 @@ impl Project {
 
                             client.send(proto::CreateBufferForPeer {
                                 project_id,
-                                peer_id: peer_id.0,
+                                peer_id: Some(peer_id),
                                 variant: Some(proto::create_buffer_for_peer::Variant::State(state)),
                             })?;
 
@@ -5580,7 +5582,7 @@ impl Project {
                                 let is_last = operations.is_empty();
                                 client.send(proto::CreateBufferForPeer {
                                     project_id,
-                                    peer_id: peer_id.0,
+                                    peer_id: Some(peer_id),
                                     variant: Some(proto::create_buffer_for_peer::Variant::Chunk(
                                         proto::BufferChunk {
                                             buffer_id,
@@ -6036,11 +6038,11 @@ impl Entity for Project {
 }
 
 impl Collaborator {
-    fn from_proto(message: proto::Collaborator) -> Self {
-        Self {
-            peer_id: PeerId(message.peer_id),
+    fn from_proto(message: proto::Collaborator) -> Result<Self> {
+        Ok(Self {
+            peer_id: message.peer_id.ok_or_else(|| anyhow!("invalid peer id"))?,
             replica_id: message.replica_id as ReplicaId,
-        }
+        })
     }
 }
 

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -9,7 +9,7 @@ message PeerId {
 message Envelope {
     uint32 id = 1;
     optional uint32 responding_to = 2;
-    PeerId original_sender_id = 3;
+    optional PeerId original_sender_id = 3;
     oneof payload {
         Hello hello = 4;
         Ack ack = 5;

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -1,10 +1,15 @@
 syntax = "proto3";
 package zed.messages;
 
+message PeerId {
+    uint32 epoch = 1;
+    uint32 id = 2;
+}
+
 message Envelope {
     uint32 id = 1;
     optional uint32 responding_to = 2;
-    optional uint32 original_sender_id = 3;
+    PeerId original_sender_id = 3;
     oneof payload {
         Hello hello = 4;
         Ack ack = 5;
@@ -125,7 +130,7 @@ message Envelope {
 // Messages
 
 message Hello {
-    uint32 peer_id = 1;
+    PeerId peer_id = 1;
 }
 
 message Ping {}
@@ -167,7 +172,7 @@ message Room {
 
 message Participant {
     uint64 user_id = 1;
-    uint32 peer_id = 2;
+    PeerId peer_id = 2;
     repeated ParticipantProject projects = 3;
     ParticipantLocation location = 4;
 }
@@ -319,7 +324,7 @@ message AddProjectCollaborator {
 
 message RemoveProjectCollaborator {
     uint64 project_id = 1;
-    uint32 peer_id = 2;
+    PeerId peer_id = 2;
 }
 
 message GetDefinition {
@@ -438,7 +443,7 @@ message OpenBufferResponse {
 
 message CreateBufferForPeer {
     uint64 project_id = 1;
-    uint32 peer_id = 2;
+    PeerId peer_id = 2;
     oneof variant {
         BufferState state = 3;
         BufferChunk chunk = 4;
@@ -794,7 +799,7 @@ message UpdateDiagnostics {
 
 message Follow {
     uint64 project_id = 1;
-    uint32 leader_id = 2;
+    PeerId leader_id = 2;
 }
 
 message FollowResponse {
@@ -804,7 +809,7 @@ message FollowResponse {
 
 message UpdateFollowers {
     uint64 project_id = 1;
-    repeated uint32 follower_ids = 2;
+    repeated PeerId follower_ids = 2;
     oneof variant {
         UpdateActiveView update_active_view = 3;
         View create_view = 4;
@@ -814,7 +819,7 @@ message UpdateFollowers {
 
 message Unfollow {
     uint64 project_id = 1;
-    uint32 leader_id = 2;
+    PeerId leader_id = 2;
 }
 
 message GetPrivateUserInfo {}
@@ -828,12 +833,12 @@ message GetPrivateUserInfoResponse {
 
 message UpdateActiveView {
     optional uint64 id = 1;
-    optional uint32 leader_id = 2;
+    optional PeerId leader_id = 2;
 }
 
 message UpdateView {
     uint64 id = 1;
-    optional uint32 leader_id = 2;
+    optional PeerId leader_id = 2;
 
     oneof variant {
         Editor editor = 3;
@@ -849,7 +854,7 @@ message UpdateView {
 
 message View {
     uint64 id = 1;
-    optional uint32 leader_id = 2;
+    optional PeerId leader_id = 2;
 
     oneof variant {
         Editor editor = 3;
@@ -865,7 +870,7 @@ message View {
 }
 
 message Collaborator {
-    uint32 peer_id = 1;
+    PeerId peer_id = 1;
     uint32 replica_id = 2;
     uint64 user_id = 3;
 }

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package zed.messages;
 
 message PeerId {
-    uint32 epoch = 1;
+    uint32 owner_id = 1;
     uint32 id = 2;
 }
 

--- a/crates/rpc/src/macros.rs
+++ b/crates/rpc/src/macros.rs
@@ -6,7 +6,10 @@ macro_rules! messages {
                 $(Some(envelope::Payload::$name(payload)) => {
                     Some(Box::new(TypedEnvelope {
                         sender_id,
-                        original_sender_id: envelope.original_sender_id.map(PeerId),
+                        original_sender_id: envelope.original_sender_id.map(|original_sender| PeerId {
+                            epoch: original_sender.epoch,
+                            id: original_sender.id
+                        }),
                         message_id: envelope.id,
                         payload,
                     }))
@@ -24,7 +27,7 @@ macro_rules! messages {
                     self,
                     id: u32,
                     responding_to: Option<u32>,
-                    original_sender_id: Option<u32>,
+                    original_sender_id: Option<PeerId>,
                 ) -> Envelope {
                     Envelope {
                         id,

--- a/crates/rpc/src/macros.rs
+++ b/crates/rpc/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! messages {
                     Some(Box::new(TypedEnvelope {
                         sender_id,
                         original_sender_id: envelope.original_sender_id.map(|original_sender| PeerId {
-                            epoch: original_sender.epoch,
+                            owner_id: original_sender.owner_id,
                             id: original_sender.id
                         }),
                         message_id: envelope.id,

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -25,14 +25,14 @@ use tracing::instrument;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 pub struct ConnectionId {
-    pub epoch: u32,
+    pub owner_id: u32,
     pub id: u32,
 }
 
 impl Into<PeerId> for ConnectionId {
     fn into(self) -> PeerId {
         PeerId {
-            epoch: self.epoch,
+            owner_id: self.owner_id,
             id: self.id,
         }
     }
@@ -41,7 +41,7 @@ impl Into<PeerId> for ConnectionId {
 impl From<PeerId> for ConnectionId {
     fn from(peer_id: PeerId) -> Self {
         Self {
-            epoch: peer_id.epoch,
+            owner_id: peer_id.owner_id,
             id: peer_id.id,
         }
     }
@@ -49,7 +49,7 @@ impl From<PeerId> for ConnectionId {
 
 impl fmt::Display for ConnectionId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/{}", self.epoch, self.id)
+        write!(f, "{}/{}", self.owner_id, self.id)
     }
 }
 
@@ -157,7 +157,7 @@ impl Peer {
         let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded();
 
         let connection_id = ConnectionId {
-            epoch: self.epoch.load(SeqCst),
+            owner_id: self.epoch.load(SeqCst),
             id: self.next_connection_id.fetch_add(1, SeqCst),
         };
         let connection_state = ConnectionState {

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -72,7 +72,7 @@ impl<T: EnvelopedMessage> AnyTypedEnvelope for TypedEnvelope<T> {
     }
 
     fn original_sender_id(&self) -> Option<PeerId> {
-        self.original_sender_id.clone()
+        self.original_sender_id
     }
 }
 

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -1,14 +1,16 @@
-use super::{entity_messages, messages, request_messages, ConnectionId, PeerId, TypedEnvelope};
+use super::{entity_messages, messages, request_messages, ConnectionId, TypedEnvelope};
 use anyhow::{anyhow, Result};
 use async_tungstenite::tungstenite::Message as WebSocketMessage;
 use futures::{SinkExt as _, StreamExt as _};
 use prost::Message as _;
 use serde::Serialize;
 use std::any::{Any, TypeId};
-use std::{cmp, iter, mem};
+use std::fmt;
+use std::str::FromStr;
 use std::{
+    cmp,
     fmt::Debug,
-    io,
+    io, iter, mem,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -21,7 +23,7 @@ pub trait EnvelopedMessage: Clone + Debug + Serialize + Sized + Send + Sync + 's
         self,
         id: u32,
         responding_to: Option<u32>,
-        original_sender_id: Option<u32>,
+        original_sender_id: Option<PeerId>,
     ) -> Envelope;
     fn from_envelope(envelope: Envelope) -> Option<Self>;
 }
@@ -70,7 +72,67 @@ impl<T: EnvelopedMessage> AnyTypedEnvelope for TypedEnvelope<T> {
     }
 
     fn original_sender_id(&self) -> Option<PeerId> {
-        self.original_sender_id
+        self.original_sender_id.clone()
+    }
+}
+
+impl PeerId {
+    pub fn from_u64(peer_id: u64) -> Self {
+        let epoch = (peer_id >> 32) as u32;
+        let id = peer_id as u32;
+        Self { epoch, id }
+    }
+
+    pub fn as_u64(self) -> u64 {
+        ((self.epoch as u64) << 32) | (self.id as u64)
+    }
+}
+
+impl Copy for PeerId {}
+
+impl Eq for PeerId {}
+
+impl Ord for PeerId {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.epoch
+            .cmp(&other.epoch)
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for PeerId {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::hash::Hash for PeerId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.epoch.hash(state);
+        self.id.hash(state);
+    }
+}
+
+impl fmt::Display for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.epoch, self.id)
+    }
+}
+
+impl FromStr for PeerId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut components = s.split('/');
+        let epoch = components
+            .next()
+            .ok_or_else(|| anyhow!("invalid peer id {:?}", s))?
+            .parse()?;
+        let id = components
+            .next()
+            .ok_or_else(|| anyhow!("invalid peer id {:?}", s))?
+            .parse()?;
+        Ok(PeerId { epoch, id })
     }
 }
 
@@ -476,5 +538,26 @@ mod tests {
         assert!(stream.encoding_buffer.capacity() <= MAX_BUFFER_LEN);
         stream.read().await.unwrap();
         assert!(stream.encoding_buffer.capacity() <= MAX_BUFFER_LEN);
+    }
+
+    #[gpui::test]
+    fn test_converting_peer_id_from_and_to_u64() {
+        let peer_id = PeerId { epoch: 10, id: 3 };
+        assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
+        let peer_id = PeerId {
+            epoch: u32::MAX,
+            id: 3,
+        };
+        assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
+        let peer_id = PeerId {
+            epoch: 10,
+            id: u32::MAX,
+        };
+        assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
+        let peer_id = PeerId {
+            epoch: u32::MAX,
+            id: u32::MAX,
+        };
+        assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
     }
 }

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -78,13 +78,13 @@ impl<T: EnvelopedMessage> AnyTypedEnvelope for TypedEnvelope<T> {
 
 impl PeerId {
     pub fn from_u64(peer_id: u64) -> Self {
-        let epoch = (peer_id >> 32) as u32;
+        let owner_id = (peer_id >> 32) as u32;
         let id = peer_id as u32;
-        Self { epoch, id }
+        Self { owner_id, id }
     }
 
     pub fn as_u64(self) -> u64 {
-        ((self.epoch as u64) << 32) | (self.id as u64)
+        ((self.owner_id as u64) << 32) | (self.id as u64)
     }
 }
 
@@ -94,8 +94,8 @@ impl Eq for PeerId {}
 
 impl Ord for PeerId {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.epoch
-            .cmp(&other.epoch)
+        self.owner_id
+            .cmp(&other.owner_id)
             .then_with(|| self.id.cmp(&other.id))
     }
 }
@@ -108,14 +108,14 @@ impl PartialOrd for PeerId {
 
 impl std::hash::Hash for PeerId {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.epoch.hash(state);
+        self.owner_id.hash(state);
         self.id.hash(state);
     }
 }
 
 impl fmt::Display for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/{}", self.epoch, self.id)
+        write!(f, "{}/{}", self.owner_id, self.id)
     }
 }
 
@@ -124,7 +124,7 @@ impl FromStr for PeerId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut components = s.split('/');
-        let epoch = components
+        let owner_id = components
             .next()
             .ok_or_else(|| anyhow!("invalid peer id {:?}", s))?
             .parse()?;
@@ -132,7 +132,7 @@ impl FromStr for PeerId {
             .next()
             .ok_or_else(|| anyhow!("invalid peer id {:?}", s))?
             .parse()?;
-        Ok(PeerId { epoch, id })
+        Ok(PeerId { owner_id, id })
     }
 }
 
@@ -542,20 +542,23 @@ mod tests {
 
     #[gpui::test]
     fn test_converting_peer_id_from_and_to_u64() {
-        let peer_id = PeerId { epoch: 10, id: 3 };
-        assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
         let peer_id = PeerId {
-            epoch: u32::MAX,
+            owner_id: 10,
             id: 3,
         };
         assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
         let peer_id = PeerId {
-            epoch: 10,
+            owner_id: u32::MAX,
+            id: 3,
+        };
+        assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
+        let peer_id = PeerId {
+            owner_id: 10,
             id: u32::MAX,
         };
         assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);
         let peer_id = PeerId {
-            epoch: u32::MAX,
+            owner_id: u32::MAX,
             id: u32::MAX,
         };
         assert_eq!(PeerId::from_u64(peer_id.as_u64()), peer_id);

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 41;
+pub const PROTOCOL_VERSION: u32 = 42;

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -280,7 +280,7 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
                     proto::update_followers::Variant::CreateView(proto::View {
                         id: followed_item.id() as u64,
                         variant: Some(message),
-                        leader_id: workspace.leader_for_pane(&pane).map(|id| id.0),
+                        leader_id: workspace.leader_for_pane(&pane),
                     }),
                     cx,
                 );
@@ -334,7 +334,7 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
                                             proto::UpdateView {
                                                 id: item.id() as u64,
                                                 variant: pending_update.borrow_mut().take(),
-                                                leader_id: leader_id.map(|id| id.0),
+                                                leader_id,
                                             },
                                         ),
                                         cx,

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use call::participant::{Frame, RemoteVideoTrack};
-use client::{PeerId, User};
+use client::{proto::PeerId, User};
 use futures::StreamExt;
 use gpui::{
     elements::*,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2050,7 +2050,7 @@ impl Workspace {
                     .get(&leader_id)
                     .map(|c| c.replica_id)
             })
-            .ok_or_else(|| anyhow!("no such collaborator {:?}", leader_id))?;
+            .ok_or_else(|| anyhow!("no such collaborator {}", leader_id))?;
 
         let item_builders = cx.update(|cx| {
             cx.default_global::<FollowableItemBuilders>()


### PR DESCRIPTION
Refs #1860 
Fixes #1970 

This pull request introduces several improvements to both the client and the server that will improve the robustness of reconnections. There isn't an overarching theme shared by these changes, but this is rather a collection of different things that we discovered after deploying `collab` to Kubernetes. Specifically:

- The server now listens for `SIGTERM` signals, which are sent by Kubernetes before terminating the pod after the new pod has announced its readiness. Without listening to these signals and forcefully disconnecting clients, Kubernetes would wait for 30s before killing the process. This would cause the reconnection timeout to expire, preventing clients from reconnecting to the newly-deployed pod.
- The Kubernetes manifest now defines a readiness probe. This ensures we're ready to serve connections when Kubernetes changes the load balancer to point to the new pod.
- `Peer` has been changed to require an `owner_id: u32` when it is instantiated. Every time the server is started up, we create an entry in the `servers` table that will generate a new id, which is then assigned when constructing the server `Peer`. Every `ConnectionId` and `PeerId` now includes this new `owner_id` integer. This ensures that, when the server talks about its peer IDs in proto messages or stores them in the database, there are no aliasing problems due to resetting the `ConnectionId` counter back to zero when the server was restarted.
- On startup, the server will wait 10s before cleaning up stale data from the previous instantiation, e.g. kicking out participants that didn't manage to reconnect, deleting old projects and deleting rooms that have no participants in them. Previously, though, we wouldn't take into account the server's environment: that is, even if preview shared the database with production, on redeploy it could delete data from production that was still accessed. With these changes, the new pod will clean up data associated with old servers belonging to the same environment.