### PR TITLE
Fix syntax-related performance problems on gigantic files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7003,7 +7003,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.9"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=36b5b6c89e55ad1a502f8b3234bb3e12ec83a5da#36b5b6c89e55ad1a502f8b3234bb3e12ec83a5da"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=125503ff3b613b08233fc1e06292be9ddd9dd448#125503ff3b613b08233fc1e06292be9ddd9dd448"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7003,7 +7003,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.9"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=125503ff3b613b08233fc1e06292be9ddd9dd448#125503ff3b613b08233fc1e06292be9ddd9dd448"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14#c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
 rand = { version = "0.8" }
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "125503ff3b613b08233fc1e06292be9ddd9dd448" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
 rand = { version = "0.8" }
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "36b5b6c89e55ad1a502f8b3234bb3e12ec83a5da" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "125503ff3b613b08233fc1e06292be9ddd9dd448" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/5899

This PR fixes a few performance problems that we found when editing vary large (> 20MB) source files in Zed, which have to do parsing and querying syntax trees.

1. **breadcrumbs** - On cursor movements, we retrieve the outline items that contain the cursor position, for the breadcrumbs view. As part of this, we grab the syntax-highlighted text of the breadcrumbs. Previously, we attempted to interleave the retrieval of the chunks with the iteration over the outline items. But this meant that we needed to build the iterator *before* we figured out what range of text we needed. As a result, we were supplying the source file's **entire range** 😬 initially, and then seeking the cursor. But the initial range  passed to `Buffer::chunks` controls how many *layers* of the SyntaxMap we retrieve. In large Rust files, there can be huge number of layers.

    Now, we compute the ranges of buffer text that we need before we construct the `Chunks` iterator, so that we can request only the chunks in a small range of the file.

2. **syntax tree balancing** - In https://github.com/tree-sitter/tree-sitter/commit/0b817a609f7cd3d7309a81dbfe96287c6945a085, I fixed a bug where Tree-sitter would sometimes fail to balance a newly-created parse tree in certain error recovery conditions. This meant that all queries and traversals of the parse tree would be very inefficient.

3. **query range limits** - In https://github.com/tree-sitter/tree-sitter/pull/2085, I optimized the execution of tree queries in a limited range. Previously, there was a lot of work done that wasn't limited by the range, so queries on small ranges of large files would be too slow.