### PR TITLE
Avoid wrapping to the 0th glyph variant when the 4th should be used

### DIFF
--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -90,11 +90,12 @@ impl SpriteCache {
         let fonts = &self.fonts;
         let atlases = &mut self.atlases;
         let subpixel_variant = (
-            (target_position.x().fract() * SUBPIXEL_VARIANTS as f32).round() as u8
+            (target_position.x().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8
                 % SUBPIXEL_VARIANTS,
-            (target_position.y().fract() * SUBPIXEL_VARIANTS as f32).round() as u8
+            (target_position.y().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8
                 % SUBPIXEL_VARIANTS,
         );
+
         self.glyphs
             .entry(GlyphDescriptor {
                 font_id,


### PR DESCRIPTION
Continued discussion and experimentation from https://github.com/zed-industries/zed/pull/2224

In the `clone` example with Verdana the x coord the `l` wanted was 227.9 and so needed the right most glyph variant but the math was rounding up causing the modulo to wrap around and use the left most variant instead. This resulted in the glyph being "correctly" positioned but the pixel contents of the glyph were to far to the left within itself.