### PR TITLE
Fix off by one error in click ranges

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -221,7 +221,8 @@ impl EditorElement {
                             position_to_display_point(e.position, text_bounds, &position_map);
                         if let Some(point) = point {
                             for (range, callback) in click_ranges.iter() {
-                                if range.contains(&point) {
+                                // Range -> RangeInclusive
+                                if range.contains(&point) || range.end == point {
                                     callback(&e, range, &position_map.snapshot, cx)
                                 }
                             }


### PR DESCRIPTION
## Description of feature or change

@JosephTLyons noticed that the right half of the code fold indicators does not respond to clicks. This has been fixed.

## Link to related issues from zed or community

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
