### PR TITLE
Include Typescript completion item `detail` field in completion label

### DIFF
--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -128,8 +128,14 @@ impl LspAdapter for TypeScriptLspAdapter {
             Kind::PROPERTY | Kind::FIELD => grammar.highlight_id_for_name("property"),
             _ => None,
         }?;
+
+        let text = match &item.detail {
+            Some(detail) => format!("{} {}", item.label, detail),
+            None => item.label.clone(),
+        };
+
         Some(language::CodeLabel {
-            text: item.label.clone(),
+            text,
             runs: vec![(0..len, highlight_id)],
             filter_range: 0..len,
         })


### PR DESCRIPTION
## Description of feature or change

We were previously just ignoring anything tsserver sent us for this field

## Link to related issues from zed or insiders

Closes https://github.com/zed-industries/zed/issues/830

