### PR TITLE
Swap atom keybinding for CollapseSelectedEntry

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -55,7 +55,7 @@
     "bindings": {
       "ctrl-[": "project_panel::CollapseSelectedEntry",
       "ctrl-b": "project_panel::CollapseSelectedEntry",
-      "h": "project_panel::CollapseSelectedEntry",
+      "alt-b": "project_panel::CollapseSelectedEntry",
       "ctrl-]": "project_panel::ExpandSelectedEntry",
       "ctrl-f": "project_panel::ExpandSelectedEntry",
       "ctrl-shift-c": "project_panel::CopyPath"


### PR DESCRIPTION
## Description of feature or change

A user submitted this bug report:

https://github.com/zed-industries/zed/issues/5991

This PR is a temporary patch that we can use until we can fix the bug:

https://linear.app/zed-industries/issue/Z-340/the-project-panel-shouldnt-be-listening-to-key-commands-when-editing-a

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
