### PR TITLE
Remove another spot with a flag old npm does not like

### DIFF
--- a/crates/zed/src/languages/installation.rs
+++ b/crates/zed/src/languages/installation.rs
@@ -64,7 +64,6 @@ pub async fn npm_install_packages(
     let output = smol::process::Command::new("npm")
         .args(["-fetch-retry-mintimeout", "2000"])
         .args(["-fetch-retry-maxtimeout", "5000"])
-        .args(["-fetch-timeout", "5000"])
         .arg("install")
         .arg("--prefix")
         .arg(directory)


### PR DESCRIPTION
Continues https://github.com/zed-industries/zed/pull/2294, found another location with this flag during my exploration for downloading our own copy of Node
