### PR TITLE
Replace terminal tab title with an icon

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -248,15 +248,15 @@ impl Item for ProjectSearchView {
         tab_theme: &theme::Tab,
         cx: &gpui::AppContext,
     ) -> ElementBox {
-        let settings = cx.global::<Settings>();
-        let search_theme = &settings.theme.search;
         Flex::row()
             .with_child(
                 Svg::new("icons/magnifying_glass_12.svg")
                     .with_color(tab_theme.label.text.color)
                     .constrained()
-                    .with_width(search_theme.tab_icon_width)
+                    .with_width(tab_theme.icon_width)
                     .aligned()
+                    .contained()
+                    .with_margin_right(tab_theme.spacing)
                     .boxed(),
             )
             .with_children(self.model.read(cx).active_query.as_ref().map(|query| {
@@ -264,8 +264,6 @@ impl Item for ProjectSearchView {
 
                 Label::new(query_text, tab_theme.label.clone())
                     .aligned()
-                    .contained()
-                    .with_margin_left(search_theme.tab_icon_spacing)
                     .boxed()
             }))
             .boxed()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -589,11 +589,16 @@ impl Item for TerminalView {
 
         Flex::row()
             .with_child(
-                Label::new(title, tab_theme.label.clone())
+                gpui::elements::Svg::new("icons/terminal_12.svg")
+                    .with_color(tab_theme.label.text.color)
+                    .constrained()
+                    .with_width(tab_theme.icon_width)
                     .aligned()
                     .contained()
+                    .with_margin_right(tab_theme.spacing)
                     .boxed(),
             )
+            .with_child(Label::new(title, tab_theme.label.clone()).aligned().boxed())
             .boxed()
     }
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -246,8 +246,6 @@ pub struct Search {
     pub match_background: Color,
     pub match_index: ContainedText,
     pub results_status: TextStyle,
-    pub tab_icon_width: f32,
-    pub tab_icon_spacing: f32,
     pub dismiss_button: Interactive<IconButton>,
 }
 

--- a/styles/src/styleTree/search.ts
+++ b/styles/src/styleTree/search.ts
@@ -29,8 +29,6 @@ export default function search(colorScheme: ColorScheme) {
   return {
     // TODO: Add an activeMatchBackground on the rust side to differenciate between active and inactive
     matchBackground: withOpacity(foreground(layer, "accent"), 0.4),
-    tabIconSpacing: 8,
-    tabIconWidth: 14,
     optionButton: {
       ...text(layer, "mono", "on"),
       background: background(layer, "on"),

--- a/styles/src/styleTree/tabBar.ts
+++ b/styles/src/styleTree/tabBar.ts
@@ -24,7 +24,7 @@ export default function tabBar(colorScheme: ColorScheme) {
     spacing: 8,
 
     // Close icons
-    iconWidth: 8,
+    iconWidth: 14,
     iconClose: foreground(layer, "variant"),
     iconCloseActive: foreground(layer, "hovered"),
 


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-86/replace-terminal-tab-title-with-an-icon

![terminal-icon](https://user-images.githubusercontent.com/28818/220724802-fb35cf0b-8c45-4f12-a118-afa6e35a4ca8.png)

@nathansobo this is my attempt to implement the terminal icon. Shout out to @ForLoveOfCats for helping me deduplicate some theme related code.

### Actions

- [x] @nathansobo or @as-cii reviews this
- [x] Merge

_When everything is checked ☝️ this is considered done._