### PR TITLE
Prevent outline items from accidentally spanning multiple lines

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2168,8 +2168,6 @@ impl BufferSnapshot {
                 continue;
             }
 
-            // TODO - move later, after processing captures
-
             let mut text = String::new();
             let mut name_ranges = Vec::new();
             let mut highlight_ranges = Vec::new();
@@ -2183,7 +2181,13 @@ impl BufferSnapshot {
                     continue;
                 }
 
-                let range = capture.node.start_byte()..capture.node.end_byte();
+                let mut range = capture.node.start_byte()..capture.node.end_byte();
+                let start = capture.node.start_position();
+                if capture.node.end_position().row > start.row {
+                    range.end =
+                        range.start + self.line_len(start.row as u32) as usize - start.column;
+                }
+
                 if !text.is_empty() {
                     text.push(' ');
                 }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -456,6 +456,32 @@ async fn test_outline(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_outline_nodes_with_newlines(cx: &mut gpui::TestAppContext) {
+    let text = r#"
+        impl A for B<
+            C
+        > {
+        };
+    "#
+    .unindent();
+
+    let buffer =
+        cx.add_model(|cx| Buffer::new(0, text, cx).with_language(Arc::new(rust_lang()), cx));
+    let outline = buffer
+        .read_with(cx, |buffer, _| buffer.snapshot().outline(None))
+        .unwrap();
+
+    assert_eq!(
+        outline
+            .items
+            .iter()
+            .map(|item| (item.text.as_str(), item.depth))
+            .collect::<Vec<_>>(),
+        &[("impl A for B<", 0)]
+    );
+}
+
+#[gpui::test]
 async fn test_symbols_containing(cx: &mut gpui::TestAppContext) {
     let text = r#"
         impl Person {

--- a/crates/zed/src/languages/go/outline.scm
+++ b/crates/zed/src/languages/go/outline.scm
@@ -40,5 +40,4 @@
       ")" @context)) @item
 
 (field_declaration
-    name: (_) @name
-    type: (_) @context) @item
+    name: (_) @name) @item


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/834
Fixes https://github.com/zed-industries/feedback/issues/797