### PR TITLE
Added build-licenses command to style tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /assets/themes/*.json
 /assets/themes/Internal/*.json
 /assets/themes/Experiments/*.json
-/assets/licenses.md
+/assets/*licenses.md
 **/venv
 .build
 Packages

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -339,7 +339,11 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Action {
                     name: "View Dependency Licenses",
-                    action: Box::new(crate::OpenLicenses),
+                    action: Box::new(crate::OpenSoftwareLicenses),
+                },
+                MenuItem::Action {
+                    name: "View Theme Licenses",
+                    action: Box::new(crate::OpenThemeLicenses),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -339,11 +339,7 @@ pub fn menus() -> Vec<Menu<'static>> {
                 },
                 MenuItem::Action {
                     name: "View Dependency Licenses",
-                    action: Box::new(crate::OpenSoftwareLicenses),
-                },
-                MenuItem::Action {
-                    name: "View Theme Licenses",
-                    action: Box::new(crate::OpenThemeLicenses),
+                    action: Box::new(crate::OpenLicenses),
                 },
                 MenuItem::Separator,
                 MenuItem::Action {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -57,7 +57,8 @@ actions!(
         DebugElements,
         OpenSettings,
         OpenLog,
-        OpenLicenses,
+        OpenSoftwareLicenses,
+        OpenThemeLicenses,
         OpenTelemetryLog,
         OpenKeymap,
         OpenDefaultSettings,
@@ -179,12 +180,27 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     });
     cx.add_action({
         let app_state = app_state.clone();
-        move |workspace: &mut Workspace, _: &OpenLicenses, cx: &mut ViewContext<Workspace>| {
+        move |workspace: &mut Workspace,
+              _: &OpenSoftwareLicenses,
+              cx: &mut ViewContext<Workspace>| {
             open_bundled_file(
                 workspace,
                 app_state.clone(),
-                "licenses.md",
+                "software_licenses.md",
                 "Open Source License Attribution",
+                "Markdown",
+                cx,
+            );
+        }
+    });
+    cx.add_action({
+        let app_state = app_state.clone();
+        move |workspace: &mut Workspace, _: &OpenThemeLicenses, cx: &mut ViewContext<Workspace>| {
+            open_bundled_file(
+                workspace,
+                app_state.clone(),
+                "theme_licenses.md",
+                "Theme License Attribution",
                 "Markdown",
                 cx,
             );

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -57,8 +57,7 @@ actions!(
         DebugElements,
         OpenSettings,
         OpenLog,
-        OpenSoftwareLicenses,
-        OpenThemeLicenses,
+        OpenLicenses,
         OpenTelemetryLog,
         OpenKeymap,
         OpenDefaultSettings,
@@ -180,27 +179,12 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     });
     cx.add_action({
         let app_state = app_state.clone();
-        move |workspace: &mut Workspace,
-              _: &OpenSoftwareLicenses,
-              cx: &mut ViewContext<Workspace>| {
+        move |workspace: &mut Workspace, _: &OpenLicenses, cx: &mut ViewContext<Workspace>| {
             open_bundled_file(
                 workspace,
                 app_state.clone(),
-                "software_licenses.md",
+                "licenses.md",
                 "Open Source License Attribution",
-                "Markdown",
-                cx,
-            );
-        }
-    });
-    cx.add_action({
-        let app_state = app_state.clone();
-        move |workspace: &mut Workspace, _: &OpenThemeLicenses, cx: &mut ViewContext<Workspace>| {
-            open_bundled_file(
-                workspace,
-                app_state.clone(),
-                "theme_licenses.md",
-                "Theme License Attribution",
                 "Markdown",
                 cx,
             );

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -4,12 +4,18 @@ set -e
 
 [[ "$(cargo about --version)" == "cargo-about 0.5.2" ]] || cargo install cargo-about --locked --git https://github.com/zed-industries/cargo-about --branch error-code-on-warn
 
-cargo about generate --fail-on-missing-license -o assets/licenses.md -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md
+echo "Generating cargo licenses"
+cargo about generate --fail-on-missing-license -o assets/software_licenses.md -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md
 
 # cargo about automatically html-escapes all output, so we need to undo it here: 
-sed -i '' 's/&quot;/"/g' assets/licenses.md
-sed -i '' 's/&#x27;/'\''/g' assets/licenses.md # `'\''` ends the string, appends a single quote, and re-opens the string
-sed -i '' 's/&#x3D;/=/g' assets/licenses.md
-sed -i '' 's/&#x60;/`/g' assets/licenses.md
-sed -i '' 's/&lt;/</g' assets/licenses.md
-sed -i '' 's/&gt;/>/g' assets/licenses.md
+sed -i '' 's/&quot;/"/g' assets/software_licenses.md
+sed -i '' 's/&#x27;/'\''/g' assets/software_licenses.md # `'\''` ends the string, appends a single quote, and re-opens the string
+sed -i '' 's/&#x3D;/=/g' assets/software_licenses.md
+sed -i '' 's/&#x60;/`/g' assets/software_licenses.md
+sed -i '' 's/&lt;/</g' assets/software_licenses.md
+sed -i '' 's/&gt;/>/g' assets/software_licenses.md
+
+# Now make theme licenses
+echo "Generating theme licenses"
+cd styles
+npm run build-licenses

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -2,20 +2,27 @@
 
 set -e
 
+OUTPUT_FILE=$(pwd)/assets/licenses.md
+
+> $OUTPUT_FILE
+
+echo -e "# ###### THEME LICENSES ######\n" >> $OUTPUT_FILE
+
+echo "Generating theme licenses"
+cd styles
+npm run --silent build-licenses >> $OUTPUT_FILE
+cd ..
+
+echo -e "# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
+
 [[ "$(cargo about --version)" == "cargo-about 0.5.2" ]] || cargo install cargo-about --locked --git https://github.com/zed-industries/cargo-about --branch error-code-on-warn
 
 echo "Generating cargo licenses"
-cargo about generate --fail-on-missing-license -o assets/software_licenses.md -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md
+cargo about generate --fail-on-missing-license -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md >> $OUTPUT_FILE
 
-# cargo about automatically html-escapes all output, so we need to undo it here: 
-sed -i '' 's/&quot;/"/g' assets/software_licenses.md
-sed -i '' 's/&#x27;/'\''/g' assets/software_licenses.md # `'\''` ends the string, appends a single quote, and re-opens the string
-sed -i '' 's/&#x3D;/=/g' assets/software_licenses.md
-sed -i '' 's/&#x60;/`/g' assets/software_licenses.md
-sed -i '' 's/&lt;/</g' assets/software_licenses.md
-sed -i '' 's/&gt;/>/g' assets/software_licenses.md
-
-# Now make theme licenses
-echo "Generating theme licenses"
-cd styles
-npm run build-licenses
+sed -i '' 's/&quot;/"/g' $OUTPUT_FILE
+sed -i '' 's/&#x27;/'\''/g' $OUTPUT_FILE # The ` '\'' ` thing ends the string, appends a single quote, and re-opens the string
+sed -i '' 's/&#x3D;/=/g' $OUTPUT_FILE
+sed -i '' 's/&#x60;/`/g' $OUTPUT_FILE
+sed -i '' 's/&lt;/</g' $OUTPUT_FILE
+sed -i '' 's/&gt;/>/g' $OUTPUT_FILE

--- a/script/licenses/template.hbs.md
+++ b/script/licenses/template.hbs.md
@@ -1,20 +1,15 @@
-# Third Party Licenses
-
-This page lists the licenses of the projects used in Zed.
-
 ## Overview of licenses:
 
 {{#each overview}}
 * {{name}} ({{count}})
 {{/each}}
 
-## All license texts:
-
+### All license texts:
 {{#each licenses}}
 
-### {{name}}
+#### {{name}}
   
-#### Used by:
+##### Used by:
 
 {{#each used_by}}
 * [{{crate.name}} {{crate.version}}]({{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}})
@@ -23,5 +18,4 @@ This page lists the licenses of the projects used in Zed.
 {{text}}
 
 --------------------------------------------------------------------------------
-           
 {{/each}}

--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -1,3 +1,5 @@
+# NOTE: This file's location is hardcoded into the theme build system in 
+# styles/src/buildLicenses.ts
 no-clearly-defined = true
 private = { ignore = true }
 accepted = [

--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -1,316 +1,327 @@
 {
-  "name": "styles",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "styles",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "@types/chroma-js": "^2.1.3",
-        "@types/node": "^17.0.23",
-        "case-anything": "^2.1.10",
-        "chroma-js": "^2.4.2",
-        "ts-node": "^10.7.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
-    },
-    "node_modules/@types/chroma-js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
-      "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
-    },
-    "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
-    },
-    "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
-    "node_modules/case-anything": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.10.tgz",
-      "integrity": "sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/chroma-js": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
-      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "node_modules/ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
+    "name": "styles",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "styles",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "@types/chroma-js": "^2.1.3",
+                "@types/node": "^17.0.23",
+                "case-anything": "^2.1.10",
+                "chroma-js": "^2.4.2",
+                "toml": "^3.0.0",
+                "ts-node": "^10.7.0"
+            }
         },
-        "@swc/wasm": {
-          "optional": true
+        "node_modules/@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "dependencies": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+        },
+        "node_modules/@types/chroma-js": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
+            "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
+        },
+        "node_modules/@types/node": {
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+        },
+        "node_modules/acorn": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
+        "node_modules/case-anything": {
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.10.tgz",
+            "integrity": "sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ==",
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
+        "node_modules/chroma-js": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+            "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "node_modules/toml": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+        },
+        "node_modules/ts-node": {
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.0",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+            "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "engines": {
+                "node": ">=6"
+            }
         }
-      }
     },
-    "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "engines": {
-        "node": ">=6"
-      }
+    "dependencies": {
+        "@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "requires": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            }
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+        },
+        "@types/chroma-js": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
+            "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
+        },
+        "@types/node": {
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+        },
+        "acorn": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
+        "acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
+        "case-anything": {
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.10.tgz",
+            "integrity": "sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ=="
+        },
+        "chroma-js": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+            "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "toml": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+        },
+        "ts-node": {
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+            "requires": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.0",
+                "yn": "3.1.1"
+            }
+        },
+        "typescript": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "peer": true
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+            "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+        }
     }
-  },
-  "dependencies": {
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
-      }
-    },
-    "@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
-    },
-    "@types/chroma-js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
-      "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
-    },
-    "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
-    },
-    "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
-    },
-    "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
-    "case-anything": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.10.tgz",
-      "integrity": "sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ=="
-    },
-    "chroma-js": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
-      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
-      "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
-        "yn": "3.1.1"
-      }
-    },
-    "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "peer": true
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
-    }
-  }
 }

