### PR TITLE
Telemetry opt out

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -79,6 +79,13 @@
     "hard_tabs": false,
     // How many columns a tab should occupy.
     "tab_size": 4,
+    // Control what info Zed sends to our servers
+    "telemetry": {
+        // Send debug info like crash reports.
+        "diagnostics": true,
+        // Send anonymized usage data like what languages you're using Zed with.
+        "metrics": true
+    },
     // Git gutter behavior configuration.
     "git": {
         // Control whether the git gutter is shown. May take 2 values:

--- a/crates/collab/src/tests/randomized_integration_tests.rs
+++ b/crates/collab/src/tests/randomized_integration_tests.rs
@@ -18,6 +18,7 @@ use rand::{
     distributions::{Alphanumeric, DistString},
     prelude::*,
 };
+use settings::Settings;
 use std::{env, ffi::OsStr, path::PathBuf, sync::Arc};
 
 #[gpui::test(iterations = 100)]
@@ -104,6 +105,8 @@ async fn test_random_collaboration(
                     cx.function_name.clone(),
                 );
 
+                client_cx.update(|cx| cx.set_global(Settings::test(cx)));
+
                 let op_start_signal = futures::channel::mpsc::unbounded();
                 let client = server.create_client(&mut client_cx, &username).await;
                 user_ids.push(client.current_user_id(&client_cx));
@@ -173,6 +176,7 @@ async fn test_random_collaboration(
                 available_users.push((removed_user_id, client.username.clone()));
                 client_cx.update(|cx| {
                     cx.clear_globals();
+                    cx.set_global(Settings::test(cx));
                     drop(client);
                 });
 
@@ -401,6 +405,7 @@ async fn test_random_collaboration(
     for (client, mut cx) in clients {
         cx.update(|cx| {
             cx.clear_globals();
+            cx.set_global(Settings::test(cx));
             drop(client);
         });
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6087,10 +6087,11 @@ impl Editor {
             let extension = Path::new(file.file_name(cx))
                 .extension()
                 .and_then(|e| e.to_str());
-            project
-                .read(cx)
-                .client()
-                .report_event(name, json!({ "File Extension": extension }));
+            project.read(cx).client().report_event(
+                name,
+                json!({ "File Extension": extension }),
+                cx.global::<Settings>().telemetry(),
+            );
         }
     }
 }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -584,7 +584,10 @@ impl Settings {
             lsp: Default::default(),
             projects_online_by_default: true,
             theme: gpui::fonts::with_font_cache(cx.font_cache().clone(), Default::default),
-            telemetry_defaults: Default::default(),
+            telemetry_defaults: TelemetrySettings {
+                diagnostics: Some(true),
+                metrics: Some(true),
+            },
             telemetry_overrides: Default::default(),
             staff_mode: false,
         }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -51,7 +51,15 @@ pub struct Settings {
     pub language_overrides: HashMap<Arc<str>, EditorSettings>,
     pub lsp: HashMap<Arc<str>, LspSettings>,
     pub theme: Arc<Theme>,
+    pub telemetry_defaults: TelemetrySettings,
+    pub telemetry_overrides: TelemetrySettings,
     pub staff_mode: bool,
+}
+
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct TelemetrySettings {
+    diagnostics: Option<bool>,
+    metrics: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -302,6 +310,8 @@ pub struct SettingsFileContent {
     #[serde(default)]
     pub theme: Option<String>,
     #[serde(default)]
+    pub telemetry: TelemetrySettings,
+    #[serde(default)]
     pub staff_mode: Option<bool>,
 }
 
@@ -312,6 +322,7 @@ pub struct LspSettings {
 }
 
 impl Settings {
+    /// Fill out the settings corresponding to the default.json file, overrides will be set later
     pub fn defaults(
         assets: impl AssetSource,
         font_cache: &FontCache,
@@ -363,11 +374,13 @@ impl Settings {
             language_overrides: Default::default(),
             lsp: defaults.lsp.clone(),
             theme: themes.get(&defaults.theme.unwrap()).unwrap(),
-
+            telemetry_defaults: defaults.telemetry,
+            telemetry_overrides: Default::default(),
             staff_mode: false,
         }
     }
 
+    // Fill out the overrride and etc. settings from the user's settings.json
     pub fn set_user_settings(
         &mut self,
         data: SettingsFileContent,
@@ -419,6 +432,7 @@ impl Settings {
         self.terminal_overrides.copy_on_select = data.terminal.copy_on_select;
         self.terminal_overrides = data.terminal;
         self.language_overrides = data.languages;
+        self.telemetry_overrides = data.telemetry;
         self.lsp = data.lsp;
     }
 
@@ -489,6 +503,20 @@ impl Settings {
             .unwrap_or_else(|| R::default())
     }
 
+    pub fn telemetry_diagnostics(&self) -> bool {
+        self.telemetry_overrides
+            .diagnostics
+            .or(self.telemetry_defaults.diagnostics)
+            .expect("missing default")
+    }
+
+    pub fn telemetry_metrics(&self) -> bool {
+        self.telemetry_overrides
+            .metrics
+            .or(self.telemetry_defaults.metrics)
+            .expect("missing default")
+    }
+
     pub fn terminal_scroll(&self) -> AlternateScroll {
         self.terminal_setting(|terminal_setting| terminal_setting.alternate_scroll.as_ref())
     }
@@ -540,6 +568,8 @@ impl Settings {
             lsp: Default::default(),
             projects_online_by_default: true,
             theme: gpui::fonts::with_font_cache(cx.font_cache().clone(), Default::default),
+            telemetry_defaults: Default::default(),
+            telemetry_overrides: Default::default(),
             staff_mode: false,
         }
     }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -62,6 +62,15 @@ pub struct TelemetrySettings {
     metrics: Option<bool>,
 }
 
+impl TelemetrySettings {
+    pub fn metrics(&self) -> bool {
+        self.metrics.unwrap()
+    }
+    pub fn diagnostics(&self) -> bool {
+        self.diagnostics.unwrap()
+    }
+}
+
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct FeatureFlags {
     pub experimental_themes: bool,
@@ -501,6 +510,13 @@ impl Settings {
             .or_else(|| f(&self.terminal_defaults))
             .cloned()
             .unwrap_or_else(|| R::default())
+    }
+
+    pub fn telemetry(&self) -> TelemetrySettings {
+        TelemetrySettings {
+            diagnostics: Some(self.telemetry_diagnostics()),
+            metrics: Some(self.telemetry_metrics()),
+        }
     }
 
     pub fn telemetry_diagnostics(&self) -> bool {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -470,7 +470,7 @@ mod tests {
     use super::*;
     use crate::{
         dock,
-        item::test::TestItem,
+        item::{self, test::TestItem},
         persistence::model::{
             SerializedItem, SerializedPane, SerializedPaneGroup, SerializedWorkspace,
         },
@@ -492,7 +492,7 @@ mod tests {
         Settings::test_async(cx);
 
         cx.update(|cx| {
-            register_deserializable_item::<TestItem>(cx);
+            register_deserializable_item::<item::test::TestItem>(cx);
         });
 
         let serialized_workspace = SerializedWorkspace {
@@ -508,7 +508,7 @@ mod tests {
                 children: vec![SerializedItem {
                     active: true,
                     item_id: 0,
-                    kind: "test".into(),
+                    kind: "TestItem".into(),
                 }],
             },
             left_sidebar_open: false,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -919,7 +919,7 @@ pub(crate) mod test {
         }
 
         fn serialized_item_kind() -> Option<&'static str> {
-            None
+            Some("TestItem")
         }
 
         fn deserialize(

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -148,7 +148,11 @@ fn main() {
         .detach();
 
         client.start_telemetry();
-        client.report_event("start app", Default::default());
+        client.report_event(
+            "start app",
+            Default::default(),
+            cx.global::<Settings>().telemetry(),
+        );
 
         let app_state = Arc::new(AppState {
             languages,


### PR DESCRIPTION
## Description of feature or change

This adds fields in the settings file to opt out of metrics and diagnostics reportings

## Link to related issues from zed or insiders

https://github.com/zed-industries/zed/issues/1986

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
