### PR TITLE
Fix mouse interrupting file/dir editing in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1176,13 +1176,15 @@ impl ProjectPanel {
             )
         })
         .on_click(MouseButton::Left, move |e, cx| {
-            if kind == EntryKind::Dir {
-                cx.dispatch_action(ToggleExpanded(entry_id))
-            } else {
-                cx.dispatch_action(Open {
-                    entry_id,
-                    change_focus: e.click_count > 1,
-                })
+            if !show_editor {
+                if kind == EntryKind::Dir {
+                    cx.dispatch_action(ToggleExpanded(entry_id))
+                } else {
+                    cx.dispatch_action(Open {
+                        entry_id,
+                        change_focus: e.click_count > 1,
+                    })
+                }
             }
         })
         .on_down(MouseButton::Right, move |e, cx| {


### PR DESCRIPTION
## Description of feature or change

The following expectation was implemented.

1. Choose a filename or dir to rename in the project panel
2. Use your mouse to click the filename to place the cursor where you want
3. **Observation:** Filename editing stops and the file opens (in case of dir, editing stops and dir collapses or expands)
4. **Expectation:** Editing should not stop and the mouse click should place the keyboard cursor at the clicked position

Thank you @as-cii for your help!!!

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/feedback/issues/544

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
