### PR TITLE
Fix panic when following due to pending selections

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5453,11 +5453,17 @@ impl Editor {
     pub fn set_selections_from_remote(
         &mut self,
         selections: Vec<Selection<Anchor>>,
+        pending_selection: Option<Selection<Anchor>>,
         cx: &mut ViewContext<Self>,
     ) {
         let old_cursor_position = self.selections.newest_anchor().head();
         self.selections.change_with(cx, |s| {
             s.select_anchors(selections);
+            if let Some(pending_selection) = pending_selection {
+                s.set_pending(pending_selection, SelectMode::Character);
+            } else {
+                s.clear_pending();
+            }
         });
         self.selections_did_change(false, &old_cursor_position, cx);
     }

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -853,9 +853,10 @@ message UpdateView {
         repeated ExcerptInsertion inserted_excerpts = 1;
         repeated uint64 deleted_excerpts = 2;
         repeated Selection selections = 3;
-        EditorAnchor scroll_top_anchor = 4;
-        float scroll_x = 5;
-        float scroll_y = 6;
+        optional Selection pending_selection = 4;
+        EditorAnchor scroll_top_anchor = 5;
+        float scroll_x = 6;
+        float scroll_y = 7;
     }
 }
 
@@ -872,9 +873,10 @@ message View {
         optional string title = 2;
         repeated Excerpt excerpts = 3;
         repeated Selection selections = 4;
-        EditorAnchor scroll_top_anchor = 5;
-        float scroll_x = 6;
-        float scroll_y = 7;
+        optional Selection pending_selection = 5;
+        EditorAnchor scroll_top_anchor = 6;
+        float scroll_x = 7;
+        float scroll_y = 8;
     }
 }
 

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 43;
+pub const PROTOCOL_VERSION: u32 = 44;


### PR DESCRIPTION
Refs https://github.com/zed-industries/zed/issues/1977

This fixes a panic that would occur when following someone who created a pending selection that overlapped or preceded another selection. We were attempting to replicate pending selections as if they were normal, disjoint selections. Now, pending selections are replicated as a separate piece of state, so that followers can represent them in as pending on their ends.

This required a protocol change.