### PR TITLE
Fix mismatched return types on CI

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1438,7 +1438,11 @@ extern "C" fn accepts_first_mouse(this: &Object, _: Sel, _: id) -> BOOL {
     unsafe {
         let state = get_window_state(this);
         let state_borrow = state.as_ref().borrow();
-        return state_borrow.kind == WindowKind::PopUp;
+        return if state_borrow.kind == WindowKind::PopUp {
+            YES
+        } else {
+            NO
+        };
     }
 }
 


### PR DESCRIPTION
## Description of feature or change

For some reason, the new 'accepts_first_mouse' callback fails to compile on CI. [The tests ran correctly](https://github.com/zed-industries/zed/actions/runs/3969819735) but [the app bundling did not](https://github.com/zed-industries/zed/actions/runs/3969819735). My guess is that the mac platform code never got compiled into the test compilation, and that somehow it didn't trigger Rust Analyzer either. Hopefully, this fixes it 🤞🏻

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
