### PR TITLE
Fix version for feedback-related commands

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -2,28 +2,21 @@ mod update_notification;
 
 use anyhow::{anyhow, Context, Result};
 use client::{http::HttpClient, ZED_SECRET_CLIENT_TOKEN};
+use client::{ZED_APP_PATH, ZED_APP_VERSION};
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
     actions, platform::AppVersion, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle,
     MutableAppContext, Task, WeakViewHandle,
 };
-use lazy_static::lazy_static;
 use serde::Deserialize;
 use smol::{fs::File, io::AsyncReadExt, process::Command};
-use std::{env, ffi::OsString, path::PathBuf, sync::Arc, time::Duration};
+use std::{ffi::OsString, sync::Arc, time::Duration};
 use update_notification::UpdateNotification;
 use util::channel::ReleaseChannel;
 use workspace::Workspace;
 
 const SHOULD_SHOW_UPDATE_NOTIFICATION_KEY: &str = "auto-updater-should-show-updated-notification";
 const POLL_INTERVAL: Duration = Duration::from_secs(60 * 60);
-
-lazy_static! {
-    pub static ref ZED_APP_VERSION: Option<AppVersion> = env::var("ZED_APP_VERSION")
-        .ok()
-        .and_then(|v| v.parse().ok());
-    pub static ref ZED_APP_PATH: Option<PathBuf> = env::var("ZED_APP_PATH").ok().map(PathBuf::from);
-}
 
 actions!(auto_update, [Check, DismissErrorMessage, ViewReleaseNotes]);
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -15,7 +15,7 @@ use futures::{future::LocalBoxFuture, AsyncReadExt, FutureExt, SinkExt, StreamEx
 use gpui::{
     actions,
     serde_json::{self, Value},
-    AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle, AppContext,
+    AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle, AppContext, AppVersion,
     AsyncAppContext, Entity, ModelHandle, MutableAppContext, Task, View, ViewContext, ViewHandle,
 };
 use http::HttpClient;
@@ -55,6 +55,11 @@ lazy_static! {
     pub static ref ADMIN_API_TOKEN: Option<String> = std::env::var("ZED_ADMIN_API_TOKEN")
         .ok()
         .and_then(|s| if s.is_empty() { None } else { Some(s) });
+    pub static ref ZED_APP_VERSION: Option<AppVersion> = std::env::var("ZED_APP_VERSION")
+        .ok()
+        .and_then(|v| v.parse().ok());
+    pub static ref ZED_APP_PATH: Option<PathBuf> =
+        std::env::var("ZED_APP_PATH").ok().map(PathBuf::from);
 }
 
 pub const ZED_SECRET_CLIENT_TOKEN: &str = "618033988749894";

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 pub mod feedback_editor;
 mod system_specs;
-use gpui::{actions, impl_actions, ClipboardItem, ViewContext};
+use gpui::{actions, impl_actions, ClipboardItem, MutableAppContext, PromptLevel, ViewContext};
 use serde::Deserialize;
 use system_specs::SystemSpecs;
 use workspace::{AppState, Workspace};
@@ -16,23 +16,32 @@ impl_actions!(zed, [OpenBrowser]);
 
 actions!(
     zed,
-    [CopySystemSpecsIntoClipboard, FileBugReport, RequestFeature,]
+    [CopySystemSpecsIntoClipboard, FileBugReport, RequestFeature]
 );
 
-pub fn init(app_state: Arc<AppState>, cx: &mut gpui::MutableAppContext) {
-    feedback_editor::init(app_state, cx);
+pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
+    let system_specs = SystemSpecs::new(&cx);
+    let system_specs_text = system_specs.to_string();
+
+    feedback_editor::init(system_specs, app_state, cx);
 
     cx.add_global_action(move |action: &OpenBrowser, cx| cx.platform().open_url(&action.url));
 
+    let url = format!(
+        "https://github.com/zed-industries/feedback/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}", 
+        urlencoding::encode(&system_specs_text)
+    );
+
     cx.add_action(
-        |_: &mut Workspace, _: &CopySystemSpecsIntoClipboard, cx: &mut ViewContext<Workspace>| {
-            let system_specs = SystemSpecs::new(cx).to_string();
-            let item = ClipboardItem::new(system_specs.clone());
+        move |_: &mut Workspace,
+              _: &CopySystemSpecsIntoClipboard,
+              cx: &mut ViewContext<Workspace>| {
             cx.prompt(
-                gpui::PromptLevel::Info,
-                &format!("Copied into clipboard:\n\n{system_specs}"),
+                PromptLevel::Info,
+                &format!("Copied into clipboard:\n\n{system_specs_text}"),
                 &["OK"],
             );
+            let item = ClipboardItem::new(system_specs_text.clone());
             cx.write_to_clipboard(item);
         },
     );
@@ -47,14 +56,9 @@ pub fn init(app_state: Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     );
 
     cx.add_action(
-        |_: &mut Workspace, _: &FileBugReport, cx: &mut ViewContext<Workspace>| {
-            let system_specs_text = SystemSpecs::new(cx).to_string();
-            let url = format!(
-                "https://github.com/zed-industries/feedback/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}", 
-                urlencoding::encode(&system_specs_text)
-            );
+        move |_: &mut Workspace, _: &FileBugReport, cx: &mut ViewContext<Workspace>| {
             cx.dispatch_action(OpenBrowser {
-                url: url.into(),
+                url: url.clone().into(),
             });
         },
     );

--- a/crates/feedback/src/system_specs.rs
+++ b/crates/feedback/src/system_specs.rs
@@ -1,14 +1,15 @@
-use std::{env, fmt::Display};
-
-use gpui::AppContext;
+use client::ZED_APP_VERSION;
+use gpui::{AppContext, AppVersion};
 use human_bytes::human_bytes;
 use serde::Serialize;
+use std::{env, fmt::Display};
 use sysinfo::{System, SystemExt};
 use util::channel::ReleaseChannel;
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct SystemSpecs {
-    app_version: &'static str,
+    #[serde(serialize_with = "serialize_app_version")]
+    app_version: Option<AppVersion>,
     release_channel: &'static str,
     os_name: &'static str,
     os_version: Option<String>,
@@ -19,18 +20,24 @@ pub struct SystemSpecs {
 impl SystemSpecs {
     pub fn new(cx: &AppContext) -> Self {
         let platform = cx.platform();
+        let app_version = ZED_APP_VERSION.or_else(|| platform.app_version().ok());
+        let release_channel = cx.global::<ReleaseChannel>().dev_name();
+        let os_name = platform.os_name();
         let system = System::new_all();
+        let memory = system.total_memory();
+        let architecture = env::consts::ARCH;
+        let os_version = platform
+            .os_version()
+            .ok()
+            .map(|os_version| os_version.to_string());
 
         SystemSpecs {
-            app_version: env!("CARGO_PKG_VERSION"),
-            release_channel: cx.global::<ReleaseChannel>().dev_name(),
-            os_name: platform.os_name(),
-            os_version: platform
-                .os_version()
-                .ok()
-                .map(|os_version| os_version.to_string()),
-            memory: system.total_memory(),
-            architecture: env::consts::ARCH,
+            app_version,
+            release_channel,
+            os_name,
+            os_version,
+            memory,
+            architecture,
         }
     }
 }
@@ -41,14 +48,28 @@ impl Display for SystemSpecs {
             Some(os_version) => format!("OS: {} {}", self.os_name, os_version),
             None => format!("OS: {}", self.os_name),
         };
+        let app_version_information = self
+            .app_version
+            .as_ref()
+            .map(|app_version| format!("Zed: v{} ({})", app_version, self.release_channel));
         let system_specs = [
-            format!("Zed: v{} ({})", self.app_version, self.release_channel),
-            os_information,
-            format!("Memory: {}", human_bytes(self.memory as f64)),
-            format!("Architecture: {}", self.architecture),
+            app_version_information,
+            Some(os_information),
+            Some(format!("Memory: {}", human_bytes(self.memory as f64))),
+            Some(format!("Architecture: {}", self.architecture)),
         ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<String>>()
         .join("\n");
 
         write!(f, "{system_specs}")
     }
+}
+
+fn serialize_app_version<S>(version: &Option<AppVersion>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    version.map(|v| v.to_string()).serialize(serializer)
 }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{anyhow, Context, Result};
 use assets::Assets;
-use auto_update::ZED_APP_VERSION;
 use backtrace::Backtrace;
 use cli::{
     ipc::{self, IpcSender},
@@ -12,7 +11,7 @@ use cli::{
 use client::{
     self,
     http::{self, HttpClient},
-    UserStore, ZED_SECRET_CLIENT_TOKEN,
+    UserStore, ZED_APP_VERSION, ZED_SECRET_CLIENT_TOKEN,
 };
 
 use futures::{


### PR DESCRIPTION
## Description of feature or change

This broke after SystemSpecs was moved from the zed crate to the the feedback crate.  The mechanism for retrieving the version worked when it was in the zed crate, but no longer worked in the feedback crate.

This will fix the incorrect version number used in:
- in-app feedback
- opening a bug report issue
- copying system specs into the clipboard

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
