### PR TITLE
fix infinite loop in path distance for fuzzy finder

### DIFF
--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -198,6 +198,25 @@ fn distance_between_paths(path: &Path, relative_to: &Path) -> usize {
     let mut path_components = path.components();
     let mut relative_components = relative_to.components();
 
-    while path_components.next() == relative_components.next() {}
+    // while path_components.next() == relative_components.next() {}
+
+    while path_components
+        .next()
+        .zip(relative_components.next())
+        .map(|(path_component, relative_component)| path_component == relative_component)
+        .unwrap_or_default()
+    {}
     path_components.count() + relative_components.count() + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::distance_between_paths;
+
+    #[test]
+    fn test_distance_between_paths_empty() {
+        distance_between_paths(Path::new(""), Path::new(""));
+    }
 }


### PR DESCRIPTION
## Description of feature or change

dumb infinite loop for base case in path distance function used to sort file finder results

## Link to related issues from zed or community

fixes https://linear.app/zed-industries/issue/Z-199/zed-freezes-and-cpu-jumps-when-using-the-file-finder

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
