### PR TITLE
Fix newly-discovered bugs in saving untitled buffers

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -2244,7 +2244,7 @@ async fn test_propagate_saves_and_fs_changes(
     });
 
     // Edit the buffer as the host and concurrently save as guest B.
-    let save_b = buffer_b.update(cx_b, |buf, cx| buf.save(cx));
+    let save_b = cx_b.update(|cx| Project::save_buffer(buffer_b.clone(), cx));
     buffer_a.update(cx_a, |buf, cx| buf.edit([(0..0, "hi-a, ")], None, cx));
     save_b.await.unwrap();
     assert_eq!(
@@ -2909,7 +2909,7 @@ async fn test_buffer_conflict_after_save(
         assert!(!buf.has_conflict());
     });
 
-    buffer_b.update(cx_b, |buf, cx| buf.save(cx)).await.unwrap();
+    cx_b.update(|cx| Project::save_buffer(buffer_b.clone(), cx)).await.unwrap();
     cx_a.foreground().forbid_parking();
     buffer_b.read_with(cx_b, |buffer_b, _| assert!(!buffer_b.is_dirty()));
     buffer_b.read_with(cx_b, |buf, _| {

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -2244,7 +2244,7 @@ async fn test_propagate_saves_and_fs_changes(
     });
 
     // Edit the buffer as the host and concurrently save as guest B.
-    let save_b = cx_b.update(|cx| Project::save_buffer(buffer_b.clone(), cx));
+    let save_b = project_b.update(cx_b, |project, cx| project.save_buffer(buffer_b.clone(), cx));
     buffer_a.update(cx_a, |buf, cx| buf.edit([(0..0, "hi-a, ")], None, cx));
     save_b.await.unwrap();
     assert_eq!(
@@ -2917,7 +2917,7 @@ async fn test_buffer_conflict_after_save(
         assert!(!buf.has_conflict());
     });
 
-    cx_b.update(|cx| Project::save_buffer(buffer_b.clone(), cx))
+    project_b.update(cx_b, |project, cx| project.save_buffer(buffer_b.clone(), cx))
         .await
         .unwrap();
     cx_a.foreground().forbid_parking();

--- a/crates/collab/src/tests/randomized_integration_tests.rs
+++ b/crates/collab/src/tests/randomized_integration_tests.rs
@@ -1064,15 +1064,16 @@ async fn randomly_query_and_mutate_buffers(
             }
         }
         30..=39 if buffer.read_with(cx, |buffer, _| buffer.is_dirty()) => {
-            let (requested_version, save) = buffer.update(cx, |buffer, cx| {
+            let requested_version = buffer.update(cx, |buffer, cx| {
                 log::info!(
                     "{}: saving buffer {} ({:?})",
                     client.username,
                     buffer.remote_id(),
                     buffer.file().unwrap().full_path(cx)
                 );
-                (buffer.version(), buffer.save(cx))
+                buffer.version()
             });
+            let save = cx.update(|cx| Project::save_buffer(buffer, cx));
             let save = cx.background().spawn(async move {
                 let (saved_version, _, _) = save
                     .await

--- a/crates/collab/src/tests/randomized_integration_tests.rs
+++ b/crates/collab/src/tests/randomized_integration_tests.rs
@@ -1073,7 +1073,7 @@ async fn randomly_query_and_mutate_buffers(
                 );
                 buffer.version()
             });
-            let save = cx.update(|cx| Project::save_buffer(buffer, cx));
+            let save = project.update(cx, |project, cx| project.save_buffer(buffer, cx));
             let save = cx.background().spawn(async move {
                 let (saved_version, _, _) = save
                     .await

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -610,9 +610,11 @@ impl Item for Editor {
         self.report_event("save editor", cx);
         let format = self.perform_format(project.clone(), cx);
         let buffers = self.buffer().clone().read(cx).all_buffers();
-        cx.spawn(|_, mut cx| async move {
+        cx.as_mut().spawn(|mut cx| async move {
             format.await?;
-            cx.update(|cx| Project::save_buffers(buffers, cx)).await?;
+            project
+                .update(&mut cx, |project, cx| project.save_buffers(buffers, cx))
+                .await?;
             Ok(())
         })
     }

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1,7 +1,6 @@
 mod anchor;
 
 pub use anchor::{Anchor, AnchorRangeExt};
-use anyhow::Result;
 use clock::ReplicaId;
 use collections::{BTreeMap, Bound, HashMap, HashSet};
 use futures::{channel::mpsc, SinkExt};
@@ -1277,20 +1276,6 @@ impl MultiBuffer {
             .borrow()
             .get(&buffer_id)
             .map(|state| state.buffer.clone())
-    }
-
-    pub fn save(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
-        let mut save_tasks = Vec::new();
-        for BufferState { buffer, .. } in self.buffers.borrow().values() {
-            save_tasks.push(buffer.update(cx, |buffer, cx| buffer.save(cx)));
-        }
-
-        cx.spawn(|_, _| async move {
-            for save in save_tasks {
-                save.await?;
-            }
-            Ok(())
-        })
     }
 
     pub fn is_completion_trigger<T>(&self, position: T, text: &str, cx: &AppContext) -> bool

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -549,16 +549,11 @@ impl Buffer {
         version: clock::Global,
         fingerprint: RopeFingerprint,
         mtime: SystemTime,
-        new_file: Option<Arc<dyn File>>,
         cx: &mut ModelContext<Self>,
     ) {
         self.saved_version = version;
         self.saved_version_fingerprint = fingerprint;
         self.saved_mtime = mtime;
-        if let Some(new_file) = new_file {
-            self.file = Some(new_file);
-            self.file_update_count += 1;
-        }
         cx.emit(Event::Saved);
         cx.notify();
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4461,16 +4461,19 @@ impl Project {
                             renamed_buffers.push((cx.handle(), old_path));
                         }
 
-                        if let Some(project_id) = self.remote_id() {
-                            self.client
-                                .send(proto::UpdateBufferFile {
-                                    project_id,
-                                    buffer_id: *buffer_id as u64,
-                                    file: Some(new_file.to_proto()),
-                                })
-                                .log_err();
+                        if new_file != *old_file {
+                            if let Some(project_id) = self.remote_id() {
+                                self.client
+                                    .send(proto::UpdateBufferFile {
+                                        project_id,
+                                        buffer_id: *buffer_id as u64,
+                                        file: Some(new_file.to_proto()),
+                                    })
+                                    .log_err();
+                            }
+
+                            buffer.file_updated(Arc::new(new_file), cx).detach();
                         }
-                        buffer.file_updated(Arc::new(new_file), cx).detach();
                     }
                 });
             } else {
@@ -6054,7 +6057,7 @@ impl Project {
                 .and_then(|buffer| buffer.upgrade(cx));
             if let Some(buffer) = buffer {
                 buffer.update(cx, |buffer, cx| {
-                    buffer.did_save(version, fingerprint, mtime, None, cx);
+                    buffer.did_save(version, fingerprint, mtime, cx);
                 });
             }
             Ok(())

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1451,7 +1451,7 @@ impl Project {
         let worktree = file.worktree.clone();
         let path = file.path.clone();
         worktree.update(cx, |worktree, cx| match worktree {
-            Worktree::Local(worktree) => worktree.save_buffer(buffer, path, cx),
+            Worktree::Local(worktree) => worktree.save_buffer(buffer, path, false, cx),
             Worktree::Remote(worktree) => worktree.save_buffer(buffer, cx),
         })
     }
@@ -1474,7 +1474,9 @@ impl Project {
             let (worktree, path) = worktree_task.await?;
             worktree
                 .update(&mut cx, |worktree, cx| match worktree {
-                    Worktree::Local(worktree) => worktree.save_buffer_as(buffer.clone(), path, cx),
+                    Worktree::Local(worktree) => {
+                        worktree.save_buffer(buffer.clone(), path.into(), true, cx)
+                    }
                     Worktree::Remote(_) => panic!("cannot remote buffers as new files"),
                 })
                 .await?;

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -243,7 +243,8 @@ async fn test_managing_language_servers(
     );
 
     // Save notifications are reported to all servers.
-    cx.update(|cx| Project::save_buffer(toml_buffer, cx))
+    project
+        .update(cx, |project, cx| project.save_buffer(toml_buffer, cx))
         .await
         .unwrap();
     assert_eq!(
@@ -2087,7 +2088,8 @@ async fn test_save_file(cx: &mut gpui::TestAppContext) {
         buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
     });
 
-    cx.update(|cx| Project::save_buffer(buffer.clone(), cx))
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
         .await
         .unwrap();
 
@@ -2115,7 +2117,8 @@ async fn test_save_in_single_file_worktree(cx: &mut gpui::TestAppContext) {
         buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
     });
 
-    cx.update(|cx| Project::save_buffer(buffer.clone(), cx))
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
         .await
         .unwrap();
 
@@ -2704,7 +2707,8 @@ async fn test_buffer_line_endings(cx: &mut gpui::TestAppContext) {
     buffer2.update(cx, |buffer, cx| {
         buffer.set_text("one\ntwo\nthree\nfour\n", cx);
     });
-    cx.update(|cx| Project::save_buffer(buffer2, cx))
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer2, cx))
         .await
         .unwrap();
     assert_eq!(

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -243,8 +243,7 @@ async fn test_managing_language_servers(
     );
 
     // Save notifications are reported to all servers.
-    toml_buffer
-        .update(cx, |buffer, cx| buffer.save(cx))
+    cx.update(|cx| Project::save_buffer(toml_buffer, cx))
         .await
         .unwrap();
     assert_eq!(
@@ -2083,12 +2082,12 @@ async fn test_save_file(cx: &mut gpui::TestAppContext) {
         .update(cx, |p, cx| p.open_local_buffer("/dir/file1", cx))
         .await
         .unwrap();
-    buffer
-        .update(cx, |buffer, cx| {
-            assert_eq!(buffer.text(), "the old contents");
-            buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
-            buffer.save(cx)
-        })
+    buffer.update(cx, |buffer, cx| {
+        assert_eq!(buffer.text(), "the old contents");
+        buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
+    });
+
+    cx.update(|cx| Project::save_buffer(buffer.clone(), cx))
         .await
         .unwrap();
 
@@ -2112,11 +2111,11 @@ async fn test_save_in_single_file_worktree(cx: &mut gpui::TestAppContext) {
         .update(cx, |p, cx| p.open_local_buffer("/dir/file1", cx))
         .await
         .unwrap();
-    buffer
-        .update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
-            buffer.save(cx)
-        })
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
+    });
+
+    cx.update(|cx| Project::save_buffer(buffer.clone(), cx))
         .await
         .unwrap();
 
@@ -2703,11 +2702,10 @@ async fn test_buffer_line_endings(cx: &mut gpui::TestAppContext) {
     });
 
     // Save a file with windows line endings. The file is written correctly.
-    buffer2
-        .update(cx, |buffer, cx| {
-            buffer.set_text("one\ntwo\nthree\nfour\n", cx);
-            buffer.save(cx)
-        })
+    buffer2.update(cx, |buffer, cx| {
+        buffer.set_text("one\ntwo\nthree\nfour\n", cx);
+    });
+    cx.update(|cx| Project::save_buffer(buffer2, cx))
         .await
         .unwrap();
     assert_eq!(

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2130,6 +2130,20 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
     fs.insert_tree("/dir", json!({})).await;
 
     let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+
+    let languages = project.read_with(cx, |project, _| project.languages().clone());
+    languages.register(
+        "/some/path",
+        LanguageConfig {
+            name: "Rust".into(),
+            path_suffixes: vec!["rs".into()],
+            ..Default::default()
+        },
+        tree_sitter_rust::language(),
+        None,
+        |_| Default::default(),
+    );
+
     let buffer = project.update(cx, |project, cx| {
         project.create_buffer("", None, cx).unwrap()
     });
@@ -2137,23 +2151,30 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
         buffer.edit([(0..0, "abc")], None, cx);
         assert!(buffer.is_dirty());
         assert!(!buffer.has_conflict());
+        assert_eq!(buffer.language().unwrap().name().as_ref(), "Plain Text");
     });
     project
         .update(cx, |project, cx| {
-            project.save_buffer_as(buffer.clone(), "/dir/file1".into(), cx)
+            project.save_buffer_as(buffer.clone(), "/dir/file1.rs".into(), cx)
         })
         .await
         .unwrap();
-    assert_eq!(fs.load(Path::new("/dir/file1")).await.unwrap(), "abc");
+    assert_eq!(fs.load(Path::new("/dir/file1.rs")).await.unwrap(), "abc");
+
+    cx.foreground().run_until_parked();
     buffer.read_with(cx, |buffer, cx| {
-        assert_eq!(buffer.file().unwrap().full_path(cx), Path::new("dir/file1"));
+        assert_eq!(
+            buffer.file().unwrap().full_path(cx),
+            Path::new("dir/file1.rs")
+        );
         assert!(!buffer.is_dirty());
         assert!(!buffer.has_conflict());
+        assert_eq!(buffer.language().unwrap().name().as_ref(), "Rust");
     });
 
     let opened_buffer = project
         .update(cx, |project, cx| {
-            project.open_local_buffer("/dir/file1", cx)
+            project.open_local_buffer("/dir/file1.rs", cx)
         })
         .await
         .unwrap();

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2482,7 +2482,6 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
             buffer.version(),
             buffer.as_rope().fingerprint(),
             buffer.file().unwrap().mtime(),
-            None,
             cx,
         );
     });

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -724,18 +724,55 @@ impl LocalWorktree {
         })
     }
 
