### PR TITLE
Made code fold indicators show up on active line indicators

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2702,6 +2702,7 @@ impl Editor {
     pub fn render_fold_indicators(
         &self,
         fold_data: Option<Vec<(u32, FoldStatus)>>,
+        active_rows: &BTreeMap<u32, bool>,
         style: &EditorStyle,
         gutter_hovered: bool,
         line_height: f32,
@@ -2717,7 +2718,10 @@ impl Editor {
                 .iter()
                 .copied()
                 .filter_map(|(fold_location, fold_status)| {
-                    (gutter_hovered || fold_status == FoldStatus::Folded).then(|| {
+                    (gutter_hovered
+                        || fold_status == FoldStatus::Folded
+                        || !*active_rows.get(&fold_location).unwrap_or(&true))
+                    .then(|| {
                         (
                             fold_location,
                             MouseEventHandler::<FoldIndicators>::new(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1858,6 +1858,7 @@ impl Element for EditorElement {
 
             view.render_fold_indicators(
                 folds,
+                &active_rows,
                 &style,
                 view.gutter_hovered,
                 line_height,


### PR DESCRIPTION
## Description of feature or change

While playing around with this feature, I realized it wasn't integrated with the active rows indicator. It now is.

## Link to related issues from zed or community

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
