### PR TITLE
WIP: Add call status indicator to the status bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "media",
  "postage",
  "project",
+ "settings",
  "util",
 ]
 

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -20,6 +20,8 @@
     // Whether to pop the completions menu while typing in an editor without
     // explicitly requesting it.
     "show_completions_on_input": true,
+    // Whether the screen sharing icon is showed in the os status bar.
+    "show_call_status_icon": true,
     // Whether new projects should start out 'online'. Online projects
     // appear in the contacts panel under your name, so that your contacts
     // can see which projects you are working on. Regardless of this

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -28,6 +28,7 @@ fs = { path = "../fs" }
 language = { path = "../language" }
 media = { path = "../media" }
 project = { path = "../project" }
+settings = { path = "../settings" }
 util = { path = "../util" }
 
 anyhow = "1.0.38"

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -1,3 +1,4 @@
+mod indicator;
 pub mod participant;
 pub mod room;
 
@@ -5,18 +6,22 @@ use anyhow::{anyhow, Result};
 use client::{proto, Client, TypedEnvelope, User, UserStore};
 use collections::HashSet;
 use gpui::{
-    AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle, MutableAppContext,
-    Subscription, Task, WeakModelHandle,
+    actions, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle, MutableAppContext,
+    Subscription, Task, ViewHandle, WeakModelHandle,
 };
+use indicator::SharingStatusIndicator;
 pub use participant::ParticipantLocation;
 use postage::watch;
 use project::Project;
 pub use room::Room;
 use std::sync::Arc;
 
+actions!(collab, [ToggleScreenSharing]);
+
 pub fn init(client: Arc<Client>, user_store: ModelHandle<UserStore>, cx: &mut MutableAppContext) {
     let active_call = cx.add_model(|cx| ActiveCall::new(client, user_store, cx));
     cx.set_global(active_call);
+    cx.add_global_action(toggle_screen_sharing);
 }
 
 #[derive(Clone)]
@@ -37,6 +42,7 @@ pub struct ActiveCall {
     ),
     client: Arc<Client>,
     user_store: ModelHandle<UserStore>,
+    sharing_status_indicator: Option<(usize, ViewHandle<SharingStatusIndicator>)>,
     _subscriptions: Vec<client::Subscription>,
 }
 
@@ -61,6 +67,7 @@ impl ActiveCall {
             ],
             client,
             user_store,
+            sharing_status_indicator: None,
         }
     }
 
@@ -279,6 +286,8 @@ impl ActiveCall {
                                 this.set_room(None, cx).detach_and_log_err(cx);
                             }
 
+                            this.set_sharing_status(room.read(cx).is_screen_sharing(), cx);
+
                             cx.notify();
                         }),
                         cx.subscribe(&room, |_, _, event, cx| cx.emit(event.clone())),
@@ -302,5 +311,29 @@ impl ActiveCall {
 
     pub fn pending_invites(&self) -> &HashSet<u64> {
         &self.pending_invites
+    }
+
+    pub fn set_sharing_status(&mut self, is_screen_sharing: bool, cx: &mut MutableAppContext) {
+        if is_screen_sharing {
+            if self.sharing_status_indicator.is_none() {
+                self.sharing_status_indicator =
+                    Some(cx.add_status_bar_item(|_| SharingStatusIndicator));
+            }
+        } else if let Some((window_id, _)) = self.sharing_status_indicator.take() {
+            cx.remove_status_bar_item(window_id);
+        }
+    }
+}
+
+pub fn toggle_screen_sharing(_: &ToggleScreenSharing, cx: &mut MutableAppContext) {
+    if let Some(room) = ActiveCall::global(cx).read(cx).room().cloned() {
+        let toggle_screen_sharing = room.update(cx, |room, cx| {
+            if room.is_screen_sharing() {
+                Task::ready(room.unshare_screen(cx))
+            } else {
+                room.share_screen(cx)
+            }
+        });
+        toggle_screen_sharing.detach_and_log_err(cx);
     }
 }

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -2,19 +2,23 @@ mod indicator;
 pub mod participant;
 pub mod room;
 
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use client::{proto, Client, TypedEnvelope, User, UserStore};
 use collections::HashSet;
+use postage::watch;
+
 use gpui::{
     actions, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle, MutableAppContext,
     Subscription, Task, ViewHandle, WeakModelHandle,
 };
+use project::Project;
+use settings::Settings;
+
 use indicator::SharingStatusIndicator;
 pub use participant::ParticipantLocation;
-use postage::watch;
-use project::Project;
 pub use room::Room;
-use std::sync::Arc;
 
 actions!(collab, [ToggleScreenSharing]);
 
