### PR TITLE
Introduce Kubernetes liveness probe to ensure database works

### DIFF
--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -59,6 +59,13 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-35/audit-existing-collab-health-checks

This is located under `/healthz` (which seems to be the convention for liveness probes in Kubernetes) and performs a simple database query that errors when a connection can't be acquired or after a 5 second timeout.