### PR TITLE
Introduce a delay before retrying a transaction after a serialization failure

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -55,7 +55,7 @@
     "bindings": {
       "ctrl-[": "project_panel::CollapseSelectedEntry",
       "ctrl-b": "project_panel::CollapseSelectedEntry",
-      "h": "project_panel::CollapseSelectedEntry",
+      "alt-b": "project_panel::CollapseSelectedEntry",
       "ctrl-]": "project_panel::ExpandSelectedEntry",
       "ctrl-f": "project_panel::ExpandSelectedEntry",
       "ctrl-shift-c": "project_panel::CopyPath"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3"
 hyper = "0.14"
 lazy_static = "1.4"
 lipsum = { version = "0.8", optional = true }
+log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 nanoid = "0.4"
 parking_lot = "0.11.1"
 prometheus = "0.13"
@@ -74,7 +75,6 @@ workspace = { path = "../workspace", features = ["test-support"] }
 
 ctor = "0.1"
 env_logger = "0.9"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 util = { path = "../util" }
 lazy_static = "1.4"
 sea-orm = { git = "https://github.com/zed-industries/sea-orm", rev = "18f4c691085712ad014a51792af75a9044bacee6", features = ["sqlx-sqlite"] }

--- a/crates/collab/src/bin/seed.rs
+++ b/crates/collab/src/bin/seed.rs
@@ -1,4 +1,4 @@
-use collab::db;
+use collab::{db, executor::Executor};
 use db::{ConnectOptions, Database};
 use serde::{de::DeserializeOwned, Deserialize};
 use std::fmt::Write;
@@ -13,7 +13,7 @@ struct GitHubUser {
 #[tokio::main]
 async fn main() {
     let database_url = std::env::var("DATABASE_URL").expect("missing DATABASE_URL env var");
-    let db = Database::new(ConnectOptions::new(database_url))
+    let db = Database::new(ConnectOptions::new(database_url), Executor::Production)
         .await
         .expect("failed to connect to postgres database");
     let github_token = std::env::var("GITHUB_TOKEN").expect("missing GITHUB_TOKEN env var");

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -2970,6 +2970,10 @@ impl Database {
         if is_serialization_error(error) {
             let base_delay = 4_u64 << prev_attempt_count.min(16);
             let randomized_delay = base_delay as f32 * self.rng.lock().await.gen_range(0.5..=2.0);
+            log::info!(
+                "retrying transaction after serialization error. delay: {} ms.",
+                randomized_delay
+            );
             self.executor
                 .sleep(Duration::from_millis(randomized_delay as u64))
                 .await;

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -10,6 +10,7 @@ mod tests;
 
 use axum::{http::StatusCode, response::IntoResponse};
 use db::Database;
+use executor::Executor;
 use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};
 
@@ -118,7 +119,7 @@ impl AppState {
     pub async fn new(config: Config) -> Result<Arc<Self>> {
         let mut db_options = db::ConnectOptions::new(config.database_url.clone());
         db_options.max_connections(config.database_max_connections);
-        let db = Database::new(db_options).await?;
+        let db = Database::new(db_options, Executor::Production).await?;
         let live_kit_client = if let Some(((server, key), secret)) = config
             .live_kit_server
             .as_ref()

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
             let config = envy::from_env::<MigrateConfig>().expect("error loading config");
             let mut db_options = db::ConnectOptions::new(config.database_url.clone());
             db_options.max_connections(5);
-            let db = Database::new(db_options).await?;
+            let db = Database::new(db_options, Executor::Production).await?;
 
             let migrations_path = config
                 .migrations_path

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -316,12 +316,20 @@ impl ContactList {
             github_login
         );
         let mut answer = cx.prompt(PromptLevel::Warning, &prompt_message, &["Remove", "Cancel"]);
+        let window_id = cx.window_id();
         cx.spawn(|_, mut cx| async move {
             if answer.next().await == Some(0) {
-                user_store
+                if let Err(e) = user_store
                     .update(&mut cx, |store, cx| store.remove_contact(user_id, cx))
                     .await
-                    .unwrap();
+                {
+                    cx.prompt(
+                        window_id,
+                        PromptLevel::Info,
+                        &format!("Failed to remove contact: {}", e),
+                        &["Ok"],
+                    );
+                }
             }
         })
         .detach();

--- a/crates/terminal/src/mappings/mouse.rs
+++ b/crates/terminal/src/mappings/mouse.rs
@@ -186,6 +186,9 @@ pub fn mouse_moved_report(point: Point, e: &MouseMovedEvent, mode: TermMode) -> 
 }
 
 pub fn mouse_side(pos: Vector2F, cur_size: TerminalSize) -> alacritty_terminal::index::Direction {
+    if cur_size.cell_width as usize == 0 {
+        return Side::Right;
+    }
     let x = pos.0.x() as usize;
     let cell_x = x.saturating_sub(cur_size.cell_width as usize) % cur_size.cell_width as usize;
     let half_cell_width = (cur_size.cell_width / 2.0) as usize;


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-329/introduce-a-delay-before-retrying-a-transaction-on-serialization

Previously, when a database transaction failed due to a transaction-serialization failure (i.e. because its reads and writes conflicted with another transactions that occurred concurrently), we retried that transaction immediately. And we would retry a transaction again and again until it succeeded. We believe that this retry logic caused a situation that we observed in production where two or more conflicting transactions would endlessly retry, always preventing each other from succeeding.

In this PR, we've introduced a delay before retrying these transactions. The delay is structured as an exponential backoff with some random jitter. This should ensure that conflicting transactions will eventually succeed, because one will run before the other.