@@ -315,7 +319,9 @@ impl ActiveCall {
 
     pub fn set_sharing_status(&mut self, is_screen_sharing: bool, cx: &mut MutableAppContext) {
         if is_screen_sharing {
-            if self.sharing_status_indicator.is_none() {
+            if self.sharing_status_indicator.is_none()
+                && cx.global::<Settings>().show_call_status_icon
+            {
                 self.sharing_status_indicator =
                     Some(cx.add_status_bar_item(|_| SharingStatusIndicator));
             }

--- a/crates/call/src/indicator.rs
+++ b/crates/call/src/indicator.rs
@@ -1,0 +1,39 @@
+use gpui::{
+    color::Color,
+    elements::{MouseEventHandler, Svg},
+    Appearance, Element, ElementBox, Entity, MouseButton, RenderContext, View,
+};
+
+use crate::ToggleScreenSharing;
+
+pub struct SharingStatusIndicator;
+
+impl Entity for SharingStatusIndicator {
+    type Event = ();
+}
+
+impl View for SharingStatusIndicator {
+    fn ui_name() -> &'static str {
+        "SharingStatusIndicator"
+    }
+
+    fn render(&mut self, cx: &mut RenderContext<'_, Self>) -> ElementBox {
+        let color = match cx.appearance {
+            Appearance::Light | Appearance::VibrantLight => Color::black(),
+            Appearance::Dark | Appearance::VibrantDark => Color::white(),
+        };
+
+        MouseEventHandler::<Self>::new(0, cx, |_, _| {
+            Svg::new("icons/disable_screen_sharing_12.svg")
+                .with_color(color)
+                .constrained()
+                .with_width(18.)
+                .aligned()
+                .boxed()
+        })
+        .on_click(MouseButton::Left, |_, cx| {
+            cx.dispatch_action(ToggleScreenSharing);
+        })
+        .boxed()
+    }
+}

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -1,5 +1,5 @@
 use crate::{contact_notification::ContactNotification, contacts_popover};
-use call::{ActiveCall, ParticipantLocation};
+use call::{ActiveCall, ParticipantLocation, ToggleScreenSharing};
 use client::{proto::PeerId, Authenticate, ContactEventKind, User, UserStore};
 use clock::ReplicaId;
 use contacts_popover::ContactsPopover;
@@ -17,14 +17,10 @@ use std::ops::Range;
 use theme::Theme;
 use workspace::{FollowNextCollaborator, JoinProject, ToggleFollow, Workspace};
 
-actions!(
-    collab,
-    [ToggleCollaborationMenu, ToggleScreenSharing, ShareProject]
-);
+actions!(collab, [ToggleCollaborationMenu, ShareProject]);
 
 pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(CollabTitlebarItem::toggle_contacts_popover);
-    cx.add_action(CollabTitlebarItem::toggle_screen_sharing);
     cx.add_action(CollabTitlebarItem::share_project);
 }
 
@@ -170,19 +166,6 @@ impl CollabTitlebarItem {
             }
         }
         cx.notify();
-    }
-
-    pub fn toggle_screen_sharing(&mut self, _: &ToggleScreenSharing, cx: &mut ViewContext<Self>) {
-        if let Some(room) = ActiveCall::global(cx).read(cx).room().cloned() {
-            let toggle_screen_sharing = room.update(cx, |room, cx| {
-                if room.is_screen_sharing() {
-                    Task::ready(room.unshare_screen(cx))
-                } else {
-                    room.share_screen(cx)
-                }
-            });
-            toggle_screen_sharing.detach_and_log_err(cx);
-        }
     }
 
     fn render_toggle_contacts_button(

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -10,7 +10,7 @@ use gpui::{
     geometry::{rect::RectF, vector::vec2f, PathBuilder},
     json::{self, ToJson},
     Border, CursorStyle, Entity, ModelHandle, MouseButton, MutableAppContext, RenderContext,
-    Subscription, Task, View, ViewContext, ViewHandle, WeakViewHandle,
+    Subscription, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use settings::Settings;
 use std::ops::Range;

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -35,6 +35,7 @@ pub struct Settings {
     pub confirm_quit: bool,
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
+    pub show_call_status_icon: bool,
     pub vim_mode: bool,
     pub autosave: Autosave,
     pub default_dock_anchor: DockAnchor,
@@ -287,6 +288,8 @@ pub struct SettingsFileContent {
     #[serde(default)]
     pub show_completions_on_input: Option<bool>,
     #[serde(default)]
+    pub show_call_status_icon: Option<bool>,
+    #[serde(default)]
     pub vim_mode: Option<bool>,
     #[serde(default)]
     pub autosave: Option<Autosave>,
@@ -346,6 +349,7 @@ impl Settings {
             cursor_blink: defaults.cursor_blink.unwrap(),
             hover_popover_enabled: defaults.hover_popover_enabled.unwrap(),
             show_completions_on_input: defaults.show_completions_on_input.unwrap(),
+            show_call_status_icon: defaults.show_call_status_icon.unwrap(),
             vim_mode: defaults.vim_mode.unwrap(),
             autosave: defaults.autosave.unwrap(),
             default_dock_anchor: defaults.default_dock_anchor.unwrap(),
@@ -540,6 +544,7 @@ impl Settings {
             cursor_blink: true,
             hover_popover_enabled: true,
             show_completions_on_input: true,
+            show_call_status_icon: true,
             vim_mode: false,
             autosave: Autosave::Off,
             default_dock_anchor: DockAnchor::Bottom,

--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -31,9 +31,10 @@ scale_factor=1
 if [[ $resolution_line =~ Retina ]]; then scale_factor=2; fi
 width=$(expr ${screen_size[0]} / 2 / $scale_factor)
 height=${screen_size[1] / $scale_factor}
+y=$(expr $height / 2)
 
-position_1=0,0
-position_2=${width},0
+position_1=0,${y}
+position_2=${width},${y}
 
 # Authenticate using the collab server's admin secret.
 export ZED_STATELESS=1


### PR DESCRIPTION
## Description of feature or change

Uses the share or unshare screen icon in the macos status bar as an extra way to indicate that the screen is being shared.

## Link to related issues from zed or insiders
https://github.com/zed-industries/zed/issues/2109

## Before Merging 
- [x] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
