### PR TITLE
Create user record automatically when someone logs in on the website

### DIFF
--- a/crates/collab/src/bin/seed.rs
+++ b/crates/collab/src/bin/seed.rs
@@ -59,7 +59,7 @@ async fn main() {
 
     for (github_user, admin) in zed_users {
         if db
-            .get_user_by_github_account(&github_user.login, Some(github_user.id))
+            .get_user_by_github_login(&github_user.login)
             .await
             .expect("failed to fetch user")
             .is_none()

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -92,8 +92,8 @@ test_both_dbs!(
 );
 
 test_both_dbs!(
-    test_get_user_by_github_account_postgres,
-    test_get_user_by_github_account_sqlite,
+    test_get_or_create_user_by_github_account_postgres,
+    test_get_or_create_user_by_github_account_sqlite,
     db,
     {
         let user_id1 = db
@@ -124,7 +124,7 @@ test_both_dbs!(
             .user_id;
 
         let user = db
-            .get_user_by_github_account("login1", None)
+            .get_or_create_user_by_github_account("login1", None, None)
             .await
             .unwrap()
             .unwrap();
@@ -133,19 +133,28 @@ test_both_dbs!(
         assert_eq!(user.github_user_id, Some(101));
 
         assert!(db
-            .get_user_by_github_account("non-existent-login", None)
+            .get_or_create_user_by_github_account("non-existent-login", None, None)
             .await
             .unwrap()
             .is_none());
 
         let user = db
-            .get_user_by_github_account("the-new-login2", Some(102))
+            .get_or_create_user_by_github_account("the-new-login2", Some(102), None)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(user.id, user_id2);
         assert_eq!(&user.github_login, "the-new-login2");
         assert_eq!(user.github_user_id, Some(102));
+
+        let user = db
+            .get_or_create_user_by_github_account("login3", Some(103), Some("user3@example.com"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&user.github_login, "login3");
+        assert_eq!(user.github_user_id, Some(103));
+        assert_eq!(user.email_address, Some("user3@example.com".into()));
     }
 );
 

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1875,7 +1875,7 @@ async fn fuzzy_search_users(
         1 | 2 => session
             .db()
             .await
-            .get_user_by_github_account(&query, None)
+            .get_user_by_github_login(&query)
             .await?
             .into_iter()
             .collect(),

--- a/crates/collab/src/tests.rs
+++ b/crates/collab/src/tests.rs
@@ -104,11 +104,7 @@ impl TestServer {
         });
 
         let http = FakeHttpClient::with_404_response();
-        let user_id = if let Ok(Some(user)) = self
-            .app_state
-            .db
-            .get_user_by_github_account(name, None)
-            .await
+        let user_id = if let Ok(Some(user)) = self.app_state.db.get_user_by_github_login(name).await
         {
             user.id
         } else {


### PR DESCRIPTION
Refs: https://linear.app/zed-industries/issue/Z-294/add-unknown-github-users-to-collab-database-automatically

Now that we are moving out of the private alpha, we should let everyone in when they try to log into zed.dev. Note that we try to capture an email address when a user is created automatically. This is provided by zed.dev by inspecting the GitHub profile and using the public email if present.