### PR TITLE
Prefer first max while fuzzy matching projects fixes unexpected behavior

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -146,6 +146,7 @@ impl PickerDelegate for RecentProjectsView {
             .matches
             .iter()
             .enumerate()
+            .rev()
             .max_by_key(|(_, m)| OrderedFloat(m.score))
             .map(|(ix, _)| ix)
             .unwrap_or(0);


### PR DESCRIPTION
## Description of feature or change

Previously whenever there was a tie in score for the recent project switcher it would select the last tied entry in the list. This lead to unexpected behavior with things like an empty query, which would lead to all items having equal score and the last item being pre-selected, despite that also being the most stale entry in the list.

I attempted to un-block-ify it while I was in there but wasn't happy with where it ended up, likely the same reason it was written as blocking in the first place
