### PR TITLE
In the case of Github release deserialize error, log response text

### DIFF
--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -9,13 +9,13 @@ pub struct GitHubLspBinaryVersion {
     pub url: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct GithubRelease {
     pub name: String,
     pub assets: Vec<GithubReleaseAsset>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct GithubReleaseAsset {
     pub name: String,
     pub browser_download_url: String,
@@ -40,7 +40,13 @@ pub async fn latest_github_release(
         .await
         .context("error reading latest release")?;
 
-    let release: GithubRelease =
-        serde_json::from_slice(body.as_slice()).context("error deserializing latest release")?;
-    Ok(release)
+    let release = serde_json::from_slice::<GithubRelease>(body.as_slice());
+    if release.is_err() {
+        log::error!(
+            "Github API response text: {:?}",
+            String::from_utf8_lossy(body.as_slice())
+        );
+    }
+
+    release.context("error deserializing latest release")
 }


### PR DESCRIPTION
We have open issues where this deserialize fails, this will allow for better debugging in the future as we are a bit at a loss as to why we could be seeing specific failure we are seeing when it happens
