### PR TITLE
Introduce `DisplayMap::replace_suggestion`

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1,5 +1,6 @@
 mod block_map;
 mod fold_map;
+mod suggestion_map;
 mod tab_map;
 mod wrap_map;
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -16,16 +16,15 @@ use gpui::{
 use language::{OffsetUtf16, Point, Subscription as BufferSubscription};
 use settings::Settings;
 use std::{any::TypeId, fmt::Debug, num::NonZeroU32, ops::Range, sync::Arc};
+use suggestion_map::SuggestionMap;
 use sum_tree::{Bias, TreeMap};
-use tab_map::TabMap;
+use tab_map::{TabMap, TabSnapshot};
 use wrap_map::WrapMap;
 
 pub use block_map::{
     BlockBufferRows as DisplayBufferRows, BlockChunks as DisplayChunks, BlockContext,
     BlockDisposition, BlockId, BlockProperties, BlockStyle, RenderBlock, TransformBlock,
 };
-
-use self::tab_map::TabSnapshot;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FoldStatus {
@@ -43,6 +42,7 @@ pub struct DisplayMap {
     buffer: ModelHandle<MultiBuffer>,
     buffer_subscription: BufferSubscription,
     fold_map: FoldMap,
+    suggestion_map: SuggestionMap,
     tab_map: TabMap,
     wrap_map: ModelHandle<WrapMap>,
     block_map: BlockMap,
@@ -68,6 +68,7 @@ impl DisplayMap {
 
         let tab_size = Self::tab_size(&buffer, cx);
         let (fold_map, snapshot) = FoldMap::new(buffer.read(cx).snapshot(cx));
+        let (suggestion_map, snapshot) = SuggestionMap::new(snapshot);
         let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
         let (wrap_map, snapshot) = WrapMap::new(snapshot, font_id, font_size, wrap_width, cx);
         let block_map = BlockMap::new(snapshot, buffer_header_height, excerpt_header_height);
@@ -76,6 +77,7 @@ impl DisplayMap {
             buffer,
             buffer_subscription,
             fold_map,
+            suggestion_map,
             tab_map,
             wrap_map,
             block_map,
@@ -87,21 +89,25 @@ impl DisplayMap {
     pub fn snapshot(&self, cx: &mut ModelContext<Self>) -> DisplaySnapshot {
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let (folds_snapshot, edits) = self.fold_map.read(buffer_snapshot, edits);
+        let (fold_snapshot, edits) = self.fold_map.read(buffer_snapshot, edits);
+        let (suggestion_snapshot, edits) = self.suggestion_map.sync(fold_snapshot.clone(), edits);
 
         let tab_size = Self::tab_size(&self.buffer, cx);
-        let (tabs_snapshot, edits) = self.tab_map.sync(folds_snapshot.clone(), edits, tab_size);
-        let (wraps_snapshot, edits) = self
+        let (tab_snapshot, edits) = self
+            .tab_map
+            .sync(suggestion_snapshot.clone(), edits, tab_size);
+        let (wrap_snapshot, edits) = self
             .wrap_map
-            .update(cx, |map, cx| map.sync(tabs_snapshot.clone(), edits, cx));
-        let blocks_snapshot = self.block_map.read(wraps_snapshot.clone(), edits);
+            .update(cx, |map, cx| map.sync(tab_snapshot.clone(), edits, cx));
+        let block_snapshot = self.block_map.read(wrap_snapshot.clone(), edits);
 
         DisplaySnapshot {
             buffer_snapshot: self.buffer.read(cx).snapshot(cx),
-            folds_snapshot,
-            tabs_snapshot,
-            wraps_snapshot,
-            blocks_snapshot,
+            fold_snapshot,
+            suggestion_snapshot,
+            tab_snapshot,
+            wrap_snapshot,
+            block_snapshot,
             text_highlights: self.text_highlights.clone(),
             clip_at_line_ends: self.clip_at_line_ends,
         }
@@ -125,12 +131,14 @@ impl DisplayMap {
         let edits = self.buffer_subscription.consume().into_inner();
         let tab_size = Self::tab_size(&self.buffer, cx);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
+        let (snapshot, edits) = self.suggestion_map.sync(snapshot, edits);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
         self.block_map.read(snapshot, edits);
         let (snapshot, edits) = fold_map.fold(ranges);
+        let (snapshot, edits) = self.suggestion_map.sync(snapshot, edits);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
         let (snapshot, edits) = self
             .wrap_map
@@ -148,12 +156,14 @@ impl DisplayMap {
         let edits = self.buffer_subscription.consume().into_inner();
         let tab_size = Self::tab_size(&self.buffer, cx);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
+        let (snapshot, edits) = self.suggestion_map.sync(snapshot, edits);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
         self.block_map.read(snapshot, edits);
         let (snapshot, edits) = fold_map.unfold(ranges, inclusive);
+        let (snapshot, edits) = self.suggestion_map.sync(snapshot, edits);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
         let (snapshot, edits) = self
             .wrap_map
@@ -170,6 +180,7 @@ impl DisplayMap {
         let edits = self.buffer_subscription.consume().into_inner();
         let tab_size = Self::tab_size(&self.buffer, cx);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
+        let (snapshot, edits) = self.suggestion_map.sync(snapshot, edits);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
         let (snapshot, edits) = self
             .wrap_map
@@ -187,6 +198,7 @@ impl DisplayMap {
         let edits = self.buffer_subscription.consume().into_inner();
         let tab_size = Self::tab_size(&self.buffer, cx);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
+        let (snapshot, edits) = self.suggestion_map.sync(snapshot, edits);
         let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
         let (snapshot, edits) = self
             .wrap_map
@@ -249,10 +261,11 @@ impl DisplayMap {
 
 pub struct DisplaySnapshot {
     pub buffer_snapshot: MultiBufferSnapshot,
-    folds_snapshot: fold_map::FoldSnapshot,
-    tabs_snapshot: tab_map::TabSnapshot,
-    wraps_snapshot: wrap_map::WrapSnapshot,
-    blocks_snapshot: block_map::BlockSnapshot,
+    fold_snapshot: fold_map::FoldSnapshot,
+    suggestion_snapshot: suggestion_map::SuggestionSnapshot,
+    tab_snapshot: tab_map::TabSnapshot,
+    wrap_snapshot: wrap_map::WrapSnapshot,
+    block_snapshot: block_map::BlockSnapshot,
     text_highlights: TextHighlights,
     clip_at_line_ends: bool,
 }
@@ -260,7 +273,7 @@ pub struct DisplaySnapshot {
 impl DisplaySnapshot {
     #[cfg(test)]
     pub fn fold_count(&self) -> usize {
-        self.folds_snapshot.fold_count()
+        self.fold_snapshot.fold_count()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -268,7 +281,7 @@ impl DisplaySnapshot {
     }
 
     pub fn buffer_rows(&self, start_row: u32) -> DisplayBufferRows {
-        self.blocks_snapshot.buffer_rows(start_row)
+        self.block_snapshot.buffer_rows(start_row)
     }
 
     pub fn max_buffer_row(&self) -> u32 {
@@ -277,9 +290,9 @@ impl DisplaySnapshot {
 
     pub fn prev_line_boundary(&self, mut point: Point) -> (Point, DisplayPoint) {
         loop {
-            let mut fold_point = self.folds_snapshot.to_fold_point(point, Bias::Left);
+            let mut fold_point = self.fold_snapshot.to_fold_point(point, Bias::Left);
             *fold_point.column_mut() = 0;
-            point = fold_point.to_buffer_point(&self.folds_snapshot);
+            point = fold_point.to_buffer_point(&self.fold_snapshot);
 
             let mut display_point = self.point_to_display_point(point, Bias::Left);
             *display_point.column_mut() = 0;
@@ -293,9 +306,9 @@ impl DisplaySnapshot {
 
     pub fn next_line_boundary(&self, mut point: Point) -> (Point, DisplayPoint) {
         loop {
-            let mut fold_point = self.folds_snapshot.to_fold_point(point, Bias::Right);
-            *fold_point.column_mut() = self.folds_snapshot.line_len(fold_point.row());
-            point = fold_point.to_buffer_point(&self.folds_snapshot);
+            let mut fold_point = self.fold_snapshot.to_fold_point(point, Bias::Right);
+            *fold_point.column_mut() = self.fold_snapshot.line_len(fold_point.row());
+            point = fold_point.to_buffer_point(&self.fold_snapshot);
 
             let mut display_point = self.point_to_display_point(point, Bias::Right);
             *display_point.column_mut() = self.line_len(display_point.row());
@@ -325,28 +338,30 @@ impl DisplaySnapshot {
     }
 
     fn point_to_display_point(&self, point: Point, bias: Bias) -> DisplayPoint {
-        let fold_point = self.folds_snapshot.to_fold_point(point, bias);
-        let tab_point = self.tabs_snapshot.to_tab_point(fold_point);
-        let wrap_point = self.wraps_snapshot.tab_point_to_wrap_point(tab_point);
-        let block_point = self.blocks_snapshot.to_block_point(wrap_point);
+        let fold_point = self.fold_snapshot.to_fold_point(point, bias);
+        let suggestion_point = self.suggestion_snapshot.to_suggestion_point(fold_point);
+        let tab_point = self.tab_snapshot.to_tab_point(suggestion_point);
+        let wrap_point = self.wrap_snapshot.tab_point_to_wrap_point(tab_point);
+        let block_point = self.block_snapshot.to_block_point(wrap_point);
         DisplayPoint(block_point)
     }
 
     fn display_point_to_point(&self, point: DisplayPoint, bias: Bias) -> Point {
         let block_point = point.0;
-        let wrap_point = self.blocks_snapshot.to_wrap_point(block_point);
-        let tab_point = self.wraps_snapshot.to_tab_point(wrap_point);
-        let fold_point = self.tabs_snapshot.to_fold_point(tab_point, bias).0;
-        fold_point.to_buffer_point(&self.folds_snapshot)
+        let wrap_point = self.block_snapshot.to_wrap_point(block_point);
+        let tab_point = self.wrap_snapshot.to_tab_point(wrap_point);
+        let suggestion_point = self.tab_snapshot.to_suggestion_point(tab_point, bias).0;
+        let fold_point = self.suggestion_snapshot.to_fold_point(suggestion_point);
+        fold_point.to_buffer_point(&self.fold_snapshot)
     }
 
     pub fn max_point(&self) -> DisplayPoint {
-        DisplayPoint(self.blocks_snapshot.max_point())
+        DisplayPoint(self.block_snapshot.max_point())
     }
 
     /// Returns text chunks starting at the given display row until the end of the file
     pub fn text_chunks(&self, display_row: u32) -> impl Iterator<Item = &str> {
-        self.blocks_snapshot
+        self.block_snapshot
             .chunks(display_row..self.max_point().row() + 1, false, None)
             .map(|h| h.text)
     }
@@ -354,7 +369,7 @@ impl DisplaySnapshot {
     /// Returns text chunks starting at the end of the given display row in reverse until the start of the file
     pub fn reverse_text_chunks(&self, display_row: u32) -> impl Iterator<Item = &str> {
         (0..=display_row).into_iter().rev().flat_map(|row| {
-            self.blocks_snapshot
+            self.block_snapshot
                 .chunks(row..row + 1, false, None)
                 .map(|h| h.text)
                 .collect::<Vec<_>>()
@@ -364,7 +379,7 @@ impl DisplaySnapshot {
     }
 
     pub fn chunks(&self, display_rows: Range<u32>, language_aware: bool) -> DisplayChunks<'_> {
-        self.blocks_snapshot
+        self.block_snapshot
             .chunks(display_rows, language_aware, Some(&self.text_highlights))
     }
 
@@ -372,7 +387,7 @@ impl DisplaySnapshot {
         &self,
         mut point: DisplayPoint,
     ) -> impl Iterator<Item = (char, DisplayPoint)> + '_ {
-        point = DisplayPoint(self.blocks_snapshot.clip_point(point.0, Bias::Left));
+        point = DisplayPoint(self.block_snapshot.clip_point(point.0, Bias::Left));
         self.text_chunks(point.row())
             .flat_map(str::chars)
             .skip_while({
@@ -399,7 +414,7 @@ impl DisplaySnapshot {
         &self,
         mut point: DisplayPoint,
     ) -> impl Iterator<Item = (char, DisplayPoint)> + '_ {
-        point = DisplayPoint(self.blocks_snapshot.clip_point(point.0, Bias::Left));
+        point = DisplayPoint(self.block_snapshot.clip_point(point.0, Bias::Left));
         self.reverse_text_chunks(point.row())
             .flat_map(|chunk| chunk.chars().rev())
             .skip_while({
@@ -513,7 +528,7 @@ impl DisplaySnapshot {
     }
 
     pub fn clip_point(&self, point: DisplayPoint, bias: Bias) -> DisplayPoint {
-        let mut clipped = self.blocks_snapshot.clip_point(point.0, bias);
+        let mut clipped = self.block_snapshot.clip_point(point.0, bias);
         if self.clip_at_line_ends {
             clipped = self.clip_at_line_end(DisplayPoint(clipped)).0
         }
@@ -524,7 +539,7 @@ impl DisplaySnapshot {
         let mut point = point.0;
         if point.column == self.line_len(point.row) {
             point.column = point.column.saturating_sub(1);
-            point = self.blocks_snapshot.clip_point(point, Bias::Left);
+            point = self.block_snapshot.clip_point(point, Bias::Left);
         }
         DisplayPoint(point)
     }
@@ -533,34 +548,34 @@ impl DisplaySnapshot {
     where
         T: ToOffset,
     {
-        self.folds_snapshot.folds_in_range(range)
+        self.fold_snapshot.folds_in_range(range)
     }
 
     pub fn blocks_in_range(
         &self,
         rows: Range<u32>,
     ) -> impl Iterator<Item = (u32, &TransformBlock)> {
-        self.blocks_snapshot.blocks_in_range(rows)
+        self.block_snapshot.blocks_in_range(rows)
     }
 
     pub fn intersects_fold<T: ToOffset>(&self, offset: T) -> bool {
-        self.folds_snapshot.intersects_fold(offset)
+        self.fold_snapshot.intersects_fold(offset)
     }
 
     pub fn is_line_folded(&self, buffer_row: u32) -> bool {
-        self.folds_snapshot.is_line_folded(buffer_row)
+        self.fold_snapshot.is_line_folded(buffer_row)
     }
 
     pub fn is_block_line(&self, display_row: u32) -> bool {
-        self.blocks_snapshot.is_block_line(display_row)
+        self.block_snapshot.is_block_line(display_row)
     }
 
     pub fn soft_wrap_indent(&self, display_row: u32) -> Option<u32> {
         let wrap_row = self
-            .blocks_snapshot
+            .block_snapshot
             .to_wrap_point(BlockPoint::new(display_row, 0))
             .row();
-        self.wraps_snapshot.soft_wrap_indent(wrap_row)
+        self.wrap_snapshot.soft_wrap_indent(wrap_row)
     }
 
     pub fn text(&self) -> String {
@@ -614,18 +629,18 @@ impl DisplaySnapshot {
                 }
             }),
             buffer.line_len(buffer_row) as usize, // Never collapse
-            self.tabs_snapshot.tab_size,
+            self.tab_snapshot.tab_size,
         );
 
         (indent_size as u32, is_blank)
     }
 
     pub fn line_len(&self, row: u32) -> u32 {
-        self.blocks_snapshot.line_len(row)
+        self.block_snapshot.line_len(row)
     }
 
     pub fn longest_row(&self) -> u32 {
-        self.blocks_snapshot.longest_row()
+        self.block_snapshot.longest_row()
     }
 
     pub fn fold_for_line(self: &Self, buffer_row: u32) -> Option<FoldStatus> {
@@ -742,10 +757,11 @@ impl DisplayPoint {
     }
 
     pub fn to_offset(self, map: &DisplaySnapshot, bias: Bias) -> usize {
-        let unblocked_point = map.blocks_snapshot.to_wrap_point(self.0);
-        let unwrapped_point = map.wraps_snapshot.to_tab_point(unblocked_point);
-        let unexpanded_point = map.tabs_snapshot.to_fold_point(unwrapped_point, bias).0;
-        unexpanded_point.to_buffer_offset(&map.folds_snapshot)
+        let wrap_point = map.block_snapshot.to_wrap_point(self.0);
+        let tab_point = map.wrap_snapshot.to_tab_point(wrap_point);
+        let suggestion_point = map.tab_snapshot.to_suggestion_point(tab_point, bias).0;
+        let fold_point = map.suggestion_snapshot.to_fold_point(suggestion_point);
+        fold_point.to_buffer_offset(&map.fold_snapshot)
     }
 }
 
@@ -868,10 +884,10 @@ pub mod tests {
 
         let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
         log::info!("buffer text: {:?}", snapshot.buffer_snapshot.text());
-        log::info!("fold text: {:?}", snapshot.folds_snapshot.text());
-        log::info!("tab text: {:?}", snapshot.tabs_snapshot.text());
-        log::info!("wrap text: {:?}", snapshot.wraps_snapshot.text());
-        log::info!("block text: {:?}", snapshot.blocks_snapshot.text());
+        log::info!("fold text: {:?}", snapshot.fold_snapshot.text());
+        log::info!("tab text: {:?}", snapshot.tab_snapshot.text());
+        log::info!("wrap text: {:?}", snapshot.wrap_snapshot.text());
+        log::info!("block text: {:?}", snapshot.block_snapshot.text());
         log::info!("display text: {:?}", snapshot.text());
 
         for _i in 0..operations {
@@ -976,10 +992,10 @@ pub mod tests {
             let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
             fold_count = snapshot.fold_count();
             log::info!("buffer text: {:?}", snapshot.buffer_snapshot.text());
-            log::info!("fold text: {:?}", snapshot.folds_snapshot.text());
-            log::info!("tab text: {:?}", snapshot.tabs_snapshot.text());
-            log::info!("wrap text: {:?}", snapshot.wraps_snapshot.text());
-            log::info!("block text: {:?}", snapshot.blocks_snapshot.text());
+            log::info!("fold text: {:?}", snapshot.fold_snapshot.text());
+            log::info!("tab text: {:?}", snapshot.tab_snapshot.text());
+            log::info!("wrap text: {:?}", snapshot.wrap_snapshot.text());
+            log::info!("block text: {:?}", snapshot.block_snapshot.text());
             log::info!("display text: {:?}", snapshot.text());
 
             // Line boundaries

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -989,6 +989,7 @@ fn offset_for_row(s: &str, target: u32) -> (u32, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::display_map::suggestion_map::SuggestionMap;
     use crate::display_map::{fold_map::FoldMap, tab_map::TabMap, wrap_map::WrapMap};
     use crate::multi_buffer::MultiBuffer;
     use gpui::{elements::Empty, Element};
@@ -1029,9 +1030,10 @@ mod tests {
         let buffer = MultiBuffer::build_simple(text, cx);
         let buffer_snapshot = buffer.read(cx).snapshot(cx);
         let subscription = buffer.update(cx, |buffer, _| buffer.subscribe());
-        let (fold_map, folds_snapshot) = FoldMap::new(buffer_snapshot.clone());
-        let (tab_map, tabs_snapshot) = TabMap::new(folds_snapshot, 1.try_into().unwrap());
-        let (wrap_map, wraps_snapshot) = WrapMap::new(tabs_snapshot, font_id, 14.0, None, cx);
+        let (fold_map, fold_snapshot) = FoldMap::new(buffer_snapshot.clone());
+        let (suggestion_map, suggestion_snapshot) = SuggestionMap::new(fold_snapshot);
+        let (tab_map, tab_snapshot) = TabMap::new(suggestion_snapshot, 1.try_into().unwrap());
+        let (wrap_map, wraps_snapshot) = WrapMap::new(tab_snapshot, font_id, 14.0, None, cx);
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
@@ -1173,12 +1175,14 @@ mod tests {
             buffer.snapshot(cx)
         });
 
-        let (folds_snapshot, fold_edits) =
+        let (fold_snapshot, fold_edits) =
             fold_map.read(buffer_snapshot, subscription.consume().into_inner());
-        let (tabs_snapshot, tab_edits) =
-            tab_map.sync(folds_snapshot, fold_edits, 4.try_into().unwrap());
+        let (suggestion_snapshot, suggestion_edits) =
+            suggestion_map.sync(fold_snapshot, fold_edits);
+        let (tab_snapshot, tab_edits) =
+            tab_map.sync(suggestion_snapshot, suggestion_edits, 4.try_into().unwrap());
         let (wraps_snapshot, wrap_edits) = wrap_map.update(cx, |wrap_map, cx| {
-            wrap_map.sync(tabs_snapshot, tab_edits, cx)
+            wrap_map.sync(tab_snapshot, tab_edits, cx)
         });
         let snapshot = block_map.read(wraps_snapshot, wrap_edits);
         assert_eq!(snapshot.text(), "aaa\n\nb!!!\n\n\nbb\nccc\nddd\n\n\n");
@@ -1201,9 +1205,10 @@ mod tests {
 
         let buffer = MultiBuffer::build_simple(text, cx);
         let buffer_snapshot = buffer.read(cx).snapshot(cx);
-        let (_, folds_snapshot) = FoldMap::new(buffer_snapshot.clone());
-        let (_, tabs_snapshot) = TabMap::new(folds_snapshot, 1.try_into().unwrap());
-        let (_, wraps_snapshot) = WrapMap::new(tabs_snapshot, font_id, 14.0, Some(60.), cx);
+        let (_, fold_snapshot) = FoldMap::new(buffer_snapshot.clone());
+        let (_, suggestion_snapshot) = SuggestionMap::new(fold_snapshot);
+        let (_, tab_snapshot) = TabMap::new(suggestion_snapshot, 1.try_into().unwrap());
+        let (_, wraps_snapshot) = WrapMap::new(tab_snapshot, font_id, 14.0, Some(60.), cx);
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
@@ -1272,10 +1277,11 @@ mod tests {
         };
 
         let mut buffer_snapshot = buffer.read(cx).snapshot(cx);
-        let (fold_map, folds_snapshot) = FoldMap::new(buffer_snapshot.clone());
-        let (tab_map, tabs_snapshot) = TabMap::new(folds_snapshot, tab_size);
+        let (fold_map, fold_snapshot) = FoldMap::new(buffer_snapshot.clone());
+        let (suggestion_map, suggestion_snapshot) = SuggestionMap::new(fold_snapshot);
+        let (tab_map, tab_snapshot) = TabMap::new(suggestion_snapshot, tab_size);
         let (wrap_map, wraps_snapshot) =
-            WrapMap::new(tabs_snapshot, font_id, font_size, wrap_width, cx);
+            WrapMap::new(tab_snapshot, font_id, font_size, wrap_width, cx);
         let mut block_map = BlockMap::new(
             wraps_snapshot,
             buffer_start_header_height,
@@ -1326,12 +1332,14 @@ mod tests {
                         })
                         .collect::<Vec<_>>();
 
-                    let (folds_snapshot, fold_edits) =
+                    let (fold_snapshot, fold_edits) =
                         fold_map.read(buffer_snapshot.clone(), vec![]);
-                    let (tabs_snapshot, tab_edits) =
-                        tab_map.sync(folds_snapshot, fold_edits, tab_size);
+                    let (suggestion_snapshot, suggestion_edits) =
+                        suggestion_map.sync(fold_snapshot, fold_edits);
+                    let (tab_snapshot, tab_edits) =
+                        tab_map.sync(suggestion_snapshot, suggestion_edits, tab_size);
                     let (wraps_snapshot, wrap_edits) = wrap_map.update(cx, |wrap_map, cx| {
-                        wrap_map.sync(tabs_snapshot, tab_edits, cx)
+                        wrap_map.sync(tab_snapshot, tab_edits, cx)
                     });
                     let mut block_map = block_map.write(wraps_snapshot, wrap_edits);
                     let block_ids = block_map.insert(block_properties.clone());
@@ -1349,12 +1357,14 @@ mod tests {
                         })
                         .collect();
 
-                    let (folds_snapshot, fold_edits) =
+                    let (fold_snapshot, fold_edits) =
                         fold_map.read(buffer_snapshot.clone(), vec![]);
-                    let (tabs_snapshot, tab_edits) =
-                        tab_map.sync(folds_snapshot, fold_edits, tab_size);
+                    let (suggestion_snapshot, suggestion_edits) =
+                        suggestion_map.sync(fold_snapshot, fold_edits);
+                    let (tab_snapshot, tab_edits) =
+                        tab_map.sync(suggestion_snapshot, suggestion_edits, tab_size);
                     let (wraps_snapshot, wrap_edits) = wrap_map.update(cx, |wrap_map, cx| {
-                        wrap_map.sync(tabs_snapshot, tab_edits, cx)
+                        wrap_map.sync(tab_snapshot, tab_edits, cx)
                     });
                     let mut block_map = block_map.write(wraps_snapshot, wrap_edits);
                     block_map.remove(block_ids_to_remove);
@@ -1371,10 +1381,13 @@ mod tests {
                 }
             }
 
-            let (folds_snapshot, fold_edits) = fold_map.read(buffer_snapshot.clone(), buffer_edits);
-            let (tabs_snapshot, tab_edits) = tab_map.sync(folds_snapshot, fold_edits, tab_size);
+            let (fold_snapshot, fold_edits) = fold_map.read(buffer_snapshot.clone(), buffer_edits);
+            let (suggestion_snapshot, suggestion_edits) =
+                suggestion_map.sync(fold_snapshot, fold_edits);
+            let (tab_snapshot, tab_edits) =
+                tab_map.sync(suggestion_snapshot, suggestion_edits, tab_size);
             let (wraps_snapshot, wrap_edits) = wrap_map.update(cx, |wrap_map, cx| {
-                wrap_map.sync(tabs_snapshot, tab_edits, cx)
+                wrap_map.sync(tab_snapshot, tab_edits, cx)
             });
             let blocks_snapshot = block_map.read(wraps_snapshot.clone(), wrap_edits);
             assert_eq!(

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -29,10 +29,6 @@ impl FoldPoint {
         self.0.row
     }
 
-    pub fn column(self) -> u32 {
-        self.0.column
-    }
-
     pub fn row_mut(&mut self) -> &mut u32 {
         &mut self.0.row
     }
@@ -653,12 +649,6 @@ impl FoldSnapshot {
             }
         }
         false
-    }
-
-    pub fn chars_at(&self, start: FoldPoint) -> impl '_ + Iterator<Item = char> {
-        let start = start.to_offset(self);
-        self.chunks(start..self.len(), false, None)
-            .flat_map(|chunk| chunk.text.chars())
     }
 
     pub fn chunks<'a>(

--- a/crates/editor/src/display_map/suggestion_map.rs
+++ b/crates/editor/src/display_map/suggestion_map.rs
@@ -1,0 +1,71 @@
+use super::fold_map::{FoldEdit, FoldOffset, FoldSnapshot};
+use gpui::fonts::HighlightStyle;
+use language::{Edit, Rope};
+use parking_lot::Mutex;
+
+pub type SuggestionEdit = Edit<SuggestionOffset>;
+
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialOrd, PartialEq)]
+pub struct SuggestionOffset(pub usize);
+
+#[derive(Clone)]
+pub struct Suggestion {
+    position: FoldOffset,
+    text: Rope,
+    highlight_style: HighlightStyle,
+}
+
+pub struct SuggestionMap(Mutex<SuggestionSnapshot>);
+
+impl SuggestionMap {
+    pub fn sync(
+        &self,
+        fold_snapshot: FoldSnapshot,
+        fold_edits: Vec<FoldEdit>,
+    ) -> (SuggestionSnapshot, Vec<SuggestionEdit>) {
+        let mut snapshot = self.0.lock();
+        let mut suggestion_edits = Vec::new();
+
+        let mut suggestion_old_len = 0;
+        let mut suggestion_new_len = 0;
+        for fold_edit in fold_edits {
+            let start = fold_edit.new.start;
+            let end = FoldOffset(start.0 + fold_edit.old_len().0);
+            if let Some(suggestion) = snapshot.suggestion.as_mut() {
+                if end < suggestion.position {
+                    suggestion.position.0 += fold_edit.new_len().0;
+                    suggestion.position.0 -= fold_edit.old_len().0;
+                } else if start > suggestion.position {
+                    suggestion_old_len = suggestion.text.len();
+                    suggestion_new_len = suggestion_old_len;
+                } else {
+                    suggestion_old_len = suggestion.text.len();
+                    snapshot.suggestion.take();
+                    suggestion_edits.push(SuggestionEdit {
+                        old: SuggestionOffset(fold_edit.old.start.0)
+                            ..SuggestionOffset(fold_edit.old.end.0 + suggestion_old_len),
+                        new: SuggestionOffset(fold_edit.new.start.0)
+                            ..SuggestionOffset(fold_edit.new.end.0),
+                    });
+                    continue;
+                }
+            }
+
+            suggestion_edits.push(SuggestionEdit {
+                old: SuggestionOffset(fold_edit.old.start.0 + suggestion_old_len)
+                    ..SuggestionOffset(fold_edit.old.end.0 + suggestion_old_len),
+                new: SuggestionOffset(fold_edit.new.start.0 + suggestion_new_len)
+                    ..SuggestionOffset(fold_edit.new.end.0 + suggestion_new_len),
+            });
+        }
+        snapshot.folds_snapshot = fold_snapshot;
+
+        (snapshot.clone(), suggestion_edits)
+    }
+}
+
+#[derive(Clone)]
+pub struct SuggestionSnapshot {
+    folds_snapshot: FoldSnapshot,
+    suggestion: Option<Suggestion>,
+}

--- a/crates/editor/src/display_map/suggestion_map.rs
+++ b/crates/editor/src/display_map/suggestion_map.rs
@@ -58,9 +58,9 @@ impl SuggestionPoint {
 
 #[derive(Clone, Debug)]
 pub struct Suggestion<T> {
-    position: T,
-    text: Rope,
-    highlight_style: HighlightStyle,
+    pub position: T,
+    pub text: Rope,
+    pub highlight_style: HighlightStyle,
 }
 
 pub struct SuggestionMap(Mutex<SuggestionSnapshot>);

--- a/crates/editor/src/display_map/suggestion_map.rs
+++ b/crates/editor/src/display_map/suggestion_map.rs
@@ -1,6 +1,10 @@
+use std::ops::{Add, AddAssign, Sub};
+
+use crate::{ToOffset, ToPoint};
+
 use super::fold_map::{FoldEdit, FoldOffset, FoldSnapshot};
 use gpui::fonts::HighlightStyle;
-use language::{Edit, Rope};
+use language::{Bias, Edit, Patch, Rope};
 use parking_lot::Mutex;
 
 pub type SuggestionEdit = Edit<SuggestionOffset>;
@@ -8,16 +12,71 @@ pub type SuggestionEdit = Edit<SuggestionOffset>;
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialOrd, PartialEq)]
 pub struct SuggestionOffset(pub usize);
 
+impl Add for SuggestionOffset {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub for SuggestionOffset {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl AddAssign for SuggestionOffset {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
 #[derive(Clone)]
 pub struct Suggestion {
-    position: FoldOffset,
+    offset: FoldOffset,
     text: Rope,
-    highlight_style: HighlightStyle,
 }
 
 pub struct SuggestionMap(Mutex<SuggestionSnapshot>);
 
 impl SuggestionMap {
+    pub fn replace<P, T>(
+        &mut self,
+        position: P,
+        text: T,
+        fold_snapshot: FoldSnapshot,
+        fold_edits: Vec<FoldEdit>,
+    ) -> (SuggestionSnapshot, Vec<SuggestionEdit>)
+    where
+        P: ToPoint,
+        T: Into<Rope>,
+    {
+        let buffer_point = position.to_point(fold_snapshot.buffer_snapshot());
+        let fold_point = fold_snapshot.to_fold_point(buffer_point, Bias::Left);
+        let fold_offset = fold_point.to_offset(&fold_snapshot);
+        let new_suggestion = Suggestion {
+            offset: fold_offset,
+            text: text.into(),
+        };
+
+        let (_, edits) = self.sync(fold_snapshot, fold_edits);
+        let mut snapshot = self.0.lock();
+        let old = if let Some(suggestion) = snapshot.suggestion.take() {
+            SuggestionOffset(suggestion.offset.0)
+                ..SuggestionOffset(suggestion.offset.0 + suggestion.text.len())
+        } else {
+            SuggestionOffset(new_suggestion.offset.0)..SuggestionOffset(new_suggestion.offset.0)
+        };
+        let new = SuggestionOffset(new_suggestion.offset.0)
+            ..SuggestionOffset(new_suggestion.offset.0 + new_suggestion.text.len());
+        let patch = Patch::new(edits).compose([SuggestionEdit { old, new }]);
+        snapshot.suggestion = Some(new_suggestion);
+        (snapshot.clone(), patch.into_inner())
+    }
+
     pub fn sync(
         &self,
         fold_snapshot: FoldSnapshot,
@@ -32,10 +91,10 @@ impl SuggestionMap {
             let start = fold_edit.new.start;
             let end = FoldOffset(start.0 + fold_edit.old_len().0);
             if let Some(suggestion) = snapshot.suggestion.as_mut() {
-                if end < suggestion.position {
-                    suggestion.position.0 += fold_edit.new_len().0;
-                    suggestion.position.0 -= fold_edit.old_len().0;
-                } else if start > suggestion.position {
+                if end < suggestion.offset {
+                    suggestion.offset.0 += fold_edit.new_len().0;
+                    suggestion.offset.0 -= fold_edit.old_len().0;
+                } else if start > suggestion.offset {
                     suggestion_old_len = suggestion.text.len();
                     suggestion_new_len = suggestion_old_len;
                 } else {

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -1,5 +1,5 @@
 use super::{
-    fold_map,
+    suggestion_map::SuggestionBufferRows,
     tab_map::{self, TabEdit, TabPoint, TabSnapshot},
     TextHighlights,
 };
@@ -64,7 +64,7 @@ pub struct WrapChunks<'a> {
 
 #[derive(Clone)]
 pub struct WrapBufferRows<'a> {
-    input_buffer_rows: fold_map::FoldBufferRows<'a>,
+    input_buffer_rows: SuggestionBufferRows<'a>,
     input_buffer_row: Option<u32>,
     output_row: u32,
     soft_wrapped: bool,
@@ -755,16 +755,24 @@ impl WrapSnapshot {
             let text = language::Rope::from(self.text().as_str());
             let input_buffer_rows = self.buffer_snapshot().buffer_rows(0).collect::<Vec<_>>();
             let mut expected_buffer_rows = Vec::new();
-            let mut prev_tab_row = 0;
+            let mut prev_fold_row = 0;
             for display_row in 0..=self.max_point().row() {
                 let tab_point = self.to_tab_point(WrapPoint::new(display_row, 0));
-                if tab_point.row() == prev_tab_row && display_row != 0 {
+                let suggestion_point = self
+                    .tab_snapshot
+                    .to_suggestion_point(tab_point, Bias::Left)
+                    .0;
+                let fold_point = self
+                    .tab_snapshot
+                    .suggestion_snapshot
+                    .to_fold_point(suggestion_point);
+                if fold_point.row() == prev_fold_row && display_row != 0 {
                     expected_buffer_rows.push(None);
                 } else {
-                    let fold_point = self.tab_snapshot.to_fold_point(tab_point, Bias::Left).0;
-                    let buffer_point = fold_point.to_buffer_point(&self.tab_snapshot.fold_snapshot);
+                    let buffer_point = fold_point
+                        .to_buffer_point(&self.tab_snapshot.suggestion_snapshot.fold_snapshot);
                     expected_buffer_rows.push(input_buffer_rows[buffer_point.row as usize]);
-                    prev_tab_row = tab_point.row();
+                    prev_fold_row = fold_point.row();
                 }
 
                 assert_eq!(self.line_len(display_row), text.line_len(display_row));
@@ -1026,7 +1034,7 @@ fn consolidate_wrap_edits(edits: &mut Vec<WrapEdit>) {
 mod tests {
     use super::*;
     use crate::{
-        display_map::{fold_map::FoldMap, tab_map::TabMap},
+        display_map::{fold_map::FoldMap, suggestion_map::SuggestionMap, tab_map::TabMap},
         MultiBuffer,
     };
     use gpui::test::observe;
@@ -1076,14 +1084,13 @@ mod tests {
             }
         });
         let mut buffer_snapshot = buffer.read_with(cx, |buffer, cx| buffer.snapshot(cx));
-        let (mut fold_map, folds_snapshot) = FoldMap::new(buffer_snapshot.clone());
-        let (tab_map, tabs_snapshot) = TabMap::new(folds_snapshot.clone(), tab_size);
-        log::info!("Unwrapped text (no folds): {:?}", buffer_snapshot.text());
-        log::info!(
-            "Unwrapped text (unexpanded tabs): {:?}",
-            folds_snapshot.text()
-        );
-        log::info!("Unwrapped text (expanded tabs): {:?}", tabs_snapshot.text());
+        log::info!("Buffer text: {:?}", buffer_snapshot.text());
+        let (mut fold_map, fold_snapshot) = FoldMap::new(buffer_snapshot.clone());
+        log::info!("FoldMap text: {:?}", fold_snapshot.text());
+        let (suggestion_map, suggestion_snapshot) = SuggestionMap::new(fold_snapshot.clone());
+        log::info!("SuggestionMap text: {:?}", suggestion_snapshot.text());
+        let (tab_map, tabs_snapshot) = TabMap::new(suggestion_snapshot.clone(), tab_size);
+        log::info!("TabMap text: {:?}", tabs_snapshot.text());
 
         let mut line_wrapper = LineWrapper::new(font_id, font_size, font_system);
         let unwrapped_text = tabs_snapshot.text();
@@ -1126,15 +1133,28 @@ mod tests {
                     wrap_map.update(cx, |map, cx| map.set_wrap_width(wrap_width, cx));
                 }
                 20..=39 => {
-                    for (folds_snapshot, fold_edits) in fold_map.randomly_mutate(&mut rng) {
+                    for (fold_snapshot, fold_edits) in fold_map.randomly_mutate(&mut rng) {
+                        let (suggestion_snapshot, suggestion_edits) =
+                            suggestion_map.sync(fold_snapshot, fold_edits);
                         let (tabs_snapshot, tab_edits) =
-                            tab_map.sync(folds_snapshot, fold_edits, tab_size);
+                            tab_map.sync(suggestion_snapshot, suggestion_edits, tab_size);
                         let (mut snapshot, wrap_edits) =
                             wrap_map.update(cx, |map, cx| map.sync(tabs_snapshot, tab_edits, cx));
                         snapshot.check_invariants();
                         snapshot.verify_chunks(&mut rng);
                         edits.push((snapshot, wrap_edits));
                     }
+                }
+                40..=59 => {
+                    let (suggestion_snapshot, suggestion_edits) =
+                        suggestion_map.randomly_mutate(&mut rng);
+                    let (tabs_snapshot, tab_edits) =
+                        tab_map.sync(suggestion_snapshot, suggestion_edits, tab_size);
+                    let (mut snapshot, wrap_edits) =
+                        wrap_map.update(cx, |map, cx| map.sync(tabs_snapshot, tab_edits, cx));
+                    snapshot.check_invariants();
+                    snapshot.verify_chunks(&mut rng);
+                    edits.push((snapshot, wrap_edits));
                 }
                 _ => {
                     buffer.update(cx, |buffer, cx| {
@@ -1147,14 +1167,15 @@ mod tests {
                 }
             }
 
-            log::info!("Unwrapped text (no folds): {:?}", buffer_snapshot.text());
-            let (folds_snapshot, fold_edits) = fold_map.read(buffer_snapshot.clone(), buffer_edits);
-            log::info!(
-                "Unwrapped text (unexpanded tabs): {:?}",
-                folds_snapshot.text()
-            );
-            let (tabs_snapshot, tab_edits) = tab_map.sync(folds_snapshot, fold_edits, tab_size);
-            log::info!("Unwrapped text (expanded tabs): {:?}", tabs_snapshot.text());
+            log::info!("Buffer text: {:?}", buffer_snapshot.text());
+            let (fold_snapshot, fold_edits) = fold_map.read(buffer_snapshot.clone(), buffer_edits);
+            log::info!("FoldMap text: {:?}", fold_snapshot.text());
+            let (suggestion_snapshot, suggestion_edits) =
+                suggestion_map.sync(fold_snapshot, fold_edits);
+            log::info!("SuggestionMap text: {:?}", suggestion_snapshot.text());
+            let (tabs_snapshot, tab_edits) =
+                tab_map.sync(suggestion_snapshot, suggestion_edits, tab_size);
+            log::info!("TabMap text: {:?}", tabs_snapshot.text());
 
             let unwrapped_text = tabs_snapshot.text();
             let expected_text = wrap_text(&unwrapped_text, wrap_width, &mut line_wrapper);
@@ -1201,7 +1222,7 @@ mod tests {
                 if tab_size.get() == 1
                     || !wrapped_snapshot
                         .tab_snapshot
-                        .fold_snapshot
+                        .suggestion_snapshot
                         .text()
                         .contains('\t')
                 {

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -69,16 +69,11 @@ pub fn up_by_rows(
         goal_column = 0;
     }
 
-    let clip_bias = if point.column() == map.line_len(point.row()) {
-        Bias::Left
-    } else {
-        Bias::Right
-    };
-
-    (
-        map.clip_point(point, clip_bias),
-        SelectionGoal::Column(goal_column),
-    )
+    let mut clipped_point = map.clip_point(point, Bias::Left);
+    if clipped_point.row() < point.row() {
+        clipped_point = map.clip_point(point, Bias::Right);
+    }
+    (clipped_point, SelectionGoal::Column(goal_column))
 }
 
 pub fn down_by_rows(
@@ -105,16 +100,11 @@ pub fn down_by_rows(
         goal_column = map.column_to_chars(point.row(), point.column())
     }
 
-    let clip_bias = if point.column() == map.line_len(point.row()) {
-        Bias::Left
-    } else {
-        Bias::Right
-    };
-
-    (
-        map.clip_point(point, clip_bias),
-        SelectionGoal::Column(goal_column),
-    )
+    let mut clipped_point = map.clip_point(point, Bias::Right);
+    if clipped_point.row() > point.row() {
+        clipped_point = map.clip_point(point, Bias::Left);
+    }
+    (clipped_point, SelectionGoal::Column(goal_column))
 }
 
 pub fn line_beginning(

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -31,7 +31,7 @@ const CHUNK_BASE: usize = 16;
 /// hash being equivalent to hashing all the text contained in the [Rope] at once.
 pub type RopeFingerprint = HashMatrix;
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 pub struct Rope {
     chunks: SumTree<Chunk>,
 }
@@ -385,6 +385,22 @@ impl fmt::Display for Rope {
         for chunk in self.chunks() {
             write!(f, "{}", chunk)?;
         }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Rope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use std::fmt::Write as _;
+
+        write!(f, "\"")?;
+        let mut format_string = String::new();
+        for chunk in self.chunks() {
+            write!(&mut format_string, "{:?}", chunk)?;
+            write!(f, "{}", &format_string[1..format_string.len() - 1])?;
+            format_string.clear();
+        }
+        write!(f, "\"")?;
         Ok(())
     }
 }


### PR DESCRIPTION
This new API is a step towards Copilot support. It lets us inject arbitrary text into an `Editor` using the following `Suggestion` struct:

```rs
pub struct Suggestion<T: ToPoint> {
    pub position: T,
    pub text: Rope,
    pub highlight_style: HighlightStyle,
}
```

The editor can only hold one suggestion at any given time, which seems like an okay limitation for now given that Copilot can only display one anyway.

![image](https://user-images.githubusercontent.com/482957/226684801-3e1177ac-b6e6-4f58-9b56-970105465546.png)
