### PR TITLE
Don't save single file worktrees

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2680,8 +2680,8 @@ pub fn activate_workspace_for_project(
     None
 }
 
-pub fn last_opened_workspace_paths() -> Option<WorkspaceLocation> {
-    DB.last_workspace().log_err().flatten()
+pub async fn last_opened_workspace_paths() -> Option<WorkspaceLocation> {
+    DB.last_workspace().await.log_err().flatten()
 }
 
 #[allow(clippy::type_complexity)]


### PR DESCRIPTION
## Description of feature or change
Prevents workspaces with single worktrees from getting loaded

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
We don't have test infrastructure to enable this as its just on app startup
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
