### PR TITLE
Select language based on a file's first content line in addition to its path

### DIFF
--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -81,14 +81,14 @@ fn test_select_language() {
     // matching file extension
     assert_eq!(
         registry
-            .language_for_path("zed/lib.rs")
+            .language_for_file("zed/lib.rs", None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Rust".into())
     );
     assert_eq!(
         registry
-            .language_for_path("zed/lib.mk")
+            .language_for_file("zed/lib.mk", None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
@@ -97,7 +97,7 @@ fn test_select_language() {
     // matching filename
     assert_eq!(
         registry
-            .language_for_path("zed/Makefile")
+            .language_for_file("zed/Makefile", None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
@@ -106,21 +106,21 @@ fn test_select_language() {
     // matching suffix that is not the full file extension or filename
     assert_eq!(
         registry
-            .language_for_path("zed/cars")
+            .language_for_file("zed/cars", None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
         registry
-            .language_for_path("zed/a.cars")
+            .language_for_file("zed/a.cars", None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
         registry
-            .language_for_path("zed/sumk")
+            .language_for_file("zed/sumk", None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None

--- a/crates/zed/src/languages/javascript/config.toml
+++ b/crates/zed/src/languages/javascript/config.toml
@@ -1,5 +1,6 @@
 name = "JavaScript"
 path_suffixes = ["js", "jsx", "mjs"]
+first_line_pattern = '^#!.*\bnode\b'
 line_comment = "// "
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/crates/zed/src/languages/python/config.toml
+++ b/crates/zed/src/languages/python/config.toml
@@ -1,5 +1,6 @@
 name = "Python"
 path_suffixes = ["py", "pyi"]
+first_line_pattern = '^#!.*\bpython[0-9.]*\b'
 line_comment = "# "
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/crates/zed/src/languages/ruby/config.toml
+++ b/crates/zed/src/languages/ruby/config.toml
@@ -1,5 +1,6 @@
 name = "Ruby"
 path_suffixes = ["rb", "Gemfile"]
+first_line_pattern = '^#!.*\bruby\b'
 line_comment = "# "
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
I was recently working on some scripts in this repo that use JavaScript, and specify `node` as their interpreter via a `#!` (shebang) line.

I noticed this experience of working on these files would be nicer if Zed detected their language based on the shebang, like other editors do. To make this happen, I added an optional `first_line_pattern` field to languages' `config.toml` files, which is used in addition the languages' `path_suffixes` to detect that the language matches a file.

I added shebang regexes for JavaScript (via `node`), Ruby, and Python.