### PR TITLE
Load languages lazily in the background

### DIFF
--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -51,7 +51,7 @@ fn test_line_endings(cx: &mut gpui::MutableAppContext) {
 
 #[gpui::test]
 fn test_select_language() {
-    let registry = LanguageRegistry::test();
+    let registry = Arc::new(LanguageRegistry::test());
     registry.add(Arc::new(Language::new(
         LanguageConfig {
             name: "Rust".into(),
@@ -71,27 +71,33 @@ fn test_select_language() {
 
     // matching file extension
     assert_eq!(
-        registry.select_language("zed/lib.rs").map(|l| l.name()),
+        registry.language_for_path("zed/lib.rs").map(|l| l.name()),
         Some("Rust".into())
     );
     assert_eq!(
-        registry.select_language("zed/lib.mk").map(|l| l.name()),
+        registry.language_for_path("zed/lib.mk").map(|l| l.name()),
         Some("Make".into())
     );
 
     // matching filename
     assert_eq!(
-        registry.select_language("zed/Makefile").map(|l| l.name()),
+        registry.language_for_path("zed/Makefile").map(|l| l.name()),
         Some("Make".into())
     );
 
     // matching suffix that is not the full file extension or filename
-    assert_eq!(registry.select_language("zed/cars").map(|l| l.name()), None);
     assert_eq!(
-        registry.select_language("zed/a.cars").map(|l| l.name()),
+        registry.language_for_path("zed/cars").map(|l| l.name()),
         None
     );
-    assert_eq!(registry.select_language("zed/sumk").map(|l| l.name()), None);
+    assert_eq!(
+        registry.language_for_path("zed/a.cars").map(|l| l.name()),
+        None
+    );
+    assert_eq!(
+        registry.language_for_path("zed/sumk").map(|l| l.name()),
+        None
+    );
 }
 
 #[gpui::test]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1802,7 +1802,7 @@ impl Project {
     ) -> Option<()> {
         // If the buffer has a language, set it and start the language server if we haven't already.
         let full_path = buffer.read(cx).file()?.full_path(cx);
-        let new_language = self.languages.select_language(&full_path)?;
+        let new_language = self.languages.language_for_path(&full_path)?;
         buffer.update(cx, |buffer, cx| {
             if buffer.language().map_or(true, |old_language| {
                 !Arc::ptr_eq(old_language, &new_language)
@@ -2211,7 +2211,7 @@ impl Project {
             })
             .collect();
         for (worktree_id, worktree_abs_path, full_path) in language_server_lookup_info {
-            let language = self.languages.select_language(&full_path)?;
+            let language = self.languages.language_for_path(&full_path)?;
             self.restart_language_server(worktree_id, worktree_abs_path, language, cx);
         }
 
@@ -3171,7 +3171,7 @@ impl Project {
                             let signature = this.symbol_signature(&project_path);
                             let language = this
                                 .languages
-                                .select_language(&project_path.path)
+                                .language_for_path(&project_path.path)
                                 .unwrap_or(adapter_language.clone());
                             let language_server_name = adapter.name.clone();
                             Some(async move {
@@ -5947,7 +5947,7 @@ impl Project {
                 worktree_id,
                 path: PathBuf::from(serialized_symbol.path).into(),
             };
-            let language = languages.select_language(&path.path);
+            let language = languages.language_for_path(&path.path);
             Ok(Symbol {
                 language_server_name: LanguageServerName(
                     serialized_symbol.language_server_name.into(),

--- a/crates/zed/src/languages/c.rs
+++ b/crates/zed/src/languages/c.rs
@@ -248,17 +248,19 @@ impl super::LspAdapter for CLspAdapter {
 
 #[cfg(test)]
 mod tests {
-    use gpui::MutableAppContext;
+    use gpui::TestAppContext;
     use language::{AutoindentMode, Buffer};
     use settings::Settings;
 
     #[gpui::test]
-    fn test_c_autoindent(cx: &mut MutableAppContext) {
+    async fn test_c_autoindent(cx: &mut TestAppContext) {
         cx.foreground().set_block_on_ticks(usize::MAX..=usize::MAX);
-        let mut settings = Settings::test(cx);
-        settings.editor_overrides.tab_size = Some(2.try_into().unwrap());
-        cx.set_global(settings);
-        let language = crate::languages::language("c", tree_sitter_c::language(), None);
+        cx.update(|cx| {
+            let mut settings = Settings::test(cx);
+            settings.editor_overrides.tab_size = Some(2.try_into().unwrap());
+            cx.set_global(settings);
+        });
+        let language = crate::languages::language("c", tree_sitter_c::language(), None).await;
 
         cx.add_model(|cx| {
             let mut buffer = Buffer::new(0, "", cx).with_language(language, cx);

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -314,8 +314,9 @@ mod tests {
         let language = language(
             "go",
             tree_sitter_go::language(),
-            Some(CachedLspAdapter::new(GoLspAdapter).await),
-        );
+            Some(Box::new(GoLspAdapter)),
+        )
+        .await;
 
         let theme = SyntaxTheme::new(vec![
             ("type".into(), Color::green().into()),

--- a/crates/zed/src/languages/python.rs
+++ b/crates/zed/src/languages/python.rs
@@ -165,17 +165,20 @@ impl LspAdapter for PythonLspAdapter {
 
 #[cfg(test)]
 mod tests {
-    use gpui::{ModelContext, MutableAppContext};
+    use gpui::{ModelContext, TestAppContext};
     use language::{AutoindentMode, Buffer};
     use settings::Settings;
 
     #[gpui::test]
-    fn test_python_autoindent(cx: &mut MutableAppContext) {
+    async fn test_python_autoindent(cx: &mut TestAppContext) {
         cx.foreground().set_block_on_ticks(usize::MAX..=usize::MAX);
-        let language = crate::languages::language("python", tree_sitter_python::language(), None);
-        let mut settings = Settings::test(cx);
-        settings.editor_overrides.tab_size = Some(2.try_into().unwrap());
-        cx.set_global(settings);
+        let language =
+            crate::languages::language("python", tree_sitter_python::language(), None).await;
+        cx.update(|cx| {
+            let mut settings = Settings::test(cx);
+            settings.editor_overrides.tab_size = Some(2.try_into().unwrap());
+            cx.set_global(settings);
+        });
 
         cx.add_model(|cx| {
             let mut buffer = Buffer::new(0, "", cx).with_language(language, cx);

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -154,17 +154,17 @@ impl LspAdapter for TypeScriptLspAdapter {
 
 #[cfg(test)]
 mod tests {
-
-    use gpui::MutableAppContext;
+    use gpui::TestAppContext;
     use unindent::Unindent;
 
     #[gpui::test]
-    fn test_outline(cx: &mut MutableAppContext) {
+    async fn test_outline(cx: &mut TestAppContext) {
         let language = crate::languages::language(
             "typescript",
             tree_sitter_typescript::language_typescript(),
             None,
-        );
+        )
+        .await;
 
         let text = r#"
             function a() {
@@ -183,7 +183,7 @@ mod tests {
 
         let buffer =
             cx.add_model(|cx| language::Buffer::new(0, text, cx).with_language(language, cx));
-        let outline = buffer.read(cx).snapshot().outline(None).unwrap();
+        let outline = buffer.read_with(cx, |buffer, _| buffer.snapshot().outline(None).unwrap());
         assert_eq!(
             outline
                 .items

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -120,11 +120,10 @@ fn main() {
 
         let client = client::Client::new(http.clone(), cx);
         let mut languages = LanguageRegistry::new(login_shell_env_loaded);
+        languages.set_executor(cx.background().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());
         let languages = Arc::new(languages);
-        let init_languages = cx
-            .background()
-            .spawn(languages::init(languages.clone(), cx.background().clone()));
+        languages::init(languages.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
 
         watch_keymap_file(keymap_file, cx);
@@ -152,14 +151,7 @@ fn main() {
         cx.spawn(|cx| watch_themes(fs.clone(), themes.clone(), cx))
             .detach();
 
-        cx.spawn({
-            let languages = languages.clone();
-            |cx| async move {
-                cx.read(|cx| languages.set_theme(cx.global::<Settings>().theme.clone()));
-                init_languages.await;
-            }
-        })
-        .detach();
+        languages.set_theme(cx.global::<Settings>().theme.clone());
         cx.observe_global::<Settings, _>({
             let languages = languages.clone();
             move |cx| languages.set_theme(cx.global::<Settings>().theme.clone())

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -306,7 +306,7 @@ pub fn initialize_workspace(
         )
         .map(|meta| meta.name)
         .collect();
-    let language_names = &languages::LANGUAGE_NAMES;
+    let language_names = app_state.languages.language_names();
 
     workspace.project().update(cx, |project, cx| {
         let action_names = cx.all_action_names().collect::<Vec<_>>();
@@ -318,7 +318,7 @@ pub fn initialize_workspace(
                 "schemas": [
                     {
                         "fileMatch": [schema_file_match(&paths::SETTINGS)],
-                        "schema": settings_file_json_schema(theme_names, language_names),
+                        "schema": settings_file_json_schema(theme_names, &language_names),
                     },
                     {
                         "fileMatch": [schema_file_match(&paths::KEYMAP)],


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/2080

### Problem

Previously, we loaded all of the built-in languages on startup, in a single background task. The languages were loaded in a fixed order, so if you restored a workspace that used languages that were loaded *later* in the task, then there would be a long delay before you saw syntax highlighting.

###  Solution

This PR adjusts our handling of the built-in languages so that we *register* then synchronously up-front (providing their TOML configuration), but avoid loading them right away. Then, when opening a buffer that needs one of these languages (which we can identify from the name and file extensions in the TOML config), we load it that language as-needed.

This means that when starting Zed up, and restoring a workspace, we immediately start loading the languages that we need (due to deserializing the buffers), as opposed to queuing them up behind other languages that we don't care about. I also think this scales better as we add more languages.

### Possible Follow-ups

The slowest language to load is Elixir: something particular about that grammar makes it take > 10x longer to validate queries. Fortunately, this problem has already been fully addressed in Tree-sitter core: https://github.com/tree-sitter/tree-sitter/pull/1589 and https://github.com/tree-sitter/tree-sitter/pull/1852. We just haven't yet re-generated the Elixir parser with this latest version of Tree-sitter. Doing that should bring down the time to load the queries below 100ms.