### PR TITLE
Added open screenshare when following into non-followable buffer

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2142,7 +2142,6 @@ impl Workspace {
         let call = self.active_call()?;
         let room = call.read(cx).room()?.read(cx);
         let participant = room.remote_participant_for_peer_id(leader_id)?;
-
         let mut items_to_add = Vec::new();
         match participant.location {
             call::ParticipantLocation::SharedProject { project_id } => {
@@ -2153,6 +2152,12 @@ impl Workspace {
                             .and_then(|id| state.items_by_leader_view_id.get(&id))
                         {
                             items_to_add.push((pane.clone(), item.boxed_clone()));
+                        } else {
+                            if let Some(shared_screen) =
+                                self.shared_screen_for_peer(leader_id, pane, cx)
+                            {
+                                items_to_add.push((pane.clone(), Box::new(shared_screen)));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description of feature or change

This causes following to automatically open the screenshare item when following into the terminal or other unfollowable item.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Figure out why screenshare item isn't working.
- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
