### PR TITLE
Don't render tooltip keystroke label if there's no focused view

### DIFF
--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -61,7 +61,7 @@ impl Tooltip {
     ) -> Self {
         struct ElementState<Tag>(Tag);
         struct MouseEventHandlerState<Tag>(Tag);
-        let focused_view_id = cx.focused_view_id(cx.window_id).unwrap();
+        let focused_view_id = cx.focused_view_id(cx.window_id);
 
         let state_handle = cx.default_element_state::<ElementState<Tag>, Rc<TooltipState>>(id);
         let state = state_handle.read(cx).clone();
@@ -132,7 +132,7 @@ impl Tooltip {
 
     pub fn render_tooltip(
         window_id: usize,
-        focused_view_id: usize,
+        focused_view_id: Option<usize>,
         text: String,
         style: TooltipStyle,
         action: Option<Box<dyn Action>>,
@@ -149,18 +149,18 @@ impl Tooltip {
                     text.flex(1., false).aligned().boxed()
                 }
             })
-            .with_children(action.map(|action| {
+            .with_children(action.and_then(|action| {
                 let keystroke_label = KeystrokeLabel::new(
                     window_id,
-                    focused_view_id,
+                    focused_view_id?,
                     action,
                     style.keystroke.container,
                     style.keystroke.text,
                 );
                 if measure {
-                    keystroke_label.boxed()
+                    Some(keystroke_label.boxed())
                 } else {
-                    keystroke_label.aligned().boxed()
+                    Some(keystroke_label.aligned().boxed())
                 }
             }))
             .contained()


### PR DESCRIPTION
Co-authored-by: Antonio Scandurra <antonio@zed.dev>
## Description of feature or change

We change the code to not assume we have a focused view id. For now, the only place I know about this occurring is when a project is disconnected, where we unfocus the entire window to avoid accepting input from the user. This is a state we need to handle, so for now we just avoid the crash by not attempting to render a keystroke. A more correct implementation would be to still potentially allow global keystrokes, but it's not clear it's worth the effort right now.

## Link to related issues from zed or insiders

Closes #2153 
