### PR TITLE
Prevent collab server from being overwhelmed with messages

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -612,9 +612,34 @@ impl Item for Editor {
         let buffers = self.buffer().clone().read(cx).all_buffers();
         cx.as_mut().spawn(|mut cx| async move {
             format.await?;
-            project
-                .update(&mut cx, |project, cx| project.save_buffers(buffers, cx))
-                .await?;
+
+            if buffers.len() == 1 {
+                project
+                    .update(&mut cx, |project, cx| project.save_buffers(buffers, cx))
+                    .await?;
+            } else {
+                // For multi-buffers, only save those ones that contain changes. For clean buffers
+                // we simulate saving by calling `Buffer::did_save`, so that language servers or
+                // other downstream listeners of save events get notified.
+                let (dirty_buffers, clean_buffers) = buffers.into_iter().partition(|buffer| {
+                    buffer.read_with(&cx, |buffer, _| buffer.is_dirty() || buffer.has_conflict())
+                });
+
+                project
+                    .update(&mut cx, |project, cx| {
+                        project.save_buffers(dirty_buffers, cx)
+                    })
+                    .await?;
+                for buffer in clean_buffers {
+                    buffer.update(&mut cx, |buffer, cx| {
+                        let version = buffer.saved_version().clone();
+                        let fingerprint = buffer.saved_version_fingerprint();
+                        let mtime = buffer.saved_mtime();
+                        buffer.did_save(version, fingerprint, mtime, cx);
+                    });
+                }
+            }
+
             Ok(())
         })
     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1353,7 +1353,13 @@ impl Buffer {
     }
 
     pub fn remove_active_selections(&mut self, cx: &mut ModelContext<Self>) {
-        self.set_active_selections(Arc::from([]), false, Default::default(), cx);
+        if self
+            .remote_selections
+            .get(&self.text.replica_id())
+            .map_or(true, |set| !set.selections.is_empty())
+        {
+            self.set_active_selections(Arc::from([]), false, Default::default(), cx);
+        }
     }
 
     pub fn set_text<T>(&mut self, text: T, cx: &mut ModelContext<Self>) -> Option<clock::Local>

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1434,19 +1434,7 @@ impl Project {
         let worktree = file.worktree.clone();
         let path = file.path.clone();
         worktree.update(cx, |worktree, cx| match worktree {
-            Worktree::Local(worktree) => {
-                if buffer.read(cx).is_dirty() || buffer.read(cx).has_conflict() {
-                    worktree.save_buffer(buffer, path, false, cx)
-                } else {
-                    buffer.update(cx, |buffer, cx| {
-                        let version = buffer.saved_version().clone();
-                        let fingerprint = buffer.saved_version_fingerprint();
-                        let mtime = buffer.saved_mtime();
-                        buffer.did_save(version.clone(), fingerprint, mtime, cx);
-                        Task::ready(Ok((version, fingerprint, mtime)))
-                    })
-                }
-            }
+            Worktree::Local(worktree) => worktree.save_buffer(buffer, path, false, cx),
             Worktree::Remote(worktree) => worktree.save_buffer(buffer, cx),
         })
     }


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-229/collab-servers-memory-usage-permanently-increased-after-a-spike-of

This pull request introduces a new mechanism on the server to apply back-pressure to clients when they send too many messages. It does so by adding a `Semaphore` with a maximum of 256 concurrent permits: the permit is acquired prior when receiving a message and released when the message has been handled. This effectively introduces an upper bound to how many messages the server can tackle at any given time for each connection. See b4561b848d05af4908b5f493767f7cad3005610d for more details on how this was implemented.

I also tried investigating what was the cause of the message spike described by @maxbrunsfeld in that issue, and my best bet is that @mikayla-maki was probably editing a multi-buffer. Specifically, we had a couple of issues that would cause clients to send lots of messages when they had a multi-buffer open:

1. Updating the active selections would cause removing selections for all buffers that didn't contain the current selections, even if those buffers didn't have active selections in the first place. In practice, this meant sending `n` `proto::UpdateBuffer` messages any time the cursor was moved, where `n` was equal to the number of buffers in the multi-buffer. In a435dc1339bd10e2b43f5bbd89f74950332abcf5, this was fixed by only updating buffers which contain active selections.
2. Saving the multi-buffer would always save the underlying buffers, even for buffers that didn't contain changes. Similar to the above case, this meant sending `n` `proto::UpdateBufferFile` messages for every save, where `n` was equal to the number of buffers in the multi-buffer. In [4ce51c8](https://github.com/zed-industries/zed/pull/2252/commits/4ce51c813841af211fb9b36284f4df4db6078a53), this was fixed by only saving buffers that are either dirty or contain conflicts.

/cc: @maxbrunsfeld for 👀 