### PR TITLE
Add more default impls to the item trait

### DIFF
--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -13,7 +13,6 @@ use gpui::{
     elements::{ChildView, Flex, Label, ParentElement},
     serde_json, AnyViewHandle, AppContext, Element, ElementBox, Entity, ModelHandle,
     MutableAppContext, PromptLevel, RenderContext, Task, View, ViewContext, ViewHandle,
-    WeakViewHandle,
 };
 use isahc::Request;
 use language::Buffer;
@@ -24,7 +23,6 @@ use serde::Serialize;
 use workspace::{
     item::{Item, ItemHandle},
     searchable::{SearchableItem, SearchableItemHandle},
-    smallvec::SmallVec,
     AppState, Workspace,
 };
 
@@ -259,15 +257,9 @@ impl Item for FeedbackEditor {
         self.editor.for_each_project_item(cx, f)
     }
 
-    fn to_item_events(_: &Self::Event) -> SmallVec<[workspace::item::ItemEvent; 2]> {
-        SmallVec::new()
-    }
-
     fn is_singleton(&self, _: &AppContext) -> bool {
         true
     }
-
-    fn set_nav_history(&mut self, _: workspace::ItemNavHistory, _: &mut ViewContext<Self>) {}
 
     fn can_save(&self, _: &AppContext) -> bool {
         true
@@ -295,7 +287,7 @@ impl Item for FeedbackEditor {
         _: ModelHandle<Project>,
         _: &mut ViewContext<Self>,
     ) -> Task<anyhow::Result<()>> {
-        unreachable!("reload should not have been called")
+        Task::Ready(Some(Ok(())))
     }
 
     fn clone_on_split(
@@ -320,20 +312,6 @@ impl Item for FeedbackEditor {
             buffer.clone(),
             cx,
         ))
-    }
-
-    fn serialized_item_kind() -> Option<&'static str> {
-        None
-    }
-
-    fn deserialize(
-        _: ModelHandle<Project>,
-        _: WeakViewHandle<Workspace>,
-        _: workspace::WorkspaceId,
-        _: workspace::ItemId,
-        _: &mut ViewContext<workspace::Pane>,
-    ) -> Task<anyhow::Result<ViewHandle<Self>>> {
-        unreachable!()
     }
 
     fn as_searchable(&self, handle: &ViewHandle<Self>) -> Option<Box<dyn SearchableItemHandle>> {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -21,7 +21,7 @@ use gpui::{
 use project::{LocalWorktree, Project};
 use serde::Deserialize;
 use settings::{Settings, TerminalBlink, WorkingDirectory};
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use smol::Timer;
 use terminal::{
     alacritty_terminal::{
@@ -616,43 +616,6 @@ impl Item for TerminalView {
         None
     }
 
-    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item)) {}
-
-    fn is_singleton(&self, _cx: &gpui::AppContext) -> bool {
-        false
-    }
-
-    fn set_nav_history(&mut self, _: workspace::ItemNavHistory, _: &mut ViewContext<Self>) {}
-
-    fn can_save(&self, _cx: &gpui::AppContext) -> bool {
-        false
-    }
-
-    fn save(
-        &mut self,
-        _project: gpui::ModelHandle<Project>,
-        _cx: &mut ViewContext<Self>,
-    ) -> gpui::Task<gpui::anyhow::Result<()>> {
-        unreachable!("save should not have been called");
-    }
-
-    fn save_as(
-        &mut self,
-        _project: gpui::ModelHandle<Project>,
-        _abs_path: std::path::PathBuf,
-        _cx: &mut ViewContext<Self>,
-    ) -> gpui::Task<gpui::anyhow::Result<()>> {
-        unreachable!("save_as should not have been called");
-    }
-
-    fn reload(
-        &mut self,
-        _project: gpui::ModelHandle<Project>,
-        _cx: &mut ViewContext<Self>,
-    ) -> gpui::Task<gpui::anyhow::Result<()>> {
-        gpui::Task::ready(Ok(()))
-    }
-
     fn is_dirty(&self, _cx: &gpui::AppContext) -> bool {
         self.has_bell()
     }
@@ -667,10 +630,10 @@ impl Item for TerminalView {
 
     fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         match event {
-            Event::BreadcrumbsChanged => smallvec::smallvec![ItemEvent::UpdateBreadcrumbs],
-            Event::TitleChanged | Event::Wakeup => smallvec::smallvec![ItemEvent::UpdateTab],
-            Event::CloseTerminal => smallvec::smallvec![ItemEvent::CloseItem],
-            _ => smallvec::smallvec![],
+            Event::BreadcrumbsChanged => smallvec![ItemEvent::UpdateBreadcrumbs],
+            Event::TitleChanged | Event::Wakeup => smallvec![ItemEvent::UpdateTab],
+            Event::CloseTerminal => smallvec![ItemEvent::CloseItem],
+            _ => smallvec![],
         }
     }
 

--- a/crates/theme_testbench/src/theme_testbench.rs
+++ b/crates/theme_testbench/src/theme_testbench.rs
@@ -11,12 +11,8 @@ use gpui::{
 };
 use project::Project;
 use settings::Settings;
-use smallvec::SmallVec;
 use theme::{ColorScheme, Layer, Style, StyleSet};
-use workspace::{
-    item::{Item, ItemEvent},
-    register_deserializable_item, Pane, Workspace,
-};
+use workspace::{item::Item, register_deserializable_item, Pane, Workspace};
 
 actions!(theme, [DeployThemeTestbench]);
 
@@ -312,47 +308,6 @@ impl Item for ThemeTestbench {
             .aligned()
             .contained()
             .boxed()
-    }
-
-    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item)) {}
-
-    fn is_singleton(&self, _: &AppContext) -> bool {
-        false
-    }
-
-    fn set_nav_history(&mut self, _: workspace::ItemNavHistory, _: &mut ViewContext<Self>) {}
-
-    fn can_save(&self, _: &AppContext) -> bool {
-        false
-    }
-
-    fn save(
-        &mut self,
-        _: gpui::ModelHandle<Project>,
-        _: &mut ViewContext<Self>,
-    ) -> gpui::Task<gpui::anyhow::Result<()>> {
-        unreachable!("save should not have been called");
-    }
-
-    fn save_as(
-        &mut self,
-        _: gpui::ModelHandle<Project>,
-        _: std::path::PathBuf,
-        _: &mut ViewContext<Self>,
-    ) -> gpui::Task<gpui::anyhow::Result<()>> {
-        unreachable!("save_as should not have been called");
-    }
-
-    fn reload(
-        &mut self,
-        _: gpui::ModelHandle<Project>,
-        _: &mut ViewContext<Self>,
-    ) -> gpui::Task<gpui::anyhow::Result<()>> {
-        gpui::Task::ready(Ok(()))
-    }
-
-    fn to_item_events(_: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
-        SmallVec::new()
     }
 
     fn serialized_item_kind() -> Option<&'static str> {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -49,9 +49,11 @@ pub trait Item: View {
     }
     fn tab_content(&self, detail: Option<usize>, style: &theme::Tab, cx: &AppContext)
         -> ElementBox;
