### PR TITLE
Add constructor to syntax overrides

### DIFF
--- a/styles/src/styleTree/feedback.ts
+++ b/styles/src/styleTree/feedback.ts
@@ -32,7 +32,13 @@ export default function feedback(colorScheme: ColorScheme) {
         },
         button_margin: 8,
         info_text_default: text(layer, "sans", "default", { size: "xs" }),
-        link_text_default: text(layer, "sans", "default", { size: "xs", underline: true }),
-        link_text_hover: text(layer, "sans", "hovered", { size: "xs", underline: true })
+        link_text_default: text(layer, "sans", "default", {
+            size: "xs",
+            underline: true,
+        }),
+        link_text_hover: text(layer, "sans", "hovered", {
+            size: "xs",
+            underline: true,
+        }),
     }
 }

--- a/styles/src/themes/common/syntax.ts
+++ b/styles/src/themes/common/syntax.ts
@@ -56,7 +56,8 @@ export interface Syntax {
     "string.regex": SyntaxHighlightStyle
 
     // == Types ====== /
-    constructor: SyntaxHighlightStyle
+    // We allow Function here because all JS objects literals have this property
+    constructor: SyntaxHighlightStyle | Function
     variant: SyntaxHighlightStyle
     type: SyntaxHighlightStyle
     // js: predefined_type
@@ -120,6 +121,7 @@ export interface Syntax {
 
 // HACK: "constructor" as a key in the syntax interface returns an error when a theme tries to use it.
 // For now hack around it by omiting constructor as a valid key for overrides.
+// export type ThemeSyntax = Partial<Omit<Syntax, "constructor">>
 export type ThemeSyntax = Partial<Syntax>
 
 const defaultSyntaxHighlightStyle: Omit<SyntaxHighlightStyle, "color"> = {

--- a/styles/src/themes/common/syntax.ts
+++ b/styles/src/themes/common/syntax.ts
@@ -120,7 +120,7 @@ export interface Syntax {
 
 // HACK: "constructor" as a key in the syntax interface returns an error when a theme tries to use it.
 // For now hack around it by omiting constructor as a valid key for overrides.
-export type ThemeSyntax = Partial<Omit<Syntax, "constructor">>
+export type ThemeSyntax = Partial<Syntax>
 
 const defaultSyntaxHighlightStyle: Omit<SyntaxHighlightStyle, "color"> = {
     weight: fontWeights.normal,
@@ -311,8 +311,6 @@ function buildDefaultSyntax(colorScheme: ColorScheme): Syntax {
             color: color.primary,
         },
     }
-
-    console.log(JSON.stringify(defaultSyntax, null, 2))
 
     return defaultSyntax
 }

--- a/styles/src/themes/common/syntax.ts
+++ b/styles/src/themes/common/syntax.ts
@@ -1,8 +1,6 @@
 import deepmerge from "deepmerge"
 import { FontWeight, fontWeights } from "../../common"
-import {
-    ColorScheme,
-} from "./colorScheme"
+import { ColorScheme } from "./colorScheme"
 
 export interface SyntaxHighlightStyle {
     color: string

--- a/styles/src/themes/one-dark.ts
+++ b/styles/src/themes/one-dark.ts
@@ -41,6 +41,8 @@ const ramps = {
     magenta: colorRamp(chroma("#be5046")),
 }
 
+
+
 const syntax: ThemeSyntax = {
     boolean: { color: color.orange },
     comment: { color: color.grey },
@@ -63,6 +65,7 @@ const syntax: ThemeSyntax = {
     type: { color: color.teal },
     "variable.special": { color: color.orange },
     variant: { color: color.blue },
+    constructor: { color: color.blue }
 }
 
 export const dark = createColorScheme(name, false, ramps, syntax)

--- a/styles/src/themes/one-dark.ts
+++ b/styles/src/themes/one-dark.ts
@@ -41,8 +41,6 @@ const ramps = {
     magenta: colorRamp(chroma("#be5046")),
 }
 
-
-
 const syntax: ThemeSyntax = {
     boolean: { color: color.orange },
     comment: { color: color.grey },
@@ -65,7 +63,7 @@ const syntax: ThemeSyntax = {
     type: { color: color.teal },
     "variable.special": { color: color.orange },
     variant: { color: color.blue },
-    constructor: { color: color.blue }
+    constructor: { color: color.blue },
 }
 
 export const dark = createColorScheme(name, false, ramps, syntax)


### PR DESCRIPTION
## Description of feature or change

Resolve a longstanding typescript error that prevented us from styling themes using the `constructor` property.

🍐 with @nathansobo 

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
