### PR TITLE
Add `reveal in finder` to additional locations

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -241,7 +241,8 @@ actions!(
         RestartLanguageServer,
         Hover,
         Format,
-        ToggleSoftWrap
+        ToggleSoftWrap,
+        RevealInFinder
     ]
 );
 
@@ -354,6 +355,7 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::open_excerpts);
     cx.add_action(Editor::jump);
     cx.add_action(Editor::toggle_soft_wrap);
+    cx.add_action(Editor::reveal_in_finder);
     cx.add_async_action(Editor::format);
     cx.add_action(Editor::restart_language_server);
     cx.add_action(Editor::show_character_palette);
@@ -5887,6 +5889,14 @@ impl Editor {
             self.soft_wrap_mode_override = Some(soft_wrap);
         }
         cx.notify();
+    }
+
+    pub fn reveal_in_finder(&mut self, _: &RevealInFinder, cx: &mut ViewContext<Self>) {
+        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
+            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
+                cx.reveal_path(&file.abs_path(cx));
+            }
+        }
     }
 
     pub fn highlight_rows(&mut self, rows: Option<Range<u32>>) {

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -6,7 +6,7 @@ use gpui::{
 
 use crate::{
     DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition, GoToTypeDefinition,
-    Rename, SelectMode, ToggleCodeActions,
+    Rename, RevealInFinder, SelectMode, ToggleCodeActions,
 };
 
 #[derive(Clone, PartialEq)]
@@ -61,6 +61,8 @@ pub fn deploy_context_menu(
                         deployed_from_indicator: false,
                     },
                 ),
+                ContextMenuItem::Separator,
+                ContextMenuItem::item("Reveal in Finder", RevealInFinder),
             ],
             cx,
         );


### PR DESCRIPTION
## Description of feature or change

I was running into wanting this quite a bit, so I just added it.

This PR adds `reveal in finder` to multiple locations:

## right-click context menu

![SCR-20230221-m72](https://user-images.githubusercontent.com/19867440/220457083-9e031e04-3e17-44da-9e25-6e9fad122005.jpeg)

*Note: I added a separator in the context menu to separate code actions out from this action, but I can remove it if others don't think it fits*

## command palette when focusing on an editor

![SCR-20230221-m7k](https://user-images.githubusercontent.com/19867440/220457180-f267669e-1e4d-46d6-a264-e3e4ff25bb58.jpeg)

This is a little QoL thing because you can skip the step of having to focus on the project panel, if you already focused on the editor.

Drawbacks: doesn't work in the multi-buffer yet, but it isn't quite clear what that should be.  I'm thinking for the right-click context menu, we can simply open the file associated with the excerpt clicked.  What should we do for the command prompt version when in a multi-buffer?  At any rate, I think this can go in as such and we can add multi-buffer support in a follow up.

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
