### PR TITLE
Put backtrace on a new line when reporting panics

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -336,7 +336,7 @@ fn init_panic_hook(app_version: String) {
         let message = match info.location() {
             Some(location) => {
                 format!(
-                    "thread '{}' panicked at '{}': {}:{}{:?}",
+                    "thread '{}' panicked at '{}': {}:{}\n{:?}",
                     thread,
                     payload,
                     location.file(),
@@ -345,7 +345,7 @@ fn init_panic_hook(app_version: String) {
                 )
             }
             None => format!(
-                "thread '{}' panicked at '{}'{:?}",
+                "thread '{}' panicked at '{}'\n{:?}",
                 thread, payload, backtrace
             ),
         };


### PR DESCRIPTION
## Description of feature or change

@maxbrunsfeld @nathansobo - would making this change disturb anything we have set up in datadog?  I'm wanting to make this simple change so I can easily identify the beginning of the backtrace by seeking for the first newline, rather than having to regex and search in a string.  To make it more clear, this is the result of grabbing the first line of each panic blob sent to our server:

```
thread 'PTY reader' panicked at 'index out of bounds: the len is 1 but the index is 1': /Users/administrator/.cargo/git/checkouts/alacritty-afea874b09a502a5/a51dbe2/alacritty_terminal/src/grid/mod.rs:429 0: backtrace::capture::Backtrace::new
```

You can see that the backtrace starts here

```
0: backtrace::capture::Backtrace::new
```

I could regex search for this, but I think it makes more sense to change it at the source, and it makes things more readable IMO.  Once this change is in place, I can use the backtrace only text when searching for duplicates in linear.  This won't take care of all duplicate, but the variable substitution we do before that causes a good chunk of duplicates, for instance:

<img width="972" alt="SCR-20230407-fbrh" src="https://user-images.githubusercontent.com/19867440/230578258-ac74888e-9734-450d-8cb4-c2abe9a6f75d.png">

If we can't change it at the source, I'll use this to pull it out:

<img width="1093" alt="SCR-20230407-fevo" src="https://user-images.githubusercontent.com/19867440/230579884-365baca1-50d1-4370-95a8-114e742190a9.png">

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
