### PR TITLE
Unify action names with keybinding name

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -140,8 +140,8 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(ProjectPanel::select_prev);
     cx.add_action(ProjectPanel::select_next);
     cx.add_action(ProjectPanel::open_entry);
-    cx.add_action(ProjectPanel::add_file);
-    cx.add_action(ProjectPanel::add_directory);
+    cx.add_action(ProjectPanel::new_file);
+    cx.add_action(ProjectPanel::new_directory);
     cx.add_action(ProjectPanel::rename);
     cx.add_async_action(ProjectPanel::delete);
     cx.add_async_action(ProjectPanel::confirm);
@@ -531,11 +531,11 @@ impl ProjectPanel {
         });
     }
 
-    fn add_file(&mut self, _: &NewFile, cx: &mut ViewContext<Self>) {
+    fn new_file(&mut self, _: &NewFile, cx: &mut ViewContext<Self>) {
         self.add_entry(false, cx)
     }
 
-    fn add_directory(&mut self, _: &NewDirectory, cx: &mut ViewContext<Self>) {
+    fn new_directory(&mut self, _: &NewDirectory, cx: &mut ViewContext<Self>) {
         self.add_entry(true, cx)
     }
 
@@ -1552,7 +1552,7 @@ mod tests {
 
         // Add a file with the root folder selected. The filename editor is placed
         // before the first file in the root folder.
-        panel.update(cx, |panel, cx| panel.add_file(&NewFile, cx));
+        panel.update(cx, |panel, cx| panel.new_file(&NewFile, cx));
         assert!(panel.read_with(cx, |panel, cx| panel.filename_editor.is_focused(cx)));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
@@ -1610,7 +1610,7 @@ mod tests {
         );
 
         select_path(&panel, "root1/b", cx);
-        panel.update(cx, |panel, cx| panel.add_file(&NewFile, cx));
+        panel.update(cx, |panel, cx| panel.new_file(&NewFile, cx));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
             &[
@@ -1709,7 +1709,7 @@ mod tests {
             ]
         );
 
-        panel.update(cx, |panel, cx| panel.add_directory(&NewDirectory, cx));
+        panel.update(cx, |panel, cx| panel.new_directory(&NewDirectory, cx));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
             &[

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -115,8 +115,8 @@ actions!(
     [
         ExpandSelectedEntry,
         CollapseSelectedEntry,
-        AddDirectory,
-        AddFile,
+        NewDirectory,
+        NewFile,
         Copy,
         CopyPath,
         RevealInFinder,
@@ -305,8 +305,8 @@ impl ProjectPanel {
                     ));
                 }
             }
-            menu_entries.push(ContextMenuItem::item("New File", AddFile));
-            menu_entries.push(ContextMenuItem::item("New Folder", AddDirectory));
+            menu_entries.push(ContextMenuItem::item("New File", NewFile));
+            menu_entries.push(ContextMenuItem::item("New Folder", NewDirectory));
             menu_entries.push(ContextMenuItem::item("Reveal in Finder", RevealInFinder));
             menu_entries.push(ContextMenuItem::Separator);
             menu_entries.push(ContextMenuItem::item("Copy", Copy));
@@ -531,11 +531,11 @@ impl ProjectPanel {
         });
     }
 
-    fn add_file(&mut self, _: &AddFile, cx: &mut ViewContext<Self>) {
+    fn add_file(&mut self, _: &NewFile, cx: &mut ViewContext<Self>) {
         self.add_entry(false, cx)
     }
 
-    fn add_directory(&mut self, _: &AddDirectory, cx: &mut ViewContext<Self>) {
+    fn add_directory(&mut self, _: &NewDirectory, cx: &mut ViewContext<Self>) {
         self.add_entry(true, cx)
     }
 
@@ -1552,7 +1552,7 @@ mod tests {
 
         // Add a file with the root folder selected. The filename editor is placed
         // before the first file in the root folder.
-        panel.update(cx, |panel, cx| panel.add_file(&AddFile, cx));
+        panel.update(cx, |panel, cx| panel.add_file(&NewFile, cx));
         assert!(panel.read_with(cx, |panel, cx| panel.filename_editor.is_focused(cx)));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
@@ -1610,7 +1610,7 @@ mod tests {
         );
 
         select_path(&panel, "root1/b", cx);
-        panel.update(cx, |panel, cx| panel.add_file(&AddFile, cx));
+        panel.update(cx, |panel, cx| panel.add_file(&NewFile, cx));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
             &[
@@ -1709,7 +1709,7 @@ mod tests {
             ]
         );
 
-        panel.update(cx, |panel, cx| panel.add_directory(&AddDirectory, cx));
+        panel.update(cx, |panel, cx| panel.add_directory(&NewDirectory, cx));
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
             &[


### PR DESCRIPTION
## Description of feature or change

This PR came about after looking into this issue:

- https://github.com/zed-industries/zed/issues/5975

The name of the actions in the project panel's context menu are

- `New File`
- `New Folder`

But the names used in the keymap are

- `project_panel::AddFile`
- `project_panel::AddDirectory`

Which makes it hard to find when using the autocomplete feature in the keymap, since you naturally want to type "New" as the first thing, which filters out the `Add<item>` bindings.

Additionally, the name of the binding for adding a new file in the workspace is

"workspace::NewFile"

So this PR makes things consistent, and less surprising, by using:

- `project_panel::NewFile`
- `project_panel::NewDirectory`

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
