### PR TITLE
Fix project panel actions

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -456,7 +456,7 @@
         }
     },
     {
-        "context": "Dock",
+        "context": "Dock > Pane",
         "bindings": {
             "shift-escape": "dock::HideDock",
             "cmd-escape": "dock::RemoveTabFromDock"
@@ -473,17 +473,6 @@
             "cmd-alt-c": "project_panel::CopyPath",
             "f2": "project_panel::Rename",
             "backspace": "project_panel::Delete"
-        }
-    },
-    {
-        "context": "ProjectPanel > Editor",
-        "bindings": {
-            "left": "editor::MoveLeft",
-            "right": "editor::MoveRight",
-            "backspace": "editor::Backspace",
-            "cmd-x": "editor::Cut",
-            "cmd-c": "editor::Copy",
-            "cmd-v": "editor::Paste"
         }
     },
     {

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -476,6 +476,17 @@
         }
     },
     {
+        "context": "ProjectPanel > Editor",
+        "bindings": {
+            "left": "editor::MoveLeft",
+            "right": "editor::MoveRight",
+            "backspace": "editor::Backspace",
+            "cmd-x": "editor::Cut",
+            "cmd-c": "editor::Copy",
+            "cmd-v": "editor::Paste"
+        }
+    },
+    {
         "context": "Terminal",
         "bindings": {
             "ctrl-cmd-space": "terminal::ShowCharacterPalette",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -456,7 +456,7 @@
         }
     },
     {
-        "context": "Dock > Pane",
+        "context": "Pane && docked",
         "bindings": {
             "shift-escape": "dock::HideDock",
             "cmd-escape": "dock::RemoveTabFromDock"

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -1294,7 +1294,7 @@ impl View for ContactList {
 
     fn keymap_context(&self, _: &AppContext) -> KeymapContext {
         let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
+        cx.add_identifier("menu");
         cx
     }
 

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -82,7 +82,7 @@ impl View for ContextMenu {
 
     fn keymap_context(&self, _: &AppContext) -> KeymapContext {
         let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
+        cx.add_identifier("menu");
         cx
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6433,17 +6433,13 @@ impl View for Editor {
             EditorMode::AutoHeight { .. } => "auto_height",
             EditorMode::Full => "full",
         };
-        context.map.insert("mode".into(), mode.into());
+        context.add_key("mode", mode);
         if self.pending_rename.is_some() {
-            context.set.insert("renaming".into());
+            context.add_identifier("renaming");
         }
         match self.context_menu.as_ref() {
-            Some(ContextMenu::Completions(_)) => {
-                context.set.insert("showing_completions".into());
-            }
-            Some(ContextMenu::CodeActions(_)) => {
-                context.set.insert("showing_code_actions".into());
-            }
+            Some(ContextMenu::Completions(_)) => context.add_identifier("showing_completions"),
+            Some(ContextMenu::CodeActions(_)) => context.add_identifier("showing_code_actions"),
             None => {}
         }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -86,7 +86,7 @@ pub trait View: Entity + Sized {
     }
     fn default_keymap_context() -> keymap_matcher::KeymapContext {
         let mut cx = keymap_matcher::KeymapContext::default();
-        cx.set.insert(Self::ui_name().into());
+        cx.add_identifier(Self::ui_name());
         cx
     }
     fn debug_json(&self, _: &AppContext) -> serde_json::Value {
@@ -6639,12 +6639,12 @@ mod tests {
         let mut view_1 = View::new(1);
         let mut view_2 = View::new(2);
         let mut view_3 = View::new(3);
-        view_1.keymap_context.set.insert("a".into());
-        view_2.keymap_context.set.insert("a".into());
-        view_2.keymap_context.set.insert("b".into());
-        view_3.keymap_context.set.insert("a".into());
-        view_3.keymap_context.set.insert("b".into());
-        view_3.keymap_context.set.insert("c".into());
+        view_1.keymap_context.add_identifier("a");
+        view_2.keymap_context.add_identifier("a");
+        view_2.keymap_context.add_identifier("b");
+        view_3.keymap_context.add_identifier("a");
+        view_3.keymap_context.add_identifier("b");
+        view_3.keymap_context.add_identifier("c");
 
         let (window_id, view_1) = cx.add_window(Default::default(), |_| view_1);
         let view_2 = cx.add_view(&view_1, |_| view_2);

--- a/crates/gpui/src/app/action.rs
+++ b/crates/gpui/src/app/action.rs
@@ -16,6 +16,14 @@ pub trait Action: 'static {
         Self: Sized;
 }
 
+impl std::fmt::Debug for dyn Action {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("dyn Action")
+            .field("namespace", &self.namespace())
+            .field("name", &self.name())
+            .finish()
+    }
+}
 /// Define a set of unit struct types that all implement the `Action` trait.
 ///
 /// The first argument is a namespace that will be associated with each of

--- a/crates/gpui/src/keymap_matcher.rs
+++ b/crates/gpui/src/keymap_matcher.rs
@@ -221,12 +221,6 @@ mod tests {
 
     use super::*;
 
-    // Takeaways for now:
-    // Revert that keymap change back to using view precedence again
-    // Solve the dock keybinding problem by adding a state context match
-    //   'Pane && docked == true'
-    // Maybeeeeee try to find other examples?
-
     #[test]
     fn test_keymap_and_view_ordering() -> Result<()> {
         actions!(test, [EditorAction, ProjectPanelAction]);

--- a/crates/gpui/src/keymap_matcher.rs
+++ b/crates/gpui/src/keymap_matcher.rs
@@ -89,7 +89,6 @@ impl KeymapMatcher {
         self.contexts
             .extend(dispatch_path.iter_mut().map(|e| std::mem::take(&mut e.1)));
 
-        dbg!(&self.contexts);
         // Find the bindings which map the pending keystrokes and current context
         for (i, (view_id, _)) in dispatch_path.iter().enumerate() {
             // Don't require pending view entry if there are no pending keystrokes
@@ -120,8 +119,6 @@ impl KeymapMatcher {
                 }
             }
         }
-
-        dbg!(&matched_bindings);
 
         if !any_pending {
             self.clear_pending();

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -126,7 +126,7 @@ impl<D: PickerDelegate> View for Picker<D> {
 
     fn keymap_context(&self, _: &AppContext) -> KeymapContext {
         let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
+        cx.add_identifier("menu");
         cx
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1314,7 +1314,7 @@ impl View for ProjectPanel {
 
     fn keymap_context(&self, _: &AppContext) -> KeymapContext {
         let mut cx = Self::default_keymap_context();
-        cx.set.insert("menu".into());
+        cx.add_identifier("menu");
         cx
     }
 }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -483,9 +483,7 @@ impl View for TerminalView {
         }
         if mode.contains(TermMode::APP_KEYPAD) {
             context.add_identifier("DECPAM");
-        }
-        //Note the ! here
-        if !mode.contains(TermMode::APP_KEYPAD) {
+        } else {
             context.add_identifier("DECPNM");
         }
         if mode.contains(TermMode::SHOW_CURSOR) {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -469,53 +469,52 @@ impl View for TerminalView {
         let mut context = Self::default_keymap_context();
 
         let mode = self.terminal.read(cx).last_content.mode;
-        context.map.insert(
-            "screen".to_string(),
-            (if mode.contains(TermMode::ALT_SCREEN) {
+        context.add_key(
+            "screen",
+            if mode.contains(TermMode::ALT_SCREEN) {
                 "alt"
             } else {
                 "normal"
-            })
-            .to_string(),
+            },
         );
 
         if mode.contains(TermMode::APP_CURSOR) {
-            context.set.insert("DECCKM".to_string());
+            context.add_identifier("DECCKM");
         }
         if mode.contains(TermMode::APP_KEYPAD) {
-            context.set.insert("DECPAM".to_string());
+            context.add_identifier("DECPAM");
         }
         //Note the ! here
         if !mode.contains(TermMode::APP_KEYPAD) {
-            context.set.insert("DECPNM".to_string());
+            context.add_identifier("DECPNM");
         }
         if mode.contains(TermMode::SHOW_CURSOR) {
-            context.set.insert("DECTCEM".to_string());
+            context.add_identifier("DECTCEM");
         }
         if mode.contains(TermMode::LINE_WRAP) {
-            context.set.insert("DECAWM".to_string());
+            context.add_identifier("DECAWM");
         }
         if mode.contains(TermMode::ORIGIN) {
-            context.set.insert("DECOM".to_string());
+            context.add_identifier("DECOM");
         }
         if mode.contains(TermMode::INSERT) {
-            context.set.insert("IRM".to_string());
+            context.add_identifier("IRM");
         }
         //LNM is apparently the name for this. https://vt100.net/docs/vt510-rm/LNM.html
         if mode.contains(TermMode::LINE_FEED_NEW_LINE) {
-            context.set.insert("LNM".to_string());
+            context.add_identifier("LNM");
         }
         if mode.contains(TermMode::FOCUS_IN_OUT) {
-            context.set.insert("report_focus".to_string());
+            context.add_identifier("report_focus");
         }
         if mode.contains(TermMode::ALTERNATE_SCROLL) {
-            context.set.insert("alternate_scroll".to_string());
+            context.add_identifier("alternate_scroll");
         }
         if mode.contains(TermMode::BRACKETED_PASTE) {
-            context.set.insert("bracketed_paste".to_string());
+            context.add_identifier("bracketed_paste");
         }
         if mode.intersects(TermMode::MOUSE_MODE) {
-            context.set.insert("any_mouse_reporting".to_string());
+            context.add_identifier("any_mouse_reporting");
         }
         {
             let mouse_reporting = if mode.contains(TermMode::MOUSE_REPORT_CLICK) {
@@ -527,9 +526,7 @@ impl View for TerminalView {
             } else {
                 "off"
             };
-            context
-                .map
-                .insert("mouse_reporting".to_string(), mouse_reporting.to_string());
+            context.add_key("mouse_reporting", mouse_reporting);
         }
         {
             let format = if mode.contains(TermMode::SGR_MOUSE) {
@@ -539,9 +536,7 @@ impl View for TerminalView {
             } else {
                 "normal"
             };
-            context
-                .map
-                .insert("mouse_format".to_string(), format.to_string());
+            context.add_key("mouse_format", format);
         }
         context
     }

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -73,34 +73,30 @@ impl VimState {
 
     pub fn keymap_context_layer(&self) -> KeymapContext {
         let mut context = KeymapContext::default();
-        context.map.insert(
-            "vim_mode".to_string(),
+        context.add_key(
+            "vim_mode",
             match self.mode {
                 Mode::Normal => "normal",
                 Mode::Visual { .. } => "visual",
                 Mode::Insert => "insert",
-            }
-            .to_string(),
+            },
         );
 
         if self.vim_controlled() {
-            context.set.insert("VimControl".to_string());
+            context.add_identifier("VimControl");
         }
 
         let active_operator = self.operator_stack.last();
 
         if let Some(active_operator) = active_operator {
             for context_flag in active_operator.context_flags().into_iter() {
-                context.set.insert(context_flag.to_string());
+                context.add_identifier(*context_flag);
             }
         }
 
-        context.map.insert(
-            "vim_operator".to_string(),
-            active_operator
-                .map(|op| op.id())
-                .unwrap_or_else(|| "none")
-                .to_string(),
+        context.add_key(
+            "vim_operator",
+            active_operator.map(|op| op.id()).unwrap_or_else(|| "none"),
         );
 
         context

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -21,6 +21,7 @@ use gpui::{
         vector::{vec2f, Vector2F},
     },
     impl_actions, impl_internal_actions,
+    keymap_matcher::KeymapContext,
     platform::{CursorStyle, NavigationDirection},
     Action, AnyViewHandle, AnyWeakViewHandle, AppContext, AsyncAppContext, Entity, EventContext,
     ModelHandle, MouseButton, MutableAppContext, PromptLevel, Quad, RenderContext, Task, View,
@@ -1549,6 +1550,14 @@ impl View for Pane {
                     .insert(active_item.id(), focused.downgrade());
             }
         }
+    }
+
+    fn keymap_context(&self, _: &AppContext) -> KeymapContext {
+        let mut keymap = Self::default_keymap_context();
+        if self.docked.is_some() {
+            keymap.add_identifier("docked");
+        }
+        keymap
     }
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2716,11 +2716,7 @@ impl View for Workspace {
     }
 
     fn keymap_context(&self, _: &AppContext) -> KeymapContext {
-        let mut keymap = Self::default_keymap_context();
-        if self.active_pane() == self.dock_pane() {
-            keymap.set.insert("Dock".into());
-        }
-        keymap
+        Self::default_keymap_context()
     }
 }
 


### PR DESCRIPTION
## Description of feature or change

In https://github.com/zed-industries/zed/pull/2188 the keymap matcher was changed to prefer file-order to view precedence. This PR reverts that change and:

- Added a test to the keymap matcher demonstrating the issue with the project panel
- Changes the `Dock` identifier to be an addition to `Pane`s instead of an addition to `Workspace`
- Uses the new identifier in the default keymap to override the `cmd-escape` action
- Adjusts the keymap context datastructure to use Cow<'static, str>s internally so we don't have to do so many `.into()`s and `.to_string()`s

## Link to related issues from zed or community

https://linear.app/zed-industries/issue/Z-167/project-panel-file-rename-is-broken

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
