### PR TITLE
Avoid tab bar background activating an item at the end of a tab drag

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1438,7 +1438,7 @@ impl View for Pane {
                                             .with_style(theme.workspace.tab_bar.container)
                                             .boxed()
                                     })
-                                    .on_click(MouseButton::Left, move |_, cx| {
+                                    .on_down(MouseButton::Left, move |_, cx| {
                                         cx.dispatch_action(ActivateItem(active_item_index));
                                     })
                                     .boxed(),


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/zed-industries/zed/pull/2173 where the tab bar would fire an item activation on mouse up of a tab drag release causing the wrong item to be activated

Closes https://linear.app/zed-industries/issue/Z-186/tab-bar-activate-on-mouse-up-triggers-when-dragging-and-releasing-tab
