### PR TITLE
Always bump worktree's scan_id when refreshing an entry

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1491,7 +1491,12 @@ impl LocalSnapshot {
         }
 
         let scan_id = self.scan_id;
-        self.entries_by_path.insert_or_replace(entry.clone(), &());
+        let removed = self.entries_by_path.insert_or_replace(entry.clone(), &());
+        if let Some(removed) = removed {
+            if removed.id != entry.id {
+                self.entries_by_id.remove(&removed.id, &());
+            }
+        }
         self.entries_by_id.insert_or_replace(
             PathEntry {
                 id: entry.id,


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/zed-industries/zed/pull/2371, which I didn't catch until running the randomized integration tests with a high operation count.

While doing this, I added a randomized test for mutating a worktree while it is performing its initial scan. This randomized test caught a separate long-standing bug in the logic for inserting an entry into a worktree, so I fixed that too.