### PR TITLE
Fix too-agressive menu bar greying

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1294,7 +1294,7 @@ impl MutableAppContext {
 
     pub fn is_action_available(&self, action: &dyn Action) -> bool {
         let action_type = action.as_any().type_id();
-        if let Some(window_id) = self.cx.platform.key_window_id() {
+        if let Some(window_id) = self.cx.platform.main_window_id() {
             if let Some(focused_view_id) = self.focused_view_id(window_id) {
                 for view_id in self.ancestors(window_id, focused_view_id) {
                     if let Some(view) = self.views.get(&(window_id, view_id)) {

--- a/crates/gpui/src/app/menu.rs
+++ b/crates/gpui/src/app/menu.rs
@@ -77,9 +77,9 @@ pub(crate) fn setup_menu_handlers(foreground_platform: &dyn ForegroundPlatform, 
         let cx = app.0.clone();
         move |action| {
             let mut cx = cx.borrow_mut();
-            if let Some(key_window_id) = cx.cx.platform.key_window_id() {
-                if let Some(view_id) = cx.focused_view_id(key_window_id) {
-                    cx.handle_dispatch_action_from_effect(key_window_id, Some(view_id), action);
+            if let Some(main_window_id) = cx.cx.platform.main_window_id() {
+                if let Some(view_id) = cx.focused_view_id(main_window_id) {
+                    cx.handle_dispatch_action_from_effect(main_window_id, Some(view_id), action);
                     return;
                 }
             }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -58,7 +58,7 @@ pub trait Platform: Send + Sync {
         options: WindowOptions,
         executor: Rc<executor::Foreground>,
     ) -> Box<dyn Window>;
-    fn key_window_id(&self) -> Option<usize>;
+    fn main_window_id(&self) -> Option<usize>;
 
     fn add_status_item(&self) -> Box<dyn Window>;
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -587,8 +587,8 @@ impl platform::Platform for MacPlatform {
         Box::new(Window::open(id, options, executor, self.fonts()))
     }
 
-    fn key_window_id(&self) -> Option<usize> {
-        Window::key_window_id()
+    fn main_window_id(&self) -> Option<usize> {
+        Window::main_window_id()
     }
 
     fn add_status_item(&self) -> Box<dyn platform::Window> {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -604,12 +604,12 @@ impl Window {
         }
     }
 
-    pub fn key_window_id() -> Option<usize> {
+    pub fn main_window_id() -> Option<usize> {
         unsafe {
             let app = NSApplication::sharedApplication(nil);
-            let key_window: id = msg_send![app, keyWindow];
-            if msg_send![key_window, isKindOfClass: WINDOW_CLASS] {
-                let id = get_window_state(&*key_window).borrow().id;
+            let main_window: id = msg_send![app, mainWindow];
+            if msg_send![main_window, isKindOfClass: WINDOW_CLASS] {
+                let id = get_window_state(&*main_window).borrow().id;
                 Some(id)
             } else {
                 None

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -157,7 +157,7 @@ impl super::Platform for Platform {
         }))
     }
 
-    fn key_window_id(&self) -> Option<usize> {
+    fn main_window_id(&self) -> Option<usize> {
         None
     }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -577,8 +577,13 @@ fn open_telemetry_log_file(
     workspace.with_local_workspace(&app_state.clone(), cx, move |_, cx| {
         cx.spawn_weak(|workspace, mut cx| async move {
             let workspace = workspace.upgrade(&cx)?;
-            let path = app_state.client.telemetry_log_file_path()?;
-            let log = app_state.fs.load(&path).await.log_err()?;
+
+            async fn fetch_log_string(app_state: &Arc<AppState>) -> Option<String> {
+                let path = app_state.client.telemetry_log_file_path()?;
+                app_state.fs.load(&path).await.log_err()
+            }
+
+            let log = fetch_log_string(&app_state).await.unwrap_or_else(|| "// No data has been collected yet".to_string());
 
             const MAX_TELEMETRY_LOG_LEN: usize = 5 * 1024 * 1024;
             let mut start_offset = log.len().saturating_sub(MAX_TELEMETRY_LOG_LEN);


### PR DESCRIPTION
## Description of feature or change

- Adds a state to the telemetry log for when there's no data.
- [x] Stop global, keyboard-less actions from getting greyed out

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
