### PR TITLE
Fixes a broken conditional that is only caught on darwin systems

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -777,7 +777,7 @@ impl platform::Window for Window {
 
             let is_panel: BOOL = msg_send![top_most_window, isKindOfClass: PANEL_CLASS];
             let is_window: BOOL = msg_send![top_most_window, isKindOfClass: WINDOW_CLASS];
-            if is_panel | is_window {
+            if is_panel == YES || is_window == YES {
                 let topmost_window_id = get_window_state(&*top_most_window).borrow().id;
                 topmost_window_id == self_id
             } else {


### PR DESCRIPTION
## Description of feature or change

I've added the Darwin target to my local rustup so this shouldn't happen again.

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
