### PR TITLE
Score matches case-sensitively when query contains an uppercase char

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -812,7 +812,7 @@ impl CompletionsMenu {
             fuzzy::match_strings(
                 &self.match_candidates,
                 query,
-                false,
+                query.chars().any(|c| c.is_uppercase()),
                 100,
                 &Default::default(),
                 executor,


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/5013