### PR TITLE
update tree-sitter-typescript to add support for new satisfies operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
  "tree-sitter-html",
  "tree-sitter-javascript",
  "tree-sitter-rust",
- "tree-sitter-typescript",
+ "tree-sitter-typescript 0.20.2",
  "unindent",
  "util",
  "workspace",
@@ -3277,7 +3277,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
- "tree-sitter-typescript",
+ "tree-sitter-typescript 0.20.1",
  "unicase",
  "unindent",
  "util",
@@ -7193,6 +7193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-typescript"
+version = "0.20.2"
+source = "git+https://github.com/tree-sitter/tree-sitter-typescript?rev=5d20856f34315b068c41edaee2ac8a100081d259#5d20856f34315b068c41edaee2ac8a100081d259"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-yaml"
 version = "0.0.1"
 source = "git+https://github.com/zed-industries/tree-sitter-yaml?rev=9050a4a4a847ed29e25485b1292a36eab8ae3492#9050a4a4a847ed29e25485b1292a36eab8ae3492"
@@ -8439,7 +8448,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scheme",
  "tree-sitter-toml",
- "tree-sitter-typescript",
+ "tree-sitter-typescript 0.20.2",
  "tree-sitter-yaml",
  "unindent",
  "url",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -59,7 +59,7 @@ smol = "1.2"
 tree-sitter-rust = { version = "*", optional = true }
 tree-sitter-html = { version = "*", optional = true }
 tree-sitter-javascript = { version = "*", optional = true }
-tree-sitter-typescript = { version = "*", optional = true }
+tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259", optional = true }
 
 [dev-dependencies]
 text = { path = "../text", features = ["test-support"] }
@@ -77,5 +77,5 @@ unindent = "0.1.7"
 tree-sitter = "0.20"
 tree-sitter-rust = "0.20"
 tree-sitter-html = "0.19"
-tree-sitter-typescript = "0.20.1"
+tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259" }
 tree-sitter-javascript = "0.20"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -105,7 +105,8 @@ tree-sitter-rust = "0.20.3"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 tree-sitter-python = "0.20.2"
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
-tree-sitter-typescript = "0.20.1"
+tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259" }
+
 tree-sitter-ruby = "0.20.0"
 tree-sitter-html = "0.19.0"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9"}

--- a/crates/zed/src/languages/typescript/highlights.scm
+++ b/crates/zed/src/languages/typescript/highlights.scm
@@ -175,6 +175,7 @@
   "new"
   "of"
   "return"
+  "satisfies"
   "set"
   "static"
   "switch"


### PR DESCRIPTION
## Description of feature or change

Responds to recent feedback message mentioning that we dont support the newest version of typescript. This fixes that.

## Link to related issues from zed or community

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
