### PR TITLE
Introduce Reveal in Finder

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -65,6 +65,7 @@ pub trait Platform: Send + Sync {
     fn write_to_clipboard(&self, item: ClipboardItem);
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn open_url(&self, url: &str);
+    fn reveal_path(&self, path: &Path);
 
     fn write_credentials(&self, url: &str, username: &str, password: &[u8]) -> Result<()>;
     fn read_credentials(&self, url: &str) -> Result<Option<(String, Vec<u8>)>>;

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -599,6 +599,19 @@ impl platform::Platform for MacPlatform {
         }
     }
 
+    fn reveal_path(&self, path: &Path) {
+        unsafe {
+            let full_path = ns_string(path.to_str().unwrap_or(""));
+            let root_full_path = ns_string("");
+            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            msg_send![
+                workspace,
+                selectFile: full_path
+                inFileViewerRootedAtPath: root_full_path
+            ]
+        }
+    }
+
     fn write_credentials(&self, url: &str, username: &str, password: &[u8]) -> Result<()> {
         let url = CFString::from(url);
         let username = CFString::from(username);

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -173,6 +173,8 @@ impl super::Platform for Platform {
 
     fn open_url(&self, _: &str) {}
 
+    fn reveal_path(&self, _: &Path) {}
+
     fn write_credentials(&self, _: &str, _: &str, _: &[u8]) -> Result<()> {
         Ok(())
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -119,6 +119,7 @@ actions!(
         AddFile,
         Copy,
         CopyPath,
+        RevealInFinder,
         Cut,
         Paste,
         Delete,
@@ -147,6 +148,7 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(ProjectPanel::cancel);
     cx.add_action(ProjectPanel::copy);
     cx.add_action(ProjectPanel::copy_path);
+    cx.add_action(ProjectPanel::reveal_in_finder);
     cx.add_action(ProjectPanel::cut);
     cx.add_action(
         |this: &mut ProjectPanel, action: &Paste, cx: &mut ViewContext<ProjectPanel>| {
@@ -305,6 +307,7 @@ impl ProjectPanel {
             }
             menu_entries.push(ContextMenuItem::item("New File", AddFile));
             menu_entries.push(ContextMenuItem::item("New Folder", AddDirectory));
+            menu_entries.push(ContextMenuItem::item("Reveal in Finder", RevealInFinder));
             menu_entries.push(ContextMenuItem::Separator);
             menu_entries.push(ContextMenuItem::item("Copy", Copy));
             menu_entries.push(ContextMenuItem::item("Copy Path", CopyPath));
@@ -784,6 +787,12 @@ impl ProjectPanel {
             path.push(worktree.root_name());
             path.push(&entry.path);
             cx.write_to_clipboard(ClipboardItem::new(path.to_string_lossy().to_string()));
+        }
+    }
+
+    fn reveal_in_finder(&mut self, _: &RevealInFinder, cx: &mut ViewContext<Self>) {
+        if let Some((_worktree, entry)) = self.selected_entry(cx) {
+            util::reveal_in_finder(&entry.path);
         }
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -791,8 +791,9 @@ impl ProjectPanel {
     }
 
     fn reveal_in_finder(&mut self, _: &RevealInFinder, cx: &mut ViewContext<Self>) {
-        if let Some((_worktree, entry)) = self.selected_entry(cx) {
-            util::reveal_in_finder(&entry.path);
+        if let Some((worktree, entry)) = self.selected_entry(cx) {
+            cx.platform()
+                .reveal_path(&worktree.abs_path().join(&entry.path));
         }
     }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -731,7 +731,7 @@ impl Terminal {
 
                 if let Some((url, url_match)) = found_url {
                     if *open {
-                        util::open(&url);
+                        cx.platform().open_url(url.as_str());
                     } else {
                         self.update_hyperlink(prev_hyperlink, url, url_match);
                     }
@@ -1072,7 +1072,7 @@ impl Terminal {
             if self.selection_phase == SelectionPhase::Ended {
                 let mouse_cell_index = content_index_for_mouse(position, &self.last_content);
                 if let Some(link) = self.last_content.cells[mouse_cell_index].hyperlink() {
-                    util::open(link.uri());
+                    cx.platform().open_url(link.uri());
                 } else {
                     self.events
                         .push_back(InternalEvent::FindHyperlink(position, true));

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -54,6 +54,14 @@ pub fn truncate_and_trailoff(s: &str, max_chars: usize) -> String {
     }
 }
 
+pub fn open<P: AsRef<Path>>(path: P) {
+    let path_to_open = path.as_ref().to_string_lossy();
+    std::process::Command::new("open")
+        .arg(path_to_open.as_ref())
+        .spawn()
+        .log_err();
+}
+
 pub fn reveal_in_finder<P: AsRef<Path>>(path: P) {
     let path_to_reveal = path.as_ref().to_string_lossy();
     std::process::Command::new("open")

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -56,19 +56,25 @@ pub fn truncate_and_trailoff(s: &str, max_chars: usize) -> String {
 
 pub fn open<P: AsRef<Path>>(path: P) {
     let path_to_open = path.as_ref().to_string_lossy();
-    std::process::Command::new("open")
-        .arg(path_to_open.as_ref())
-        .spawn()
-        .log_err();
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(path_to_open.as_ref())
+            .spawn()
+            .log_err();
+    }
 }
 
 pub fn reveal_in_finder<P: AsRef<Path>>(path: P) {
     let path_to_reveal = path.as_ref().to_string_lossy();
-    std::process::Command::new("open")
-        .arg("-R") // To reveal in Finder instead of opening the file
-        .arg(path_to_reveal.as_ref())
-        .spawn()
-        .log_err();
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("-R") // To reveal in Finder instead of opening the file
+            .arg(path_to_reveal.as_ref())
+            .spawn()
+            .log_err();
+    }
 }
 
 pub fn post_inc<T: From<u8> + AddAssign<T> + Copy>(value: &mut T) -> T {

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -65,18 +65,6 @@ pub fn open<P: AsRef<Path>>(path: P) {
     }
 }
 
-pub fn reveal_in_finder<P: AsRef<Path>>(path: P) {
-    let path_to_reveal = path.as_ref().to_string_lossy();
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .arg("-R") // To reveal in Finder instead of opening the file
-            .arg(path_to_reveal.as_ref())
-            .spawn()
-            .log_err();
-    }
-}
-
 pub fn post_inc<T: From<u8> + AddAssign<T> + Copy>(value: &mut T) -> T {
     let prev = *value;
     *value += T::from(1);

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -9,6 +9,7 @@ use rand::{seq::SliceRandom, Rng};
 use std::{
     cmp::Ordering,
     ops::AddAssign,
+    path::Path,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -51,6 +52,15 @@ pub fn truncate_and_trailoff(s: &str, max_chars: usize) -> String {
         Some(length) => s[..length].to_string() + "…",
         None => s.to_string(),
     }
+}
+
+pub fn reveal_in_finder<P: AsRef<Path>>(path: P) {
+    let path_to_reveal = path.as_ref().to_string_lossy();
+    std::process::Command::new("open")
+        .arg("-R") // To reveal in Finder instead of opening the file
+        .arg(path_to_reveal.as_ref())
+        .spawn()
+        .log_err();
 }
 
 pub fn post_inc<T: From<u8> + AddAssign<T> + Copy>(value: &mut T) -> T {

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -9,7 +9,6 @@ use rand::{seq::SliceRandom, Rng};
 use std::{
     cmp::Ordering,
     ops::AddAssign,
-    path::Path,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -51,17 +50,6 @@ pub fn truncate_and_trailoff(s: &str, max_chars: usize) -> String {
     match truncation_ix {
         Some(length) => s[..length].to_string() + "…",
         None => s.to_string(),
-    }
-}
-
-pub fn open<P: AsRef<Path>>(path: P) {
-    let path_to_open = path.as_ref().to_string_lossy();
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .arg(path_to_open.as_ref())
-            .spawn()
-            .log_err();
     }
 }
 

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -146,11 +146,8 @@ pub mod simple_message_notification {
     pub fn init(cx: &mut MutableAppContext) {
         cx.add_action(MessageNotification::dismiss);
         cx.add_action(
-            |_workspace: &mut Workspace, open_action: &OsOpen, _cx: &mut ViewContext<Workspace>| {
-                #[cfg(target_os = "macos")]
-                {
-                    util::open(&open_action.0);
-                }
+            |_workspace: &mut Workspace, open_action: &OsOpen, cx: &mut ViewContext<Workspace>| {
+                cx.platform().open_url(open_action.0.as_str());
             },
         )
     }

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -121,7 +121,6 @@ impl Workspace {
 }
 
 pub mod simple_message_notification {
-    use std::process::Command;
 
     use gpui::{
         actions,
@@ -150,10 +149,7 @@ pub mod simple_message_notification {
             |_workspace: &mut Workspace, open_action: &OsOpen, _cx: &mut ViewContext<Workspace>| {
                 #[cfg(target_os = "macos")]
                 {
-                    let mut command = Command::new("open");
-                    command.arg(open_action.0.clone());
-
-                    command.spawn().ok();
+                    util::open(&open_action.0);
                 }
             },
         )


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/5398

Introducing new functionality to be able to reveal the selected entry in the project pane in macOS finder.

I have based the solution on [windows - With Rust, Open Explorer on a File - Stack Overflow](https://stackoverflow.com/questions/66485945/with-rust-open-explorer-on-a-file) and only added the `-R` option to `open` for it to open the enclosing folder instead of opening the folder/file itself.

I had used a `PathBuf` argument originally, but @mikayla-maki helped me improve the function signature:

Before:

```rust
pub fn reveal_in_finder(path: PathBuf)
```

After:

```rust
pub fn reveal_in_finder<P: AsRef<Path>>(path: P)
```

Which now allows us to pass a plethora of different types that know how to be a `Path`. Or at least this is what I have understood 😄.

@mikayla-maki suggested we move the two functions from `util` to `platform` which I am not sure exactly how to do best. I plan to ask @as-cii for thoughts and help.

@JosephTLyons also suggested in the original issue:

> Additionally, having a command to reveal the file of the currently-focused editor in finder would be awesome too.

I think I would prefer to tackle that part with a follow up pull request. But I have already started [asking suggestions](https://discord.com/channels/824559261756424192/937753672870395926/1074606765871738950) for what the best approach would be design-wise.

### Actions

- [x] Implement functionality to open a path in Finder
- [x] Pair review with @mikayla-maki 
- [x] Refactor some of the older code to use the new function
- [x] Pair review with @as-cii 
- [x] Move code from util to platform and use the macOS API instead of spawning an external process
- [x] Refactor older code to use `open_url`
- [x] Do we need tests? (I think not)
- [x] Docs?
- [x] Merge
