### PR TITLE
Theme syntax overrides

### DIFF
--- a/styles/package-lock.json
+++ b/styles/package-lock.json
@@ -14,6 +14,7 @@
                 "bezier-easing": "^2.1.0",
                 "case-anything": "^2.1.10",
                 "chroma-js": "^2.4.2",
+                "deepmerge": "^4.3.0",
                 "toml": "^3.0.0",
                 "ts-node": "^10.9.1"
             }
@@ -130,6 +131,14 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+            "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -310,6 +319,11 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "deepmerge": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+            "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
         },
         "diff": {
             "version": "4.0.2",

--- a/styles/package.json
+++ b/styles/package.json
@@ -15,6 +15,7 @@
         "bezier-easing": "^2.1.0",
         "case-anything": "^2.1.10",
         "chroma-js": "^2.4.2",
+        "deepmerge": "^4.3.0",
         "toml": "^3.0.0",
         "ts-node": "^10.9.1"
     },

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -38,7 +38,7 @@ export default function editor(colorScheme: ColorScheme) {
         }
     }
 
-    const syntax: Syntax = {
+    const defaultSyntax: Syntax = {
         primary: {
             color: colorScheme.ramps.neutral(1).hex(),
             weight: fontWeights.normal,
@@ -134,10 +134,10 @@ export default function editor(colorScheme: ColorScheme) {
 
     function createSyntax(colorScheme: ColorScheme): Syntax {
         if (!colorScheme.syntax) {
-            return syntax
+            return defaultSyntax
         }
 
-        return deepmerge<Syntax, Partial<ThemeSyntax>>(syntax, colorScheme.syntax, {
+        return deepmerge<Syntax, Partial<ThemeSyntax>>(defaultSyntax, colorScheme.syntax, {
             arrayMerge: (destinationArray, sourceArray) => [
                 ...destinationArray,
                 ...sourceArray,
@@ -145,7 +145,7 @@ export default function editor(colorScheme: ColorScheme) {
         });
     }
 
-    const mergedSyntax = createSyntax(colorScheme)
+    const syntax = createSyntax(colorScheme)
 
     return {
         textColor: syntax.primary.color,
@@ -303,6 +303,6 @@ export default function editor(colorScheme: ColorScheme) {
                 color: borderColor(layer),
             },
         },
-        syntax: mergedSyntax,
+        syntax,
     }
 }

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -1,11 +1,16 @@
 import { fontWeights } from "../common"
 import { withOpacity } from "../utils/color"
-import { ColorScheme, Layer, StyleSets, Syntax, ThemeSyntax } from "../themes/common/colorScheme"
+import {
+    ColorScheme,
+    Layer,
+    StyleSets,
+    Syntax,
+    ThemeSyntax,
+} from "../themes/common/colorScheme"
 import { background, border, borderColor, foreground, text } from "./components"
 import hoverPopover from "./hoverPopover"
 
-import deepmerge from 'deepmerge';
-
+import deepmerge from "deepmerge"
 
 export default function editor(colorScheme: ColorScheme) {
     let layer = colorScheme.highest
@@ -137,12 +142,16 @@ export default function editor(colorScheme: ColorScheme) {
             return defaultSyntax
         }
 
-        return deepmerge<Syntax, Partial<ThemeSyntax>>(defaultSyntax, colorScheme.syntax, {
-            arrayMerge: (destinationArray, sourceArray) => [
-                ...destinationArray,
-                ...sourceArray,
-            ],
-        });
+        return deepmerge<Syntax, Partial<ThemeSyntax>>(
+            defaultSyntax,
+            colorScheme.syntax,
+            {
+                arrayMerge: (destinationArray, sourceArray) => [
+                    ...destinationArray,
+                    ...sourceArray,
+                ],
+            }
+        )
     }
 
     const syntax = createSyntax(colorScheme)

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -1,8 +1,11 @@
 import { fontWeights } from "../common"
 import { withOpacity } from "../utils/color"
-import { ColorScheme, Layer, StyleSets } from "../themes/common/colorScheme"
+import { ColorScheme, Layer, StyleSets, Syntax, ThemeSyntax } from "../themes/common/colorScheme"
 import { background, border, borderColor, foreground, text } from "./components"
 import hoverPopover from "./hoverPopover"
+
+import deepmerge from 'deepmerge';
+
 
 export default function editor(colorScheme: ColorScheme) {
     let layer = colorScheme.highest
@@ -35,7 +38,7 @@ export default function editor(colorScheme: ColorScheme) {
         }
     }
 
-    const syntax = {
+    const syntax: Syntax = {
         primary: {
             color: colorScheme.ramps.neutral(1).hex(),
             weight: fontWeights.normal,
@@ -128,6 +131,21 @@ export default function editor(colorScheme: ColorScheme) {
             italic: true,
         },
     }
+
+    function createSyntax(colorScheme: ColorScheme): Syntax {
+        if (!colorScheme.syntax) {
+            return syntax
+        }
+
+        return deepmerge<Syntax, Partial<ThemeSyntax>>(syntax, colorScheme.syntax, {
+            arrayMerge: (destinationArray, sourceArray) => [
+                ...destinationArray,
+                ...sourceArray,
+            ],
+        });
+    }
+
+    const mergedSyntax = createSyntax(colorScheme)
 
     return {
         textColor: syntax.primary.color,
@@ -285,6 +303,6 @@ export default function editor(colorScheme: ColorScheme) {
                 color: borderColor(layer),
             },
         },
-        syntax,
+        syntax: mergedSyntax,
     }
 }

--- a/styles/src/themes/common/colorScheme.ts
+++ b/styles/src/themes/common/colorScheme.ts
@@ -102,34 +102,34 @@ export interface Style {
 }
 
 export interface SyntaxHighlightStyle {
-    color: string,
+    color: string
     weight?: FontWeight
     underline?: boolean
     italic?: boolean
 }
 
 export interface Syntax {
-    primary: SyntaxHighlightStyle,
-    "variable.special": SyntaxHighlightStyle,
-    comment: SyntaxHighlightStyle,
-    punctuation: SyntaxHighlightStyle,
-    constant: SyntaxHighlightStyle,
-    keyword: SyntaxHighlightStyle,
-    function: SyntaxHighlightStyle,
-    type: SyntaxHighlightStyle,
-    constructor: SyntaxHighlightStyle,
-    variant: SyntaxHighlightStyle,
-    property: SyntaxHighlightStyle,
-    enum: SyntaxHighlightStyle,
-    operator: SyntaxHighlightStyle,
-    string: SyntaxHighlightStyle,
-    number: SyntaxHighlightStyle,
-    boolean: SyntaxHighlightStyle,
-    predictive: SyntaxHighlightStyle,
-    title: SyntaxHighlightStyle,
-    emphasis: SyntaxHighlightStyle,
-    "emphasis.strong": SyntaxHighlightStyle,
-    linkUri: SyntaxHighlightStyle,
+    primary: SyntaxHighlightStyle
+    "variable.special": SyntaxHighlightStyle
+    comment: SyntaxHighlightStyle
+    punctuation: SyntaxHighlightStyle
+    constant: SyntaxHighlightStyle
+    keyword: SyntaxHighlightStyle
+    function: SyntaxHighlightStyle
+    type: SyntaxHighlightStyle
+    constructor: SyntaxHighlightStyle
+    variant: SyntaxHighlightStyle
+    property: SyntaxHighlightStyle
+    enum: SyntaxHighlightStyle
+    operator: SyntaxHighlightStyle
+    string: SyntaxHighlightStyle
+    number: SyntaxHighlightStyle
+    boolean: SyntaxHighlightStyle
+    predictive: SyntaxHighlightStyle
+    title: SyntaxHighlightStyle
+    emphasis: SyntaxHighlightStyle
+    "emphasis.strong": SyntaxHighlightStyle
+    linkUri: SyntaxHighlightStyle
     linkText: SyntaxHighlightStyle
 }
 

--- a/styles/src/themes/common/colorScheme.ts
+++ b/styles/src/themes/common/colorScheme.ts
@@ -1,4 +1,5 @@
 import { Scale } from "chroma-js"
+import { FontWeight } from "../../common"
 
 export interface ColorScheme {
     name: string
@@ -14,6 +15,7 @@ export interface ColorScheme {
     modalShadow: Shadow
 
     players: Players
+    syntax?: Partial<ThemeSyntax>
 }
 
 export interface Meta {
@@ -98,3 +100,39 @@ export interface Style {
     border: string
     foreground: string
 }
+
+export interface SyntaxHighlightStyle {
+    color: string,
+    weight?: FontWeight
+    underline?: boolean
+    italic?: boolean
+}
+
+export interface Syntax {
+    primary: SyntaxHighlightStyle,
+    "variable.special": SyntaxHighlightStyle,
+    comment: SyntaxHighlightStyle,
+    punctuation: SyntaxHighlightStyle,
+    constant: SyntaxHighlightStyle,
+    keyword: SyntaxHighlightStyle,
+    function: SyntaxHighlightStyle,
+    type: SyntaxHighlightStyle,
+    constructor: SyntaxHighlightStyle,
+    variant: SyntaxHighlightStyle,
+    property: SyntaxHighlightStyle,
+    enum: SyntaxHighlightStyle,
+    operator: SyntaxHighlightStyle,
+    string: SyntaxHighlightStyle,
+    number: SyntaxHighlightStyle,
+    boolean: SyntaxHighlightStyle,
+    predictive: SyntaxHighlightStyle,
+    title: SyntaxHighlightStyle,
+    emphasis: SyntaxHighlightStyle,
+    "emphasis.strong": SyntaxHighlightStyle,
+    linkUri: SyntaxHighlightStyle,
+    linkText: SyntaxHighlightStyle
+}
+
+// HACK: "constructor" as a key in the syntax interface returns an error when a theme tries to use it.
+// For now hack around it by omiting constructor as a valid key for overrides.
+export type ThemeSyntax = Partial<Omit<Syntax, "constructor">>

--- a/styles/src/themes/common/ramps.ts
+++ b/styles/src/themes/common/ramps.ts
@@ -7,6 +7,7 @@ import {
     Style,
     Styles,
     StyleSet,
+    ThemeSyntax,
 } from "./colorScheme"
 
 export function colorRamp(color: Color): Scale {
@@ -18,7 +19,8 @@ export function colorRamp(color: Color): Scale {
 export function createColorScheme(
     name: string,
     isLight: boolean,
-    colorRamps: { [rampName: string]: Scale }
+    colorRamps: { [rampName: string]: Scale },
+    syntax?: ThemeSyntax
 ): ColorScheme {
     // Chromajs scales from 0 to 1 flipped if isLight is true
     let ramps: RampSet = {} as any
@@ -31,14 +33,14 @@ export function createColorScheme(
     // function to any in order to get the colors back out from the original ramps.
     if (isLight) {
         for (var rampName in colorRamps) {
-            ;(ramps as any)[rampName] = chroma.scale(
+            ; (ramps as any)[rampName] = chroma.scale(
                 colorRamps[rampName].colors(100).reverse()
             )
         }
         ramps.neutral = chroma.scale(colorRamps.neutral.colors(100).reverse())
     } else {
         for (var rampName in colorRamps) {
-            ;(ramps as any)[rampName] = chroma.scale(
+            ; (ramps as any)[rampName] = chroma.scale(
                 colorRamps[rampName].colors(100)
             )
         }
@@ -94,6 +96,7 @@ export function createColorScheme(
         modalShadow,
 
         players,
+        syntax
     }
 }
 

--- a/styles/src/themes/common/ramps.ts
+++ b/styles/src/themes/common/ramps.ts
@@ -33,14 +33,14 @@ export function createColorScheme(
     // function to any in order to get the colors back out from the original ramps.
     if (isLight) {
         for (var rampName in colorRamps) {
-            ; (ramps as any)[rampName] = chroma.scale(
+            ;(ramps as any)[rampName] = chroma.scale(
                 colorRamps[rampName].colors(100).reverse()
             )
         }
         ramps.neutral = chroma.scale(colorRamps.neutral.colors(100).reverse())
     } else {
         for (var rampName in colorRamps) {
-            ; (ramps as any)[rampName] = chroma.scale(
+            ;(ramps as any)[rampName] = chroma.scale(
                 colorRamps[rampName].colors(100)
             )
         }
@@ -96,7 +96,7 @@ export function createColorScheme(
         modalShadow,
 
         players,
-        syntax
+        syntax,
     }
 }
 

--- a/styles/src/themes/one-dark.ts
+++ b/styles/src/themes/one-dark.ts
@@ -14,7 +14,7 @@ const color = {
     teal: "#6FB4C0",
     blue: "#74ADE9",
     purple: "#B478CF",
-};
+}
 
 const ramps = {
     neutral: chroma
@@ -37,7 +37,7 @@ const ramps = {
     blue: colorRamp(chroma(color.blue)),
     violet: colorRamp(chroma(color.purple)),
     magenta: colorRamp(chroma("#be5046")),
-};
+}
 
 const syntax: ThemeSyntax = {
     primary: { color: color.white },
@@ -50,7 +50,7 @@ const syntax: ThemeSyntax = {
     keyword: { color: color.purple },
     boolean: { color: color.orange },
     punctuation: { color: color.white },
-    operator: { color: color.teal }
+    operator: { color: color.teal },
 }
 
 export const dark = createColorScheme(name, false, ramps, syntax)

--- a/styles/src/themes/one-dark.ts
+++ b/styles/src/themes/one-dark.ts
@@ -1,10 +1,22 @@
 import chroma from "chroma-js"
-import { Meta } from "./common/colorScheme"
+import { Meta, ThemeSyntax } from "./common/colorScheme"
 import { colorRamp, createColorScheme } from "./common/ramps"
 
 const name = "One Dark"
 
-export const dark = createColorScheme(`${name}`, false, {
+const color = {
+    white: "#ACB2BE",
+    grey: "#5D636F",
+    red: "#D07277",
+    orange: "#C0966B",
+    yellow: "#DFC184",
+    green: "#A1C181",
+    teal: "#6FB4C0",
+    blue: "#74ADE9",
+    purple: "#B478CF",
+};
+
+const ramps = {
     neutral: chroma
         .scale([
             "#282c34",
@@ -17,16 +29,31 @@ export const dark = createColorScheme(`${name}`, false, {
             "#c8ccd4",
         ])
         .domain([0.05, 0.22, 0.25, 0.45, 0.62, 0.8, 0.9, 1]),
-
-    red: colorRamp(chroma("#e06c75")),
-    orange: colorRamp(chroma("#d19a66")),
-    yellow: colorRamp(chroma("#e5c07b")),
-    green: colorRamp(chroma("#98c379")),
-    cyan: colorRamp(chroma("#56b6c2")),
-    blue: colorRamp(chroma("#61afef")),
-    violet: colorRamp(chroma("#c678dd")),
+    red: colorRamp(chroma(color.red)),
+    orange: colorRamp(chroma(color.orange)),
+    yellow: colorRamp(chroma(color.yellow)),
+    green: colorRamp(chroma(color.green)),
+    cyan: colorRamp(chroma(color.teal)),
+    blue: colorRamp(chroma(color.blue)),
+    violet: colorRamp(chroma(color.purple)),
     magenta: colorRamp(chroma("#be5046")),
-})
+};
+
+const syntax: ThemeSyntax = {
+    primary: { color: color.white },
+    comment: { color: color.grey },
+    function: { color: color.blue },
+    type: { color: color.teal },
+    property: { color: color.red },
+    number: { color: color.orange },
+    string: { color: color.green },
+    keyword: { color: color.purple },
+    boolean: { color: color.orange },
+    punctuation: { color: color.white },
+    operator: { color: color.teal }
+}
+
+export const dark = createColorScheme(name, false, ramps, syntax)
 
 export const meta: Meta = {
     name,

--- a/styles/src/themes/one-light.ts
+++ b/styles/src/themes/one-light.ts
@@ -1,5 +1,5 @@
 import chroma from "chroma-js"
-import { fontWeights } from "../common";
+import { fontWeights } from "../common"
 import { Meta, ThemeSyntax } from "./common/colorScheme"
 import { colorRamp, createColorScheme } from "./common/ramps"
 
@@ -15,8 +15,8 @@ const color = {
     teal: "#3982B7",
     blue: "#5B79E3",
     purple: "#A449AB",
-    magenta: "#994EA6"
-};
+    magenta: "#994EA6",
+}
 
 const ramps = {
     neutral: chroma
@@ -30,8 +30,7 @@ const ramps = {
             "#EAEAEB",
             "#FAFAFA",
         ])
-        .domain([0.05, 0.22, 0.25, 0.45, 0.62, 0.8, 0.9, 1])
-    ,
+        .domain([0.05, 0.22, 0.25, 0.45, 0.62, 0.8, 0.9, 1]),
     red: colorRamp(chroma(color.red)),
     orange: colorRamp(chroma(color.orange)),
     yellow: colorRamp(chroma(color.yellow)),
@@ -40,7 +39,7 @@ const ramps = {
     blue: colorRamp(chroma(color.blue)),
     violet: colorRamp(chroma(color.purple)),
     magenta: colorRamp(chroma(color.magenta)),
-};
+}
 
 const syntax: ThemeSyntax = {
     primary: { color: color.black },

--- a/styles/src/themes/one-light.ts
+++ b/styles/src/themes/one-light.ts
@@ -1,32 +1,71 @@
 import chroma from "chroma-js"
-import { Meta } from "./common/colorScheme"
+import { fontWeights } from "../common";
+import { Meta, ThemeSyntax } from "./common/colorScheme"
 import { colorRamp, createColorScheme } from "./common/ramps"
 
 const name = "One Light"
 
-export const light = createColorScheme(`${name}`, true, {
+const color = {
+    black: "#383A41",
+    grey: "#A2A3A7",
+    red: "#D36050",
+    orange: "#AD6F26",
+    yellow: "#DFC184",
+    green: "#659F58",
+    teal: "#3982B7",
+    blue: "#5B79E3",
+    purple: "#A449AB",
+    magenta: "#994EA6"
+};
+
+const ramps = {
     neutral: chroma
         .scale([
-            "#090a0b",
-            "#202227",
-            "#383a42",
+            "#383A41",
+            "#535456",
             "#696c77",
-            "#a0a1a7",
-            "#e5e5e6",
-            "#f0f0f1",
-            "#fafafa",
+            "#9D9D9F",
+            "#A9A9A9",
+            "#DBDBDC",
+            "#EAEAEB",
+            "#FAFAFA",
         ])
-        .domain([0.05, 0.22, 0.25, 0.45, 0.62, 0.8, 0.9, 1]),
+        .domain([0.05, 0.22, 0.25, 0.45, 0.62, 0.8, 0.9, 1])
+    ,
+    red: colorRamp(chroma(color.red)),
+    orange: colorRamp(chroma(color.orange)),
+    yellow: colorRamp(chroma(color.yellow)),
+    green: colorRamp(chroma(color.green)),
+    cyan: colorRamp(chroma(color.teal)),
+    blue: colorRamp(chroma(color.blue)),
+    violet: colorRamp(chroma(color.purple)),
+    magenta: colorRamp(chroma(color.magenta)),
+};
 
-    red: colorRamp(chroma("#ca1243")),
-    orange: colorRamp(chroma("#d75f00")),
-    yellow: colorRamp(chroma("#c18401")),
-    green: colorRamp(chroma("#50a14f")),
-    cyan: colorRamp(chroma("#0184bc")),
-    blue: colorRamp(chroma("#4078f2")),
-    violet: colorRamp(chroma("#a626a4")),
-    magenta: colorRamp(chroma("#986801")),
-})
+const syntax: ThemeSyntax = {
+    primary: { color: color.black },
+    "variable.special": { color: color.orange },
+    comment: { color: color.grey },
+    punctuation: { color: color.black },
+    keyword: { color: color.purple },
+    function: { color: color.blue },
+    type: { color: color.teal },
+    variant: { color: color.blue },
+    property: { color: color.red },
+    enum: { color: color.red },
+    operator: { color: color.teal },
+    string: { color: color.green },
+    number: { color: color.orange },
+    boolean: { color: color.orange },
+    title: { color: color.red, weight: fontWeights.normal },
+    "emphasis.strong": {
+        color: color.orange,
+    },
+    linkText: { color: color.blue },
+    linkUri: { color: color.teal },
+}
+
+export const light = createColorScheme(name, true, ramps, syntax)
 
 export const meta: Meta = {
     name,


### PR DESCRIPTION
## Description of feature or change

This PR adds the ability to override the `color`, `fontWeight`, `underline` or `italic` of any `SyntaxHighlightStyle` in our default `Syntax` config.

You can add one or more styles to a new optional fourth property of `createColorScheme`.

Simple example:

```ts
// one-light.ts

const syntax: ThemeSyntax = {
    "variable.special": { color: color.orange },
    property: { color: color.red },
    linkText: { color: color.blue },
    linkUri: { color: color.teal },
}

export const light = createColorScheme(name, true, ramps, syntax)
```

This will deep merge any properties you provide with our default syntax.

Currently you can't _only_ provide a property other than `color`. So this won't work:

```ts
const syntax: ThemeSyntax = {
    primary: { weight: fontWeights.bold },
}
```

We can make this possible with a little bit of work, but I wanted to keep this PR focused.

We'll need to split the default `Syntax` interface and what gets provided as an override to ensure that when working on the default styles you must provide a color for a style.

This would be an improvement overall, as today we have to do this:

```ts
        emphasis: {
            color: colorScheme.ramps.blue(0.5).hex(),
            weight: fontWeights.normal,
        },
        "emphasis.strong": {
            color: colorScheme.ramps.blue(0.5).hex(),
            weight: fontWeights.bold,
        },
```

But if we added a interface for syntax styles that don't _need_ a color, or inherit one from another style, we could do something like this:

```ts
        emphasis: {
            color: colorScheme.ramps.blue(0.5).hex(),
            weight: fontWeights.normal,
        },
        "emphasis.strong": {
            weight: fontWeights.bold,
        },
```

> **Warning**
> There is some weirdness where we have to exclude `constructor` as a valid key:
> 
> ```ts
> // HACK: "constructor" as a key in the syntax interface returns an error when a theme tries to use it.
> // For now hack around it by omiting constructor as a valid key for overrides.
> export type ThemeSyntax = Partial<Omit<Syntax, "constructor">>
> ```
> 
>  You get an error because Object.constructor already exists. (Thanks to @Kethku for helping me understand why this was happening before.)

---

### Before / After

**One Dark**

Before:
<img width="1727" alt="CleanShot - 2023-02-26 at 10 41 52@2x" src="https://user-images.githubusercontent.com/1714999/221420672-6c00c522-43e1-42f7-acb4-308e783637db.png">

After:
<img width="1728" alt="CleanShot - 2023-02-26 at 10 41 34@2x" src="https://user-images.githubusercontent.com/1714999/221420657-855a88a0-ebc7-48a3-8b79-971f9c4169a3.png">

Atom:

<img width="1728" alt="CleanShot - 2023-02-26 at 10 42 17@2x" src="https://user-images.githubusercontent.com/1714999/221420694-bb8afd47-20b8-4d4d-acad-3469b5950a7b.png">

**One Light**

Before:
<img width="1728" alt="CleanShot - 2023-02-26 at 10 39 15@2x" src="https://user-images.githubusercontent.com/1714999/221420556-2c114457-398d-4fa5-9176-182bb564ae77.png">

After:
<img width="1728" alt="CleanShot - 2023-02-26 at 10 40 37@2x" src="https://user-images.githubusercontent.com/1714999/221420609-c6bcd040-c9c5-4128-acd3-965724f3dad1.png">

Atom:

![CleanShot - 2023-02-26 at 10 38 12@2x](https://user-images.githubusercontent.com/1714999/221420502-eeb3bd87-894a-46ef-bfbc-56d3f747cab6.png)

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
