### PR TITLE
Adjust window's traffic light position when setting its title

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -737,6 +737,7 @@ impl platform::Window for Window {
             let title = ns_string(title);
             let _: () = msg_send![app, changeWindowsItem:window title:title filename:false];
             let _: () = msg_send![window, setTitle: title];
+            self.0.borrow().move_traffic_light();
         }
     }
 


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-181/regression-traffic-light-is-wrongly-positioned-until-you-resize-the

Previously, upon first opening a Zed window, its traffic light would be positioned incorrectly until you resized it. I guess this started happening because we introduced a call to `NSWindow setTitle:`.