### PR TITLE
Fix several action dispatching bugs

### DIFF
--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -63,6 +63,7 @@ pub struct ContextMenu {
     visible: bool,
     previously_focused_view_id: Option<usize>,
     clicked: bool,
+    parent_view_id: usize,
     _actions_observation: Subscription,
 }
 
@@ -114,6 +115,8 @@ impl View for ContextMenu {
 
 impl ContextMenu {
     pub fn new(cx: &mut ViewContext<Self>) -> Self {
+        let parent_view_id = cx.parent().unwrap();
+
         Self {
             show_count: 0,
             anchor_position: Default::default(),
@@ -123,6 +126,7 @@ impl ContextMenu {
             visible: Default::default(),
             previously_focused_view_id: Default::default(),
             clicked: false,
+            parent_view_id,
             _actions_observation: cx.observe_actions(Self::action_dispatched),
         }
     }
@@ -251,6 +255,7 @@ impl ContextMenu {
     }
 
     fn render_menu_for_measurement(&self, cx: &mut RenderContext<Self>) -> impl Element {
+        let window_id = cx.window_id();
         let style = cx.global::<Settings>().theme.context_menu.clone();
         Flex::row()
             .with_child(
@@ -289,6 +294,8 @@ impl ContextMenu {
                                     Some(ix) == self.selected_index,
                                 );
                                 KeystrokeLabel::new(
+                                    window_id,
+                                    self.parent_view_id,
                                     action.boxed_clone(),
                                     style.keystroke.container,
                                     style.keystroke.text.clone(),
@@ -318,6 +325,7 @@ impl ContextMenu {
 
         let style = cx.global::<Settings>().theme.context_menu.clone();
 
+        let window_id = cx.window_id();
         MouseEventHandler::<Menu>::new(0, cx, |_, cx| {
             Flex::column()
                 .with_children(self.items.iter().enumerate().map(|(ix, item)| {
@@ -337,6 +345,8 @@ impl ContextMenu {
                                     )
                                     .with_child({
                                         KeystrokeLabel::new(
+                                            window_id,
+                                            self.parent_view_id,
                                             action.boxed_clone(),
                                             style.keystroke.container,
                                             style.keystroke.text.clone(),

--- a/crates/gpui/src/elements/keystroke_label.rs
+++ b/crates/gpui/src/elements/keystroke_label.rs
@@ -12,15 +12,21 @@ pub struct KeystrokeLabel {
     action: Box<dyn Action>,
     container_style: ContainerStyle,
     text_style: TextStyle,
+    window_id: usize,
+    view_id: usize,
 }
 
 impl KeystrokeLabel {
     pub fn new(
+        window_id: usize,
+        view_id: usize,
         action: Box<dyn Action>,
         container_style: ContainerStyle,
         text_style: TextStyle,
     ) -> Self {
         Self {
+            window_id,
+            view_id,
             action,
             container_style,
             text_style,
@@ -37,7 +43,10 @@ impl Element for KeystrokeLabel {
         constraint: SizeConstraint,
         cx: &mut LayoutContext,
     ) -> (Vector2F, ElementBox) {
-        let mut element = if let Some(keystrokes) = cx.keystrokes_for_action(self.action.as_ref()) {
+        let mut element = if let Some(keystrokes) =
+            cx.app
+                .keystrokes_for_action(self.window_id, self.view_id, self.action.as_ref())
+        {
             Flex::row()
                 .with_children(keystrokes.iter().map(|keystroke| {
                     Label::new(keystroke.to_string(), self.text_style.clone())

--- a/crates/gpui/src/keymap_matcher/binding.rs
+++ b/crates/gpui/src/keymap_matcher/binding.rs
@@ -41,7 +41,7 @@ impl Binding {
         })
     }
 
-    fn match_context(&self, contexts: &[KeymapContext]) -> bool {
+    pub fn match_context(&self, contexts: &[KeymapContext]) -> bool {
         self.context_predicate
             .as_ref()
             .map(|predicate| predicate.eval(contexts))

--- a/crates/gpui/src/keymap_matcher/keymap_context.rs
+++ b/crates/gpui/src/keymap_matcher/keymap_context.rs
@@ -43,7 +43,7 @@ impl KeymapContextPredicate {
     pub fn eval(&self, contexts: &[KeymapContext]) -> bool {
         let Some(context) = contexts.first() else { return false };
         match self {
-            Self::Identifier(name) => context.set.contains(name.as_str()),
+            Self::Identifier(name) => (&context.set).contains(name.as_str()),
             Self::Equal(left, right) => context
                 .map
                 .get(left)

--- a/crates/gpui/src/platform/mac/geometry.rs
+++ b/crates/gpui/src/platform/mac/geometry.rs
@@ -19,7 +19,7 @@ pub trait Vector2FExt {
 impl Vector2FExt for Vector2F {
     fn to_screen_ns_point(&self, native_window: id) -> NSPoint {
         unsafe {
-            let point = NSPoint::new(self.x() as f64, -self.y() as f64);
+            let point = NSPoint::new(self.x() as f64, self.y() as f64);
             msg_send![native_window, convertPointToScreen: point]
         }
     }

--- a/crates/gpui/src/platform/mac/geometry.rs
+++ b/crates/gpui/src/platform/mac/geometry.rs
@@ -14,12 +14,12 @@ use pathfinder_geometry::{
 
 pub trait Vector2FExt {
     /// Converts self to an NSPoint with y axis pointing up.
-    fn to_screen_ns_point(&self, native_window: id) -> NSPoint;
+    fn to_screen_ns_point(&self, native_window: id, window_height: f64) -> NSPoint;
 }
 impl Vector2FExt for Vector2F {
-    fn to_screen_ns_point(&self, native_window: id) -> NSPoint {
+    fn to_screen_ns_point(&self, native_window: id, window_height: f64) -> NSPoint {
         unsafe {
-            let point = NSPoint::new(self.x() as f64, self.y() as f64);
+            let point = NSPoint::new(self.x() as f64, window_height - self.y() as f64);
             msg_send![native_window, convertPointToScreen: point]
         }
     }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -483,6 +483,7 @@ impl Window {
 
             let native_view: id = msg_send![VIEW_CLASS, alloc];
             let native_view = NSView::init(native_view);
+
             assert!(!native_view.is_null());
 
             let window = Self(Rc::new(RefCell::new(WindowState {
@@ -828,12 +829,11 @@ impl platform::Window for Window {
         let self_id = self_borrow.id;
 
         unsafe {
-            let window_frame = self_borrow.frame();
             let app = NSApplication::sharedApplication(nil);
 
             // Convert back to screen coordinates
-            let screen_point =
-                (position + window_frame.origin()).to_screen_ns_point(self_borrow.native_window);
+            let screen_point = position.to_screen_ns_point(self_borrow.native_window);
+
             let window_number: NSInteger = msg_send![class!(NSWindow), windowNumberAtPoint:screen_point belowWindowWithWindowNumber:0];
             let top_most_window: id = msg_send![app, windowWithWindowNumber: window_number];
 

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -832,7 +832,10 @@ impl platform::Window for Window {
             let app = NSApplication::sharedApplication(nil);
 
             // Convert back to screen coordinates
-            let screen_point = position.to_screen_ns_point(self_borrow.native_window);
+            let screen_point = position.to_screen_ns_point(
+                self_borrow.native_window,
+                self_borrow.content_size().y() as f64,
+            );
 
             let window_number: NSInteger = msg_send![class!(NSWindow), windowNumberAtPoint:screen_point belowWindowWithWindowNumber:0];
             let top_most_window: id = msg_send![app, windowWithWindowNumber: window_number];

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -4,7 +4,6 @@ use crate::{
     font_cache::FontCache,
     geometry::rect::RectF,
     json::{self, ToJson},
-    keymap_matcher::Keystroke,
     platform::{CursorStyle, Event},
     scene::{
         CursorRegion, MouseClick, MouseDown, MouseDownOut, MouseDrag, MouseEvent, MouseHover,
@@ -604,14 +603,6 @@ pub struct LayoutContext<'a> {
 }
 
 impl<'a> LayoutContext<'a> {
-    pub(crate) fn keystrokes_for_action(
-        &mut self,
-        action: &dyn Action,
-    ) -> Option<SmallVec<[Keystroke; 2]>> {
-        self.app
-            .keystrokes_for_action(self.window_id, &self.view_stack, action)
-    }
-
     fn layout(&mut self, view_id: usize, constraint: SizeConstraint) -> Vector2F {
         let print_error = |view_id| {
             format!(


### PR DESCRIPTION
- Fixed a bug where the command palette wouldn't check the keymap context when showing available actions 
- Fixed a bug where context menus wouldn't show action keystrokes 
- Fix a bug where tooltips won't show action keystrokes
- Fix a bug where cursor styles won't be set as we're detecting the window incorrectly