### PR TITLE
add go to definition binding to vim normal mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -234,7 +234,8 @@
             "escape": [
                 "vim::SwitchMode",
                 "Normal"
-            ]
+            ],
+            "d": "editor::GoToDefinition"
         }
     },
     {


### PR DESCRIPTION
Adds a common binding `g` `d` to vim normal mode for the go to definition action
