### PR TITLE
Add handlers for LogMessage and statusNotification to copilot LSP

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -11,7 +11,7 @@ use gpui::{
     Task,
 };
 use language::{point_from_lsp, point_to_lsp, Anchor, Bias, Buffer, BufferSnapshot, ToPointUtf16};
-use log::{debug, error, info, warn};
+use log::{debug, error};
 use lsp::LanguageServer;
 use node_runtime::NodeRuntime;
 use request::{LogMessage, StatusNotification};

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -11,8 +11,10 @@ use gpui::{
     Task,
 };
 use language::{point_from_lsp, point_to_lsp, Anchor, Bias, Buffer, BufferSnapshot, ToPointUtf16};
+use log::{debug, error, info, warn};
 use lsp::LanguageServer;
 use node_runtime::NodeRuntime;
+use request::{LogMessage, StatusNotification};
 use settings::Settings;
 use smol::{fs, io::BufReader, stream::StreamExt};
 use std::{
@@ -241,6 +243,27 @@ impl Copilot {
                         local_checks_only: false,
                     })
                     .await?;
+
+                server
+                    .on_notification::<LogMessage, _>(|params, _cx| {
+                        match params.level {
+                            // Copilot is pretty agressive about logging
+                            0 => debug!("copilot: {}", params.message),
+                            1 => debug!("copilot: {}", params.message),
+                            _ => error!("copilot: {}", params.message),
+                        }
+
+                        debug!("copilot metadata: {}", params.metadata_str);
+                        debug!("copilot extra: {:?}", params.extra);
+                    })
+                    .detach();
+
+                server
+                    .on_notification::<StatusNotification, _>(
+                        |_, _| { /* Silence the notification */ },
+                    )
+                    .detach();
+
                 anyhow::Ok((server, status))
             };
 

--- a/crates/copilot/src/request.rs
+++ b/crates/copilot/src/request.rs
@@ -140,3 +140,32 @@ impl lsp::request::Request for GetCompletionsCycling {
     type Result = GetCompletionsResult;
     const METHOD: &'static str = "getCompletionsCycling";
 }
+
+pub enum LogMessage {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogMessageParams {
+    pub message: String,
+    pub level: u8,
+    pub metadata_str: String,
+    pub extra: Vec<String>,
+}
+
+impl lsp::notification::Notification for LogMessage {
+    type Params = LogMessageParams;
+    const METHOD: &'static str = "LogMessage";
+}
+
+pub enum StatusNotification {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatusNotificationParams {
+    pub message: String,
+    pub status: String, // One of Normal/InProgress
+}
+
+impl lsp::notification::Notification for StatusNotification {
+    type Params = StatusNotificationParams;
+    const METHOD: &'static str = "statusNotification";
+}

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -475,7 +475,7 @@ impl LanguageServer {
         let prev_handler = self.notification_handlers.lock().insert(
             method,
             Box::new(move |_, params, cx| {
-                if let Some(params) = serde_json::from_str(params).log_err() {
+                if let Some(params) = serde_json::from_str(dbg!(params)).log_err() {
                     f(params, cx);
                 }
             }),

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -475,7 +475,7 @@ impl LanguageServer {
         let prev_handler = self.notification_handlers.lock().insert(
             method,
             Box::new(move |_, params, cx| {
-                if let Some(params) = serde_json::from_str(dbg!(params)).log_err() {
+                if let Some(params) = serde_json::from_str(params).log_err() {
                     f(params, cx);
                 }
             }),


### PR DESCRIPTION
## Description of feature or change

We didn't handle a couple notifications from LSP that where filling up the zed log. This fixes those

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
