### PR TITLE
Add settings to normalize whitespace on save

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -51,6 +51,8 @@
     // 3. Position the dock full screen over the entire workspace"
     //     "default_dock_anchor": "expanded"
     "default_dock_anchor": "right",
+    // Whether or not to remove trailing whitespace from lines before saving.
+    "remove_trailing_whitespace_on_save": true,
     // Whether or not to perform a buffer format before saving
     "format_on_save": "on",
     // How to perform a buffer format. This setting can take two values:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -51,8 +51,12 @@
     // 3. Position the dock full screen over the entire workspace"
     //     "default_dock_anchor": "expanded"
     "default_dock_anchor": "right",
-    // Whether or not to remove trailing whitespace from lines before saving.
+    // Whether or not to remove any trailing whitespace from lines of a buffer
+    // before saving it.
     "remove_trailing_whitespace_on_save": true,
+    // Whether or not to ensure there's a single newline at the end of a buffer
+    // when saving it.
+    "ensure_final_newline_on_save": true,
     // Whether or not to perform a buffer format before saving
     "format_on_save": "on",
     // How to perform a buffer format. This setting can take two values:

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3892,9 +3892,11 @@ async fn test_formatting_buffer(
         })
         .await
         .unwrap();
+
+    // The edits from the LSP are applied, and a final newline is added.
     assert_eq!(
         buffer_b.read_with(cx_b, |buffer, _| buffer.text()),
-        "let honey = \"two\""
+        "let honey = \"two\"\n"
     );
 
     // Ensure buffer can be formatted using an external command. Notice how the

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1,23 +1,23 @@
-use drag_and_drop::DragAndDrop;
-use futures::StreamExt;
-use indoc::indoc;
-use std::{cell::RefCell, rc::Rc, time::Instant};
-use unindent::Unindent;
-
 use super::*;
 use crate::test::{
     assert_text_with_selections, build_editor, editor_lsp_test_context::EditorLspTestContext,
     editor_test_context::EditorTestContext, select_ranges,
 };
+use drag_and_drop::DragAndDrop;
+use futures::StreamExt;
 use gpui::{
     executor::Deterministic,
     geometry::{rect::RectF, vector::vec2f},
     platform::{WindowBounds, WindowOptions},
     serde_json,
 };
+use indoc::indoc;
 use language::{BracketPairConfig, FakeLspAdapter, LanguageConfig, LanguageRegistry, Point};
+use parking_lot::Mutex;
 use project::FakeFs;
 use settings::EditorSettings;
