### PR TITLE
Clean up some default settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -22,11 +22,6 @@
     "show_completions_on_input": true,
     // Whether the screen sharing icon is showed in the os status bar.
     "show_call_status_icon": true,
-    // Whether new projects should start out 'online'. Online projects
-    // appear in the contacts panel under your name, so that your contacts
-    // can see which projects you are working on. Regardless of this
-    // setting, projects keep their last online status when you reopen them.
-    "projects_online_by_default": true,
     // Whether to use language servers to provide code intelligence.
     "enable_language_server": true,
     // When to automatically save edited buffers. This setting can
@@ -202,12 +197,6 @@
         "Plain Text": {
             "soft_wrap": "preferred_line_length"
         },
-        "C": {
-            "tab_size": 2
-        },
-        "C++": {
-            "tab_size": 2
-        },
         "Elixir": {
             "tab_size": 2
         },
@@ -217,9 +206,6 @@
         },
         "Markdown": {
             "soft_wrap": "preferred_line_length"
-        },
-        "Rust": {
-            "tab_size": 4
         },
         "JavaScript": {
             "tab_size": 2

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -275,8 +275,6 @@ impl Column for DockAnchor {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SettingsFileContent {
     #[serde(default)]
-    pub projects_online_by_default: Option<bool>,
-    #[serde(default)]
     pub buffer_font_family: Option<String>,
     #[serde(default)]
     pub buffer_font_size: Option<f32>,


### PR DESCRIPTION
Input welcome, we had some discussions during hackday but any more input is valuable.

General vibe is that format on save is too intense to have by default, more-so while we do not have .editorconfig, eslint, and project specific settings.

C/C++ is enough of chaos that it should just use whatever your editor level tab size setting

Rust's tab size setting had no effect, remove for clarity

Projects online by default no longer exists

Update: Leaving the new settings `remove_trailing_whitespace_on_save` and `ensure_final_newline_on_save` with their original defaults (on) as those are not really problematic in the same way that auto-format on save is in my opinion