### PR TITLE
Remove screen sharing indicator when call ends

### DIFF
--- a/crates/collab_ui/src/sharing_status_indicator.rs
+++ b/crates/collab_ui/src/sharing_status_indicator.rs
@@ -21,6 +21,8 @@ pub fn init(cx: &mut MutableAppContext) {
             } else if let Some((window_id, _)) = status_indicator.take() {
                 cx.remove_status_bar_item(window_id);
             }
+        } else if let Some((window_id, _)) = status_indicator.take() {
+            cx.remove_status_bar_item(window_id);
         }
     })
     .detach();


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-80/when-call-ends-screen-sharing-indicator-persists-and-cant-be-removed

Previously, we would only remove it when the screen sharing stopped.