### PR TITLE
Increase the amount of max connections to the database

### DIFF
--- a/crates/collab/.env.toml
+++ b/crates/collab/.env.toml
@@ -1,4 +1,5 @@
 DATABASE_URL = "postgres://postgres@localhost/zed"
+DATABASE_MAX_CONNECTIONS = 5
 HTTP_PORT = 8080
 API_TOKEN = "secret"
 INVITE_LINK_PREFIX = "http://localhost:3000/invites/"

--- a/crates/collab/k8s/environments/preview.sh
+++ b/crates/collab/k8s/environments/preview.sh
@@ -1,3 +1,4 @@
 ZED_ENVIRONMENT=preview
 RUST_LOG=info
 INVITE_LINK_PREFIX=https://zed.dev/invites/
+DATABASE_MAX_CONNECTIONS=10

--- a/crates/collab/k8s/environments/production.sh
+++ b/crates/collab/k8s/environments/production.sh
@@ -1,3 +1,4 @@
 ZED_ENVIRONMENT=production
 RUST_LOG=info
 INVITE_LINK_PREFIX=https://zed.dev/invites/
+DATABASE_MAX_CONNECTIONS=85

--- a/crates/collab/k8s/environments/staging.sh
+++ b/crates/collab/k8s/environments/staging.sh
@@ -1,3 +1,4 @@
 ZED_ENVIRONMENT=staging
 RUST_LOG=info
 INVITE_LINK_PREFIX=https://staging.zed.dev/invites/
+DATABASE_MAX_CONNECTIONS=5

--- a/crates/collab/k8s/manifest.template.yml
+++ b/crates/collab/k8s/manifest.template.yml
@@ -80,6 +80,8 @@ spec:
                 secretKeyRef:
                   name: database
                   key: url
+            - name: DATABASE_MAX_CONNECTIONS
+              value: ${DATABASE_MAX_CONNECTIONS}
             - name: API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -91,6 +91,7 @@ impl std::error::Error for Error {}
 pub struct Config {
     pub http_port: u16,
     pub database_url: String,
+    pub database_max_connections: u32,
     pub api_token: String,
     pub invite_link_prefix: String,
     pub live_kit_server: Option<String>,
@@ -116,7 +117,7 @@ pub struct AppState {
 impl AppState {
     pub async fn new(config: Config) -> Result<Arc<Self>> {
         let mut db_options = db::ConnectOptions::new(config.database_url.clone());
-        db_options.max_connections(5);
+        db_options.max_connections(config.database_max_connections);
         let db = Database::new(db_options).await?;
         let live_kit_client = if let Some(((server, key), secret)) = config
             .live_kit_server


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-263/make-postgres-machine-more-powerful

Our production database now supports up to 197 concurrent connections. This pull request introduces a new `DATABASE_MAX_CONNECTIONS` environment variable which is set to:

- `85` concurrent connections on production
- `10` concurrent connections on preview
- `5` concurrent connections on staging
- `5` concurrent connections locally

Regarding production and preview (which target the same database instance), those numbers were picked because at any given time we may have two parallel pods for each environment (one being torn down and one being spinned up). Therefore:

- Maximum amount of connections on production: `85 * 2 = 170`
- Maximum amount of connections on preview: `10 * 2 = 20`
- Total amount of connections at any given time: `190`

This leaves 7 connections that can be used to inspect the database and having some leeway just seems nice in general. Moreover, not overwhelming any given instance with too many connections ensures we have a bound on how many queries can be run at any given time, which imposes a bound on the amount of RAM that gets used.