### PR TITLE
Unify spelling of `key binding` to be two words

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -6834,7 +6834,7 @@ mod tests {
             None
         );
 
-        // Produces a list of actions and keybindings
+        // Produces a list of actions and key bindings
         fn available_actions(
             window_id: usize,
             view_id: usize,

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -150,7 +150,7 @@ mod tests {
 
         // Test loading the keymap base at all
         cx.update(|cx| {
-            assert_keybindings_for(
+            assert_key_bindings_for(
                 cx,
                 vec![("backspace", &A), ("k", &ActivatePreviousPane)],
                 line!(),
@@ -178,7 +178,7 @@ mod tests {
         cx.foreground().run_until_parked();
 
         cx.update(|cx| {
-            assert_keybindings_for(
+            assert_key_bindings_for(
                 cx,
                 vec![("backspace", &B), ("k", &ActivatePreviousPane)],
                 line!(),
@@ -202,7 +202,7 @@ mod tests {
         cx.foreground().run_until_parked();
 
         cx.update(|cx| {
-            assert_keybindings_for(
+            assert_key_bindings_for(
                 cx,
                 vec![("backspace", &B), ("[", &ActivatePrevItem)],
                 line!(),
@@ -210,7 +210,7 @@ mod tests {
         });
     }
 
-    fn assert_keybindings_for<'a>(
+    fn assert_key_bindings_for<'a>(
         cx: &mut MutableAppContext,
         actions: Vec<(&'static str, &'a dyn Action)>,
         line: u32,
@@ -226,7 +226,7 @@ mod tests {
                     && b.iter()
                         .any(|binding| binding.keystrokes().iter().any(|k| k.key == key))
                 }),
-                "On {} Failed to find {} with keybinding {}",
+                "On {} Failed to find {} with key binding {}",
                 line,
                 action.name(),
                 key

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -85,7 +85,7 @@ impl<'a> NeovimBackedTestContext<'a> {
                 let mut marked_text = unmarked_text.clone();
                 marked_text.insert(*cursor_offset, 'ˇ');
 
-                // None represents all keybindings being exempted for that initial state
+                // None represents all key bindings being exempted for that initial state
                 self.exemptions.insert(marked_text, None);
             }
         }


### PR DESCRIPTION
## Description of feature or change

I've updated all docs and the website to use two words for keybinding - just doing the same here

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
