### PR TITLE
Add an 'Unknown' state for a mouse-driven way to select a file language

### DIFF
--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -50,21 +50,23 @@ impl View for ActiveBufferLanguage {
     }
 
     fn render(&mut self, cx: &mut RenderContext<Self>) -> ElementBox {
-        if let Some(active_language) = self.active_language.as_ref() {
-            MouseEventHandler::<Self>::new(0, cx, |state, cx| {
-                let theme = &cx.global::<Settings>().theme.workspace.status_bar;
-                let style = theme.active_language.style_for(state, false);
-                Label::new(active_language.to_string(), style.text.clone())
-                    .contained()
-                    .with_style(style.container)
-                    .boxed()
-            })
-            .with_cursor_style(CursorStyle::PointingHand)
-            .on_click(MouseButton::Left, |_, cx| cx.dispatch_action(crate::Toggle))
-            .boxed()
+        let active_language = if let Some(active_language) = self.active_language.as_ref() {
+            active_language.to_string()
         } else {
-            Empty::new().boxed()
-        }
+            "Unkown".to_string()
+        };
+
+        MouseEventHandler::<Self>::new(0, cx, |state, cx| {
+            let theme = &cx.global::<Settings>().theme.workspace.status_bar;
+            let style = theme.active_language.style_for(state, false);
+            Label::new(active_language, style.text.clone())
+                .contained()
+                .with_style(style.container)
+                .boxed()
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_click(MouseButton::Left, |_, cx| cx.dispatch_action(crate::Toggle))
+        .boxed()
     }
 }
 


### PR DESCRIPTION
## Description of feature or change

This should reduce the number of reports we have of needing a way to set the language.

## Link to related issues from zed or community

https://linear.app/zed-industries/issue/Z-357/add-plain-text-or-unknown-as-a-language-type-in-the-status-bar

## Before Merging 

- [x] Does this have tests or have existing tests been updated to cover this change?
- [x] Have you added the necessary settings to configure this feature?
- [x] Has documentation been created or updated (including above changes to settings)?
