### PR TITLE
Allow overriding language configuration parameters in specific syntactic contexts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1737,7 +1737,7 @@ impl Editor {
         for (selection, autoclose_region) in
             self.selections_with_autoclose_regions(selections, &snapshot)
         {
-            if let Some(language) = snapshot.language_at(selection.head()) {
+            if let Some(language) = snapshot.language_config_at(selection.head()) {
                 // Determine if the inserted text matches the opening or closing
                 // bracket of any of this language's bracket pairs.
                 let mut bracket_pair = None;
@@ -1898,7 +1898,7 @@ impl Editor {
                         let end = selection.end;
 
                         let mut insert_extra_newline = false;
-                        if let Some(language) = buffer.language_at(start) {
+                        if let Some(language) = buffer.language_config_at(start) {
                             let leading_whitespace_len = buffer
                                 .reversed_chars_at(start)
                                 .take_while(|c| c.is_whitespace() && *c != '\n')
@@ -4533,7 +4533,10 @@ impl Editor {
 
             // TODO: Handle selections that cross excerpts
             for selection in &mut selections {
-                let language = if let Some(language) = snapshot.language_at(selection.start) {
+                let start_column = snapshot.indent_size_for_line(selection.start.row).len;
+                let language = if let Some(language) =
+                    snapshot.language_config_at(Point::new(selection.start.row, start_column))
+                {
                     language
                 } else {
                     continue;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1737,7 +1737,7 @@ impl Editor {
         for (selection, autoclose_region) in
             self.selections_with_autoclose_regions(selections, &snapshot)
         {
-            if let Some(language) = snapshot.language_config_at(selection.head()) {
+            if let Some(language) = snapshot.language_scope_at(selection.head()) {
                 // Determine if the inserted text matches the opening or closing
                 // bracket of any of this language's bracket pairs.
                 let mut bracket_pair = None;
@@ -1898,7 +1898,7 @@ impl Editor {
                         let end = selection.end;
 
                         let mut insert_extra_newline = false;
-                        if let Some(language) = buffer.language_config_at(start) {
+                        if let Some(language) = buffer.language_scope_at(start) {
                             let leading_whitespace_len = buffer
                                 .reversed_chars_at(start)
                                 .take_while(|c| c.is_whitespace() && *c != '\n')
@@ -4535,7 +4535,7 @@ impl Editor {
             for selection in &mut selections {
                 let start_column = snapshot.indent_size_for_line(selection.start.row).len;
                 let language = if let Some(language) =
-                    snapshot.language_config_at(Point::new(selection.start.row, start_column))
+                    snapshot.language_scope_at(Point::new(selection.start.row, start_column))
                 {
                     language
                 } else {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -10,9 +10,9 @@ use gpui::{AppContext, Entity, ModelContext, ModelHandle, Task};
 pub use language::Completion;
 use language::{
     char_kind, AutoindentMode, Buffer, BufferChunks, BufferSnapshot, CharKind, Chunk, CursorShape,
-    DiagnosticEntry, IndentSize, Language, LanguageConfigYeet, OffsetRangeExt, OffsetUtf16,
-    Outline, OutlineItem, Point, PointUtf16, Selection, TextDimension, ToOffset as _,
-    ToOffsetUtf16 as _, ToPoint as _, ToPointUtf16 as _, TransactionId, Unclipped,
+    DiagnosticEntry, IndentSize, Language, LanguageScope, OffsetRangeExt, OffsetUtf16, Outline,
+    OutlineItem, Point, PointUtf16, Selection, TextDimension, ToOffset as _, ToOffsetUtf16 as _,
+    ToPoint as _, ToPointUtf16 as _, TransactionId, Unclipped,
 };
 use std::{
     borrow::Cow,
@@ -2691,9 +2691,9 @@ impl MultiBufferSnapshot {
             .and_then(|(buffer, offset)| buffer.language_at(offset))
     }
 
-    pub fn language_config_at<'a, T: ToOffset>(&'a self, point: T) -> Option<LanguageConfigYeet> {
+    pub fn language_scope_at<'a, T: ToOffset>(&'a self, point: T) -> Option<LanguageScope> {
         self.point_to_buffer_offset(point)
-            .and_then(|(buffer, offset)| buffer.language_config_at(offset))
+            .and_then(|(buffer, offset)| buffer.language_scope_at(offset))
     }
 
     pub fn is_dirty(&self) -> bool {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -10,9 +10,9 @@ use gpui::{AppContext, Entity, ModelContext, ModelHandle, Task};
 pub use language::Completion;
 use language::{
     char_kind, AutoindentMode, Buffer, BufferChunks, BufferSnapshot, CharKind, Chunk, CursorShape,
-    DiagnosticEntry, IndentSize, Language, OffsetRangeExt, OffsetUtf16, Outline, OutlineItem,
-    Point, PointUtf16, Selection, TextDimension, ToOffset as _, ToOffsetUtf16 as _, ToPoint as _,
-    ToPointUtf16 as _, TransactionId, Unclipped,
+    DiagnosticEntry, IndentSize, Language, LanguageConfigYeet, OffsetRangeExt, OffsetUtf16,
+    Outline, OutlineItem, Point, PointUtf16, Selection, TextDimension, ToOffset as _,
+    ToOffsetUtf16 as _, ToPoint as _, ToPointUtf16 as _, TransactionId, Unclipped,
 };
 use std::{
     borrow::Cow,
@@ -2689,6 +2689,11 @@ impl MultiBufferSnapshot {
     pub fn language_at<'a, T: ToOffset>(&'a self, point: T) -> Option<&'a Arc<Language>> {
         self.point_to_buffer_offset(point)
             .and_then(|(buffer, offset)| buffer.language_at(offset))
+    }
+
+    pub fn language_config_at<'a, T: ToOffset>(&'a self, point: T) -> Option<LanguageConfigYeet> {
+        self.point_to_buffer_offset(point)
+            .and_then(|(buffer, offset)| buffer.language_config_at(offset))
     }
 
     pub fn is_dirty(&self) -> bool {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -9,7 +9,7 @@ use crate::{
     syntax_map::{
         SyntaxMap, SyntaxMapCapture, SyntaxMapCaptures, SyntaxSnapshot, ToTreeSitterPoint,
     },
-    CodeLabel, Outline,
+    CodeLabel, LanguageConfigYeet, Outline,
 };
 use anyhow::{anyhow, Result};
 use clock::ReplicaId;
@@ -2013,6 +2013,27 @@ impl BufferSnapshot {
             .last()
             .map(|info| info.language)
             .or(self.language.as_ref())
+    }
+
+    pub fn language_config_at<D: ToOffset>(&self, position: D) -> Option<LanguageConfigYeet> {
+        let offset = position.to_offset(self);
+
+        if let Some(layer_info) = self
+            .syntax
+            .layers_for_range(offset..offset, &self.text)
+            .filter(|l| l.node.end_byte() > offset)
+            .last()
+        {
+            Some(LanguageConfigYeet {
+                language: layer_info.language.clone(),
+                override_id: layer_info.override_id(offset, &self.text),
+            })
+        } else {
+            self.language.clone().map(|language| LanguageConfigYeet {
+                language,
+                override_id: None,
+            })
+        }
     }
 
     pub fn surrounding_word<T: ToOffset>(&self, start: T) -> (Range<usize>, Option<CharKind>) {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -9,7 +9,7 @@ use crate::{
     syntax_map::{
         SyntaxMap, SyntaxMapCapture, SyntaxMapCaptures, SyntaxSnapshot, ToTreeSitterPoint,
     },
-    CodeLabel, LanguageConfigYeet, Outline,
+    CodeLabel, LanguageScope, Outline,
 };
 use anyhow::{anyhow, Result};
 use clock::ReplicaId;
@@ -2015,7 +2015,7 @@ impl BufferSnapshot {
             .or(self.language.as_ref())
     }
 
-    pub fn language_config_at<D: ToOffset>(&self, position: D) -> Option<LanguageConfigYeet> {
+    pub fn language_scope_at<D: ToOffset>(&self, position: D) -> Option<LanguageScope> {
         let offset = position.to_offset(self);
 
         if let Some(layer_info) = self
@@ -2024,12 +2024,12 @@ impl BufferSnapshot {
             .filter(|l| l.node.end_byte() > offset)
             .last()
         {
-            Some(LanguageConfigYeet {
+            Some(LanguageScope {
                 language: layer_info.language.clone(),
                 override_id: layer_info.override_id(offset, &self.text),
             })
         } else {
-            self.language.clone().map(|language| LanguageConfigYeet {
+            self.language.clone().map(|language| LanguageScope {
                 language,
                 override_id: None,
             })

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1421,8 +1421,8 @@ fn test_language_config_at(cx: &mut MutableAppContext) {
         )
         .with_override_query(
             r#"
-                (jsx_element) @override.element
-                (string) @override.string
+                (jsx_element) @element
+                (string) @string
             "#,
         )
         .unwrap();

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -829,10 +829,10 @@ impl Language {
 
         let mut values = HashMap::default();
         for (ix, name) in query.capture_names().iter().enumerate() {
-            if let Some(override_name) = name.strip_prefix("override.") {
-                let value = self.config.overrides.remove(override_name).ok_or_else(|| {
+            if !name.starts_with('_') {
+                let value = self.config.overrides.remove(name).ok_or_else(|| {
                     anyhow!(
-                        "language {:?} has override in query but not in config: {override_name:?}",
+                        "language {:?} has override in query but not in config: {name:?}",
                         self.config.name
                     )
                 })?;

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use gpui::executor::Background;
 pub use language::*;
 use lazy_static::lazy_static;
@@ -145,7 +146,9 @@ pub(crate) fn language(
             .unwrap()
             .data,
     )
+    .with_context(|| format!("failed to load config.toml for language {name:?}"))
     .unwrap();
+
     let mut language = Language::new(config, Some(grammar));
 
     if let Some(query) = load_query(name, "/highlights") {

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -173,6 +173,11 @@ pub(crate) fn language(
             .with_injection_query(query.as_ref())
             .expect("failed to load injection query");
     }
+    if let Some(query) = load_query(name, "/overrides") {
+        language = language
+            .with_override_query(query.as_ref())
+            .expect("failed to load override query");
+    }
     if let Some(lsp_adapter) = lsp_adapter {
         language = language.with_lsp_adapter(lsp_adapter)
     }

--- a/crates/zed/src/languages/c/config.toml
+++ b/crates/zed/src/languages/c/config.toml
@@ -7,5 +7,20 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/c/overrides.scm
+++ b/crates/zed/src/languages/c/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string_literal) @override.string

--- a/crates/zed/src/languages/c/overrides.scm
+++ b/crates/zed/src/languages/c/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string_literal) @override.string
+(comment) @comment
+(string_literal) @string

--- a/crates/zed/src/languages/cpp/config.toml
+++ b/crates/zed/src/languages/cpp/config.toml
@@ -7,5 +7,20 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/cpp/overrides.scm
+++ b/crates/zed/src/languages/cpp/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string_literal) @override.string

--- a/crates/zed/src/languages/cpp/overrides.scm
+++ b/crates/zed/src/languages/cpp/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string_literal) @override.string
+(comment) @comment
+(string_literal) @string

--- a/crates/zed/src/languages/css/config.toml
+++ b/crates/zed/src/languages/css/config.toml
@@ -5,5 +5,20 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "\"", end = "\"", close = true, newline = false }
+    { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/css/overrides.scm
+++ b/crates/zed/src/languages/css/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string_value) @override.string

--- a/crates/zed/src/languages/css/overrides.scm
+++ b/crates/zed/src/languages/css/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string_value) @override.string
+(comment) @comment
+(string_value) @string

--- a/crates/zed/src/languages/elixir/config.toml
+++ b/crates/zed/src/languages/elixir/config.toml
@@ -6,5 +6,20 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "\"", end = "\"", close = true, newline = false }
+    { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/elixir/overrides.scm
+++ b/crates/zed/src/languages/elixir/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+[(string) (charlist)] @override.string

--- a/crates/zed/src/languages/elixir/overrides.scm
+++ b/crates/zed/src/languages/elixir/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-[(string) (charlist)] @override.string
+(comment) @comment
+[(string) (charlist)] @string

--- a/crates/zed/src/languages/erb/config.toml
+++ b/crates/zed/src/languages/erb/config.toml
@@ -4,5 +4,4 @@ autoclose_before = ">})"
 brackets = [
     { start = "<", end = ">", close = true, newline = true },
 ]
-
 block_comment = ["<%#", "%>"]

--- a/crates/zed/src/languages/go/config.toml
+++ b/crates/zed/src/languages/go/config.toml
@@ -7,5 +7,20 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/go/overrides.scm
+++ b/crates/zed/src/languages/go/overrides.scm
@@ -1,6 +1,6 @@
-(comment) @override.comment
+(comment) @comment
 [
   (interpreted_string_literal)
   (raw_string_literal)
   (rune_literal)
-] @override.string
+] @string

--- a/crates/zed/src/languages/go/overrides.scm
+++ b/crates/zed/src/languages/go/overrides.scm
@@ -1,0 +1,6 @@
+(comment) @override.comment
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (rune_literal)
+] @override.string

--- a/crates/zed/src/languages/html/config.toml
+++ b/crates/zed/src/languages/html/config.toml
@@ -10,3 +10,17 @@ brackets = [
 ]
 
 block_comment = ["<!-- ", " -->"]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]

--- a/crates/zed/src/languages/html/overrides.scm
+++ b/crates/zed/src/languages/html/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(quoted_attribute_value) @override.string

--- a/crates/zed/src/languages/html/overrides.scm
+++ b/crates/zed/src/languages/html/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(quoted_attribute_value) @override.string
+(comment) @comment
+(quoted_attribute_value) @string

--- a/crates/zed/src/languages/javascript/config.toml
+++ b/crates/zed/src/languages/javascript/config.toml
@@ -12,3 +12,21 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
 ]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.element]
+line_comment = { remove = true }
+block_comment = ["{/* ", " */}"]

--- a/crates/zed/src/languages/javascript/overrides.scm
+++ b/crates/zed/src/languages/javascript/overrides.scm
@@ -1,9 +1,9 @@
-(comment) @override.comment
-(string) @override.string
+(comment) @comment
+(string) @string
 
 [
   (jsx_element)
   (jsx_fragment)
   (jsx_self_closing_element)
   (jsx_expression)
-] @override.element
+] @element

--- a/crates/zed/src/languages/javascript/overrides.scm
+++ b/crates/zed/src/languages/javascript/overrides.scm
@@ -1,0 +1,9 @@
+(comment) @override.comment
+(string) @override.string
+
+[
+  (jsx_element)
+  (jsx_fragment)
+  (jsx_self_closing_element)
+  (jsx_expression)
+] @override.element

--- a/crates/zed/src/languages/json/config.toml
+++ b/crates/zed/src/languages/json/config.toml
@@ -7,3 +7,9 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false },
 ]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+]

--- a/crates/zed/src/languages/json/overrides.scm
+++ b/crates/zed/src/languages/json/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @comment
+(string) @override.string

--- a/crates/zed/src/languages/json/overrides.scm
+++ b/crates/zed/src/languages/json/overrides.scm
@@ -1,2 +1,1 @@
-(comment) @comment
-(string) @override.string
+(string) @string

--- a/crates/zed/src/languages/python/config.toml
+++ b/crates/zed/src/languages/python/config.toml
@@ -13,3 +13,17 @@ brackets = [
 auto_indent_using_last_non_empty_line = false
 increase_indent_pattern = ":$"
 decrease_indent_pattern = "^\\s*(else|elif|except|finally)\\b.*:"
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]

--- a/crates/zed/src/languages/python/overrides.scm
+++ b/crates/zed/src/languages/python/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string) @override.string

--- a/crates/zed/src/languages/python/overrides.scm
+++ b/crates/zed/src/languages/python/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string) @override.string
+(comment) @comment
+(string) @string

--- a/crates/zed/src/languages/ruby/config.toml
+++ b/crates/zed/src/languages/ruby/config.toml
@@ -7,5 +7,19 @@ brackets = [
   { start = "[", end = "]", close = true, newline = true },
   { start = "(", end = ")", close = true, newline = true },
   { start = "\"", end = "\"", close = true, newline = false },
-  { start = "'", end = "'", close = false, newline = false },
+  { start = "'", end = "'", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/ruby/overrides.scm
+++ b/crates/zed/src/languages/ruby/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string) @override.string

--- a/crates/zed/src/languages/ruby/overrides.scm
+++ b/crates/zed/src/languages/ruby/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string) @override.string
+(comment) @comment
+(string) @string

--- a/crates/zed/src/languages/rust/config.toml
+++ b/crates/zed/src/languages/rust/config.toml
@@ -11,3 +11,19 @@ brackets = [
     { start = "'", end = "'", close = false, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
 ]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true },
+]

--- a/crates/zed/src/languages/rust/overrides.scm
+++ b/crates/zed/src/languages/rust/overrides.scm
@@ -1,8 +1,8 @@
 [
   (string_literal)
   (raw_string_literal)
-] @override.string
+] @string
 [
   (line_comment)
   (block_comment)
-] @override.comment
+] @comment

--- a/crates/zed/src/languages/rust/overrides.scm
+++ b/crates/zed/src/languages/rust/overrides.scm
@@ -1,0 +1,8 @@
+[
+  (string_literal)
+  (raw_string_literal)
+] @override.string
+[
+  (line_comment)
+  (block_comment)
+] @override.comment

--- a/crates/zed/src/languages/scheme/config.toml
+++ b/crates/zed/src/languages/scheme/config.toml
@@ -7,3 +7,15 @@ brackets = [
     { start = "(", end = ")", close = true, newline = false },
     { start = "\"", end = "\"", close = true, newline = false },
 ]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+]

--- a/crates/zed/src/languages/scheme/overrides.scm
+++ b/crates/zed/src/languages/scheme/overrides.scm
@@ -2,5 +2,5 @@
     (comment)
     (block_comment)
     (directive)
-] @override.comment
-(string) @override.string
+] @comment
+(string) @string

--- a/crates/zed/src/languages/scheme/overrides.scm
+++ b/crates/zed/src/languages/scheme/overrides.scm
@@ -1,0 +1,6 @@
+[
+    (comment)
+    (block_comment)
+    (directive)
+] @override.comment
+(string) @override.string

--- a/crates/zed/src/languages/toml/config.toml
+++ b/crates/zed/src/languages/toml/config.toml
@@ -6,4 +6,17 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
+]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
 ]

--- a/crates/zed/src/languages/toml/overrides.scm
+++ b/crates/zed/src/languages/toml/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string) @override.string

--- a/crates/zed/src/languages/toml/overrides.scm
+++ b/crates/zed/src/languages/toml/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string) @override.string
+(comment) @comment
+(string) @string

--- a/crates/zed/src/languages/tsx/config.toml
+++ b/crates/zed/src/languages/tsx/config.toml
@@ -12,3 +12,12 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
 ]
+
+[overrides.element]
+line_comment = { remove = true }
+block_comment = ["{/* ", " */}"]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+]

--- a/crates/zed/src/languages/tsx/overrides.scm
+++ b/crates/zed/src/languages/tsx/overrides.scm
@@ -1,2 +1,7 @@
-(jsx_element) @override.element
+[
+  (jsx_element)
+  (jsx_fragment)
+  (jsx_self_closing_element)
+  (jsx_expression)
+] @override.element
 (string) @override.string

--- a/crates/zed/src/languages/tsx/overrides.scm
+++ b/crates/zed/src/languages/tsx/overrides.scm
@@ -3,5 +3,5 @@
   (jsx_fragment)
   (jsx_self_closing_element)
   (jsx_expression)
-] @override.element
-(string) @override.string
+] @element
+(string) @string

--- a/crates/zed/src/languages/tsx/overrides.scm
+++ b/crates/zed/src/languages/tsx/overrides.scm
@@ -1,0 +1,2 @@
+(jsx_element) @override.element
+(string) @override.string

--- a/crates/zed/src/languages/typescript/config.toml
+++ b/crates/zed/src/languages/typescript/config.toml
@@ -12,3 +12,17 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false },
     { start = "/*", end = " */", close = true, newline = false },
 ]
+
+[overrides.comment]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+
+[overrides.string]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]

--- a/crates/zed/src/languages/typescript/overrides.scm
+++ b/crates/zed/src/languages/typescript/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @override.comment
+(string) @override.string

--- a/crates/zed/src/languages/typescript/overrides.scm
+++ b/crates/zed/src/languages/typescript/overrides.scm
@@ -1,2 +1,2 @@
-(comment) @override.comment
-(string) @override.string
+(comment) @comment
+(string) @string


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/684
Fixes https://github.com/zed-industries/feedback/issues/197
References https://github.com/zed-industries/feedback/issues/316

This PR adds a new concept called "overrides" to Zed's language system. Overrides allow us to specify custom configuration parameters (bracket-matching, auto-closing, etc) in certain syntactic constructs (strings, comments, etc). We're currently using overrides in most languages, for the following purposes:

* Avoiding auto-closing single quotes in comments (so that you can use apostrophes in prose)
* Avoiding auto-closing string delimiters in strings
* Custom comment delimiters in JSX blocks within JavaScript and TSX files.