### PR TITLE
Put back shift-escape binding for FocusDock action

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -432,6 +432,12 @@
         }
     },
     {
+        "context": "Workspace",
+        "bindings": {
+            "shift-escape": "dock::FocusDock"
+        }
+    },
+    {
         "bindings": {
             "cmd-shift-k cmd-shift-right": "dock::AnchorDockRight",
             "cmd-shift-k cmd-shift-down": "dock::AnchorDockBottom",


### PR DESCRIPTION
I think this binding was spuriously removed in https://github.com/zed-industries/zed/pull/2160.