### PR TITLE
Move reveal_path to ForegroundPlatform

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -190,8 +190,8 @@ pub struct AsyncAppContext(Rc<RefCell<MutableAppContext>>);
 impl App {
     pub fn new(asset_source: impl AssetSource) -> Result<Self> {
         let platform = platform::current::platform();
-        let foreground_platform = platform::current::foreground_platform();
         let foreground = Rc::new(executor::Foreground::platform(platform.dispatcher())?);
+        let foreground_platform = platform::current::foreground_platform(foreground.clone());
         let app = Self(Rc::new(RefCell::new(MutableAppContext::new(
             foreground,
             Arc::new(executor::Background::new()),
@@ -898,6 +898,10 @@ impl MutableAppContext {
 
     pub fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>> {
         self.foreground_platform.prompt_for_new_path(directory)
+    }
+
+    pub fn reveal_path(&self, path: &Path) {
+        self.foreground_platform.reveal_path(path)
     }
 
     pub fn emit_global<E: Any>(&mut self, payload: E) {
@@ -3635,6 +3639,10 @@ impl<'a, T: View> ViewContext<'a, T> {
 
     pub fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>> {
         self.app.prompt_for_new_path(directory)
+    }
+
+    pub fn reveal_path(&self, path: &Path) {
+        self.app.reveal_path(path)
     }
 
     pub fn debug_elements(&self) -> crate::json::Value {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -65,7 +65,6 @@ pub trait Platform: Send + Sync {
     fn write_to_clipboard(&self, item: ClipboardItem);
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn open_url(&self, url: &str);
-    fn reveal_path(&self, path: &Path);
 
     fn write_credentials(&self, url: &str, username: &str, password: &[u8]) -> Result<()>;
     fn read_credentials(&self, url: &str) -> Result<Option<(String, Vec<u8>)>>;
@@ -101,6 +100,7 @@ pub(crate) trait ForegroundPlatform {
         options: PathPromptOptions,
     ) -> oneshot::Receiver<Option<Vec<PathBuf>>>;
     fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>>;
+    fn reveal_path(&self, path: &Path);
 }
 
 pub trait Dispatcher: Send + Sync {

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -23,12 +23,16 @@ pub use renderer::Surface;
 use std::{ops::Range, rc::Rc, sync::Arc};
 use window::Window;
 
+use crate::executor;
+
 pub(crate) fn platform() -> Arc<dyn super::Platform> {
     Arc::new(MacPlatform::new())
 }
 
-pub(crate) fn foreground_platform() -> Rc<dyn super::ForegroundPlatform> {
-    Rc::new(MacForegroundPlatform::default())
+pub(crate) fn foreground_platform(
+    foreground: Rc<executor::Foreground>,
+) -> Rc<dyn super::ForegroundPlatform> {
+    Rc::new(MacForegroundPlatform::new(foreground))
 }
 
 trait BoolExt {

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -16,7 +16,7 @@ use cocoa::{
         NSEventModifierFlags, NSMenu, NSMenuItem, NSModalResponse, NSOpenPanel, NSPasteboard,
         NSPasteboardTypeString, NSSavePanel, NSWindow,
     },
-    base::{id, nil, selector, YES},
+    base::{id, nil, selector, BOOL, YES},
     foundation::{
         NSArray, NSAutoreleasePool, NSBundle, NSData, NSInteger, NSProcessInfo, NSString,
         NSUInteger, NSURL,
@@ -114,10 +114,8 @@ unsafe fn build_classes() {
     }
 }
 
-#[derive(Default)]
 pub struct MacForegroundPlatform(RefCell<MacForegroundPlatformState>);
 
-#[derive(Default)]
 pub struct MacForegroundPlatformState {
     become_active: Option<Box<dyn FnMut()>>,
     resign_active: Option<Box<dyn FnMut()>>,
@@ -129,9 +127,26 @@ pub struct MacForegroundPlatformState {
     open_urls: Option<Box<dyn FnMut(Vec<String>)>>,
     finish_launching: Option<Box<dyn FnOnce()>>,
     menu_actions: Vec<Box<dyn Action>>,
+    foreground: Rc<executor::Foreground>,
 }
 
 impl MacForegroundPlatform {
+    pub fn new(foreground: Rc<executor::Foreground>) -> Self {
+        Self(RefCell::new(MacForegroundPlatformState {
+            become_active: Default::default(),
+            resign_active: Default::default(),
+            quit: Default::default(),
+            event: Default::default(),
+            menu_command: Default::default(),
+            validate_menu_command: Default::default(),
+            will_open_menu: Default::default(),
+            open_urls: Default::default(),
+            finish_launching: Default::default(),
+            menu_actions: Default::default(),
+            foreground,
+        }))
+    }
+
     unsafe fn create_menu_bar(
         &self,
         menus: Vec<Menu>,
@@ -399,6 +414,26 @@ impl platform::ForegroundPlatform for MacForegroundPlatform {
             done_rx
         }
     }
+
+    fn reveal_path(&self, path: &Path) {
+        unsafe {
+            let path = path.to_path_buf();
+            self.0
+                .borrow()
+                .foreground
+                .spawn(async move {
+                    let full_path = ns_string(path.to_str().unwrap_or(""));
+                    let root_full_path = ns_string("");
+                    let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+                    let _: BOOL = msg_send![
+                        workspace,
+                        selectFile: full_path
+                        inFileViewerRootedAtPath: root_full_path
+                    ];
+                })
+                .detach();
+        }
+    }
 }
 
 pub struct MacPlatform {
@@ -597,19 +632,6 @@ impl platform::Platform for MacPlatform {
                 .autorelease();
             let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
             msg_send![workspace, openURL: url]
-        }
-    }
-
-    fn reveal_path(&self, path: &Path) {
-        unsafe {
-            let full_path = ns_string(path.to_str().unwrap_or(""));
-            let root_full_path = ns_string("");
-            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-            msg_send![
-                workspace,
-                selectFile: full_path
-                inFileViewerRootedAtPath: root_full_path
-            ]
         }
     }
 

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -92,6 +92,8 @@ impl super::ForegroundPlatform for ForegroundPlatform {
         *self.last_prompt_for_new_path_args.borrow_mut() = Some((path.to_path_buf(), done_tx));
         done_rx
     }
+
+    fn reveal_path(&self, _: &Path) {}
 }
 
 pub fn platform() -> Platform {
@@ -172,8 +174,6 @@ impl super::Platform for Platform {
     }
 
     fn open_url(&self, _: &str) {}
-
-    fn reveal_path(&self, _: &Path) {}
 
     fn write_credentials(&self, _: &str, _: &str, _: &[u8]) -> Result<()> {
         Ok(())

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -792,8 +792,7 @@ impl ProjectPanel {
 
     fn reveal_in_finder(&mut self, _: &RevealInFinder, cx: &mut ViewContext<Self>) {
         if let Some((worktree, entry)) = self.selected_entry(cx) {
-            cx.platform()
-                .reveal_path(&worktree.abs_path().join(&entry.path));
+            cx.reveal_path(&worktree.abs_path().join(&entry.path));
         }
     }
 


### PR DESCRIPTION
Resolves https://linear.app/zed-industries/issue/Z-53/reveal-in-finder-crashes-zed

So that we can use `spawn` to call the OS API. This way the process runs in the next tick of the event loop, avoiding the intermittent cases of `already mutably borrowed: BorrowError`.

I will let @as-cii explain this better if needed, as I know @JosephTLyons was interested at understanding the details behind that panic.