### PR TITLE
Correct default settings' name key for RA in init options example

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -221,7 +221,7 @@
         // rust-analyzer
         // typescript-language-server
         // vscode-json-languageserver
-        // "rust_analyzer": {
+        // "rust-analyzer": {
         //     //These initialization options are merged into Zed's defaults
         //     "initialization_options": {
         //         "checkOnSave": {


### PR DESCRIPTION
## Description of feature or change

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/feedback/issues/535
