### PR TITLE
Limit focus grabbing in followed pane

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5623,7 +5623,6 @@ async fn test_following(
             .downcast::<Editor>()
             .unwrap()
     });
-    assert!(cx_b.read(|cx| editor_b2.is_focused(cx)));
     assert_eq!(
         cx_b.read(|cx| editor_b2.project_path(cx)),
         Some((worktree_id, "2.txt").into())

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -6394,6 +6394,8 @@ mod tests {
             cx.focus(&view_1);
             cx.focus(&view_2);
         });
+        assert!(cx.is_child_focused(view_1.clone()));
+        assert!(!cx.is_child_focused(view_2.clone()));
         assert_eq!(
             mem::take(&mut *view_events.lock()),
             [
@@ -6418,6 +6420,8 @@ mod tests {
         );
 
         view_1.update(cx, |_, cx| cx.focus(&view_1));
+        assert!(!cx.is_child_focused(view_1.clone()));
+        assert!(!cx.is_child_focused(view_2.clone()));
         assert_eq!(
             mem::take(&mut *view_events.lock()),
             ["view 2 blurred", "view 1 focused"],


### PR DESCRIPTION
## Description of feature or change

Adds `is_child_focused` to AppContext
Change `workspace::leader_updated` to only focus the new tab when the previous active tab in that pane was also focused.

## Link to related issues from zed or insiders
fixes https://github.com/zed-industries/zed/issues/1836

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
