### PR TITLE
Prioritize displaying right statusbar items overtop left items if needed

### DIFF
--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -227,6 +227,7 @@ pub enum Lifecycle<T: Element> {
         paint: T::PaintState,
     },
 }
+
 pub struct ElementBox(ElementRc);
 
 #[derive(Clone)]


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-458/long-errors-should-truncate-should-not-extend-the-width-of-the-status

![CleanShot 2023-04-05 at 12 10 29](https://user-images.githubusercontent.com/30666851/230140317-e4d58889-5468-47fe-af2a-5f515df23d1b.png)
