### PR TITLE
Avoid stalling the UI thread when running large searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,8 +739,7 @@ dependencies = [
 [[package]]
 name = "bromberg_sl2"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed88064f69518b7e3ea50ecfc1b61d43f19248618a377b95ae5c8b611134d4d"
+source = "git+https://github.com/zed-industries/bromberg_sl2?rev=dac565a90e8f9245f48ff46225c915dc50f76920#dac565a90e8f9245f48ff46225c915dc50f76920"
 dependencies = [
  "digest 0.9.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5510,6 +5510,7 @@ dependencies = [
  "anyhow",
  "collections",
  "editor",
+ "futures 0.3.25",
  "gpui",
  "language",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5520,6 +5520,7 @@ dependencies = [
  "serde_json",
  "settings",
  "smallvec",
+ "smol",
  "theme",
  "unindent",
  "util",

--- a/crates/collab/src/tests/randomized_integration_tests.rs
+++ b/crates/collab/src/tests/randomized_integration_tests.rs
@@ -410,10 +410,10 @@ async fn test_random_collaboration(
                     guest_buffer.read_with(client_cx, |b, _| b.saved_version().clone());
                 assert_eq!(guest_saved_version, host_saved_version);
 
-                let host_saved_version_fingerprint = host_buffer
-                    .read_with(host_cx, |b, _| b.saved_version_fingerprint().to_string());
-                let guest_saved_version_fingerprint = guest_buffer
-                    .read_with(client_cx, |b, _| b.saved_version_fingerprint().to_string());
+                let host_saved_version_fingerprint =
+                    host_buffer.read_with(host_cx, |b, _| b.saved_version_fingerprint());
+                let guest_saved_version_fingerprint =
+                    guest_buffer.read_with(client_cx, |b, _| b.saved_version_fingerprint());
                 assert_eq!(
                     guest_saved_version_fingerprint,
                     host_saved_version_fingerprint

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -13,8 +13,10 @@ use gpui::{
     elements::*, geometry::vector::vec2f, AppContext, Entity, ModelHandle, MutableAppContext,
     RenderContext, Subscription, Task, View, ViewContext, ViewHandle, WeakViewHandle,
 };
-use language::proto::serialize_anchor as serialize_text_anchor;
-use language::{Bias, Buffer, File as _, OffsetRangeExt, Point, SelectionGoal};
+use language::{
+    proto::serialize_anchor as serialize_text_anchor, Bias, Buffer, File as _, OffsetRangeExt,
+    Point, SelectionGoal,
+};
 use project::{File, FormatTrigger, Project, ProjectEntryId, ProjectPath};
 use rpc::proto::{self, update_view};
 use settings::Settings;
@@ -1165,9 +1167,11 @@ fn path_for_file<'a>(
 mod tests {
     use super::*;
     use gpui::MutableAppContext;
+    use language::RopeFingerprint;
     use std::{
         path::{Path, PathBuf},
         sync::Arc,
+        time::SystemTime,
     };
 
     #[gpui::test]
@@ -1197,7 +1201,7 @@ mod tests {
             todo!()
         }
 
-        fn mtime(&self) -> std::time::SystemTime {
+        fn mtime(&self) -> SystemTime {
             todo!()
         }
 
@@ -1216,7 +1220,7 @@ mod tests {
             _: clock::Global,
             _: project::LineEnding,
             _: &mut MutableAppContext,
-        ) -> gpui::Task<anyhow::Result<(clock::Global, String, std::time::SystemTime)>> {
+        ) -> gpui::Task<anyhow::Result<(clock::Global, RopeFingerprint, SystemTime)>> {
             todo!()
         }
 

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -4,6 +4,7 @@ pub use anchor::{Anchor, AnchorRangeExt};
 use anyhow::Result;
 use clock::ReplicaId;
 use collections::{BTreeMap, Bound, HashMap, HashSet};
+use futures::{channel::mpsc, SinkExt};
 use git::diff::DiffHunk;
 use gpui::{AppContext, Entity, ModelContext, ModelHandle, Task};
 pub use language::Completion;
@@ -764,6 +765,63 @@ impl MultiBuffer {
         None
     }
 
+    pub fn stream_excerpts_with_context_lines(
+        &mut self,
+        excerpts: Vec<(ModelHandle<Buffer>, Vec<Range<text::Anchor>>)>,
+        context_line_count: u32,
+        cx: &mut ModelContext<Self>,
+    ) -> (Task<()>, mpsc::Receiver<Range<Anchor>>) {
+        let (mut tx, rx) = mpsc::channel(256);
+        let task = cx.spawn(|this, mut cx| async move {
+            for (buffer, ranges) in excerpts {
+                let buffer_id = buffer.id();
+                let buffer_snapshot = buffer.read_with(&cx, |buffer, _| buffer.snapshot());
+
+                let mut excerpt_ranges = Vec::new();
+                let mut range_counts = Vec::new();
+                cx.background()
+                    .scoped(|scope| {
+                        scope.spawn(async {
+                            let (ranges, counts) =
+                                build_excerpt_ranges(&buffer_snapshot, &ranges, context_line_count);
+                            excerpt_ranges = ranges;
+                            range_counts = counts;
+                        });
+                    })
+                    .await;
+
+                let mut ranges = ranges.into_iter();
+                let mut range_counts = range_counts.into_iter();
+                for excerpt_ranges in excerpt_ranges.chunks(100) {
+                    let excerpt_ids = this.update(&mut cx, |this, cx| {
+                        this.push_excerpts(buffer.clone(), excerpt_ranges.iter().cloned(), cx)
+                    });
+
+                    for (excerpt_id, range_count) in
+                        excerpt_ids.into_iter().zip(range_counts.by_ref())
+                    {
+                        for range in ranges.by_ref().take(range_count) {
+                            let start = Anchor {
+                                buffer_id: Some(buffer_id),
+                                excerpt_id: excerpt_id.clone(),
+                                text_anchor: range.start,
+                            };
+                            let end = Anchor {
+                                buffer_id: Some(buffer_id),
+                                excerpt_id: excerpt_id.clone(),
+                                text_anchor: range.end,
+                            };
+                            if tx.send(start..end).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        (task, rx)
+    }
+
     pub fn push_excerpts<O>(
         &mut self,
         buffer: ModelHandle<Buffer>,
@@ -788,39 +846,8 @@ impl MultiBuffer {
     {
         let buffer_id = buffer.id();
         let buffer_snapshot = buffer.read(cx).snapshot();
-        let max_point = buffer_snapshot.max_point();
-
-        let mut range_counts = Vec::new();
-        let mut excerpt_ranges = Vec::new();
-        let mut range_iter = ranges
-            .iter()
-            .map(|range| {
-                range.start.to_point(&buffer_snapshot)..range.end.to_point(&buffer_snapshot)
-            })
-            .peekable();
-        while let Some(range) = range_iter.next() {
-            let excerpt_start = Point::new(range.start.row.saturating_sub(context_line_count), 0);
-            let mut excerpt_end =
-                Point::new(range.end.row + 1 + context_line_count, 0).min(max_point);
-            let mut ranges_in_excerpt = 1;
-
-            while let Some(next_range) = range_iter.peek() {
-                if next_range.start.row <= excerpt_end.row + context_line_count {
-                    excerpt_end =
-                        Point::new(next_range.end.row + 1 + context_line_count, 0).min(max_point);
-                    ranges_in_excerpt += 1;
-                    range_iter.next();
-                } else {
-                    break;
-                }
-            }
-
-            excerpt_ranges.push(ExcerptRange {
-                context: excerpt_start..excerpt_end,
-                primary: Some(range),
-            });
-            range_counts.push(ranges_in_excerpt);
-        }
+        let (excerpt_ranges, range_counts) =
+            build_excerpt_ranges(&buffer_snapshot, &ranges, context_line_count);
 
         let excerpt_ids = self.push_excerpts(buffer, excerpt_ranges, cx);
 
@@ -3603,6 +3630,47 @@ impl ToPointUtf16 for PointUtf16 {
     fn to_point_utf16<'a>(&self, _: &MultiBufferSnapshot) -> PointUtf16 {
         *self
     }
+}
+
+fn build_excerpt_ranges<T>(
+    buffer: &BufferSnapshot,
+    ranges: &[Range<T>],
+    context_line_count: u32,
+) -> (Vec<ExcerptRange<Point>>, Vec<usize>)
+where
+    T: text::ToPoint,
+{
+    let max_point = buffer.max_point();
+    let mut range_counts = Vec::new();
+    let mut excerpt_ranges = Vec::new();
+    let mut range_iter = ranges
+        .iter()
+        .map(|range| range.start.to_point(buffer)..range.end.to_point(buffer))
+        .peekable();
+    while let Some(range) = range_iter.next() {
+        let excerpt_start = Point::new(range.start.row.saturating_sub(context_line_count), 0);
+        let mut excerpt_end = Point::new(range.end.row + 1 + context_line_count, 0).min(max_point);
+        let mut ranges_in_excerpt = 1;
+
+        while let Some(next_range) = range_iter.peek() {
+            if next_range.start.row <= excerpt_end.row + context_line_count {
+                excerpt_end =
+                    Point::new(next_range.end.row + 1 + context_line_count, 0).min(max_point);
+                ranges_in_excerpt += 1;
+                range_iter.next();
+            } else {
+                break;
+            }
+        }
+
+        excerpt_ranges.push(ExcerptRange {
+            context: excerpt_start..excerpt_end,
+            primary: Some(range),
+        });
+        range_counts.push(ranges_in_excerpt);
+    }
+
+    (excerpt_ranges, range_counts)
 }
 
 #[cfg(test)]

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -11,6 +11,15 @@ use text::*;
 
 pub use proto::{BufferState, Operation};
 
+pub fn serialize_fingerprint(fingerprint: RopeFingerprint) -> String {
+    fingerprint.to_hex()
+}
+
+pub fn deserialize_fingerprint(fingerprint: &str) -> Result<RopeFingerprint> {
+    RopeFingerprint::from_hex(fingerprint)
+        .map_err(|error| anyhow!("invalid fingerprint: {}", error))
+}
+
 pub fn deserialize_line_ending(message: proto::LineEnding) -> fs::LineEnding {
     match message {
         proto::LineEnding::Unix => fs::LineEnding::Unix,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -22,8 +22,8 @@ use gpui::{
 use language::{
     point_to_lsp,
     proto::{
-        deserialize_anchor, deserialize_line_ending, deserialize_version, serialize_anchor,
-        serialize_version,
+        deserialize_anchor, deserialize_fingerprint, deserialize_line_ending, deserialize_version,
+        serialize_anchor, serialize_version,
     },
     range_from_lsp, range_to_lsp, Anchor, Bias, Buffer, CachedLspAdapter, CharKind, CodeAction,
     CodeLabel, Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Event as BufferEvent,
@@ -5123,7 +5123,7 @@ impl Project {
             buffer_id,
             version: serialize_version(&saved_version),
             mtime: Some(mtime.into()),
-            fingerprint,
+            fingerprint: language::proto::serialize_fingerprint(fingerprint),
         })
     }
 
@@ -5215,7 +5215,9 @@ impl Project {
                             buffer_id,
                             version: language::proto::serialize_version(buffer.saved_version()),
                             mtime: Some(buffer.saved_mtime().into()),
-                            fingerprint: buffer.saved_version_fingerprint().into(),
+                            fingerprint: language::proto::serialize_fingerprint(
+                                buffer.saved_version_fingerprint(),
+                            ),
                             line_ending: language::proto::serialize_line_ending(
                                 buffer.line_ending(),
                             ) as i32,
@@ -5970,6 +5972,7 @@ impl Project {
         _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
+        let fingerprint = deserialize_fingerprint(&envelope.payload.fingerprint)?;
         let version = deserialize_version(envelope.payload.version);
         let mtime = envelope
             .payload
@@ -5984,7 +5987,7 @@ impl Project {
                 .and_then(|buffer| buffer.upgrade(cx));
             if let Some(buffer) = buffer {
                 buffer.update(cx, |buffer, cx| {
-                    buffer.did_save(version, envelope.payload.fingerprint, mtime, None, cx);
+                    buffer.did_save(version, fingerprint, mtime, None, cx);
                 });
             }
             Ok(())
@@ -5999,6 +6002,7 @@ impl Project {
     ) -> Result<()> {
         let payload = envelope.payload;
         let version = deserialize_version(payload.version);
+        let fingerprint = deserialize_fingerprint(&payload.fingerprint)?;
         let line_ending = deserialize_line_ending(
             proto::LineEnding::from_i32(payload.line_ending)
                 .ok_or_else(|| anyhow!("missing line ending"))?,
@@ -6014,7 +6018,7 @@ impl Project {
                 .and_then(|buffer| buffer.upgrade(cx));
             if let Some(buffer) = buffer {
                 buffer.update(cx, |buffer, cx| {
-                    buffer.did_reload(version, payload.fingerprint, line_ending, mtime, cx);
+                    buffer.did_reload(version, fingerprint, line_ending, mtime, cx);
                 });
             }
             Ok(())

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "src/rope.rs"
 
 [dependencies]
-bromberg_sl2 = "0.6"
+bromberg_sl2 = { git = "https://github.com/zed-industries/bromberg_sl2", rev = "dac565a90e8f9245f48ff46225c915dc50f76920" }
 smallvec = { version = "1.6", features = ["union"] }
 sum_tree = { path = "../sum_tree" }
 arrayvec = "0.7.1"

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -4,7 +4,7 @@ mod point_utf16;
 mod unclipped;
 
 use arrayvec::ArrayString;
-use bromberg_sl2::{DigestString, HashMatrix};
+use bromberg_sl2::HashMatrix;
 use smallvec::SmallVec;
 use std::{
     cmp, fmt, io, mem,
@@ -24,6 +24,8 @@ const CHUNK_BASE: usize = 6;
 
 #[cfg(not(test))]
 const CHUNK_BASE: usize = 16;
+
+pub type RopeFingerprint = HashMatrix;
 
 #[derive(Clone, Default, Debug)]
 pub struct Rope {
@@ -361,8 +363,8 @@ impl Rope {
             .column
     }
 
-    pub fn fingerprint(&self) -> String {
-        self.chunks.summary().fingerprint.to_hex()
+    pub fn fingerprint(&self) -> RopeFingerprint {
+        self.chunks.summary().fingerprint
     }
 }
 

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -25,6 +25,10 @@ const CHUNK_BASE: usize = 6;
 #[cfg(not(test))]
 const CHUNK_BASE: usize = 16;
 
+/// Type alias to [HashMatrix], an implementation of a homomorphic hash function. Two [Rope] instances
+/// containing the same text will produce the same fingerprint. This hash function is special in that
+/// it allows us to hash individual chunks and aggregate them up the [Rope]'s tree, with the resulting
+/// hash being equivalent to hashing all the text contained in the [Rope] at once.
 pub type RopeFingerprint = HashMatrix;
 
 #[derive(Clone, Default, Debug)]
@@ -858,7 +862,7 @@ impl sum_tree::Item for Chunk {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ChunkSummary {
     text: TextSummary,
-    fingerprint: HashMatrix,
+    fingerprint: RopeFingerprint,
 }
 
 impl<'a> From<&'a str> for ChunkSummary {

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -19,6 +19,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 anyhow = "1.0"
+futures = "0.3"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 postage = { version = "0.4.1", features = ["futures-traits"] }
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -23,6 +23,7 @@ log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 postage = { version = "0.4.1", features = ["futures-traits"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 smallvec = { version = "1.6", features = ["union"] }
+smol = "1.2"
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -130,7 +130,7 @@ impl ProjectSearch {
             let matches = search.await.log_err()?;
             let this = this.upgrade(&cx)?;
             let mut matches = matches.into_iter().collect::<Vec<_>>();
-            let (_rebuild, mut match_ranges) = this.update(&mut cx, |this, cx| {
+            let (_task, mut match_ranges) = this.update(&mut cx, |this, cx| {
                 this.match_ranges.clear();
                 matches.sort_by_key(|(buffer, _)| buffer.read(cx).file().map(|file| file.path()));
                 this.excerpts.update(cx, |excerpts, cx| {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -949,13 +949,13 @@ impl ToolbarItemView for ProjectSearchBar {
 mod tests {
     use super::*;
     use editor::DisplayPoint;
-    use gpui::{color::Color, TestAppContext};
+    use gpui::{color::Color, executor::Deterministic, TestAppContext};
     use project::FakeFs;
     use serde_json::json;
     use std::sync::Arc;
 
     #[gpui::test]
-    async fn test_project_search(cx: &mut TestAppContext) {
+    async fn test_project_search(deterministic: Arc<Deterministic>, cx: &mut TestAppContext) {
         let fonts = cx.font_cache();
         let mut theme = gpui::fonts::with_font_cache(fonts.clone(), theme::Theme::default);
         theme.search.match_background = Color::red();
@@ -987,7 +987,7 @@ mod tests {
                 .update(cx, |query_editor, cx| query_editor.set_text("TWO", cx));
             search_view.search(cx);
         });
-        search_view.next_notification(cx).await;
+        deterministic.run_until_parked();
         search_view.update(cx, |search_view, cx| {
             assert_eq!(
                 search_view


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/685

When running a project search that yielded a massive amount of results, we would previously stall the UI thread for two main reasons:

1. Synchronizing the `MultiBuffer`'s underlying buffers was expensive. This was primarily due to `Rope::fingerprint` which used to return a string. This is okay if the number of buffers was relatively small, but started to show up in the profiler for large searches. In a653e87658618b9315bd96d975c341cd5a6f56a5 and 8ca0f9ac99457095e3a0a6a181a65c1a34fea579, `Rope::fingerprint` was changed to return a `Copy` value representing the `HashMatrix` (type-aliased to `RopeFingerprint`). Note that we still encode the fingerprint to a hex string when sending it over the wire. This required us to create a fork of [`bromberg_sl2`](https://github.com/zed-industries/bromberg_sl2) that allows serialization/deserialization of a `HashMatrix` by encoding/decoding it to hex.
2. Pushing lots of excerpts all at once would block the main thread. In 5ce065ac92381ad629dcd8e6bd4ee5ab2a1155bd, a new `MultiBuffer::stream_excerpts_with_context_lines` method was introduced. This new method computes the excerpt ranges in the background and pushes them into the multi-buffer asynchronously, streaming the corresponding multi-buffer ranges back to the caller as it does so. This lets us stream search results without blocking the UI.

Note that thanks to 1) all multi-buffers will be significantly cheaper to read/edit, which should also alleviate some of the sluggishness we were observing across the board when a multi-buffer contained a large amount of underlying buffers.


![Kapture 2023-01-19 at 16 11 32](https://user-images.githubusercontent.com/482957/213480020-a69d8fa8-6a25-4458-80e8-12d0b7e58b56.gif)
