### PR TITLE
Remove check for staffmode

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -350,9 +350,7 @@ pub fn initialize_workspace(
     workspace.status_bar().update(cx, |status_bar, cx| {
         status_bar.add_left_item(diagnostic_summary, cx);
         status_bar.add_left_item(activity_indicator, cx);
-        if **cx.default_global::<StaffMode>() {
-            status_bar.add_right_item(toggle_terminal, cx);
-        }
+        status_bar.add_right_item(toggle_terminal, cx);
         status_bar.add_right_item(feedback_button, cx);
         status_bar.add_right_item(active_buffer_language, cx);
         status_bar.add_right_item(cursor_position, cx);


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-298/the-terminal-button-is-not-shown-for-staff

It wasn't working in production anyway.
