### PR TITLE
Fix cursor style thrashing on overlapping windows

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -21,6 +21,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use pathfinder_geometry::vector::Vector2F;
 use postage::oneshot;
 use smallvec::SmallVec;
 use smol::prelude::*;
@@ -863,6 +864,12 @@ impl MutableAppContext {
                 type_name::<A>()
             );
         }
+    }
+
+    pub fn screen_position(&self, window_id: usize, view_position: &Vector2F) -> Option<Vector2F> {
+        self.presenters_and_platform_windows
+            .get(&window_id)
+            .map(|(_, window)| window.screen_position(view_position))
     }
 
     pub fn window_ids(&self) -> impl Iterator<Item = usize> + '_ {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -866,10 +866,12 @@ impl MutableAppContext {
         }
     }
 
-    pub fn screen_position(&self, window_id: usize, view_position: &Vector2F) -> Option<Vector2F> {
+    pub fn is_topmost_window_for_position(&self, window_id: usize, position: Vector2F) -> bool {
         self.presenters_and_platform_windows
             .get(&window_id)
-            .map(|(_, window)| window.screen_position(view_position))
+            .map_or(false, |(_, window)| {
+                window.is_topmost_for_position(position)
+            })
     }
 
     pub fn window_ids(&self) -> impl Iterator<Item = usize> + '_ {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -64,7 +64,7 @@ pub trait Platform: Send + Sync {
     fn read_credentials(&self, url: &str) -> Result<Option<(String, Vec<u8>)>>;
     fn delete_credentials(&self, url: &str) -> Result<()>;
 
-    fn set_cursor_style(&self, style: CursorStyle, window_id: usize, screen_position: &Vector2F);
+    fn set_cursor_style(&self, style: CursorStyle);
     fn should_auto_hide_scrollbars(&self) -> bool;
 
     fn local_timezone(&self) -> UtcOffset;
@@ -145,7 +145,7 @@ pub trait Window {
     fn present_scene(&mut self, scene: Scene);
     fn appearance(&self) -> Appearance;
     fn on_appearance_changed(&mut self, callback: Box<dyn FnMut()>);
-    fn screen_position(&self, view_position: &Vector2F) -> Vector2F;
+    fn is_topmost_for_position(&self, position: Vector2F) -> bool;
 }
 
 #[derive(Debug)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -64,7 +64,7 @@ pub trait Platform: Send + Sync {
     fn read_credentials(&self, url: &str) -> Result<Option<(String, Vec<u8>)>>;
     fn delete_credentials(&self, url: &str) -> Result<()>;
 
-    fn set_cursor_style(&self, style: CursorStyle);
+    fn set_cursor_style(&self, style: CursorStyle, window_id: usize, screen_position: &Vector2F);
     fn should_auto_hide_scrollbars(&self) -> bool;
 
     fn local_timezone(&self) -> UtcOffset;
@@ -145,6 +145,7 @@ pub trait Window {
     fn present_scene(&mut self, scene: Scene);
     fn appearance(&self) -> Appearance;
     fn on_appearance_changed(&mut self, callback: Box<dyn FnMut()>);
+    fn screen_position(&self, view_position: &Vector2F) -> Vector2F;
 }
 
 #[derive(Debug)]

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -125,6 +125,7 @@ impl Event {
                         button,
                         position: vec2f(
                             native_event.locationInWindow().x as f32,
+                            // MacOS screen coordinates are relative to bottom left
                             window_height - native_event.locationInWindow().y as f32,
                         ),
                         modifiers: read_modifiers(native_event),
@@ -150,6 +151,7 @@ impl Event {
                         button,
                         position: vec2f(
                             native_event.locationInWindow().x as f32,
+                            // MacOS view coordinates are relative to bottom left
                             window_height - native_event.locationInWindow().y as f32,
                         ),
                         modifiers: read_modifiers(native_event),

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -37,6 +37,7 @@ use objc::{
     runtime::{Class, Object, Sel},
     sel, sel_impl,
 };
+use pathfinder_geometry::vector::Vector2F;
 use postage::oneshot;
 use ptr::null_mut;
 use std::{
@@ -695,7 +696,19 @@ impl platform::Platform for MacPlatform {
         Ok(())
     }
 
-    fn set_cursor_style(&self, style: CursorStyle) {
+    fn set_cursor_style(&self, style: CursorStyle, window_id: usize, screen_position: &Vector2F) {
+        let top_most = Window::window_id_under(screen_position);
+        if top_most.is_none() {
+            return;
+        }
+        if top_most.unwrap() != window_id {
+            return;
+        }
+
+        dbg!(top_most.unwrap(), window_id);
+
+        dbg!(style);
+
         unsafe {
             let cursor: id = match style {
                 CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -37,7 +37,6 @@ use objc::{
     runtime::{Class, Object, Sel},
     sel, sel_impl,
 };
-use pathfinder_geometry::vector::Vector2F;
 use postage::oneshot;
 use ptr::null_mut;
 use std::{
@@ -696,21 +695,18 @@ impl platform::Platform for MacPlatform {
         Ok(())
     }
 
-    fn set_cursor_style(&self, style: CursorStyle, window_id: usize, screen_position: &Vector2F) {
-        if Some(window_id) == Window::window_id_under(screen_position) {
-            dbg!(screen_position, style);
-            unsafe {
-                let cursor: id = match style {
-                    CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],
-                    CursorStyle::ResizeLeftRight => {
-                        msg_send![class!(NSCursor), resizeLeftRightCursor]
-                    }
-                    CursorStyle::ResizeUpDown => msg_send![class!(NSCursor), resizeUpDownCursor],
-                    CursorStyle::PointingHand => msg_send![class!(NSCursor), pointingHandCursor],
-                    CursorStyle::IBeam => msg_send![class!(NSCursor), IBeamCursor],
-                };
-                let _: () = msg_send![cursor, set];
-            }
+    fn set_cursor_style(&self, style: CursorStyle) {
+        unsafe {
+            let cursor: id = match style {
+                CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],
+                CursorStyle::ResizeLeftRight => {
+                    msg_send![class!(NSCursor), resizeLeftRightCursor]
+                }
+                CursorStyle::ResizeUpDown => msg_send![class!(NSCursor), resizeUpDownCursor],
+                CursorStyle::PointingHand => msg_send![class!(NSCursor), pointingHandCursor],
+                CursorStyle::IBeam => msg_send![class!(NSCursor), IBeamCursor],
+            };
+            let _: () = msg_send![cursor, set];
         }
     }
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -697,27 +697,20 @@ impl platform::Platform for MacPlatform {
     }
 
     fn set_cursor_style(&self, style: CursorStyle, window_id: usize, screen_position: &Vector2F) {
-        let top_most = Window::window_id_under(screen_position);
-        if top_most.is_none() {
-            return;
-        }
-        if top_most.unwrap() != window_id {
-            return;
-        }
-
-        dbg!(top_most.unwrap(), window_id);
-
-        dbg!(style);
-
-        unsafe {
-            let cursor: id = match style {
-                CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],
-                CursorStyle::ResizeLeftRight => msg_send![class!(NSCursor), resizeLeftRightCursor],
-                CursorStyle::ResizeUpDown => msg_send![class!(NSCursor), resizeUpDownCursor],
-                CursorStyle::PointingHand => msg_send![class!(NSCursor), pointingHandCursor],
-                CursorStyle::IBeam => msg_send![class!(NSCursor), IBeamCursor],
-            };
-            let _: () = msg_send![cursor, set];
+        if Some(window_id) == Window::window_id_under(screen_position) {
+            dbg!(screen_position, style);
+            unsafe {
+                let cursor: id = match style {
+                    CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],
+                    CursorStyle::ResizeLeftRight => {
+                        msg_send![class!(NSCursor), resizeLeftRightCursor]
+                    }
+                    CursorStyle::ResizeUpDown => msg_send![class!(NSCursor), resizeUpDownCursor],
+                    CursorStyle::PointingHand => msg_send![class!(NSCursor), pointingHandCursor],
+                    CursorStyle::IBeam => msg_send![class!(NSCursor), IBeamCursor],
+                };
+                let _: () = msg_send![cursor, set];
+            }
         }
     }
 

--- a/crates/gpui/src/platform/mac/status_item.rs
+++ b/crates/gpui/src/platform/mac/status_item.rs
@@ -259,8 +259,8 @@ impl platform::Window for StatusItem {
         }
     }
 
-    fn screen_position(&self, _view_position: &Vector2F) -> Vector2F {
-        unimplemented!()
+    fn is_topmost_for_position(&self, _: Vector2F) -> bool {
+        true
     }
 }
 

--- a/crates/gpui/src/platform/mac/status_item.rs
+++ b/crates/gpui/src/platform/mac/status_item.rs
@@ -258,6 +258,10 @@ impl platform::Window for StatusItem {
             crate::Appearance::from_native(appearance)
         }
     }
+
+    fn screen_position(&self, _view_position: &Vector2F) -> Vector2F {
+        unimplemented!()
+    }
 }
 
 impl StatusItemState {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -52,6 +52,8 @@ use std::{
     time::Duration,
 };
 
+use super::geometry::Vector2FExt;
+
 const WINDOW_STATE_IVAR: &str = "windowState";
 
 static mut WINDOW_CLASS: *const Class = ptr::null();
@@ -564,11 +566,13 @@ impl Window {
         unsafe {
             let app = NSApplication::sharedApplication(nil);
 
-            let point = NSPoint::new(screen_position.x() as f64, screen_position.y() as f64);
-            let window_number: NSInteger = msg_send![class!(NSWindow), windowNumberAtPoint:point belowWindowWithWindowNumber:0 as NSInteger];
+            let point = screen_position.to_ns_point();
+            let window_number: NSInteger = msg_send![class!(NSWindow), windowNumberAtPoint:point belowWindowWithWindowNumber:0];
+
             // For some reason this API doesn't work when our two windows are on top of each other
             let top_most_window: id = msg_send![app, windowWithWindowNumber: window_number];
-            dbg!(top_most_window);
+
+            // dbg!(top_most_window);
             let is_panel: BOOL = msg_send![top_most_window, isKindOfClass: PANEL_CLASS];
             let is_window: BOOL = msg_send![top_most_window, isKindOfClass: WINDOW_CLASS];
             if is_panel | is_window {
@@ -779,7 +783,7 @@ impl platform::Window for Window {
     fn screen_position(&self, view_position: &Vector2F) -> Vector2F {
         let self_borrow = self.0.borrow_mut();
         unsafe {
-            let point = NSPoint::new(view_position.x() as f64, view_position.y() as f64);
+            let point = view_position.to_ns_point();
             let screen_point: NSPoint =
                 msg_send![self_borrow.native_window, convertPointToScreen: point];
             vec2f(screen_point.x as f32, screen_point.y as f32)

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -178,7 +178,7 @@ impl super::Platform for Platform {
         Ok(())
     }
 
-    fn set_cursor_style(&self, style: CursorStyle, _window_id: usize, _position: &Vector2F) {
+    fn set_cursor_style(&self, style: CursorStyle) {
         *self.cursor.lock() = style;
     }
 
@@ -333,8 +333,8 @@ impl super::Window for Window {
 
     fn on_appearance_changed(&mut self, _: Box<dyn FnMut()>) {}
 
-    fn screen_position(&self, view_position: &Vector2F) -> Vector2F {
-        view_position.clone()
+    fn is_topmost_for_position(&self, _position: Vector2F) -> bool {
+        true
     }
 }
 

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -178,7 +178,7 @@ impl super::Platform for Platform {
         Ok(())
     }
 
-    fn set_cursor_style(&self, style: CursorStyle) {
+    fn set_cursor_style(&self, style: CursorStyle, _window_id: usize, _position: &Vector2F) {
         *self.cursor.lock() = style;
     }
 
@@ -332,6 +332,10 @@ impl super::Window for Window {
     }
 
     fn on_appearance_changed(&mut self, _: Box<dyn FnMut()>) {}
+
+    fn screen_position(&self, view_position: &Vector2F) -> Vector2F {
+        view_position.clone()
+    }
 }
 
 pub fn platform() -> Platform {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -317,6 +317,9 @@ impl Presenter {
                     }
                 }
 
+                dbg!("*******");
+                dbg!(position);
+                dbg!(event_reused);
                 if let Some(screen_position) = cx.screen_position(self.window_id, position) {
                     cx.platform().set_cursor_style(
                         style_to_assign,

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -316,7 +316,14 @@ impl Presenter {
                         break;
                     }
                 }
-                cx.platform().set_cursor_style(style_to_assign);
+
+                if let Some(screen_position) = cx.screen_position(self.window_id, position) {
+                    cx.platform().set_cursor_style(
+                        style_to_assign,
+                        self.window_id,
+                        &screen_position,
+                    );
+                }
 
                 if !event_reused {
                     if pressed_button.is_some() {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -31,7 +31,6 @@ use std::{
     ops::{Deref, DerefMut, Range},
     sync::Arc,
 };
-use time::Instant;
 
 pub struct Presenter {
     window_id: usize,
@@ -318,8 +317,14 @@ impl Presenter {
                     }
                 }
 
-                if cx.is_topmost_window_for_position(self.window_id, *position) {
+                let t0 = std::time::Instant::now();
+                let is_topmost_window =
+                    cx.is_topmost_window_for_position(self.window_id, *position);
+                println!("is_topmost_window => {:?}", t0.elapsed());
+                if is_topmost_window {
+                    let t1 = std::time::Instant::now();
                     cx.platform().set_cursor_style(style_to_assign);
+                    println!("set_cursor_style => {:?}", t1.elapsed());
                 }
 
                 if !event_reused {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -31,6 +31,7 @@ use std::{
     ops::{Deref, DerefMut, Range},
     sync::Arc,
 };
+use time::Instant;
 
 pub struct Presenter {
     window_id: usize,
@@ -317,15 +318,8 @@ impl Presenter {
                     }
                 }
 
-                dbg!("*******");
-                dbg!(position);
-                dbg!(event_reused);
-                if let Some(screen_position) = cx.screen_position(self.window_id, position) {
-                    cx.platform().set_cursor_style(
-                        style_to_assign,
-                        self.window_id,
-                        &screen_position,
-                    );
+                if cx.is_topmost_window_for_position(self.window_id, *position) {
+                    cx.platform().set_cursor_style(style_to_assign);
                 }
 
                 if !event_reused {

--- a/crates/gpui/src/presenter/event_dispatcher.rs
+++ b/crates/gpui/src/presenter/event_dispatcher.rs
@@ -209,6 +209,7 @@ impl EventDispatcher {
                         break;
                     }
                 }
+
                 cx.platform().set_cursor_style(style_to_assign);
 
                 if !event_reused {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -31,8 +31,9 @@ use futures::{
 };
 use gpui::{
     actions,
+    color::Color,
     elements::*,
-    geometry::vector::Vector2F,
+    geometry::vector::{vec2f, Vector2F},
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
     platform::{CursorStyle, WindowOptions},
@@ -263,6 +264,59 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
     client.add_view_request_handler(Workspace::handle_follow);
     client.add_view_message_handler(Workspace::handle_unfollow);
     client.add_view_message_handler(Workspace::handle_update_followers);
+
+    // REMEMBER TO DELETE THE SHOW NOTIF
+    cx.add_action(
+        |_workspace: &mut Workspace, _: &ShowNotif, cx: &mut ViewContext<Workspace>| {
+            struct DummyView;
+
+            impl Entity for DummyView {
+                type Event = ();
+            }
+
+            impl View for DummyView {
+                fn ui_name() -> &'static str {
+                    "DummyView"
+                }
+                fn render(&mut self, cx: &mut RenderContext<'_, Self>) -> ElementBox {
+                    MouseEventHandler::<DummyView>::new(0, cx, |state, _cx| {
+                        Empty::new()
+                            .contained()
+                            .with_background_color(if state.hovered() {
+                                Color::red()
+                            } else {
+                                Color::blue()
+                            })
+                            .constrained()
+                            .with_width(200.)
+                            .with_height(200.)
+                            .boxed()
+                    })
+                    .on_click(MouseButton::Left, |_, _| {
+                        println!("click");
+                    })
+                    .with_cursor_style(CursorStyle::ResizeUpDown)
+                    .boxed()
+                }
+            }
+
+            cx.add_window(
+                WindowOptions {
+                    bounds: gpui::WindowBounds::Fixed(gpui::geometry::rect::RectF::new(
+                        vec2f(400., 200.),
+                        vec2f(300., 200.),
+                    )),
+                    titlebar: None,
+                    center: false,
+                    focus: false,
+                    kind: gpui::WindowKind::PopUp,
+                    is_movable: true,
+                    screen: None,
+                },
+                |_cx| DummyView,
+            )
+        },
+    )
 }
 
 type ProjectItemBuilders = HashMap<

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -31,9 +31,8 @@ use futures::{
 };
 use gpui::{
     actions,
-    color::Color,
     elements::*,
-    geometry::vector::{vec2f, Vector2F},
+    geometry::vector::Vector2F,
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
     platform::{CursorStyle, WindowOptions},
@@ -101,7 +100,6 @@ actions!(
         NewTerminal,
         NewSearch,
         Feedback,
-        ShowNotif,
     ]
 );
 
@@ -264,59 +262,6 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
     client.add_view_request_handler(Workspace::handle_follow);
     client.add_view_message_handler(Workspace::handle_unfollow);
     client.add_view_message_handler(Workspace::handle_update_followers);
-
-    // REMEMBER TO DELETE THE SHOW NOTIF
-    cx.add_action(
-        |_workspace: &mut Workspace, _: &ShowNotif, cx: &mut ViewContext<Workspace>| {
-            struct DummyView;
-
-            impl Entity for DummyView {
-                type Event = ();
-            }
-
-            impl View for DummyView {
-                fn ui_name() -> &'static str {
-                    "DummyView"
-                }
-                fn render(&mut self, cx: &mut RenderContext<'_, Self>) -> ElementBox {
-                    MouseEventHandler::<DummyView>::new(0, cx, |state, _cx| {
-                        Empty::new()
-                            .contained()
-                            .with_background_color(if state.hovered() {
-                                Color::red()
-                            } else {
-                                Color::blue()
-                            })
-                            .constrained()
-                            .with_width(200.)
-                            .with_height(200.)
-                            .boxed()
-                    })
-                    .on_click(MouseButton::Left, |_, _| {
-                        println!("click");
-                    })
-                    .with_cursor_style(CursorStyle::ResizeUpDown)
-                    .boxed()
-                }
-            }
-
-            cx.add_window(
-                WindowOptions {
-                    bounds: gpui::WindowBounds::Fixed(gpui::geometry::rect::RectF::new(
-                        vec2f(400., 200.),
-                        vec2f(300., 200.),
-                    )),
-                    titlebar: None,
-                    center: false,
-                    focus: false,
-                    kind: gpui::WindowKind::PopUp,
-                    is_movable: true,
-                    screen: None,
-                },
-                |_cx| DummyView,
-            )
-        },
-    )
 }
 
 type ProjectItemBuilders = HashMap<


### PR DESCRIPTION
## Description of feature or change

This fixes a bug where the cursor style would be set multiple times if there was a popup over an app window. 

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
