### PR TITLE
Make app menu and context menu labels consistent

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -52,8 +52,8 @@ pub fn deploy_context_menu(
             AnchorCorner::TopLeft,
             vec![
                 ContextMenuItem::item("Rename Symbol", Rename),
-                ContextMenuItem::item("Go To Definition", GoToDefinition),
-                ContextMenuItem::item("Go To Type Definition", GoToTypeDefinition),
+                ContextMenuItem::item("Go to Definition", GoToDefinition),
+                ContextMenuItem::item("Go to Type Definition", GoToTypeDefinition),
                 ContextMenuItem::item("Find All References", FindAllReferences),
                 ContextMenuItem::item(
                     "Code Actions",

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -293,7 +293,7 @@ pub fn menus() -> Vec<Menu<'static>> {
                     action: Box::new(editor::GoToTypeDefinition),
                 },
                 MenuItem::Action {
-                    name: "Go to References",
+                    name: "Find All References",
                     action: Box::new(editor::FindAllReferences),
                 },
                 MenuItem::Action {


### PR DESCRIPTION
Make app menu and context menu labels consistent. I chose to standardize on "Find All References" instead of "Go to References" as that felt more natural, but also this is how the internal function is called.

Fixes https://github.com/zed-industries/feedback/issues/922

![CleanShot 2023-02-03 at 12 19 50](https://user-images.githubusercontent.com/28818/216575652-3a424465-a478-44b4-af85-0489c9aa1bc4.png)

cc @JosephTLyons for suggesting we tackle this as a very quick fix
cc @as-cii for a quick review