### PR TITLE
Reset search matches when the terminal is cleared

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -21,6 +21,7 @@ use language::{
 use project::{DiagnosticSummary, Project, ProjectPath};
 use serde_json::json;
 use settings::Settings;
+use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
     cmp::Ordering,
@@ -579,7 +580,7 @@ impl Item for ProjectDiagnosticsEditor {
             .update(cx, |editor, cx| editor.git_diff_recalc(project, cx))
     }
 
-    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
+    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         Editor::to_item_events(event)
     }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -19,6 +19,7 @@ use language::{
 use project::{FormatTrigger, Item as _, Project, ProjectPath};
 use rpc::proto::{self, update_view};
 use settings::Settings;
+use smallvec::SmallVec;
 use std::{
     borrow::Cow,
     cmp::{self, Ordering},
@@ -693,8 +694,8 @@ impl Item for Editor {
         Task::ready(Ok(()))
     }
 
-    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
-        let mut result = Vec::new();
+    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
+        let mut result = SmallVec::new();
         match event {
             Event::Closed => result.push(ItemEvent::CloseItem),
             Event::Saved | Event::TitleChanged => {

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -24,6 +24,7 @@ use serde::Serialize;
 use workspace::{
     item::{Item, ItemHandle},
     searchable::{SearchableItem, SearchableItemHandle},
+    smallvec::SmallVec,
     AppState, Workspace,
 };
 
@@ -258,8 +259,8 @@ impl Item for FeedbackEditor {
         self.editor.for_each_project_item(cx, f)
     }
 
-    fn to_item_events(_: &Self::Event) -> Vec<workspace::item::ItemEvent> {
-        Vec::new()
+    fn to_item_events(_: &Self::Event) -> SmallVec<[workspace::item::ItemEvent; 2]> {
+        SmallVec::new()
     }
 
     fn is_singleton(&self, _: &AppContext) -> bool {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -16,6 +16,7 @@ use gpui::{
 use menu::Confirm;
 use project::{search::SearchQuery, Project};
 use settings::Settings;
+use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
     mem,
@@ -345,11 +346,13 @@ impl Item for ProjectSearchView {
             .update(cx, |editor, cx| editor.git_diff_recalc(project, cx))
     }
 
-    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
+    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         match event {
-            ViewEvent::UpdateTab => vec![ItemEvent::UpdateBreadcrumbs, ItemEvent::UpdateTab],
+            ViewEvent::UpdateTab => {
+                smallvec::smallvec![ItemEvent::UpdateBreadcrumbs, ItemEvent::UpdateTab]
+            }
             ViewEvent::EditorEvent(editor_event) => Editor::to_item_events(editor_event),
-            _ => Vec::new(),
+            _ => SmallVec::new(),
         }
     }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -643,6 +643,8 @@ impl Terminal {
                 if (new_cursor.line.0 as usize) < term.screen_lines() - 1 {
                     term.grid_mut().reset_region((new_cursor.line + 1)..);
                 }
+
+                cx.emit(Event::Wakeup);
             }
             InternalEvent::Scroll(scroll) => {
                 term.scroll_display(*scroll);

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -21,6 +21,7 @@ use gpui::{
 use project::{LocalWorktree, Project};
 use serde::Deserialize;
 use settings::{Settings, TerminalBlink, WorkingDirectory};
+use smallvec::SmallVec;
 use smol::Timer;
 use terminal::{
     alacritty_terminal::{
@@ -664,12 +665,12 @@ impl Item for TerminalView {
         Some(Box::new(handle.clone()))
     }
 
-    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
+    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         match event {
-            Event::BreadcrumbsChanged => vec![ItemEvent::UpdateBreadcrumbs],
-            Event::TitleChanged | Event::Wakeup => vec![ItemEvent::UpdateTab],
-            Event::CloseTerminal => vec![ItemEvent::CloseItem],
-            _ => vec![],
+            Event::BreadcrumbsChanged => smallvec::smallvec![ItemEvent::UpdateBreadcrumbs],
+            Event::TitleChanged | Event::Wakeup => smallvec::smallvec![ItemEvent::UpdateTab],
+            Event::CloseTerminal => smallvec::smallvec![ItemEvent::CloseItem],
+            _ => smallvec::smallvec![],
         }
     }
 

--- a/crates/theme_testbench/src/theme_testbench.rs
+++ b/crates/theme_testbench/src/theme_testbench.rs
@@ -11,6 +11,7 @@ use gpui::{
 };
 use project::Project;
 use settings::Settings;
+use smallvec::SmallVec;
 use theme::{ColorScheme, Layer, Style, StyleSet};
 use workspace::{
     item::{Item, ItemEvent},
@@ -350,8 +351,8 @@ impl Item for ThemeTestbench {
         gpui::Task::ready(Ok(()))
     }
 
-    fn to_item_events(_: &Self::Event) -> Vec<ItemEvent> {
-        Vec::new()
+    fn to_item_events(_: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
+        SmallVec::new()
     }
 
     fn serialized_item_kind() -> Option<&'static str> {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -88,7 +88,7 @@ pub trait Item: View {
     ) -> Task<Result<()>> {
         Task::ready(Ok(()))
     }
-    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent>;
+    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]>;
     fn should_close_item_on_event(_: &Self::Event) -> bool {
         false
     }
@@ -723,6 +723,7 @@ pub(crate) mod test {
         RenderContext, Task, View, ViewContext, ViewHandle, WeakViewHandle,
     };
     use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
+    use smallvec::SmallVec;
     use std::{any::Any, borrow::Cow, cell::Cell, path::Path};
 
     pub struct TestProjectItem {
@@ -985,8 +986,8 @@ pub(crate) mod test {
             Task::ready(Ok(()))
         }
 
-        fn to_item_events(_: &Self::Event) -> Vec<ItemEvent> {
-            vec![ItemEvent::UpdateTab, ItemEvent::Edit]
+        fn to_item_events(_: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
+            [ItemEvent::UpdateTab, ItemEvent::Edit].into()
         }
 
         fn serialized_item_kind() -> Option<&'static str> {

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -13,6 +13,7 @@ use gpui::{
 };
 use project::Project;
 use settings::Settings;
+use smallvec::SmallVec;
 use std::{
     path::PathBuf,
     sync::{Arc, Weak},
@@ -177,9 +178,9 @@ impl Item for SharedScreen {
         Task::ready(Err(anyhow!("Item::reload called on SharedScreen")))
     }
 
-    fn to_item_events(event: &Self::Event) -> Vec<ItemEvent> {
+    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         match event {
-            Event::Close => vec![ItemEvent::CloseItem],
+            Event::Close => smallvec::smallvec!(ItemEvent::CloseItem),
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -14,6 +14,8 @@ pub mod sidebar;
 mod status_bar;
 mod toolbar;
 
+pub use smallvec;
+
 use anyhow::{anyhow, Result};
 use call::ActiveCall;
 use client::{


### PR DESCRIPTION
## Description of feature or change

- Switches item event translation to use SmallVec
- Fixes https://github.com/zed-industries/zed/issues/5933

## Link to related issues from zed or insiders

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
