### PR TITLE
Fix dock opening on collaboration

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -165,12 +165,13 @@ impl PickerDelegate for RecentProjectsView {
     }
 
     fn confirm(&mut self, cx: &mut ViewContext<Self>) {
-        let selected_match = &self.matches[self.selected_index()];
-        let workspace_location = &self.workspace_locations[selected_match.candidate_id];
-        cx.dispatch_global_action(OpenPaths {
-            paths: workspace_location.paths().as_ref().clone(),
-        });
-        cx.emit(Event::Dismissed);
+        if let Some(selected_match) = &self.matches.get(self.selected_index()) {
+            let workspace_location = &self.workspace_locations[selected_match.candidate_id];
+            cx.dispatch_global_action(OpenPaths {
+                paths: workspace_location.paths().as_ref().clone(),
+            });
+            cx.emit(Event::Dismissed);
+        }
     }
 
     fn dismiss(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -750,7 +750,7 @@ impl Workspace {
             cx.defer(move |_, cx| {
                 Self::load_from_serialized_workspace(weak_handle, serialized_workspace, cx)
             });
-        } else {
+        } else if project.read(cx).is_local() {
             if cx.global::<Settings>().default_dock_anchor != DockAnchor::Expanded {
                 Dock::show(&mut this, false, cx);
             }


### PR DESCRIPTION
## Description of feature or change

Closes https://linear.app/zed-industries/issue/Z-288/dont-try-to-open-a-terminal-when-opening-a-remote-project

This keeps the dock, and hence the terminal error message, from showing up when starting collaboration.

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