-    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item));
-    fn is_singleton(&self, cx: &AppContext) -> bool;
-    fn set_nav_history(&mut self, _: ItemNavHistory, _: &mut ViewContext<Self>);
+    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item)) {}
+    fn is_singleton(&self, _cx: &AppContext) -> bool {
+        false
+    }
+    fn set_nav_history(&mut self, _: ItemNavHistory, _: &mut ViewContext<Self>) {}
     fn clone_on_split(&self, _workspace_id: WorkspaceId, _: &mut ViewContext<Self>) -> Option<Self>
     where
         Self: Sized,
@@ -64,23 +66,31 @@ pub trait Item: View {
     fn has_conflict(&self, _: &AppContext) -> bool {
         false
     }
-    fn can_save(&self, cx: &AppContext) -> bool;
+    fn can_save(&self, _cx: &AppContext) -> bool {
+        false
+    }
     fn save(
         &mut self,
-        project: ModelHandle<Project>,
-        cx: &mut ViewContext<Self>,
-    ) -> Task<Result<()>>;
+        _project: ModelHandle<Project>,
+        _cx: &mut ViewContext<Self>,
+    ) -> Task<Result<()>> {
+        unimplemented!("save() must be implemented if can_save() returns true")
+    }
     fn save_as(
         &mut self,
-        project: ModelHandle<Project>,
-        abs_path: PathBuf,
-        cx: &mut ViewContext<Self>,
-    ) -> Task<Result<()>>;
+        _project: ModelHandle<Project>,
+        _abs_path: PathBuf,
+        _cx: &mut ViewContext<Self>,
+    ) -> Task<Result<()>> {
+        unimplemented!("save_as() must be implemented if can_save() returns true")
+    }
     fn reload(
         &mut self,
-        project: ModelHandle<Project>,
-        cx: &mut ViewContext<Self>,
-    ) -> Task<Result<()>>;
+        _project: ModelHandle<Project>,
+        _cx: &mut ViewContext<Self>,
+    ) -> Task<Result<()>> {
+        unimplemented!("reload() must be implemented if can_save() returns true")
+    }
     fn git_diff_recalc(
         &mut self,
         _project: ModelHandle<Project>,
@@ -88,7 +98,9 @@ pub trait Item: View {
     ) -> Task<Result<()>> {
         Task::ready(Ok(()))
     }
-    fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]>;
+    fn to_item_events(_event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
+        SmallVec::new()
+    }
     fn should_close_item_on_event(_: &Self::Event) -> bool {
         false
     }
