### PR TITLE
Close remote project windows when leaving a call

### DIFF
--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -275,6 +275,7 @@ impl Room {
             if let Some(project) = project.upgrade(cx) {
                 project.update(cx, |project, cx| {
                     project.disconnected_from_host(cx);
+                    project.close(cx);
                 });
             }
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -175,6 +175,7 @@ pub enum Event {
     },
     RemoteIdChanged(Option<u64>),
     DisconnectedFromHost,
+    Closed,
     CollaboratorUpdated {
         old_peer_id: proto::PeerId,
         new_peer_id: proto::PeerId,
@@ -1170,6 +1171,10 @@ impl Project {
             // to give them a chance to fail now that we've disconnected.
             *self.opened_buffer.0.borrow_mut() = ();
         }
+    }
+
+    pub fn close(&mut self, cx: &mut ModelContext<Self>) {
+        cx.emit(Event::Closed);
     }
 
     pub fn is_read_only(&self) -> bool {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -598,6 +598,11 @@ impl Workspace {
                     cx.blur();
                 }
 
+                project::Event::Closed => {
+                    let window_id = cx.window_id();
+                    cx.remove_window(window_id);
+                }
+
                 _ => {}
             }
             cx.notify()


### PR DESCRIPTION
When you actively leave a call, it doesn't make sense to leave the remote project windows around in a "disconnected" state. That state is more appropriate for when you become disconnected through no action of your own.

This PR updates the behavior of explicitly leaving a call so that remote windows close immediately.