### PR TITLE
Sort matches in file finder by distance to active item after score

### DIFF
--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -39,7 +39,7 @@ impl<'a> EditorLspTestContext<'a> {
             pane::init(cx);
         });
 
-        let params = cx.update(AppState::test);
+        let app_state = cx.update(AppState::test);
 
         let file_name = format!(
             "file.{}",
@@ -56,10 +56,10 @@ impl<'a> EditorLspTestContext<'a> {
             }))
             .await;
 
-        let project = Project::test(params.fs.clone(), [], cx).await;
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
         project.update(cx, |project, _| project.languages().add(Arc::new(language)));
 
-        params
+        app_state
             .fs
             .as_fake()
             .insert_tree("/root", json!({ "dir": { file_name.clone(): "" }}))

--- a/crates/fuzzy/src/matcher.rs
+++ b/crates/fuzzy/src/matcher.rs
@@ -443,6 +443,7 @@ mod tests {
                 positions: Vec::new(),
                 path: candidate.path.clone(),
                 path_prefix: "".into(),
+                distance_to_relative_ancestor: usize::MAX,
             },
         );
 

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -194,13 +194,9 @@ fn distance_to_relative_ancestor(path: &Path, relative_to: &Option<Arc<Path>>) -
         return usize::MAX;
     };
 
-    for (path_ancestor_count, path_ancestor) in path.ancestors().enumerate() {
-        for (relative_ancestor_count, relative_ancestor) in relative_to.ancestors().enumerate() {
-            if path_ancestor == relative_ancestor {
-                return path_ancestor_count + relative_ancestor_count;
-            }
-        }
-    }
+    let mut path_components = path.components();
+    let mut relative_components = relative_to.components();
 
-    usize::MAX
+    while path_components.next() == relative_components.next() {}
+    path_components.count() + relative_components.count() + 1
 }

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -159,9 +159,14 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                                     positions: Vec::new(),
                                     path: candidate.path.clone(),
                                     path_prefix: candidate_set.prefix(),
-                                    distance_to_relative_ancestor: distance_to_relative_ancestor(
-                                        candidate.path.as_ref(),
-                                        &relative_to,
+                                    distance_to_relative_ancestor: relative_to.as_ref().map_or(
+                                        usize::MAX,
+                                        |relative_to| {
+                                            distance_between_paths(
+                                                candidate.path.as_ref(),
+                                                relative_to.as_ref(),
+                                            )
+                                        },
                                     ),
                                 },
                             );
@@ -189,11 +194,7 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
 
 /// Compute the distance from a given path to some other path
 /// If there is no shared path, returns usize::MAX
-fn distance_to_relative_ancestor(path: &Path, relative_to: &Option<Arc<Path>>) -> usize {
-    let Some(relative_to) = relative_to else {
-        return usize::MAX;
-    };
-
+fn distance_between_paths(path: &Path, relative_to: &Path) -> usize {
     let mut path_components = path.components();
     let mut relative_components = relative_to.components();
 


### PR DESCRIPTION
## Description of feature or change

You are more likely to want a file match that is closer to the active item than the alphabetic one.
For example, if you are editing a rust file and open up file finder with `cargo.toml`, you are highly likely to want the Cargo.toml file in the same same crate as the file you are editing.
This PR achieves that by sorting equal matches by the distance to the active item putting those files higher up in the results list.

## Link to related issues from zed or community

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
