### PR TITLE
Increase git diff gutter width slightly

### DIFF
--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -99,8 +99,8 @@ export default function editor(colorScheme: ColorScheme) {
             modified: foreground(layer, "warning"),
             inserted: foreground(layer, "positive"),
             removedWidthEm: 0.275,
-            widthEm: 0.16,
-            cornerRadius: 0.05,
+            widthEm: 0.22,
+            cornerRadius: 0.2,
         },
         /** Highlights matching occurences of what is under the cursor
          * as well as matched brackets


### PR DESCRIPTION
A long standing issue I'd been meaning to look at is how the follow outline eats into the git gutter a considerable amount. After looking making the editor aware of if the pane is being followed in order to adjust the positioning of the diff hunks I decided it not worth it. Telling the item about if the outline is being drawn seems a bit unfortunate and adjusting the edges of the item when painting an outline would shift content around by a pixel which is also unfortunate.

So I did the brain dead thing and increased the width of the git diff gutter to have the pane followed overlay not be as significant of a cover. I tried not to increase it too much as we have had a few small discussions about this before.

Not following before/after
![CleanShot 2023-03-17 at 15 27 24](https://user-images.githubusercontent.com/30666851/226002807-cc6d7fe8-f903-456f-a62f-8f6fa67ac6f6.png)
![CleanShot 2023-03-17 at 15 28 03](https://user-images.githubusercontent.com/30666851/226002919-dc421259-9c0e-47be-b318-1dfbadd892ad.png)

Following before/after
![CleanShot 2023-03-17 at 15 27 48](https://user-images.githubusercontent.com/30666851/226003025-093ce353-b125-45f1-906d-2d955b77b814.png)
![CleanShot 2023-03-17 at 15 28 09](https://user-images.githubusercontent.com/30666851/226003086-5631c4ae-99aa-4ed1-8196-279c7fee2ff9.png)

With a theme like One Light this issue was exacerbated, following before/after
![CleanShot 2023-03-17 at 19 29 11](https://user-images.githubusercontent.com/30666851/226069393-475cabe9-e5ec-4a96-b964-55f05a215f5a.png)
![CleanShot 2023-03-17 at 19 29 19](https://user-images.githubusercontent.com/30666851/226069401-ec4bf05d-061d-4efc-9453-f86ceff29e72.png)

cc @iamnbutler, I know this issue can be made even better with even more improved contrast but it seems valuable to buff this up slightly too