### PR TITLE
Preserve contacts popover editor contents when switching to search mode

### DIFF
--- a/crates/collab_ui/src/contact_finder.rs
+++ b/crates/collab_ui/src/contact_finder.rs
@@ -1,7 +1,7 @@
 use client::{ContactRequestStatus, User, UserStore};
 use gpui::{
-    elements::*, AnyViewHandle, Entity, ModelHandle, MouseState, MutableAppContext, RenderContext,
-    Task, View, ViewContext, ViewHandle,
+    elements::*, AnyViewHandle, AppContext, Entity, ModelHandle, MouseState, MutableAppContext,
+    RenderContext, Task, View, ViewContext, ViewHandle,
 };
 use picker::{Picker, PickerDelegate};
 use settings::Settings;
@@ -177,5 +177,15 @@ impl ContactFinder {
             user_store,
             selected_index: 0,
         }
+    }
+
+    pub fn editor_text(&self, cx: &AppContext) -> String {
+        self.picker.read(cx).query(cx)
+    }
+
+    pub fn with_editor_text(self, editor_text: String, cx: &mut ViewContext<Self>) -> Self {
+        self.picker
+            .update(cx, |picker, cx| picker.set_query(editor_text, cx));
+        self
     }
 }

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -294,6 +294,16 @@ impl ContactList {
         this
     }
 
+    pub fn editor_text(&self, cx: &AppContext) -> String {
+        self.filter_editor.read(cx).text(cx)
+    }
+
+    pub fn with_editor_text(self, editor_text: String, cx: &mut ViewContext<Self>) -> Self {
+        self.filter_editor
+            .update(cx, |picker, cx| picker.set_text(editor_text, cx));
+        self
+    }
+
     fn remove_contact(&mut self, request: &RemoveContact, cx: &mut ViewContext<Self>) {
         let user_id = request.0;
         let user_store = self.user_store.clone();

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -205,6 +205,11 @@ impl<D: PickerDelegate> Picker<D> {
         self.query_editor.read(cx).text(cx)
     }
 
+    pub fn set_query(&self, query: impl Into<Arc<str>>, cx: &mut ViewContext<Self>) {
+        self.query_editor
+            .update(cx, |editor, cx| editor.set_text(query, cx));
+    }
+
     fn on_query_editor_event(
         &mut self,
         _: ViewHandle<Editor>,


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-134/preserve-editor-text-when-clicking-search-for-new-contact-button-in