### PR TITLE
Fix connection staleness issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,5 +84,3 @@ split-debuginfo = "unpacked"
 
 [profile.release]
 debug = true
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR app
 COPY . .
 
 # Compile collab server
+ARG CARGO_PROFILE_RELEASE_PANIC=abort
 RUN --mount=type=cache,target=./script/node_modules \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=./target \

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -1586,12 +1586,8 @@ impl Database {
                     .filter(
                         Condition::all()
                             .add(
-                                room_participant::Column::CallingConnectionId
-                                    .eq(connection.id as i32),
-                            )
-                            .add(
-                                room_participant::Column::CallingConnectionServerId
-                                    .eq(connection.owner_id as i32),
+                                room_participant::Column::CallingUserId
+                                    .eq(leaving_participant.user_id),
                             )
                             .add(room_participant::Column::AnsweringConnectionId.is_null()),
                     )

--- a/crates/collab/src/tests/randomized_integration_tests.rs
+++ b/crates/collab/src/tests/randomized_integration_tests.rs
@@ -166,12 +166,10 @@ async fn test_random_collaboration(
                     let contacts = server.app_state.db.get_contacts(*user_id).await.unwrap();
                     let pool = server.connection_pool.lock();
                     for contact in contacts {
-                        if let db::Contact::Accepted { user_id, .. } = contact {
-                            if pool.is_user_online(user_id) {
-                                assert_ne!(
-                                    user_id, removed_user_id,
-                                    "removed client is still a contact of another peer"
-                                );
+                        if let db::Contact::Accepted { user_id, busy, .. } = contact {
+                            if user_id == removed_user_id {
+                                assert!(!pool.is_user_online(user_id));
+                                assert!(!busy);
                             }
                         }
                     }

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::{
     cmp,
     fmt::Debug,
-    io, iter, mem,
+    io, iter,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -489,16 +489,26 @@ pub fn split_worktree_update(
             return None;
         }
 
-        let chunk_size = cmp::min(message.updated_entries.len(), max_chunk_size);
-        let updated_entries = message.updated_entries.drain(..chunk_size).collect();
-        done = message.updated_entries.is_empty();
+        let updated_entries_chunk_size = cmp::min(message.updated_entries.len(), max_chunk_size);
+        let updated_entries = message
+            .updated_entries
+            .drain(..updated_entries_chunk_size)
+            .collect();
+
+        let removed_entries_chunk_size = cmp::min(message.removed_entries.len(), max_chunk_size);
+        let removed_entries = message
+            .removed_entries
+            .drain(..removed_entries_chunk_size)
+            .collect();
+
+        done = message.updated_entries.is_empty() && message.removed_entries.is_empty();
         Some(UpdateWorktree {
             project_id: message.project_id,
             worktree_id: message.worktree_id,
             root_name: message.root_name.clone(),
             abs_path: message.abs_path.clone(),
             updated_entries,
-            removed_entries: mem::take(&mut message.removed_entries),
+            removed_entries,
             scan_id: message.scan_id,
             is_last_update: done && message.is_last_update,
         })


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/2065
Fixes https://github.com/zed-industries/feedback/issues/851

Previously, when a `proto::UpdateWorktree` message contained lots of `removed_entries` we would try to remove them all at once using a single database call. This would cause the thread managing the Postgres connection to panic without aborting the process, which left the server in an invalid state because some connections would not be cleaned up.

This pull request addresses the issue in two ways:

1. Clients will now split `removed_entries` into chunks, as they already did for `updated_entries`. This prevents the message from getting too large and fixes the root of the panic.
2. The docker image is built with `CARGO_PROFILE_RELEASE_PANIC=abort`. This is a last resort ensuring that a panic in any thread aborts the process, causing Kubernetes to restart it and not leave any invalid state around (the reconnection work we did should smooth out these crashes). I specified this as an environment variable in the `Dockerfile` as opposed to changing the `Cargo.toml` because there's a limitation in cargo that forces you to apply the abort behavior to all crates in a workspace, which is something we don't want for the Zed.app.

As part of investigating this, I also added an assertion about the `busy` status of contacts in the randomized test and caught another staleness issue caused by calling someone, reconnecting and then leaving the room while the call was still pending (see 74aeec360d03d23a3ec878fb517336495a99ea88 for more details).