### PR TITLE
Focus the editor when activating previous pane

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4915,6 +4915,12 @@ impl<T: View> From<ViewHandle<T>> for AnyViewHandle {
     }
 }
 
+impl<T> PartialEq<ViewHandle<T>> for AnyViewHandle {
+    fn eq(&self, other: &ViewHandle<T>) -> bool {
+        self.window_id == other.window_id && self.view_id == other.view_id
+    }
+}
+
 impl Drop for AnyViewHandle {
     fn drop(&mut self) {
         self.ref_counts

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1527,7 +1527,7 @@ impl View for Pane {
                 }
 
                 cx.focus(active_item);
-            } else {
+            } else if focused != self.tab_bar_context_menu {
                 self.last_focused_view_by_item
                     .insert(active_item.id(), focused.downgrade());
             }


### PR DESCRIPTION
Fixes #731

Turns out the reason [for this behavior](https://github.com/zed-industries/zed/issues/731#issuecomment-1412210018), is that we remember the tab bar context menu as the last active view in the pane where the split originates from. So when you use the keyboard to activate the previous pane, focus goes to the context menu instead of the editor. This PR fixes the issue.

I gave [a lot more context](https://github.com/zed-industries/zed/issues/731#issuecomment-1414144137) about why I chose to fix this one if you are interested.

cc @as-cii for helping me with this one 🙇‍♂️ 
cc @maxbrunsfeld for opening #731 