### PR TITLE
Faster access token validation

### DIFF
--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -97,7 +97,7 @@ fn hash_access_token(token: &str) -> Result<String> {
     let params = if cfg!(debug_assertions) {
         scrypt::Params::new(1, 1, 1).unwrap()
     } else {
-        scrypt::Params::recommended()
+        scrypt::Params::new(14, 8, 1).unwrap()
     };
 
     Ok(Scrypt

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -177,30 +177,63 @@ test_both_dbs!(
             .unwrap()
             .user_id;
 
-        db.create_access_token_hash(user, "h1", 3).await.unwrap();
-        db.create_access_token_hash(user, "h2", 3).await.unwrap();
+        let token_1 = db.create_access_token(user, "h1", 2).await.unwrap();
+        let token_2 = db.create_access_token(user, "h2", 2).await.unwrap();
         assert_eq!(
-            db.get_access_token_hashes(user).await.unwrap(),
-            &["h2".to_string(), "h1".to_string()]
+            db.get_access_token(token_1).await.unwrap(),
+            access_token::Model {
+                id: token_1,
+                user_id: user,
+                hash: "h1".into(),
+            }
+        );
+        assert_eq!(
+            db.get_access_token(token_2).await.unwrap(),
+            access_token::Model {
+                id: token_2,
+                user_id: user,
+                hash: "h2".into()
+            }
         );
 
-        db.create_access_token_hash(user, "h3", 3).await.unwrap();
+        let token_3 = db.create_access_token(user, "h3", 2).await.unwrap();
         assert_eq!(
-            db.get_access_token_hashes(user).await.unwrap(),
-            &["h3".to_string(), "h2".to_string(), "h1".to_string(),]
+            db.get_access_token(token_3).await.unwrap(),
+            access_token::Model {
+                id: token_3,
+                user_id: user,
+                hash: "h3".into()
+            }
         );
+        assert_eq!(
+            db.get_access_token(token_2).await.unwrap(),
+            access_token::Model {
+                id: token_2,
+                user_id: user,
+                hash: "h2".into()
+            }
+        );
+        assert!(db.get_access_token(token_1).await.is_err());
 
-        db.create_access_token_hash(user, "h4", 3).await.unwrap();
+        let token_4 = db.create_access_token(user, "h4", 2).await.unwrap();
         assert_eq!(
-            db.get_access_token_hashes(user).await.unwrap(),
-            &["h4".to_string(), "h3".to_string(), "h2".to_string(),]
+            db.get_access_token(token_4).await.unwrap(),
+            access_token::Model {
+                id: token_4,
+                user_id: user,
+                hash: "h4".into()
+            }
         );
-
-        db.create_access_token_hash(user, "h5", 3).await.unwrap();
         assert_eq!(
-            db.get_access_token_hashes(user).await.unwrap(),
-            &["h5".to_string(), "h4".to_string(), "h3".to_string()]
+            db.get_access_token(token_3).await.unwrap(),
+            access_token::Model {
+                id: token_3,
+                user_id: user,
+                hash: "h3".into()
+            }
         );
+        assert!(db.get_access_token(token_2).await.is_err());
+        assert!(db.get_access_token(token_1).await.is_err());
     }
 );
 


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-345/use-a-less-expensive-hashing-function-to-hash-user-access-tokens
Closes https://linear.app/zed-industries/issue/Z-344/add-telemetry-measuring-how-long-its-taking-to-scrypt-hash-user-access

In this PR, we've updated our approach to authenticating incoming websocket connections. Previously, when establishing a websocket connection, the Zed client would only tell us the user id and the access token. But we store multiple access tokens per user (in case people use Zed on different devices), so we had to check this incoming token against multiple stored hashes. We store access tokens hashed with the Scrypt password hashing algorithm in order to mitigate attackers' ability to obtain stolen passwords from our database by bruce force, so the hashing is expensive.

Now, when connecting to our websocket endpoint, the client sends us a JSON payload that includes the ID of the access token itself in our database, so we don't need to hash multiple tokens. This doesn't require client-side changes, because we put this JSON in the same opaque string that the client already deals with, and stores in its keychain.

In addition, we're using a slightly lower "work factor" for scrypt now, so hashing will be a little cheaper.

Finally, we added logging and prometheus metrics for the time that we spend verifying tokens.

Note - this server-side change *will* invalidate all current access tokens. Users will have to authenticate with GitHub one time after we deploy this. We think this is worth it, because we can immediately stop doing so much work when authenticating connections, hopefully avoiding outages like the one on 3/16.