--- a/styles/package.json
+++ b/styles/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "build": "ts-node ./src/buildThemes.ts"
+        "build": "ts-node ./src/buildThemes.ts",
+        "build-licenses": "ts-node ./src/buildLicenses.ts"
     },
     "author": "",
     "license": "ISC",
@@ -13,6 +14,7 @@
         "@types/node": "^17.0.23",
         "case-anything": "^2.1.10",
         "chroma-js": "^2.4.2",
+        "toml": "^3.0.0",
         "ts-node": "^10.7.0"
     }
 }

--- a/styles/src/buildLicenses.ts
+++ b/styles/src/buildLicenses.ts
@@ -6,7 +6,7 @@ import {
 import { Meta } from "./themes/common/colorScheme";
 import https from "https";
 import crypto from "crypto";
-const license_file = `${__dirname}/../../assets/theme_licenses.md`
+
 const accepted_licenses_file = `${__dirname}/../../script/licenses/zed-licenses.toml`
 
 // Use the cargo-about configuration file as the source of truth for supported licenses.
@@ -62,14 +62,13 @@ function getLicenseText(schemeMeta: Meta[], callback: (meta: Meta, license_text:
   }
 }
 
-function writeLicense(schemeMeta: Meta, text: String, stream: fs.WriteStream) {
-  stream.write(`# [${schemeMeta.name}](${schemeMeta.url})\n\n${text}\n******************************************************************************** \n`)
+function writeLicense(schemeMeta: Meta, text: String) {
+  process.stdout.write(`## [${schemeMeta.name}](${schemeMeta.url})\n\n${text}\n********************************************************************************\n\n`)
 }
 
 const accepted_licenses = parseAcceptedToml(accepted_licenses_file);
 checkLicenses(schemeMeta, accepted_licenses)
 
-const stream = fs.createWriteStream(license_file);
 getLicenseText(schemeMeta, (meta, text) => {
-  writeLicense(meta, text, stream)
+  writeLicense(meta, text)
 });

--- a/styles/src/buildLicenses.ts
+++ b/styles/src/buildLicenses.ts
@@ -1,0 +1,75 @@
+import * as fs from "fs";
+import toml from "toml";
+import {
+  schemeMeta
+} from "./colorSchemes";
+import { Meta } from "./themes/common/colorScheme";
+import https from "https";
+import crypto from "crypto";
+const license_file = `${__dirname}/../../assets/theme_licenses.md`
+const accepted_licenses_file = `${__dirname}/../../script/licenses/zed-licenses.toml`
+
+// Use the cargo-about configuration file as the source of truth for supported licenses.
+function parseAcceptedToml(file: string): string[] {
+  let buffer = fs.readFileSync(file).toString();
+
+  let obj = toml.parse(buffer);
+
+  if (!Array.isArray(obj.accepted)) {
+    throw Error("Accepted license source is malformed")
+  }
+
+  return obj.accepted
+}
+
+
+function checkLicenses(schemeMeta: Meta[], licenses: string[]) {
+  for (let meta of schemeMeta) {
+    // FIXME: Add support for conjuctions and conditions
+    if (licenses.indexOf(meta.license.SPDX) < 0) {
+      throw Error(`License for theme ${meta.name} (${meta.license.SPDX}) is not supported`)
+    }
+  }
+}
+
+
+function getLicenseText(schemeMeta: Meta[], callback: (meta: Meta, license_text: string) => void) {
+  for (let meta of schemeMeta) {
+    // The following copied from the example code on nodejs.org: 
+    // https://nodejs.org/api/http.html#httpgetoptions-callback
+    https.get(meta.license.https_url, (res) => {
+      const { statusCode } = res;
+
+      if (statusCode < 200 || statusCode >= 300) {
+        throw new Error('Failed to fetch license file.\n' +
+          `Status Code: ${statusCode}`);
+      }
+
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => { rawData += chunk; });
+      res.on('end', () => {
+        const hash = crypto.createHash('sha256').update(rawData).digest('hex');
+        if (meta.license.license_checksum == hash) {
+          callback(meta, rawData)
+        } else {
+          throw Error(`Checksum for ${meta.name} did not match file downloaded from ${meta.license.https_url}`)
+        }
+      });
+    }).on('error', (e) => {
+      throw e
+    });
+  }
+}
+
+function writeLicense(schemeMeta: Meta, text: String, stream: fs.WriteStream) {
+  stream.write(`# [${schemeMeta.name}](${schemeMeta.url})\n\n${text}\n******************************************************************************** \n`)
+}
+
+const accepted_licenses = parseAcceptedToml(accepted_licenses_file);
+checkLicenses(schemeMeta, accepted_licenses)
+
+const stream = fs.createWriteStream(license_file);
+getLicenseText(schemeMeta, (meta, text) => {
+  writeLicense(meta, text, stream)
+});

--- a/styles/src/buildThemes.ts
+++ b/styles/src/buildThemes.ts
@@ -1,15 +1,15 @@
 import * as fs from "fs";
-import * as path from "path";
 import { tmpdir } from "os";
-import app from "./styleTree/app";
+import * as path from "path";
 import colorSchemes, {
-  internalColorSchemes,
-  experimentalColorSchemes,
+  experimentalColorSchemes, internalColorSchemes
 } from "./colorSchemes";
-import snakeCase from "./utils/snakeCase";
+import app from "./styleTree/app";
 import { ColorScheme } from "./themes/common/colorScheme";
+import snakeCase from "./utils/snakeCase";
 
-const themeDirectory = `${__dirname}/../../assets/themes`;
+const assetsDirectory = `${__dirname}/../../assets`
+const themeDirectory = `${assetsDirectory}/themes`;
 const internalDirectory = `${themeDirectory}/Internal`;
 const experimentsDirectory = `${themeDirectory}/Experiments`;
 

--- a/styles/src/colorSchemes.ts
+++ b/styles/src/colorSchemes.ts
@@ -1,9 +1,12 @@
 import fs from "fs";
 import path from "path";
-import { ColorScheme } from "./themes/common/colorScheme";
+import { ColorScheme, Meta } from "./themes/common/colorScheme";
 
 const colorSchemes: ColorScheme[] = [];
 export default colorSchemes;
+
+const schemeMeta: Meta[] = [];
+export { schemeMeta };
 
 const internalColorSchemes: ColorScheme[] = [];
 export { internalColorSchemes };
@@ -11,25 +14,45 @@ export { internalColorSchemes };
 const experimentalColorSchemes: ColorScheme[] = [];
 export { experimentalColorSchemes };
 
-function fillColorSchemes(themesPath: string, colorSchemes: ColorScheme[]) {
+const themes_directory = path.resolve(`${__dirname}/themes`);
+
+function for_all_color_schemes_in(themesPath: string, callback: (module: any, path: string) => void) {
   for (const fileName of fs.readdirSync(themesPath)) {
     if (fileName == "template.ts") continue;
     const filePath = path.join(themesPath, fileName);
 
     if (fs.statSync(filePath).isFile()) {
       const colorScheme = require(filePath);
-      if (colorScheme.dark) colorSchemes.push(colorScheme.dark);
-      if (colorScheme.light) colorSchemes.push(colorScheme.light);
+      callback(colorScheme, path.basename(filePath));
     }
   }
 }
 
-fillColorSchemes(path.resolve(`${__dirname}/themes`), colorSchemes);
+function fillColorSchemes(themesPath: string, colorSchemes: ColorScheme[]) {
+  for_all_color_schemes_in(themesPath, (colorScheme, _path) => {
+    if (colorScheme.dark) colorSchemes.push(colorScheme.dark);
+    if (colorScheme.light) colorSchemes.push(colorScheme.light);
+  })
+}
+
+fillColorSchemes(themes_directory, colorSchemes);
 fillColorSchemes(
-  path.resolve(`${__dirname}/themes/internal`),
+  path.resolve(`${themes_directory}/internal`),
   internalColorSchemes
 );
 fillColorSchemes(
-  path.resolve(`${__dirname}/themes/experiments`),
+  path.resolve(`${themes_directory}/experiments`),
   experimentalColorSchemes
 );
+
+function fillMeta(themesPath: string, meta: Meta[]) {
+  for_all_color_schemes_in(themesPath, (colorScheme, path) => {
+    if (colorScheme.meta) {
+      meta.push(colorScheme.meta)
+    } else {
+      throw Error(`Public theme ${path} must have a meta field`)
+    }
+  })
+}
+
+fillMeta(themes_directory, schemeMeta);

--- a/styles/src/themes/andromeda.ts
+++ b/styles/src/themes/andromeda.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Andromeda";
-const author = "EliverLara";
-const url = "https://github.com/EliverLara/Andromeda";
-const license = {
-  type: "MIT",
-  url: "https://github.com/EliverLara/Andromeda/blob/master/LICENSE.md",
-};
 
 const ramps = {
   neutral: chroma
@@ -33,3 +28,14 @@ const ramps = {
 };
 
 export const dark = createColorScheme(`${name}`, false, ramps);
+
+export const meta: Meta = {
+  name,
+  author: "EliverLara",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/EliverLara/Andromeda/master/LICENSE.md",
+    license_checksum: "2f7886f1a05cefc2c26f5e49de1a39fa4466413c1ccb06fc80960e73f5ed4b89"
+  },
+  url: "https://github.com/EliverLara/Andromeda"
+}

--- a/styles/src/themes/atelier-cave.ts
+++ b/styles/src/themes/atelier-cave.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Atelier Cave";
-const author = "atelierbram";
-const url = "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/";
-const license = {
-  type: "MIT",
-  url: "https://github.com/atelierbram/syntax-highlighting/blob/master/LICENSE",
-};
 
 export const dark = createColorScheme(`${name} Dark`, false, {
   neutral: chroma
@@ -54,3 +49,15 @@ export const light = createColorScheme(`${name} Light`, true, {
   violet: colorRamp(chroma("#955ae7")),
   magenta: colorRamp(chroma("#bf40bf")),
 });
+
+
+export const meta: Meta = {
+  name,
+  author: "atelierbram",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/atelierbram/syntax-highlighting/master/LICENSE",
+    license_checksum: "6c2353bb9dd0b7b211364d98184ab482e54f40f611eda0c02974c3a1f9e6193c"
+  },
+  url: "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+}

--- a/styles/src/themes/atelier-sulphurpool.ts
+++ b/styles/src/themes/atelier-sulphurpool.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Atelier Sulphurpool";
-const author = "atelierbram";
-const url = "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune/";
-const license = {
-  type: "MIT",
-  url: "https://github.com/atelierbram/syntax-highlighting/blob/master/LICENSE",
-};
 
 const ramps = {
   neutral: chroma
@@ -34,3 +29,14 @@ const ramps = {
 
 export const dark = createColorScheme(`${name} Dark`, false, ramps);
 export const light = createColorScheme(`${name} Light`, true, ramps);
+
+export const meta: Meta = {
+  name,
+  author: "atelierbram",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/atelierbram/syntax-highlighting/master/LICENSE",
+    license_checksum: "6c2353bb9dd0b7b211364d98184ab482e54f40f611eda0c02974c3a1f9e6193c"
+  },
+  url: "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune/"
+}

--- a/styles/src/themes/common/colorScheme.ts
+++ b/styles/src/themes/common/colorScheme.ts
@@ -16,6 +16,28 @@ export interface ColorScheme {
   players: Players;
 }
 
+export interface Meta {
+  name: string,
+  author: string,
+  url: string,
+  license: License
+}
+
+export interface License {
+  SPDX: SPDXExpression,
+  /// A url where we can download the license's text
+  https_url: string,
+  license_checksum: string
+}
+
+// License name -> License text
+export interface Licenses {
+  [key: string]: string
+}
+
+// FIXME: Add support for the SPDX expression syntax
+export type SPDXExpression = "MIT";
+
 export interface Player {
   cursor: string;
   selection: string;

--- a/styles/src/themes/one-dark.ts
+++ b/styles/src/themes/one-dark.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "One Dark";
-const author = "simurai";
-const url = "https://github.com/atom/atom/tree/master/packages/one-dark-ui";
-const license = {
-  type: "MIT",
-  url: "https://github.com/atom/atom/blob/master/packages/one-dark-ui/LICENSE.md",
-};
 
 export const dark = createColorScheme(`${name}`, false, {
   neutral: chroma
@@ -32,3 +27,14 @@ export const dark = createColorScheme(`${name}`, false, {
   violet: colorRamp(chroma("#c678dd")),
   magenta: colorRamp(chroma("#be5046")),
 });
+
+export const meta: Meta = {
+  name,
+  author: "simurai",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/atom/atom/master/packages/one-light-ui/LICENSE.md",
+    license_checksum: "d5af8fc171f6f600c0ab4e7597dca398dda80dbe6821ce01cef78e859e7a00f8"
+  },
+  url: "https://github.com/atom/atom/tree/master/packages/one-dark-ui"
+}

--- a/styles/src/themes/one-light.ts
+++ b/styles/src/themes/one-light.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "One Light";
-const author = "simurai";
-const url = "https://github.com/atom/atom/tree/master/packages/one-light-ui";
-const license = {
-  type: "MIT",
-  url: "https://github.com/atom/atom/blob/master/packages/one-light-ui/LICENSE.md",
-};
 
 export const light = createColorScheme(`${name}`, true, {
   neutral: chroma.scale([
@@ -31,3 +26,14 @@ export const light = createColorScheme(`${name}`, true, {
   violet: colorRamp(chroma("#a626a4")),
   magenta: colorRamp(chroma("#986801")),
 });
+
+export const meta: Meta = {
+  name,
+  author: "simurai",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/atom/atom/master/packages/one-light-ui/LICENSE.md",
+    license_checksum: "d5af8fc171f6f600c0ab4e7597dca398dda80dbe6821ce01cef78e859e7a00f8"
+  },
+  url: "https://github.com/atom/atom/tree/master/packages/one-light-ui"
+}

--- a/styles/src/themes/rose-pine-dawn.ts
+++ b/styles/src/themes/rose-pine-dawn.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Rosé Pine Dawn";
-const author = "edunfelt";
-const url = "https://github.com/edunfelt/base16-rose-pine-scheme";
-const license = {
-  type: "MIT",
-  url: "https://github.com/edunfelt/base16-rose-pine-scheme/blob/main/rose-pine-dawn.yaml",
-};
 
 const ramps = {
   neutral: chroma
@@ -33,3 +28,14 @@ const ramps = {
 };
 
 export const light = createColorScheme(`${name}`, true, ramps);
+
+export const meta: Meta = {
+  name,
+  author: "edunfelt",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/edunfelt/base16-rose-pine-scheme/main/LICENSE",
+    license_checksum: "6ca1b9da8c78c8441c5aa43d024a4e4a7bf59d1ecca1480196e94fda0f91ee4a"
+  },
+  url: "https://github.com/edunfelt/base16-rose-pine-scheme"
+}

--- a/styles/src/themes/rose-pine-moon.ts
+++ b/styles/src/themes/rose-pine-moon.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Rosé Pine Moon";
-const author = "edunfelt";
-const url = "https://github.com/edunfelt/base16-rose-pine-scheme";
-const license = {
-  type: "MIT",
-  url: "https://github.com/edunfelt/base16-rose-pine-scheme/blob/main/rose-pine-moon.yaml",
-};
 
 const ramps = {
   neutral: chroma
@@ -33,3 +28,14 @@ const ramps = {
 };
 
 export const dark = createColorScheme(`${name}`, false, ramps);
+
+export const meta: Meta = {
+  name,
+  author: "edunfelt",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/edunfelt/base16-rose-pine-scheme/main/LICENSE",
+    license_checksum: "6ca1b9da8c78c8441c5aa43d024a4e4a7bf59d1ecca1480196e94fda0f91ee4a"
+  },
+  url: "https://github.com/edunfelt/base16-rose-pine-scheme"
+}

--- a/styles/src/themes/rose-pine.ts
+++ b/styles/src/themes/rose-pine.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Rosé Pine";
-const author = "edunfelt";
-const url = "https://github.com/edunfelt/base16-rose-pine-scheme";
-const license = {
-  type: "MIT",
-  url: "https://github.com/edunfelt/base16-rose-pine-scheme",
-};
 
 const ramps = {
   neutral: chroma.scale([
@@ -31,3 +26,14 @@ const ramps = {
 };
 
 export const dark = createColorScheme(`${name}`, false, ramps);
+
+export const meta: Meta = {
+  name,
+  author: "edunfelt",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/edunfelt/base16-rose-pine-scheme/main/LICENSE",
+    license_checksum: "6ca1b9da8c78c8441c5aa43d024a4e4a7bf59d1ecca1480196e94fda0f91ee4a"
+  },
+  url: "https://github.com/edunfelt/base16-rose-pine-scheme"
+}

--- a/styles/src/themes/sandcastle.ts
+++ b/styles/src/themes/sandcastle.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Sandcastle";
-const author = "gessig";
-const url = "https://github.com/gessig/base16-sandcastle-scheme";
-const license = {
-  type: "MIT",
-  url: "https://github.com/gessig/base16-sandcastle-scheme/blob/master/LICENSE",
-};
 
 const ramps = {
   neutral: chroma.scale([
@@ -31,3 +26,15 @@ const ramps = {
 };
 
 export const dark = createColorScheme(`${name}`, false, ramps);
+
+export const meta: Meta = {
+  name,
+  author: "gessig",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/gessig/base16-sandcastle-scheme/master/LICENSE",
+    license_checksum: "8399d44b4d935b60be9fee0a76d7cc9a817b4f3f11574c9d6d1e8fd57e72ffdc"
+  },
+  url: "https://github.com/gessig/base16-sandcastle-scheme"
+}
+

--- a/styles/src/themes/solarized.ts
+++ b/styles/src/themes/solarized.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta as Metadata } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Solarized";
-const author = "Ethan Schoonover";
-const url = "https://github.com/altercation/solarized";
-const license = {
-  type: "MIT",
-  url: "https://github.com/altercation/solarized/blob/master/README.md",
-};
 
 const ramps = {
   neutral: chroma
@@ -34,3 +29,15 @@ const ramps = {
 
 export const dark = createColorScheme(`${name} Dark`, false, ramps);
 export const light = createColorScheme(`${name} Light`, true, ramps);
+
+export const meta: Metadata = {
+  name,
+  author: "Ethan Schoonover",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/altercation/solarized/master/LICENSE",
+    license_checksum: "494aefdabf86acce06bd63001ad8aedad4ee38da23509d3f917d95aa3368b9a6"
+  },
+  url: "https://github.com/altercation/solarized"
+}
+

--- a/styles/src/themes/summercamp.ts
+++ b/styles/src/themes/summercamp.ts
@@ -1,13 +1,8 @@
 import chroma from "chroma-js";
+import { Meta } from "./common/colorScheme";
 import { colorRamp, createColorScheme } from "./common/ramps";
 
 const name = "Summercamp";
-const author = "zoefiri";
-const url = "https://github.com/zoefiri/base16-sc";
-const license = {
-  type: "MIT",
-  url: "https://github.com/zoefiri/base16-sc/blob/master/summercamp.yaml",
-};
 
 const ramps = {
   neutral: chroma
@@ -33,3 +28,13 @@ const ramps = {
 };
 
 export const dark = createColorScheme(`${name}`, false, ramps);
+export const meta: Meta = {
+  name,
+  author: "zoefiri",
+  url: "https://github.com/zoefiri/base16-sc",
+  license: {
+    SPDX: "MIT",
+    https_url: "https://raw.githubusercontent.com/zoefiri/base16-sc/master/LICENSE",
+    license_checksum: "fadcc834b7eaf2943800956600e8aeea4b495ecf6490f4c4b6c91556a90accaf"
+  }
+}


### PR DESCRIPTION
## Description of feature or change

Adds automated open source attribution and monitoring to the theme build system.

Note, this implementation would be cleaner if we could incorporate external dependencies into cargo-about's resolution and generation steps. Unfortunately, their tool would require a major rewrite to support non-rust dependencies and so I settled on parallel license files.