### PR TITLE
Flip screen sharing icon states

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -395,10 +395,10 @@ impl CollabTitlebarItem {
         let icon;
         let tooltip;
         if room.read(cx).is_screen_sharing() {
-            icon = "icons/disable_screen_sharing_12.svg";
+            icon = "icons/enable_screen_sharing_12.svg";
             tooltip = "Stop Sharing Screen"
         } else {
-            icon = "icons/enable_screen_sharing_12.svg";
+            icon = "icons/disable_screen_sharing_12.svg";
             tooltip = "Share Screen";
         }
 


### PR DESCRIPTION
## Description of feature or change

Fixes: https://linear.app/zed-industries/issue/Z-428/flip-share-screen-state-icons

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
