### PR TITLE
Trim leading and trailing whitespace in feedback

### DIFF
--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -125,7 +125,9 @@ impl FeedbackEditor {
         _: ModelHandle<Project>,
         cx: &mut ViewContext<Self>,
     ) -> Task<anyhow::Result<()>> {
-        let feedback_char_count = self.editor.read(cx).text(cx).chars().count();
+        let feedback_text = self.editor.read(cx).text(cx);
+        let feedback_char_count = feedback_text.chars().count();
+        let feedback_text = feedback_text.trim().to_string();
 
         let error = if feedback_char_count < *FEEDBACK_CHAR_LIMIT.start() {
             Some(format!(
@@ -154,7 +156,6 @@ impl FeedbackEditor {
 
         let this = cx.handle();
         let client = cx.global::<Arc<Client>>().clone();
-        let feedback_text = self.editor.read(cx).text(cx);
         let specs = self.system_specs.clone();
 
         cx.spawn(|_, mut cx| async move {


### PR DESCRIPTION
## Description of feature or change

A user submitted feedback with a leading newline, which made it seem like there was no feedback.  Let's trim this out.

<img width="1832" alt="SCR-20230202-hnt" src="https://user-images.githubusercontent.com/19867440/216401548-4a3c2aed-e4aa-41d2-85b7-2584937c5833.png">

<img width="1847" alt="SCR-20230202-hnw" src="https://user-images.githubusercontent.com/19867440/216401552-ae3cc6da-7c67-413f-a03f-a120b8acf32c.png">



## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
