### PR TITLE
Avoid creating more than one room when inviting multiple people at once

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use client::{proto, Client, TypedEnvelope, User, UserStore};
 use collections::HashSet;
+use futures::{future::Shared, FutureExt};
 use postage::watch;
 
 use gpui::{
@@ -33,6 +34,7 @@ pub struct IncomingCall {
 /// Singleton global maintaining the user's participation in a room across workspaces.
 pub struct ActiveCall {
     room: Option<(ModelHandle<Room>, Vec<Subscription>)>,
+    pending_room_creation: Option<Shared<Task<Result<ModelHandle<Room>, Arc<anyhow::Error>>>>>,
     location: Option<WeakModelHandle<Project>>,
     pending_invites: HashSet<u64>,
     incoming_call: (
@@ -56,6 +58,7 @@ impl ActiveCall {
     ) -> Self {
         Self {
             room: None,
+            pending_room_creation: None,
             location: None,
             pending_invites: Default::default(),
             incoming_call: watch::channel(),
@@ -124,45 +127,74 @@ impl ActiveCall {
         initial_project: Option<ModelHandle<Project>>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<()>> {
-        let client = self.client.clone();
-        let user_store = self.user_store.clone();
         if !self.pending_invites.insert(called_user_id) {
             return Task::ready(Err(anyhow!("user was already invited")));
         }
-
         cx.notify();
-        cx.spawn(|this, mut cx| async move {
-            let invite = async {
-                if let Some(room) = this.read_with(&cx, |this, _| this.room().cloned()) {
-                    let initial_project_id = if let Some(initial_project) = initial_project {
-                        Some(
-                            room.update(&mut cx, |room, cx| {
-                                room.share_project(initial_project, cx)
-                            })
+
+        let room = if let Some(room) = self.room().cloned() {
+            Some(Task::ready(Ok(room)).shared())
+        } else {
+            self.pending_room_creation.clone()
+        };
+
+        let invite = if let Some(room) = room {
+            cx.spawn_weak(|_, mut cx| async move {
+                let room = room.await.map_err(|err| anyhow!("{:?}", err))?;
+
+                let initial_project_id = if let Some(initial_project) = initial_project {
+                    Some(
+                        room.update(&mut cx, |room, cx| room.share_project(initial_project, cx))
                             .await?,
-                        )
-                    } else {
-                        None
-                    };
-
-                    room.update(&mut cx, |room, cx| {
-                        room.call(called_user_id, initial_project_id, cx)
-                    })
-                    .await?;
+                    )
                 } else {
-                    let room = cx
-                        .update(|cx| {
-                            Room::create(called_user_id, initial_project, client, user_store, cx)
-                        })
-                        .await?;
-
-                    this.update(&mut cx, |this, cx| this.set_room(Some(room), cx))
-                        .await?;
+                    None
                 };
 
-                Ok(())
-            };
+                room.update(&mut cx, |room, cx| {
+                    room.call(called_user_id, initial_project_id, cx)
+                })
+                .await?;
 
+                anyhow::Ok(())
+            })
+        } else {
+            let client = self.client.clone();
+            let user_store = self.user_store.clone();
+            let room = cx
+                .spawn(|this, mut cx| async move {
+                    let create_room = async {
+                        let room = cx
+                            .update(|cx| {
+                                Room::create(
+                                    called_user_id,
+                                    initial_project,
+                                    client,
+                                    user_store,
+                                    cx,
+                                )
+                            })
+                            .await?;
+
+                        this.update(&mut cx, |this, cx| this.set_room(Some(room.clone()), cx))
+                            .await?;
+
+                        anyhow::Ok(room)
+                    };
+
+                    let room = create_room.await;
+                    this.update(&mut cx, |this, _| this.pending_room_creation = None);
+                    room.map_err(Arc::new)
+                })
+                .shared();
+            self.pending_room_creation = Some(room.clone());
+            cx.foreground().spawn(async move {
+                room.await.map_err(|err| anyhow!("{:?}", err))?;
+                anyhow::Ok(())
+            })
+        };
+
+        cx.spawn(|this, mut cx| async move {
             let result = invite.await;
             this.update(&mut cx, |this, cx| {
                 this.pending_invites.remove(&called_user_id);

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -166,9 +166,67 @@ async fn test_basic_calls(
         }
     );
 
+    // Call user C again from user A.
+    active_call_a
+        .update(cx_a, |call, cx| {
+            call.invite(client_c.user_id().unwrap(), None, cx)
+        })
+        .await
+        .unwrap();
+
+    deterministic.run_until_parked();
+    assert_eq!(
+        room_participants(&room_a, cx_a),
+        RoomParticipants {
+            remote: vec!["user_b".to_string()],
+            pending: vec!["user_c".to_string()]
+        }
+    );
+    assert_eq!(
+        room_participants(&room_b, cx_b),
+        RoomParticipants {
+            remote: vec!["user_a".to_string()],
+            pending: vec!["user_c".to_string()]
+        }
+    );
+
+    // User C accepts the call.
+    let call_c = incoming_call_c.next().await.unwrap().unwrap();
+    assert_eq!(call_c.calling_user.github_login, "user_a");
+    active_call_c
+        .update(cx_c, |call, cx| call.accept_incoming(cx))
+        .await
+        .unwrap();
+    assert!(incoming_call_c.next().await.unwrap().is_none());
+    let room_c = active_call_c.read_with(cx_c, |call, _| call.room().unwrap().clone());
+
+    deterministic.run_until_parked();
+    assert_eq!(
+        room_participants(&room_a, cx_a),
+        RoomParticipants {
+            remote: vec!["user_b".to_string(), "user_c".to_string()],
+            pending: Default::default()
+        }
+    );
+    assert_eq!(
+        room_participants(&room_b, cx_b),
+        RoomParticipants {
+            remote: vec!["user_a".to_string(), "user_c".to_string()],
+            pending: Default::default()
+        }
+    );
+    assert_eq!(
+        room_participants(&room_c, cx_c),
+        RoomParticipants {
+            remote: vec!["user_a".to_string(), "user_b".to_string()],
+            pending: Default::default()
+        }
+    );
+
     // User A shares their screen
     let display = MacOSDisplay::new();
     let events_b = active_call_events(cx_b);
+    let events_c = active_call_events(cx_c);
     active_call_a
         .update(cx_a, |call, cx| {
             call.room().unwrap().update(cx, |room, cx| {
@@ -181,11 +239,29 @@ async fn test_basic_calls(
 
     deterministic.run_until_parked();
 
+    // User B observes the remote screen sharing track.
     assert_eq!(events_b.borrow().len(), 1);
-    let event = events_b.borrow().first().unwrap().clone();
-    if let call::room::Event::RemoteVideoTracksChanged { participant_id } = event {
+    let event_b = events_b.borrow().first().unwrap().clone();
+    if let call::room::Event::RemoteVideoTracksChanged { participant_id } = event_b {
         assert_eq!(participant_id, client_a.peer_id().unwrap());
         room_b.read_with(cx_b, |room, _| {
+            assert_eq!(
+                room.remote_participants()[&client_a.user_id().unwrap()]
+                    .tracks
+                    .len(),
+                1
+            );
+        });
+    } else {
+        panic!("unexpected event")
+    }
+
+    // User C observes the remote screen sharing track.
+    assert_eq!(events_c.borrow().len(), 1);
+    let event_c = events_c.borrow().first().unwrap().clone();
+    if let call::room::Event::RemoteVideoTracksChanged { participant_id } = event_c {
+        assert_eq!(participant_id, client_a.peer_id().unwrap());
+        room_c.read_with(cx_c, |room, _| {
             assert_eq!(
                 room.remote_participants()[&client_a.user_id().unwrap()]
                     .tracks
@@ -213,18 +289,28 @@ async fn test_basic_calls(
     assert_eq!(
         room_participants(&room_b, cx_b),
         RoomParticipants {
-            remote: Default::default(),
+            remote: vec!["user_c".to_string()],
+            pending: Default::default()
+        }
+    );
+    assert_eq!(
+        room_participants(&room_c, cx_c),
+        RoomParticipants {
+            remote: vec!["user_b".to_string()],
             pending: Default::default()
         }
     );
 
     // User B gets disconnected from the LiveKit server, which causes them
-    // to automatically leave the room.
+    // to automatically leave the room. User C leaves the room as well because
+    // nobody else is in there.
     server
         .test_live_kit_server
-        .disconnect_client(client_b.peer_id().unwrap().to_string())
+        .disconnect_client(client_b.user_id().unwrap().to_string())
         .await;
-    active_call_b.update(cx_b, |call, _| assert!(call.room().is_none()));
+    deterministic.run_until_parked();
+    active_call_b.read_with(cx_b, |call, _| assert!(call.room().is_none()));
+    active_call_c.read_with(cx_c, |call, _| assert!(call.room().is_none()));
     assert_eq!(
         room_participants(&room_a, cx_a),
         RoomParticipants {
@@ -234,6 +320,13 @@ async fn test_basic_calls(
     );
     assert_eq!(
         room_participants(&room_b, cx_b),
+        RoomParticipants {
+            remote: Default::default(),
+            pending: Default::default()
+        }
+    );
+    assert_eq!(
+        room_participants(&room_c, cx_c),
         RoomParticipants {
             remote: Default::default(),
             pending: Default::default()
@@ -2572,7 +2665,7 @@ async fn test_fs_operations(
         .await
         .unwrap();
     deterministic.run_until_parked();
-    
+
     worktree_a.read_with(cx_a, |worktree, _| {
         assert_eq!(
             worktree


### PR DESCRIPTION
Fixes #2162 

Previously, when initiating a call by calling multiple people, only the first person would get the call while all the others would briefly show a "pending" status but never get the call.

This would happen because `ActiveCall` was trying to a create a different room for each person called, because the original room creation hadn't finished and so a `ModelHandle<Room>` wasn't being store in the active call.

With this pull request, only one room can be created at any given time and further invites have to wait until that room creation is done.