### PR TITLE
When opening projects, only reuse the current window if it is empty

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -167,7 +167,7 @@ impl PickerDelegate for RecentProjectsView {
     fn confirm(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(selected_match) = &self.matches.get(self.selected_index()) {
             let workspace_location = &self.workspace_locations[selected_match.candidate_id];
-            cx.dispatch_global_action(OpenPaths {
+            cx.dispatch_action(OpenPaths {
                 paths: workspace_location.paths().as_ref().clone(),
             });
             cx.emit(Event::Dismissed);


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-649/cmdo-should-open-a-new-window