### PR TITLE
Add "editor: copy highlight json" command

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -39,7 +39,7 @@ use gpui::{
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
     platform::CursorStyle,
-    serde_json::json,
+    serde_json::{self, json},
     AnyViewHandle, AppContext, AsyncAppContext, ClipboardItem, Element, ElementBox, Entity,
     ModelHandle, MouseButton, MutableAppContext, RenderContext, Subscription, Task, View,
     ViewContext, ViewHandle, WeakViewHandle,
@@ -258,7 +258,8 @@ actions!(
         Hover,
         Format,
         ToggleSoftWrap,
-        RevealInFinder
+        RevealInFinder,
+        CopyHighlightJson
     ]
 );
 
@@ -378,6 +379,7 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::jump);
     cx.add_action(Editor::toggle_soft_wrap);
     cx.add_action(Editor::reveal_in_finder);
+    cx.add_action(Editor::copy_highlight_json);
     cx.add_async_action(Editor::format);
     cx.add_action(Editor::restart_language_server);
     cx.add_action(Editor::show_character_palette);
@@ -6332,6 +6334,41 @@ impl Editor {
                 cx.global::<Settings>().telemetry(),
             );
         }
+    }
+
+    /// Copy the highlighted chunks to the clipboard as JSON. The format is an array of lines,
+    /// with each line being an array of {text, highlight} objects.
+    fn copy_highlight_json(&mut self, _: &CopyHighlightJson, cx: &mut ViewContext<Self>) {
+        let Some(buffer) = self.buffer.read(cx).as_singleton() else {
+            return;
+        };
+
+        #[derive(Serialize)]
+        struct Chunk<'a> {
+            text: &'a str,
+            highlight: Option<&'a str>,
+        }
+
+        let snapshot = buffer.read(cx).snapshot();
+        let chunks = snapshot.chunks(0..snapshot.len(), true);
+        let mut lines = Vec::new();
+        let mut line = Vec::new();
+
+        let theme = &cx.global::<Settings>().theme.editor.syntax;
+
+        for chunk in chunks {
+            let highlight = chunk.syntax_highlight_id.and_then(|id| id.name(theme));
+            let mut chunk_lines = chunk.text.split("\n").peekable();
+            while let Some(text) = chunk_lines.next() {
+                line.push(Chunk { text, highlight });
+                if chunk_lines.peek().is_some() {
+                    lines.push(mem::take(&mut line));
+                }
+            }
+        }
+
+        let Some(lines) = serde_json::to_string_pretty(&lines).log_err() else { return; };
+        cx.write_to_clipboard(ClipboardItem::new(lines));
     }
 }
 

--- a/crates/language/src/highlight_map.rs
+++ b/crates/language/src/highlight_map.rs
@@ -59,7 +59,6 @@ impl HighlightId {
         theme.highlights.get(self.0 as usize).map(|entry| entry.1)
     }
 
-    #[cfg(any(test, feature = "test-support"))]
     pub fn name<'a>(&self, theme: &'a SyntaxTheme) -> Option<&'a str> {
         theme.highlights.get(self.0 as usize).map(|e| e.0.as_str())
     }


### PR DESCRIPTION
@iamnbutler needs this to render highlighted code in Figma.

When you run `editor: copy highlight json` in the command palette with an editor open, we put JSON with the following format on your clipboard...

The top level is an array of lines. Each line is an array of `{text: string, highlight: string | null}`.

```json
[
  [
    {
      "text": "// Allow binary to be called Zed for a nice application menu when running executable direcly",
      "highlight": "comment"
    },
    {
      "text": "",
      "highlight": null
    }
  ],
  [
    {
      "text": "#!",
      "highlight": null
    },
    {
      "text": "[",
      "highlight": "punctuation.bracket"
    },
    {
      "text": "allow",
      "highlight": null
    },
    {
      "text": "(",
      "highlight": "punctuation.bracket"
    },
    {
      "text": "non_snake_case",
      "highlight": null
    },
    {
      "text": ")]",
      "highlight": "punctuation.bracket"
    },
    {
      "text": "",
      "highlight": null
    }
  ],
  [
    {
      "text": "",
      "highlight": null
    }
  ]
]
```