### PR TITLE
Revert "Avoid tab bar background activating an item at the end of a tab drag"

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1438,7 +1438,7 @@ impl View for Pane {
                                             .with_style(theme.workspace.tab_bar.container)
                                             .boxed()
                                     })
-                                    .on_down(MouseButton::Left, move |_, cx| {
+                                    .on_click(MouseButton::Left, move |_, cx| {
                                         cx.dispatch_action(ActivateItem(active_item_index));
                                     })
                                     .boxed(),


### PR DESCRIPTION
Reverts zed-industries/zed#2232

This PR made it so that you can't click a tab to change tabs. Reverting until we can figure out what caused the issue.