### PR TITLE
Make terminal fallback correctly when unable to deserialize a cwd

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -653,7 +653,7 @@ impl Item for TerminalView {
 
     fn deserialize(
         project: ModelHandle<Project>,
-        _workspace: WeakViewHandle<Workspace>,
+        workspace: WeakViewHandle<Workspace>,
         workspace_id: workspace::WorkspaceId,
         item_id: workspace::ItemId,
         cx: &mut ViewContext<Pane>,
@@ -663,7 +663,18 @@ impl Item for TerminalView {
             let cwd = TERMINAL_DB
                 .get_working_directory(item_id, workspace_id)
                 .log_err()
-                .flatten();
+                .flatten()
+                .or_else(|| {
+                    cx.read(|cx| {
+                        let strategy = cx.global::<Settings>().terminal_strategy();
+                        workspace
+                            .upgrade(cx)
+                            .map(|workspace| {
+                                get_working_directory(workspace.read(cx), cx, strategy)
+                            })
+                            .flatten()
+                    })
+                });
 
             cx.update(|cx| {
                 let terminal = project.update(cx, |project, cx| {


### PR DESCRIPTION
## Description of feature or change

This does not fix the incorrect querying of the process state, but it does make our handling of it better.

## Link to related issues from zed or community

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
