### PR TITLE
Allow waiting for language to be loaded in LanguageRegistry APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,7 @@ dependencies = [
 name = "journal"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "dirs 4.0.0",
  "editor",

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -224,7 +224,7 @@ impl Telemetry {
                             .header("Content-Type", "application/json")
                             .body(json_bytes.into())?;
                         this.http_client.send(request).await?;
-                        Ok(())
+                        anyhow::Ok(())
                     }
                     .log_err(),
                 )
@@ -320,7 +320,7 @@ impl Telemetry {
                             .header("Content-Type", "application/json")
                             .body(json_bytes.into())?;
                         this.http_client.send(request).await?;
-                        Ok(())
+                        anyhow::Ok(())
                     }
                     .log_err(),
                 )

--- a/crates/collab_ui/src/contact_finder.rs
+++ b/crates/collab_ui/src/contact_finder.rs
@@ -68,7 +68,7 @@ impl PickerDelegate for ContactFinder {
                     this.potential_contacts = potential_contacts.into();
                     cx.notify();
                 });
-                Ok(())
+                anyhow::Ok(())
             }
             .log_err()
             .await;

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -13,6 +13,7 @@ editor = { path = "../editor" }
 gpui = { path = "../gpui" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
+anyhow = "1.0"
 chrono = "0.4"
 dirs = "4.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -73,7 +73,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut MutableAppContext) {
                 }
             }
 
-            Ok(())
+            anyhow::Ok(())
         }
         .log_err()
     })

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -80,31 +80,49 @@ fn test_select_language() {
 
     // matching file extension
     assert_eq!(
-        registry.language_for_path("zed/lib.rs").map(|l| l.name()),
+        registry
+            .language_for_path("zed/lib.rs")
+            .now_or_never()
+            .and_then(|l| Some(l.ok()?.name())),
         Some("Rust".into())
     );
     assert_eq!(
-        registry.language_for_path("zed/lib.mk").map(|l| l.name()),
+        registry
+            .language_for_path("zed/lib.mk")
+            .now_or_never()
+            .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
     );
 
     // matching filename
     assert_eq!(
-        registry.language_for_path("zed/Makefile").map(|l| l.name()),
+        registry
+            .language_for_path("zed/Makefile")
+            .now_or_never()
+            .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
     );
 
     // matching suffix that is not the full file extension or filename
     assert_eq!(
-        registry.language_for_path("zed/cars").map(|l| l.name()),
+        registry
+            .language_for_path("zed/cars")
+            .now_or_never()
+            .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
-        registry.language_for_path("zed/a.cars").map(|l| l.name()),
+        registry
+            .language_for_path("zed/a.cars")
+            .now_or_never()
+            .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
-        registry.language_for_path("zed/sumk").map(|l| l.name()),
+        registry
+            .language_for_path("zed/sumk")
+            .now_or_never()
+            .and_then(|l| Some(l.ok()?.name())),
         None
     );
 }
