### PR TITLE
Fix hover popover rendering lots of `&emsp` for YAML

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -133,6 +133,13 @@ impl CachedLspAdapter {
         self.adapter.cached_server_binary(container_dir).await
     }
 
+    pub fn workspace_configuration(
+        &self,
+        cx: &mut MutableAppContext,
+    ) -> Option<BoxFuture<'static, Value>> {
+        self.adapter.workspace_configuration(cx)
+    }
+
     pub async fn process_diagnostics(&self, params: &mut lsp::PublishDiagnosticsParams) {
         self.adapter.process_diagnostics(params).await
     }
@@ -552,6 +559,13 @@ impl LanguageRegistry {
         let mut language_configs = Vec::new();
         for language in self.available_languages.read().iter() {
             if let Some(adapter) = language.lsp_adapter.as_ref() {
+                if let Some(language_config) = adapter.workspace_configuration(cx) {
+                    language_configs.push(language_config);
+                }
+            }
+        }
+        for language in self.languages.read().iter() {
+            if let Some(adapter) = language.lsp_adapter() {
                 if let Some(language_config) = adapter.workspace_configuration(cx) {
                     language_configs.push(language_config);
                 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1958,6 +1958,8 @@ impl Project {
                 self.language_servers.insert(
                     server_id,
                     LanguageServerState::Starting(cx.spawn_weak(|this, mut cx| async move {
+                        let workspace_config =
+                            cx.update(|cx| languages.workspace_configuration(cx)).await;
                         let language_server = language_server?.await.log_err()?;
                         let language_server = language_server
                             .initialize(initialization_options)
@@ -2088,8 +2090,6 @@ impl Project {
                             })
                             .detach();
 
-                        let workspace_config =
-                            cx.update(|cx| languages.workspace_configuration(cx)).await;
                         language_server
                             .notify::<lsp::notification::DidChangeConfiguration>(
                                 lsp::DidChangeConfigurationParams {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -64,7 +64,7 @@ use std::{
 };
 use terminals::Terminals;
 
-use util::{debug_panic, defer, post_inc, ResultExt, TryFutureExt as _};
+use util::{debug_panic, defer, merge_json_value_into, post_inc, ResultExt, TryFutureExt as _};
 
 pub use fs::*;
 pub use worktree::*;
@@ -125,6 +125,7 @@ pub struct Project {
     buffers_being_formatted: HashSet<usize>,
     nonce: u128,
     _maintain_buffer_languages: Task<()>,
+    _maintain_workspace_config: Task<()>,
     terminals: Terminals,
 }
 
@@ -428,6 +429,7 @@ impl Project {
             client_subscriptions: Vec::new(),
             _subscriptions: vec![cx.observe_global::<Settings, _>(Self::on_settings_changed)],
             _maintain_buffer_languages: Self::maintain_buffer_languages(&languages, cx),
+            _maintain_workspace_config: Self::maintain_workspace_config(languages.clone(), cx),
             active_entry: None,
             languages,
             client,
@@ -486,6 +488,7 @@ impl Project {
                 active_entry: None,
                 collaborators: Default::default(),
                 _maintain_buffer_languages: Self::maintain_buffer_languages(&languages, cx),
+                _maintain_workspace_config: Self::maintain_workspace_config(languages.clone(), cx),
                 languages,
                 user_store: user_store.clone(),
                 fs,
@@ -1836,6 +1839,46 @@ impl Project {
         })
     }
 
+    fn maintain_workspace_config(
+        languages: Arc<LanguageRegistry>,
+        cx: &mut ModelContext<Project>,
+    ) -> Task<()> {
+        let mut languages_changed = languages.subscribe();
+        let (mut settings_changed_tx, mut settings_changed_rx) = watch::channel();
+        let settings_observation = cx.observe_global::<Settings, _>(move |_, _| {
+            *settings_changed_tx.borrow_mut() = ();
+        });
+        cx.spawn_weak(|this, mut cx| async move {
+            loop {
+                futures::select_biased! {
+                    _ = languages_changed.next().fuse() => {},
+                    _ = settings_changed_rx.next().fuse() => {}
+                }
+
+                let workspace_config = cx.update(|cx| languages.workspace_configuration(cx)).await;
+                if let Some(this) = this.upgrade(&cx) {
+                    this.read_with(&cx, |this, _| {
+                        for server_state in this.language_servers.values() {
+                            if let LanguageServerState::Running { server, .. } = server_state {
+                                server
+                                    .notify::<lsp::notification::DidChangeConfiguration>(
+                                        lsp::DidChangeConfigurationParams {
+                                            settings: workspace_config.clone(),
+                                        },
+                                    )
+                                    .ok();
+                            }
+                        }
+                    })
+                } else {
+                    break;
+                }
+            }
+
+            drop(settings_observation);
+        })
+    }
+
     fn detect_language_for_buffer(
         &mut self,
         buffer: &ModelHandle<Buffer>,
@@ -1875,24 +1918,6 @@ impl Project {
         }
     }
 
-    fn merge_json_value_into(source: serde_json::Value, target: &mut serde_json::Value) {
-        use serde_json::Value;
-
-        match (source, target) {
-            (Value::Object(source), Value::Object(target)) => {
-                for (key, value) in source {
-                    if let Some(target) = target.get_mut(&key) {
-                        Self::merge_json_value_into(value, target);
-                    } else {
-                        target.insert(key.clone(), value);
-                    }
-                }
-            }
-
-            (source, target) => *target = source,
-        }
-    }
-
     fn start_language_server(
         &mut self,
         worktree_id: WorktreeId,
@@ -1920,17 +1945,16 @@ impl Project {
         let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
         match (&mut initialization_options, override_options) {
             (Some(initialization_options), Some(override_options)) => {
-                Self::merge_json_value_into(override_options, initialization_options);
+                merge_json_value_into(override_options, initialization_options);
             }
-
             (None, override_options) => initialization_options = override_options,
-
             _ => {}
         }
 
         self.language_server_ids
             .entry(key.clone())
             .or_insert_with(|| {
+                let languages = self.languages.clone();
                 let server_id = post_inc(&mut self.next_language_server_id);
                 let language_server = self.languages.start_language_server(
                     server_id,
@@ -1977,23 +2001,24 @@ impl Project {
 
                         language_server
                             .on_request::<lsp::request::WorkspaceConfiguration, _, _>({
-                                let settings = this.read_with(&cx, |this, _| {
-                                    this.language_server_settings.clone()
-                                });
-                                move |params, _| {
-                                    let settings = settings.lock().clone();
+                                move |params, mut cx| {
+                                    let languages = languages.clone();
                                     async move {
+                                        let workspace_config = cx
+                                            .update(|cx| languages.workspace_configuration(cx))
+                                            .await;
+
                                         Ok(params
                                             .items
                                             .into_iter()
                                             .map(|item| {
                                                 if let Some(section) = &item.section {
-                                                    settings
+                                                    workspace_config
                                                         .get(section)
                                                         .cloned()
                                                         .unwrap_or(serde_json::Value::Null)
                                                 } else {
-                                                    settings.clone()
+                                                    workspace_config.clone()
                                                 }
                                             })
                                             .collect())
@@ -2537,21 +2562,6 @@ impl Project {
                 })
                 .log_err();
         }
-    }
-
-    pub fn set_language_server_settings(&mut self, settings: serde_json::Value) {
-        for server_state in self.language_servers.values() {
-            if let LanguageServerState::Running { server, .. } = server_state {
-                server
-                    .notify::<lsp::notification::DidChangeConfiguration>(
-                        lsp::DidChangeConfigurationParams {
-                            settings: settings.clone(),
-                        },
-                    )
-                    .ok();
-            }
-        }
-        *self.language_server_settings.lock() = settings;
     }
 
     pub fn language_server_statuses(

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/util.rs"
 doctest = false
 
 [features]
-test-support = ["serde_json", "tempdir", "git2"]
+test-support = ["tempdir", "git2"]
 
 [dependencies]
 anyhow = "1.0.38"
@@ -19,11 +19,10 @@ log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 lazy_static = "1.4.0"
 rand = { workspace = true }
 tempdir = { version = "0.3.7", optional = true }
-serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 git2 = { version = "0.15", default-features = false, optional = true }
 dirs = "3.0"
 
 [dev-dependencies]
 tempdir = { version = "0.3.7" }
-serde_json = { version = "1.0", features = ["preserve_order"] }
 git2 = { version = "0.15", default-features = false }

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -83,6 +83,24 @@ where
     }
 }
 
+pub fn merge_json_value_into(source: serde_json::Value, target: &mut serde_json::Value) {
+    use serde_json::Value;
+
+    match (source, target) {
+        (Value::Object(source), Value::Object(target)) => {
+            for (key, value) in source {
+                if let Some(target) = target.get_mut(&key) {
+                    merge_json_value_into(value, target);
+                } else {
+                    target.insert(key.clone(), value);
+                }
+            }
+        }
+
+        (source, target) => *target = source,
+    }
+}
+
 pub trait ResultExt {
     type Ok;
 

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -37,12 +37,12 @@ pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
         (
             "c",
             tree_sitter_c::language(),
-            Some(Box::new(c::CLspAdapter) as Box<dyn LspAdapter>),
+            Some(Arc::new(c::CLspAdapter) as Arc<dyn LspAdapter>),
         ),
         (
             "cpp",
             tree_sitter_cpp::language(),
-            Some(Box::new(c::CLspAdapter)),
+            Some(Arc::new(c::CLspAdapter)),
         ),
         (
             "css",
@@ -52,17 +52,17 @@ pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
         (
             "elixir",
             tree_sitter_elixir::language(),
-            Some(Box::new(elixir::ElixirLspAdapter)),
+            Some(Arc::new(elixir::ElixirLspAdapter)),
         ),
         (
             "go",
             tree_sitter_go::language(),
-            Some(Box::new(go::GoLspAdapter)),
+            Some(Arc::new(go::GoLspAdapter)),
         ),
         (
             "json",
             tree_sitter_json::language(),
-            Some(Box::new(json::JsonLspAdapter::new(
+            Some(Arc::new(json::JsonLspAdapter::new(
                 languages.clone(),
                 themes.clone(),
             ))),
@@ -75,12 +75,12 @@ pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
         (
             "python",
             tree_sitter_python::language(),
-            Some(Box::new(python::PythonLspAdapter)),
+            Some(Arc::new(python::PythonLspAdapter)),
         ),
         (
             "rust",
             tree_sitter_rust::language(),
-            Some(Box::new(rust::RustLspAdapter)),
+            Some(Arc::new(rust::RustLspAdapter)),
         ),
         (
             "toml",
@@ -90,32 +90,32 @@ pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
         (
             "tsx",
             tree_sitter_typescript::language_tsx(),
-            Some(Box::new(typescript::TypeScriptLspAdapter)),
+            Some(Arc::new(typescript::TypeScriptLspAdapter)),
         ),
         (
             "typescript",
             tree_sitter_typescript::language_typescript(),
-            Some(Box::new(typescript::TypeScriptLspAdapter)),
+            Some(Arc::new(typescript::TypeScriptLspAdapter)),
         ),
         (
             "javascript",
             tree_sitter_typescript::language_tsx(),
-            Some(Box::new(typescript::TypeScriptLspAdapter)),
+            Some(Arc::new(typescript::TypeScriptLspAdapter)),
         ),
         (
             "html",
             tree_sitter_html::language(),
-            Some(Box::new(html::HtmlLspAdapter)),
+            Some(Arc::new(html::HtmlLspAdapter)),
         ),
         (
             "ruby",
             tree_sitter_ruby::language(),
-            Some(Box::new(ruby::RubyLanguageServer)),
+            Some(Arc::new(ruby::RubyLanguageServer)),
         ),
         (
             "erb",
             tree_sitter_embedded_template::language(),
-            Some(Box::new(ruby::RubyLanguageServer)),
+            Some(Arc::new(ruby::RubyLanguageServer)),
         ),
         (
             "scheme",
@@ -130,12 +130,12 @@ pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
         (
             "lua",
             tree_sitter_lua::language(),
-            Some(Box::new(lua::LuaLspAdapter)),
+            Some(Arc::new(lua::LuaLspAdapter)),
         ),
         (
             "yaml",
             tree_sitter_yaml::language(),
-            Some(Box::new(yaml::YamlLspAdapter)),
+            Some(Arc::new(yaml::YamlLspAdapter)),
         ),
     ] {
         languages.register(name, load_config(name), grammar, lsp_adapter, load_queries);
@@ -146,7 +146,7 @@ pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
 pub async fn language(
     name: &str,
     grammar: tree_sitter::Language,
-    lsp_adapter: Option<Box<dyn LspAdapter>>,
+    lsp_adapter: Option<Arc<dyn LspAdapter>>,
 ) -> Arc<Language> {
     Arc::new(
         Language::new(load_config(name), Some(grammar))

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 pub use language::*;
 use rust_embed::RustEmbed;
 use std::{borrow::Cow, str, sync::Arc};
+use theme::ThemeRegistry;
 
 mod c;
 mod elixir;
@@ -31,7 +32,7 @@ mod yaml;
 #[exclude = "*.rs"]
 struct LanguageDir;
 
-pub fn init(languages: Arc<LanguageRegistry>) {
+pub fn init(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) {
     for (name, grammar, lsp_adapter) in [
         (
             "c",
@@ -61,7 +62,10 @@ pub fn init(languages: Arc<LanguageRegistry>) {
         (
             "json",
             tree_sitter_json::language(),
-            Some(Box::new(json::JsonLspAdapter)),
+            Some(Box::new(json::JsonLspAdapter::new(
+                languages.clone(),
+                themes.clone(),
+            ))),
         ),
         (
             "markdown",

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -314,7 +314,7 @@ mod tests {
         let language = language(
             "go",
             tree_sitter_go::language(),
-            Some(Box::new(GoLspAdapter)),
+            Some(Arc::new(GoLspAdapter)),
         )
         .await;
 

--- a/crates/zed/src/languages/json.rs
+++ b/crates/zed/src/languages/json.rs
@@ -4,14 +4,32 @@ use async_compression::futures::bufread::GzipDecoder;
 use async_trait::async_trait;
 use client::http::HttpClient;
 use collections::HashMap;
-use futures::{io::BufReader, StreamExt};
-use language::{LanguageServerName, LspAdapter};
+use futures::{future::BoxFuture, io::BufReader, FutureExt, StreamExt};
+use gpui::MutableAppContext;
+use language::{LanguageRegistry, LanguageServerName, LspAdapter};
 use serde_json::json;
+use settings::{keymap_file_json_schema, settings_file_json_schema};
 use smol::fs::{self, File};
-use std::{any::Any, env::consts, path::PathBuf, sync::Arc};
-use util::ResultExt;
+use std::{
+    any::Any,
+    env::consts,
+    future,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use theme::ThemeRegistry;
+use util::{paths, ResultExt, StaffMode};
 
-pub struct JsonLspAdapter;
+pub struct JsonLspAdapter {
+    languages: Arc<LanguageRegistry>,
+    themes: Arc<ThemeRegistry>,
+}
+
+impl JsonLspAdapter {
+    pub fn new(languages: Arc<LanguageRegistry>, themes: Arc<ThemeRegistry>) -> Self {
+        Self { languages, themes }
+    }
+}
 
 #[async_trait]
 impl LspAdapter for JsonLspAdapter {
@@ -102,7 +120,45 @@ impl LspAdapter for JsonLspAdapter {
         }))
     }
 
+    fn workspace_configuration(
+        &self,
+        cx: &mut MutableAppContext,
+    ) -> Option<BoxFuture<'static, serde_json::Value>> {
+        let action_names = cx.all_action_names().collect::<Vec<_>>();
+        let theme_names = self
+            .themes
+            .list(**cx.default_global::<StaffMode>())
+            .map(|meta| meta.name)
+            .collect();
+        let language_names = self.languages.language_names();
+        Some(
+            future::ready(serde_json::json!({
+                "json": {
+                    "format": {
+                        "enable": true,
+                    },
+                    "schemas": [
+                        {
+                            "fileMatch": [schema_file_match(&paths::SETTINGS)],
+                            "schema": settings_file_json_schema(theme_names, &language_names),
+                        },
+                        {
+                            "fileMatch": [schema_file_match(&paths::KEYMAP)],
+                            "schema": keymap_file_json_schema(&action_names),
+                        }
+                    ]
+                }
+            }))
+            .boxed(),
+        )
+    }
+
     async fn language_ids(&self) -> HashMap<String, String> {
         [("JSON".into(), "jsonc".into())].into_iter().collect()
     }
+}
+
+fn schema_file_match(path: &Path) -> &Path {
+    path.strip_prefix(path.parent().unwrap().parent().unwrap())
+        .unwrap()
 }

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -306,7 +306,7 @@ mod tests {
         let language = language(
             "rust",
             tree_sitter_rust::language(),
-            Some(Box::new(RustLspAdapter)),
+            Some(Arc::new(RustLspAdapter)),
         )
         .await;
         let grammar = language.grammar().unwrap();
@@ -392,7 +392,7 @@ mod tests {
         let language = language(
             "rust",
             tree_sitter_rust::language(),
-            Some(Box::new(RustLspAdapter)),
+            Some(Arc::new(RustLspAdapter)),
         )
         .await;
         let grammar = language.grammar().unwrap();

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
         languages.set_executor(cx.background().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());
         let languages = Arc::new(languages);
-        languages::init(languages.clone());
+        languages::init(languages.clone(), themes.clone());
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
 
         cx.set_global(client.clone());


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-311/rendering-of-yaml-hover-information-is-broken

This pull request introduces a pretty significant change to the way we provide [`WorkspaceConfiguration`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration) settings to the language server.

Previously, we had hardcoded a few settings related to JSON so that we could provide schema information for settings and keymaps. However, other languages need to be able to provide their own entries in the workspace configuration. This was the case for the YAML language server,  which needed the following configuration to be present in order to correctly display hover information:

```jsonc
"[yaml]": {
    "editor.tabSize": 4 // this should be dynamically read from the settings
}
```

As such, the `LspAdapter` trait now allows implementing the following `workspace_configuration` method:

```rs
fn workspace_configuration(&self, cx: &mut MutableAppContext) -> Option<BoxFuture<'static, Value>> {}
```

This gets used in the JSON adapter:

https://github.com/zed-industries/zed/blob/f5a4c6a7c1afb2696d101b0118a548b9cb7b78f3/crates/zed/src/languages/json.rs#L123-L154

And in the YAML adapter as well:

https://github.com/zed-industries/zed/blob/f5a4c6a7c1afb2696d101b0118a548b9cb7b78f3/crates/zed/src/languages/yaml.rs#L95-L108

The project then uses the new `LanguageRegistry::workspace_configuration` method to aggregate all the various configurations into one JSON blob and feeds it to the language server, which then extracts the relevant parts. In the process of implementing this, I also fixed a race condition in `LanguageRegistry` that could cause languages to momentarily disappear from the language selector if they were being loaded (4d52fc0d12dff4cc1ad171a6741a17a5aa849677).