### PR TITLE
Avoid slowdowns with long lines by skipping tab expansion beyond a certain column

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -648,7 +648,7 @@ impl DisplaySnapshot {
                     false
                 }
             }),
-            buffer.line_len(buffer_row) as usize, // Never collapse
+            buffer.line_len(buffer_row), // Never collapse
         );
 
         (indent_size as u32, is_blank)

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -19,7 +19,7 @@ use std::{any::TypeId, fmt::Debug, num::NonZeroU32, ops::Range, sync::Arc};
 pub use suggestion_map::Suggestion;
 use suggestion_map::SuggestionMap;
 use sum_tree::{Bias, TreeMap};
-use tab_map::{TabMap, TabSnapshot};
+use tab_map::TabMap;
 use wrap_map::WrapMap;
 
 pub use block_map::{
@@ -637,7 +637,7 @@ impl DisplaySnapshot {
         let chars = buffer.chars_at(Point::new(range.start.row, 0));
 
         let mut is_blank = false;
-        let indent_size = TabSnapshot::expand_tabs(
+        let indent_size = self.tab_snapshot.expand_tabs(
             chars.take_while(|c| {
                 if *c == ' ' || *c == '\t' {
                     true
@@ -649,7 +649,6 @@ impl DisplaySnapshot {
                 }
             }),
             buffer.line_len(buffer_row) as usize, // Never collapse
-            self.tab_snapshot.tab_size,
         );
 
         (indent_size as u32, is_blank)

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -634,24 +634,21 @@ impl DisplaySnapshot {
             .buffer_snapshot
             .buffer_line_for_row(buffer_row)
             .unwrap();
-        let chars = buffer.chars_at(Point::new(range.start.row, 0));
 
+        let mut indent_size = 0;
         let mut is_blank = false;
-        let indent_size = self.tab_snapshot.expand_tabs(
-            chars.take_while(|c| {
-                if *c == ' ' || *c == '\t' {
-                    true
-                } else {
-                    if *c == '\n' {
-                        is_blank = true;
-                    }
-                    false
+        for c in buffer.chars_at(Point::new(range.start.row, 0)) {
+            if c == ' ' || c == '\t' {
+                indent_size += 1;
+            } else {
+                if c == '\n' {
+                    is_blank = true;
                 }
-            }),
-            buffer.line_len(buffer_row), // Never collapse
-        );
+                break;
+            }
+        }
 
-        (indent_size as u32, is_blank)
+        (indent_size, is_blank)
     }
 
     pub fn line_len(&self, row: u32) -> u32 {

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -227,7 +227,7 @@ impl TabSnapshot {
                 text: &SPACES[0..(to_next_stop as usize)],
                 ..Default::default()
             },
-            skip_leading_tab: to_next_stop > 0,
+            inside_leading_tab: to_next_stop > 0,
         }
     }
 
@@ -454,7 +454,7 @@ pub struct TabChunks<'a> {
     input_column: u32,
     max_output_position: Point,
     tab_size: NonZeroU32,
-    skip_leading_tab: bool,
+    inside_leading_tab: bool,
 }
 
 impl<'a> Iterator for TabChunks<'a> {
@@ -464,9 +464,9 @@ impl<'a> Iterator for TabChunks<'a> {
         if self.chunk.text.is_empty() {
             if let Some(chunk) = self.suggestion_chunks.next() {
                 self.chunk = chunk;
-                if self.skip_leading_tab {
+                if self.inside_leading_tab {
                     self.chunk.text = &self.chunk.text[1..];
-                    self.skip_leading_tab = false;
+                    self.inside_leading_tab = false;
                     self.input_column += 1;
                 }
             } else {
@@ -513,7 +513,7 @@ impl<'a> Iterator for TabChunks<'a> {
                 }
                 _ => {
                     self.column += 1;
-                    if !self.skip_leading_tab {
+                    if !self.inside_leading_tab {
                         self.input_column += c.len_utf8() as u32;
                     }
                     self.output_position.column += c.len_utf8() as u32;

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -290,7 +290,7 @@ impl TabSnapshot {
         fold_point.to_buffer_point(&self.suggestion_snapshot.fold_snapshot)
     }
 
-    pub fn expand_tabs(&self, chars: impl Iterator<Item = char>, column: u32) -> u32 {
+    fn expand_tabs(&self, chars: impl Iterator<Item = char>, column: u32) -> u32 {
         let tab_size = self.tab_size.get();
 
         let mut expanded_chars = 0;

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -1089,7 +1089,8 @@ mod tests {
         log::info!("FoldMap text: {:?}", fold_snapshot.text());
         let (suggestion_map, suggestion_snapshot) = SuggestionMap::new(fold_snapshot.clone());
         log::info!("SuggestionMap text: {:?}", suggestion_snapshot.text());
-        let (tab_map, tabs_snapshot) = TabMap::new(suggestion_snapshot.clone(), tab_size);
+        let (tab_map, _) = TabMap::new(suggestion_snapshot.clone(), tab_size);
+        let tabs_snapshot = tab_map.set_max_expansion_column(32);
         log::info!("TabMap text: {:?}", tabs_snapshot.text());
 
         let mut line_wrapper = LineWrapper::new(font_id, font_size, font_system);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -630,7 +630,7 @@ fn test_cancel(cx: &mut gpui::MutableAppContext) {
 }
 
 #[gpui::test]
-fn test_fold(cx: &mut gpui::MutableAppContext) {
+fn test_fold_action(cx: &mut gpui::MutableAppContext) {
     cx.set_global(Settings::test(cx));
     let buffer = MultiBuffer::build_simple(
         &"


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-398/long-lines-cause-hangs

In the editor, when we translate between display and buffer coordinates, one of the steps is expanding tabs to the appropriate number of spaces (such that the next character appears at a multiple of the tab size). This requires iterating through every character in the given line, up to the given column, in order to locate all of the tabs and their columns. Right now, this causes Zed to become unresponsive when there are very long lines.

In this PR, we limit the tab expansion so that it only happens in the first N bytes of each line (currently 256). Beyond that column, tabs are simply treated as a single space. The idea behind this is that, when a line is that long, it's unlikely that the exact presentation of the tabs matters very much.

### Todo

* [x] Randomized wrap map test failure when we crank the iterations up:
    ```
    SEED=984 cargo test -p editor random_wraps -- --nocapture
    ```