### PR TITLE
Allow each language adapter to provide their own code action kinds array

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -20,6 +20,7 @@ use futures::{
 use gpui::{executor::Background, MutableAppContext, Task};
 use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
+use lsp::CodeActionKind;
 use parking_lot::{Mutex, RwLock};
 use postage::watch;
 use regex::Regex;
@@ -140,6 +141,10 @@ impl CachedLspAdapter {
         self.adapter.cached_server_binary(container_dir).await
     }
 
+    pub fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
+        self.adapter.code_action_kinds()
+    }
+
     pub fn workspace_configuration(
         &self,
         cx: &mut MutableAppContext,
@@ -223,6 +228,16 @@ pub trait LspAdapter: 'static + Send + Sync {
         _: &mut MutableAppContext,
     ) -> Option<BoxFuture<'static, Value>> {
         None
+    }
+
+    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
+        Some(vec![
+            CodeActionKind::EMPTY,
+            CodeActionKind::QUICKFIX,
+            CodeActionKind::REFACTOR,
+            CodeActionKind::REFACTOR_EXTRACT,
+            CodeActionKind::SOURCE,
+        ])
     }
 
     async fn disk_based_diagnostic_sources(&self) -> Vec<String> {
@@ -825,6 +840,7 @@ impl LanguageRegistry {
                 &binary.path,
                 &binary.arguments,
                 &root_path,
+                adapter.code_action_kinds(),
                 cx,
             )?;
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3773,7 +3773,7 @@ impl Project {
             worktree = file.worktree.clone();
             buffer_abs_path = file.as_local().map(|f| f.abs_path(cx));
         } else {
-            return Task::ready(Ok(Default::default()));
+            return Task::ready(Ok(Vec::new()));
         };
         let range = buffer.anchor_before(range.start)..buffer.anchor_before(range.end);
 
@@ -3783,13 +3783,13 @@ impl Project {
             {
                 server.clone()
             } else {
-                return Task::ready(Ok(Default::default()));
+                return Task::ready(Ok(Vec::new()));
             };
 
             let lsp_range = range_to_lsp(range.to_point_utf16(buffer));
             cx.foreground().spawn(async move {
                 if lang_server.capabilities().code_action_provider.is_none() {
-                    return Ok(Default::default());
+                    return Ok(Vec::new());
                 }
 
                 Ok(lang_server
@@ -3802,13 +3802,7 @@ impl Project {
                         partial_result_params: Default::default(),
                         context: lsp::CodeActionContext {
                             diagnostics: relevant_diagnostics,
-                            only: Some(vec![
-                                lsp::CodeActionKind::EMPTY,
-                                lsp::CodeActionKind::QUICKFIX,
-                                lsp::CodeActionKind::REFACTOR,
-                                lsp::CodeActionKind::REFACTOR_EXTRACT,
-                                lsp::CodeActionKind::SOURCE,
-                            ]),
+                            only: lang_server.code_action_kinds(),
                         },
                     })
                     .await?

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use client::http::HttpClient;
 use futures::StreamExt;
 use language::{LanguageServerBinary, LanguageServerName, LspAdapter};
+use lsp::CodeActionKind;
 use serde_json::json;
 use smol::fs;
 use std::{
@@ -140,6 +141,15 @@ impl LspAdapter for TypeScriptLspAdapter {
         })()
         .await
         .log_err()
+    }
+
+    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
+        Some(vec![
+            CodeActionKind::QUICKFIX,
+            CodeActionKind::REFACTOR,
+            CodeActionKind::REFACTOR_EXTRACT,
+            CodeActionKind::SOURCE,
+        ])
     }
 
     async fn label_for_completion(


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-392/code-actions-in-ts-files-are-duplicated

It's always a `tsserver` bug 😭

The combination of `Empty` and `Source` code action kinds being enabled caused tsserver to report duplicates of source-wide actions. As this is the third time I've had to chase down some weird behavior caused by different servers reacting to these differently I've added the ability for each adapter to specify what set of action kinds they want reported to its server.

See https://github.com/zed-industries/zed/pull/1865 and the ironically named follow up https://github.com/zed-industries/zed/pull/1875 for history