+    pub fn save_buffer(
+        &self,
+        buffer_handle: ModelHandle<Buffer>,
+        path: Arc<Path>,
+        cx: &mut ModelContext<Worktree>,
+    ) -> Task<Result<(clock::Global, RopeFingerprint, SystemTime)>> {
+        let buffer = buffer_handle.read(cx);
+
+        let rpc = self.client.clone();
+        let buffer_id = buffer.remote_id();
+        let project_id = self.share.as_ref().map(|share| share.project_id);
+
+        let text = buffer.as_rope().clone();
+        let fingerprint = text.fingerprint();
+        let version = buffer.version();
+        let save = self.write_file(path, text, buffer.line_ending(), cx);
+
+        cx.as_mut().spawn(|mut cx| async move {
+            let mtime = save.await?.mtime;
+            if let Some(project_id) = project_id {
+                rpc.send(proto::BufferSaved {
+                    project_id,
+                    buffer_id,
+                    version: serialize_version(&version),
+                    mtime: Some(mtime.into()),
+                    fingerprint: serialize_fingerprint(fingerprint),
+                })?;
+            }
+            buffer_handle.update(&mut cx, |buffer, cx| {
+                buffer.did_save(version.clone(), fingerprint, mtime, None, cx);
+            });
+            anyhow::Ok((version, fingerprint, mtime))
+        })
+    }
+
     pub fn save_buffer_as(
         &self,
         buffer_handle: ModelHandle<Buffer>,
         path: impl Into<Arc<Path>>,
         cx: &mut ModelContext<Worktree>,
     ) -> Task<Result<()>> {
+        let handle = cx.handle();
         let buffer = buffer_handle.read(cx);
+
         let text = buffer.as_rope().clone();
         let fingerprint = text.fingerprint();
         let version = buffer.version();
         let save = self.write_file(path, text, buffer.line_ending(), cx);
-        let handle = cx.handle();
+
         cx.as_mut().spawn(|mut cx| async move {
             let entry = save.await?;
             let file = File {
@@ -1083,6 +1120,39 @@ impl RemoteWorktree {
         self.updates_tx.take();
         self.snapshot_subscriptions.clear();
         self.disconnected = true;
+    }
+
+    pub fn save_buffer(
+        &self,
+        buffer_handle: ModelHandle<Buffer>,
+        cx: &mut ModelContext<Worktree>,
+    ) -> Task<Result<(clock::Global, RopeFingerprint, SystemTime)>> {
+        let buffer = buffer_handle.read(cx);
+        let buffer_id = buffer.remote_id();
+        let version = buffer.version();
+        let rpc = self.client.clone();
+        let project_id = self.project_id;
+        cx.as_mut().spawn(|mut cx| async move {
+            let response = rpc
+                .request(proto::SaveBuffer {
+                    project_id,
+                    buffer_id,
+                    version: serialize_version(&version),
+                })
+                .await?;
+            let version = deserialize_version(response.version);
+            let fingerprint = deserialize_fingerprint(&response.fingerprint)?;
+            let mtime = response
+                .mtime
+                .ok_or_else(|| anyhow!("missing mtime"))?
+                .into();
+
+            buffer_handle.update(&mut cx, |buffer, cx| {
+                buffer.did_save(version.clone(), fingerprint, mtime, None, cx);
+            });
+
+            Ok((version, fingerprint, mtime))
+        })
     }
 
     pub fn update_from_remote(&mut self, update: proto::UpdateWorktree) {
@@ -1857,57 +1927,6 @@ impl language::File for File {
 
     fn is_deleted(&self) -> bool {
         self.is_deleted
-    }
-
-    fn save(
-        &self,
-        buffer_id: u64,
-        text: Rope,
-        version: clock::Global,
-        line_ending: LineEnding,
-        cx: &mut MutableAppContext,
-    ) -> Task<Result<(clock::Global, RopeFingerprint, SystemTime)>> {
-        self.worktree.update(cx, |worktree, cx| match worktree {
-            Worktree::Local(worktree) => {
-                let rpc = worktree.client.clone();
-                let project_id = worktree.share.as_ref().map(|share| share.project_id);
-                let fingerprint = text.fingerprint();
-                let save = worktree.write_file(self.path.clone(), text, line_ending, cx);
-                cx.background().spawn(async move {
-                    let entry = save.await?;
-                    if let Some(project_id) = project_id {
-                        rpc.send(proto::BufferSaved {
-                            project_id,
-                            buffer_id,
-                            version: serialize_version(&version),
-                            mtime: Some(entry.mtime.into()),
-                            fingerprint: serialize_fingerprint(fingerprint),
-                        })?;
-                    }
-                    Ok((version, fingerprint, entry.mtime))
-                })
-            }
-            Worktree::Remote(worktree) => {
-                let rpc = worktree.client.clone();
-                let project_id = worktree.project_id;
-                cx.foreground().spawn(async move {
-                    let response = rpc
-                        .request(proto::SaveBuffer {
-                            project_id,
-                            buffer_id,
-                            version: serialize_version(&version),
-                        })
-                        .await?;
-                    let version = deserialize_version(response.version);
-                    let fingerprint = deserialize_fingerprint(&response.fingerprint)?;
-                    let mtime = response
-                        .mtime
-                        .ok_or_else(|| anyhow!("missing mtime"))?
-                        .into();
-                    Ok((version, fingerprint, mtime))
-                })
-            }
-        })
     }
 
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
* [x] When an untitled buffer was given a file name that caused it to match a language that had not yet been loaded, the buffer's language was not correctly updated when the language finished loading.
* [x] When a buffer was newly assigned a file, guests did not apply the change on their end
* [x] When a file is saved via 'save as', its new saved metadata (`saved_version`, `saved_mtime`) were not replicated to guests.

In addition, this PR removes many redundant `UpdateBufferFile` messages that we were previously sending. We sent them for all buffers belonging to a worktree whenever that worktree rescanned.