### PR TITLE
Make "Restart to update Zed" look clickable

### DIFF
--- a/styles/src/styleTree/components.ts
+++ b/styles/src/styleTree/components.ts
@@ -97,79 +97,79 @@ export interface TextProperties {
     size?: keyof typeof fontSizes
     weight?: FontWeight
     underline?: boolean
-    color?: string,
-    features?: FontFeatures,
+    color?: string
+    features?: FontFeatures
 }
 
 interface FontFeatures {
     /** Contextual Alternates: Applies a second substitution feature based on a match of a character pattern within a context of surrounding patterns */
-    calt?: boolean;
+    calt?: boolean
     /** Case-Sensitive Forms: Shifts various punctuation marks up to a position that works better with all-capital sequences */
-    case?: boolean;
+    case?: boolean
     /** Capital Spacing: Adjusts inter-glyph spacing for all-capital text */
-    cpsp?: boolean;
+    cpsp?: boolean
     /** Fractions: Replaces figures separated by a slash with diagonal fractions */
-    frac?: boolean;
+    frac?: boolean
     /** Standard Ligatures: Replaces a sequence of glyphs with a single glyph which is preferred for typographic purposes */
-    liga?: boolean;
+    liga?: boolean
     /** Oldstyle Figures: Changes selected figures from the default or lining style to oldstyle form. */
-    onum?: boolean;
+    onum?: boolean
     /** Ordinals: Replaces default alphabetic glyphs with the corresponding ordinal forms for use after figures */
-    ordn?: boolean;
+    ordn?: boolean
     /** Proportional Figures: Replaces figure glyphs set on uniform (tabular) widths with corresponding glyphs set on proportional widths */
-    pnum?: boolean;
+    pnum?: boolean
     /** Stylistic set 01 */
-    ss01?: boolean;
+    ss01?: boolean
     /** Stylistic set 02 */
-    ss02?: boolean;
+    ss02?: boolean
     /** Stylistic set 03 */
-    ss03?: boolean;
+    ss03?: boolean
     /** Stylistic set 04 */
-    ss04?: boolean;
+    ss04?: boolean
     /** Stylistic set 05 */
-    ss05?: boolean;
+    ss05?: boolean
     /** Stylistic set 06 */
-    ss06?: boolean;
+    ss06?: boolean
     /** Stylistic set 07 */
-    ss07?: boolean;
+    ss07?: boolean
     /** Stylistic set 08 */
-    ss08?: boolean;
+    ss08?: boolean
     /** Stylistic set 09 */
-    ss09?: boolean;
+    ss09?: boolean
     /** Stylistic set 10 */
-    ss10?: boolean;
+    ss10?: boolean
     /** Stylistic set 11 */
-    ss11?: boolean;
+    ss11?: boolean
     /** Stylistic set 12 */
-    ss12?: boolean;
+    ss12?: boolean
     /** Stylistic set 13 */
-    ss13?: boolean;
+    ss13?: boolean
     /** Stylistic set 14 */
-    ss14?: boolean;
+    ss14?: boolean
     /** Stylistic set 15 */
-    ss15?: boolean;
+    ss15?: boolean
     /** Stylistic set 16 */
-    ss16?: boolean;
+    ss16?: boolean
     /** Stylistic set 17 */
-    ss17?: boolean;
+    ss17?: boolean
     /** Stylistic set 18 */
-    ss18?: boolean;
+    ss18?: boolean
     /** Stylistic set 19 */
-    ss19?: boolean;
+    ss19?: boolean
     /** Stylistic set 20 */
-    ss20?: boolean;
+    ss20?: boolean
     /** Subscript: Replaces default glyphs with subscript glyphs */
-    subs?: boolean;
+    subs?: boolean
     /** Superscript: Replaces default glyphs with superscript glyphs */
-    sups?: boolean;
+    sups?: boolean
     /** Swash: Replaces default glyphs with swash glyphs for stylistic purposes */
-    swsh?: boolean;
+    swsh?: boolean
     /** Titling: Replaces default glyphs with titling glyphs for use in large-size settings */
-    titl?: boolean;
+    titl?: boolean
     /** Tabular Figures: Replaces figure glyphs set on proportional widths with corresponding glyphs set on uniform (tabular) widths */
-    tnum?: boolean;
+    tnum?: boolean
     /** Slashed Zero: Replaces default zero with a slashed zero for better distinction between "0" and "O" */
-    zero?: boolean;
+    zero?: boolean
 }
 
 export function text(

--- a/styles/src/styleTree/statusBar.ts
+++ b/styles/src/styleTree/statusBar.ts
@@ -44,7 +44,7 @@ export default function statusBar(colorScheme: ColorScheme) {
             hover: {
                 message: text(layer, "sans"),
                 iconColor: foreground(layer),
-                background: background(layer),
+                background: background(layer, "hovered"),
             },
         },
         diagnosticMessage: {

--- a/styles/src/styleTree/workspace.ts
+++ b/styles/src/styleTree/workspace.ts
@@ -175,7 +175,7 @@ export default function workspace(colorScheme: ColorScheme) {
             // FlatButton, Variant
             signInPrompt: {
                 margin: {
-                    left: itemSpacing
+                    left: itemSpacing,
                 },
                 ...titlebarButton,
             },


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-349/make-restart-to-update-zed-look-clickable

This is how it looks:

![hover-style](https://user-images.githubusercontent.com/28818/227930097-6a5c78e9-1422-48d8-baa4-4dbb2173b007.gif)
