### PR TITLE
Leave room on quit

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -264,12 +264,13 @@ impl ActiveCall {
         Ok(())
     }
 
-    pub fn hang_up(&mut self, cx: &mut ModelContext<Self>) -> Result<()> {
+    pub fn hang_up(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        cx.notify();
         if let Some((room, _)) = self.room.take() {
-            room.update(cx, |room, cx| room.leave(cx))?;
-            cx.notify();
+            room.update(cx, |room, cx| room.leave(cx))
+        } else {
+            Task::ready(Ok(()))
         }
-        Ok(())
     }
 
     pub fn share_project(

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -186,7 +186,7 @@ impl Server {
             .add_request_handler(create_room)
             .add_request_handler(join_room)
             .add_request_handler(rejoin_room)
-            .add_message_handler(leave_room)
+            .add_request_handler(leave_room)
             .add_request_handler(call)
             .add_request_handler(cancel_call)
             .add_message_handler(decline_call)
@@ -1102,8 +1102,14 @@ async fn rejoin_room(
     Ok(())
 }
 
-async fn leave_room(_message: proto::LeaveRoom, session: Session) -> Result<()> {
-    leave_room_for_session(&session).await
+async fn leave_room(
+    _: proto::LeaveRoom,
+    response: Response<proto::LeaveRoom>,
+    session: Session,
+) -> Result<()> {
+    leave_room_for_session(&session).await?;
+    response.send(proto::Ack {})?;
+    Ok(())
 }
 
 async fn call(

--- a/crates/collab/src/tests/randomized_integration_tests.rs
+++ b/crates/collab/src/tests/randomized_integration_tests.rs
@@ -641,7 +641,7 @@ async fn randomly_mutate_active_call(
                 if can_hang_up && active_call.read_with(cx, |call, _| call.room().is_some()) =>
             {
                 log::info!("{}: hanging up", client.username);
-                active_call.update(cx, |call, cx| call.hang_up(cx))?;
+                active_call.update(cx, |call, cx| call.hang_up(cx)).await?;
             }
             _ => {}
         }

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -342,7 +342,7 @@ impl CollabTitlebarItem {
     fn leave_call(&mut self, _: &LeaveCall, cx: &mut ViewContext<Self>) {
         ActiveCall::global(cx)
             .update(cx, |call, cx| call.hang_up(cx))
-            .log_err();
+            .detach_and_log_err(cx);
     }
 
     fn render_toggle_contacts_button(

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -588,17 +588,20 @@ impl MutableAppContext {
 
     pub fn quit(&mut self) {
         let mut futures = Vec::new();
-        for model_id in self.cx.models.keys().copied().collect::<Vec<_>>() {
-            let mut model = self.cx.models.remove(&model_id).unwrap();
-            futures.extend(model.app_will_quit(self));
-            self.cx.models.insert(model_id, model);
-        }
 
-        for view_id in self.cx.views.keys().copied().collect::<Vec<_>>() {
-            let mut view = self.cx.views.remove(&view_id).unwrap();
-            futures.extend(view.app_will_quit(self));
-            self.cx.views.insert(view_id, view);
-        }
+        self.update(|cx| {
+            for model_id in cx.models.keys().copied().collect::<Vec<_>>() {
+                let mut model = cx.cx.models.remove(&model_id).unwrap();
+                futures.extend(model.app_will_quit(cx));
+                cx.cx.models.insert(model_id, model);
+            }
+
+            for view_id in cx.views.keys().copied().collect::<Vec<_>>() {
+                let mut view = cx.cx.views.remove(&view_id).unwrap();
+                futures.extend(view.app_will_quit(cx));
+                cx.cx.views.insert(view_id, view);
+            }
+        });
 
         self.remove_all_windows();
 

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -269,6 +269,7 @@ request_messages!(
     (JoinChannel, JoinChannelResponse),
     (JoinProject, JoinProjectResponse),
     (JoinRoom, JoinRoomResponse),
+    (LeaveRoom, Ack),
     (RejoinRoom, RejoinRoomResponse),
     (IncomingCall, Ack),
     (OpenBufferById, OpenBufferResponse),

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 49;
+pub const PROTOCOL_VERSION: u32 = 50;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1064,7 +1064,10 @@ impl Workspace {
                     if answer == Some(1) {
                         return anyhow::Ok(false);
                     } else {
-                        active_call.update(&mut cx, |call, cx| call.hang_up(cx))?;
+                        active_call
+                            .update(&mut cx, |call, cx| call.hang_up(cx))
+                            .await
+                            .log_err();
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-277/quitting-zed-should-explicitly-leave-the-current-call