### PR TITLE
Fix error when running TypeScript language server after version 3.0.2

### DIFF
--- a/crates/zed/src/languages/installation.rs
+++ b/crates/zed/src/languages/installation.rs
@@ -37,6 +37,8 @@ pub(crate) struct GithubReleaseAsset {
 
 pub async fn npm_package_latest_version(name: &str) -> Result<String> {
     let output = smol::process::Command::new("npm")
+        .args(["-fetch-retry-mintimeout", "2000"])
+        .args(["-fetch-retry-maxtimeout", "5000"])
         .args(["info", name, "--json"])
         .output()
         .await
@@ -60,6 +62,8 @@ pub async fn npm_install_packages(
     directory: &Path,
 ) -> Result<()> {
     let output = smol::process::Command::new("npm")
+        .args(["-fetch-retry-mintimeout", "2000"])
+        .args(["-fetch-retry-maxtimeout", "5000"])
         .arg("install")
         .arg("--prefix")
         .arg(directory)


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/509
Fixes https://github.com/zed-industries/feedback/issues/445

As pointed out by one of our community members, the language server authors changed the executable extension from `.js` to `.mjs`. This pull request fixes the problem by first trying to use the new `.mjs` CLI binary and falling back to the old `.js` binary when that doesn't work.

Moreover, with these changes we are also adding a 5s retry timeout to `npm info` and `npm install`. This prevents those two commands from getting stuck when hitting the NPM package registry while being offline.