### PR TITLE
Dont open project items in dock

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -450,15 +450,16 @@
         }
     },
     {
-        "context": "Dock",
+        "context": "Pane",
         "bindings": {
-            "shift-escape": "dock::HideDock"
+            "cmd-escape": "dock::AddTabToDock"
         }
     },
     {
-        "context": "Pane",
+        "context": "Dock",
         "bindings": {
-            "cmd-escape": "dock::MoveActiveItemToDock"
+            "shift-escape": "dock::HideDock",
+            "cmd-escape": "dock::RemoveTabFromDock"
         }
     },
     {

--- a/crates/gpui/src/keymap_matcher.rs
+++ b/crates/gpui/src/keymap_matcher.rs
@@ -60,6 +60,16 @@ impl KeymapMatcher {
         !self.pending_keystrokes.is_empty()
     }
 
+    /// Pushes a keystroke onto the matcher.
+    /// The result of the new keystroke is returned:
+    ///     MatchResult::None =>
+    ///         No match is valid for this key given any pending keystrokes.
+    ///     MatchResult::Pending =>
+    ///         There exist bindings which are still waiting for more keys.
+    ///     MatchResult::Complete(matches) =>
+    ///         1 or more bindings have recieved the necessary key presses.
+    ///         The order of the matched actions is by order in the keymap file first and
+    ///         position of the matching view second.
     pub fn push_keystroke(
         &mut self,
         keystroke: Keystroke,
@@ -117,6 +127,8 @@ impl KeymapMatcher {
         }
 
         if !matched_bindings.is_empty() {
+            // Collect the sorted matched bindings into the final vec for ease of use
+            // Matched bindings are in order by precedence
             MatchResult::Matches(matched_bindings.into_values().flatten().collect())
         } else if any_pending {
             MatchResult::Pending

--- a/crates/gpui/src/keymap_matcher.rs
+++ b/crates/gpui/src/keymap_matcher.rs
@@ -76,8 +76,10 @@ impl KeymapMatcher {
         mut dispatch_path: Vec<(usize, KeymapContext)>,
     ) -> MatchResult {
         let mut any_pending = false;
-        // Collect matched bindings into an ordered list using the position in the bindings
-        // list as the precedence
+        // Collect matched bindings into an ordered list using the position in the matching binding first,
+        // and then the order the binding matched in the view tree second.
+        // The key is the reverse position of the binding in the bindings list so that later bindings
+        // match before earlier ones in the user's config
         let mut matched_bindings: BTreeMap<usize, Vec<(usize, Box<dyn Action>)>> =
             Default::default();
 

--- a/crates/workspace/src/dock/toggle_dock_button.rs
+++ b/crates/workspace/src/dock/toggle_dock_button.rs
@@ -1,0 +1,112 @@
+use gpui::{
+    elements::{Empty, MouseEventHandler, Svg},
+    CursorStyle, Element, ElementBox, Entity, MouseButton, View, ViewContext, ViewHandle,
+    WeakViewHandle,
+};
+use settings::Settings;
+
+use crate::{handle_dropped_item, StatusItemView, Workspace};
+
+use super::{icon_for_dock_anchor, FocusDock, HideDock};
+
+pub struct ToggleDockButton {
+    workspace: WeakViewHandle<Workspace>,
+}
+
+impl ToggleDockButton {
+    pub fn new(workspace: ViewHandle<Workspace>, cx: &mut ViewContext<Self>) -> Self {
+        // When dock moves, redraw so that the icon and toggle status matches.
+        cx.subscribe(&workspace, |_, _, _, cx| cx.notify()).detach();
+
+        Self {
+            workspace: workspace.downgrade(),
+        }
+    }
+}
+
+impl Entity for ToggleDockButton {
+    type Event = ();
+}
+
+impl View for ToggleDockButton {
+    fn ui_name() -> &'static str {
+        "Dock Toggle"
+    }
+
+    fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> ElementBox {
+        let workspace = self.workspace.upgrade(cx);
+
+        if workspace.is_none() {
+            return Empty::new().boxed();
+        }
+
+        let workspace = workspace.unwrap();
+        let dock_position = workspace.read(cx).dock.position;
+
+        let theme = cx.global::<Settings>().theme.clone();
+
+        let button = MouseEventHandler::<Self>::new(0, cx, {
+            let theme = theme.clone();
+            move |state, _| {
+                let style = theme
+                    .workspace
+                    .status_bar
+                    .sidebar_buttons
+                    .item
+                    .style_for(state, dock_position.is_visible());
+
+                Svg::new(icon_for_dock_anchor(dock_position.anchor()))
+                    .with_color(style.icon_color)
+                    .constrained()
+                    .with_width(style.icon_size)
+                    .with_height(style.icon_size)
+                    .contained()
+                    .with_style(style.container)
+                    .boxed()
+            }
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_up(MouseButton::Left, move |event, cx| {
+            let dock_pane = workspace.read(cx.app).dock_pane();
+            let drop_index = dock_pane.read(cx.app).items_len() + 1;
+            handle_dropped_item(event, &dock_pane.downgrade(), drop_index, false, None, cx);
+        });
+
+        if dock_position.is_visible() {
+            button
+                .on_click(MouseButton::Left, |_, cx| {
+                    cx.dispatch_action(HideDock);
+                })
+                .with_tooltip::<Self, _>(
+                    0,
+                    "Hide Dock".into(),
+                    Some(Box::new(HideDock)),
+                    theme.tooltip.clone(),
+                    cx,
+                )
+        } else {
+            button
+                .on_click(MouseButton::Left, |_, cx| {
+                    cx.dispatch_action(FocusDock);
+                })
+                .with_tooltip::<Self, _>(
+                    0,
+                    "Focus Dock".into(),
+                    Some(Box::new(FocusDock)),
+                    theme.tooltip.clone(),
+                    cx,
+                )
+        }
+        .boxed()
+    }
+}
+
+impl StatusItemView for ToggleDockButton {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn crate::ItemHandle>,
+        _cx: &mut ViewContext<Self>,
+    ) {
+        //Not applicable
+    }
+}

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1432,7 +1432,7 @@ impl View for Pane {
                                 enum TabBarEventHandler {}
                                 stack.add_child(
                                     MouseEventHandler::<TabBarEventHandler>::new(0, cx, |_, _| {
-                                        Flex::row()
+                                        Empty::new()
                                             .contained()
                                             .with_style(theme.workspace.tab_bar.container)
                                             .boxed()


### PR DESCRIPTION
## Description of feature or change
- Makes it so that open_path adds items to the center panes and never the dock. This makes using it more intuitive and makes the existence of items in the dock more intentional.
- Adds a command to move an item out of the dock and into the center panes. This action is bound to `cmd-escape` just like the command which moves active items to the dock.
- Changes the keymap matcher to iterate over the keymaps first and the dispatch path second. This makes the precedence rules more intuitive as all bindings later in the keymap will get matched before those earlier in the file rather than being dependent on the particular view tree at a given point in time.

## Link to related issues from zed or community
Fixes https://github.com/zed-industries/zed/issues/5724

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