@@ -666,14 +684,14 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
         indoc! {"
             mod x {
                 moˇd y {
-                
+
                 }
             }
             let foo = 1;"},
         vec![indoc! {"
             mod x «{»
                 mod y {
-                
+
                 }
             «}»
             let foo = 1;"}],
@@ -683,7 +701,7 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
         indoc! {"
             mod x {
                 mod y ˇ{
-                
+
                 }
             }
             let foo = 1;"},
@@ -691,14 +709,14 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
             indoc! {"
                 mod x «{»
                     mod y {
-                    
+
                     }
                 «}»
                 let foo = 1;"},
             indoc! {"
                 mod x {
                     mod y «{»
-                    
+
                     «}»
                 }
                 let foo = 1;"},
@@ -709,7 +727,7 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
         indoc! {"
             mod x {
                 mod y {
-                
+
                 }ˇ
             }
             let foo = 1;"},
@@ -717,14 +735,14 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
             indoc! {"
                 mod x «{»
                     mod y {
-                    
+
                     }
                 «}»
                 let foo = 1;"},
             indoc! {"
                 mod x {
                     mod y «{»
-                    
+
                     «}»
                 }
                 let foo = 1;"},
@@ -735,14 +753,14 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
         indoc! {"
             mod x {
                 mod y {
-                
+
                 }
             ˇ}
             let foo = 1;"},
         vec![indoc! {"
             mod x «{»
                 mod y {
-                
+
                 }
             «}»
             let foo = 1;"}],
@@ -752,7 +770,7 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
         indoc! {"
             mod x {
                 mod y {
-                
+
                 }
             }
             let fˇoo = 1;"},
@@ -764,7 +782,7 @@ fn test_enclosing_bracket_ranges(cx: &mut MutableAppContext) {
         indoc! {"
             mod x {
                 mod y {
-                
+
                 }
             }
             let foo = 1;ˇ"},

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1838,7 +1838,11 @@ impl Project {
     ) -> Option<()> {
         // If the buffer has a language, set it and start the language server if we haven't already.
         let full_path = buffer.read(cx).file()?.full_path(cx);
-        let new_language = self.languages.language_for_path(&full_path)?;
+        let new_language = self
+            .languages
+            .language_for_path(&full_path)
+            .now_or_never()?
+            .ok()?;
         buffer.update(cx, |buffer, cx| {
             if buffer.language().map_or(true, |old_language| {
                 !Arc::ptr_eq(old_language, &new_language)
@@ -2248,8 +2252,14 @@ impl Project {
             })
             .collect();
         for (worktree_id, worktree_abs_path, full_path) in language_server_lookup_info {
-            let language = self.languages.language_for_path(&full_path)?;
-            self.restart_language_server(worktree_id, worktree_abs_path, language, cx);
+            if let Some(language) = self
+                .languages
+                .language_for_path(&full_path)
+                .now_or_never()
+                .and_then(|language| language.ok())
+            {
+                self.restart_language_server(worktree_id, worktree_abs_path, language, cx);
+            }
         }
 
         None
@@ -3278,12 +3288,14 @@ impl Project {
                                 path: path.into(),
                             };
                             let signature = this.symbol_signature(&project_path);
+                            let adapter_language = adapter_language.clone();
                             let language = this
                                 .languages
                                 .language_for_path(&project_path.path)
-                                .unwrap_or(adapter_language.clone());
+                                .unwrap_or_else(move |_| adapter_language);
                             let language_server_name = adapter.name.clone();
                             Some(async move {
+                                let language = language.await;
                                 let label = language
                                     .label_for_symbol(&lsp_symbol.name, lsp_symbol.kind)
                                     .await;
@@ -6060,7 +6072,7 @@ impl Project {
                 worktree_id,
                 path: PathBuf::from(serialized_symbol.path).into(),
             };
-            let language = languages.language_for_path(&path.path);
+            let language = languages.language_for_path(&path.path).await.log_err();
             Ok(Symbol {
                 language_server_name: LanguageServerName(
                     serialized_symbol.language_server_name.into(),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5831,7 +5831,7 @@ impl Project {
                                 })?;
                             }
 
-                            Ok(())
+                            anyhow::Ok(())
                         }
                         .log_err(),
                     )

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -167,9 +167,8 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     });
     cx.add_action({
         let app_state = app_state.clone();
-        move |workspace: &mut Workspace, _: &OpenLicenses, cx: &mut ViewContext<Workspace>| {
+        move |_: &mut Workspace, _: &OpenLicenses, cx: &mut ViewContext<Workspace>| {
             open_bundled_file(
-                workspace,
                 app_state.clone(),
                 "licenses.md",
                 "Open Source License Attribution",
@@ -192,9 +191,8 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     });
     cx.add_action({
         let app_state = app_state.clone();
-        move |workspace: &mut Workspace, _: &OpenDefaultKeymap, cx: &mut ViewContext<Workspace>| {
+        move |_: &mut Workspace, _: &OpenDefaultKeymap, cx: &mut ViewContext<Workspace>| {
             open_bundled_file(
-                workspace,
                 app_state.clone(),
                 "keymaps/default.json",
                 "Default Key Bindings",
@@ -205,11 +203,8 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
     });
     cx.add_action({
         let app_state = app_state.clone();
-        move |workspace: &mut Workspace,
-              _: &OpenDefaultSettings,
-              cx: &mut ViewContext<Workspace>| {
+        move |_: &mut Workspace, _: &OpenDefaultSettings, cx: &mut ViewContext<Workspace>| {
             open_bundled_file(
-                workspace,
                 app_state.clone(),
                 "settings/default.json",
                 "Default Settings",
@@ -218,32 +213,41 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::MutableAppContext) {
             );
         }
     });
-    cx.add_action(
-        |workspace: &mut Workspace, _: &DebugElements, cx: &mut ViewContext<Workspace>| {
+    cx.add_action({
+        let app_state = app_state.clone();
+        move |_: &mut Workspace, _: &DebugElements, cx: &mut ViewContext<Workspace>| {
+            let app_state = app_state.clone();
+            let markdown = app_state.languages.language_for_name("JSON");
             let content = to_string_pretty(&cx.debug_elements()).unwrap();
-            let project = workspace.project().clone();
-            let json_language = project
-                .read(cx)
-                .languages()
-                .language_for_name("JSON")
-                .unwrap();
-            if project.read(cx).is_remote() {
-                cx.propagate_action();
-            } else if let Some(buffer) = project
-                .update(cx, |project, cx| {
-                    project.create_buffer(&content, Some(json_language), cx)
-                })
-                .log_err()
-            {
-                workspace.add_item(
-                    Box::new(
-                        cx.add_view(|cx| Editor::for_buffer(buffer, Some(project.clone()), cx)),
-                    ),
-                    cx,
-                );
-            }
-        },
-    );
+            cx.spawn(|workspace, mut cx| async move {
+                let markdown = markdown.await.log_err();
+                workspace
+                    .update(&mut cx, |workspace, cx| {
+                        workspace.with_local_workspace(&app_state, cx, move |workspace, cx| {
+                            let project = workspace.project().clone();
+
+                            let buffer = project
+                                .update(cx, |project, cx| {
+                                    project.create_buffer(&content, markdown, cx)
+                                })
+                                .expect("creating buffers on a local workspace always succeeds");
+                            let buffer = cx.add_model(|cx| {
+                                MultiBuffer::singleton(buffer, cx)
+                                    .with_title("Debug Elements".into())
+                            });
+                            workspace.add_item(
+                                Box::new(cx.add_view(|cx| {
+                                    Editor::for_multibuffer(buffer, Some(project.clone()), cx)
+                                })),
+                                cx,
+                            );
+                        })
+                    })
+                    .await;
+            })
+            .detach();
+        }
+    });
     cx.add_action(
         |workspace: &mut Workspace,
          _: &project_panel::ToggleFocus,
@@ -628,6 +632,7 @@ fn open_telemetry_log_file(
                 start_offset += newline_offset + 1;
             }
             let log_suffix = &log[start_offset..];
+            let json = app_state.languages.language_for_name("JSON").await.log_err();
 
             workspace.update(&mut cx, |workspace, cx| {
                 let project = workspace.project().clone();
@@ -635,7 +640,7 @@ fn open_telemetry_log_file(
                     .update(cx, |project, cx| project.create_buffer("", None, cx))
                     .expect("creating buffers on a local workspace always succeeds");
                 buffer.update(cx, |buffer, cx| {
-                    buffer.set_language(app_state.languages.language_for_name("JSON"), cx);
+                    buffer.set_language(json, cx);
                     buffer.edit(
                         [(
                             0..0,
@@ -668,35 +673,42 @@ fn open_telemetry_log_file(
 }
 
 fn open_bundled_file(
-    workspace: &mut Workspace,
     app_state: Arc<AppState>,
     asset_path: &'static str,
     title: &'static str,
     language: &'static str,
     cx: &mut ViewContext<Workspace>,
 ) {
-    workspace
-        .with_local_workspace(&app_state, cx, |workspace, cx| {
-            let project = workspace.project().clone();
-            let buffer = project.update(cx, |project, cx| {
-                let text = Assets::get(asset_path)
-                    .map(|f| f.data)
-                    .unwrap_or_else(|| Cow::Borrowed(b"File not found"));
-                let text = str::from_utf8(text.as_ref()).unwrap();
-                project
-                    .create_buffer(text, project.languages().language_for_name(language), cx)
-                    .expect("creating buffers on a local workspace always succeeds")
-            });
-            let buffer =
-                cx.add_model(|cx| MultiBuffer::singleton(buffer, cx).with_title(title.into()));
-            workspace.add_item(
-                Box::new(
-                    cx.add_view(|cx| Editor::for_multibuffer(buffer, Some(project.clone()), cx)),
-                ),
-                cx,
-            );
-        })
-        .detach();
+    let language = app_state.languages.language_for_name(language);
+    cx.spawn(|workspace, mut cx| async move {
+        let language = language.await.log_err();
+        workspace
+            .update(&mut cx, |workspace, cx| {
+                workspace.with_local_workspace(&app_state, cx, |workspace, cx| {
+                    let project = workspace.project();
+                    let buffer = project.update(cx, |project, cx| {
+                        let text = Assets::get(asset_path)
+                            .map(|f| f.data)
+                            .unwrap_or_else(|| Cow::Borrowed(b"File not found"));
+                        let text = str::from_utf8(text.as_ref()).unwrap();
+                        project
+                            .create_buffer(text, language, cx)
+                            .expect("creating buffers on a local workspace always succeeds")
+                    });
+                    let buffer = cx.add_model(|cx| {
+                        MultiBuffer::singleton(buffer, cx).with_title(title.into())
+                    });
+                    workspace.add_item(
+                        Box::new(cx.add_view(|cx| {
+                            Editor::for_multibuffer(buffer, Some(project.clone()), cx)
+                        })),
+                        cx,
+                    );
+                })
+            })
+            .await;
+    })
+    .detach();
 }
 
 fn schema_file_match(path: &Path) -> &Path {


### PR DESCRIPTION
Language loading is asynchronous and on-demand, meaning we will only load languages when we need to and loading them happens in the background. 

In the context of https://linear.app/zed-industries/issue/Z-57/affordance-for-setting-language-on-a-buffer, when selecting a language we need a way of waiting for such language to be fully loaded before setting it on the buffer. To achieve that, all language registry APIs now return a future that resolves when the language has been loaded (or an error if it couldn't be loaded).

Note that some code paths still require a synchronous interface for retrieving a language. In those cases, we use the `now_or_never` extension method from `futures`, which returns immediately if the language was already loaded when querying it.