### PR TITLE
Fix Recent Project Panic

### DIFF
--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -174,7 +174,7 @@ pub mod simple_message_notification {
     }
 
     impl MessageNotification {
-        pub fn new_messsage<S: AsRef<str>>(message: S) -> MessageNotification {
+        pub fn new_message<S: AsRef<str>>(message: S) -> MessageNotification {
             Self {
                 message: message.as_ref().to_string(),
                 click_action: None,
@@ -320,7 +320,7 @@ where
             Err(err) => {
                 workspace.show_notification(0, cx, |cx| {
                     cx.add_view(|_cx| {
-                        simple_message_notification::MessageNotification::new_messsage(format!(
+                        simple_message_notification::MessageNotification::new_message(format!(
                             "Error: {:?}",
                             err,
                         ))


### PR DESCRIPTION
## Description of feature or change

Address panic when no projects have been available and the recent project picker is opened

## Link to related issues from zed or insiders

Fixes https://github.com/zed-industries/zed/issues/2122

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
