### PR TITLE
Add auto update setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -90,6 +90,8 @@
         // Send anonymized usage data like what languages you're using Zed with.
         "metrics": true
     },
+    // Automatically update Zed
+    "auto_update": true,
     // Git gutter behavior configuration.
     "git": {
         // Control whether the git gutter is shown. May take 2 values:

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -53,6 +53,7 @@ pub struct Settings {
     pub theme: Arc<Theme>,
     pub telemetry_defaults: TelemetrySettings,
     pub telemetry_overrides: TelemetrySettings,
+    pub auto_update: bool,
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -312,6 +313,8 @@ pub struct SettingsFileContent {
     pub theme: Option<String>,
     #[serde(default)]
     pub telemetry: TelemetrySettings,
+    #[serde(default)]
+    pub auto_update: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -375,6 +378,7 @@ impl Settings {
             theme: themes.get(&defaults.theme.unwrap()).unwrap(),
             telemetry_defaults: defaults.telemetry,
             telemetry_overrides: Default::default(),
+            auto_update: defaults.auto_update.unwrap(),
         }
     }
 
@@ -427,6 +431,7 @@ impl Settings {
         self.language_overrides = data.languages;
         self.telemetry_overrides = data.telemetry;
         self.lsp = data.lsp;
+        merge(&mut self.auto_update, data.auto_update);
     }
 
     pub fn with_language_defaults(
@@ -573,6 +578,7 @@ impl Settings {
                 metrics: Some(true),
             },
             telemetry_overrides: Default::default(),
+            auto_update: true,
         }
     }
 


### PR DESCRIPTION
## Description of feature or change

This adds a setting to disable the auto update. Auto update checks eagerly when the settings is changed to true, from false.

## Link to related issues from zed or insiders

https://github.com/zed-industries/zed/issues/5917

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
