### PR TITLE
Don't open the doc when joining a remote project

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -750,10 +750,10 @@ impl Workspace {
             cx.defer(move |_, cx| {
                 Self::load_from_serialized_workspace(weak_handle, serialized_workspace, cx)
             });
-        } else {
-            if cx.global::<Settings>().default_dock_anchor != DockAnchor::Expanded {
-                Dock::show(&mut this, false, cx);
-            }
+        } else if project.read(cx).is_local()
+            && cx.global::<Settings>().default_dock_anchor != DockAnchor::Expanded
+        {
+            Dock::show(&mut this, false, cx);
         }
 
         this


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-288/dont-try-to-open-a-terminal-when-opening-a-remote-project