### PR TITLE
Fix open URLs, restarts, and make bundling easier to use

### DIFF
--- a/script/bundle
+++ b/script/bundle
@@ -2,6 +2,24 @@
 
 set -e
 
+build_flag="--release"
+target_dir="release"
+open_result=false
+
+# If -o option is specified, the folder of the resulting dmg will be opened in finder
+# If -d is specified, Zed will be compiled in debug mode and the application's path printed
+# If -od or -do is specified Zed will be bundled in debug and the application will be run. 
+while getopts 'od' flag
+do
+    case "${flag}" in
+        o) open_result=true;;
+        d) 
+            build_flag="";
+            target_dir="debug"
+            ;;
+    esac
+done
+
 export ZED_BUNDLE=true
 export MACOSX_DEPLOYMENT_TARGET=10.15.7
 
@@ -12,13 +30,13 @@ rustup target add wasm32-wasi
 export CXXFLAGS="-stdlib=libc++"
 
 echo "Compiling zed binary for aarch64-apple-darwin"
-cargo build --release --package zed --target aarch64-apple-darwin
+cargo build ${build_flag} --package zed --target aarch64-apple-darwin
 echo "Compiling zed binary for x86_64-apple-darwin"
-cargo build --release --package zed --target x86_64-apple-darwin
+cargo build ${build_flag} --package zed --target x86_64-apple-darwin
 echo "Compiling cli binary for aarch64-apple-darwin"
-cargo build --release --package cli --target aarch64-apple-darwin
+cargo build ${build_flag} --package cli --target aarch64-apple-darwin
 echo "Compiling cli binary for x86_64-apple-darwin"
-cargo build --release --package cli --target x86_64-apple-darwin
+cargo build ${build_flag} --package cli --target x86_64-apple-darwin
 
 echo "Creating application bundle"
 pushd crates/zed
@@ -28,7 +46,10 @@ sed \
     -i .backup \
     "s/package.metadata.bundle-${channel}/package.metadata.bundle/" \
     Cargo.toml
-app_path=$(cargo bundle --release --target x86_64-apple-darwin | xargs)
+app_path=$(cargo bundle ${build_flag} --target x86_64-apple-darwin | xargs)
+
+echo app_path
+
 mv Cargo.toml.backup Cargo.toml
 popd
 echo "Bundled ${app_path}"
@@ -36,18 +57,18 @@ echo "Bundled ${app_path}"
 echo "Creating fat binaries"
 lipo \
     -create \
-    target/{x86_64-apple-darwin,aarch64-apple-darwin}/release/Zed \
+    target/{x86_64-apple-darwin,aarch64-apple-darwin}/${target_dir}/Zed \
     -output \
     "${app_path}/Contents/MacOS/zed"
 lipo \
     -create \
-    target/{x86_64-apple-darwin,aarch64-apple-darwin}/release/cli \
+    target/{x86_64-apple-darwin,aarch64-apple-darwin}/${target_dir}/cli \
     -output \
     "${app_path}/Contents/MacOS/cli"
 
 echo "Copying WebRTC.framework into the frameworks folder"
 mkdir "${app_path}/Contents/Frameworks"
-cp -R target/x86_64-apple-darwin/release/WebRTC.framework "${app_path}/Contents/Frameworks/"
+cp -R target/x86_64-apple-darwin/${target_dir}/WebRTC.framework "${app_path}/Contents/Frameworks/"
 
 mv "${app_path}/Contents/Info.plist" "${app_path}/Contents/WithoutDocumentTypes.plist"
 awk \
@@ -73,7 +94,17 @@ else
     codesign --force --deep --sign - "${app_path}" -v
 fi
 
-dmg_target_directory="target/release"
+if [ "$target_dir" = "debug" ]; then
+    if [ "$open_result" = true ]; then
+        open "$app_path"
+    else
+        echo "Created application bundle:"
+        echo "$app_path"
+    fi
+    exit 0
+fi
+
+dmg_target_directory="target/${target_dir}"
 dmg_source_directory="${dmg_target_directory}/dmg"
 dmg_file_path="${dmg_target_directory}/Zed.dmg"
 
@@ -94,10 +125,6 @@ if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTAR
     npx notarize-cli --file ${dmg_file_path} --bundle-id dev.zed.Zed --username "$APPLE_NOTARIZATION_USERNAME" --password "$APPLE_NOTARIZATION_PASSWORD"
 fi
 
-# If -o option is specified, open the $dmg_target_directory directory in Finder to reveal the DMG
-while getopts o flag
-do
-    case "${flag}" in
-        o) open $dmg_target_directory;;
-    esac
-done
+if [ "$open_result" = true ]; then
+    open $dmg_target_directory
+fi


### PR DESCRIPTION
## Description of feature or change

- Adds a `-d` flag to the bundle script in order to compile the application in dev mode.
- Fixes a race condition on the new restart command
- Fixes a race condition on app initialization when opened with a specific url

## Link to related issues from zed or community

https://github.com/zed-industries/zed/issues/5919

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
