### PR TITLE
Labeled Tasks

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5066,7 +5066,7 @@ impl Editor {
             GotoDefinitionKind::Type => project.type_definition(&buffer, head, cx),
         });
 
-        cx.spawn(|workspace, mut cx| async move {
+        cx.spawn_labeled("Fetching Definition...", |workspace, mut cx| async move {
             let definitions = definitions.await?;
             workspace.update(&mut cx, |workspace, cx| {
                 Editor::navigate_to_definitions(workspace, editor_handle, definitions, cx);
@@ -5146,7 +5146,7 @@ impl Editor {
 
         let project = workspace.project().clone();
         let references = project.update(cx, |project, cx| project.references(&buffer, head, cx));
-        Some(cx.spawn(|workspace, mut cx| async move {
+        Some(cx.spawn_labeled("Finding All References...", |workspace, mut cx| async move {
             let locations = references.await?;
             if locations.is_empty() {
                 return Ok(());

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -6906,7 +6906,10 @@ mod tests {
             Some("Test Label"),
             cx.update(|cx| cx.active_labeled_tasks().next())
         );
-        sender.send(()).await;
+        sender
+            .send(())
+            .await
+            .expect("Could not send message to complete task");
         task.await;
 
         assert_eq!(None, cx.update(|cx| cx.active_labeled_tasks().next()));

--- a/crates/gpui/src/keymap_matcher.rs
+++ b/crates/gpui/src/keymap_matcher.rs
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_push_keystroke() -> Result<()> {
-        actions!(test, [B, AB, C, D, DA]);
+        actions!(test, [B, AB, C, D, DA, E, EF]);
 
         let mut context1 = KeymapContext::default();
         context1.set.insert("1".into());
@@ -286,6 +286,7 @@ mod tests {
             matcher.push_keystroke(Keystroke::parse("d")?, dispatch_path.clone()),
             MatchResult::Matches(vec![(2, Box::new(D)), (1, Box::new(D))]),
         );
+
         // If none of the d action handlers consume the binding, a pending
         // binding may then be used
         assert_eq!(


### PR DESCRIPTION
## Description of feature or change

Executing a language server backed action and not getting any response sucks. This PR partially addresses this by adding the ability to optionally label spawned tasks in gpui. Any time you spawn a task you can instead call `spawn_labeled` passing a static str. Doing so will add the label to a sorted list in the MutableAppContext. When the task completes, the label will be removed.

I use this in the ActivityIndicator to track and render the most recent task that is still in progress. I then changed GoToDefinition and FindAllReferences to use `spawn_labeled` so that there is a visual indicator when we are waiting on the server for something.

## Link to related issues from zed or community

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
