### PR TITLE
Align dispatch_keystroke with other uses of ancestors iterator

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1479,15 +1479,11 @@ impl MutableAppContext {
         if let Some(focused_view_id) = self.focused_view_id(window_id) {
             let dispatch_path = self
                 .ancestors(window_id, focused_view_id)
-                .map(|view_id| {
-                    (
-                        view_id,
-                        self.cx
-                            .views
-                            .get(&(window_id, view_id))
-                            .unwrap()
-                            .keymap_context(self.as_ref()),
-                    )
+                .filter_map(|view_id| {
+                    self.cx
+                        .views
+                        .get(&(window_id, view_id))
+                        .map(|view| (view_id, view.keymap_context(self.as_ref())))
                 })
                 .collect();
 


### PR DESCRIPTION
This fixes https://linear.app/zed-industries/issue/Z-336/dangling-child-view-causes-panic-in-dispatch-keystroke

Was working on this with @as-cii earlier today. The fundamental problem is that dropping a view does not always drop all of it's children (e.g. they're being kept alive by a spawned task). But the `parents` mapping unconditionally removes entries for dropped views and leaves these child views with dangling 'pointers' to the parent view. This is a pretty big problem, but the `ancestors()` function that this powers is used in a lot of places, particularly the `focus_in()` API and dispatch path traversal, and we weren't quite sure if we wanted to do such a big refactor. 

As such, I propose that we switch to simply filtering out dangling pointers manually in the `keystroke_dispatch()` code, as this follows the way the `ancestors()` iterator is used for other dispatch path traversals (e.g. `available_actions`, `key_down`, `modifiers_changed`) and then when we have bandwidth for the deeper refactoring, we can strip all these checks out.

## Description of feature or change

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
