### PR TITLE
❓ Remove subpixel shift ❓

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -350,7 +350,6 @@ pub trait FontSystem: Send + Sync {
         font_id: FontId,
         font_size: f32,
         glyph_id: GlyphId,
-        subpixel_shift: Vector2F,
         scale_factor: f32,
         options: RasterizationOptions,
     ) -> Option<(RectI, Vec<u8>)>;

--- a/crates/gpui/src/platform/mac/image_cache.rs
+++ b/crates/gpui/src/platform/mac/image_cache.rs
@@ -84,7 +84,6 @@ impl ImageCache {
                     image_glyph.font_id,
                     image_glyph.font_size,
                     image_glyph.id,
-                    Default::default(),
                     self.scale_factor,
                     RasterizationOptions::Bgra,
                 )?;

--- a/crates/gpui/src/platform/mac/renderer.rs
+++ b/crates/gpui/src/platform/mac/renderer.rs
@@ -618,12 +618,10 @@ impl Renderer {
         let mut sprites_by_atlas = HashMap::new();
 
         for glyph in glyphs {
-            if let Some(sprite) = self.sprite_cache.render_glyph(
-                glyph.font_id,
-                glyph.font_size,
-                glyph.id,
-                glyph.origin,
-            ) {
+            if let Some(sprite) =
+                self.sprite_cache
+                    .render_glyph(glyph.font_id, glyph.font_size, glyph.id)
+            {
                 // Snap sprite to pixel grid.
                 let origin = (glyph.origin * scale_factor).floor() + sprite.offset.to_f32();
                 sprites_by_atlas

--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -1,7 +1,7 @@
 use super::atlas::AtlasAllocator;
 use crate::{
     fonts::{FontId, GlyphId},
-    geometry::vector::{vec2f, Vector2F, Vector2I},
+    geometry::vector::Vector2I,
     platform::{self, RasterizationOptions},
 };
 use collections::hash_map::Entry;
@@ -14,7 +14,6 @@ struct GlyphDescriptor {
     font_id: FontId,
     font_size: OrderedFloat<f32>,
     glyph_id: GlyphId,
-    subpixel_variant: (u8, u8),
 }
 
 #[derive(Clone)]
@@ -81,37 +80,22 @@ impl SpriteCache {
         font_id: FontId,
         font_size: f32,
         glyph_id: GlyphId,
-        target_position: Vector2F,
     ) -> Option<GlyphSprite> {
-        const SUBPIXEL_VARIANTS: u8 = 4;
-
         let scale_factor = self.scale_factor;
-        let target_position = target_position * scale_factor;
         let fonts = &self.fonts;
         let atlases = &mut self.atlases;
-        let subpixel_variant = (
-            (target_position.x().fract() * SUBPIXEL_VARIANTS as f32).round() as u8
-                % SUBPIXEL_VARIANTS,
-            (target_position.y().fract() * SUBPIXEL_VARIANTS as f32).round() as u8
-                % SUBPIXEL_VARIANTS,
-        );
+
         self.glyphs
             .entry(GlyphDescriptor {
                 font_id,
                 font_size: OrderedFloat(font_size),
                 glyph_id,
-                subpixel_variant,
             })
             .or_insert_with(|| {
-                let subpixel_shift = vec2f(
-                    subpixel_variant.0 as f32 / SUBPIXEL_VARIANTS as f32,
-                    subpixel_variant.1 as f32 / SUBPIXEL_VARIANTS as f32,
-                );
                 let (glyph_bounds, mask) = fonts.rasterize_glyph(
                     font_id,
                     font_size,
                     glyph_id,
-                    subpixel_shift,
                     scale_factor,
                     RasterizationOptions::Alpha,
                 )?;


### PR DESCRIPTION
Bit of an odd one this, finally bothered enough to peek at our sometimes terrible kerning and found this mechanism. Its use is not entirely apparent to me as CoreText/CoreGraphics is incapable of subpixel rasterization for fonts. It does however seem to be the cause of \*most\* (but not all) of our kerning issues.

Here are some screenshots to demonstrate.
In all screenshots the windows are in this order: Zed Preview, this branch, Sublime Text 4

Default font (monospace), 16 font size
![CleanShot 2023-02-27 at 00 42 45](https://user-images.githubusercontent.com/30666851/221484798-28bc5417-0354-4271-a0fb-d8f32605f5eb.png)


Verdana font (proportional), 16 font size
![CleanShot 2023-02-27 at 00 41 06](https://user-images.githubusercontent.com/30666851/221484986-b059904c-dd27-4e8c-ae3e-d6f7dfd5633d.png)

For the monospace font the kerning issues are more subtle, which is why this hasn't been such an issue, but they are there none-the-less. The proportional font though highlights the issue pretty significantly at some coordinates, this is supposed to be the word "clone", it looks more like "done" (Zed Preview)
![CleanShot 2023-02-27 at 00 53 59](https://user-images.githubusercontent.com/30666851/221485419-8d7ff567-15bd-404e-968c-a6ab24b9ab33.png)

This same situation with this branch
![CleanShot 2023-02-27 at 00 55 33](https://user-images.githubusercontent.com/30666851/221485586-b5a34176-faa3-4427-9114-2d6ee5ef501b.png)

The git blame shows that this mechanism was added by (cc) @as-cii  and (cc) @nathansobo, roping them in to see what they think

Removing this mechanism does not fix all our kerning issues, comparing the branch against Sublime Text highlights more kerning issues remaining but they are significantly more minor than the existing issues. I have experimented with rounding glyph coordinates instead of flooring them and oddly enough that make the issues worse which I found surprising.

Pending more information about the original intent of this mechanism my interest is in getting this merged as this is a general annoyance I have personally given my use of proportional fonts, but also something I'd like to resolve for general polish reasons given their presence with our default font. If removing this would reintroduce some more insidious issue then I'd like to sit down with someone with context on this and map out what else may be at play here.