### PR TITLE
Remove borrow from reveal_path()

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -191,7 +191,7 @@ impl App {
     pub fn new(asset_source: impl AssetSource) -> Result<Self> {
         let platform = platform::current::platform();
         let foreground = Rc::new(executor::Foreground::platform(platform.dispatcher())?);
-        let foreground_platform = platform::current::foreground_platform(foreground.clone());
+        let foreground_platform = platform::current::foreground_platform();
         let app = Self(Rc::new(RefCell::new(MutableAppContext::new(
             foreground,
             Arc::new(executor::Background::new()),

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -23,16 +23,12 @@ pub use renderer::Surface;
 use std::{ops::Range, rc::Rc, sync::Arc};
 use window::Window;
 
-use crate::executor;
-
 pub(crate) fn platform() -> Arc<dyn super::Platform> {
     Arc::new(MacPlatform::new())
 }
 
-pub(crate) fn foreground_platform(
-    foreground: Rc<executor::Foreground>,
-) -> Rc<dyn super::ForegroundPlatform> {
-    Rc::new(MacForegroundPlatform::new(foreground))
+pub(crate) fn foreground_platform() -> Rc<dyn super::ForegroundPlatform> {
+    Rc::new(MacForegroundPlatform::new())
 }
 
 trait BoolExt {

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -152,11 +152,10 @@ pub struct MacForegroundPlatformState {
     open_urls: Option<Box<dyn FnMut(Vec<String>)>>,
     finish_launching: Option<Box<dyn FnOnce()>>,
     menu_actions: Vec<Box<dyn Action>>,
-    foreground: Rc<executor::Foreground>,
 }
 
 impl MacForegroundPlatform {
-    pub fn new(foreground: Rc<executor::Foreground>) -> Self {
+    pub fn new() -> Self {
         Self(RefCell::new(MacForegroundPlatformState {
             become_active: Default::default(),
             resign_active: Default::default(),
@@ -168,7 +167,6 @@ impl MacForegroundPlatform {
             open_urls: Default::default(),
             finish_launching: Default::default(),
             menu_actions: Default::default(),
-            foreground,
         }))
     }
 
@@ -456,21 +454,14 @@ impl platform::ForegroundPlatform for MacForegroundPlatform {
 
     fn reveal_path(&self, path: &Path) {
         unsafe {
-            let path = path.to_path_buf();
-            self.0
-                .borrow()
-                .foreground
-                .spawn(async move {
-                    let full_path = ns_string(path.to_str().unwrap_or(""));
-                    let root_full_path = ns_string("");
-                    let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-                    let _: BOOL = msg_send![
-                        workspace,
-                        selectFile: full_path
-                        inFileViewerRootedAtPath: root_full_path
-                    ];
-                })
-                .detach();
+            let full_path = ns_string(path.to_str().unwrap_or(""));
+            let root_full_path = ns_string("");
+            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            let _: BOOL = msg_send![
+                workspace,
+                selectFile: full_path
+                inFileViewerRootedAtPath: root_full_path
+            ];
         }
     }
 }


### PR DESCRIPTION
## Description of feature or change

The `Reveal in Finder` action in the project menu is prone to crashing. Thankfully, the offending borrow can be safely removed without loss of functionality. 

## Link to related issues from zed or community

https://github.com/zed-industries/zed/issues/5955

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
