### PR TITLE
Refine Copilot settings names and the UX around configuration

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1,6 +1,11 @@
 {
     // The name of the Zed theme to use for the UI
     "theme": "One Dark",
+    // Features that can be globally enabled or disabled
+    "features": {
+        // Show Copilot icon in status bar
+        "copilot": true
+    },
     // The name of a font to use for rendering text in the editor
     "buffer_font_family": "Zed Mono",
     // The OpenType features to enable for text in the editor.
@@ -13,11 +18,6 @@
     // The factor to grow the active pane by. Defaults to 1.0
     // which gives the same size as all other panes.
     "active_pane_magnification": 1.0,
-    // Enable / disable copilot integration.
-    "enable_copilot_integration": true,
-    // Controls whether copilot provides suggestion immediately
-    // or waits for a `copilot::Toggle`
-    "copilot": "on",
     // Whether to enable vim modes and key bindings
     "vim_mode": false,
     // Whether to show the informational hover box when moving the mouse
@@ -30,6 +30,9 @@
     // Whether to pop the completions menu while typing in an editor without
     // explicitly requesting it.
     "show_completions_on_input": true,
+    // Controls whether copilot provides suggestion immediately
+    // or waits for a `copilot::Toggle`
+    "show_copilot_suggestions": true,
     // Whether the screen sharing icon is shown in the os status bar.
     "show_call_status_icon": true,
     // Whether to use language servers to provide code intelligence.

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -172,7 +172,7 @@ impl Copilot {
             let http = http.clone();
             let node_runtime = node_runtime.clone();
             move |this, cx| {
-                if cx.global::<Settings>().enable_copilot_integration {
+                if cx.global::<Settings>().features.copilot {
                     if matches!(this.server, CopilotServer::Disabled) {
                         let start_task = cx
                             .spawn({
@@ -194,7 +194,7 @@ impl Copilot {
         })
         .detach();
 
-        if cx.global::<Settings>().enable_copilot_integration {
+        if cx.global::<Settings>().features.copilot {
             let start_task = cx
                 .spawn({
                     let http = http.clone();

--- a/crates/copilot/src/sign_in.rs
+++ b/crates/copilot/src/sign_in.rs
@@ -5,7 +5,7 @@ use gpui::{
     platform::{WindowBounds, WindowKind, WindowOptions},
     AppContext, ClipboardItem, Element, Entity, View, ViewContext, ViewHandle,
 };
-use settings::Settings;
+use settings::{settings_file::SettingsFile, Settings};
 use theme::ui::modal;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -196,6 +196,20 @@ impl CopilotCodeVerification {
                     {
                         let verification_uri = data.verification_uri.clone();
                         move |_, cx| cx.platform().open_url(&verification_uri)
+                    },
+                )
+                .boxed(),
+                theme::ui::cta_button_with_click(
+                    "Disable Copilot Integration",
+                    style.auth.content_width,
+                    &style.auth.cta_button,
+                    cx,
+                    {
+                        move |_, cx| {
+                            SettingsFile::update(cx, move |settings| {
+                                settings.features.copilot = Some(false);
+                            });
+                        }
                     },
                 )
                 .boxed(),

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -254,12 +254,8 @@ impl CopilotButton {
 
             menu_options.push(ContextMenuItem::item(
                 format!(
-                    "{} Copilot for {}",
-                    if language_enabled {
-                        "Disable"
-                    } else {
-                        "Enable"
-                    },
+                    "{} Suggestions for {}",
+                    if language_enabled { "Hide" } else { "Show" },
                     language
                 ),
                 ToggleCopilotForLanguage {
@@ -271,9 +267,9 @@ impl CopilotButton {
         let globally_enabled = cx.global::<Settings>().show_copilot_suggestions(None);
         menu_options.push(ContextMenuItem::item(
             if globally_enabled {
-                "Disable Copilot Globally"
+                "Hide Suggestions for All Files"
             } else {
-                "Enable Copilot Globally"
+                "Show Suggestions for All Files"
             },
             ToggleCopilotGlobally,
         ));

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1265,7 +1265,7 @@ impl Editor {
                 cx.subscribe(&buffer, Self::on_buffer_event),
                 cx.observe(&display_map, Self::on_display_map_changed),
                 cx.observe(&blink_manager, |_, _, cx| cx.notify()),
-                cx.observe_global::<Settings, _>(Self::on_settings_changed),
+                cx.observe_global::<Settings, _>(Self::settings_changed),
             ],
         };
         this.end_selection(cx);
@@ -2808,7 +2808,7 @@ impl Editor {
     fn refresh_copilot_suggestions(&mut self, cx: &mut ViewContext<Self>) -> Option<()> {
         let copilot = Copilot::global(cx)?;
         if self.mode != EditorMode::Full || !copilot.read(cx).status().is_authorized() {
-            self.hide_copilot_suggestion(cx);
+            self.clear_copilot_suggestions(cx);
             return None;
         }
         self.update_visible_copilot_suggestion(cx);
@@ -2820,7 +2820,7 @@ impl Editor {
             .global::<Settings>()
             .show_copilot_suggestions(language_name.as_deref())
         {
-            self.hide_copilot_suggestion(cx);
+            self.clear_copilot_suggestions(cx);
             return None;
         }
 
@@ -2939,6 +2939,11 @@ impl Editor {
         } else {
             self.hide_copilot_suggestion(cx);
         }
+    }
+
+    fn clear_copilot_suggestions(&mut self, cx: &mut ViewContext<Self>) {
+        self.copilot_state = Default::default();
+        self.hide_copilot_suggestion(cx);
     }
 
     pub fn render_code_actions_indicator(
@@ -6494,7 +6499,7 @@ impl Editor {
         cx.notify();
     }
 
-    fn on_settings_changed(&mut self, cx: &mut ViewContext<Self>) {
+    fn settings_changed(&mut self, cx: &mut ViewContext<Self>) {
         self.refresh_copilot_suggestions(cx);
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2816,7 +2816,10 @@ impl Editor {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let cursor = self.selections.newest_anchor().head();
         let language_name = snapshot.language_at(cursor).map(|language| language.name());
-        if !cx.global::<Settings>().copilot_on(language_name.as_deref()) {
+        if !cx
+            .global::<Settings>()
+            .show_copilot_suggestions(language_name.as_deref())
+        {
             self.hide_copilot_suggestion(cx);
             return None;
         }

--- a/styles/src/styleTree/copilot.ts
+++ b/styles/src/styleTree/copilot.ts
@@ -113,7 +113,7 @@ export default function copilot(colorScheme: ColorScheme) {
             },
             dimensions: {
                 width: 280,
-                height: 280,
+                height: 320,
             },
         },
 


### PR DESCRIPTION
This PR refines some aspects of working with copilot settings.

In settings.json, to enable or disable Copilot entirely, we introduced a new `features` section:

```json
{
  "features": {
    "copilot": false,
  }
}
```

We also renamed the setting that controls whether we show suggestions for all files or a specific language to `show_copilot_suggestions`, and made it boolean instead of `"on"` or `"off"`.

In the UI, we updated the language in the menu.

<img width="436" alt="Screen Shot 2023-04-19 at 3 41 26 PM" src="https://user-images.githubusercontent.com/1789/233207267-4b433b77-d91d-4041-930a-8fa848073352.png">

We also added an affordance to disable copilot to the sign in modal, for those who don't want to use it or see it in their status bar. @iamnbutler, this could probably use some design love, but we thought it was important to get in.

<img width="392" alt="Screen Shot 2023-04-19 at 3 41 40 PM" src="https://user-images.githubusercontent.com/1789/233207380-e7fc6b8e-c108-4a60-a53f-9db45bfbd9a3.png">

/cc @mikayla-maki 