### PR TITLE
Add vim mode metric

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6619,13 +6619,15 @@ impl Editor {
                 .as_singleton()
                 .and_then(|b| b.read(cx).file()),
         ) {
+            let settings = cx.global::<Settings>();
+
             let extension = Path::new(file.file_name(cx))
                 .extension()
                 .and_then(|e| e.to_str());
             project.read(cx).client().report_event(
                 name,
-                json!({ "File Extension": extension }),
-                cx.global::<Settings>().telemetry(),
+                json!({ "File Extension": extension, "Vim Mode": settings.vim_mode  }),
+                settings.telemetry(),
             );
         }
     }


### PR DESCRIPTION
## Description of feature or change

Adds a vim mode event property to all file operation events, which gets us set up for: https://linear.app/zed-industries/issue/C-12/track-how-many-users-are-using-vim-mode

## Link to related issues from zed or community

## Before Merging 

- [ ] Does this have tests or have existing tests been updated to cover this change?
- [ ] Have you added the necessary settings to configure this feature?
- [ ] Has documentation been created or updated (including above changes to settings)?
