### PR TITLE
Avoid adjusting indentation of lines inside of newly-created errors

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1666,6 +1666,16 @@ impl Buffer {
 
 #[cfg(any(test, feature = "test-support"))]
 impl Buffer {
+    pub fn edit_via_marked_text(
+        &mut self,
+        marked_string: &str,
+        autoindent_mode: Option<AutoindentMode>,
+        cx: &mut ModelContext<Self>,
+    ) {
+        let edits = self.edits_for_marked_text(marked_string);
+        self.edit(edits, autoindent_mode, cx);
+    }
+
     pub fn set_group_interval(&mut self, group_interval: Duration) {
         self.text.set_group_interval(group_interval);
     }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -348,6 +348,7 @@ pub struct Language {
 pub struct Grammar {
     id: usize,
     pub(crate) ts_language: tree_sitter::Language,
+    pub(crate) error_query: Query,
     pub(crate) highlights_query: Option<Query>,
     pub(crate) brackets_config: Option<BracketConfig>,
     pub(crate) indents_config: Option<IndentConfig>,
@@ -684,6 +685,7 @@ impl Language {
                     indents_config: None,
                     injection_config: None,
                     override_config: None,
+                    error_query: Query::new(ts_language, "(ERROR) @error").unwrap(),
                     ts_language,
                     highlight_map: Default::default(),
                 })

--- a/crates/zed/src/languages/rust/highlights.scm
+++ b/crates/zed/src/languages/rust/highlights.scm
@@ -52,6 +52,7 @@
 [
   "as"
   "async"
+  "await"
   "break"
   "const"
   "continue"

--- a/crates/zed/src/languages/rust/indents.scm
+++ b/crates/zed/src/languages/rust/indents.scm
@@ -5,6 +5,7 @@
     (assignment_expression)
     (let_declaration)
     (let_chain)
+    (await_expression)
 ] @indent
 
 (_ "[" "]" @end) @indent


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/389

This PR makes Zed's auto-indentation a little bit more conservative, to avoid a problem where lines were unexpectedly outdented when in the middle of typing something, due to the tree structure being temporarily disturbed.

Now, when computing auto-indent adjustments, if a line was previously error-free and is now inside of a syntax error, we avoid adjusting that line's indentation. This fixes the main case where the adjustment was undesired before. And from my manual testing, it doesn't prevent any adjustments that are important. There may be some cases where the adjustment would have been correct, but in general, I think it's fine to err on the side of *not* adjusting existing lines' indentation.