### PR TITLE
Make display uuid optional if the display is disconnected

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -124,7 +124,7 @@ pub trait InputHandler {
 pub trait Screen: Debug {
     fn as_any(&self) -> &dyn Any;
     fn bounds(&self) -> RectF;
-    fn display_uuid(&self) -> Uuid;
+    fn display_uuid(&self) -> Option<Uuid>;
 }
 
 pub trait Window {

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -238,8 +238,8 @@ impl super::Screen for Screen {
         RectF::new(Vector2F::zero(), Vector2F::new(1920., 1080.))
     }
 
-    fn display_uuid(&self) -> uuid::Uuid {
-        uuid::Uuid::new_v4()
+    fn display_uuid(&self) -> Option<uuid::Uuid> {
+        Some(uuid::Uuid::new_v4())
     }
 }
 


### PR DESCRIPTION
## Description of feature or change

Fix panic when a thunderbolt display is disconnected during sleep.

## Link to related issues from zed or insiders

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
