### PR TITLE
Change fold icon size to scale with font size

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2746,7 +2746,7 @@ impl Editor {
                                             .color,
                                     )
                                     .constrained()
-                                    .with_width(style.icon_width)
+                                    .with_width(gutter_margin * style.icon_margin_scale)
                                     .aligned()
                                     .constrained()
                                     .with_height(line_height)

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -666,7 +666,7 @@ pub struct Folds {
     pub indicator: Interactive<InteractiveColor>,
     pub ellipses: FoldEllipses,
     pub fold_background: Color,
-    pub icon_width: f32,
+    pub icon_margin_scale: f32,
     pub folded_icon: String,
     pub foldable_icon: String,
 }

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -60,7 +60,7 @@ export default function editor(colorScheme: ColorScheme) {
             verticalScale: 0.55,
         },
         folds: {
-            iconWidth: 8,
+            iconMarginScale: 2.5,
             foldedIcon: "icons/chevron_right_8.svg",
             foldableIcon: "icons/chevron_down_8.svg",
             indicator: {


### PR DESCRIPTION
## Description of feature or change

Rather than being a static size, the code fold icon now matches the rest of the UI.

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
