### PR TITLE
Change `LSHandlerRank` to `Alternate`

### DIFF
--- a/crates/zed/BundleDocumentTypes.plist
+++ b/crates/zed/BundleDocumentTypes.plist
@@ -6,7 +6,7 @@
         <key>CFBundleTypeRole</key>
         <string>Editor</string>
         <key>LSHandlerRank</key>
-        <string>Default</string>
+        <string>Alternate</string>
         <key>LSItemContentTypes</key>
         <array>
             <string>public.text</string>


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-321/zed-steals-file-association-on-some-systems
(hopefully)

 - Sublime uses Alternate for all files that aren't Sublime specific
 - VSCode doesn't use any handler rank
 - XCode uses Default for a select few file types and no handler rank for the rest

Bump us down to Alternate to be more of a kind neighbor