@@ -124,15 +136,21 @@ pub trait Item: View {
 
     fn added_to_workspace(&mut self, _workspace: &mut Workspace, _cx: &mut ViewContext<Self>) {}
 
-    fn serialized_item_kind() -> Option<&'static str>;
+    fn serialized_item_kind() -> Option<&'static str> {
+        None
+    }
 
     fn deserialize(
-        project: ModelHandle<Project>,
-        workspace: WeakViewHandle<Workspace>,
-        workspace_id: WorkspaceId,
-        item_id: ItemId,
-        cx: &mut ViewContext<Pane>,
-    ) -> Task<Result<ViewHandle<Self>>>;
+        _project: ModelHandle<Project>,
+        _workspace: WeakViewHandle<Workspace>,
+        _workspace_id: WorkspaceId,
+        _item_id: ItemId,
+        _cx: &mut ViewContext<Pane>,
+    ) -> Task<Result<ViewHandle<Self>>> {
+        unimplemented!(
+            "deserialize() must be implemented if serialized_item_kind() returns Some(_)"
+        )
+    }
 }
 
 pub trait ItemHandle: 'static + fmt::Debug {

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -1,23 +1,18 @@
 use crate::{
-    item::ItemEvent, persistence::model::ItemId, Item, ItemNavHistory, Pane, Workspace, WorkspaceId,
+    item::{Item, ItemEvent},
+    ItemNavHistory, WorkspaceId,
 };
-use anyhow::{anyhow, Result};
 use call::participant::{Frame, RemoteVideoTrack};
 use client::{proto::PeerId, User};
 use futures::StreamExt;
 use gpui::{
     elements::*,
     geometry::{rect::RectF, vector::vec2f},
-    AppContext, Entity, ModelHandle, MouseButton, RenderContext, Task, View, ViewContext,
-    ViewHandle, WeakViewHandle,
+    AppContext, Entity, MouseButton, RenderContext, Task, View, ViewContext,
 };
-use project::Project;
 use settings::Settings;
 use smallvec::SmallVec;
-use std::{
-    path::PathBuf,
-    sync::{Arc, Weak},
-};
+use std::sync::{Arc, Weak};
 
 pub enum Event {
     Close,
@@ -130,12 +125,6 @@ impl Item for SharedScreen {
             .boxed()
     }
 
-    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item)) {}
-
-    fn is_singleton(&self, _: &AppContext) -> bool {
-        false
-    }
-
     fn set_nav_history(&mut self, history: ItemNavHistory, _: &mut ViewContext<Self>) {
         self.nav_history = Some(history);
     }
@@ -149,52 +138,9 @@ impl Item for SharedScreen {
         Some(Self::new(&track, self.peer_id, self.user.clone(), cx))
     }
 
-    fn can_save(&self, _: &AppContext) -> bool {
-        false
-    }
-
-    fn save(
-        &mut self,
-        _: ModelHandle<project::Project>,
-        _: &mut ViewContext<Self>,
-    ) -> Task<Result<()>> {
-        Task::ready(Err(anyhow!("Item::save called on SharedScreen")))
-    }
-
-    fn save_as(
-        &mut self,
-        _: ModelHandle<project::Project>,
-        _: PathBuf,
-        _: &mut ViewContext<Self>,
-    ) -> Task<Result<()>> {
-        Task::ready(Err(anyhow!("Item::save_as called on SharedScreen")))
-    }
-
-    fn reload(
-        &mut self,
-        _: ModelHandle<project::Project>,
-        _: &mut ViewContext<Self>,
-    ) -> Task<Result<()>> {
-        Task::ready(Err(anyhow!("Item::reload called on SharedScreen")))
-    }
-
     fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         match event {
             Event::Close => smallvec::smallvec!(ItemEvent::CloseItem),
         }
-    }
-
-    fn serialized_item_kind() -> Option<&'static str> {
-        None
-    }
-
-    fn deserialize(
-        _project: ModelHandle<Project>,
-        _workspace: WeakViewHandle<Workspace>,
-        _workspace_id: WorkspaceId,
-        _item_id: ItemId,
-        _cx: &mut ViewContext<Pane>,
-    ) -> Task<Result<ViewHandle<Self>>> {
-        unreachable!("Shared screen can not be deserialized")
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1589,13 +1589,17 @@ impl Workspace {
         }
 
         let item = pane.read(cx).active_item()?;
-        let new_pane = self.add_pane(cx);
-        if let Some(clone) = item.clone_on_split(self.database_id(), cx.as_mut()) {
-            Pane::add_item(self, &new_pane, clone, true, true, None, cx);
-        }
-        self.center.split(&pane, &new_pane, direction).unwrap();
+        let maybe_pane_handle =
+            if let Some(clone) = item.clone_on_split(self.database_id(), cx.as_mut()) {
+                let new_pane = self.add_pane(cx);
+                Pane::add_item(self, &new_pane, clone, true, true, None, cx);
+                self.center.split(&pane, &new_pane, direction).unwrap();
+                Some(new_pane)
+            } else {
+                None
+            };
         cx.notify();
-        Some(new_pane)
+        maybe_pane_handle
     }
 
     pub fn split_pane_with_item(&mut self, action: &SplitWithItem, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
After my experience with the terminal, and working with @JosephTLyons on the feedback item, and now working on the welcome experience, most of the Item trait methods can be safely defaulted to no-ops. Ironically, the one exception is the `clone_on_split()` method, which already has a default impl, which leaves a phantom pane behind if the underlying item cannot be cloned. This PR fixes that footgun and adds default impls to all of the item traits except `tab_content()`