### PR TITLE
Fix issue with sidebars resizing themselves when dock is toggled

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -2,8 +2,10 @@ use collections::HashMap;
 use gpui::{
     actions,
     elements::{ChildView, Container, Empty, MouseEventHandler, ParentElement, Side, Stack, Svg},
+    geometry::vector::Vector2F,
     impl_internal_actions, Border, CursorStyle, Element, ElementBox, Entity, MouseButton,
-    MutableAppContext, RenderContext, View, ViewContext, ViewHandle, WeakViewHandle,
+    MutableAppContext, RenderContext, SizeConstraint, View, ViewContext, ViewHandle,
+    WeakViewHandle,
 };
 use serde::Deserialize;
 use settings::{DockAnchor, Settings};
@@ -312,7 +314,27 @@ impl Dock {
                         }
                     });
 
-                    resizable.flex(5., false).boxed()
+                    if anchor == DockAnchor::Right {
+                        resizable
+                            .constrained()
+                            .dynamically(|constraint, cx| {
+                                SizeConstraint::new(
+                                    Vector2F::new(20., constraint.min.y()),
+                                    Vector2F::new(cx.window_size.x() * 0.8, constraint.max.y()),
+                                )
+                            })
+                            .boxed()
+                    } else {
+                        resizable
+                            .constrained()
+                            .dynamically(|constraint, cx| {
+                                SizeConstraint::new(
+                                    Vector2F::new(constraint.min.x(), 50.),
+                                    Vector2F::new(constraint.max.x(), cx.window_size.y() * 0.8),
+                                )
+                            })
+                            .boxed()
+                    }
                 }
                 DockAnchor::Expanded => {
                     enum ExpandedDockWash {}

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -32,12 +32,13 @@ use futures::{
 use gpui::{
     actions,
     elements::*,
+    geometry::vector::Vector2F,
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
     platform::{CursorStyle, WindowOptions},
     AnyModelHandle, AnyViewHandle, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle,
-    MouseButton, MutableAppContext, PathPromptOptions, PromptLevel, RenderContext, Task, View,
-    ViewContext, ViewHandle, WeakViewHandle,
+    MouseButton, MutableAppContext, PathPromptOptions, PromptLevel, RenderContext, SizeConstraint,
+    Task, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use item::{FollowableItem, FollowableItemHandle, Item, ItemHandle, ProjectItem};
 use language::LanguageRegistry;
@@ -2471,7 +2472,16 @@ impl View for Workspace {
                                         if self.left_sidebar.read(cx).active_item().is_some() {
                                             Some(
                                                 ChildView::new(&self.left_sidebar, cx)
-                                                    .flex(0.8, false)
+                                                    .constrained()
+                                                    .dynamically(|constraint, cx| {
+                                                        SizeConstraint::new(
+                                                            Vector2F::new(20., constraint.min.y()),
+                                                            Vector2F::new(
+                                                                cx.window_size.x() * 0.8,
+                                                                constraint.max.y(),
+                                                            ),
+                                                        )
+                                                    })
                                                     .boxed(),
                                             )
                                         } else {
@@ -2508,7 +2518,16 @@ impl View for Workspace {
                                         if self.right_sidebar.read(cx).active_item().is_some() {
                                             Some(
                                                 ChildView::new(&self.right_sidebar, cx)
-                                                    .flex(0.8, false)
+                                                    .constrained()
+                                                    .dynamically(|constraint, cx| {
+                                                        SizeConstraint::new(
+                                                            Vector2F::new(20., constraint.min.y()),
+                                                            Vector2F::new(
+                                                                cx.window_size.x() * 0.8,
+                                                                constraint.max.y(),
+                                                            ),
+                                                        )
+                                                    })
                                                     .boxed(),
                                             )
                                         } else {


### PR DESCRIPTION
## Description of feature or change
Swaps the sidebars to be rendered with constrained boxes instead of 

## Link to related issues from zed or insiders

fixes https://github.com/zed-industries/feedback/issues/545

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
N/A. We do not have test infrastructure for these types of layouts
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
