### PR TITLE
Differentiate between follow state on a per-project basis

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -1996,6 +1996,7 @@ impl Database {
             followers.push(proto::Follower {
                 leader_id: Some(db_follower.leader_connection().into()),
                 follower_id: Some(db_follower.follower_connection().into()),
+                project_id: db_follower.project_id.to_proto(),
             });
         }
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5934,7 +5934,7 @@ async fn test_following(
         active_call.read_with(*cx, |call, cx| {
             let room = call.room().unwrap().read(cx);
             assert_eq!(
-                room.followers_for(peer_id_a),
+                room.followers_for(peer_id_a, project_id),
                 &[peer_id_b, peer_id_c],
                 "checking followers for A as {name}"
             );
@@ -5956,7 +5956,7 @@ async fn test_following(
         active_call.read_with(*cx, |call, cx| {
             let room = call.room().unwrap().read(cx);
             assert_eq!(
-                room.followers_for(peer_id_a),
+                room.followers_for(peer_id_a, project_id),
                 &[peer_id_b],
                 "checking followers for A as {name}"
             );

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -231,6 +231,7 @@ message ParticipantProject {
 message Follower {
     PeerId leader_id = 1;
     PeerId follower_id = 2;
+    uint64 project_id = 3;
 }
 
 message ParticipantLocation {

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 48;
+pub const PROTOCOL_VERSION: u32 = 49;


### PR DESCRIPTION

![CleanShot 2023-02-24 at 00 06 58](https://user-images.githubusercontent.com/30666851/221096823-6d3e16b6-a9f1-42b2-a721-685ced76ee46.png)


Closes https://linear.app/zed-industries/issue/Z-165/follower-avatars-should-reflect-the-follow-state-of-the-current