### PR TITLE
add command to copy system information to the clipboard

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -34,16 +34,15 @@ use gpui::{
     elements::*,
     impl_actions, impl_internal_actions,
     platform::{CursorStyle, WindowOptions},
-    AnyModelHandle, AnyViewHandle, AppContext, AsyncAppContext, ClipboardItem, Entity,
-    ModelContext, ModelHandle, MouseButton, MutableAppContext, PathPromptOptions, PromptLevel,
-    RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
+    AnyModelHandle, AnyViewHandle, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle,
+    MouseButton, MutableAppContext, PathPromptOptions, PromptLevel, RenderContext, Task, View,
+    ViewContext, ViewHandle, WeakViewHandle,
 };
 use item::{FollowableItem, FollowableItemHandle, Item, ItemHandle, ProjectItem};
 use language::LanguageRegistry;
 use std::{
     any::TypeId,
     borrow::Cow,
-    env,
     future::Future,
     path::{Path, PathBuf},
     sync::Arc,
@@ -73,7 +72,7 @@ use status_bar::StatusBar;
 pub use status_bar::StatusItemView;
 use theme::{Theme, ThemeRegistry};
 pub use toolbar::{ToolbarItemLocation, ToolbarItemView};
-use util::{channel::ReleaseChannel, ResultExt};
+use util::ResultExt;
 
 #[derive(Clone, PartialEq)]
 pub struct RemoveWorktreeFromProject(pub WorktreeId);
@@ -96,8 +95,7 @@ actions!(
         ToggleLeftSidebar,
         ToggleRightSidebar,
         NewTerminal,
-        NewSearch,
-        CopySystemDetailsIntoClipboard
+        NewSearch
     ]
 );
 
@@ -298,12 +296,6 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                         Ok(())
                     })
                 })
-        },
-    );
-
-    cx.add_action(
-        |workspace: &mut Workspace, _: &CopySystemDetailsIntoClipboard, cx| {
-            workspace.copy_system_details_into_clipboard(cx);
         },
     );
 
@@ -986,42 +978,6 @@ impl Workspace {
             }
             Ok(true)
         })
-    }
-
-    fn copy_system_details_into_clipboard(&mut self, cx: &mut ViewContext<Self>) {
-        let platform = cx.platform();
-
-        let os_name: String = platform.os_name().into();
-        let os_version = platform.os_version().ok();
-        let app_version = env!("CARGO_PKG_VERSION");
-        let release_channel = cx.global::<ReleaseChannel>().dev_name();
-        let architecture = env::var("CARGO_CFG_TARGET_ARCH");
-
-        let os_information = match os_version {
-            Some(os_version) => format!("OS: {os_name} {os_version}"),
-            None => format!("OS: {os_name}"),
-        };
-        let system_information = vec![
-            Some(os_information),
-            Some(format!("Zed: {app_version} ({release_channel})")),
-            architecture
-                .map(|architecture| format!("Architecture: {architecture}"))
-                .ok(),
-        ];
-
-        let system_information = system_information
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let item = ClipboardItem::new(system_information.clone());
-        cx.prompt(
-            gpui::PromptLevel::Info,
-            &format!("Copied into clipboard:\n\n{system_information}"),
-            &["OK"],
-        );
-        cx.write_to_clipboard(item.clone());
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -339,15 +339,20 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
-                    name: "Documentation",
-                    action: Box::new(crate::OpenBrowser {
-                        url: "https://zed.dev/docs".into(),
-                    }),
+                    name: "Copy System Details Into Clipboard",
+                    action: Box::new(workspace::CopySystemDetailsIntoClipboard),
                 },
                 MenuItem::Action {
                     name: "Give Feedback",
                     action: Box::new(crate::OpenBrowser {
                         url: super::feedback::NEW_ISSUE_URL.into(),
+                    }),
+                },
+                MenuItem::Separator,
+                MenuItem::Action {
+                    name: "Documentation",
+                    action: Box::new(crate::OpenBrowser {
+                        url: "https://zed.dev/docs".into(),
                     }),
                 },
                 MenuItem::Action {

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -339,8 +339,8 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Separator,
                 MenuItem::Action {
-                    name: "Copy System Details Into Clipboard",
-                    action: Box::new(workspace::CopySystemDetailsIntoClipboard),
+                    name: "Copy System Specs Into Clipboard",
+                    action: Box::new(crate::CopySystemSpecsIntoClipboard),
                 },
                 MenuItem::Action {
                     name: "Give Feedback",

--- a/crates/zed/src/system_specs.rs
+++ b/crates/zed/src/system_specs.rs
@@ -1,0 +1,46 @@
+use std::{env, fmt::Display};
+
+use gpui::AppContext;
+use util::channel::ReleaseChannel;
+
+pub struct SystemSpecs {
+    os_name: &'static str,
+    os_version: Option<String>,
+    app_version: &'static str,
+    release_channel: &'static str,
+    architecture: &'static str,
+}
+
+impl SystemSpecs {
+    pub fn new(cx: &AppContext) -> Self {
+        let platform = cx.platform();
+
+        SystemSpecs {
+            os_name: platform.os_name(),
+            os_version: platform
+                .os_version()
+                .ok()
+                .map(|os_version| os_version.to_string()),
+            app_version: env!("CARGO_PKG_VERSION"),
+            release_channel: cx.global::<ReleaseChannel>().dev_name(),
+            architecture: env::consts::ARCH,
+        }
+    }
+}
+
+impl Display for SystemSpecs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let os_information = match &self.os_version {
+            Some(os_version) => format!("OS: {} {}", self.os_name, os_version),
+            None => format!("OS: {}", self.os_name),
+        };
+        let system_specs = [
+            os_information,
+            format!("Zed: {} ({})", self.app_version, self.release_channel),
+            format!("Architecture: {}", self.architecture),
+        ]
+        .join("\n");
+
+        write!(f, "{system_specs}")
+    }
+}


### PR DESCRIPTION
## Description of feature or change

What is the correct way to get the CPU architecture within Zed?  What I'm doing here is copy-paste from somewhere else and doesn't seem to work in dev builds.

When complete, closes: https://github.com/zed-industries/feedback/issues/703

![SCR-20221222-4w5](https://user-images.githubusercontent.com/19867440/209091820-2bb4f2c1-1389-46ea-9423-b86dc002f887.jpeg)
![SCR-20221222-4w7](https://user-images.githubusercontent.com/19867440/209091823-2a7dce5f-29bb-4b75-b534-9ca641112a5e.jpeg)

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
