### PR TITLE
Remove toggle right sidebar command

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -431,13 +431,6 @@
         }
     },
     {
-        "context": "Workspace",
-        "bindings": {
-            "shift-escape": "dock::FocusDock",
-            "cmd-shift-b": "workspace::ToggleRightSidebar"
-        }
-    },
-    {
         "bindings": {
             "cmd-shift-k cmd-shift-right": "dock::AnchorDockRight",
             "cmd-shift-k cmd-shift-down": "dock::AnchorDockBottom",

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -96,7 +96,6 @@ actions!(
         ActivateNextPane,
         FollowNextCollaborator,
         ToggleLeftSidebar,
-        ToggleRightSidebar,
         NewTerminal,
         NewSearch,
         Feedback,
@@ -229,9 +228,6 @@ pub fn init(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
     });
     cx.add_action(|workspace: &mut Workspace, _: &ToggleLeftSidebar, cx| {
         workspace.toggle_sidebar(SidebarSide::Left, cx);
-    });
-    cx.add_action(|workspace: &mut Workspace, _: &ToggleRightSidebar, cx| {
-        workspace.toggle_sidebar(SidebarSide::Right, cx);
     });
     cx.add_action(Workspace::activate_pane_at_index);
 

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -219,10 +219,6 @@ pub fn menus() -> Vec<Menu<'static>> {
                     name: "Toggle Left Sidebar",
                     action: Box::new(workspace::ToggleLeftSidebar),
                 },
-                MenuItem::Action {
-                    name: "Toggle Right Sidebar",
-                    action: Box::new(workspace::ToggleRightSidebar),
-                },
                 MenuItem::Submenu(Menu {
                     name: "Editor Layout",
                     items: vec![


### PR DESCRIPTION
## Description of feature or change

This command is no longer being used and has confused a user:

<img width="612" alt="SCR-20230211-uya" src="https://user-images.githubusercontent.com/19867440/218291016-ac2ff409-ac40-42eb-8049-442222260035.png">

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
