### PR TITLE
Highlight functions called with a turbofish in Rust

### DIFF
--- a/crates/zed/src/languages/rust/highlights.scm
+++ b/crates/zed/src/languages/rust/highlights.scm
@@ -12,6 +12,15 @@
       field: (field_identifier) @function.method)
   ])
 
+(generic_function
+  function: [
+    (identifier) @function
+    (scoped_identifier
+      name: (identifier) @function)
+    (field_expression
+      field: (field_identifier) @function.method)
+  ])
+
 (function_item name: (identifier) @function.definition)
 (function_signature_item name: (identifier) @function.definition)
 


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/5934