### PR TITLE
Fix LSP status messages persisting

### DIFF
--- a/crates/client/src/http.rs
+++ b/crates/client/src/http.rs
@@ -9,7 +9,7 @@ pub use isahc::{
     Error,
 };
 use smol::future::FutureExt;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 pub use url::Url;
 
 pub type Request = isahc::Request<AsyncBody>;
@@ -41,7 +41,13 @@ pub trait HttpClient: Send + Sync {
 }
 
 pub fn client() -> Arc<dyn HttpClient> {
-    Arc::new(isahc::HttpClient::builder().build().unwrap())
+    Arc::new(
+        isahc::HttpClient::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .low_speed_timeout(100, Duration::from_secs(5))
+            .build()
+            .unwrap(),
+    )
 }
 
 impl HttpClient for isahc::HttpClient {

--- a/crates/zed/src/languages/installation.rs
+++ b/crates/zed/src/languages/installation.rs
@@ -39,6 +39,7 @@ pub async fn npm_package_latest_version(name: &str) -> Result<String> {
     let output = smol::process::Command::new("npm")
         .args(["-fetch-retry-mintimeout", "2000"])
         .args(["-fetch-retry-maxtimeout", "5000"])
+        .args(["-fetch-timeout", "5000"])
         .args(["info", name, "--json"])
         .output()
         .await
@@ -64,6 +65,7 @@ pub async fn npm_install_packages(
     let output = smol::process::Command::new("npm")
         .args(["-fetch-retry-mintimeout", "2000"])
         .args(["-fetch-retry-maxtimeout", "5000"])
+        .args(["-fetch-timeout", "5000"])
         .arg("install")
         .arg("--prefix")
         .arg(directory)


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/5821

It was kinda tricky to reproduce the problem locally, but I believe this happens when network connectivity is spotty. I found a couple of places where we didn't have timeouts:

- When running `npm info` and `npm install`, we only had retry timeouts but no HTTP request timeout. The default timeout was 5 minutes, so I fixed that in 2482a1a9cee549b33b7c60c885eb99a22f9e830c by supplying a 5s timeout instead.
- When running HTTP requests via isahc, the default connection timeout was 5 minutes and there was no request timeout. I fixed that in 5df50e2fc97a92f875c7174a760da5914be03bd5 by supplying a 5s timeout for connecting to a URL as well as failing the request when its speed is below 100bytes/sec for more than 5s.

@JosephTLyons: I'd love if you could keep an eye on this after I merge it to see if it fixes the problem for you.