### PR TITLE
Add dismiss buffer search button & fix some faulty icon button styling

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4038,7 +4038,7 @@ pub struct RenderContext<'a, T: View> {
     pub refreshing: bool,
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct MouseState {
     hovered: bool,
     clicked: Option<MouseButton>,

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -247,6 +247,7 @@ pub struct Search {
     pub results_status: TextStyle,
     pub tab_icon_width: f32,
     pub tab_icon_spacing: f32,
+    pub dismiss_button: Interactive<IconButton>,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/styles/src/styleTree/contactNotification.ts
+++ b/styles/src/styleTree/contactNotification.ts
@@ -32,13 +32,13 @@ export default function contactNotification(colorScheme: ColorScheme): Object {
       },
     },
     dismissButton: {
-      color: foreground(layer, "on"),
+      color: foreground(layer, "variant"),
       iconWidth: 8,
       iconHeight: 8,
       buttonWidth: 8,
       buttonHeight: 8,
       hover: {
-        color: foreground(layer, "on", "hovered"),
+        color: foreground(layer, "hovered"),
       },
     },
   };

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -257,7 +257,6 @@ export default function editor(colorScheme: ColorScheme) {
         right: 6,
       },
       hover: {
-        color: foreground(layer, "on", "hovered"),
         background: background(layer, "on", "hovered"),
       },
     },

--- a/styles/src/styleTree/search.ts
+++ b/styles/src/styleTree/search.ts
@@ -80,5 +80,17 @@ export default function search(colorScheme: ColorScheme) {
       ...text(layer, "mono", "on"),
       size: 18,
     },
+    dismissButton: {
+      color: foreground(layer, "variant"),
+      iconWidth: 12,
+      buttonWidth: 14,
+      padding: {
+        left: 10,
+        right: 10,
+      },
+      hover: {
+        color: foreground(layer, "hovered"),
+      },
+    },
   };
 }

--- a/styles/src/styleTree/tabBar.ts
+++ b/styles/src/styleTree/tabBar.ts
@@ -26,7 +26,7 @@ export default function tabBar(colorScheme: ColorScheme) {
     // Close icons
     iconWidth: 8,
     iconClose: foreground(layer, "variant"),
-    iconCloseActive: foreground(layer),
+    iconCloseActive: foreground(layer, "hovered"),
 
     // Indicators
     iconConflict: foreground(layer, "warning"),


### PR DESCRIPTION
## Description of feature or change

Closing the buffer search is now possible with the mouse. A few locations were incorrectly using `foreground(layer, "on", "hovered")` styling for a few icon buttons which is logically incorrect, resolve this appropriately.

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/feedback/issues/808
