### PR TITLE
Workspace window position persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,7 @@ source = "git+https://github.com/servo/core-foundation-rs?rev=079665882507dd5e2f
 dependencies = [
  "core-foundation-sys",
  "libc",
+ "uuid 0.5.1",
 ]
 
 [[package]]
@@ -2591,6 +2592,7 @@ dependencies = [
  "tiny-skia",
  "usvg",
  "util",
+ "uuid 1.2.2",
  "waker-fn",
 ]
 
@@ -6014,6 +6016,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "smol",
  "thread_local",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -7326,6 +7329,12 @@ dependencies = [
 
 [[package]]
 name = "uuid"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+
+[[package]]
+name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
@@ -8169,6 +8178,7 @@ dependencies = [
  "smallvec",
  "theme",
  "util",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -8312,6 +8322,7 @@ dependencies = [
  "url",
  "urlencoding",
  "util",
+ "uuid 1.2.2",
  "vim",
  "workspace",
 ]

--- a/crates/collab/src/tests.rs
+++ b/crates/collab/src/tests.rs
@@ -196,7 +196,7 @@ impl TestServer {
             languages: Arc::new(LanguageRegistry::new(Task::ready(()))),
             themes: ThemeRegistry::new((), cx.font_cache()),
             fs: fs.clone(),
-            build_window_options: Default::default,
+            build_window_options: |_| Default::default(),
             initialize_workspace: |_, _, _| unimplemented!(),
             dock_default_item_factory: |_, _| unimplemented!(),
         });

--- a/crates/collab/src/tests.rs
+++ b/crates/collab/src/tests.rs
@@ -196,7 +196,7 @@ impl TestServer {
             languages: Arc::new(LanguageRegistry::new(Task::ready(()))),
             themes: ThemeRegistry::new((), cx.font_cache()),
             fs: fs.clone(),
-            build_window_options: |_| Default::default(),
+            build_window_options: |_, _, _| Default::default(),
             initialize_workspace: |_, _, _| unimplemented!(),
             dock_default_item_factory: |_, _| unimplemented!(),
         });

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -54,17 +54,20 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                     })
                     .await?;
 
-                let (_, workspace) = cx.add_window((app_state.build_window_options)(None), |cx| {
-                    let mut workspace = Workspace::new(
-                        Default::default(),
-                        0,
-                        project,
-                        app_state.dock_default_item_factory,
-                        cx,
-                    );
-                    (app_state.initialize_workspace)(&mut workspace, &app_state, cx);
-                    workspace
-                });
+                let (_, workspace) = cx.add_window(
+                    (app_state.build_window_options)(None, None, cx.platform().as_ref()),
+                    |cx| {
+                        let mut workspace = Workspace::new(
+                            Default::default(),
+                            0,
+                            project,
+                            app_state.dock_default_item_factory,
+                            cx,
+                        );
+                        (app_state.initialize_workspace)(&mut workspace, &app_state, cx);
+                        workspace
+                    },
+                );
                 workspace
             };
 

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -54,7 +54,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                     })
                     .await?;
 
