### PR TITLE
Rename `close clean items` to `close saved items`

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -21,7 +21,7 @@
             "alt-cmd-right": "pane::ActivateNextItem",
             "cmd-w": "pane::CloseActiveItem",
             "alt-cmd-t": "pane::CloseInactiveItems",
-            "cmd-k u": "pane::CloseCleanItems",
+            "cmd-k u": "pane::CloseSavedItems",
             "cmd-k cmd-w": "pane::CloseAllItems",
             "cmd-shift-w": "workspace::CloseWindow",
             "cmd-s": "workspace::Save",


### PR DESCRIPTION
## Description of feature or change

Renames `close clean items` to `close saved items` .... `clean` was used because it refers to a buffer in a non-dirty state, but it's a pretty bad way to describe an editor to a user.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
