### PR TITLE
Introduce `editor: toggle soft wrap` bound to `alt-z`

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -164,6 +164,7 @@
         "bindings": {
             "enter": "editor::Newline",
             "cmd-enter": "editor::NewlineBelow",
+            "alt-z": "editor::ToggleSoftWrap",
             "cmd-f": [
                 "buffer_search::Deploy",
                 {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -236,6 +236,7 @@ actions!(
         RestartLanguageServer,
         Hover,
         Format,
+        ToggleSoftWrap
     ]
 );
 
@@ -346,6 +347,7 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::toggle_code_actions);
     cx.add_action(Editor::open_excerpts);
     cx.add_action(Editor::jump);
+    cx.add_action(Editor::toggle_soft_wrap);
     cx.add_async_action(Editor::format);
     cx.add_action(Editor::restart_language_server);
     cx.add_action(Editor::show_character_palette);
@@ -5810,6 +5812,19 @@ impl Editor {
     pub fn set_wrap_width(&self, width: Option<f32>, cx: &mut MutableAppContext) -> bool {
         self.display_map
             .update(cx, |map, cx| map.set_wrap_width(width, cx))
+    }
+
+    pub fn toggle_soft_wrap(&mut self, _: &ToggleSoftWrap, cx: &mut ViewContext<Self>) {
+        if self.soft_wrap_mode_override.is_some() {
+            self.soft_wrap_mode_override.take();
+        } else {
+            let soft_wrap = match self.soft_wrap_mode(cx) {
+                SoftWrap::None => settings::SoftWrap::EditorWidth,
+                SoftWrap::EditorWidth | SoftWrap::Column(_) => settings::SoftWrap::None,
+            };
+            self.soft_wrap_mode_override = Some(soft_wrap);
+        }
+        cx.notify();
     }
 
     pub fn highlight_rows(&mut self, rows: Option<Range<u32>>) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1534,15 +1534,14 @@ impl Element for EditorElement {
         let snapshot = self.update_view(cx.app, |view, cx| {
             view.set_visible_line_count(size.y() / line_height);
 
+            let editor_width = text_width - gutter_margin - overscroll.x() - em_width;
             let wrap_width = match view.soft_wrap_mode(cx) {
-                SoftWrap::None => Some((MAX_LINE_LEN / 2) as f32 * em_advance),
-                SoftWrap::EditorWidth => {
-                    Some(text_width - gutter_margin - overscroll.x() - em_width)
-                }
-                SoftWrap::Column(column) => Some(column as f32 * em_advance),
+                SoftWrap::None => (MAX_LINE_LEN / 2) as f32 * em_advance,
+                SoftWrap::EditorWidth => editor_width,
+                SoftWrap::Column(column) => editor_width.min(column as f32 * em_advance),
             };
 
-            if view.set_wrap_width(wrap_width, cx) {
+            if view.set_wrap_width(Some(wrap_width), cx) {
                 view.snapshot(cx)
             } else {
                 snapshot


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/5886
Closes https://github.com/zed-industries/zed/issues/5928

When there isn't a default soft-wrapping for the active editor, we will soft wrap at the editor width. This is consistent with Visual Studio Code. Otherwise, we will flip back and forth between the user's preferred soft-wrapping mode for the language  and no soft-wrapping.

With this pull request, we will also start soft-wrapping at the editor width if it's narrower than preferred line length.