### PR TITLE
Feedback/929 project search crashes

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -259,11 +259,7 @@ impl Item for ProjectSearchView {
                     .boxed(),
             )
             .with_children(self.model.read(cx).active_query.as_ref().map(|query| {
-                let query_text = if query.as_str().len() > MAX_TAB_TITLE_LEN {
-                    query.as_str()[..MAX_TAB_TITLE_LEN].to_string() + "…"
-                } else {
-                    query.as_str().to_string()
-                };
+                let query_text = util::truncate_and_trailoff(query.as_str(), MAX_TAB_TITLE_LEN);
 
                 Label::new(query_text, tab_theme.label.clone())
                     .aligned()

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -46,10 +46,10 @@ pub fn truncate(s: &str, max_chars: usize) -> &str {
 pub fn truncate_and_trailoff(s: &str, max_chars: usize) -> String {
     debug_assert!(max_chars >= 5);
 
-    if s.len() > max_chars {
-        format!("{}…", truncate(s, max_chars.saturating_sub(3)))
-    } else {
-        s.to_string()
+    let truncation_ix = s.char_indices().map(|(i, _)| i).nth(max_chars);
+    match truncation_ix {
+        Some(length) => s[..length].to_string() + "…",
+        None => s.to_string(),
     }
 }
 
@@ -279,12 +279,9 @@ mod tests {
 
     #[test]
     fn test_trancate_and_trailoff() {
-        const MAX_CHARS: usize = 24;
-        assert_eq!(
-            truncate_and_trailoff("ajouter un compte d'èèèès", MAX_CHARS),
-            "ajouter un compte d'è…"
-        );
-        assert_eq!(truncate_and_trailoff("ajouter", MAX_CHARS), "ajouter");
-        assert_eq!(truncate_and_trailoff("", MAX_CHARS), "");
+        assert_eq!(truncate_and_trailoff("", 5), "");
+        assert_eq!(truncate_and_trailoff("èèèèèè", 7), "èèèèèè");
+        assert_eq!(truncate_and_trailoff("èèèèèè", 6), "èèèèèè");
+        assert_eq!(truncate_and_trailoff("èèèèèè", 5), "èèèèè…");
     }
 }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -276,4 +276,15 @@ mod tests {
 
         assert_eq!(foo, None);
     }
+
+    #[test]
+    fn test_trancate_and_trailoff() {
+        const MAX_CHARS: usize = 24;
+        assert_eq!(
+            truncate_and_trailoff("ajouter un compte d'èèèès", MAX_CHARS),
+            "ajouter un compte d'è…"
+        );
+        assert_eq!(truncate_and_trailoff("ajouter", MAX_CHARS), "ajouter");
+        assert_eq!(truncate_and_trailoff("", MAX_CHARS), "");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/feedback/issues/929

### Steps

1. Start project search with <kbd>CMD</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>
2. Paste the phrase "ajouter un compte d'accès" without the quotes and hit <kbd>Enter</kbd>
3. **Observation:** Zed crashes
4. **Expectation:** Zed should not crash

### Notes

<!-- Replace this with anything you feel will help the investigation. Links, screenshots, etc.-->

Part of the trace:

```shell
Inhibit thread 'main' panicked at 'byte index 24 is not a char boundary; 
it is inside 'è' (bytes 23..25) of `ajouter un compte d'accès`'
: crates/search/src/project_search.rs:263
```

It turns out this was about the title of the search pane right after someone hits enter. We want to truncate the search query if it's above 24 characters. And we were doing it with code that doesn't respect unicode characters.

Turns out we already have a `util::truncate_and_trailoff` function that uses `format!` which seems to be working fine.

I have added a test with three cases just to make sure things work.

### What is the impact?

Folks searching in their project strings with unicode characters may crash the app. Pretty high impact.

### Actions

- [x] Fix the issue
- [x] Add tests if it makes sense
- [x] Review or pair-review it

_When everything is checked ☝️ this is considered done._