### PR TITLE
Don't panic if worktree was dropped before sending path changes

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -838,8 +838,7 @@ impl LocalWorktree {
                     .unwrap()
                     .path_changes_tx
                     .try_send((vec![abs_path], tx))
-                    .unwrap();
-            });
+            })?;
             rx.recv().await;
             Ok(())
         }))
@@ -930,7 +929,7 @@ impl LocalWorktree {
             }
 
             let (tx, mut rx) = barrier::channel();
-            path_changes_tx.try_send((paths, tx)).unwrap();
+            path_changes_tx.try_send((paths, tx))?;
             rx.recv().await;
             this.upgrade(&cx)
                 .ok_or_else(|| anyhow!("worktree was dropped"))?


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-570/thread-main-panicked-at-called-resultunwrap-on-an-err-value-closed

In `refresh_entry`, we send a message to the `self.path_changes_tx` channel to notify the background thread that a path has changed. However, given that `refresh_entry` uses `spawn_weak`, the worktree could get dropped before sending the message, which could cause a panic.

This pull request changes the code to return an error instead of panicking.