-                let (_, workspace) = cx.add_window((app_state.build_window_options)(), |cx| {
+                let (_, workspace) = cx.add_window((app_state.build_window_options)(None), |cx| {
                     let mut workspace = Workspace::new(
                         Default::default(),
                         0,

--- a/crates/collab_ui/src/incoming_call_notification.rs
+++ b/crates/collab_ui/src/incoming_call_notification.rs
@@ -32,11 +32,12 @@ pub fn init(cx: &mut MutableAppContext) {
                 });
 
                 for screen in cx.platform().screens() {
-                    let screen_size = screen.size();
+                    let screen_bounds = screen.bounds();
                     let (window_id, _) = cx.add_window(
                         WindowOptions {
                             bounds: WindowBounds::Fixed(RectF::new(
-                                vec2f(screen_size.x() - window_size.x() - PADDING, PADDING),
+                                screen_bounds.upper_right()
+                                    - vec2f(PADDING + window_size.x(), PADDING),
                                 window_size,
                             )),
                             titlebar: None,

--- a/crates/collab_ui/src/project_shared_notification.rs
+++ b/crates/collab_ui/src/project_shared_notification.rs
@@ -31,11 +31,11 @@ pub fn init(cx: &mut MutableAppContext) {
             let window_size = vec2f(theme.window_width, theme.window_height);
 
             for screen in cx.platform().screens() {
-                let screen_size = screen.size();
+                let screen_bounds = screen.bounds();
                 let (window_id, _) = cx.add_window(
                     WindowOptions {
                         bounds: WindowBounds::Fixed(RectF::new(
-                            vec2f(screen_size.x() - window_size.x() - PADDING, PADDING),
+                            screen_bounds.upper_right() - vec2f(PADDING + window_size.x(), PADDING),
                             window_size,
                         )),
                         titlebar: None,

--- a/crates/editor/src/persistence.rs
+++ b/crates/editor/src/persistence.rs
@@ -6,7 +6,7 @@ use db::{define_connection, query};
 use workspace::{ItemId, WorkspaceDb, WorkspaceId};
 
 define_connection!(
-    // Current table shape using pseudo-rust syntax:
+    // Current schema shape using pseudo-rust syntax:
     // editors(
     //   item_id: usize,
     //   workspace_id: usize,

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -47,6 +47,7 @@ smol = "1.2"
 time = { version = "0.3", features = ["serde", "serde-well-known"] }
 tiny-skia = "0.5"
 usvg = "0.14"
+uuid = { version = "1.1.2", features = ["v4"] }
 waker-fn = "1.1.0"
 
 [build-dependencies]
@@ -66,7 +67,7 @@ media = { path = "../media" }
 anyhow = "1"
 block = "0.1"
 cocoa = "0.24"
-core-foundation = "0.9.3"
+core-foundation = { version = "0.9.3", features = ["with-uuid"] }
 core-graphics = "0.22.3"
 core-text = "19.2"
 font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "8eaf7a918eafa28b0a37dc759e2e0e7683fa24f1" }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2377,10 +2377,19 @@ impl MutableAppContext {
             let window = this.cx.windows.get_mut(&window_id)?;
             window.is_fullscreen = is_fullscreen;
 
-            let mut observations = this.window_fullscreen_observations.clone();
-            observations.emit(window_id, this, |callback, this| {
+            let mut fullscreen_observations = this.window_fullscreen_observations.clone();
+            fullscreen_observations.emit(window_id, this, |callback, this| {
                 callback(is_fullscreen, this)
             });
+
+            let bounds = if this.window_is_fullscreen(window_id) {
+                WindowBounds::Fullscreen
+            } else {
+                WindowBounds::Fixed(this.window_bounds(window_id))
+            };
+
+            let mut bounds_observations = this.window_bounds_observations.clone();
+            bounds_observations.emit(window_id, this, |callback, this| callback(bounds, this));
 
             Some(())
         });

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -123,7 +123,7 @@ pub trait InputHandler {
 
 pub trait Screen: Debug {
     fn as_any(&self) -> &dyn Any;
-    fn size(&self) -> Vector2F;
+    fn bounds(&self) -> RectF;
     fn display_uuid(&self) -> Uuid;
 }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -126,6 +126,7 @@ pub trait Window {
     fn on_active_status_change(&mut self, callback: Box<dyn FnMut(bool)>);
     fn on_resize(&mut self, callback: Box<dyn FnMut()>);
     fn on_fullscreen(&mut self, callback: Box<dyn FnMut(bool)>);
+    fn on_moved(&mut self, callback: Box<dyn FnMut()>);
     fn on_should_close(&mut self, callback: Box<dyn FnMut() -> bool>);
     fn on_close(&mut self, callback: Box<dyn FnOnce()>);
     fn set_input_handler(&mut self, input_handler: Box<dyn InputHandler>);
@@ -186,8 +187,9 @@ pub enum WindowKind {
     PopUp,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum WindowBounds {
+    Fullscreen,
     Maximized,
     Fixed(RectF),
 }

--- a/crates/gpui/src/platform/mac/geometry.rs
+++ b/crates/gpui/src/platform/mac/geometry.rs
@@ -1,27 +1,99 @@
-use cocoa::foundation::{NSPoint, NSRect, NSSize};
-use pathfinder_geometry::{rect::RectF, vector::Vector2F};
+use cocoa::{
+    appkit::NSWindow,
+    base::id,
+    foundation::{NSPoint, NSRect, NSSize},
+};
+use objc::{msg_send, sel, sel_impl};
+use pathfinder_geometry::{
+    rect::RectF,
+    vector::{vec2f, Vector2F},
+};
+
+///! Macos screen have a y axis that goings up from the bottom of the screen and
+///! an origin at the bottom left of the main display.
 
 pub trait Vector2FExt {
-    fn to_ns_point(&self) -> NSPoint;
-    fn to_ns_size(&self) -> NSSize;
+    /// Converts self to an NSPoint with y axis pointing up.
+    fn to_screen_ns_point(&self, native_window: id) -> NSPoint;
+}
+impl Vector2FExt for Vector2F {
+    fn to_screen_ns_point(&self, native_window: id) -> NSPoint {
+        unsafe {
+            let point = NSPoint::new(self.x() as f64, -self.y() as f64);
+            msg_send![native_window, convertPointToScreen: point]
+        }
+    }
 }
 
 pub trait RectFExt {
+    /// Converts self to an NSRect with y axis pointing up.
+    /// The resulting NSRect will have an origin at the bottom left of the rectangle.
+    /// Also takes care of converting from window scaled coordinates to screen coordinates
+    fn to_screen_ns_rect(&self, native_window: id) -> NSRect;
+
+    /// Converts self to an NSRect with y axis point up.
+    /// The resulting NSRect will have an origin at the bottom left of the rectangle.
+    /// Unlike to_screen_ns_rect, coordinates are not converted and are assumed to already be in screen scale
     fn to_ns_rect(&self) -> NSRect;
 }
-
-impl Vector2FExt for Vector2F {
-    fn to_ns_point(&self) -> NSPoint {
-        NSPoint::new(self.x() as f64, self.y() as f64)
+impl RectFExt for RectF {
+    fn to_screen_ns_rect(&self, native_window: id) -> NSRect {
+        unsafe { native_window.convertRectToScreen_(self.to_ns_rect()) }
     }
 
-    fn to_ns_size(&self) -> NSSize {
-        NSSize::new(self.x() as f64, self.y() as f64)
+    fn to_ns_rect(&self) -> NSRect {
+        dbg!(&self);
+        NSRect::new(
+            NSPoint::new(
+                dbg!(self.origin_x() as f64),
+                dbg!(-(self.origin_y() - self.height()) as f64),
+            ),
+            NSSize::new(self.width() as f64, self.height() as f64),
+        )
     }
 }
 
-impl RectFExt for RectF {
-    fn to_ns_rect(&self) -> NSRect {
-        NSRect::new(self.origin().to_ns_point(), self.size().to_ns_size())
+pub trait NSPointExt {
+    /// Converts self to a Vector2F with y axis pointing down.
+    /// Also takes care of converting from window scaled coordinates to screen coordinates
+    fn to_window_vector2f(&self, native_window: id) -> Vector2F;
+}
+impl NSPointExt for NSPoint {
+    fn to_window_vector2f(&self, native_window: id) -> Vector2F {
+        unsafe {
+            let point: NSPoint = msg_send![native_window, convertPointFromScreen: self];
+            vec2f(point.x as f32, -point.y as f32)
+        }
+    }
+}
+
+pub trait NSRectExt {
+    /// Converts self to a RectF with y axis pointing down.
+    /// The resulting RectF will have an origin at the top left of the rectangle.
+    /// Also takes care of converting from screen scale coordinates to window coordinates
+    fn to_window_rectf(&self, native_window: id) -> RectF;
+
+    /// Converts self to a RectF with y axis pointing down.
+    /// The resulting RectF will have an origin at the top left of the rectangle.
+    /// Unlike to_screen_ns_rect, coordinates are not converted and are assumed to already be in screen scale
+    fn to_rectf(&self) -> RectF;
+}
+impl NSRectExt for NSRect {
+    fn to_window_rectf(&self, native_window: id) -> RectF {
+        unsafe {
+            dbg!(self.origin.x);
+            let rect: NSRect = native_window.convertRectFromScreen_(*self);
+            rect.to_rectf()
+        }
+    }
+
+    fn to_rectf(&self) -> RectF {
+        RectF::new(
+            vec2f(
+                dbg!(self.origin.x as f32),
+                dbg!(-(self.origin.y - self.size.height) as f32),
+            ),
+            vec2f(self.size.width as f32, self.size.height as f32),
+        )
     }
 }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -440,6 +440,10 @@ impl platform::Platform for MacPlatform {
         self.dispatcher.clone()
     }
 
+    fn fonts(&self) -> Arc<dyn platform::FontSystem> {
+        self.fonts.clone()
+    }
+
     fn activate(&self, ignoring_other_apps: bool) {
         unsafe {
             let app = NSApplication::sharedApplication(nil);
@@ -488,6 +492,10 @@ impl platform::Platform for MacPlatform {
         }
     }
 
+    fn screen_by_id(&self, id: uuid::Uuid) -> Option<Rc<dyn crate::Screen>> {
+        Screen::find_by_id(id).map(|screen| Rc::new(screen) as Rc<_>)
+    }
+
     fn screens(&self) -> Vec<Rc<dyn platform::Screen>> {
         Screen::all()
             .into_iter()
@@ -510,10 +518,6 @@ impl platform::Platform for MacPlatform {
 
     fn add_status_item(&self) -> Box<dyn platform::Window> {
         Box::new(StatusItem::add(self.fonts()))
-    }
-
-    fn fonts(&self) -> Arc<dyn platform::FontSystem> {
-        self.fonts.clone()
     }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {

--- a/crates/gpui/src/platform/mac/status_item.rs
+++ b/crates/gpui/src/platform/mac/status_item.rs
@@ -7,7 +7,7 @@ use crate::{
         self,
         mac::{platform::NSViewLayerContentsRedrawDuringViewResize, renderer::Renderer},
     },
-    Event, FontSystem, Scene,
+    Event, FontSystem, Scene, WindowBounds,
 };
 use cocoa::{
     appkit::{NSScreen, NSSquareStatusItemLength, NSStatusBar, NSStatusItem, NSView, NSWindow},
@@ -31,6 +31,8 @@ use std::{
     rc::{Rc, Weak},
     sync::Arc,
 };
+
+use super::screen::Screen;
 
 static mut VIEW_CLASS: *const Class = ptr::null();
 const STATE_IVAR: &str = "state";
@@ -167,29 +169,41 @@ impl StatusItem {
 }
 
 impl platform::Window for StatusItem {
+    fn bounds(&self) -> WindowBounds {
+        self.0.borrow().bounds()
+    }
+
+    fn content_size(&self) -> Vector2F {
+        self.0.borrow().content_size()
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.0.borrow().scale_factor()
+    }
+
+    fn titlebar_height(&self) -> f32 {
+        0.
+    }
+
+    fn appearance(&self) -> crate::Appearance {
+        unsafe {
+            let appearance: id =
+                msg_send![self.0.borrow().native_item.button(), effectiveAppearance];
+            crate::Appearance::from_native(appearance)
+        }
+    }
+
+    fn screen(&self) -> Rc<dyn crate::Screen> {
+        unsafe {
+            Rc::new(Screen {
+                native_screen: self.0.borrow().native_window().screen(),
+            })
+        }
+    }
+
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
     }
-
-    fn on_event(&mut self, callback: Box<dyn FnMut(crate::Event) -> bool>) {
-        self.0.borrow_mut().event_callback = Some(callback);
-    }
-
-    fn on_appearance_changed(&mut self, callback: Box<dyn FnMut()>) {
-        self.0.borrow_mut().appearance_changed_callback = Some(callback);
-    }
-
-    fn on_active_status_change(&mut self, _: Box<dyn FnMut(bool)>) {}
-
-    fn on_resize(&mut self, _: Box<dyn FnMut()>) {}
-
-    fn on_moved(&mut self, _: Box<dyn FnMut()>) {}
-
-    fn on_fullscreen(&mut self, _: Box<dyn FnMut(bool)>) {}
-
-    fn on_should_close(&mut self, _: Box<dyn FnMut() -> bool>) {}
-
-    fn on_close(&mut self, _: Box<dyn FnOnce()>) {}
 
     fn set_input_handler(&mut self, _: Box<dyn crate::InputHandler>) {}
 
@@ -226,26 +240,6 @@ impl platform::Window for StatusItem {
         unimplemented!()
     }
 
-    fn toggle_full_screen(&self) {
-        unimplemented!()
-    }
-
-    fn bounds(&self) -> RectF {
-        self.0.borrow().bounds()
-    }
-
-    fn content_size(&self) -> Vector2F {
-        self.0.borrow().content_size()
-    }
-
-    fn scale_factor(&self) -> f32 {
-        self.0.borrow().scale_factor()
-    }
-
-    fn titlebar_height(&self) -> f32 {
-        0.
-    }
-
     fn present_scene(&mut self, scene: Scene) {
         self.0.borrow_mut().scene = Some(scene);
         unsafe {
@@ -253,12 +247,28 @@ impl platform::Window for StatusItem {
         }
     }
 
-    fn appearance(&self) -> crate::Appearance {
-        unsafe {
-            let appearance: id =
-                msg_send![self.0.borrow().native_item.button(), effectiveAppearance];
-            crate::Appearance::from_native(appearance)
-        }
+    fn toggle_full_screen(&self) {
+        unimplemented!()
+    }
+
+    fn on_event(&mut self, callback: Box<dyn FnMut(crate::Event) -> bool>) {
+        self.0.borrow_mut().event_callback = Some(callback);
+    }
+
+    fn on_active_status_change(&mut self, _: Box<dyn FnMut(bool)>) {}
+
+    fn on_resize(&mut self, _: Box<dyn FnMut()>) {}
+
+    fn on_fullscreen(&mut self, _: Box<dyn FnMut(bool)>) {}
+
+    fn on_moved(&mut self, _: Box<dyn FnMut()>) {}
+
+    fn on_should_close(&mut self, _: Box<dyn FnMut() -> bool>) {}
+
+    fn on_close(&mut self, _: Box<dyn FnOnce()>) {}
+
+    fn on_appearance_changed(&mut self, callback: Box<dyn FnMut()>) {
+        self.0.borrow_mut().appearance_changed_callback = Some(callback);
     }
 
     fn is_topmost_for_position(&self, _: Vector2F) -> bool {
@@ -267,9 +277,9 @@ impl platform::Window for StatusItem {
 }
 
 impl StatusItemState {
-    fn bounds(&self) -> RectF {
+    fn bounds(&self) -> WindowBounds {
         unsafe {
-            let window: id = msg_send![self.native_item.button(), window];
+            let window: id = self.native_window();
             let screen_frame = window.screen().visibleFrame();
             let window_frame = NSWindow::frame(window);
             let origin = vec2f(
@@ -281,7 +291,7 @@ impl StatusItemState {
                 window_frame.size.width as f32,
                 window_frame.size.height as f32,
             );
-            RectF::new(origin, size)
+            WindowBounds::Fixed(RectF::new(origin, size))
         }
     }
 
@@ -298,6 +308,10 @@ impl StatusItemState {
             let window: id = msg_send![self.native_item.button(), window];
             NSScreen::backingScaleFactor(window.screen()) as f32
         }
+    }
+
+    pub fn native_window(&self) -> id {
+        unsafe { msg_send![self.native_item.button(), window] }
     }
 }
 

--- a/crates/gpui/src/platform/mac/status_item.rs
+++ b/crates/gpui/src/platform/mac/status_item.rs
@@ -183,6 +183,8 @@ impl platform::Window for StatusItem {
 
     fn on_resize(&mut self, _: Box<dyn FnMut()>) {}
 
+    fn on_moved(&mut self, _: Box<dyn FnMut()>) {}
+
     fn on_fullscreen(&mut self, _: Box<dyn FnMut(bool)>) {}
 
     fn on_should_close(&mut self, _: Box<dyn FnMut() -> bool>) {}

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -40,6 +40,7 @@ pub struct Window {
     current_scene: Option<crate::Scene>,
     event_handlers: Vec<Box<dyn FnMut(super::Event) -> bool>>,
     pub(crate) resize_handlers: Vec<Box<dyn FnMut()>>,
+    pub(crate) moved_handlers: Vec<Box<dyn FnMut()>>,
     close_handlers: Vec<Box<dyn FnOnce()>>,
     fullscreen_handlers: Vec<Box<dyn FnMut(bool)>>,
     pub(crate) active_status_change_handlers: Vec<Box<dyn FnMut(bool)>>,
@@ -143,7 +144,7 @@ impl super::Platform for Platform {
         _executor: Rc<super::executor::Foreground>,
     ) -> Box<dyn super::Window> {
         Box::new(Window::new(match options.bounds {
-            WindowBounds::Maximized => vec2f(1024., 768.),
+            WindowBounds::Maximized | WindowBounds::Fullscreen => vec2f(1024., 768.),
             WindowBounds::Fixed(rect) => rect.size(),
         }))
     }
@@ -225,6 +226,7 @@ impl Window {
             size,
             event_handlers: Default::default(),
             resize_handlers: Default::default(),
+            moved_handlers: Default::default(),
             close_handlers: Default::default(),
             should_close_handler: Default::default(),
             active_status_change_handlers: Default::default(),
@@ -271,6 +273,10 @@ impl super::Window for Window {
 
     fn on_resize(&mut self, callback: Box<dyn FnMut()>) {
         self.resize_handlers.push(callback);
+    }
+
+    fn on_moved(&mut self, callback: Box<dyn FnMut()>) {
+        self.moved_handlers.push(callback);
     }
 
     fn on_close(&mut self, callback: Box<dyn FnOnce()>) {

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -234,8 +234,8 @@ impl super::Screen for Screen {
         self
     }
 
-    fn size(&self) -> Vector2F {
-        Vector2F::new(1920., 1080.)
+    fn bounds(&self) -> RectF {
+        RectF::new(Vector2F::zero(), Vector2F::new(1920., 1080.))
     }
 
     fn display_uuid(&self) -> uuid::Uuid {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -23,7 +23,7 @@ use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
 use smallvec::SmallVec;
 use sqlez::{
-    bindable::{Bind, Column, StaticRowComponent},
+    bindable::{Bind, Column, StaticColumnCount},
     statement::Statement,
 };
 use std::{
@@ -932,7 +932,7 @@ impl ToJson for Axis {
     }
 }
 
-impl StaticRowComponent for Axis {}
+impl StaticColumnCount for Axis {}
 impl Bind for Axis {
     fn bind(&self, statement: &Statement, start_index: i32) -> anyhow::Result<i32> {
         match self {

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -23,7 +23,7 @@ use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
 use smallvec::SmallVec;
 use sqlez::{
-    bindable::{Bind, Column},
+    bindable::{Bind, Column, StaticRowComponent},
     statement::Statement,
 };
 use std::{
@@ -932,6 +932,7 @@ impl ToJson for Axis {
     }
 }
 
+impl StaticRowComponent for Axis {}
 impl Bind for Axis {
     fn bind(&self, statement: &Statement, start_index: i32) -> anyhow::Result<i32> {
         match self {

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -15,7 +15,7 @@ use schemars::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use sqlez::{
-    bindable::{Bind, Column, StaticRowComponent},
+    bindable::{Bind, Column, StaticColumnCount},
     statement::Statement,
 };
 use std::{collections::HashMap, fmt::Write as _, num::NonZeroU32, str, sync::Arc};
@@ -253,7 +253,7 @@ pub enum DockAnchor {
     Expanded,
 }
 
-impl StaticRowComponent for DockAnchor {}
+impl StaticColumnCount for DockAnchor {}
 impl Bind for DockAnchor {
     fn bind(&self, statement: &Statement, start_index: i32) -> anyhow::Result<i32> {
         match self {

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -15,7 +15,7 @@ use schemars::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use sqlez::{
-    bindable::{Bind, Column},
+    bindable::{Bind, Column, StaticRowComponent},
     statement::Statement,
 };
 use std::{collections::HashMap, fmt::Write as _, num::NonZeroU32, str, sync::Arc};
@@ -253,6 +253,7 @@ pub enum DockAnchor {
     Expanded,
 }
 
+impl StaticRowComponent for DockAnchor {}
 impl Bind for DockAnchor {
     fn bind(&self, statement: &Statement, start_index: i32) -> anyhow::Result<i32> {
         match self {

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -15,3 +15,4 @@ thread_local = "1.1.4"
 lazy_static = "1.4"
 parking_lot = "0.11.1"
 futures = "0.3"
+uuid = { version = "1.1.2", features = ["v4"] }

--- a/crates/sqlez/src/bindable.rs
+++ b/crates/sqlez/src/bindable.rs
@@ -9,14 +9,37 @@ use anyhow::{Context, Result};
 
 use crate::statement::{SqlType, Statement};
 
-pub trait Bind {
+pub trait StaticRowComponent {
+    fn static_column_count() -> usize {
+        1
+    }
+}
+
+pub trait RowComponent {
+    fn column_count(&self) -> usize;
+}
+
+impl<T: StaticRowComponent> RowComponent for T {
+    fn column_count(&self) -> usize {
+        T::static_column_count()
+    }
+}
+
+impl<T: StaticRowComponent> StaticRowComponent for &T {
+    fn static_column_count() -> usize {
+        T::static_column_count()
+    }
+}
+
+pub trait Bind: RowComponent {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32>;
 }
 
-pub trait Column: Sized {
+pub trait Column: Sized + RowComponent {
     fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)>;
 }
 
+impl StaticRowComponent for bool {}
 impl Bind for bool {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -33,6 +56,7 @@ impl Column for bool {
     }
 }
 
+impl StaticRowComponent for &[u8] {}
 impl Bind for &[u8] {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -42,6 +66,7 @@ impl Bind for &[u8] {
     }
 }
 
+impl<const C: usize> StaticRowComponent for &[u8; C] {}
 impl<const C: usize> Bind for &[u8; C] {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -51,6 +76,7 @@ impl<const C: usize> Bind for &[u8; C] {
     }
 }
 
+impl StaticRowComponent for Vec<u8> {}
 impl Bind for Vec<u8> {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -70,6 +96,7 @@ impl Column for Vec<u8> {
     }
 }
 
+impl StaticRowComponent for f64 {}
 impl Bind for f64 {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -89,6 +116,7 @@ impl Column for f64 {
     }
 }
 
+impl StaticRowComponent for f32 {}
 impl Bind for f32 {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -109,6 +137,7 @@ impl Column for f32 {
     }
 }
 
+impl StaticRowComponent for i32 {}
 impl Bind for i32 {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -126,6 +155,7 @@ impl Column for i32 {
     }
 }
 
+impl StaticRowComponent for i64 {}
 impl Bind for i64 {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement
@@ -142,6 +172,7 @@ impl Column for i64 {
     }
 }
 
+impl StaticRowComponent for u32 {}
 impl Bind for u32 {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         (*self as i64)
@@ -157,6 +188,7 @@ impl Column for u32 {
     }
 }
 
+impl StaticRowComponent for usize {}
 impl Bind for usize {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         (*self as i64)
@@ -172,6 +204,7 @@ impl Column for usize {
     }
 }
 
+impl StaticRowComponent for &str {}
 impl Bind for &str {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement.bind_text(start_index, self)?;
@@ -179,6 +212,7 @@ impl Bind for &str {
     }
 }
 
+impl StaticRowComponent for Arc<str> {}
 impl Bind for Arc<str> {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement.bind_text(start_index, self.as_ref())?;
@@ -186,6 +220,7 @@ impl Bind for Arc<str> {
     }
 }
 
+impl StaticRowComponent for String {}
 impl Bind for String {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         statement.bind_text(start_index, self)?;
@@ -207,28 +242,41 @@ impl Column for String {
     }
 }
 
-impl<T: Bind> Bind for Option<T> {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
+impl<T: StaticRowComponent> StaticRowComponent for Option<T> {
+    fn static_column_count() -> usize {
+        T::static_column_count()
+    }
+}
+impl<T: Bind + StaticRowComponent> Bind for Option<T> {
+    fn bind(&self, statement: &Statement, mut start_index: i32) -> Result<i32> {
         if let Some(this) = self {
             this.bind(statement, start_index)
         } else {
-            statement.bind_null(start_index)?;
-            Ok(start_index + 1)
+            for _ in 0..T::static_column_count() {
+                statement.bind_null(start_index)?;
+                start_index += 1;
+            }
+            Ok(start_index)
         }
     }
 }
 
-impl<T: Column> Column for Option<T> {
+impl<T: Column + StaticRowComponent> Column for Option<T> {
     fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
         if let SqlType::Null = statement.column_type(start_index)? {
-            Ok((None, start_index + 1))
+            Ok((None, start_index + T::static_column_count() as i32))
         } else {
             T::column(statement, start_index).map(|(result, next_index)| (Some(result), next_index))
         }
     }
 }
 
-impl<T: Bind, const COUNT: usize> Bind for [T; COUNT] {
+impl<T: StaticRowComponent, const COUNT: usize> StaticRowComponent for [T; COUNT] {
+    fn static_column_count() -> usize {
+        T::static_column_count() * COUNT
+    }
+}
+impl<T: Bind + StaticRowComponent, const COUNT: usize> Bind for [T; COUNT] {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         let mut current_index = start_index;
         for binding in self {
@@ -239,7 +287,7 @@ impl<T: Bind, const COUNT: usize> Bind for [T; COUNT] {
     }
 }
 
-impl<T: Column + Default + Copy, const COUNT: usize> Column for [T; COUNT] {
+impl<T: Column + StaticRowComponent + Default + Copy, const COUNT: usize> Column for [T; COUNT] {
     fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
         let mut array = [Default::default(); COUNT];
         let mut current_index = start_index;
@@ -250,40 +298,21 @@ impl<T: Column + Default + Copy, const COUNT: usize> Column for [T; COUNT] {
     }
 }
 
-impl<T: Bind> Bind for Vec<T> {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
-        let mut current_index = start_index;
-        for binding in self.iter() {
-            current_index = binding.bind(statement, current_index)?
-        }
-
-        Ok(current_index)
-    }
-}
-
-impl<T: Bind> Bind for &[T] {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
-        let mut current_index = start_index;
-        for binding in *self {
-            current_index = binding.bind(statement, current_index)?
-        }
-
-        Ok(current_index)
-    }
-}
-
+impl StaticRowComponent for &Path {}
 impl Bind for &Path {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         self.as_os_str().as_bytes().bind(statement, start_index)
     }
 }
 
+impl StaticRowComponent for Arc<Path> {}
 impl Bind for Arc<Path> {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         self.as_ref().bind(statement, start_index)
     }
 }
 
+impl StaticRowComponent for PathBuf {}
 impl Bind for PathBuf {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         (self.as_ref() as &Path).bind(statement, start_index)
@@ -301,6 +330,11 @@ impl Column for PathBuf {
     }
 }
 
+impl StaticRowComponent for () {
+    fn static_column_count() -> usize {
+        0
+    }
+}
 /// Unit impls do nothing. This simplifies query macros
 impl Bind for () {
     fn bind(&self, _statement: &Statement, start_index: i32) -> Result<i32> {
@@ -314,74 +348,80 @@ impl Column for () {
     }
 }
 
-impl<T1: Bind, T2: Bind> Bind for (T1, T2) {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
-        let next_index = self.0.bind(statement, start_index)?;
-        self.1.bind(statement, next_index)
+macro_rules! impl_tuple_row_traits {
+    ( $($local:ident: $type:ident),+ ) => {
+        impl<$($type: RowComponent),+> RowComponent for ($($type,)+) {
+            fn column_count(&self) -> usize {
+                let ($($local,)+) = self;
+                let mut count = 0;
+                $(count += $local.column_count();)+
+                count
+            }
+        }
+
+        impl<$($type: Bind),+> Bind for ($($type,)+) {
+            fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
+                let mut next_index = start_index;
+                let ($($local,)+) = self;
+                $(next_index = $local.bind(statement, next_index)?;)+
+                Ok(next_index)
+            }
+        }
+
+        impl<$($type: Column),+> Column for ($($type,)+) {
+            fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
+                let mut next_index = start_index;
+                Ok((
+                    (
+                        $({
+                            let value;
+                            (value, next_index) = $type::column(statement, next_index)?;
+                            value
+                        },)+
+                    ),
+                    next_index,
+                ))
+            }
+        }
     }
 }
 
-impl<T1: Column, T2: Column> Column for (T1, T2) {
-    fn column<'a>(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
-        let (first, next_index) = T1::column(statement, start_index)?;
-        let (second, next_index) = T2::column(statement, next_index)?;
-        Ok(((first, second), next_index))
-    }
-}
-
-impl<T1: Bind, T2: Bind, T3: Bind> Bind for (T1, T2, T3) {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
-        let next_index = self.0.bind(statement, start_index)?;
-        let next_index = self.1.bind(statement, next_index)?;
-        self.2.bind(statement, next_index)
-    }
-}
-
-impl<T1: Column, T2: Column, T3: Column> Column for (T1, T2, T3) {
-    fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
-        let (first, next_index) = T1::column(statement, start_index)?;
-        let (second, next_index) = T2::column(statement, next_index)?;
-        let (third, next_index) = T3::column(statement, next_index)?;
-        Ok(((first, second, third), next_index))
-    }
-}
-
-impl<T1: Bind, T2: Bind, T3: Bind, T4: Bind> Bind for (T1, T2, T3, T4) {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
-        let next_index = self.0.bind(statement, start_index)?;
-        let next_index = self.1.bind(statement, next_index)?;
-        let next_index = self.2.bind(statement, next_index)?;
-        self.3.bind(statement, next_index)
-    }
-}
-
-impl<T1: Column, T2: Column, T3: Column, T4: Column> Column for (T1, T2, T3, T4) {
-    fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
-        let (first, next_index) = T1::column(statement, start_index)?;
-        let (second, next_index) = T2::column(statement, next_index)?;
-        let (third, next_index) = T3::column(statement, next_index)?;
-        let (fourth, next_index) = T4::column(statement, next_index)?;
-        Ok(((first, second, third, fourth), next_index))
-    }
-}
-
-impl<T1: Bind, T2: Bind, T3: Bind, T4: Bind, T5: Bind> Bind for (T1, T2, T3, T4, T5) {
-    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
-        let next_index = self.0.bind(statement, start_index)?;
-        let next_index = self.1.bind(statement, next_index)?;
-        let next_index = self.2.bind(statement, next_index)?;
-        let next_index = self.3.bind(statement, next_index)?;
-        self.4.bind(statement, next_index)
-    }
-}
-
-impl<T1: Column, T2: Column, T3: Column, T4: Column, T5: Column> Column for (T1, T2, T3, T4, T5) {
-    fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
-        let (first, next_index) = T1::column(statement, start_index)?;
-        let (second, next_index) = T2::column(statement, next_index)?;
-        let (third, next_index) = T3::column(statement, next_index)?;
-        let (fourth, next_index) = T4::column(statement, next_index)?;
-        let (fifth, next_index) = T5::column(statement, next_index)?;
-        Ok(((first, second, third, fourth, fifth), next_index))
-    }
-}
+impl_tuple_row_traits!(t1: T1, t2: T2);
+impl_tuple_row_traits!(t1: T1, t2: T2, t3: T3);
+impl_tuple_row_traits!(t1: T1, t2: T2, t3: T3, t4: T4);
+impl_tuple_row_traits!(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5);
+impl_tuple_row_traits!(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6);
+impl_tuple_row_traits!(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7);
+impl_tuple_row_traits!(
+    t1: T1,
+    t2: T2,
+    t3: T3,
+    t4: T4,
+    t5: T5,
+    t6: T6,
+    t7: T7,
+    t8: T8
+);
+impl_tuple_row_traits!(
+    t1: T1,
+    t2: T2,
+    t3: T3,
+    t4: T4,
+    t5: T5,
+    t6: T6,
+    t7: T7,
+    t8: T8,
+    t9: T9
+);
+impl_tuple_row_traits!(
+    t1: T1,
+    t2: T2,
+    t3: T3,
+    t4: T4,
+    t5: T5,
+    t6: T6,
+    t7: T7,
+    t8: T8,
+    t9: T9,
+    t10: T10
+);

--- a/crates/sqlez/src/statement.rs
+++ b/crates/sqlez/src/statement.rs
@@ -238,15 +238,11 @@ impl<'a> Statement<'a> {
 
     pub fn bind<T: Bind>(&self, value: T, index: i32) -> Result<i32> {
         debug_assert!(index > 0);
-        let after = value.bind(self, index)?;
-        debug_assert_eq!((after - index) as usize, value.column_count());
-        Ok(after)
+        Ok(value.bind(self, index)?)
     }
 
     pub fn column<T: Column>(&mut self) -> Result<T> {
-        let (result, after) = T::column(self, 0)?;
-        debug_assert_eq!(T::column_count(&result), after as usize);
-        Ok(result)
+        Ok(T::column(self, 0)?.0)
     }
 
     pub fn column_type(&mut self, index: i32) -> Result<SqlType> {
@@ -263,9 +259,7 @@ impl<'a> Statement<'a> {
     }
 
     pub fn with_bindings(&mut self, bindings: impl Bind) -> Result<&mut Self> {
-        let column_count = bindings.column_count();
-        let after = self.bind(bindings, 1)?;
-        debug_assert_eq!((after - 1) as usize, column_count);
+        self.bind(bindings, 1)?;
         Ok(self)
     }
 

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -46,6 +46,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 smallvec = { version = "1.6", features = ["union"] }
 indoc = "1.0.4"
+uuid = { version = "1.1.2", features = ["v4"] }
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -534,6 +534,8 @@ mod tests {
                 }],
             },
             left_sidebar_open: false,
+            fullscreen: false,
+            bounds: Default::default(),
         };
 
         let fs = FakeFs::new(cx.background());

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -534,8 +534,8 @@ mod tests {
                 }],
             },
             left_sidebar_open: false,
-            fullscreen: false,
             bounds: Default::default(),
+            display: Default::default(),
         };
 
         let fs = FakeFs::new(cx.background());

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -6,9 +6,7 @@ use std::{
 use anyhow::{Context, Result};
 
 use async_recursion::async_recursion;
-use gpui::{
-    geometry::rect::RectF, AsyncAppContext, Axis, ModelHandle, Task, ViewHandle, WindowBounds,
-};
+use gpui::{AsyncAppContext, Axis, ModelHandle, Task, ViewHandle, WindowBounds};
 
 use db::sqlez::{
     bindable::{Bind, Column, StaticColumnCount},
@@ -17,6 +15,7 @@ use db::sqlez::{
 use project::Project;
 use settings::DockAnchor;
 use util::ResultExt;
+use uuid::Uuid;
 
 use crate::{
     dock::DockPosition, ItemDeserializers, Member, Pane, PaneAxis, Workspace, WorkspaceId,
@@ -69,20 +68,8 @@ pub struct SerializedWorkspace {
     pub center_group: SerializedPaneGroup,
     pub dock_pane: SerializedPane,
     pub left_sidebar_open: bool,
-    pub fullscreen: bool,
-    pub bounds: Option<RectF>,
-}
-
-impl SerializedWorkspace {
-    pub fn bounds(&self) -> WindowBounds {
-        if self.fullscreen {
-            WindowBounds::Fullscreen
-        } else if let Some(bounds) = self.bounds {
-            WindowBounds::Fixed(bounds)
-        } else {
-            WindowBounds::Maximized
-        }
-    }
+    pub bounds: Option<WindowBounds>,
+    pub display: Option<Uuid>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 
 use db::sqlez::{
-    bindable::{Bind, Column, StaticRowComponent},
+    bindable::{Bind, Column, StaticColumnCount},
     statement::Statement,
 };
 use project::Project;
@@ -42,7 +42,7 @@ impl<P: AsRef<Path>, T: IntoIterator<Item = P>> From<T> for WorkspaceLocation {
     }
 }
 
-impl StaticRowComponent for WorkspaceLocation {}
+impl StaticColumnCount for WorkspaceLocation {}
 impl Bind for &WorkspaceLocation {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         bincode::serialize(&self.0)
@@ -254,8 +254,8 @@ impl Default for SerializedItem {
     }
 }
 
-impl StaticRowComponent for SerializedItem {
-    fn static_column_count() -> usize {
+impl StaticColumnCount for SerializedItem {
+    fn column_count() -> usize {
         3
     }
 }
@@ -283,8 +283,8 @@ impl Column for SerializedItem {
     }
 }
 
-impl StaticRowComponent for DockPosition {
-    fn static_column_count() -> usize {
+impl StaticColumnCount for DockPosition {
+    fn column_count() -> usize {
         2
     }
 }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -111,6 +111,7 @@ tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev =
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a"}
 url = "2.2"
 urlencoding = "2.1.2"
+uuid = { version = "1.1.2", features = ["v4"] }
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -369,12 +369,15 @@ pub fn initialize_workspace(
     });
 }
 
-pub fn build_window_options() -> WindowOptions<'static> {
-    let bounds = if let Some((position, size)) = ZED_WINDOW_POSITION.zip(*ZED_WINDOW_SIZE) {
-        WindowBounds::Fixed(RectF::new(position, size))
-    } else {
-        WindowBounds::Maximized
-    };
+pub fn build_window_options(bounds: Option<WindowBounds>) -> WindowOptions<'static> {
+    let bounds = bounds
+        .or_else(|| {
+            ZED_WINDOW_POSITION
+                .zip(*ZED_WINDOW_SIZE)
+                .map(|(position, size)| WindowBounds::Fixed(RectF::new(position, size)))
+        })
+        .unwrap_or(WindowBounds::Maximized);
+
     WindowOptions {
         bounds,
         titlebar: Some(TitlebarOptions {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -20,8 +20,7 @@ use gpui::{
     },
     impl_actions,
     platform::{WindowBounds, WindowOptions},
-    AssetSource, AsyncAppContext, ClipboardItem, Platform, PromptLevel, TitlebarOptions,
-    ViewContext, WindowKind,
+    AssetSource, AsyncAppContext, Platform, PromptLevel, TitlebarOptions, ViewContext, WindowKind,
 };
 use language::Rope;
 use lazy_static::lazy_static;


### PR DESCRIPTION
## Description of feature or change

Stores the workspace position in the persistence db.
Adds the ability to check whether the window is fullscreen.
Stores the screen the window was on with a reasonable fallback.
Refactors window trait's bounds function to return the WindowBounds struct

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
