### PR TITLE
Fix embedded highlight in ruby

### DIFF
--- a/crates/zed/src/languages/ruby/highlights.scm
+++ b/crates/zed/src/languages/ruby/highlights.scm
@@ -109,10 +109,6 @@
   (false)
 ] @constant.builtin
 
-(interpolation
-  "#{" @punctuation.special
-  "}" @punctuation.special) @embedded
-
 (comment) @comment
 
 ; Operators
@@ -179,3 +175,7 @@
   "%w("
   "%i("
 ] @punctuation.bracket
+
+(interpolation
+  "#{" @punctuation.special
+  "}" @punctuation.special) @embedded


### PR DESCRIPTION
## Description of feature or change

Just reordering the highlight properties.

before:

![image](https://user-images.githubusercontent.com/1714999/229860008-c083bad3-b1b8-43ca-90e2-d4c2f9ea6298.png)

after:

![image](https://user-images.githubusercontent.com/1714999/229860051-4d0ee368-f319-44a4-ad2e-535be6ba4858.png)

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
