### PR TITLE
Disable key ordering diagnostic for YAML

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -335,6 +335,7 @@ impl LanguageServer {
                     did_change_configuration: Some(DynamicRegistrationClientCapabilities {
                         dynamic_registration: Some(true),
                     }),
+                    workspace_folders: Some(true),
                     ..Default::default()
                 }),
                 text_document: Some(TextDocumentClientCapabilities {

--- a/crates/zed/src/languages/yaml.rs
+++ b/crates/zed/src/languages/yaml.rs
@@ -106,6 +106,9 @@ impl LspAdapter for YamlLspAdapter {
         let settings = cx.global::<Settings>();
         Some(
             future::ready(serde_json::json!({
+                "yaml": {
+                    "keyOrdering": false
+                },
                 "[yaml]": {
                     "editor.tabSize": settings.tab_size(Some("YAML"))
                 }


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-427/remove-key-ordering-from-yaml

As mentioned in 2c0a645f193fdc2eebf9e76d9d03113c72f5a865, we should cherry-pick this pull request to prevent the YAML language server from not responding. In https://github.com/zed-industries/zed/pull/2258 we started passing the `did_change_watched_files`, which caused the server to throw an error because we were not also passing the `workspace_folders` capability.

/cc: @maxbrunsfeld 