### PR TITLE
Add actions for requesting features and filing bug reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7232,6 +7232,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
 name = "usvg"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8273,6 +8279,7 @@ dependencies = [
  "tree-sitter-typescript",
  "unindent",
  "url",
+ "urlencoding",
  "util",
  "vim",
  "workspace",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -110,6 +110,7 @@ tree-sitter-html = "0.19.0"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9"}
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a"}
 url = "2.2"
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -343,10 +343,12 @@ pub fn menus() -> Vec<Menu<'static>> {
                     action: Box::new(crate::CopySystemSpecsIntoClipboard),
                 },
                 MenuItem::Action {
-                    name: "Give Feedback",
-                    action: Box::new(crate::OpenBrowser {
-                        url: super::feedback::NEW_ISSUE_URL.into(),
-                    }),
+                    name: "File Bug Report",
+                    action: Box::new(crate::FileBugReport),
+                },
+                MenuItem::Action {
+                    name: "Request Feature",
+                    action: Box::new(crate::RequestFeature),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -69,7 +69,9 @@ actions!(
         ResetBufferFontSize,
         InstallCommandLineInterface,
         ResetDatabase,
-        CopySystemSpecsIntoClipboard
+        CopySystemSpecsIntoClipboard,
+        RequestFeature,
+        FileBugReport
     ]
 );
 
@@ -258,6 +260,28 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
                 &["OK"],
             );
             cx.write_to_clipboard(item);
+        },
+    );
+
+    cx.add_action(
+        |_: &mut Workspace, _: &RequestFeature, cx: &mut ViewContext<Workspace>| {
+            let url = "https://github.com/zed-industries/feedback/issues/new?assignees=&labels=enhancement%2Ctriage&template=0_feature_request.yml";
+            cx.dispatch_action(OpenBrowser {
+                url: url.into(),
+            });
+        },
+    );
+
+    cx.add_action(
+        |_: &mut Workspace, _: &FileBugReport, cx: &mut ViewContext<Workspace>| {
+            let system_specs_text = SystemSpecs::new(cx).to_string();
+            let url = format!(
+                "https://github.com/zed-industries/feedback/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}", 
+                urlencoding::encode(&system_specs_text)
+            );
+            cx.dispatch_action(OpenBrowser {
+                url: url.into(),
+            });
         },
     );
 


### PR DESCRIPTION
## Description of feature or change

https://user-images.githubusercontent.com/19867440/209269147-4166ae1a-788b-4b63-bf6c-31c7eafd0630.mov

![SCR-20221222-w6t](https://user-images.githubusercontent.com/19867440/209269349-bde38dba-11b3-4d82-82d0-d3129d5d99d6.jpeg)


This change makes it a bit easier to give feedback.  It adds command palette actions / menu actions for:
- `file bug report`
- `request feature`

Both actions automatically open the browser with the correct template.
The `file bug report` action automatically fills in the system information on the issue.

Future plans:

We still have the "Give Feedback" button, which right now just takes you to the issue template picker view on GH.  My plan is to swap that action over to opening up a textfield window for the user to type in some fast feedback (stuff Nathan and I discussed).  After that PR, the user will have a few options for feedback:

1. Super quick in-app feedback via a textfield window
2. More detailed feedback via:
    - Bug Report Action
    - Feature Request Action

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
