### PR TITLE
Tidy up `SpriteCache::render_glyph`

### DIFF
--- a/crates/gpui/src/platform/mac/sprite_cache.rs
+++ b/crates/gpui/src/platform/mac/sprite_cache.rs
@@ -85,15 +85,10 @@ impl SpriteCache {
     ) -> Option<GlyphSprite> {
         const SUBPIXEL_VARIANTS: u8 = 4;
 
-        let scale_factor = self.scale_factor;
-        let target_position = target_position * scale_factor;
-        let fonts = &self.fonts;
-        let atlases = &mut self.atlases;
+        let target_position = target_position * self.scale_factor;
         let subpixel_variant = (
-            (target_position.x().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8
-                % SUBPIXEL_VARIANTS,
-            (target_position.y().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8
-                % SUBPIXEL_VARIANTS,
+            (target_position.x().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8,
+            (target_position.y().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8,
         );
 
         self.glyphs
@@ -108,16 +103,17 @@ impl SpriteCache {
                     subpixel_variant.0 as f32 / SUBPIXEL_VARIANTS as f32,
                     subpixel_variant.1 as f32 / SUBPIXEL_VARIANTS as f32,
                 );
-                let (glyph_bounds, mask) = fonts.rasterize_glyph(
+                let (glyph_bounds, mask) = self.fonts.rasterize_glyph(
                     font_id,
                     font_size,
                     glyph_id,
                     subpixel_shift,
-                    scale_factor,
+                    self.scale_factor,
                     RasterizationOptions::Alpha,
                 )?;
 
-                let (alloc_id, atlas_bounds) = atlases
+                let (alloc_id, atlas_bounds) = self
+                    .atlases
                     .upload(glyph_bounds.size(), &mask)
                     .expect("could not upload glyph");
                 Some(GlyphSprite {


### PR DESCRIPTION
This pull request contains two minor improvements to the `SpriteCache::render_glyph` method:

1. It removes the `% SUBPIXEL_VARIANTS` operation when computing the sub-pixel variant. Now that we use `floor`, the `(fract() * SUBPIXEL_VARIANTS as f32).floor()` expression should always return a value that is `<= 3`.
2. It avoids capturing a few instance variables on the stack manually now that the borrow checker is smarter about what it captures inside of closures.

@ForLoveOfCats: can you help me check this still renders everything correctly on your machine? I tested it a bunch with tricky fonts such as Zapfino and it seemed to work correctly, but I'd love a second pair of eyes on this.