### PR TITLE
Add tab tooltips

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -532,7 +532,7 @@ impl Item for ProjectDiagnosticsEditor {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, _: &AppContext) -> Option<Cow<str>> {
         Some("Project Diagnostics".into())
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -24,6 +24,7 @@ use settings::Settings;
 use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
+    borrow::Cow,
     cmp::Ordering,
     ops::Range,
     path::PathBuf,
@@ -529,6 +530,10 @@ impl Item for ProjectDiagnosticsEditor {
     fn navigate(&mut self, data: Box<dyn Any>, cx: &mut ViewContext<Self>) -> bool {
         self.editor
             .update(cx, |editor, cx| editor.navigate(data, cx))
+    }
+
+    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+        Some("Project Diagnostics".into())
     }
 
     fn is_dirty(&self, cx: &AppContext) -> bool {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -514,7 +514,7 @@ impl Item for Editor {
         }
     }
 
-    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<Cow<str>> {
         let file_path = self
             .buffer()
             .read(cx)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -514,6 +514,23 @@ impl Item for Editor {
         }
     }
 
+    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+        let file_path = self
+            .buffer()
+            .read(cx)
+            .as_singleton()?
+            .read(cx)
+            .file()
+            .and_then(|f| f.as_local())?
+            .abs_path(cx);
+
+        let file_path = util::paths::compact(&file_path)
+            .to_string_lossy()
+            .to_string();
+
+        Some(file_path.into())
+    }
+
     fn tab_description<'a>(&'a self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>> {
         match path_for_buffer(&self.buffer, detail, true, cx)? {
             Cow::Borrowed(path) => Some(path.to_string_lossy()),

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -531,7 +531,7 @@ impl Item for Editor {
         Some(file_path.into())
     }
 
-    fn tab_description<'a>(&'a self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_description<'a>(&'a self, detail: usize, cx: &'a AppContext) -> Option<Cow<str>> {
         match path_for_buffer(&self.buffer, detail, true, cx)? {
             Cow::Borrowed(path) => Some(path.to_string_lossy()),
             Cow::Owned(path) => Some(path.to_string_lossy().to_string().into()),

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -249,7 +249,7 @@ impl Entity for FeedbackEditor {
 }
 
 impl Item for FeedbackEditor {
-    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, _: &AppContext) -> Option<Cow<str>> {
         Some("Send Feedback".into())
     }
 

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -1,5 +1,6 @@
 use std::{
     any::TypeId,
+    borrow::Cow,
     ops::{Range, RangeInclusive},
     sync::Arc,
 };
@@ -248,6 +249,10 @@ impl Entity for FeedbackEditor {
 }
 
 impl Item for FeedbackEditor {
+    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+        Some("Send Feedback".into())
+    }
+
     fn tab_content(&self, _: Option<usize>, style: &theme::Tab, _: &AppContext) -> ElementBox {
         Flex::row()
             .with_child(

--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -39,7 +39,7 @@ pub struct TooltipStyle {
     pub container: ContainerStyle,
     pub text: TextStyle,
     keystroke: KeystrokeStyle,
-    pub max_text_width: f32,
+    pub max_text_width: Option<f32>,
 }
 
 #[derive(Clone, Deserialize, Default)]
@@ -140,9 +140,14 @@ impl Tooltip {
     ) -> impl Element {
         Flex::row()
             .with_child({
-                let text = Text::new(text, style.text)
-                    .constrained()
-                    .with_max_width(style.max_text_width);
+                let text = if let Some(max_text_width) = style.max_text_width {
+                    Text::new(text, style.text)
+                        .constrained()
+                        .with_max_width(max_text_width)
+                } else {
+                    Text::new(text, style.text).constrained()
+                };
+
                 if measure {
                     text.flex(1., false).boxed()
                 } else {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -226,7 +226,7 @@ impl View for ProjectSearchView {
 }
 
 impl Item for ProjectSearchView {
-    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<Cow<str>> {
         Some(self.query_editor.read(cx).text(cx).into())
     }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -22,6 +22,7 @@ use settings::Settings;
 use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
+    borrow::Cow,
     mem,
     ops::Range,
     path::PathBuf,
@@ -225,6 +226,10 @@ impl View for ProjectSearchView {
 }
 
 impl Item for ProjectSearchView {
+    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+        Some(self.query_editor.read(cx).text(cx).into())
+    }
+
     fn act_as_type<'a>(
         &'a self,
         type_id: TypeId,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -544,7 +544,7 @@ impl View for TerminalView {
 }
 
 impl Item for TerminalView {
-    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<Cow<str>> {
         Some(self.terminal().read(cx).title().into())
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -3,6 +3,7 @@ pub mod terminal_button;
 pub mod terminal_element;
 
 use std::{
+    borrow::Cow,
     ops::RangeInclusive,
     path::{Path, PathBuf},
     time::Duration,
@@ -543,6 +544,10 @@ impl View for TerminalView {
 }
 
 impl Item for TerminalView {
+    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+        Some(self.terminal().read(cx).title().into())
+    }
+
     fn tab_content(
         &self,
         _detail: Option<usize>,

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -198,7 +198,7 @@ impl WelcomePage {
 }
 
 impl Item for WelcomePage {
-    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, _: &AppContext) -> Option<Cow<str>> {
         Some("Welcome to Zed!".into())
     }
 

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -1,6 +1,6 @@
 mod base_keymap_picker;
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
@@ -198,6 +198,10 @@ impl WelcomePage {
 }
 
 impl Item for WelcomePage {
+    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+        Some("Welcome to Zed!".into())
+    }
+
     fn tab_content(
         &self,
         _detail: Option<usize>,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -47,7 +47,7 @@ pub trait Item: View {
     fn tab_tooltip_text(&self, _: &AppContext) -> Option<Cow<str>> {
         None
     }
-    fn tab_description<'a>(&'a self, _: usize, _: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_description<'a>(&'a self, _: usize, _: &'a AppContext) -> Option<Cow<str>> {
         None
     }
     fn tab_content(&self, detail: Option<usize>, style: &theme::Tab, cx: &AppContext)
@@ -165,8 +165,8 @@ pub trait ItemHandle: 'static + fmt::Debug {
         cx: &mut AppContext,
         handler: Box<dyn Fn(ItemEvent, &mut AppContext)>,
     ) -> gpui::Subscription;
-    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<str>>;
-    fn tab_description<'a>(&self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>>;
+    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>>;
+    fn tab_description<'a>(&'a self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>>;
     fn tab_content(&self, detail: Option<usize>, style: &theme::Tab, cx: &AppContext)
         -> ElementBox;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
@@ -252,11 +252,11 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
         })
     }
 
-    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<str>> {
+    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
         self.read(cx).tab_tooltip_text(cx)
     }
 
-    fn tab_description<'a>(&self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_description<'a>(&'a self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>> {
         self.read(cx).tab_description(detail, cx)
     }
 
@@ -913,7 +913,7 @@ pub(crate) mod test {
     }
 
     impl Item for TestItem {
-        fn tab_description<'a>(&'a self, detail: usize, _: &'a AppContext) -> Option<Cow<'a, str>> {
+        fn tab_description(&self, detail: usize, _: &AppContext) -> Option<Cow<str>> {
             self.tab_descriptions.as_ref().and_then(|descriptions| {
                 let description = *descriptions.get(detail).or_else(|| descriptions.last())?;
                 Some(description.into())

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -44,6 +44,9 @@ pub trait Item: View {
     fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) -> bool {
         false
     }
+    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+        None
+    }
     fn tab_description<'a>(&'a self, _: usize, _: &'a AppContext) -> Option<Cow<'a, str>> {
         None
     }
@@ -162,6 +165,7 @@ pub trait ItemHandle: 'static + fmt::Debug {
         cx: &mut AppContext,
         handler: Box<dyn Fn(ItemEvent, &mut AppContext)>,
     ) -> gpui::Subscription;
+    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>>;
     fn tab_description<'a>(&self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>>;
     fn tab_content(&self, detail: Option<usize>, style: &theme::Tab, cx: &AppContext)
         -> ElementBox;
@@ -246,6 +250,10 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
                 handler(item_event, cx)
             }
         })
+    }
+
+    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+        self.read(cx).tab_tooltip_text(cx)
     }
 
     fn tab_description<'a>(&self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>> {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -44,7 +44,7 @@ pub trait Item: View {
     fn navigate(&mut self, _: Box<dyn Any>, _: &mut ViewContext<Self>) -> bool {
         false
     }
-    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, _: &AppContext) -> Option<Cow<str>> {
         None
     }
     fn tab_description<'a>(&'a self, _: usize, _: &'a AppContext) -> Option<Cow<'a, str>> {
@@ -165,7 +165,7 @@ pub trait ItemHandle: 'static + fmt::Debug {
         cx: &mut AppContext,
         handler: Box<dyn Fn(ItemEvent, &mut AppContext)>,
     ) -> gpui::Subscription;
-    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>>;
+    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<str>>;
     fn tab_description<'a>(&self, detail: usize, cx: &'a AppContext) -> Option<Cow<'a, str>>;
     fn tab_content(&self, detail: Option<usize>, style: &theme::Tab, cx: &AppContext)
         -> ElementBox;
@@ -252,7 +252,7 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
         })
     }
 
-    fn tab_tooltip_text<'a>(&self, cx: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text<'a>(&'a self, cx: &'a AppContext) -> Option<Cow<str>> {
         self.read(cx).tab_tooltip_text(cx)
     }
 

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -95,7 +95,7 @@ impl View for SharedScreen {
 }
 
 impl Item for SharedScreen {
-    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+    fn tab_tooltip_text(&self, _: &AppContext) -> Option<Cow<str>> {
         Some(format!("{}'s screen", self.user.github_login).into())
     }
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -13,7 +13,10 @@ use gpui::{
 };
 use settings::Settings;
 use smallvec::SmallVec;
-use std::sync::{Arc, Weak};
+use std::{
+    borrow::Cow,
+    sync::{Arc, Weak},
+};
 
 pub enum Event {
     Close,
@@ -92,6 +95,9 @@ impl View for SharedScreen {
 }
 
 impl Item for SharedScreen {
+    fn tab_tooltip_text<'a>(&'a self, _: &'a AppContext) -> Option<Cow<'a, str>> {
+        Some(format!("{}'s screen", self.user.github_login).into())
+    }
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(nav_history) = self.nav_history.as_ref() {
             nav_history.push::<()>(None, cx);


### PR DESCRIPTION
## Description of feature or change

https://user-images.githubusercontent.com/19867440/232176457-db5d76e5-a5af-4b1e-bbb8-1544e2010066.mov

This PR adds tooltips to tab items.  I had this partially added in my last [tab context menu PR](https://github.com/zed-industries/zed/pull/2368), but removed it to reduce the size of of that PR.

This PR introduces a `tab_tooltip_text` trait method on `Item`.  Each item can choose what they want to return for its tooltip text.

One caveat is that not all of our editors are `Item`s.  For instance, the `Find All References` editor is generated on the spot and isn't an `Item`, so this system doesn't work for those.  We have other tab-related trait methods on `Item`, such as `tab_description`, so it made sense to follow that convention and continue to allow the editors that don't `impl` `Item` be the odd ones out.

Also, I added tooltips to things that might not make sense, where the tooltip is just the same static text as the tab title (terminal, welcome screen, etc.), so maybe it makes sense to just remove those and skip them?  Lastly, I changed the tooltip system to accept an `Option` for the max width, so that I could turn it off just for the tab tooltips.  It would weirdly break the paths for tabs.

With the max width, you'd get something like this:

<img width="360" alt="SCR-20230414-slha" src="https://user-images.githubusercontent.com/19867440/232176159-cdf13686-81b4-4861-83da-32785a2a01fc.png">

Turning it off, you get:

<img width="502" alt="SCR-20230414-slar" src="https://user-images.githubusercontent.com/19867440/232176170-d8161877-85a8-4320-9393-ed58824b83ea.png">
