### PR TITLE
Add "Close Window" global action which does not need a focused workspace

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -875,7 +875,7 @@ impl MutableAppContext {
     }
 
     pub fn window_ids(&self) -> impl Iterator<Item = usize> + '_ {
-        self.cx.windows.keys().cloned()
+        self.cx.windows.keys().copied()
     }
 
     pub fn activate_window(&self, window_id: usize) {


### PR DESCRIPTION
## Description of feature or change

Allows firing "Close Window" keyboard shortcut or menubar entry in windows which do not have a focused workspace, IE a window which has lost the connection to the remote project