### PR TITLE
Don't export platform::* from gpui

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -2,8 +2,10 @@ use auto_update::{AutoUpdateStatus, AutoUpdater, DismissErrorMessage};
 use editor::Editor;
 use futures::StreamExt;
 use gpui::{
-    actions, elements::*, platform::CursorStyle, Action, AppContext, Entity, ModelHandle,
-    MouseButton, RenderContext, View, ViewContext, ViewHandle,
+    actions,
+    elements::*,
+    platform::{CursorStyle, MouseButton},
+    Action, AppContext, Entity, ModelHandle, RenderContext, View, ViewContext, ViewHandle,
 };
 use language::{LanguageRegistry, LanguageServerBinaryStatus};
 use project::{LanguageServerProgress, Project};

--- a/crates/auto_update/src/update_notification.rs
+++ b/crates/auto_update/src/update_notification.rs
@@ -1,8 +1,8 @@
 use crate::ViewReleaseNotes;
 use gpui::{
     elements::{Flex, MouseEventHandler, Padding, ParentElement, Svg, Text},
-    platform::{AppVersion, CursorStyle},
-    Element, Entity, MouseButton, View, ViewContext,
+    platform::{AppVersion, CursorStyle, MouseButton},
+    Element, Entity, View, ViewContext,
 };
 use menu::Cancel;
 use settings::Settings;

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    elements::*, AppContext, Entity, MouseButton, RenderContext, Subscription, View, ViewContext,
-    ViewHandle,
+    elements::*, platform::MouseButton, AppContext, Entity, RenderContext, Subscription, View,
+    ViewContext, ViewHandle,
 };
 use itertools::Itertools;
 use search::ProjectSearchView;

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -13,8 +13,9 @@ use async_tungstenite::tungstenite::{
 use futures::{future::LocalBoxFuture, AsyncReadExt, FutureExt, SinkExt, StreamExt, TryStreamExt};
 use gpui::{
     actions,
+    platform::AppVersion,
     serde_json::{self, Value},
-    AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle, AppContext, AppVersion,
+    AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle, AppContext,
     AsyncAppContext, Entity, ModelHandle, Task, View, ViewContext, ViewHandle,
 };
 use lazy_static::lazy_static;

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -15,8 +15,9 @@ use gpui::{
     geometry::{rect::RectF, vector::vec2f, PathBuilder},
     impl_internal_actions,
     json::{self, ToJson},
-    AppContext, CursorStyle, Entity, ImageData, ModelHandle, MouseButton, RenderContext,
-    Subscription, View, ViewContext, ViewHandle, WeakViewHandle,
+    platform::{CursorStyle, MouseButton},
+    AppContext, Entity, ImageData, ModelHandle, RenderContext, Subscription, View, ViewContext,
+    ViewHandle, WeakViewHandle,
 };
 use settings::Settings;
 use std::{ops::Range, sync::Arc};

--- a/crates/collab_ui/src/collaborator_list_popover.rs
+++ b/crates/collab_ui/src/collaborator_list_popover.rs
@@ -2,7 +2,8 @@ use call::ActiveCall;
 use client::UserStore;
 use gpui::Action;
 use gpui::{
-    actions, elements::*, Entity, ModelHandle, MouseButton, RenderContext, View, ViewContext,
+    actions, elements::*, platform::MouseButton, Entity, ModelHandle, RenderContext, View,
+    ViewContext,
 };
 use settings::Settings;
 

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -10,8 +10,8 @@ use gpui::{
     geometry::{rect::RectF, vector::vec2f},
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
-    AppContext, CursorStyle, Entity, ModelHandle, MouseButton, PromptLevel, RenderContext,
-    Subscription, View, ViewContext, ViewHandle,
+    platform::{CursorStyle, MouseButton, PromptLevel},
+    AppContext, Entity, ModelHandle, RenderContext, Subscription, View, ViewContext, ViewHandle,
 };
 use menu::{Confirm, SelectNext, SelectPrev};
 use project::Project;

--- a/crates/collab_ui/src/contacts_popover.rs
+++ b/crates/collab_ui/src/contacts_popover.rs
@@ -1,8 +1,8 @@
 use crate::{contact_finder::ContactFinder, contact_list::ContactList, ToggleContactsMenu};
 use client::UserStore;
 use gpui::{
-    actions, elements::*, AppContext, Entity, ModelHandle, MouseButton, RenderContext, View,
-    ViewContext, ViewHandle,
+    actions, elements::*, platform::MouseButton, AppContext, Entity, ModelHandle, RenderContext,
+    View, ViewContext, ViewHandle,
 };
 use project::Project;
 use settings::Settings;

--- a/crates/collab_ui/src/incoming_call_notification.rs
+++ b/crates/collab_ui/src/incoming_call_notification.rs
@@ -4,8 +4,9 @@ use futures::StreamExt;
 use gpui::{
     elements::*,
     geometry::{rect::RectF, vector::vec2f},
-    impl_internal_actions, AppContext, CursorStyle, Entity, MouseButton, RenderContext, View,
-    ViewContext, WindowBounds, WindowKind, WindowOptions,
+    impl_internal_actions,
+    platform::{CursorStyle, MouseButton, WindowBounds, WindowKind, WindowOptions},
+    AppContext, Entity, RenderContext, View, ViewContext,
 };
 use settings::Settings;
 use util::ResultExt;

--- a/crates/collab_ui/src/notifications.rs
+++ b/crates/collab_ui/src/notifications.rs
@@ -1,7 +1,8 @@
 use client::User;
 use gpui::{
-    elements::*, platform::CursorStyle, Action, Element, ElementBox, MouseButton, RenderContext,
-    View,
+    elements::*,
+    platform::{CursorStyle, MouseButton},
+    Action, Element, ElementBox, RenderContext, View,
 };
 use settings::Settings;
 use std::sync::Arc;

--- a/crates/collab_ui/src/project_shared_notification.rs
+++ b/crates/collab_ui/src/project_shared_notification.rs
@@ -5,8 +5,8 @@ use gpui::{
     actions,
     elements::*,
     geometry::{rect::RectF, vector::vec2f},
-    AppContext, CursorStyle, Entity, MouseButton, RenderContext, View, ViewContext, WindowBounds,
-    WindowKind, WindowOptions,
+    platform::{CursorStyle, MouseButton, WindowBounds, WindowKind, WindowOptions},
+    AppContext, Entity, RenderContext, View, ViewContext,
 };
 use settings::Settings;
 use std::sync::Arc;

--- a/crates/collab_ui/src/sharing_status_indicator.rs
+++ b/crates/collab_ui/src/sharing_status_indicator.rs
@@ -2,7 +2,8 @@ use call::ActiveCall;
 use gpui::{
     color::Color,
     elements::{MouseEventHandler, Svg},
-    AppContext, Appearance, Element, ElementBox, Entity, MouseButton, RenderContext, View,
+    platform::{Appearance, MouseButton},
+    AppContext, Element, ElementBox, Entity, RenderContext, View,
 };
 use settings::Settings;
 

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -1,7 +1,11 @@
 use gpui::{
-    elements::*, geometry::vector::Vector2F, impl_internal_actions, keymap_matcher::KeymapContext,
-    platform::CursorStyle, Action, AnyViewHandle, AppContext, Axis, Entity, MouseButton,
-    MouseState, RenderContext, SizeConstraint, Subscription, View, ViewContext,
+    elements::*,
+    geometry::vector::Vector2F,
+    impl_internal_actions,
+    keymap_matcher::KeymapContext,
+    platform::{CursorStyle, MouseButton},
+    Action, AnyViewHandle, AppContext, Axis, Entity, MouseState, RenderContext, SizeConstraint,
+    Subscription, View, ViewContext,
 };
 use menu::*;
 use settings::Settings;

--- a/crates/copilot/src/sign_in.rs
+++ b/crates/copilot/src/sign_in.rs
@@ -1,7 +1,9 @@
 use crate::{request::PromptUserDeviceFlow, Copilot, Status};
 use gpui::{
-    elements::*, geometry::rect::RectF, AppContext, ClipboardItem, Element, Entity, View,
-    ViewContext, ViewHandle, WindowKind, WindowOptions,
+    elements::*,
+    geometry::rect::RectF,
+    platform::{WindowBounds, WindowKind, WindowOptions},
+    AppContext, ClipboardItem, Element, Entity, View, ViewContext, ViewHandle,
 };
 use settings::Settings;
 use theme::ui::modal;
@@ -63,7 +65,7 @@ fn create_copilot_auth_window(
 ) {
     let window_size = cx.global::<Settings>().theme.copilot.modal.dimensions();
     let window_options = WindowOptions {
-        bounds: gpui::WindowBounds::Fixed(RectF::new(Default::default(), window_size)),
+        bounds: WindowBounds::Fixed(RectF::new(Default::default(), window_size)),
         titlebar: None,
         center: true,
         focus: true,
@@ -128,7 +130,7 @@ impl CopilotCodeVerification {
                 .with_style(device_code_style.cta.style_for(state, false).container)
                 .boxed()
         })
-        .on_click(gpui::MouseButton::Left, {
+        .on_click(gpui::platform::MouseButton::Left, {
             let user_code = data.user_code.clone();
             move |_, cx| {
                 cx.platform()
@@ -136,7 +138,7 @@ impl CopilotCodeVerification {
                 cx.notify();
             }
         })
-        .with_cursor_style(gpui::CursorStyle::PointingHand)
+        .with_cursor_style(gpui::platform::CursorStyle::PointingHand)
         .boxed()
     }
 

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 use context_menu::{ContextMenu, ContextMenuItem};
 use editor::Editor;
 use gpui::{
-    elements::*, impl_internal_actions, AppContext, CursorStyle, Element, ElementBox, Entity,
-    MouseButton, MouseState, RenderContext, Subscription, View, ViewContext, ViewHandle,
+    elements::*,
+    impl_internal_actions,
+    platform::{CursorStyle, MouseButton},
+    AppContext, Element, ElementBox, Entity, MouseState, RenderContext, Subscription, View,
+    ViewContext, ViewHandle,
 };
 use settings::{settings_file::SettingsFile, Settings};
 use workspace::{

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -1,8 +1,10 @@
 use collections::HashSet;
 use editor::{Editor, GoToDiagnostic};
 use gpui::{
-    elements::*, platform::CursorStyle, serde_json, AppContext, Entity, ModelHandle, MouseButton,
-    RenderContext, Subscription, View, ViewContext, ViewHandle, WeakViewHandle,
+    elements::*,
+    platform::{CursorStyle, MouseButton},
+    serde_json, AppContext, Entity, ModelHandle, RenderContext, Subscription, View, ViewContext,
+    ViewHandle, WeakViewHandle,
 };
 use language::Diagnostic;
 use project::Project;

--- a/crates/drag_and_drop/src/drag_and_drop.rs
+++ b/crates/drag_and_drop/src/drag_and_drop.rs
@@ -4,9 +4,9 @@ use collections::HashSet;
 use gpui::{
     elements::{Empty, MouseEventHandler, Overlay},
     geometry::{rect::RectF, vector::Vector2F},
+    platform::{CursorStyle, MouseButton},
     scene::{MouseDown, MouseDrag},
-    AppContext, CursorStyle, Element, ElementBox, EventContext, MouseButton, RenderContext, View,
-    WeakViewHandle,
+    AppContext, Element, ElementBox, EventContext, RenderContext, View, WeakViewHandle,
 };
 
 const DEAD_ZONE: f32 = 4.;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -39,11 +39,10 @@ use gpui::{
     geometry::vector::Vector2F,
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
-    platform::CursorStyle,
+    platform::{CursorStyle, MouseButton},
     serde_json::{self, json},
     AnyViewHandle, AppContext, AsyncAppContext, ClipboardItem, Element, ElementBox, Entity,
-    ModelHandle, MouseButton, RenderContext, Subscription, Task, View, ViewContext, ViewHandle,
-    WeakViewHandle,
+    ModelHandle, RenderContext, Subscription, Task, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HideHover, HoverState};
@@ -6866,7 +6865,7 @@ impl View for Editor {
 
     fn modifiers_changed(
         &mut self,
-        event: &gpui::ModifiersChangedEvent,
+        event: &gpui::platform::ModifiersChangedEvent,
         cx: &mut ViewContext<Self>,
     ) -> bool {
         let pending_selection = self.has_pending_selection();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -29,11 +29,10 @@ use gpui::{
         PathBuilder,
     },
     json::{self, ToJson},
-    platform::CursorStyle,
+    platform::{CursorStyle, Modifiers, MouseButton, MouseButtonEvent, MouseMovedEvent},
     text_layout::{self, Line, RunStyle, TextLayoutCache},
     AppContext, Axis, Border, CursorRegion, Element, ElementBox, EventContext, LayoutContext,
-    Modifiers, MouseButton, MouseButtonEvent, MouseMovedEvent, MouseRegion, PaintContext, Quad,
-    SceneBuilder, SizeConstraint, ViewContext, WeakViewHandle,
+    MouseRegion, PaintContext, Quad, SceneBuilder, SizeConstraint, ViewContext, WeakViewHandle,
 };
 use itertools::Itertools;
 use json::json;

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -3,9 +3,8 @@ use gpui::{
     actions,
     elements::{Flex, MouseEventHandler, Padding, Text},
     impl_internal_actions,
-    platform::CursorStyle,
-    AppContext, Axis, Element, ElementBox, ModelHandle, MouseButton, RenderContext, Task,
-    ViewContext,
+    platform::{CursorStyle, MouseButton},
+    AppContext, Axis, Element, ElementBox, ModelHandle, RenderContext, Task, ViewContext,
 };
 use language::{Bias, DiagnosticEntry, DiagnosticSeverity};
 use project::{HoverBlock, Project};

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -358,7 +358,10 @@ fn go_to_fetched_definition_of_kind(
 #[cfg(test)]
 mod tests {
     use futures::StreamExt;
-    use gpui::{Modifiers, ModifiersChangedEvent, View};
+    use gpui::{
+        platform::{self, Modifiers, ModifiersChangedEvent},
+        View,
+    };
     use indoc::indoc;
     use lsp::request::{GotoDefinition, GotoTypeDefinition};
 
@@ -430,7 +433,7 @@ mod tests {
         // Unpress shift causes highlight to go away (normal goto-definition is not valid here)
         cx.update_editor(|editor, cx| {
             editor.modifiers_changed(
-                &gpui::ModifiersChangedEvent {
+                &platform::ModifiersChangedEvent {
                     modifiers: Modifiers {
                         cmd: true,
                         ..Default::default()

--- a/crates/feedback/src/deploy_feedback_button.rs
+++ b/crates/feedback/src/deploy_feedback_button.rs
@@ -1,4 +1,8 @@
-use gpui::{elements::*, CursorStyle, Entity, MouseButton, RenderContext, View, ViewContext};
+use gpui::{
+    elements::*,
+    platform::{CursorStyle, MouseButton},
+    Entity, RenderContext, View, ViewContext,
+};
 use settings::Settings;
 use workspace::{item::ItemHandle, StatusItemView};
 

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -6,7 +6,7 @@ pub mod submit_feedback_button;
 use std::sync::Arc;
 
 mod system_specs;
-use gpui::{actions, impl_actions, AppContext, ClipboardItem, PromptLevel, ViewContext};
+use gpui::{actions, impl_actions, platform::PromptLevel, AppContext, ClipboardItem, ViewContext};
 use serde::Deserialize;
 use system_specs::SystemSpecs;
 use workspace::{AppState, Workspace};
@@ -37,7 +37,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {
     cx.add_global_action(move |action: &OpenBrowser, cx| cx.platform().open_url(&action.url));
 
     let url = format!(
-        "https://github.com/zed-industries/community/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}", 
+        "https://github.com/zed-industries/community/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}",
         urlencoding::encode(&system_specs_text)
     );
 

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -11,8 +11,9 @@ use futures::AsyncReadExt;
 use gpui::{
     actions,
     elements::{ChildView, Flex, Label, ParentElement, Svg},
-    serde_json, AnyViewHandle, AppContext, Element, ElementBox, Entity, ModelHandle, PromptLevel,
-    RenderContext, Task, View, ViewContext, ViewHandle,
+    platform::PromptLevel,
+    serde_json, AnyViewHandle, AppContext, Element, ElementBox, Entity, ModelHandle, RenderContext,
+    Task, View, ViewContext, ViewHandle,
 };
 use isahc::Request;
 use language::Buffer;

--- a/crates/feedback/src/feedback_info_text.rs
+++ b/crates/feedback/src/feedback_info_text.rs
@@ -1,7 +1,7 @@
 use gpui::{
     elements::{Flex, Label, MouseEventHandler, ParentElement, Text},
-    CursorStyle, Element, ElementBox, Entity, MouseButton, RenderContext, View, ViewContext,
-    ViewHandle,
+    platform::{CursorStyle, MouseButton},
+    Element, ElementBox, Entity, RenderContext, View, ViewContext, ViewHandle,
 };
 use settings::Settings;
 use workspace::{item::ItemHandle, ToolbarItemLocation, ToolbarItemView};

--- a/crates/feedback/src/submit_feedback_button.rs
+++ b/crates/feedback/src/submit_feedback_button.rs
@@ -1,7 +1,7 @@
 use gpui::{
     elements::{Label, MouseEventHandler},
-    CursorStyle, Element, ElementBox, Entity, MouseButton, RenderContext, View, ViewContext,
-    ViewHandle,
+    platform::{CursorStyle, MouseButton},
+    Element, ElementBox, Entity, RenderContext, View, ViewContext, ViewHandle,
 };
 use settings::Settings;
 use workspace::{item::ItemHandle, ToolbarItemLocation, ToolbarItemView};

--- a/crates/feedback/src/system_specs.rs
+++ b/crates/feedback/src/system_specs.rs
@@ -1,5 +1,5 @@
 use client::ZED_APP_VERSION;
-use gpui::{AppContext, AppVersion};
+use gpui::{platform::AppVersion, AppContext};
 use human_bytes::human_bytes;
 use serde::Serialize;
 use std::{env, fmt::Display};

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -44,12 +44,13 @@ use crate::{
     elements::ElementBox,
     executor::{self, Task},
     keymap_matcher::{self, Binding, KeymapContext, KeymapMatcher, Keystroke, MatchResult},
-    platform::{self, KeyDownEvent, Platform, PromptLevel, WindowOptions},
+    platform::{
+        self, Appearance, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton,
+        PathPromptOptions, Platform, PromptLevel, WindowBounds, WindowOptions,
+    },
     presenter::Presenter,
     util::post_inc,
-    Appearance, AssetCache, AssetSource, ClipboardItem, FontCache, KeyUpEvent,
-    ModifiersChangedEvent, MouseButton, MouseRegionId, PathPromptOptions, TextLayoutCache,
-    WindowBounds,
+    AssetCache, AssetSource, ClipboardItem, FontCache, MouseRegionId, TextLayoutCache,
 };
 
 use self::ref_counts::RefCounts;
@@ -2801,7 +2802,7 @@ impl AppContext {
     }
 }
 
-struct Window {
+pub struct Window {
     root_view: AnyViewHandle,
     focused_view_id: Option<usize>,
     is_active: bool,
@@ -5136,7 +5137,12 @@ impl Subscription {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{actions, elements::*, impl_actions, MouseButton, MouseButtonEvent};
+    use crate::{
+        actions,
+        elements::*,
+        impl_actions,
+        platform::{MouseButton, MouseButtonEvent},
+    };
     use itertools::Itertools;
     use postage::{sink::Sink, stream::Stream};
     use serde::Deserialize;

--- a/crates/gpui/src/app/menu.rs
+++ b/crates/gpui/src/app/menu.rs
@@ -1,4 +1,4 @@
-use crate::{Action, App, AppContext, ForegroundPlatform};
+use crate::{platform::ForegroundPlatform, Action, App, AppContext};
 
 pub struct Menu<'a> {
     pub name: &'a str,

--- a/crates/gpui/src/app/test_app_context.rs
+++ b/crates/gpui/src/app/test_app_context.rs
@@ -17,10 +17,14 @@ use parking_lot::{Mutex, RwLock};
 use smol::stream::StreamExt;
 
 use crate::{
-    executor, geometry::vector::Vector2F, keymap_matcher::Keystroke, platform, Action,
-    AnyViewHandle, AppContext, Appearance, Entity, Event, FontCache, Handle, InputHandler,
-    KeyDownEvent, ModelContext, ModelHandle, Platform, ReadModelWith, ReadViewWith, RenderContext,
-    Task, UpdateModel, UpdateView, View, ViewContext, ViewHandle, WeakHandle,
+    executor,
+    geometry::vector::Vector2F,
+    keymap_matcher::Keystroke,
+    platform,
+    platform::{Appearance, Event, InputHandler, KeyDownEvent, Platform},
+    Action, AnyViewHandle, AppContext, Entity, FontCache, Handle, ModelContext, ModelHandle,
+    ReadModelWith, ReadViewWith, RenderContext, Task, UpdateModel, UpdateView, View, ViewContext,
+    ViewHandle, WeakHandle,
 };
 use collections::BTreeMap;
 

--- a/crates/gpui/src/app/window_input_handler.rs
+++ b/crates/gpui/src/app/window_input_handler.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, ops::Range, rc::Rc};
 
 use pathfinder_geometry::rect::RectF;
 
-use crate::{AnyView, AppContext, InputHandler};
+use crate::{platform::InputHandler, AnyView, AppContext};
 
 pub struct WindowInputHandler {
     pub app: Rc<RefCell<AppContext>>,

--- a/crates/gpui/src/elements/mouse_event_handler.rs
+++ b/crates/gpui/src/elements/mouse_event_handler.rs
@@ -5,12 +5,13 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     platform::CursorStyle,
+    platform::MouseButton,
     scene::{
         CursorRegion, HandlerSet, MouseClick, MouseDown, MouseDownOut, MouseDrag, MouseHover,
         MouseMove, MouseMoveOut, MouseScrollWheel, MouseUp, MouseUpOut,
     },
     DebugContext, Element, ElementBox, EventContext, LayoutContext, MeasurementContext,
-    MouseButton, MouseRegion, MouseState, PaintContext, RenderContext, SizeConstraint, View,
+    MouseRegion, MouseState, PaintContext, RenderContext, SizeConstraint, View,
 };
 use serde_json::json;
 use std::{marker::PhantomData, ops::Range};

--- a/crates/gpui/src/elements/resizable.rs
+++ b/crates/gpui/src/elements/resizable.rs
@@ -4,8 +4,10 @@ use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
 
 use crate::{
-    geometry::rect::RectF, scene::MouseDrag, Axis, CursorStyle, Element, ElementBox,
-    ElementStateHandle, MouseButton, MouseRegion, RenderContext, View,
+    geometry::rect::RectF,
+    platform::{CursorStyle, MouseButton},
+    scene::MouseDrag,
+    Axis, Element, ElementBox, ElementStateHandle, MouseRegion, RenderContext, View,
 };
 
 use super::{ConstrainedBox, Hook};

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -5,9 +5,10 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     json::{self, json},
+    platform::ScrollWheelEvent,
     presenter::MeasurementContext,
     scene::MouseScrollWheel,
-    ElementBox, MouseRegion, RenderContext, ScrollWheelEvent, View,
+    ElementBox, MouseRegion, RenderContext, View,
 };
 use json::ToJson;
 use std::{cell::RefCell, cmp, ops::Range, rc::Rc};

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -28,7 +28,6 @@ pub mod json;
 pub mod keymap_matcher;
 pub mod platform;
 pub use gpui_macros::test;
-pub use platform::*;
 pub use presenter::{
     Axis, DebugContext, EventContext, LayoutContext, MeasurementContext, PaintContext,
     SizeConstraint, Vector2FExt,

--- a/crates/gpui/src/platform/mac/appearance.rs
+++ b/crates/gpui/src/platform/mac/appearance.rs
@@ -1,13 +1,12 @@
 use std::ffi::CStr;
 
+use crate::platform::Appearance;
 use cocoa::{
     appkit::{NSAppearanceNameVibrantDark, NSAppearanceNameVibrantLight},
     base::id,
     foundation::NSString,
 };
 use objc::{msg_send, sel, sel_impl};
-
-use crate::Appearance;
 
 impl Appearance {
     pub unsafe fn from_native(appearance: id) -> Self {

--- a/crates/gpui/src/platform/mac/event.rs
+++ b/crates/gpui/src/platform/mac/event.rs
@@ -1,9 +1,11 @@
 use crate::{
     geometry::vector::vec2f,
     keymap_matcher::Keystroke,
-    platform::{Event, NavigationDirection},
-    KeyDownEvent, KeyUpEvent, Modifiers, ModifiersChangedEvent, MouseButton, MouseButtonEvent,
-    MouseExitedEvent, MouseMovedEvent, ScrollDelta, ScrollWheelEvent, TouchPhase,
+    platform::{
+        Event, KeyDownEvent, KeyUpEvent, Modifiers, ModifiersChangedEvent, MouseButton,
+        MouseButtonEvent, MouseExitedEvent, MouseMovedEvent, NavigationDirection, ScrollDelta,
+        ScrollWheelEvent, TouchPhase,
+    },
 };
 use cocoa::{
     appkit::{NSEvent, NSEventModifierFlags, NSEventPhase, NSEventType},

--- a/crates/gpui/src/platform/mac/image_cache.rs
+++ b/crates/gpui/src/platform/mac/image_cache.rs
@@ -2,9 +2,9 @@ use super::atlas::{AllocId, AtlasAllocator};
 use crate::{
     fonts::{FontId, GlyphId},
     geometry::{rect::RectI, vector::Vector2I},
-    platform::RasterizationOptions,
+    platform::{FontSystem, RasterizationOptions},
     scene::ImageGlyph,
-    FontSystem, ImageData,
+    ImageData,
 };
 use anyhow::anyhow;
 use metal::{MTLPixelFormat, TextureDescriptor, TextureRef};

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -5,8 +5,8 @@ use super::{
 use crate::{
     executor,
     keymap_matcher::KeymapMatcher,
-    platform::{self, CursorStyle},
-    Action, AppVersion, ClipboardItem, Event, Menu, MenuItem,
+    platform::{self, AppVersion, CursorStyle, Event},
+    Action, ClipboardItem, Menu, MenuItem,
 };
 use anyhow::{anyhow, Result};
 use block::ConcreteBlock;
@@ -150,7 +150,7 @@ pub struct MacForegroundPlatformState {
     resign_active: Option<Box<dyn FnMut()>>,
     reopen: Option<Box<dyn FnMut()>>,
     quit: Option<Box<dyn FnMut()>>,
-    event: Option<Box<dyn FnMut(crate::Event) -> bool>>,
+    event: Option<Box<dyn FnMut(platform::Event) -> bool>>,
     menu_command: Option<Box<dyn FnMut(&dyn Action)>>,
     validate_menu_command: Option<Box<dyn FnMut(&dyn Action) -> bool>>,
     will_open_menu: Option<Box<dyn FnMut()>>,
@@ -342,7 +342,7 @@ impl platform::ForegroundPlatform for MacForegroundPlatform {
         self.0.borrow_mut().reopen = Some(callback);
     }
 
-    fn on_event(&self, callback: Box<dyn FnMut(crate::Event) -> bool>) {
+    fn on_event(&self, callback: Box<dyn FnMut(platform::Event) -> bool>) {
         self.0.borrow_mut().event = Some(callback);
     }
 
@@ -577,7 +577,7 @@ impl platform::Platform for MacPlatform {
         }
     }
 
-    fn screen_by_id(&self, id: uuid::Uuid) -> Option<Rc<dyn crate::Screen>> {
+    fn screen_by_id(&self, id: uuid::Uuid) -> Option<Rc<dyn platform::Screen>> {
         Screen::find_by_id(id).map(|screen| Rc::new(screen) as Rc<_>)
     }
 
@@ -864,7 +864,7 @@ impl platform::Platform for MacPlatform {
         "macOS"
     }
 
-    fn os_version(&self) -> Result<crate::AppVersion> {
+    fn os_version(&self) -> Result<crate::platform::AppVersion> {
         unsafe {
             let process_info = NSProcessInfo::processInfo(nil);
             let version = process_info.operatingSystemVersion();

--- a/crates/gpui/src/platform/mac/status_item.rs
+++ b/crates/gpui/src/platform/mac/status_item.rs
@@ -6,8 +6,9 @@ use crate::{
     platform::{
         self,
         mac::{platform::NSViewLayerContentsRedrawDuringViewResize, renderer::Renderer},
+        Event, FontSystem, WindowBounds,
     },
-    Event, FontSystem, Scene, WindowBounds,
+    Scene,
 };
 use cocoa::{
     appkit::{NSScreen, NSSquareStatusItemLength, NSStatusBar, NSStatusItem, NSView, NSWindow},
@@ -185,15 +186,15 @@ impl platform::Window for StatusItem {
         0.
     }
 
-    fn appearance(&self) -> crate::Appearance {
+    fn appearance(&self) -> platform::Appearance {
         unsafe {
             let appearance: id =
                 msg_send![self.0.borrow().native_item.button(), effectiveAppearance];
-            crate::Appearance::from_native(appearance)
+            platform::Appearance::from_native(appearance)
         }
     }
 
-    fn screen(&self) -> Rc<dyn crate::Screen> {
+    fn screen(&self) -> Rc<dyn platform::Screen> {
         unsafe {
             Rc::new(Screen {
                 native_screen: self.0.borrow().native_window().screen(),
@@ -205,11 +206,11 @@ impl platform::Window for StatusItem {
         self
     }
 
-    fn set_input_handler(&mut self, _: Box<dyn crate::InputHandler>) {}
+    fn set_input_handler(&mut self, _: Box<dyn platform::InputHandler>) {}
 
     fn prompt(
         &self,
-        _: crate::PromptLevel,
+        _: crate::platform::PromptLevel,
         _: &str,
         _: &[&str],
     ) -> postage::oneshot::Receiver<usize> {
@@ -251,7 +252,7 @@ impl platform::Window for StatusItem {
         unimplemented!()
     }
 
-    fn on_event(&mut self, callback: Box<dyn FnMut(crate::Event) -> bool>) {
+    fn on_event(&mut self, callback: Box<dyn FnMut(platform::Event) -> bool>) {
         self.0.borrow_mut().event_callback = Some(callback);
     }
 

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -5,14 +5,14 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     keymap_matcher::Keystroke,
-    mac::platform::NSViewLayerContentsRedrawDuringViewResize,
     platform::{
         self,
-        mac::{renderer::Renderer, screen::Screen},
-        Event, WindowBounds,
+        mac::{
+            platform::NSViewLayerContentsRedrawDuringViewResize, renderer::Renderer, screen::Screen,
+        },
+        Event, InputHandler, KeyDownEvent, ModifiersChangedEvent, MouseButton, MouseButtonEvent,
+        MouseMovedEvent, Scene, WindowBounds, WindowKind,
     },
-    InputHandler, KeyDownEvent, ModifiersChangedEvent, MouseButton, MouseButtonEvent,
-    MouseMovedEvent, Scene, WindowKind,
 };
 use block::ConcreteBlock;
 use cocoa::{
@@ -670,14 +670,14 @@ impl platform::Window for Window {
         self.0.as_ref().borrow().titlebar_height()
     }
 
-    fn appearance(&self) -> crate::Appearance {
+    fn appearance(&self) -> platform::Appearance {
         unsafe {
             let appearance: id = msg_send![self.0.borrow().native_window, effectiveAppearance];
-            crate::Appearance::from_native(appearance)
+            platform::Appearance::from_native(appearance)
         }
     }
 
-    fn screen(&self) -> Rc<dyn crate::Screen> {
+    fn screen(&self) -> Rc<dyn platform::Screen> {
         unsafe {
             Rc::new(Screen {
                 native_screen: self.0.as_ref().borrow().native_window.screen(),

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -64,7 +64,7 @@ impl super::ForegroundPlatform for ForegroundPlatform {
     fn on_resign_active(&self, _: Box<dyn FnMut()>) {}
     fn on_quit(&self, _: Box<dyn FnMut()>) {}
     fn on_reopen(&self, _: Box<dyn FnMut()>) {}
-    fn on_event(&self, _: Box<dyn FnMut(crate::Event) -> bool>) {}
+    fn on_event(&self, _: Box<dyn FnMut(crate::platform::Event) -> bool>) {}
     fn on_open_urls(&self, _: Box<dyn FnMut(Vec<String>)>) {}
 
     fn run(&self, _on_finish_launching: Box<dyn FnOnce()>) {
@@ -134,11 +134,11 @@ impl super::Platform for Platform {
 
     fn quit(&self) {}
 
-    fn screen_by_id(&self, _id: uuid::Uuid) -> Option<Rc<dyn crate::Screen>> {
+    fn screen_by_id(&self, _id: uuid::Uuid) -> Option<Rc<dyn crate::platform::Screen>> {
         None
     }
 
-    fn screens(&self) -> Vec<Rc<dyn crate::Screen>> {
+    fn screens(&self) -> Vec<Rc<dyn crate::platform::Screen>> {
         Default::default()
     }
 
@@ -158,7 +158,7 @@ impl super::Platform for Platform {
         None
     }
 
-    fn add_status_item(&self) -> Box<dyn crate::Window> {
+    fn add_status_item(&self) -> Box<dyn crate::platform::Window> {
         Box::new(Window::new(vec2f(24., 24.)))
     }
 
@@ -301,11 +301,11 @@ impl super::Window for Window {
         24.
     }
 
-    fn appearance(&self) -> crate::Appearance {
-        crate::Appearance::Light
+    fn appearance(&self) -> crate::platform::Appearance {
+        crate::platform::Appearance::Light
     }
 
-    fn screen(&self) -> Rc<dyn crate::Screen> {
+    fn screen(&self) -> Rc<dyn crate::platform::Screen> {
         Rc::new(Screen)
     }
 
@@ -313,9 +313,14 @@ impl super::Window for Window {
         self
     }
 
-    fn set_input_handler(&mut self, _: Box<dyn crate::InputHandler>) {}
+    fn set_input_handler(&mut self, _: Box<dyn crate::platform::InputHandler>) {}
 
-    fn prompt(&self, _: crate::PromptLevel, _: &str, _: &[&str]) -> oneshot::Receiver<usize> {
+    fn prompt(
+        &self,
+        _: crate::platform::PromptLevel,
+        _: &str,
+        _: &[&str],
+    ) -> oneshot::Receiver<usize> {
         let (done_tx, done_rx) = oneshot::channel();
         self.pending_prompts.borrow_mut().push_back(done_tx);
         done_rx
@@ -343,7 +348,7 @@ impl super::Window for Window {
 
     fn toggle_full_screen(&self) {}
 
-    fn on_event(&mut self, callback: Box<dyn FnMut(crate::Event) -> bool>) {
+    fn on_event(&mut self, callback: Box<dyn FnMut(crate::platform::Event) -> bool>) {
         self.event_handlers.push(callback);
     }
 

--- a/crates/gpui/src/presenter.rs
+++ b/crates/gpui/src/presenter.rs
@@ -4,17 +4,16 @@ use crate::{
     font_cache::FontCache,
     geometry::rect::RectF,
     json::{self, ToJson},
-    platform::{CursorStyle, Event},
+    platform::{Appearance, CursorStyle, Event, FontSystem, MouseButton, MouseMovedEvent},
     scene::{
         CursorRegion, MouseClick, MouseDown, MouseDownOut, MouseDrag, MouseEvent, MouseHover,
         MouseMove, MouseMoveOut, MouseScrollWheel, MouseUp, MouseUpOut, Scene,
     },
     text_layout::TextLayoutCache,
     Action, AnyModelHandle, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle, AppContext,
-    Appearance, AssetCache, ElementBox, Entity, FontSystem, ModelHandle, MouseButton,
-    MouseMovedEvent, MouseRegion, MouseRegionId, MouseState, ParentId, ReadModel, ReadView,
-    RenderContext, RenderParams, SceneBuilder, UpgradeModelHandle, UpgradeViewHandle, View,
-    ViewHandle, WeakModelHandle, WeakViewHandle,
+    AssetCache, ElementBox, Entity, ModelHandle, MouseRegion, MouseRegionId, MouseState, ParentId,
+    ReadModel, ReadView, RenderContext, RenderParams, SceneBuilder, UpgradeModelHandle,
+    UpgradeViewHandle, View, ViewHandle, WeakModelHandle, WeakViewHandle,
 };
 use anyhow::bail;
 use collections::{HashMap, HashSet};

--- a/crates/gpui/src/scene/mouse_event.rs
+++ b/crates/gpui/src/scene/mouse_event.rs
@@ -1,11 +1,12 @@
+use crate::{
+    platform::{MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent},
+    scene::mouse_region::HandlerKey,
+};
+use pathfinder_geometry::{rect::RectF, vector::Vector2F};
 use std::{
     mem::{discriminant, Discriminant},
     ops::Deref,
 };
-
-use pathfinder_geometry::{rect::RectF, vector::Vector2F};
-
-use crate::{scene::mouse_region::HandlerKey, MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent};
 
 #[derive(Debug, Default, Clone)]
 pub struct MouseMove {

--- a/crates/gpui/src/scene/mouse_region.rs
+++ b/crates/gpui/src/scene/mouse_region.rs
@@ -5,7 +5,7 @@ use collections::HashMap;
 use pathfinder_geometry::rect::RectF;
 use smallvec::SmallVec;
 
-use crate::{EventContext, MouseButton};
+use crate::{platform::MouseButton, EventContext};
 
 use super::{
     mouse_event::{
@@ -290,7 +290,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Move, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Move, found {:?}",
                         region_event);
                 }
             }));
@@ -307,7 +307,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::MoveOut, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::MoveOut, found {:?}",
                         region_event);
                 }
             }));
@@ -325,7 +325,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Down, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Down, found {:?}",
                         region_event);
                 }
             }));
@@ -343,7 +343,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Up, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Up, found {:?}",
                         region_event);
                 }
             }));
@@ -361,7 +361,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Click, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Click, found {:?}",
                         region_event);
                 }
             }));
@@ -379,7 +379,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::DownOut, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::DownOut, found {:?}",
                         region_event);
                 }
             }));
@@ -397,7 +397,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::UpOut, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::UpOut, found {:?}",
                         region_event);
                 }
             }));
@@ -415,7 +415,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Drag, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Drag, found {:?}",
                         region_event);
                 }
             }));
@@ -429,7 +429,7 @@ impl HandlerSet {
                     handler(e, cx);
                 } else {
                     panic!(
-                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Hover, found {:?}", 
+                        "Mouse Region Event incorrectly called with mismatched event type. Expected MouseRegionEvent::Hover, found {:?}",
                         region_event);
                 }
             }));

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -17,9 +17,10 @@ use crate::{
     elements::Empty,
     executor::{self, ExecutorEvent},
     platform,
+    platform::Platform,
     util::CwdBacktrace,
-    AppContext, Element, ElementBox, Entity, FontCache, Handle, Platform, RenderContext,
-    Subscription, TestAppContext, View,
+    AppContext, Element, ElementBox, Entity, FontCache, Handle, RenderContext, Subscription,
+    TestAppContext, View,
 };
 
 #[cfg(test)]

--- a/crates/gpui/src/text_layout.rs
+++ b/crates/gpui/src/text_layout.rs
@@ -5,7 +5,9 @@ use crate::{
         rect::RectF,
         vector::{vec2f, Vector2F},
     },
-    platform, scene, FontSystem, PaintContext,
+    platform,
+    platform::FontSystem,
+    scene, PaintContext,
 };
 use ordered_float::OrderedFloat;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};

--- a/crates/gpui/src/views/select.rs
+++ b/crates/gpui/src/views/select.rs
@@ -1,8 +1,8 @@
 use serde::Deserialize;
 
 use crate::{
-    actions, elements::*, impl_actions, AppContext, Entity, MouseButton, RenderContext, View,
-    ViewContext, WeakViewHandle,
+    actions, elements::*, impl_actions, platform::MouseButton, AppContext, Entity, RenderContext,
+    View, ViewContext, WeakViewHandle,
 };
 
 pub struct Select {

--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -1,7 +1,8 @@
 use editor::Editor;
 use gpui::{
-    elements::*, CursorStyle, Entity, MouseButton, RenderContext, Subscription, View, ViewContext,
-    ViewHandle,
+    elements::*,
+    platform::{CursorStyle, MouseButton},
+    Entity, RenderContext, Subscription, View, ViewContext, ViewHandle,
 };
 use settings::Settings;
 use std::sync::Arc;

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -3,9 +3,9 @@ use gpui::{
     elements::*,
     geometry::vector::{vec2f, Vector2F},
     keymap_matcher::KeymapContext,
-    platform::CursorStyle,
-    AnyViewHandle, AppContext, Axis, Entity, MouseButton, MouseState, RenderContext, Task, View,
-    ViewContext, ViewHandle, WeakViewHandle,
+    platform::{CursorStyle, MouseButton},
+    AnyViewHandle, AppContext, Axis, Entity, MouseState, RenderContext, Task, View, ViewContext,
+    ViewHandle, WeakViewHandle,
 };
 use menu::{Cancel, Confirm, SelectFirst, SelectIndex, SelectLast, SelectNext, SelectPrev};
 use parking_lot::Mutex;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -12,9 +12,9 @@ use gpui::{
     geometry::vector::Vector2F,
     impl_internal_actions,
     keymap_matcher::KeymapContext,
-    platform::CursorStyle,
-    AppContext, ClipboardItem, Element, ElementBox, Entity, ModelHandle, MouseButton, PromptLevel,
-    RenderContext, Task, View, ViewContext, ViewHandle,
+    platform::{CursorStyle, MouseButton, PromptLevel},
+    AppContext, ClipboardItem, Element, ElementBox, Entity, ModelHandle, RenderContext, Task, View,
+    ViewContext, ViewHandle,
 };
 use menu::{Confirm, SelectNext, SelectPrev};
 use project::{Entry, EntryKind, Project, ProjectEntryId, ProjectPath, Worktree, WorktreeId};

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -5,8 +5,12 @@ use crate::{
 use collections::HashMap;
 use editor::Editor;
 use gpui::{
-    actions, elements::*, impl_actions, platform::CursorStyle, Action, AnyViewHandle, AppContext,
-    Entity, MouseButton, RenderContext, Subscription, Task, View, ViewContext, ViewHandle,
+    actions,
+    elements::*,
+    impl_actions,
+    platform::{CursorStyle, MouseButton},
+    Action, AnyViewHandle, AppContext, Entity, RenderContext, Subscription, Task, View,
+    ViewContext, ViewHandle,
 };
 use project::search::SearchQuery;
 use serde::Deserialize;

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -9,9 +9,12 @@ use editor::{
 };
 use futures::StreamExt;
 use gpui::{
-    actions, elements::*, platform::CursorStyle, Action, AnyViewHandle, AppContext, ElementBox,
-    Entity, ModelContext, ModelHandle, MouseButton, RenderContext, Subscription, Task, View,
-    ViewContext, ViewHandle, WeakModelHandle, WeakViewHandle,
+    actions,
+    elements::*,
+    platform::{CursorStyle, MouseButton},
+    Action, AnyViewHandle, AppContext, ElementBox, Entity, ModelContext, ModelHandle,
+    RenderContext, Subscription, Task, View, ViewContext, ViewHandle, WeakModelHandle,
+    WeakViewHandle,
 };
 use menu::Confirm;
 use project::{search::SearchQuery, Project};

--- a/crates/terminal/src/mappings/mouse.rs
+++ b/crates/terminal/src/mappings/mouse.rs
@@ -6,8 +6,12 @@ use alacritty_terminal::grid::Dimensions;
 /// with modifications for our circumstances
 use alacritty_terminal::index::{Column as GridCol, Line as GridLine, Point, Side};
 use alacritty_terminal::term::TermMode;
+use gpui::platform;
 use gpui::scene::MouseScrollWheel;
-use gpui::{geometry::vector::Vector2F, MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent};
+use gpui::{
+    geometry::vector::Vector2F,
+    platform::{MouseButtonEvent, MouseMovedEvent, ScrollWheelEvent},
+};
 
 use crate::TerminalSize;
 
@@ -78,10 +82,10 @@ impl MouseButton {
     fn from_move(e: &MouseMovedEvent) -> Self {
         match e.pressed_button {
             Some(b) => match b {
-                gpui::MouseButton::Left => MouseButton::LeftMove,
-                gpui::MouseButton::Middle => MouseButton::MiddleMove,
-                gpui::MouseButton::Right => MouseButton::RightMove,
-                gpui::MouseButton::Navigate(_) => MouseButton::Other,
+                platform::MouseButton::Left => MouseButton::LeftMove,
+                platform::MouseButton::Middle => MouseButton::MiddleMove,
+                platform::MouseButton::Right => MouseButton::RightMove,
+                platform::MouseButton::Navigate(_) => MouseButton::Other,
             },
             None => MouseButton::NoneMove,
         }
@@ -89,10 +93,10 @@ impl MouseButton {
 
     fn from_button(e: &MouseButtonEvent) -> Self {
         match e.button {
-            gpui::MouseButton::Left => MouseButton::LeftButton,
-            gpui::MouseButton::Right => MouseButton::MiddleButton,
-            gpui::MouseButton::Middle => MouseButton::RightButton,
-            gpui::MouseButton::Navigate(_) => MouseButton::Other,
+            platform::MouseButton::Left => MouseButton::LeftButton,
+            platform::MouseButton::Right => MouseButton::MiddleButton,
+            platform::MouseButton::Middle => MouseButton::RightButton,
+            platform::MouseButton::Navigate(_) => MouseButton::Other,
         }
     }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -49,8 +49,9 @@ use thiserror::Error;
 use gpui::{
     geometry::vector::{vec2f, Vector2F},
     keymap_matcher::Keystroke,
+    platform::{MouseButton, MouseMovedEvent, TouchPhase},
     scene::{MouseDown, MouseDrag, MouseScrollWheel, MouseUp},
-    ClipboardItem, Entity, ModelContext, MouseButton, MouseMovedEvent, Task,
+    ClipboardItem, Entity, ModelContext, Task,
 };
 
 use crate::mappings::{
@@ -1132,12 +1133,12 @@ impl Terminal {
         let line_height = self.last_content.size.line_height;
         match e.phase {
             /* Reset scroll state on started */
-            Some(gpui::TouchPhase::Started) => {
+            Some(TouchPhase::Started) => {
                 self.scroll_px = 0.;
                 None
             }
             /* Calculate the appropriate scroll lines */
-            Some(gpui::TouchPhase::Moved) => {
+            Some(gpui::platform::TouchPhase::Moved) => {
                 let old_offset = (self.scroll_px / line_height) as i32;
 
                 self.scroll_px += e.delta.pixel_delta(line_height).y() * scroll_multiplier;

--- a/crates/terminal_view/src/terminal_button.rs
+++ b/crates/terminal_view/src/terminal_button.rs
@@ -1,7 +1,10 @@
 use context_menu::{ContextMenu, ContextMenuItem};
 use gpui::{
-    elements::*, impl_internal_actions, AppContext, CursorStyle, Element, ElementBox, Entity,
-    MouseButton, RenderContext, View, ViewContext, ViewHandle, WeakModelHandle, WeakViewHandle,
+    elements::*,
+    impl_internal_actions,
+    platform::{CursorStyle, MouseButton},
+    AppContext, Element, ElementBox, Entity, RenderContext, View, ViewContext, ViewHandle,
+    WeakModelHandle, WeakViewHandle,
 };
 use settings::Settings;
 use std::any::TypeId;

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -7,10 +7,11 @@ use gpui::{
         rect::RectF,
         vector::{vec2f, Vector2F},
     },
+    platform::{CursorStyle, MouseButton},
     serde_json::json,
     text_layout::{Line, RunStyle},
-    Element, ElementBox, EventContext, FontCache, ModelContext, MouseButton, MouseRegion,
-    PaintContext, Quad, SizeConstraint, TextLayoutCache, WeakModelHandle, WeakViewHandle,
+    Element, ElementBox, EventContext, FontCache, ModelContext, MouseRegion, PaintContext, Quad,
+    SizeConstraint, TextLayoutCache, WeakModelHandle, WeakViewHandle,
 };
 use itertools::Itertools;
 use language::CursorShape;
@@ -735,9 +736,9 @@ impl Element for TerminalElement {
             cx.scene.push_cursor_region(gpui::CursorRegion {
                 bounds,
                 style: if layout.hyperlink_tooltip.is_some() {
-                    gpui::CursorStyle::PointingHand
+                    CursorStyle::PointingHand
                 } else {
-                    gpui::CursorStyle::IBeam
+                    CursorStyle::IBeam
                 },
             });
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -16,6 +16,7 @@ use gpui::{
     geometry::vector::Vector2F,
     impl_actions, impl_internal_actions,
     keymap_matcher::{KeymapContext, Keystroke},
+    platform::KeyDownEvent,
     AnyViewHandle, AppContext, Element, ElementBox, Entity, ModelHandle, Task, View, ViewContext,
     ViewHandle, WeakViewHandle,
 };
@@ -425,7 +426,7 @@ impl View for TerminalView {
         cx.notify();
     }
 
-    fn key_down(&mut self, event: &gpui::KeyDownEvent, cx: &mut ViewContext<Self>) -> bool {
+    fn key_down(&mut self, event: &KeyDownEvent, cx: &mut ViewContext<Self>) -> bool {
         self.clear_bel(cx);
         self.pause_cursor_blinking(cx);
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -4,7 +4,7 @@ use gpui::{
     color::Color,
     elements::{ContainerStyle, ImageStyle, LabelStyle, Shadow, TooltipStyle},
     fonts::{HighlightStyle, TextStyle},
-    Border, MouseState,
+    platform, Border, MouseState,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
@@ -754,14 +754,15 @@ impl<T> Interactive<T> {
                 self.hover_and_active
                     .as_ref()
                     .unwrap_or(self.active.as_ref().unwrap_or(&self.default))
-            } else if state.clicked() == Some(gpui::MouseButton::Left) && self.clicked.is_some() {
+            } else if state.clicked() == Some(platform::MouseButton::Left) && self.clicked.is_some()
+            {
                 self.click_and_active
                     .as_ref()
                     .unwrap_or(self.active.as_ref().unwrap_or(&self.default))
             } else {
                 self.active.as_ref().unwrap_or(&self.default)
             }
-        } else if state.clicked() == Some(gpui::MouseButton::Left) && self.clicked.is_some() {
+        } else if state.clicked() == Some(platform::MouseButton::Left) && self.clicked.is_some() {
             self.clicked.as_ref().unwrap()
         } else if state.hovered() {
             self.hover.as_ref().unwrap_or(&self.default)

--- a/crates/theme/src/ui.rs
+++ b/crates/theme/src/ui.rs
@@ -8,8 +8,10 @@ use gpui::{
     },
     fonts::TextStyle,
     geometry::vector::{vec2f, Vector2F},
+    platform,
+    platform::MouseButton,
     scene::MouseClick,
-    Action, Element, ElementBox, EventContext, MouseButton, MouseState, RenderContext, View,
+    Action, Element, ElementBox, EventContext, MouseState, RenderContext, View,
 };
 use serde::Deserialize;
 
@@ -80,8 +82,10 @@ pub fn checkbox_with_label<T: 'static, V: View>(
             .align_children_center()
             .boxed()
     })
-    .on_click(gpui::MouseButton::Left, move |_, cx| change(!checked, cx))
-    .with_cursor_style(gpui::CursorStyle::PointingHand)
+    .on_click(platform::MouseButton::Left, move |_, cx| {
+        change(!checked, cx)
+    })
+    .with_cursor_style(platform::CursorStyle::PointingHand)
 }
 
 #[derive(Clone, Deserialize, Default)]
@@ -212,7 +216,7 @@ where
             .boxed()
     })
     .on_click(MouseButton::Left, f)
-    .with_cursor_style(gpui::CursorStyle::PointingHand)
+    .with_cursor_style(platform::CursorStyle::PointingHand)
 }
 
 #[derive(Clone, Deserialize, Default)]
@@ -261,11 +265,11 @@ where
                         let style = style.close_icon.style_for(state, false);
                         icon(style).boxed()
                     })
-                    .on_click(gpui::MouseButton::Left, move |_, cx| {
+                    .on_click(platform::MouseButton::Left, move |_, cx| {
                         let window_id = cx.window_id();
                         cx.remove_window(window_id);
                     })
-                    .with_cursor_style(gpui::CursorStyle::PointingHand)
+                    .with_cursor_style(platform::CursorStyle::PointingHand)
                     .aligned()
                     .right()
                     .boxed(),

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -7,8 +7,10 @@ use gpui::{
     actions,
     elements::{ChildView, Container, Empty, MouseEventHandler, ParentElement, Side, Stack},
     geometry::vector::Vector2F,
-    impl_internal_actions, AppContext, Border, CursorStyle, Element, ElementBox, MouseButton,
-    RenderContext, SizeConstraint, ViewContext, ViewHandle,
+    impl_internal_actions,
+    platform::{CursorStyle, MouseButton},
+    AppContext, Border, Element, ElementBox, RenderContext, SizeConstraint, ViewContext,
+    ViewHandle,
 };
 use settings::{DockAnchor, Settings};
 use theme::Theme;

--- a/crates/workspace/src/dock/toggle_dock_button.rs
+++ b/crates/workspace/src/dock/toggle_dock_button.rs
@@ -1,7 +1,8 @@
 use gpui::{
     elements::{Empty, MouseEventHandler, Svg},
-    CursorStyle, Element, ElementBox, Entity, MouseButton, View, ViewContext, ViewHandle,
-    WeakViewHandle,
+    platform::CursorStyle,
+    platform::MouseButton,
+    Element, ElementBox, Entity, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use settings::Settings;
 

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -138,8 +138,9 @@ pub mod simple_message_notification {
     use gpui::{
         actions,
         elements::{Flex, MouseEventHandler, Padding, ParentElement, Svg, Text},
-        impl_actions, Action, AppContext, CursorStyle, Element, Entity, MouseButton, View,
-        ViewContext,
+        impl_actions,
+        platform::{CursorStyle, MouseButton},
+        Action, AppContext, Element, Entity, View, ViewContext,
     };
     use menu::Cancel;
     use serde::Deserialize;

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -22,10 +22,10 @@ use gpui::{
     },
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
-    platform::{CursorStyle, NavigationDirection},
+    platform::{CursorStyle, MouseButton, NavigationDirection, PromptLevel},
     Action, AnyViewHandle, AnyWeakViewHandle, AppContext, AsyncAppContext, Entity, EventContext,
-    ModelHandle, MouseButton, MouseRegion, PromptLevel, Quad, RenderContext, Task, View,
-    ViewContext, ViewHandle, WeakViewHandle,
+    ModelHandle, MouseRegion, Quad, RenderContext, Task, View, ViewContext, ViewHandle,
+    WeakViewHandle,
 };
 use project::{Project, ProjectEntryId, ProjectPath};
 use serde::Deserialize;
@@ -1887,7 +1887,7 @@ impl Element for PaneBackdrop {
         let child_view_id = self.child_view;
         cx.scene.push_mouse_region(
             MouseRegion::new::<Self>(child_view_id, 0, visible_bounds).on_down(
-                gpui::MouseButton::Left,
+                gpui::platform::MouseButton::Left,
                 move |_, cx| {
                     let window_id = cx.window_id;
                     cx.focus(window_id, Some(child_view_id))

--- a/crates/workspace/src/pane/dragged_item_receiver.rs
+++ b/crates/workspace/src/pane/dragged_item_receiver.rs
@@ -3,9 +3,9 @@ use gpui::{
     color::Color,
     elements::{Canvas, MouseEventHandler, ParentElement, Stack},
     geometry::{rect::RectF, vector::Vector2F},
+    platform::MouseButton,
     scene::MouseUp,
-    AppContext, Element, ElementBox, EventContext, MouseButton, MouseState, Quad, RenderContext,
-    WeakViewHandle,
+    AppContext, Element, ElementBox, EventContext, MouseState, Quad, RenderContext, WeakViewHandle,
 };
 use project::ProjectEntryId;
 use settings::Settings;

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -4,7 +4,8 @@ use call::{ActiveCall, ParticipantLocation};
 use gpui::{
     elements::*,
     geometry::{rect::RectF, vector::Vector2F},
-    Axis, Border, CursorStyle, ModelHandle, MouseButton, RenderContext, ViewHandle,
+    platform::{CursorStyle, MouseButton},
+    Axis, Border, ModelHandle, RenderContext, ViewHandle,
 };
 use project::Project;
 use serde::Deserialize;

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
 use db::{define_connection, query, sqlez::connection::Connection, sqlez_macros::sql};
-use gpui::{Axis, WindowBounds};
+use gpui::{platform::WindowBounds, Axis};
 
 use util::{unzip_option, ResultExt};
 use uuid::Uuid;
@@ -566,7 +566,7 @@ mod tests {
                     CREATE TABLE test_table(
                         text TEXT,
                         workspace_id INTEGER,
-                        FOREIGN KEY(workspace_id) 
+                        FOREIGN KEY(workspace_id)
                             REFERENCES workspaces(workspace_id)
                         ON DELETE CASCADE
                     ) STRICT;)],

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, Result};
 
 use async_recursion::async_recursion;
-use gpui::{AsyncAppContext, Axis, ModelHandle, Task, ViewHandle, WindowBounds};
+use gpui::{platform::WindowBounds, AsyncAppContext, Axis, ModelHandle, Task, ViewHandle};
 
 use db::sqlez::{
     bindable::{Bind, Column, StaticColumnCount},

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -8,7 +8,8 @@ use futures::StreamExt;
 use gpui::{
     elements::*,
     geometry::{rect::RectF, vector::vec2f},
-    AppContext, Entity, MouseButton, RenderContext, Task, View, ViewContext,
+    platform::MouseButton,
+    AppContext, Entity, RenderContext, Task, View, ViewContext,
 };
 use settings::Settings;
 use smallvec::SmallVec;
@@ -75,7 +76,7 @@ impl View for SharedScreen {
                         vec2f(frame.width() as f32, frame.height() as f32),
                     );
                     let origin = bounds.origin() + (bounds.size() / 2.) - size / 2.;
-                    cx.scene.push_surface(gpui::mac::Surface {
+                    cx.scene.push_surface(gpui::platform::mac::Surface {
                         bounds: RectF::new(origin, size),
                         image_buffer: frame.image(),
                     });

--- a/crates/workspace/src/sidebar.rs
+++ b/crates/workspace/src/sidebar.rs
@@ -1,7 +1,7 @@
 use crate::StatusItemView;
 use gpui::{
-    elements::*, impl_actions, platform::CursorStyle, AnyViewHandle, AppContext, Entity,
-    MouseButton, RenderContext, Subscription, View, ViewContext, ViewHandle,
+    elements::*, impl_actions, platform::CursorStyle, platform::MouseButton, AnyViewHandle,
+    AppContext, Entity, RenderContext, Subscription, View, ViewContext, ViewHandle,
 };
 use serde::Deserialize;
 use settings::Settings;

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -1,7 +1,7 @@
 use crate::{ItemHandle, Pane};
 use gpui::{
-    elements::*, platform::CursorStyle, Action, AnyViewHandle, AppContext, ElementBox, Entity,
-    MouseButton, RenderContext, View, ViewContext, ViewHandle, WeakViewHandle,
+    elements::*, platform::CursorStyle, platform::MouseButton, Action, AnyViewHandle, AppContext,
+    ElementBox, Entity, RenderContext, View, ViewContext, ViewHandle, WeakViewHandle,
 };
 use settings::Settings;
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -40,11 +40,13 @@ use gpui::{
     },
     impl_actions, impl_internal_actions,
     keymap_matcher::KeymapContext,
-    platform::{CursorStyle, WindowOptions},
+    platform::{
+        CursorStyle, MouseButton, PathPromptOptions, Platform, PromptLevel, WindowBounds,
+        WindowOptions,
+    },
     Action, AnyModelHandle, AnyViewHandle, AppContext, AsyncAppContext, Entity, ModelContext,
-    ModelHandle, MouseButton, PathPromptOptions, Platform, PromptLevel, RenderContext,
-    SizeConstraint, Subscription, Task, View, ViewContext, ViewHandle, WeakViewHandle,
-    WindowBounds,
+    ModelHandle, RenderContext, SizeConstraint, Subscription, Task, View, ViewContext, ViewHandle,
+    WeakViewHandle,
 };
 use item::{FollowableItem, FollowableItemHandle, Item, ItemHandle, ProjectItem};
 use language::LanguageRegistry;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -19,8 +19,8 @@ use gpui::{
     actions,
     geometry::vector::vec2f,
     impl_actions,
-    platform::{WindowBounds, WindowOptions},
-    AssetSource, Platform, PromptLevel, TitlebarOptions, ViewContext, WindowKind,
+    platform::{Platform, PromptLevel, TitlebarOptions, WindowBounds, WindowKind, WindowOptions},
+    AssetSource, ViewContext,
 };
 use language::Rope;
 pub use lsp;
@@ -458,11 +458,7 @@ fn quit(_: &Quit, cx: &mut gpui::AppContext) {
 fn about(_: &mut Workspace, _: &About, cx: &mut gpui::ViewContext<Workspace>) {
     let app_name = cx.global::<ReleaseChannel>().display_name();
     let version = env!("CARGO_PKG_VERSION");
-    cx.prompt(
-        gpui::PromptLevel::Info,
-        &format!("{app_name} {version}"),
-        &["OK"],
-    );
+    cx.prompt(PromptLevel::Info, &format!("{app_name} {version}"), &["OK"]);
 }
 
 fn open_config_file(


### PR DESCRIPTION
I'm doing some cleanup on GPUI, and I don't think it's good longterm to export so much from the root module. I like being explicit about what is part of the underlying platform.