### PR TITLE
Omit hidden worktrees when showing projects in collaboration UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "v*"
+      - "v[0-9]+.[0-9]+.x"
     tags:
       - "v*"
   pull_request:

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -1924,7 +1924,9 @@ impl Database {
                 };
 
                 if let Some(db_worktree) = db_worktree {
-                    project.worktree_root_names.push(db_worktree.root_name);
+                    if db_worktree.visible {
+                        project.worktree_root_names.push(db_worktree.root_name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This way, in the call notification and collaboration menu, you won't see the names of hidden, single-file worktrees.