### PR TITLE
Update copy path commands

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -477,6 +477,7 @@
             "cmd-c": "project_panel::Copy",
             "cmd-v": "project_panel::Paste",
             "cmd-alt-c": "project_panel::CopyPath",
+            "alt-cmd-shift-c": "project_panel::CopyRelativePath",
             "f2": "project_panel::Rename",
             "backspace": "project_panel::Delete",
             "alt-cmd-r": "project_panel::RevealInFinder"

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -261,6 +261,8 @@ actions!(
         Format,
         ToggleSoftWrap,
         RevealInFinder,
+        CopyPath,
+        CopyRelativePath,
         CopyHighlightJson
     ]
 );
@@ -381,6 +383,8 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_action(Editor::jump);
     cx.add_action(Editor::toggle_soft_wrap);
     cx.add_action(Editor::reveal_in_finder);
+    cx.add_action(Editor::copy_path);
+    cx.add_action(Editor::copy_relative_path);
     cx.add_action(Editor::copy_highlight_json);
     cx.add_async_action(Editor::format);
     cx.add_action(Editor::restart_language_server);
@@ -6248,6 +6252,26 @@ impl Editor {
         if let Some(buffer) = self.buffer().read(cx).as_singleton() {
             if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
                 cx.reveal_path(&file.abs_path(cx));
+            }
+        }
+    }
+
+    pub fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {
+        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
+            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
+                if let Some(path) = file.abs_path(cx).to_str() {
+                    cx.write_to_clipboard(ClipboardItem::new(path.to_string()));
+                }
+            }
+        }
+    }
+
+    pub fn copy_relative_path(&mut self, _: &CopyRelativePath, cx: &mut ViewContext<Self>) {
+        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
+            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
+                if let Some(path) = file.path().to_str() {
+                    cx.write_to_clipboard(ClipboardItem::new(path.to_string()));
+                }
             }
         }
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -24,7 +24,7 @@ use std::{
     collections::{hash_map, HashMap},
     ffi::OsStr,
     ops::Range,
-    path::{Path, PathBuf},
+    path::Path,
     sync::Arc,
 };
 use theme::ProjectPanelEntry;
@@ -119,6 +119,7 @@ actions!(
         NewFile,
         Copy,
         CopyPath,
+        CopyRelativePath,
         RevealInFinder,
         Cut,
         Paste,
@@ -146,10 +147,11 @@ pub fn init(cx: &mut MutableAppContext) {
     cx.add_async_action(ProjectPanel::delete);
     cx.add_async_action(ProjectPanel::confirm);
     cx.add_action(ProjectPanel::cancel);
+    cx.add_action(ProjectPanel::cut);
     cx.add_action(ProjectPanel::copy);
     cx.add_action(ProjectPanel::copy_path);
+    cx.add_action(ProjectPanel::copy_relative_path);
     cx.add_action(ProjectPanel::reveal_in_finder);
-    cx.add_action(ProjectPanel::cut);
     cx.add_action(
         |this: &mut ProjectPanel, action: &Paste, cx: &mut ViewContext<ProjectPanel>| {
             this.paste(action, cx);
@@ -307,11 +309,16 @@ impl ProjectPanel {
             }
             menu_entries.push(ContextMenuItem::item("New File", NewFile));
             menu_entries.push(ContextMenuItem::item("New Folder", NewDirectory));
-            menu_entries.push(ContextMenuItem::item("Reveal in Finder", RevealInFinder));
             menu_entries.push(ContextMenuItem::Separator);
-            menu_entries.push(ContextMenuItem::item("Copy", Copy));
-            menu_entries.push(ContextMenuItem::item("Copy Path", CopyPath));
             menu_entries.push(ContextMenuItem::item("Cut", Cut));
+            menu_entries.push(ContextMenuItem::item("Copy", Copy));
+            menu_entries.push(ContextMenuItem::Separator);
+            menu_entries.push(ContextMenuItem::item("Copy Path", CopyPath));
+            menu_entries.push(ContextMenuItem::item(
+                "Copy Relative Path",
+                CopyRelativePath,
+            ));
+            menu_entries.push(ContextMenuItem::item("Reveal in Finder", RevealInFinder));
             if let Some(clipboard_entry) = self.clipboard_entry {
                 if clipboard_entry.worktree_id() == worktree.id() {
                     menu_entries.push(ContextMenuItem::item("Paste", Paste));
@@ -785,10 +792,19 @@ impl ProjectPanel {
 
     fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {
         if let Some((worktree, entry)) = self.selected_entry(cx) {
-            let mut path = PathBuf::new();
-            path.push(worktree.root_name());
-            path.push(&entry.path);
-            cx.write_to_clipboard(ClipboardItem::new(path.to_string_lossy().to_string()));
+            cx.write_to_clipboard(ClipboardItem::new(
+                worktree
+                    .abs_path()
+                    .join(&entry.path)
+                    .to_string_lossy()
+                    .to_string(),
+            ));
+        }
+    }
+
+    fn copy_relative_path(&mut self, _: &CopyRelativePath, cx: &mut ViewContext<Self>) {
+        if let Some((_, entry)) = self.selected_entry(cx) {
+            cx.write_to_clipboard(ClipboardItem::new(entry.path.to_string_lossy().to_string()));
         }
     }
 


### PR DESCRIPTION
## Description of feature or change

Fixes: https://github.com/zed-industries/zed/issues/6087
Fixes: https://github.com/zed-industries/zed/issues/6094

In both VS Code and Atom, if you use the command to copy the relative path to `editor.rs` in the Zed project, you get:

`crates/editor/src/editor.rs`

In Zed, if you use `Copy Path` in the project panel, you get

`zed/crates/editor/src/editor.rs`

We should not include the project root.  Instead, we should have two commands in the project panel

`Copy Path` and `Copy Relative Path`:

<img width="382" alt="SCR-20230407-dcvu" src="https://user-images.githubusercontent.com/19867440/230555058-9ad806c4-876a-4b2e-b95e-f54aea1c2047.png">

This matches VS Code:

<img width="397" alt="SCR-20230407-dbtj" src="https://user-images.githubusercontent.com/19867440/230554626-d5f980b5-d25f-43e4-a0b3-aea76ce0b57c.png">

Atom also has both of these (with different names)

After this PR, using the following project panel action results in:

`Copy Path`: `/Users/josephlyons/Work/zed/crates/editor/src/editor.rs`
`Copy Relative Path`: `crates/editor/src/editor.rs`

This PR also adds the same actions to the command palette when the editor is in focus:

<img width="582" alt="SCR-20230407-ddhc" src="https://user-images.githubusercontent.com/19867440/230555236-3242ef24-8a89-442d-9521-d34374ad5edd.png">

https://user-images.githubusercontent.com/19867440/230555732-919cdb84-d6c9-4703-bb3f-bdc55174c945.mov

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
