### PR TITLE
Fix crash when restarting a language server after it reports an unknown buffer version

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2081,6 +2081,7 @@ impl Project {
                                         .buffer_snapshots
                                         .entry(buffer.remote_id())
                                         .or_insert_with(|| vec![(0, buffer.text_snapshot())]);
+
                                     let (version, initial_snapshot) = versions.last().unwrap();
                                     let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
                                     language_server
@@ -2617,6 +2618,7 @@ impl Project {
             worktree_id: worktree.read(cx).id(),
             path: relative_path.into(),
         };
+
         if let Some(buffer) = self.get_open_buffer(&project_path, cx) {
             self.update_buffer_diagnostics(&buffer, diagnostics.clone(), version, cx)?;
         }
@@ -6124,25 +6126,20 @@ impl Project {
                 .buffer_snapshots
                 .get_mut(&buffer_id)
                 .ok_or_else(|| anyhow!("no snapshot found for buffer {}", buffer_id))?;
-            let mut found_snapshot = None;
-            snapshots.retain(|(snapshot_version, snapshot)| {
-                if snapshot_version + OLD_VERSIONS_TO_RETAIN < version {
-                    false
-                } else {
-                    if *snapshot_version == version {
-                        found_snapshot = Some(snapshot.clone());
-                    }
-                    true
-                }
+            let found_snapshot = snapshots
+                .binary_search_by_key(&version, |e| e.0)
+                .map(|ix| snapshots[ix].1.clone())
+                .map_err(|_| {
+                    anyhow!(
+                        "snapshot not found for buffer {} at version {}",
+                        buffer_id,
+                        version
+                    )
+                })?;
+            snapshots.retain(|(snapshot_version, _)| {
+                snapshot_version + OLD_VERSIONS_TO_RETAIN >= version
             });
-
-            found_snapshot.ok_or_else(|| {
-                anyhow!(
-                    "snapshot not found for buffer {} at version {}",
-                    buffer_id,
-                    version
-                )
-            })
+            Ok(found_snapshot)
         } else {
             Ok((buffer.read(cx)).text_snapshot())
         }


### PR DESCRIPTION
Fixes https://us5.datadoghq.com/logs?query=panic%20report%20-%40version%3Adev%20kube_namespace%3Aproduction%20service%3Acollab&cols=host%2Cservice&event=AgAAAYWHgJbzwaYbngAAAAAAAAAYAAAAAEFZV0hnS3NDQUFDTWI0YXF4c2o4UGdBRQAAACQAAAAAMDE4NTg3YTUtYTMwYS00NDFjLWJkOTAtYTkzNGVkNTBiMWFj&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1670799418266&to_ts=1673391418266&live=true