### PR TITLE
disable vim mode in non full editors

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -37,9 +37,7 @@ fn editor_focused(EditorFocused(editor): &EditorFocused, cx: &mut MutableAppCont
         let editor_mode = editor.mode();
         let newest_selection_empty = editor.selections.newest::<usize>(cx).is_empty();
 
-        if editor_mode != EditorMode::Full {
-            vim.switch_mode(Mode::Insert, true, cx);
-        } else if !newest_selection_empty {
+        if editor_mode == EditorMode::Full && !newest_selection_empty {
             vim.switch_mode(Mode::Visual { line: false }, true, cx);
         }
     });

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -84,9 +84,6 @@ async fn test_buffer_search(cx: &mut gpui::TestAppContext) {
     );
     cx.simulate_keystroke("/");
 
-    // We now use a weird insert mode with selection when jumping to a single line editor
-    assert_eq!(cx.mode(), Mode::Insert);
-
     let search_bar = cx.workspace(|workspace, cx| {
         workspace
             .active_pane()

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -12,7 +12,7 @@ mod visual;
 
 use collections::HashMap;
 use command_palette::CommandPaletteFilter;
-use editor::{Bias, Cancel, Editor};
+use editor::{Bias, Cancel, Editor, EditorMode};
 use gpui::{
     impl_actions,
     keymap_matcher::{KeyPressed, Keystroke},
@@ -267,7 +267,7 @@ impl Vim {
         for editor in self.editors.values() {
             if let Some(editor) = editor.upgrade(cx) {
                 editor.update(cx, |editor, cx| {
-                    if self.enabled {
+                    if self.enabled && editor.mode() == EditorMode::Full {
                         editor.set_cursor_shape(cursor_shape, cx);
                         editor.set_clip_at_line_ends(state.clip_at_line_end(), cx);
                         editor.set_input_enabled(!state.vim_controlled());


### PR DESCRIPTION

## Description of feature or change
We've gotten multiple bits of feedback where folks disliked having vim bindings in single line editors. This removes it for now. At some point we may consider adding it back as vim mode becomes more complete or a way to opt in, but this is a reasonable quality fix for the moment.

## Link to related issues from zed or insiders
fixes https://github.com/zed-industries/feedback/issues/855
fixes https://github.com/zed-industries/feedback/issues/368
fixes https://github.com/zed-industries/feedback/issues/475

## Before Merging 
- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
