### PR TITLE
Don't have contacts popover affect appearance of Share/Unshare button

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -459,9 +459,7 @@ impl CollabTitlebarItem {
                 .with_child(
                     MouseEventHandler::<ShareUnshare>::new(0, cx, |state, _| {
                         //TODO: Ensure this button has consistant width for both text variations
-                        let style = titlebar
-                            .share_button
-                            .style_for(state, self.contacts_popover.is_some());
+                        let style = titlebar.share_button.style_for(state, false);
                         Label::new(label, style.text.clone())
                             .contained()
                             .with_style(style.container)


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-693/shareunshare-button-shows-active-state-when-collaborator-menu-is-open