### PR TITLE
Add default keybindings for reveal in finder

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -249,7 +249,8 @@
             "alt-cmd-[": "editor::Fold",
             "alt-cmd-]": "editor::UnfoldLines",
             "ctrl-space": "editor::ShowCompletions",
-            "cmd-.": "editor::ToggleCodeActions"
+            "cmd-.": "editor::ToggleCodeActions",
+            "alt-cmd-r": "editor::RevealInFinder"
         }
     },
     {
@@ -474,7 +475,8 @@
             "cmd-v": "project_panel::Paste",
             "cmd-alt-c": "project_panel::CopyPath",
             "f2": "project_panel::Rename",
-            "backspace": "project_panel::Delete"
+            "backspace": "project_panel::Delete",
+            "alt-cmd-r": "project_panel::RevealInFinder"
         }
     },
     {


### PR DESCRIPTION
## Description of feature or change

VS Code defaults to `alt-cmd-r` for Reveal in Finder, so I added that in both our project panel action and the editor one

<img width="329" alt="SCR-20230312-fbzq" src="https://user-images.githubusercontent.com/19867440/224534683-46a0dd0c-b8d1-4c93-9631-7f17fce002e0.png">


## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
