### PR TITLE
Sort language names case agnostically

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -537,7 +537,7 @@ impl LanguageRegistry {
                     .map(|l| l.config.name.to_string()),
             )
             .collect::<Vec<_>>();
-        result.sort_unstable();
+        result.sort_unstable_by_key(|language_name| language_name.to_lowercase());
         result
     }
 


### PR DESCRIPTION
## Description of feature or change

No one okayed this, so feel free to close.

I'm simply sorting the language names case agnostically because ERB looks weird in its place to me:

Before sorting
<img width="538" alt="SCR-20230314-stfi" src="https://user-images.githubusercontent.com/19867440/225183322-073e4fc0-10cc-4e23-8646-7f48498a6ec4.png">

After sorting
<img width="541" alt="SCR-20230314-stgo" src="https://user-images.githubusercontent.com/19867440/225183361-f6d642fb-5781-48ae-a607-5ef5c867406c.png">


## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
