### PR TITLE
Initialize code fold indicators on buffer startup

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -8,6 +8,7 @@ use block_map::{BlockMap, BlockPoint};
 use collections::{HashMap, HashSet};
 use fold_map::FoldMap;
 use gpui::{
+    color::Color,
     fonts::{FontId, HighlightStyle},
     Entity, ModelContext, ModelHandle,
 };
@@ -216,6 +217,10 @@ impl DisplayMap {
     pub fn set_font(&self, font_id: FontId, font_size: f32, cx: &mut ModelContext<Self>) -> bool {
         self.wrap_map
             .update(cx, |map, cx| map.set_font(font_id, font_size, cx))
+    }
+
+    pub fn set_fold_ellipses_color(&mut self, color: Color) -> bool {
+        self.fold_map.set_ellipses_color(color)
     }
 
     pub fn set_wrap_width(&self, width: Option<f32>, cx: &mut ModelContext<Self>) -> bool {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -643,7 +643,6 @@ impl DisplaySnapshot {
                     break;
                 }
             }
-
             let end = end.unwrap_or(max_point);
             Some(start..end)
         } else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -39,11 +39,10 @@ use gpui::{
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
     platform::CursorStyle,
-    scene::MouseClick,
     serde_json::json,
     AnyViewHandle, AppContext, AsyncAppContext, ClipboardItem, Element, ElementBox, Entity,
-    EventContext, ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription, Task,
-    View, ViewContext, ViewHandle, WeakViewHandle,
+    ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription, Task, View,
+    ViewContext, ViewHandle, WeakViewHandle,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HideHover, HoverState};
@@ -6448,6 +6447,7 @@ impl View for Editor {
     fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {
         let style = self.style(cx);
         let font_changed = self.display_map.update(cx, |map, cx| {
+            map.set_fold_ellipses_color(style.folds.ellipses.text_color);
             map.set_font(style.text.font_id, style.text.font_size, cx)
         });
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4159,10 +4159,10 @@ pub struct RenderContext<'a, T: View> {
 
 #[derive(Debug, Clone, Default)]
 pub struct MouseState {
-    hovered: bool,
-    clicked: Option<MouseButton>,
-    accessed_hovered: bool,
-    accessed_clicked: bool,
+    pub(crate) hovered: bool,
+    pub(crate) clicked: Option<MouseButton>,
+    pub(crate) accessed_hovered: bool,
+    pub(crate) accessed_clicked: bool,
 }
 
 impl MouseState {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -633,15 +633,21 @@ pub struct FieldEditor {
 }
 
 #[derive(Clone, Deserialize, Default)]
+pub struct InteractiveColor {
+    pub color: Color,
+}
+
+#[derive(Clone, Deserialize, Default)]
 pub struct CodeActions {
     #[serde(default)]
-    pub indicator: Interactive<Indicator>,
+    pub indicator: Interactive<InteractiveColor>,
     pub vertical_scale: f32,
 }
 
 #[derive(Clone, Deserialize, Default)]
 pub struct Folds {
-    pub indicator: Interactive<Indicator>,
+    pub indicator: Interactive<InteractiveColor>,
+    pub ellipses: FoldEllipses,
     pub fold_background: Color,
     pub icon_width: f32,
     pub folded_icon: String,
@@ -649,8 +655,10 @@ pub struct Folds {
 }
 
 #[derive(Clone, Deserialize, Default)]
-pub struct Indicator {
-    pub color: Color,
+pub struct FoldEllipses {
+    pub text_color: Color,
+    pub background: Interactive<InteractiveColor>,
+    pub corner_radius_factor: f32,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -76,6 +76,22 @@ export default function editor(colorScheme: ColorScheme) {
                     color: foreground(layer, "on"),
                 },
             },
+            ellipses: {
+                textColor: colorScheme.ramps.neutral(0.71).hex(),
+                cornerRadiusFactor: 0.15,
+                background: {
+                    // Copied from hover_popover highlight
+                    color: colorScheme.ramps.neutral(0.5).alpha(0.0).hex(),
+
+                    hover: {
+                        color: colorScheme.ramps.neutral(0.5).alpha(0.5).hex(),
+                    },
+
+                    clicked: {
+                        color: colorScheme.ramps.neutral(0.5).alpha(0.7).hex(),
+                    },
+                }
+            },
             foldBackground: foreground(layer, "variant"),
         },
         diff: {


### PR DESCRIPTION
## Description of feature or change

This PR initializes code fold indicators on editor creation and makes them interactive! Hack day contribution with @maxbrunsfeld .

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