+use std::{cell::RefCell, rc::Rc, time::Instant};
+use unindent::Unindent;
 use util::{
     assert_set_eq,
     test::{marked_text_ranges, marked_text_ranges_by, sample_text, TextRangeMarker},
@@ -4299,6 +4299,111 @@ async fn test_concurrent_format_requests(cx: &mut gpui::TestAppContext) {
         one
             .twoˇ
     "});
+}
+
+#[gpui::test]
+async fn test_strip_whitespace_and_format_via_lsp(cx: &mut gpui::TestAppContext) {
+    cx.foreground().forbid_parking();
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            document_formatting_provider: Some(lsp::OneOf::Left(true)),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    // Set up a buffer white some trailing whitespace.
+    cx.set_state(
+        &[
+            "one ",   //
+            "twoˇ",  //
+            "three ", //
+        ]
+        .join("\n"),
+    );
+
+    // Submit a format request.
+    let format = cx
+        .update_editor(|editor, cx| editor.format(&Format, cx))
+        .unwrap();
+
+    // Record which buffer changes have been sent to the language server
+    let buffer_changes = Arc::new(Mutex::new(Vec::new()));
+    cx.lsp
+        .handle_notification::<lsp::notification::DidChangeTextDocument, _>({
+            let buffer_changes = buffer_changes.clone();
+            move |params, _| {
+                buffer_changes.lock().extend(
+                    params
+                        .content_changes
+                        .into_iter()
+                        .map(|e| (e.range.unwrap(), e.text)),
+                );
+            }
+        });
+
+    // Handle formatting requests to the language server.
+    cx.lsp.handle_request::<lsp::request::Formatting, _, _>({
+        let buffer_changes = buffer_changes.clone();
+        move |_, _| {
+            // When formatting is requested, trailing whitespace has already been stripped.
+            assert_eq!(
+                &buffer_changes.lock()[1..],
+                &[
+                    (
+                        lsp::Range::new(lsp::Position::new(0, 3), lsp::Position::new(0, 4)),
+                        "".into()
+                    ),
+                    (
+                        lsp::Range::new(lsp::Position::new(2, 5), lsp::Position::new(2, 6)),
+                        "".into()
+                    ),
+                ]
+            );
+
+            // Insert blank lines between each line of the buffer.
+            async move {
+                Ok(Some(vec![
+                    lsp::TextEdit {
+                        range: lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(1, 0)),
+                        new_text: "\n".into(),
+                    },
+                    lsp::TextEdit {
+                        range: lsp::Range::new(lsp::Position::new(2, 0), lsp::Position::new(2, 0)),
+                        new_text: "\n".into(),
+                    },
+                ]))
+            }
+        }
+    });
+
+    // After formatting the buffer, the trailing whitespace is stripped and the
+    // edits provided by the language server have been applied.
+    format.await.unwrap();
+    cx.assert_editor_state(
+        &[
+            "one",   //
+            "",      //
+            "twoˇ", //
+            "",      //
+            "three", //
+        ]
+        .join("\n"),
+    );
+
+    // Undoing the formatting undoes both the trailing whitespace removal and the
+    // LSP edits.
+    cx.update_buffer(|buffer, cx| buffer.undo(cx));
+    cx.assert_editor_state(
+        &[
+            "one ",   //
+            "twoˇ",  //
+            "three ", //
+        ]
+        .join("\n"),
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -185,6 +185,7 @@ impl<'a> EditorTestContext<'a> {
     /// of its selections using a string containing embedded range markers.
     ///
     /// See the `util::test::marked_text_ranges` function for more information.
+    #[track_caller]
     pub fn assert_editor_state(&mut self, marked_text: &str) {
         let (unmarked_text, expected_selections) = marked_text_ranges(marked_text, true);
         let buffer_text = self.buffer_text();

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1154,7 +1154,7 @@ impl Buffer {
         })
     }
 
-    pub fn normalize_whitespace(&self, cx: &AppContext) -> Task<Diff> {
+    pub fn remove_trailing_whitespace(&self, cx: &AppContext) -> Task<Diff> {
         let old_text = self.as_rope().clone();
         let line_ending = self.line_ending();
         let base_version = self.version();
@@ -1189,7 +1189,7 @@ impl Buffer {
         &mut self,
         diff: Diff,
         cx: &mut ModelContext<Self>,
-    ) -> Option<&Transaction> {
+    ) -> Option<TransactionId> {
         // Check for any edits to the buffer that have occurred since this diff
         // was computed.
         let snapshot = self.snapshot();
@@ -1219,12 +1219,10 @@ impl Buffer {
             Some((start..end, new_text))
         });
 
-        self.finalize_last_transaction();
         self.start_transaction();
         self.text.set_line_ending(diff.line_ending);
         self.edit(adjusted_edits, None, cx);
-        self.end_transaction(cx)?;
-        self.finalize_last_transaction()
+        self.end_transaction(cx)
     }
 
     pub fn is_dirty(&self) -> bool {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1199,7 +1199,10 @@ impl Buffer {
 
     pub fn apply_diff(&mut self, diff: Diff, cx: &mut ModelContext<Self>) -> Option<TransactionId> {
         if self.version == diff.base_version {
-            self.apply_non_conflicting_portion_of_diff(diff, cx)
+            self.start_transaction();
+            self.text.set_line_ending(diff.line_ending);
+            self.edit(diff.edits, None, cx);
+            self.end_transaction(cx)
         } else {
             return None;
         }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -254,7 +254,7 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
     let format_diff = format.await;
     buffer.update(cx, |buffer, cx| {
         let version_before_format = format_diff.base_version.clone();
-        buffer.apply_non_conflicting_portion_of_diff(format_diff, cx);
+        buffer.apply_diff(format_diff, cx);
 
         // The outcome depends on the order of concurrent taks.
         //

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -6,6 +6,7 @@ use gpui::{ModelHandle, MutableAppContext};
 use indoc::indoc;
 use proto::deserialize_operation;
 use rand::prelude::*;
+use regex::RegexBuilder;
 use settings::Settings;
 use std::{
     cell::RefCell,
@@ -17,6 +18,13 @@ use std::{
 use text::network::Network;
 use unindent::Unindent as _;
 use util::{assert_set_eq, post_inc, test::marked_text_ranges, RandomCharIter};
+
+lazy_static! {
+    static ref TRAILING_WHITESPACE_REGEX: Regex = RegexBuilder::new("[ \t]+$")
+        .multi_line(true)
+        .build()
+        .unwrap();
+}
 
 #[cfg(test)]
 #[ctor::ctor]
@@ -208,6 +216,79 @@ async fn test_apply_diff(cx: &mut gpui::TestAppContext) {
         buffer.apply_diff(diff, cx).unwrap();
         assert_eq!(buffer.text(), text);
         assert_eq!(anchor.to_point(buffer), Point::new(4, 4));
+    });
+}
+
+#[gpui::test(iterations = 10)]
+async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
+    let text = [
+        "zero",     //
+        "one  ",    // 2 trailing spaces
+        "two",      //
+        "three   ", // 3 trailing spaces
+        "four",     //
+        "five    ", // 4 trailing spaces
+    ]
+    .join("\n");
+
+    let buffer = cx.add_model(|cx| Buffer::new(0, text, cx));
+
+    // Spawn a task to format the buffer's whitespace.
+    // Pause so that the foratting task starts running.
+    let format = buffer.read_with(cx, |buffer, cx| buffer.normalize_whitespace(cx));
+    smol::future::yield_now().await;
+
+    // Edit the buffer while the normalization task is running.
+    let version_before_edit = buffer.read_with(cx, |buffer, _| buffer.version());
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit(
+            [
+                (Point::new(0, 1)..Point::new(0, 1), "EE"),
+                (Point::new(3, 5)..Point::new(3, 5), "EEE"),
+            ],
+            None,
+            cx,
+        );
+    });
+
+    let format_diff = format.await;
+    buffer.update(cx, |buffer, cx| {
+        let version_before_format = format_diff.base_version.clone();
+        buffer.apply_diff_force(format_diff, cx);
+
+        // The outcome depends on the order of concurrent taks.
+        //
+        // If the edit occurred while searching for trailing whitespace ranges,
+        // then the trailing whitespace region touched by the edit is left intact.
+        if version_before_format == version_before_edit {
+            assert_eq!(
+                buffer.text(),
+                [
+                    "zEEero",      //
+                    "one",         //
+                    "two",         //
+                    "threeEEE   ", //
+                    "four",        //
+                    "five",        //
+                ]
+                .join("\n")
+            );
+        }
+        // Otherwise, all trailing whitespace is removed.
+        else {
+            assert_eq!(
+                buffer.text(),
+                [
+                    "zEEero",   //
+                    "one",      //
+                    "two",      //
+                    "threeEEE", //
+                    "four",     //
+                    "five",     //
+                ]
+                .join("\n")
+            );
+        }
     });
 }
 
@@ -1940,6 +2021,45 @@ fn test_contiguous_ranges() {
         )
         .collect::<Vec<_>>(),
         &[2..5, 5..8, 8..10, 23..26, 26..27, 30..32],
+    );
+}
+
+#[gpui::test(iterations = 500)]
+fn test_trailing_whitespace_ranges(mut rng: StdRng) {
+    // Generate a random multi-line string containing
+    // some lines with trailing whitespace.
+    let mut text = String::new();
+    for _ in 0..rng.gen_range(0..16) {
+        for _ in 0..rng.gen_range(0..36) {
+            text.push(match rng.gen_range(0..10) {
+                0..=1 => ' ',
+                3 => '\t',
+                _ => rng.gen_range('a'..'z'),
+            });
+        }
+        text.push('\n');
+    }
+
+    match rng.gen_range(0..10) {
+        // sometimes remove the last newline
+        0..=1 => drop(text.pop()), //
+
+        // sometimes add extra newlines
+        2..=3 => text.push_str(&"\n".repeat(rng.gen_range(1..5))),
+        _ => {}
+    }
+
+    let rope = Rope::from(text.as_str());
+    let actual_ranges = trailing_whitespace_ranges(&rope);
+    let expected_ranges = TRAILING_WHITESPACE_REGEX
+        .find_iter(&text)
+        .map(|m| m.range())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual_ranges,
+        expected_ranges,
+        "wrong ranges for text lines:\n{:?}",
+        text.split("\n").collect::<Vec<_>>()
     );
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -235,7 +235,7 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
 
     // Spawn a task to format the buffer's whitespace.
     // Pause so that the foratting task starts running.
-    let format = buffer.read_with(cx, |buffer, cx| buffer.normalize_whitespace(cx));
+    let format = buffer.read_with(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx));
     smol::future::yield_now().await;
 
     // Edit the buffer while the normalization task is running.

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -254,7 +254,7 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
     let format_diff = format.await;
     buffer.update(cx, |buffer, cx| {
         let version_before_format = format_diff.base_version.clone();
-        buffer.apply_diff_force(format_diff, cx);
+        buffer.apply_non_conflicting_portion_of_diff(format_diff, cx);
 
         // The outcome depends on the order of concurrent taks.
         //

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2921,7 +2921,7 @@ impl Project {
                         buffer.finalize_last_transaction();
                         buffer.start_transaction();
                         if let Some(diff) = trailing_whitespace_diff {
-                            buffer.apply_non_conflicting_portion_of_diff(diff, cx);
+                            buffer.apply_diff(diff, cx);
                         }
                         if ensure_final_newline {
                             buffer.ensure_final_newline(cx);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2906,7 +2906,7 @@ impl Project {
                             .await;
                         buffer.update(&mut cx, move |buffer, cx| {
                             buffer.finalize_last_transaction();
-                            buffer.apply_diff_force(diff, cx)
+                            buffer.apply_non_conflicting_portion_of_diff(diff, cx)
                         })
                     } else {
                         None

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -94,6 +94,7 @@ pub struct EditorSettings {
     pub soft_wrap: Option<SoftWrap>,
     pub preferred_line_length: Option<u32>,
     pub format_on_save: Option<FormatOnSave>,
+    pub remove_trailing_whitespace_on_save: Option<bool>,
     pub formatter: Option<Formatter>,
     pub enable_language_server: Option<bool>,
 }
@@ -361,6 +362,9 @@ impl Settings {
                 hard_tabs: required(defaults.editor.hard_tabs),
                 soft_wrap: required(defaults.editor.soft_wrap),
                 preferred_line_length: required(defaults.editor.preferred_line_length),
+                remove_trailing_whitespace_on_save: required(
+                    defaults.editor.remove_trailing_whitespace_on_save,
+                ),
                 format_on_save: required(defaults.editor.format_on_save),
                 formatter: required(defaults.editor.formatter),
                 enable_language_server: required(defaults.editor.enable_language_server),
@@ -458,6 +462,12 @@ impl Settings {
 
     pub fn preferred_line_length(&self, language: Option<&str>) -> u32 {
         self.language_setting(language, |settings| settings.preferred_line_length)
+    }
+
+    pub fn remove_trailing_whitespace_on_save(&self, language: Option<&str>) -> bool {
+        self.language_setting(language, |settings| {
+            settings.remove_trailing_whitespace_on_save.clone()
+        })
     }
 
     pub fn format_on_save(&self, language: Option<&str>) -> FormatOnSave {
@@ -558,6 +568,7 @@ impl Settings {
                 hard_tabs: Some(false),
                 soft_wrap: Some(SoftWrap::None),
                 preferred_line_length: Some(80),
+                remove_trailing_whitespace_on_save: Some(true),
                 format_on_save: Some(FormatOnSave::On),
                 formatter: Some(Formatter::LanguageServer),
                 enable_language_server: Some(true),

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -95,6 +95,7 @@ pub struct EditorSettings {
     pub preferred_line_length: Option<u32>,
     pub format_on_save: Option<FormatOnSave>,
     pub remove_trailing_whitespace_on_save: Option<bool>,
+    pub ensure_final_newline_on_save: Option<bool>,
     pub formatter: Option<Formatter>,
     pub enable_language_server: Option<bool>,
 }
@@ -365,6 +366,9 @@ impl Settings {
                 remove_trailing_whitespace_on_save: required(
                     defaults.editor.remove_trailing_whitespace_on_save,
                 ),
+                ensure_final_newline_on_save: required(
+                    defaults.editor.ensure_final_newline_on_save,
+                ),
                 format_on_save: required(defaults.editor.format_on_save),
                 formatter: required(defaults.editor.formatter),
                 enable_language_server: required(defaults.editor.enable_language_server),
@@ -470,6 +474,12 @@ impl Settings {
         })
     }
 
+    pub fn ensure_final_newline_on_save(&self, language: Option<&str>) -> bool {
+        self.language_setting(language, |settings| {
+            settings.ensure_final_newline_on_save.clone()
+        })
+    }
+
     pub fn format_on_save(&self, language: Option<&str>) -> FormatOnSave {
         self.language_setting(language, |settings| settings.format_on_save.clone())
     }
@@ -569,6 +579,7 @@ impl Settings {
                 soft_wrap: Some(SoftWrap::None),
                 preferred_line_length: Some(80),
                 remove_trailing_whitespace_on_save: Some(true),
+                ensure_final_newline_on_save: Some(true),
                 format_on_save: Some(FormatOnSave::On),
                 formatter: Some(Formatter::LanguageServer),
                 enable_language_server: Some(true),


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-58/settings-for-handling-whitespace

### Description

This PR adds two new boolean settings to Zed, which are both enabled by default.
* `remove_trailing_whitespace_on_save`
* `ensure_final_newline_on_save`

If `remove_trailing_whitespace_on_save` is enabled, then when a buffer is saved, we will spawn a background task that searches the entire buffer for whitespace at the ends of lines. When that task completes, we'll remove that whitespace. To make the search as fast as possible, I wrote a dedicated routine for it which avoids allocating or copying any text.

Similarly, if `ensure_final_newline_on_save` is enabled, then when a buffer is saved, we'll ensure that the buffer ends with a newline, and that this one newline is the only whitespace at the end of the buffer.

Both of these operations are performed *before* we do any language-specific formatting (either via the LSP or via an external command).

### Concurrency

As I said above, searching for trailing whitespace is done in the background, because it must scan through the entire buffer. So it is an asynchronous operation. LSP formatting is also asynchronous. Meanwhile, it's important that all of the formatting operations (trailing whitespace, newline, and language-specific formatting) are able to be undone via a single `Undo` action. 

So there some edge cases that are important:
1. You edit the buffer while searching for trailing whitespace. In that case, the whitespace removal will **still proceed**. We'll just discard any whitespace-removing edits that touched any of the edits done while the search was running.
2. You edit the buffer after trailing whitespace is removed, but *before* the LSP formatting request completes. In that case, we cancel the LSP formatting, because can't be combined with the whitespace removal into a single transaction of consecutive edits.

### Before Merging


- [x] Figure out why this PR is causing a different behavior when large buffers are reloaded after FS changes caused by saves. Unrelated bug that happens to be triggered now, or related?
- [x] update tests to reflect newline additions now happening by default
- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
