### PR TITLE
Allow pasting the same entry more than once in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -763,7 +763,6 @@ impl ProjectPanel {
                 ix += 1;
             }
 
-            self.clipboard_entry.take();
             if clipboard_entry.is_cut() {
                 if let Some(task) = self.project.update(cx, |project, cx| {
                     project.rename_entry(clipboard_entry.entry_id(), new_path, cx)


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/786

We noticed that we were removing the contents of the clipboard after a paste in the project panel.