### PR TITLE
Add option to advance cursor downward when toggling comment

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -228,7 +228,12 @@
                     "replace_newest": true
                 }
             ],
-            "cmd-/": "editor::ToggleComments",
+            "cmd-/": [
+                "editor::ToggleComments",
+                {
+                    "advance_downwards": false
+                }
+            ],
             "alt-up": "editor::SelectLargerSyntaxNode",
             "alt-down": "editor::SelectSmallerSyntaxNode",
             "cmd-u": "editor::UndoSelection",

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -146,7 +146,7 @@ pub fn menus() -> Vec<Menu<'static>> {
                 MenuItem::Separator,
                 MenuItem::Action {
                     name: "Toggle Line Comment",
-                    action: Box::new(editor::ToggleComments),
+                    action: Box::new(editor::ToggleComments::default()),
                 },
                 MenuItem::Action {
                     name: "Emoji & Symbols",


### PR DESCRIPTION
## Description of feature or change

Closes: https://github.com/zed-industries/zed/issues/5864

This helps to bring some expected JetBrains editor functionality over to Zed.  I figured landing this during quality week made the most sense.  Also, this is something I've been wanting for awhile personally.  I'll add this to the Jetbrains keymap if this lands and once it's in stable.

The ways in which the cursor moves horizontally match that of what JetBrains' IDEs do.  I think we can make these less surprising, but these behaviors come up rather naturally, and so for the first iteration, we can just match the behavior, and later on, we can go the extra mile to #MakeItBetter.

One thing I'm not entirely sure of is the option name.  If you have a suggestion for what you think it should be, I'd love to hear it.

Thanks for the help @ForLoveOfCats

## Link to related issues from zed or insiders

## Before Merging 

- [X] Does this have tests or have existing tests been updated to cover this change?
- [X] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
