### PR TITLE
Allow buffers to use multiple language servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "editor",
  "gpui",
  "language",
+ "lsp",
  "postage",
  "project",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ serde_derive = { version = "1.0", features = ["deserialize_in_place"] }
 serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
 rand = { version = "0.8" }
 postage = { version = "0.5", features = ["futures-traits"] }
+smallvec = { version = "1.6", features = ["union"] }
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14" }

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -18,4 +18,4 @@ settings = { path = "../settings" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 futures = "0.3"
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }

--- a/crates/clock/Cargo.toml
+++ b/crates/clock/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/clock.rs"
 doctest = false
 
 [dependencies]
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3477,6 +3477,7 @@ async fn test_collaborating_with_diagnostics(
                     worktree_id,
                     path: Arc::from(Path::new("a.rs")),
                 },
+                0,
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 0,
@@ -3512,6 +3513,7 @@ async fn test_collaborating_with_diagnostics(
                 worktree_id,
                 path: Arc::from(Path::new("a.rs")),
             },
+            0,
             DiagnosticSummary {
                 error_count: 1,
                 warning_count: 0,
@@ -3552,10 +3554,10 @@ async fn test_collaborating_with_diagnostics(
                     worktree_id,
                     path: Arc::from(Path::new("a.rs")),
                 },
+                0,
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 1,
-                    ..Default::default()
                 },
             )]
         );
@@ -3568,10 +3570,10 @@ async fn test_collaborating_with_diagnostics(
                     worktree_id,
                     path: Arc::from(Path::new("a.rs")),
                 },
+                0,
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 1,
-                    ..Default::default()
                 },
             )]
         );

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -22,6 +22,7 @@ use language::{
     LanguageConfig, OffsetRangeExt, Point, Rope,
 };
 use live_kit_client::MacOSDisplay;
+use lsp::LanguageServerId;
 use project::{search::SearchQuery, DiagnosticSummary, Project, ProjectPath};
 use rand::prelude::*;
 use serde_json::json;
@@ -3477,7 +3478,7 @@ async fn test_collaborating_with_diagnostics(
                     worktree_id,
                     path: Arc::from(Path::new("a.rs")),
                 },
-                0,
+                LanguageServerId(0),
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 0,
@@ -3513,7 +3514,7 @@ async fn test_collaborating_with_diagnostics(
                 worktree_id,
                 path: Arc::from(Path::new("a.rs")),
             },
-            0,
+            LanguageServerId(0),
             DiagnosticSummary {
                 error_count: 1,
                 warning_count: 0,
@@ -3554,7 +3555,7 @@ async fn test_collaborating_with_diagnostics(
                     worktree_id,
                     path: Arc::from(Path::new("a.rs")),
                 },
-                0,
+                LanguageServerId(0),
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 1,
@@ -3570,7 +3571,7 @@ async fn test_collaborating_with_diagnostics(
                     worktree_id,
                     path: Arc::from(Path::new("a.rs")),
                 },
-                0,
+                LanguageServerId(0),
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 1,

--- a/crates/context_menu/Cargo.toml
+++ b/crates/context_menu/Cargo.toml
@@ -13,4 +13,4 @@ gpui = { path = "../gpui" }
 menu = { path = "../menu" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
-smallvec = "1.6"
+smallvec = { workspace = true }

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -14,7 +14,7 @@ use language::{
     ToPointUtf16,
 };
 use log::{debug, error};
-use lsp::LanguageServer;
+use lsp::{LanguageServer, LanguageServerId};
 use node_runtime::NodeRuntime;
 use request::{LogMessage, StatusNotification};
 use settings::Settings;
@@ -380,7 +380,7 @@ impl Copilot {
                 let node_path = node_runtime.binary_path().await?;
                 let arguments: &[OsString] = &[server_path.into(), "--stdio".into()];
                 let server = LanguageServer::new(
-                    0,
+                    LanguageServerId(0),
                     &node_path,
                     arguments,
                     Path::new("/"),

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -14,6 +14,7 @@ smallvec = { version = "1.6", features = ["union"] }
 collections = { path = "../collections" }
 editor = { path = "../editor" }
 language = { path = "../language" }
+lsp = { path = "../lsp" }
 gpui = { path = "../gpui" }
 project = { path = "../project" }
 settings = { path = "../settings" }
@@ -27,6 +28,7 @@ unindent = "0.1"
 client = { path = "../client", features = ["test-support"] }
 editor = { path = "../editor", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
+lsp = { path = "../lsp", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
 serde_json = { workspace = true }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 collections = { path = "../collections" }
 editor = { path = "../editor" }
 language = { path = "../language" }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -168,7 +168,7 @@ impl ProjectDiagnosticsEditor {
         let project = project_handle.read(cx);
         let paths_to_update = project
             .diagnostic_summaries(cx)
-            .map(|e| (e.0, e.1.language_server_id))
+            .map(|(path, server_id, _)| (path, server_id))
             .collect();
         let summary = project.diagnostic_summary(cx);
         let mut this = Self {

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -7,6 +7,7 @@ use gpui::{
     ViewHandle, WeakViewHandle,
 };
 use language::Diagnostic;
+use lsp::LanguageServerId;
 use project::Project;
 use settings::Settings;
 use workspace::{item::ItemHandle, StatusItemView};
@@ -15,7 +16,7 @@ pub struct DiagnosticIndicator {
     summary: project::DiagnosticSummary,
     active_editor: Option<WeakViewHandle<Editor>>,
     current_diagnostic: Option<Diagnostic>,
-    in_progress_checks: HashSet<usize>,
+    in_progress_checks: HashSet<LanguageServerId>,
     _observe_active_editor: Option<Subscription>,
 }
 

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -58,7 +58,7 @@ postage = { workspace = true }
 rand = { version = "0.8.3", optional = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2"
 tree-sitter-rust = { version = "*", optional = true }
 tree-sitter-html = { version = "*", optional = true }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4371,7 +4371,7 @@ async fn test_strip_whitespace_and_format_via_lsp(cx: &mut gpui::TestAppContext)
     cx.set_state(
         &[
             "one ",   //
-            "twoˇ",  //
+            "twoˇ",   //
             "three ", //
             "four",   //
         ]
@@ -4446,7 +4446,7 @@ async fn test_strip_whitespace_and_format_via_lsp(cx: &mut gpui::TestAppContext)
         &[
             "one",   //
             "",      //
-            "twoˇ", //
+            "twoˇ",  //
             "",      //
             "three", //
             "four",  //
@@ -4461,7 +4461,7 @@ async fn test_strip_whitespace_and_format_via_lsp(cx: &mut gpui::TestAppContext)
     cx.assert_editor_state(
         &[
             "one ",   //
-            "twoˇ",  //
+            "twoˇ",   //
             "three ", //
             "four",   //
         ]

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -620,7 +620,7 @@ mod tests {
                 }],
                 &snapshot,
             );
-            buffer.update_diagnostics(set, cx);
+            buffer.update_diagnostics(0, set, cx);
         });
 
         // Hover pops diagnostic immediately

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -436,6 +436,7 @@ mod tests {
     use indoc::indoc;
 
     use language::{Diagnostic, DiagnosticSet};
+    use lsp::LanguageServerId;
     use project::HoverBlock;
     use smol::stream::StreamExt;
 
@@ -620,7 +621,7 @@ mod tests {
                 }],
                 &snapshot,
             );
-            buffer.update_diagnostics(0, set, cx);
+            buffer.update_diagnostics(LanguageServerId(0), set, cx);
         });
 
         // Hover pops diagnostic immediately

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -2800,7 +2800,7 @@ impl MultiBufferSnapshot {
     ) -> impl Iterator<Item = DiagnosticEntry<O>> + 'a
     where
         T: 'a + ToOffset,
-        O: 'a + text::FromAnchor,
+        O: 'a + text::FromAnchor + Ord,
     {
         self.as_singleton()
             .into_iter()

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -2764,6 +2764,15 @@ impl MultiBufferSnapshot {
             .and_then(|(buffer, offset)| buffer.language_scope_at(offset))
     }
 
+    pub fn language_indent_size_at<T: ToOffset>(
+        &self,
+        position: T,
+        cx: &AppContext,
+    ) -> Option<IndentSize> {
+        let (buffer_snapshot, offset) = self.point_to_buffer_offset(position)?;
+        Some(buffer_snapshot.language_indent_size_at(offset, cx))
+    }
+
     pub fn is_dirty(&self) -> bool {
         self.is_dirty
     }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -44,7 +44,7 @@ seahash = "4.1"
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2"
 time = { version = "0.3", features = ["serde", "serde-well-known"] }
 tiny-skia = "0.5"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -50,7 +50,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 similar = "1.3"
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2"
 tree-sitter = "0.20"
 tree-sitter-rust = { version = "*", optional = true }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -156,6 +156,7 @@ pub struct Completion {
 
 #[derive(Clone, Debug)]
 pub struct CodeAction {
+    pub server_id: usize,
     pub range: Range<Anchor>,
     pub lsp_action: lsp::CodeAction,
 }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1866,7 +1866,7 @@ fn test_random_collaboration(cx: &mut AppContext, mut rng: StdRng) {
                         buffer,
                     );
                     log::info!("peer {} setting diagnostics: {:?}", replica_id, diagnostics);
-                    buffer.update_diagnostics(diagnostics, cx);
+                    buffer.update_diagnostics(0, diagnostics, cx);
                 });
                 mutation_count -= 1;
             }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1866,7 +1866,7 @@ fn test_random_collaboration(cx: &mut AppContext, mut rng: StdRng) {
                         buffer,
                     );
                     log::info!("peer {} setting diagnostics: {:?}", replica_id, diagnostics);
-                    buffer.update_diagnostics(0, diagnostics, cx);
+                    buffer.update_diagnostics(LanguageServerId(0), diagnostics, cx);
                 });
                 mutation_count -= 1;
             }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1588,7 +1588,7 @@ mod tests {
                 ..Default::default()
             },
             tree_sitter_javascript::language(),
-            None,
+            vec![],
             |_| Default::default(),
         );
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -817,7 +817,9 @@ impl LanguageRegistry {
                     .detach();
                 Ok(server)
             });
-            return vec![PendingLanguageServer { server_id: 0, task }];
+
+            let server_id = post_inc(&mut self.state.write().next_language_server_id);
+            return vec![PendingLanguageServer { server_id, task }];
         }
 
         let download_dir = self

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -462,6 +462,7 @@ pub async fn deserialize_completion(
 
 pub fn serialize_code_action(action: &CodeAction) -> proto::CodeAction {
     proto::CodeAction {
+        server_id: action.server_id as u64,
         start: Some(serialize_anchor(&action.range.start)),
         end: Some(serialize_anchor(&action.range.end)),
         lsp_action: serde_json::to_vec(&action.lsp_action).unwrap(),
@@ -479,6 +480,7 @@ pub fn deserialize_code_action(action: proto::CodeAction) -> Result<CodeAction> 
         .ok_or_else(|| anyhow!("invalid end"))?;
     let lsp_action = serde_json::from_slice(&action.lsp_action)?;
     Ok(CodeAction {
+        server_id: action.server_id as usize,
         range: start..end,
         lsp_action,
     })

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -250,10 +250,6 @@ impl LanguageServer {
             log::trace!("incoming message:{}", String::from_utf8_lossy(&buffer));
 
             if let Ok(msg) = serde_json::from_slice::<AnyNotification>(&buffer) {
-                dbg!(
-                    msg.method,
-                    notification_handlers.lock().keys().collect::<Vec<_>>()
-                );
                 if let Some(handler) = notification_handlers.lock().get_mut(msg.method) {
                     handler(msg.id, msg.params.get(), cx.clone());
                 } else {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -250,6 +250,10 @@ impl LanguageServer {
             log::trace!("incoming message:{}", String::from_utf8_lossy(&buffer));
 
             if let Ok(msg) = serde_json::from_slice::<AnyNotification>(&buffer) {
+                dbg!(
+                    msg.method,
+                    notification_handlers.lock().keys().collect::<Vec<_>>()
+                );
                 if let Some(handler) = notification_handlers.lock().get_mut(msg.method) {
                     handler(msg.id, msg.params.get(), cx.clone());
                 } else {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -33,21 +33,25 @@ pub(crate) trait LspCommand: 'static + Sized {
         language_server: &Arc<LanguageServer>,
         cx: &AppContext,
     ) -> <Self::LspRequest as lsp::request::Request>::Params;
+
     async fn response_from_lsp(
         self,
         message: <Self::LspRequest as lsp::request::Request>::Result,
         project: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        server_id: usize,
         cx: AsyncAppContext,
     ) -> Result<Self::Response>;
 
     fn to_proto(&self, project_id: u64, buffer: &Buffer) -> Self::ProtoRequest;
+
     async fn from_proto(
         message: Self::ProtoRequest,
         project: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
         cx: AsyncAppContext,
     ) -> Result<Self>;
+
     fn response_to_proto(
         response: Self::Response,
         project: &mut Project,
@@ -55,6 +59,7 @@ pub(crate) trait LspCommand: 'static + Sized {
         buffer_version: &clock::Global,
         cx: &mut AppContext,
     ) -> <Self::ProtoRequest as proto::RequestMessage>::Response;
+
     async fn response_from_proto(
         self,
         message: <Self::ProtoRequest as proto::RequestMessage>::Response,
@@ -62,6 +67,7 @@ pub(crate) trait LspCommand: 'static + Sized {
         buffer: ModelHandle<Buffer>,
         cx: AsyncAppContext,
     ) -> Result<Self::Response>;
+
     fn buffer_id_from_proto(message: &Self::ProtoRequest) -> u64;
 }
 
@@ -137,6 +143,7 @@ impl LspCommand for PrepareRename {
         message: Option<lsp::PrepareRenameResponse>,
         _: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        _: usize,
         cx: AsyncAppContext,
     ) -> Result<Option<Range<Anchor>>> {
         buffer.read_with(&cx, |buffer, _| {
@@ -263,10 +270,12 @@ impl LspCommand for PerformRename {
         message: Option<lsp::WorkspaceEdit>,
         project: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        server_id: usize,
         mut cx: AsyncAppContext,
     ) -> Result<ProjectTransaction> {
         if let Some(edit) = message {
-            let (lsp_adapter, lsp_server) = language_server_for_buffer(&project, &buffer, &mut cx)?;
+            let (lsp_adapter, lsp_server) =
+                language_server_for_buffer(&project, &buffer, server_id, &mut cx)?;
             Project::deserialize_workspace_edit(
                 project,
                 edit,
@@ -380,9 +389,10 @@ impl LspCommand for GetDefinition {
         message: Option<lsp::GotoDefinitionResponse>,
         project: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        server_id: usize,
         cx: AsyncAppContext,
     ) -> Result<Vec<LocationLink>> {
-        location_links_from_lsp(message, project, buffer, cx).await
+        location_links_from_lsp(message, project, buffer, server_id, cx).await
     }
 
     fn to_proto(&self, project_id: u64, buffer: &Buffer) -> proto::GetDefinition {
@@ -472,9 +482,10 @@ impl LspCommand for GetTypeDefinition {
         message: Option<lsp::GotoTypeDefinitionResponse>,
         project: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        server_id: usize,
         cx: AsyncAppContext,
     ) -> Result<Vec<LocationLink>> {
-        location_links_from_lsp(message, project, buffer, cx).await
+        location_links_from_lsp(message, project, buffer, server_id, cx).await
     }
 
     fn to_proto(&self, project_id: u64, buffer: &Buffer) -> proto::GetTypeDefinition {
@@ -537,12 +548,13 @@ impl LspCommand for GetTypeDefinition {
 fn language_server_for_buffer(
     project: &ModelHandle<Project>,
     buffer: &ModelHandle<Buffer>,
+    server_id: usize,
     cx: &mut AsyncAppContext,
 ) -> Result<(Arc<CachedLspAdapter>, Arc<LanguageServer>)> {
     project
         .read_with(cx, |project, cx| {
             project
-                .language_server_for_buffer(buffer.read(cx), cx)
+                .language_server_for_buffer(buffer.read(cx), server_id, cx)
                 .map(|(adapter, server)| (adapter.clone(), server.clone()))
         })
         .ok_or_else(|| anyhow!("no language server found for buffer"))
@@ -614,6 +626,7 @@ async fn location_links_from_lsp(
     message: Option<lsp::GotoDefinitionResponse>,
     project: ModelHandle<Project>,
     buffer: ModelHandle<Buffer>,
+    server_id: usize,
     mut cx: AsyncAppContext,
 ) -> Result<Vec<LocationLink>> {
     let message = match message {
@@ -642,7 +655,8 @@ async fn location_links_from_lsp(
         }
     }
 
-    let (lsp_adapter, language_server) = language_server_for_buffer(&project, &buffer, &mut cx)?;
+    let (lsp_adapter, language_server) =
+        language_server_for_buffer(&project, &buffer, server_id, &mut cx)?;
     let mut definitions = Vec::new();
     for (origin_range, target_uri, target_range) in unresolved_links {
         let target_buffer_handle = project
@@ -756,11 +770,12 @@ impl LspCommand for GetReferences {
         locations: Option<Vec<lsp::Location>>,
         project: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        server_id: usize,
         mut cx: AsyncAppContext,
     ) -> Result<Vec<Location>> {
         let mut references = Vec::new();
         let (lsp_adapter, language_server) =
-            language_server_for_buffer(&project, &buffer, &mut cx)?;
+            language_server_for_buffer(&project, &buffer, server_id, &mut cx)?;
 
         if let Some(locations) = locations {
             for lsp_location in locations {
@@ -917,6 +932,7 @@ impl LspCommand for GetDocumentHighlights {
         lsp_highlights: Option<Vec<lsp::DocumentHighlight>>,
         _: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        _: usize,
         cx: AsyncAppContext,
     ) -> Result<Vec<DocumentHighlight>> {
         buffer.read_with(&cx, |buffer, _| {
@@ -1062,6 +1078,7 @@ impl LspCommand for GetHover {
         message: Option<lsp::Hover>,
         _: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        _: usize,
         cx: AsyncAppContext,
     ) -> Result<Self::Response> {
         Ok(message.and_then(|hover| {
@@ -1283,6 +1300,7 @@ impl LspCommand for GetCompletions {
         completions: Option<lsp::CompletionResponse>,
         _: ModelHandle<Project>,
         buffer: ModelHandle<Buffer>,
+        _: usize,
         cx: AsyncAppContext,
     ) -> Result<Vec<Completion>> {
         let completions = if let Some(completions) = completions {
@@ -1502,6 +1520,7 @@ impl LspCommand for GetCodeActions {
         actions: Option<lsp::CodeActionResponse>,
         _: ModelHandle<Project>,
         _: ModelHandle<Buffer>,
+        server_id: usize,
         _: AsyncAppContext,
     ) -> Result<Vec<CodeAction>> {
         Ok(actions
@@ -1510,6 +1529,7 @@ impl LspCommand for GetCodeActions {
             .filter_map(|entry| {
                 if let lsp::CodeActionOrCommand::CodeAction(lsp_action) = entry {
                     Some(CodeAction {
+                        server_id,
                         range: self.range.clone(),
                         lsp_action,
                     })

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2137,17 +2137,23 @@ impl Project {
             return;
         }
 
-        let adapters = language.lsp_adapters();
-        let language_servers = self.languages.start_language_servers(
-            language.clone(),
-            worktree_path.clone(),
-            self.client.http_client(),
-            cx,
-        );
-        debug_assert_eq!(adapters.len(), language_servers.len());
-
-        for (adapter, pending_server) in adapters.into_iter().zip(language_servers.into_iter()) {
+        for adapter in language.lsp_adapters() {
             let key = (worktree_id, adapter.name.clone());
+            if self.language_server_ids.contains_key(&key) {
+                continue;
+            }
+
+            let pending_server = match self.languages.start_language_server(
+                language.clone(),
+                adapter.clone(),
+                worktree_path.clone(),
+                self.client.http_client(),
+                cx,
+            ) {
+                Some(pending_server) => pending_server,
+                None => continue,
+            };
+
             let lsp = &cx.global::<Settings>().lsp.get(&adapter.name.0);
             let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
 
@@ -2160,17 +2166,17 @@ impl Project {
                 _ => {}
             }
 
-            if !self.language_server_ids.contains_key(&key) {
-                let adapter = self.setup_pending_language_server(
-                    initialization_options,
-                    pending_server,
-                    adapter.clone(),
-                    language.clone(),
-                    key.clone(),
-                    cx,
-                );
-                self.language_server_ids.insert(key.clone(), adapter);
-            }
+            let server_id = pending_server.server_id;
+            let state = self.setup_pending_language_server(
+                initialization_options,
+                pending_server,
+                adapter.clone(),
+                language.clone(),
+                key.clone(),
+                cx,
+            );
+            self.language_servers.insert(server_id, state);
+            self.language_server_ids.insert(key.clone(), server_id);
         }
     }
 
@@ -2182,286 +2188,281 @@ impl Project {
         language: Arc<Language>,
         key: (WorktreeId, LanguageServerName),
         cx: &mut ModelContext<Project>,
-    ) -> usize {
+    ) -> LanguageServerState {
         let server_id = pending_server.server_id;
         let languages = self.languages.clone();
 
-        self.language_servers.insert(
-            server_id,
-            LanguageServerState::Starting(cx.spawn_weak(|this, mut cx| async move {
-                let workspace_config = cx.update(|cx| languages.workspace_configuration(cx)).await;
-                let language_server = pending_server.task.await.log_err()?;
-                let language_server = language_server
-                    .initialize(initialization_options)
-                    .await
-                    .log_err()?;
-                let this = this.upgrade(&cx)?;
+        LanguageServerState::Starting(cx.spawn_weak(|this, mut cx| async move {
+            let workspace_config = cx.update(|cx| languages.workspace_configuration(cx)).await;
+            let language_server = pending_server.task.await.log_err()?;
+            let language_server = language_server
+                .initialize(initialization_options)
+                .await
+                .log_err()?;
+            let this = this.upgrade(&cx)?;
 
-                language_server
-                    .on_notification::<lsp::notification::PublishDiagnostics, _>({
-                        let this = this.downgrade();
+            language_server
+                .on_notification::<lsp::notification::PublishDiagnostics, _>({
+                    let this = this.downgrade();
+                    let adapter = adapter.clone();
+                    move |mut params, cx| {
+                        let this = this;
                         let adapter = adapter.clone();
-                        move |mut params, cx| {
-                            let this = this;
-                            let adapter = adapter.clone();
-                            cx.spawn(|mut cx| async move {
-                                adapter.process_diagnostics(&mut params).await;
-                                if let Some(this) = this.upgrade(&cx) {
-                                    this.update(&mut cx, |this, cx| {
-                                        this.update_diagnostics(
-                                            server_id,
-                                            params,
-                                            &adapter.disk_based_diagnostic_sources,
-                                            cx,
-                                        )
-                                        .log_err();
-                                    });
-                                }
-                            })
-                            .detach();
-                        }
-                    })
-                    .detach();
-
-                language_server
-                    .on_request::<lsp::request::WorkspaceConfiguration, _, _>({
-                        let languages = languages.clone();
-                        move |params, mut cx| {
-                            let languages = languages.clone();
-                            async move {
-                                dbg!(&params.items);
-                                let workspace_config =
-                                    cx.update(|cx| languages.workspace_configuration(cx)).await;
-                                Ok(params
-                                    .items
-                                    .into_iter()
-                                    .map(|item| {
-                                        if let Some(section) = &item.section {
-                                            workspace_config
-                                                .get(section)
-                                                .cloned()
-                                                .unwrap_or(serde_json::Value::Null)
-                                        } else {
-                                            workspace_config.clone()
-                                        }
-                                    })
-                                    .collect())
-                            }
-                        }
-                    })
-                    .detach();
-
-                // Even though we don't have handling for these requests, respond to them to
-                // avoid stalling any language server like `gopls` which waits for a response
-                // to these requests when initializing.
-                language_server
-                    .on_request::<lsp::request::WorkDoneProgressCreate, _, _>({
-                        let this = this.downgrade();
-                        move |params, mut cx| async move {
-                            if let Some(this) = this.upgrade(&cx) {
-                                this.update(&mut cx, |this, _| {
-                                    if let Some(status) =
-                                        this.language_server_statuses.get_mut(&server_id)
-                                    {
-                                        if let lsp::NumberOrString::String(token) = params.token {
-                                            status.progress_tokens.insert(token);
-                                        }
-                                    }
-                                });
-                            }
-                            Ok(())
-                        }
-                    })
-                    .detach();
-                language_server
-                    .on_request::<lsp::request::RegisterCapability, _, _>({
-                        let this = this.downgrade();
-                        move |params, mut cx| async move {
-                            let this = this
-                                .upgrade(&cx)
-                                .ok_or_else(|| anyhow!("project dropped"))?;
-                            for reg in params.registrations {
-                                if reg.method == "workspace/didChangeWatchedFiles" {
-                                    if let Some(options) = reg.register_options {
-                                        let options = serde_json::from_value(options)?;
-                                        this.update(&mut cx, |this, cx| {
-                                            this.on_lsp_did_change_watched_files(
-                                                server_id, options, cx,
-                                            );
-                                        });
-                                    }
-                                }
-                            }
-                            Ok(())
-                        }
-                    })
-                    .detach();
-
-                language_server
-                    .on_request::<lsp::request::ApplyWorkspaceEdit, _, _>({
-                        let this = this.downgrade();
-                        let adapter = adapter.clone();
-                        let language_server = language_server.clone();
-                        move |params, cx| {
-                            Self::on_lsp_workspace_edit(
-                                this,
-                                params,
-                                server_id,
-                                adapter.clone(),
-                                language_server.clone(),
-                                cx,
-                            )
-                        }
-                    })
-                    .detach();
-
-                let disk_based_diagnostics_progress_token =
-                    adapter.disk_based_diagnostics_progress_token.clone();
-
-                language_server
-                    .on_notification::<lsp::notification::Progress, _>({
-                        let this = this.downgrade();
-                        move |params, mut cx| {
+                        cx.spawn(|mut cx| async move {
+                            adapter.process_diagnostics(&mut params).await;
                             if let Some(this) = this.upgrade(&cx) {
                                 this.update(&mut cx, |this, cx| {
-                                    this.on_lsp_progress(
-                                        params,
+                                    this.update_diagnostics(
                                         server_id,
-                                        disk_based_diagnostics_progress_token.clone(),
+                                        params,
+                                        &adapter.disk_based_diagnostic_sources,
                                         cx,
-                                    );
+                                    )
+                                    .log_err();
                                 });
+                            }
+                        })
+                        .detach();
+                    }
+                })
+                .detach();
+
+            language_server
+                .on_request::<lsp::request::WorkspaceConfiguration, _, _>({
+                    let languages = languages.clone();
+                    move |params, mut cx| {
+                        let languages = languages.clone();
+                        async move {
+                            let workspace_config =
+                                cx.update(|cx| languages.workspace_configuration(cx)).await;
+                            Ok(params
+                                .items
+                                .into_iter()
+                                .map(|item| {
+                                    if let Some(section) = &item.section {
+                                        workspace_config
+                                            .get(section)
+                                            .cloned()
+                                            .unwrap_or(serde_json::Value::Null)
+                                    } else {
+                                        workspace_config.clone()
+                                    }
+                                })
+                                .collect())
+                        }
+                    }
+                })
+                .detach();
+
+            // Even though we don't have handling for these requests, respond to them to
+            // avoid stalling any language server like `gopls` which waits for a response
+            // to these requests when initializing.
+            language_server
+                .on_request::<lsp::request::WorkDoneProgressCreate, _, _>({
+                    let this = this.downgrade();
+                    move |params, mut cx| async move {
+                        if let Some(this) = this.upgrade(&cx) {
+                            this.update(&mut cx, |this, _| {
+                                if let Some(status) =
+                                    this.language_server_statuses.get_mut(&server_id)
+                                {
+                                    if let lsp::NumberOrString::String(token) = params.token {
+                                        status.progress_tokens.insert(token);
+                                    }
+                                }
+                            });
+                        }
+                        Ok(())
+                    }
+                })
+                .detach();
+            language_server
+                .on_request::<lsp::request::RegisterCapability, _, _>({
+                    let this = this.downgrade();
+                    move |params, mut cx| async move {
+                        let this = this
+                            .upgrade(&cx)
+                            .ok_or_else(|| anyhow!("project dropped"))?;
+                        for reg in params.registrations {
+                            if reg.method == "workspace/didChangeWatchedFiles" {
+                                if let Some(options) = reg.register_options {
+                                    let options = serde_json::from_value(options)?;
+                                    this.update(&mut cx, |this, cx| {
+                                        this.on_lsp_did_change_watched_files(
+                                            server_id, options, cx,
+                                        );
+                                    });
+                                }
                             }
                         }
-                    })
-                    .detach();
-
-                language_server
-                    .notify::<lsp::notification::DidChangeConfiguration>(
-                        lsp::DidChangeConfigurationParams {
-                            settings: workspace_config,
-                        },
-                    )
-                    .ok();
-
-                this.update(&mut cx, |this, cx| {
-                    // If the language server for this key doesn't match the server id, don't store the
-                    // server. Which will cause it to be dropped, killing the process
-                    if this
-                        .language_server_ids
-                        .get(&key)
-                        .map(|id| id != &server_id)
-                        .unwrap_or(false)
-                    {
-                        return None;
+                        Ok(())
                     }
+                })
+                .detach();
 
-                    // Update language_servers collection with Running variant of LanguageServerState
-                    // indicating that the server is up and running and ready
-                    this.language_servers.insert(
-                        server_id,
-                        LanguageServerState::Running {
-                            adapter: adapter.clone(),
-                            language: language.clone(),
-                            watched_paths: Default::default(),
-                            server: language_server.clone(),
-                            simulate_disk_based_diagnostics_completion: None,
-                        },
-                    );
-                    this.language_server_statuses.insert(
-                        server_id,
-                        LanguageServerStatus {
-                            name: language_server.name().to_string(),
-                            pending_work: Default::default(),
-                            has_pending_diagnostic_updates: false,
-                            progress_tokens: Default::default(),
-                        },
-                    );
-
-                    if let Some(project_id) = this.remote_id() {
-                        this.client
-                            .send(proto::StartLanguageServer {
-                                project_id,
-                                server: Some(proto::LanguageServer {
-                                    id: server_id as u64,
-                                    name: language_server.name().to_string(),
-                                }),
-                            })
-                            .log_err();
+            language_server
+                .on_request::<lsp::request::ApplyWorkspaceEdit, _, _>({
+                    let this = this.downgrade();
+                    let adapter = adapter.clone();
+                    let language_server = language_server.clone();
+                    move |params, cx| {
+                        Self::on_lsp_workspace_edit(
+                            this,
+                            params,
+                            server_id,
+                            adapter.clone(),
+                            language_server.clone(),
+                            cx,
+                        )
                     }
+                })
+                .detach();
 
-                    // Tell the language server about every open buffer in the worktree that matches the language.
-                    for buffer in this.opened_buffers.values() {
-                        if let Some(buffer_handle) = buffer.upgrade(cx) {
-                            let buffer = buffer_handle.read(cx);
-                            let file = match File::from_dyn(buffer.file()) {
-                                Some(file) => file,
-                                None => continue,
-                            };
-                            let language = match buffer.language() {
-                                Some(language) => language,
-                                None => continue,
-                            };
+            let disk_based_diagnostics_progress_token =
+                adapter.disk_based_diagnostics_progress_token.clone();
 
-                            if file.worktree.read(cx).id() != key.0
-                                || !language.lsp_adapters().iter().any(|a| a.name == key.1)
-                            {
-                                continue;
-                            }
-
-                            let file = file.as_local()?;
-                            let versions = this
-                                .buffer_snapshots
-                                .entry(buffer.remote_id())
-                                .or_default()
-                                .entry(server_id)
-                                .or_insert_with(|| {
-                                    vec![LspBufferSnapshot {
-                                        version: 0,
-                                        snapshot: buffer.text_snapshot(),
-                                    }]
-                                });
-
-                            let snapshot = versions.last().unwrap();
-                            let version = snapshot.version;
-                            let initial_snapshot = &snapshot.snapshot;
-                            let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
-                            language_server
-                                .notify::<lsp::notification::DidOpenTextDocument>(
-                                    lsp::DidOpenTextDocumentParams {
-                                        text_document: lsp::TextDocumentItem::new(
-                                            uri,
-                                            adapter
-                                                .language_ids
-                                                .get(language.name().as_ref())
-                                                .cloned()
-                                                .unwrap_or_default(),
-                                            version,
-                                            initial_snapshot.text(),
-                                        ),
-                                    },
-                                )
-                                .log_err()?;
-                            buffer_handle.update(cx, |buffer, cx| {
-                                buffer.set_completion_triggers(
-                                    language_server
-                                        .capabilities()
-                                        .completion_provider
-                                        .as_ref()
-                                        .and_then(|provider| provider.trigger_characters.clone())
-                                        .unwrap_or_default(),
+            language_server
+                .on_notification::<lsp::notification::Progress, _>({
+                    let this = this.downgrade();
+                    move |params, mut cx| {
+                        if let Some(this) = this.upgrade(&cx) {
+                            this.update(&mut cx, |this, cx| {
+                                this.on_lsp_progress(
+                                    params,
+                                    server_id,
+                                    disk_based_diagnostics_progress_token.clone(),
                                     cx,
-                                )
+                                );
                             });
                         }
                     }
-
-                    cx.notify();
-                    Some(language_server)
                 })
-            })),
-        );
-        server_id
+                .detach();
+
+            language_server
+                .notify::<lsp::notification::DidChangeConfiguration>(
+                    lsp::DidChangeConfigurationParams {
+                        settings: workspace_config,
+                    },
+                )
+                .ok();
+
+            this.update(&mut cx, |this, cx| {
+                // If the language server for this key doesn't match the server id, don't store the
+                // server. Which will cause it to be dropped, killing the process
+                if this
+                    .language_server_ids
+                    .get(&key)
+                    .map(|id| id != &server_id)
+                    .unwrap_or(false)
+                {
+                    return None;
+                }
+
+                // Update language_servers collection with Running variant of LanguageServerState
+                // indicating that the server is up and running and ready
+                this.language_servers.insert(
+                    server_id,
+                    LanguageServerState::Running {
+                        adapter: adapter.clone(),
+                        language: language.clone(),
+                        watched_paths: Default::default(),
+                        server: language_server.clone(),
+                        simulate_disk_based_diagnostics_completion: None,
+                    },
+                );
+                this.language_server_statuses.insert(
+                    server_id,
+                    LanguageServerStatus {
+                        name: language_server.name().to_string(),
+                        pending_work: Default::default(),
+                        has_pending_diagnostic_updates: false,
+                        progress_tokens: Default::default(),
+                    },
+                );
+
+                if let Some(project_id) = this.remote_id() {
+                    this.client
+                        .send(proto::StartLanguageServer {
+                            project_id,
+                            server: Some(proto::LanguageServer {
+                                id: server_id as u64,
+                                name: language_server.name().to_string(),
+                            }),
+                        })
+                        .log_err();
+                }
+
+                // Tell the language server about every open buffer in the worktree that matches the language.
+                for buffer in this.opened_buffers.values() {
+                    if let Some(buffer_handle) = buffer.upgrade(cx) {
+                        let buffer = buffer_handle.read(cx);
+                        let file = match File::from_dyn(buffer.file()) {
+                            Some(file) => file,
+                            None => continue,
+                        };
+                        let language = match buffer.language() {
+                            Some(language) => language,
+                            None => continue,
+                        };
+
+                        if file.worktree.read(cx).id() != key.0
+                            || !language.lsp_adapters().iter().any(|a| a.name == key.1)
+                        {
+                            continue;
+                        }
+
+                        let file = file.as_local()?;
+                        let versions = this
+                            .buffer_snapshots
+                            .entry(buffer.remote_id())
+                            .or_default()
+                            .entry(server_id)
+                            .or_insert_with(|| {
+                                vec![LspBufferSnapshot {
+                                    version: 0,
+                                    snapshot: buffer.text_snapshot(),
+                                }]
+                            });
+
+                        let snapshot = versions.last().unwrap();
+                        let version = snapshot.version;
+                        let initial_snapshot = &snapshot.snapshot;
+                        let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
+                        language_server
+                            .notify::<lsp::notification::DidOpenTextDocument>(
+                                lsp::DidOpenTextDocumentParams {
+                                    text_document: lsp::TextDocumentItem::new(
+                                        uri,
+                                        adapter
+                                            .language_ids
+                                            .get(language.name().as_ref())
+                                            .cloned()
+                                            .unwrap_or_default(),
+                                        version,
+                                        initial_snapshot.text(),
+                                    ),
+                                },
+                            )
+                            .log_err()?;
+                        buffer_handle.update(cx, |buffer, cx| {
+                            buffer.set_completion_triggers(
+                                language_server
+                                    .capabilities()
+                                    .completion_provider
+                                    .as_ref()
+                                    .and_then(|provider| provider.trigger_characters.clone())
+                                    .unwrap_or_default(),
+                                cx,
+                            )
+                        });
+                    }
+                }
+
+                cx.notify();
+                Some(language_server)
+            })
+        }))
     }
 
     // Returns a list of all of the worktrees which no longer have a language server and the root path

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2161,8 +2161,7 @@ impl Project {
             }
 
             if !self.language_server_ids.contains_key(&key) {
-                let adapter = self.setup_language_adapter(
-                    worktree_path.clone(),
+                let adapter = self.setup_pending_language_server(
                     initialization_options,
                     pending_server,
                     adapter.clone(),
@@ -2175,9 +2174,8 @@ impl Project {
         }
     }
 
-    fn setup_language_adapter(
+    fn setup_pending_language_server(
         &mut self,
-        worktree_path: Arc<Path>,
         initialization_options: Option<serde_json::Value>,
         pending_server: PendingLanguageServer,
         adapter: Arc<CachedLspAdapter>,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -31,8 +31,8 @@ use language::{
     range_from_lsp, range_to_lsp, Anchor, Bias, Buffer, CachedLspAdapter, CodeAction, CodeLabel,
     Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Diff, Event as BufferEvent, File as _,
     Language, LanguageRegistry, LanguageServerName, LocalFile, OffsetRangeExt, Operation, Patch,
-    PointUtf16, RopeFingerprint, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction,
-    Unclipped,
+    PendingLanguageServer, PointUtf16, RopeFingerprint, TextBufferSnapshot, ToOffset, ToPointUtf16,
+    Transaction, Unclipped,
 };
 use lsp::{
     DiagnosticSeverity, DiagnosticTag, DidChangeWatchedFilesRegistrationOptions,
@@ -99,7 +99,6 @@ pub struct Project {
     language_server_ids: HashMap<(WorktreeId, LanguageServerName), usize>,
     language_server_statuses: BTreeMap<usize, LanguageServerStatus>,
     last_workspace_edits_by_language_server: HashMap<usize, ProjectTransaction>,
-    next_language_server_id: usize,
     client: Arc<client::Client>,
     next_entry_id: Arc<AtomicUsize>,
     join_project_response_message_id: u32,
@@ -124,13 +123,18 @@ pub struct Project {
     /// A mapping from a buffer ID to None means that we've started waiting for an ID but haven't finished loading it.
     /// Used for re-issuing buffer requests when peers temporarily disconnect
     incomplete_remote_buffers: HashMap<u64, Option<ModelHandle<Buffer>>>,
-    buffer_snapshots: HashMap<u64, Vec<(i32, TextBufferSnapshot)>>,
+    buffer_snapshots: HashMap<u64, HashMap<usize, Vec<LspBufferSnapshot>>>, // buffer_id -> server_id -> vec of snapshots
     buffers_being_formatted: HashSet<usize>,
     nonce: u128,
     _maintain_buffer_languages: Task<()>,
     _maintain_workspace_config: Task<()>,
     terminals: Terminals,
     copilot_enabled: bool,
+}
+
+struct LspBufferSnapshot {
+    version: i32,
+    snapshot: TextBufferSnapshot,
 }
 
 enum BufferMessage {
@@ -469,7 +473,6 @@ impl Project {
                 language_server_statuses: Default::default(),
                 last_workspace_edits_by_language_server: Default::default(),
                 buffers_being_formatted: Default::default(),
-                next_language_server_id: 0,
                 nonce: StdRng::from_entropy().gen(),
                 terminals: Terminals {
                     local_handles: Vec::new(),
@@ -554,7 +557,6 @@ impl Project {
                     })
                     .collect(),
                 last_workspace_edits_by_language_server: Default::default(),
-                next_language_server_id: 0,
                 opened_buffers: Default::default(),
                 buffers_being_formatted: Default::default(),
                 buffer_snapshots: Default::default(),
@@ -645,7 +647,7 @@ impl Project {
 
         let mut language_servers_to_stop = Vec::new();
         for language in self.languages.to_vec() {
-            if let Some(lsp_adapter) = language.lsp_adapter() {
+            for lsp_adapter in language.lsp_adapters() {
                 if !settings.enable_language_server(Some(&language.name())) {
                     let lsp_name = &lsp_adapter.name;
                     for (worktree_id, started_lsp_name) in self.language_server_ids.keys() {
@@ -665,7 +667,7 @@ impl Project {
 
         // Start all the newly-enabled language servers.
         for (worktree_id, worktree_path, language) in language_servers_to_start {
-            self.start_language_server(worktree_id, worktree_path, language, cx);
+            self.start_language_servers(worktree_id, worktree_path, language, cx);
         }
 
         if !self.copilot_enabled && Copilot::global(cx).is_some() {
@@ -1550,7 +1552,7 @@ impl Project {
         cx.spawn(|this, mut cx| async move {
             if let Some(old_path) = old_path {
                 this.update(&mut cx, |this, cx| {
-                    this.unregister_buffer_from_language_server(&buffer, old_path, cx);
+                    this.unregister_buffer_from_language_servers(&buffer, old_path, cx);
                 });
             }
             let (worktree, path) = worktree_task.await?;
@@ -1564,7 +1566,7 @@ impl Project {
                 .await?;
             this.update(&mut cx, |this, cx| {
                 this.detect_language_for_buffer(&buffer, cx);
-                this.register_buffer_with_language_server(&buffer, cx);
+                this.register_buffer_with_language_servers(&buffer, cx);
             });
             Ok(())
         })
@@ -1628,14 +1630,15 @@ impl Project {
         .detach();
 
         self.detect_language_for_buffer(buffer, cx);
-        self.register_buffer_with_language_server(buffer, cx);
+        self.register_buffer_with_language_servers(buffer, cx);
         self.register_buffer_with_copilot(buffer, cx);
         cx.observe_release(buffer, |this, buffer, cx| {
             if let Some(file) = File::from_dyn(buffer.file()) {
                 if file.is_local() {
                     let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
-                    if let Some((_, server)) = this.language_server_for_buffer(buffer, cx) {
+                    for server in this.language_servers_for_buffer(buffer, cx) {
                         server
+                            .1
                             .notify::<lsp::notification::DidCloseTextDocument>(
                                 lsp::DidCloseTextDocumentParams {
                                     text_document: lsp::TextDocumentIdentifier::new(uri),
@@ -1652,46 +1655,50 @@ impl Project {
         Ok(())
     }
 
-    fn register_buffer_with_language_server(
+    fn register_buffer_with_language_servers(
         &mut self,
         buffer_handle: &ModelHandle<Buffer>,
         cx: &mut ModelContext<Self>,
     ) {
         let buffer = buffer_handle.read(cx);
         let buffer_id = buffer.remote_id();
+
         if let Some(file) = File::from_dyn(buffer.file()) {
-            if file.is_local() {
-                let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
-                let initial_snapshot = buffer.text_snapshot();
+            if !file.is_local() {
+                return;
+            }
 
-                let mut language_server = None;
-                let mut language_id = None;
-                if let Some(language) = buffer.language() {
-                    let worktree_id = file.worktree_id(cx);
-                    if let Some(adapter) = language.lsp_adapter() {
-                        language_id = adapter.language_ids.get(language.name().as_ref()).cloned();
-                        language_server = self
-                            .language_server_ids
-                            .get(&(worktree_id, adapter.name.clone()))
-                            .and_then(|id| self.language_servers.get(id))
-                            .and_then(|server_state| {
-                                if let LanguageServerState::Running { server, .. } = server_state {
-                                    Some(server.clone())
-                                } else {
-                                    None
-                                }
-                            });
-                    }
+            let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
+            let initial_snapshot = buffer.text_snapshot();
+
+            if let Some(local_worktree) = file.worktree.read(cx).as_local() {
+                if let Some(diagnostics) = local_worktree.diagnostics_for_path(file.path()) {
+                    self.update_buffer_diagnostics(buffer_handle, diagnostics, None, cx)
+                        .log_err();
                 }
+            }
 
-                if let Some(local_worktree) = file.worktree.read(cx).as_local() {
-                    if let Some(diagnostics) = local_worktree.diagnostics_for_path(file.path()) {
-                        self.update_buffer_diagnostics(buffer_handle, diagnostics, None, cx)
-                            .log_err();
-                    }
-                }
+            if let Some(language) = buffer.language() {
+                let worktree_id = file.worktree_id(cx);
 
-                if let Some(server) = language_server {
+                for adapter in language.lsp_adapters() {
+                    let language_id = adapter.language_ids.get(language.name().as_ref()).cloned();
+                    let server = self
+                        .language_server_ids
+                        .get(&(worktree_id, adapter.name.clone()))
+                        .and_then(|id| self.language_servers.get(id))
+                        .and_then(|server_state| {
+                            if let LanguageServerState::Running { server, .. } = server_state {
+                                Some(server.clone())
+                            } else {
+                                None
+                            }
+                        });
+                    let server = match server {
+                        Some(server) => server,
+                        None => continue,
+                    };
+
                     server
                         .notify::<lsp::notification::DidOpenTextDocument>(
                             lsp::DidOpenTextDocumentParams {
@@ -1704,6 +1711,7 @@ impl Project {
                             },
                         )
                         .log_err();
+
                     buffer_handle.update(cx, |buffer, cx| {
                         buffer.set_completion_triggers(
                             server
@@ -1713,16 +1721,23 @@ impl Project {
                                 .and_then(|provider| provider.trigger_characters.clone())
                                 .unwrap_or_default(),
                             cx,
-                        )
+                        );
                     });
+
+                    let snapshot = LspBufferSnapshot {
+                        version: 0,
+                        snapshot: initial_snapshot,
+                    };
                     self.buffer_snapshots
-                        .insert(buffer_id, vec![(0, initial_snapshot)]);
+                        .entry(buffer_id)
+                        .or_default()
+                        .insert(server.server_id(), vec![snapshot]);
                 }
             }
         }
     }
 
-    fn unregister_buffer_from_language_server(
+    fn unregister_buffer_from_language_servers(
         &mut self,
         buffer: &ModelHandle<Buffer>,
         old_path: PathBuf,
@@ -1731,7 +1746,7 @@ impl Project {
         buffer.update(cx, |buffer, cx| {
             buffer.update_diagnostics(Default::default(), cx);
             self.buffer_snapshots.remove(&buffer.remote_id());
-            if let Some((_, language_server)) = self.language_server_for_buffer(buffer, cx) {
+            for (_, language_server) in self.language_servers_for_buffer(buffer, cx) {
                 language_server
                     .notify::<lsp::notification::DidCloseTextDocument>(
                         lsp::DidCloseTextDocumentParams {
@@ -1833,52 +1848,62 @@ impl Project {
                     })
                     .ok();
             }
+
             BufferEvent::Edited { .. } => {
-                let language_server = self
-                    .language_server_for_buffer(buffer.read(cx), cx)
-                    .map(|(_, server)| server.clone())?;
                 let buffer = buffer.read(cx);
                 let file = File::from_dyn(buffer.file())?;
                 let abs_path = file.as_local()?.abs_path(cx);
                 let uri = lsp::Url::from_file_path(abs_path).unwrap();
-                let buffer_snapshots = self.buffer_snapshots.get_mut(&buffer.remote_id())?;
-                let (version, prev_snapshot) = buffer_snapshots.last()?;
                 let next_snapshot = buffer.text_snapshot();
-                let next_version = version + 1;
 
-                let content_changes = buffer
-                    .edits_since::<(PointUtf16, usize)>(prev_snapshot.version())
-                    .map(|edit| {
-                        let edit_start = edit.new.start.0;
-                        let edit_end = edit_start + (edit.old.end.0 - edit.old.start.0);
-                        let new_text = next_snapshot
-                            .text_for_range(edit.new.start.1..edit.new.end.1)
-                            .collect();
-                        lsp::TextDocumentContentChangeEvent {
-                            range: Some(lsp::Range::new(
-                                point_to_lsp(edit_start),
-                                point_to_lsp(edit_end),
-                            )),
-                            range_length: None,
-                            text: new_text,
-                        }
-                    })
-                    .collect();
+                for (_, language_server) in self.language_servers_for_buffer(buffer, cx) {
+                    let language_server = language_server.clone();
 
-                buffer_snapshots.push((next_version, next_snapshot));
+                    let buffer_snapshots = self
+                        .buffer_snapshots
+                        .get_mut(&buffer.remote_id())
+                        .and_then(|m| m.get_mut(&language_server.server_id()))?;
+                    let previous_snapshot = buffer_snapshots.last()?;
+                    let next_version = previous_snapshot.version + 1;
 
-                language_server
-                    .notify::<lsp::notification::DidChangeTextDocument>(
-                        lsp::DidChangeTextDocumentParams {
-                            text_document: lsp::VersionedTextDocumentIdentifier::new(
-                                uri,
-                                next_version,
-                            ),
-                            content_changes,
-                        },
-                    )
-                    .log_err();
+                    let content_changes = buffer
+                        .edits_since::<(PointUtf16, usize)>(previous_snapshot.snapshot.version())
+                        .map(|edit| {
+                            let edit_start = edit.new.start.0;
+                            let edit_end = edit_start + (edit.old.end.0 - edit.old.start.0);
+                            let new_text = next_snapshot
+                                .text_for_range(edit.new.start.1..edit.new.end.1)
+                                .collect();
+                            lsp::TextDocumentContentChangeEvent {
+                                range: Some(lsp::Range::new(
+                                    point_to_lsp(edit_start),
+                                    point_to_lsp(edit_end),
+                                )),
+                                range_length: None,
+                                text: new_text,
+                            }
+                        })
+                        .collect();
+
+                    buffer_snapshots.push(LspBufferSnapshot {
+                        version: next_version,
+                        snapshot: next_snapshot,
+                    });
+
+                    language_server
+                        .notify::<lsp::notification::DidChangeTextDocument>(
+                            lsp::DidChangeTextDocumentParams {
+                                text_document: lsp::VersionedTextDocumentIdentifier::new(
+                                    uri,
+                                    next_version,
+                                ),
+                                content_changes,
+                            },
+                        )
+                        .log_err();
+                }
             }
+
             BufferEvent::Saved => {
                 let file = File::from_dyn(buffer.read(cx).file())?;
                 let worktree_id = file.worktree_id(cx);
@@ -1898,13 +1923,17 @@ impl Project {
                         .log_err();
                 }
 
-                let language_server_id = self.language_server_id_for_buffer(buffer.read(cx), cx)?;
-                if let Some(LanguageServerState::Running {
-                    adapter,
-                    simulate_disk_based_diagnostics_completion,
-                    ..
-                }) = self.language_servers.get_mut(&language_server_id)
-                {
+                let language_server_ids = self.language_server_ids_for_buffer(buffer.read(cx), cx);
+                for language_server_id in language_server_ids {
+                    let LanguageServerState::Running {
+                        adapter,
+                        simulate_disk_based_diagnostics_completion,
+                        ..
+                    } = match self.language_servers.get_mut(&language_server_id) {
+                        Some(state) => state,
+                        None => continue,
+                    };
+
                     // After saving a buffer using a language server that doesn't provide
                     // a disk-based progress token, kick off a timer that will reset every
                     // time the buffer is saved. If the timer eventually fires, simulate
@@ -1933,6 +1962,7 @@ impl Project {
                     }
                 }
             }
+
             _ => {}
         }
 
@@ -1987,7 +2017,7 @@ impl Project {
 
                         for buffer in plain_text_buffers {
                             project.detect_language_for_buffer(&buffer, cx);
-                            project.register_buffer_with_language_server(&buffer, cx);
+                            project.register_buffer_with_language_servers(&buffer, cx);
                         }
 
                         for buffer in buffers_with_unknown_injections {
@@ -2071,12 +2101,12 @@ impl Project {
             if let Some(worktree) = file.worktree.read(cx).as_local() {
                 let worktree_id = worktree.id();
                 let worktree_abs_path = worktree.abs_path().clone();
-                self.start_language_server(worktree_id, worktree_abs_path, new_language, cx);
+                self.start_language_servers(worktree_id, worktree_abs_path, new_language, cx);
             }
         }
     }
 
-    fn start_language_server(
+    fn start_language_servers(
         &mut self,
         worktree_id: WorktreeId,
         worktree_path: Arc<Path>,
@@ -2090,313 +2120,333 @@ impl Project {
             return;
         }
 
-        let adapter = if let Some(adapter) = language.lsp_adapter() {
-            adapter
-        } else {
-            return;
-        };
-        let key = (worktree_id, adapter.name.clone());
+        let adapters = language.lsp_adapters();
+        let language_servers = self.languages.start_language_servers(
+            language.clone(),
+            worktree_path,
+            self.client.http_client(),
+            cx,
+        );
+        debug_assert_eq!(adapters.len(), language_servers.len());
 
-        let mut initialization_options = adapter.initialization_options.clone();
+        for (adapter, pending_server) in adapters.into_iter().zip(language_servers.into_iter()) {
+            let key = (worktree_id, adapter.name.clone());
+            let lsp = &cx.global::<Settings>().lsp.get(&adapter.name.0);
+            let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
 
-        let lsp = &cx.global::<Settings>().lsp.get(&adapter.name.0);
-        let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
-        match (&mut initialization_options, override_options) {
-            (Some(initialization_options), Some(override_options)) => {
-                merge_json_value_into(override_options, initialization_options);
+            let mut initialization_options = adapter.initialization_options.clone();
+            match (&mut initialization_options, override_options) {
+                (Some(initialization_options), Some(override_options)) => {
+                    merge_json_value_into(override_options, initialization_options);
+                }
+                (None, override_options) => initialization_options = override_options,
+                _ => {}
             }
-            (None, override_options) => initialization_options = override_options,
-            _ => {}
+
+            self.language_server_ids
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    self.setup_language_adapter(
+                        worktree_path,
+                        initialization_options,
+                        pending_server,
+                        adapter,
+                        &language,
+                        key,
+                        cx,
+                    )
+                });
         }
+    }
 
-        self.language_server_ids
-            .entry(key.clone())
-            .or_insert_with(|| {
-                let languages = self.languages.clone();
-                let server_id = post_inc(&mut self.next_language_server_id);
-                let language_server = self.languages.start_language_server(
-                    server_id,
-                    language.clone(),
-                    worktree_path,
-                    self.client.http_client(),
-                    cx,
-                );
-                self.language_servers.insert(
-                    server_id,
-                    LanguageServerState::Starting(cx.spawn_weak(|this, mut cx| async move {
-                        let workspace_config =
-                            cx.update(|cx| languages.workspace_configuration(cx)).await;
-                        let language_server = language_server?.await.log_err()?;
-                        let language_server = language_server
-                            .initialize(initialization_options)
-                            .await
-                            .log_err()?;
-                        let this = this.upgrade(&cx)?;
+    fn setup_language_adapter(
+        &mut self,
+        worktree_path: Arc<Path>,
+        initialization_options: Option<serde_json::Value>,
+        pending_server: PendingLanguageServer,
+        adapter: &Arc<CachedLspAdapter>,
+        language: &Arc<Language>,
+        key: (WorktreeId, LanguageServerName),
+        cx: &mut ModelContext<Project>,
+    ) -> usize {
+        let server_id = pending_server.server_id;
+        let languages = self.languages.clone();
 
-                        language_server
-                            .on_notification::<lsp::notification::PublishDiagnostics, _>({
-                                let this = this.downgrade();
-                                let adapter = adapter.clone();
-                                move |mut params, cx| {
-                                    let this = this;
-                                    let adapter = adapter.clone();
-                                    cx.spawn(|mut cx| async move {
-                                        adapter.process_diagnostics(&mut params).await;
-                                        if let Some(this) = this.upgrade(&cx) {
-                                            this.update(&mut cx, |this, cx| {
-                                                this.update_diagnostics(
-                                                    server_id,
-                                                    params,
-                                                    &adapter.disk_based_diagnostic_sources,
-                                                    cx,
-                                                )
-                                                .log_err();
-                                            });
+        self.language_servers.insert(
+            server_id,
+            LanguageServerState::Starting(cx.spawn_weak(|this, mut cx| async move {
+                let workspace_config = cx.update(|cx| languages.workspace_configuration(cx)).await;
+                let language_server = pending_server.task.await.log_err()?;
+                let language_server = language_server
+                    .initialize(initialization_options)
+                    .await
+                    .log_err()?;
+                let this = this.upgrade(&cx)?;
+
+                language_server
+                    .on_notification::<lsp::notification::PublishDiagnostics, _>({
+                        let this = this.downgrade();
+                        let adapter = adapter.clone();
+                        move |mut params, cx| {
+                            let this = this;
+                            let adapter = adapter.clone();
+                            cx.spawn(|mut cx| async move {
+                                adapter.process_diagnostics(&mut params).await;
+                                if let Some(this) = this.upgrade(&cx) {
+                                    this.update(&mut cx, |this, cx| {
+                                        this.update_diagnostics(
+                                            server_id,
+                                            params,
+                                            &adapter.disk_based_diagnostic_sources,
+                                            cx,
+                                        )
+                                        .log_err();
+                                    });
+                                }
+                            })
+                            .detach();
+                        }
+                    })
+                    .detach();
+
+                language_server
+                    .on_request::<lsp::request::WorkspaceConfiguration, _, _>({
+                        let languages = languages.clone();
+                        move |params, mut cx| {
+                            let languages = languages.clone();
+                            async move {
+                                let workspace_config =
+                                    cx.update(|cx| languages.workspace_configuration(cx)).await;
+                                Ok(params
+                                    .items
+                                    .into_iter()
+                                    .map(|item| {
+                                        if let Some(section) = &item.section {
+                                            workspace_config
+                                                .get(section)
+                                                .cloned()
+                                                .unwrap_or(serde_json::Value::Null)
+                                        } else {
+                                            workspace_config.clone()
                                         }
                                     })
-                                    .detach();
-                                }
-                            })
-                            .detach();
+                                    .collect())
+                            }
+                        }
+                    })
+                    .detach();
 
-                        language_server
-                            .on_request::<lsp::request::WorkspaceConfiguration, _, _>({
-                                let languages = languages.clone();
-                                move |params, mut cx| {
-                                    let languages = languages.clone();
-                                    async move {
-                                        let workspace_config = cx
-                                            .update(|cx| languages.workspace_configuration(cx))
-                                            .await;
-                                        Ok(params
-                                            .items
-                                            .into_iter()
-                                            .map(|item| {
-                                                if let Some(section) = &item.section {
-                                                    workspace_config
-                                                        .get(section)
-                                                        .cloned()
-                                                        .unwrap_or(serde_json::Value::Null)
-                                                } else {
-                                                    workspace_config.clone()
-                                                }
-                                            })
-                                            .collect())
-                                    }
-                                }
-                            })
-                            .detach();
-
-                        // Even though we don't have handling for these requests, respond to them to
-                        // avoid stalling any language server like `gopls` which waits for a response
-                        // to these requests when initializing.
-                        language_server
-                            .on_request::<lsp::request::WorkDoneProgressCreate, _, _>({
-                                let this = this.downgrade();
-                                move |params, mut cx| async move {
-                                    if let Some(this) = this.upgrade(&cx) {
-                                        this.update(&mut cx, |this, _| {
-                                            if let Some(status) =
-                                                this.language_server_statuses.get_mut(&server_id)
-                                            {
-                                                if let lsp::NumberOrString::String(token) =
-                                                    params.token
-                                                {
-                                                    status.progress_tokens.insert(token);
-                                                }
-                                            }
-                                        });
-                                    }
-                                    Ok(())
-                                }
-                            })
-                            .detach();
-                        language_server
-                            .on_request::<lsp::request::RegisterCapability, _, _>({
-                                let this = this.downgrade();
-                                move |params, mut cx| async move {
-                                    let this = this
-                                        .upgrade(&cx)
-                                        .ok_or_else(|| anyhow!("project dropped"))?;
-                                    for reg in params.registrations {
-                                        if reg.method == "workspace/didChangeWatchedFiles" {
-                                            if let Some(options) = reg.register_options {
-                                                let options = serde_json::from_value(options)?;
-                                                this.update(&mut cx, |this, cx| {
-                                                    this.on_lsp_did_change_watched_files(
-                                                        server_id, options, cx,
-                                                    );
-                                                });
-                                            }
+                // Even though we don't have handling for these requests, respond to them to
+                // avoid stalling any language server like `gopls` which waits for a response
+                // to these requests when initializing.
+                language_server
+                    .on_request::<lsp::request::WorkDoneProgressCreate, _, _>({
+                        let this = this.downgrade();
+                        move |params, mut cx| async move {
+                            if let Some(this) = this.upgrade(&cx) {
+                                this.update(&mut cx, |this, _| {
+                                    if let Some(status) =
+                                        this.language_server_statuses.get_mut(&server_id)
+                                    {
+                                        if let lsp::NumberOrString::String(token) = params.token {
+                                            status.progress_tokens.insert(token);
                                         }
                                     }
-                                    Ok(())
-                                }
-                            })
-                            .detach();
-
-                        language_server
-                            .on_request::<lsp::request::ApplyWorkspaceEdit, _, _>({
-                                let this = this.downgrade();
-                                let adapter = adapter.clone();
-                                let language_server = language_server.clone();
-                                move |params, cx| {
-                                    Self::on_lsp_workspace_edit(
-                                        this,
-                                        params,
-                                        server_id,
-                                        adapter.clone(),
-                                        language_server.clone(),
-                                        cx,
-                                    )
-                                }
-                            })
-                            .detach();
-
-                        let disk_based_diagnostics_progress_token =
-                            adapter.disk_based_diagnostics_progress_token.clone();
-
-                        language_server
-                            .on_notification::<lsp::notification::Progress, _>({
-                                let this = this.downgrade();
-                                move |params, mut cx| {
-                                    if let Some(this) = this.upgrade(&cx) {
+                                });
+                            }
+                            Ok(())
+                        }
+                    })
+                    .detach();
+                language_server
+                    .on_request::<lsp::request::RegisterCapability, _, _>({
+                        let this = this.downgrade();
+                        move |params, mut cx| async move {
+                            let this = this
+                                .upgrade(&cx)
+                                .ok_or_else(|| anyhow!("project dropped"))?;
+                            for reg in params.registrations {
+                                if reg.method == "workspace/didChangeWatchedFiles" {
+                                    if let Some(options) = reg.register_options {
+                                        let options = serde_json::from_value(options)?;
                                         this.update(&mut cx, |this, cx| {
-                                            this.on_lsp_progress(
-                                                params,
-                                                server_id,
-                                                disk_based_diagnostics_progress_token.clone(),
-                                                cx,
+                                            this.on_lsp_did_change_watched_files(
+                                                server_id, options, cx,
                                             );
                                         });
                                     }
                                 }
-                            })
-                            .detach();
+                            }
+                            Ok(())
+                        }
+                    })
+                    .detach();
 
-                        language_server
-                            .notify::<lsp::notification::DidChangeConfiguration>(
-                                lsp::DidChangeConfigurationParams {
-                                    settings: workspace_config,
-                                },
+                language_server
+                    .on_request::<lsp::request::ApplyWorkspaceEdit, _, _>({
+                        let this = this.downgrade();
+                        let adapter = adapter.clone();
+                        let language_server = language_server.clone();
+                        move |params, cx| {
+                            Self::on_lsp_workspace_edit(
+                                this,
+                                params,
+                                server_id,
+                                adapter.clone(),
+                                language_server.clone(),
+                                cx,
                             )
-                            .ok();
+                        }
+                    })
+                    .detach();
 
-                        this.update(&mut cx, |this, cx| {
-                            // If the language server for this key doesn't match the server id, don't store the
-                            // server. Which will cause it to be dropped, killing the process
-                            if this
-                                .language_server_ids
-                                .get(&key)
-                                .map(|id| id != &server_id)
-                                .unwrap_or(false)
-                            {
-                                return None;
+                let disk_based_diagnostics_progress_token =
+                    adapter.disk_based_diagnostics_progress_token.clone();
+
+                language_server
+                    .on_notification::<lsp::notification::Progress, _>({
+                        let this = this.downgrade();
+                        move |params, mut cx| {
+                            if let Some(this) = this.upgrade(&cx) {
+                                this.update(&mut cx, |this, cx| {
+                                    this.on_lsp_progress(
+                                        params,
+                                        server_id,
+                                        disk_based_diagnostics_progress_token.clone(),
+                                        cx,
+                                    );
+                                });
                             }
+                        }
+                    })
+                    .detach();
 
-                            // Update language_servers collection with Running variant of LanguageServerState
-                            // indicating that the server is up and running and ready
-                            this.language_servers.insert(
-                                server_id,
-                                LanguageServerState::Running {
-                                    adapter: adapter.clone(),
-                                    language,
-                                    watched_paths: Default::default(),
-                                    server: language_server.clone(),
-                                    simulate_disk_based_diagnostics_completion: None,
-                                },
-                            );
-                            this.language_server_statuses.insert(
-                                server_id,
-                                LanguageServerStatus {
+                language_server
+                    .notify::<lsp::notification::DidChangeConfiguration>(
+                        lsp::DidChangeConfigurationParams {
+                            settings: workspace_config,
+                        },
+                    )
+                    .ok();
+
+                this.update(&mut cx, |this, cx| {
+                    // If the language server for this key doesn't match the server id, don't store the
+                    // server. Which will cause it to be dropped, killing the process
+                    if this
+                        .language_server_ids
+                        .get(&key)
+                        .map(|id| id != &server_id)
+                        .unwrap_or(false)
+                    {
+                        return None;
+                    }
+
+                    // Update language_servers collection with Running variant of LanguageServerState
+                    // indicating that the server is up and running and ready
+                    this.language_servers.insert(
+                        server_id,
+                        LanguageServerState::Running {
+                            adapter: adapter.clone(),
+                            language: language.clone(),
+                            watched_paths: Default::default(),
+                            server: language_server.clone(),
+                            simulate_disk_based_diagnostics_completion: None,
+                        },
+                    );
+                    this.language_server_statuses.insert(
+                        server_id,
+                        LanguageServerStatus {
+                            name: language_server.name().to_string(),
+                            pending_work: Default::default(),
+                            has_pending_diagnostic_updates: false,
+                            progress_tokens: Default::default(),
+                        },
+                    );
+
+                    if let Some(project_id) = this.remote_id() {
+                        this.client
+                            .send(proto::StartLanguageServer {
+                                project_id,
+                                server: Some(proto::LanguageServer {
+                                    id: server_id as u64,
                                     name: language_server.name().to_string(),
-                                    pending_work: Default::default(),
-                                    has_pending_diagnostic_updates: false,
-                                    progress_tokens: Default::default(),
-                                },
-                            );
+                                }),
+                            })
+                            .log_err();
+                    }
 
-                            if let Some(project_id) = this.remote_id() {
-                                this.client
-                                    .send(proto::StartLanguageServer {
-                                        project_id,
-                                        server: Some(proto::LanguageServer {
-                                            id: server_id as u64,
-                                            name: language_server.name().to_string(),
-                                        }),
-                                    })
-                                    .log_err();
+                    // Tell the language server about every open buffer in the worktree that matches the language.
+                    for buffer in this.opened_buffers.values() {
+                        if let Some(buffer_handle) = buffer.upgrade(cx) {
+                            let buffer = buffer_handle.read(cx);
+                            let file = match File::from_dyn(buffer.file()) {
+                                Some(file) => file,
+                                None => continue,
+                            };
+                            let language = match buffer.language() {
+                                Some(language) => language,
+                                None => continue,
+                            };
+
+                            if file.worktree.read(cx).id() != key.0
+                                || !language.lsp_adapters().iter().any(|a| a.name == key.1)
+                            {
+                                continue;
                             }
 
-                            // Tell the language server about every open buffer in the worktree that matches the language.
-                            for buffer in this.opened_buffers.values() {
-                                if let Some(buffer_handle) = buffer.upgrade(cx) {
-                                    let buffer = buffer_handle.read(cx);
-                                    let file = if let Some(file) = File::from_dyn(buffer.file()) {
-                                        file
-                                    } else {
-                                        continue;
-                                    };
-                                    let language = if let Some(language) = buffer.language() {
-                                        language
-                                    } else {
-                                        continue;
-                                    };
-                                    if file.worktree.read(cx).id() != key.0
-                                        || language.lsp_adapter().map(|a| a.name.clone())
-                                            != Some(key.1.clone())
-                                    {
-                                        continue;
-                                    }
+                            let file = file.as_local()?;
+                            let versions = this
+                                .buffer_snapshots
+                                .entry(buffer.remote_id())
+                                .or_default()
+                                .entry(server_id)
+                                .or_insert_with(|| {
+                                    vec![LspBufferSnapshot {
+                                        version: 0,
+                                        snapshot: buffer.text_snapshot(),
+                                    }]
+                                });
 
-                                    let file = file.as_local()?;
-                                    let versions = this
-                                        .buffer_snapshots
-                                        .entry(buffer.remote_id())
-                                        .or_insert_with(|| vec![(0, buffer.text_snapshot())]);
-
-                                    let (version, initial_snapshot) = versions.last().unwrap();
-                                    let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
-                                    language_server
-                                        .notify::<lsp::notification::DidOpenTextDocument>(
-                                            lsp::DidOpenTextDocumentParams {
-                                                text_document: lsp::TextDocumentItem::new(
-                                                    uri,
-                                                    adapter
-                                                        .language_ids
-                                                        .get(language.name().as_ref())
-                                                        .cloned()
-                                                        .unwrap_or_default(),
-                                                    *version,
-                                                    initial_snapshot.text(),
-                                                ),
-                                            },
-                                        )
-                                        .log_err()?;
-                                    buffer_handle.update(cx, |buffer, cx| {
-                                        buffer.set_completion_triggers(
-                                            language_server
-                                                .capabilities()
-                                                .completion_provider
-                                                .as_ref()
-                                                .and_then(|provider| {
-                                                    provider.trigger_characters.clone()
-                                                })
+                            let snapshot = versions.last().unwrap();
+                            let version = snapshot.version;
+                            let initial_snapshot = snapshot.snapshot;
+                            let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
+                            language_server
+                                .notify::<lsp::notification::DidOpenTextDocument>(
+                                    lsp::DidOpenTextDocumentParams {
+                                        text_document: lsp::TextDocumentItem::new(
+                                            uri,
+                                            adapter
+                                                .language_ids
+                                                .get(language.name().as_ref())
+                                                .cloned()
                                                 .unwrap_or_default(),
-                                            cx,
-                                        )
-                                    });
-                                }
-                            }
+                                            version,
+                                            initial_snapshot.text(),
+                                        ),
+                                    },
+                                )
+                                .log_err()?;
+                            buffer_handle.update(cx, |buffer, cx| {
+                                buffer.set_completion_triggers(
+                                    language_server
+                                        .capabilities()
+                                        .completion_provider
+                                        .as_ref()
+                                        .and_then(|provider| provider.trigger_characters.clone())
+                                        .unwrap_or_default(),
+                                    cx,
+                                )
+                            });
+                        }
+                    }
 
-                            cx.notify();
-                            Some(language_server)
-                        })
-                    })),
-                );
-
-                server_id
-            });
+                    cx.notify();
+                    Some(language_server)
+                })
+            })),
+        );
+        server_id
     }
 
     // Returns a list of all of the worktrees which no longer have a language server and the root path
@@ -2476,52 +2526,64 @@ impl Project {
             })
             .collect();
         for (worktree_id, worktree_abs_path, language) in language_server_lookup_info {
-            self.restart_language_server(worktree_id, worktree_abs_path, language, cx);
+            self.restart_language_servers(worktree_id, worktree_abs_path, language, cx);
         }
 
         None
     }
 
-    fn restart_language_server(
+    fn restart_language_servers(
         &mut self,
         worktree_id: WorktreeId,
         fallback_path: Arc<Path>,
         language: Arc<Language>,
         cx: &mut ModelContext<Self>,
     ) {
-        let adapter = if let Some(adapter) = language.lsp_adapter() {
-            adapter
-        } else {
+        let mut stops = Vec::new();
+        for adapter in language.lsp_adapters() {
+            stops.push(self.stop_language_server(worktree_id, adapter.name.clone(), cx));
+        }
+
+        if stops.is_empty() {
             return;
-        };
+        }
+        let mut stops = stops.into_iter();
 
-        let server_name = adapter.name.clone();
-        let stop = self.stop_language_server(worktree_id, server_name.clone(), cx);
         cx.spawn_weak(|this, mut cx| async move {
-            let (original_root_path, orphaned_worktrees) = stop.await;
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, cx| {
-                    // Attempt to restart using original server path. Fallback to passed in
-                    // path if we could not retrieve the root path
-                    let root_path = original_root_path
-                        .map(|path_buf| Arc::from(path_buf.as_path()))
-                        .unwrap_or(fallback_path);
+            let (original_root_path, mut orphaned_worktrees) = stops.next().unwrap().await;
+            for stop in stops {
+                let (_, worktrees) = stop.await;
+                orphaned_worktrees.extend_from_slice(&worktrees);
+            }
 
-                    this.start_language_server(worktree_id, root_path, language, cx);
+            let this = match this.upgrade(&cx) {
+                Some(this) => this,
+                None => return,
+            };
 
-                    // Lookup new server id and set it for each of the orphaned worktrees
+            this.update(&mut cx, |this, cx| {
+                // Attempt to restart using original server path. Fallback to passed in
+                // path if we could not retrieve the root path
+                let root_path = original_root_path
+                    .map(|path_buf| Arc::from(path_buf.as_path()))
+                    .unwrap_or(fallback_path);
+
+                this.start_language_servers(worktree_id, root_path, language, cx);
+
+                // Lookup new server ids and set them for each of the orphaned worktrees
+                for adapter in language.lsp_adapters() {
                     if let Some(new_server_id) = this
                         .language_server_ids
-                        .get(&(worktree_id, server_name.clone()))
+                        .get(&(worktree_id, adapter.name.clone()))
                         .cloned()
                     {
                         for orphaned_worktree in orphaned_worktrees {
                             this.language_server_ids
-                                .insert((orphaned_worktree, server_name.clone()), new_server_id);
+                                .insert((orphaned_worktree, adapter.name.clone()), new_server_id);
                         }
                     }
-                });
-            }
+                }
+            });
         })
         .detach();
     }
@@ -3074,7 +3136,7 @@ impl Project {
                     let file = File::from_dyn(buffer.file())?;
                     let buffer_abs_path = file.as_local().map(|f| f.abs_path(cx));
                     let server = self
-                        .language_server_for_buffer(buffer, cx)
+                        .primary_language_servers_for_buffer(buffer, cx)
                         .map(|s| s.1.clone());
                     Some((buffer_handle, buffer_abs_path, server))
                 })
@@ -3323,7 +3385,7 @@ impl Project {
 
         if let Some(lsp_edits) = lsp_edits {
             this.update(cx, |this, cx| {
-                this.edits_from_lsp(buffer, lsp_edits, None, cx)
+                this.edits_from_lsp(buffer, lsp_edits, language_server.server_id(), None, cx)
             })
             .await
         } else {
@@ -3654,7 +3716,7 @@ impl Project {
         let buffer_id = buffer.remote_id();
 
         if self.is_local() {
-            let lang_server = match self.language_server_for_buffer(buffer, cx) {
+            let lang_server = match self.primary_language_servers_for_buffer(buffer, cx) {
                 Some((_, server)) => server.clone(),
                 _ => return Task::ready(Ok(Default::default())),
             };
@@ -3667,7 +3729,13 @@ impl Project {
                 if let Some(edits) = resolved_completion.additional_text_edits {
                     let edits = this
                         .update(&mut cx, |this, cx| {
-                            this.edits_from_lsp(&buffer_handle, edits, None, cx)
+                            this.edits_from_lsp(
+                                &buffer_handle,
+                                edits,
+                                lang_server.server_id(),
+                                None,
+                                cx,
+                            )
                         })
                         .await?;
 
@@ -3757,12 +3825,13 @@ impl Project {
     ) -> Task<Result<ProjectTransaction>> {
         if self.is_local() {
             let buffer = buffer_handle.read(cx);
-            let (lsp_adapter, lang_server) =
-                if let Some((adapter, server)) = self.language_server_for_buffer(buffer, cx) {
-                    (adapter.clone(), server.clone())
-                } else {
-                    return Task::ready(Ok(Default::default()));
-                };
+            let (lsp_adapter, lang_server) = if let Some((adapter, server)) =
+                self.language_server_for_buffer(buffer, action.server_id, cx)
+            {
+                (adapter.clone(), server.clone())
+            } else {
+                return Task::ready(Ok(Default::default()));
+            };
             let range = action.range.to_point_utf16(buffer);
 
             cx.spawn(|this, mut cx| async move {
@@ -3896,6 +3965,7 @@ impl Project {
                             .await?;
                     }
                 }
+
                 lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(op)) => {
                     let source_abs_path = op
                         .old_uri
@@ -3912,6 +3982,7 @@ impl Project {
                     )
                     .await?;
                 }
+
                 lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(op)) => {
                     let abs_path = op
                         .uri
@@ -3924,6 +3995,7 @@ impl Project {
                         fs.remove_file(&abs_path, options).await?;
                     }
                 }
+
                 lsp::DocumentChangeOperation::Edit(op) => {
                     let buffer_to_edit = this
                         .update(cx, |this, cx| {
@@ -3945,6 +4017,7 @@ impl Project {
                             this.edits_from_lsp(
                                 &buffer_to_edit,
                                 edits,
+                                language_server.server_id(),
                                 op.text_document.version,
                                 cx,
                             )
@@ -4214,6 +4287,7 @@ impl Project {
         }
     }
 
+    // TODO: Wire this up to allow selecting a server?
     fn request_lsp<R: LspCommand>(
         &self,
         buffer_handle: ModelHandle<Buffer>,
@@ -4227,7 +4301,7 @@ impl Project {
         if self.is_local() {
             let file = File::from_dyn(buffer.file()).and_then(File::as_local);
             if let Some((file, language_server)) = file.zip(
-                self.language_server_for_buffer(buffer, cx)
+                self.primary_language_servers_for_buffer(buffer, cx)
                     .map(|(_, server)| server.clone()),
             ) {
                 let lsp_params = request.to_lsp(&file.abs_path(cx), buffer, &language_server, cx);
@@ -4241,7 +4315,13 @@ impl Project {
                         .await
                         .context("lsp request failed")?;
                     request
-                        .response_from_lsp(response, this, buffer_handle, cx)
+                        .response_from_lsp(
+                            response,
+                            this,
+                            buffer_handle,
+                            language_server.server_id(),
+                            cx,
+                        )
                         .await
                 });
             }
@@ -4491,9 +4571,9 @@ impl Project {
         }
 
         for (buffer, old_path) in renamed_buffers {
-            self.unregister_buffer_from_language_server(&buffer, old_path, cx);
+            self.unregister_buffer_from_language_servers(&buffer, old_path, cx);
             self.detect_language_for_buffer(&buffer, cx);
-            self.register_buffer_with_language_server(&buffer, cx);
+            self.register_buffer_with_language_servers(&buffer, cx);
         }
     }
 
@@ -6048,10 +6128,11 @@ impl Project {
         &mut self,
         buffer: &ModelHandle<Buffer>,
         lsp_edits: impl 'static + Send + IntoIterator<Item = lsp::TextEdit>,
+        server_id: usize,
         version: Option<i32>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Vec<(Range<Anchor>, String)>>> {
-        let snapshot = self.buffer_snapshot_for_lsp_version(buffer, version, cx);
+        let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx);
         cx.background().spawn(async move {
             let snapshot = snapshot?;
             let mut lsp_edits = lsp_edits
@@ -6150,6 +6231,7 @@ impl Project {
     fn buffer_snapshot_for_lsp_version(
         &mut self,
         buffer: &ModelHandle<Buffer>,
+        server_id: usize,
         version: Option<i32>,
         cx: &AppContext,
     ) -> Result<TextBufferSnapshot> {
@@ -6160,51 +6242,85 @@ impl Project {
             let snapshots = self
                 .buffer_snapshots
                 .get_mut(&buffer_id)
-                .ok_or_else(|| anyhow!("no snapshot found for buffer {}", buffer_id))?;
-            let found_snapshot = snapshots
-                .binary_search_by_key(&version, |e| e.0)
-                .map(|ix| snapshots[ix].1.clone())
-                .map_err(|_| {
-                    anyhow!(
-                        "snapshot not found for buffer {} at version {}",
-                        buffer_id,
-                        version
-                    )
+                .and_then(|m| m.get_mut(&server_id))
+                .ok_or_else(|| {
+                    anyhow!("no snapshots found for buffer {buffer_id} and server {server_id}")
                 })?;
-            snapshots.retain(|(snapshot_version, _)| {
-                snapshot_version + OLD_VERSIONS_TO_RETAIN >= version
-            });
+
+            let found_snapshot = snapshots
+                .binary_search_by_key(&version, |e| e.version)
+                .map(|ix| snapshots[ix].snapshot.clone())
+                .map_err(|_| {
+                    anyhow!("snapshot not found for buffer {buffer_id} server {server_id} at version {version}")
+                })?;
+
+            snapshots.retain(|snapshot| snapshot.version + OLD_VERSIONS_TO_RETAIN >= version);
             Ok(found_snapshot)
         } else {
             Ok((buffer.read(cx)).text_snapshot())
         }
     }
 
-    fn language_server_for_buffer(
+    fn running_language_servers_for_buffer(
+        &self,
+        buffer: &Buffer,
+        cx: &AppContext,
+    ) -> impl Iterator<Item = (&Arc<CachedLspAdapter>, &Arc<LanguageServer>)> {
+        self.language_server_ids_for_buffer(buffer, cx)
+            .into_iter()
+            .filter_map(|server_id| {
+                let server = self.language_servers.get(&server_id)?;
+                if let LanguageServerState::Running {
+                    adapter, server, ..
+                } = server
+                {
+                    Some((adapter, server))
+                } else {
+                    None
+                }
+            })
+    }
+
+    fn language_servers_for_buffer(
+        &self,
+        buffer: &Buffer,
+        cx: &AppContext,
+    ) -> Vec<(&Arc<CachedLspAdapter>, &Arc<LanguageServer>)> {
+        self.running_language_servers_for_buffer(buffer, cx)
+            .collect()
+    }
+
+    fn primary_language_servers_for_buffer(
         &self,
         buffer: &Buffer,
         cx: &AppContext,
     ) -> Option<(&Arc<CachedLspAdapter>, &Arc<LanguageServer>)> {
-        let server_id = self.language_server_id_for_buffer(buffer, cx)?;
-        let server = self.language_servers.get(&server_id)?;
-        if let LanguageServerState::Running {
-            adapter, server, ..
-        } = server
-        {
-            Some((adapter, server))
-        } else {
-            None
-        }
+        self.running_language_servers_for_buffer(buffer, cx).next()
     }
 
-    fn language_server_id_for_buffer(&self, buffer: &Buffer, cx: &AppContext) -> Option<usize> {
+    fn language_server_for_buffer(
+        &self,
+        buffer: &Buffer,
+        server_id: usize,
+        cx: &AppContext,
+    ) -> Option<(&Arc<CachedLspAdapter>, &Arc<LanguageServer>)> {
+        self.running_language_servers_for_buffer(buffer, cx)
+            .find(|(_, s)| s.server_id() == server_id)
+    }
+
+    fn language_server_ids_for_buffer(&self, buffer: &Buffer, cx: &AppContext) -> Vec<usize> {
         if let Some((file, language)) = File::from_dyn(buffer.file()).zip(buffer.language()) {
-            let name = language.lsp_adapter()?.name.clone();
             let worktree_id = file.worktree_id(cx);
-            let key = (worktree_id, name);
-            self.language_server_ids.get(&key).copied()
+            language
+                .lsp_adapters()
+                .iter()
+                .flat_map(|adapter| {
+                    let key = (worktree_id, adapter.name.clone());
+                    self.language_server_ids.get(&key).copied()
+                })
+                .collect()
         } else {
-            None
+            Vec::new()
         }
     }
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2217,6 +2217,7 @@ impl Project {
                         move |params, mut cx| {
                             let languages = languages.clone();
                             async move {
+                                dbg!(&params.items);
                                 let workspace_config =
                                     cx.update(|cx| languages.workspace_configuration(cx)).await;
                                 Ok(params

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -303,7 +303,7 @@ async fn test_managing_language_servers(
 
     rust_buffer2.update(cx, |buffer, cx| {
         buffer.update_diagnostics(
-            0,
+            LanguageServerId(0),
             DiagnosticSet::from_sorted_entries(
                 vec![DiagnosticEntry {
                     diagnostic: Default::default(),
@@ -582,7 +582,7 @@ async fn test_single_file_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
     project.update(cx, |project, cx| {
         project
             .update_diagnostics(
-                0,
+                LanguageServerId(0),
                 lsp::PublishDiagnosticsParams {
                     uri: Url::from_file_path("/dir/a.rs").unwrap(),
                     version: None,
@@ -599,7 +599,7 @@ async fn test_single_file_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
             .unwrap();
         project
             .update_diagnostics(
-                0,
+                LanguageServerId(0),
                 lsp::PublishDiagnosticsParams {
                     uri: Url::from_file_path("/dir/b.rs").unwrap(),
                     version: None,
@@ -675,7 +675,7 @@ async fn test_hidden_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
     project.update(cx, |project, cx| {
         project
             .update_diagnostics(
-                0,
+                LanguageServerId(0),
                 lsp::PublishDiagnosticsParams {
                     uri: Url::from_file_path("/root/other.rs").unwrap(),
                     version: None,
@@ -767,7 +767,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsStarted {
-            language_server_id: 0,
+            language_server_id: LanguageServerId(0),
         }
     );
 
@@ -784,7 +784,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiagnosticsUpdated {
-            language_server_id: 0,
+            language_server_id: LanguageServerId(0),
             path: (worktree_id, Path::new("a.rs")).into()
         }
     );
@@ -793,7 +793,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsFinished {
-            language_server_id: 0
+            language_server_id: LanguageServerId(0)
         }
     );
 
@@ -831,7 +831,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiagnosticsUpdated {
-            language_server_id: 0,
+            language_server_id: LanguageServerId(0),
             path: (worktree_id, Path::new("a.rs")).into()
         }
     );
@@ -892,7 +892,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsStarted {
-            language_server_id: 1
+            language_server_id: LanguageServerId(1)
         }
     );
     project.read_with(cx, |project, _| {
@@ -900,7 +900,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
             project
                 .language_servers_running_disk_based_diagnostics()
                 .collect::<Vec<_>>(),
-            [1]
+            [LanguageServerId(1)]
         );
     });
 
@@ -910,7 +910,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsFinished {
-            language_server_id: 1
+            language_server_id: LanguageServerId(1)
         }
     );
     project.read_with(cx, |project, _| {
@@ -918,7 +918,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
             project
                 .language_servers_running_disk_based_diagnostics()
                 .collect::<Vec<_>>(),
-            [0; 0]
+            [LanguageServerId(0); 0]
         );
     });
 }
@@ -1403,7 +1403,7 @@ async fn test_empty_diagnostic_ranges(cx: &mut gpui::TestAppContext) {
         project
             .update_buffer_diagnostics(
                 &buffer,
-                0,
+                LanguageServerId(0),
                 None,
                 vec![
                     DiagnosticEntry {
@@ -1464,7 +1464,7 @@ async fn test_diagnostics_from_multiple_language_servers(cx: &mut gpui::TestAppC
     project.update(cx, |project, cx| {
         project
             .update_diagnostic_entries(
-                0,
+                LanguageServerId(0),
                 Path::new("/dir/a.rs").to_owned(),
                 None,
                 vec![DiagnosticEntry {
@@ -1481,7 +1481,7 @@ async fn test_diagnostics_from_multiple_language_servers(cx: &mut gpui::TestAppC
             .unwrap();
         project
             .update_diagnostic_entries(
-                1,
+                LanguageServerId(1),
                 Path::new("/dir/a.rs").to_owned(),
                 None,
                 vec![DiagnosticEntry {
@@ -1633,7 +1633,7 @@ async fn test_edits_from_lsp_with_past_version(cx: &mut gpui::TestAppContext) {
                         new_text: "".into(),
                     },
                 ],
-                0,
+                LanguageServerId(0),
                 Some(lsp_document_version),
                 cx,
             )
@@ -1728,7 +1728,7 @@ async fn test_edits_from_lsp_with_edits_on_adjacent_lines(cx: &mut gpui::TestApp
                         new_text: "".into(),
                     },
                 ],
-                0,
+                LanguageServerId(0),
                 None,
                 cx,
             )
@@ -1832,7 +1832,7 @@ async fn test_invalid_edits_from_lsp(cx: &mut gpui::TestAppContext) {
                         .unindent(),
                     },
                 ],
-                0,
+                LanguageServerId(0),
                 None,
                 cx,
             )
@@ -3011,7 +3011,9 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
     };
 
     project
-        .update(cx, |p, cx| p.update_diagnostics(0, message, &[], cx))
+        .update(cx, |p, cx| {
+            p.update_diagnostics(LanguageServerId(0), message, &[], cx)
+        })
         .unwrap();
     let buffer = buffer.read_with(cx, |buffer, _| buffer.snapshot());
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1573,6 +1573,7 @@ async fn test_edits_from_lsp_with_past_version(cx: &mut gpui::TestAppContext) {
                         new_text: "".into(),
                     },
                 ],
+                0,
                 Some(lsp_document_version),
                 cx,
             )
@@ -1667,6 +1668,7 @@ async fn test_edits_from_lsp_with_edits_on_adjacent_lines(cx: &mut gpui::TestApp
                         new_text: "".into(),
                     },
                 ],
+                0,
                 None,
                 cx,
             )
@@ -1770,6 +1772,7 @@ async fn test_invalid_edits_from_lsp(cx: &mut gpui::TestAppContext) {
                         .unindent(),
                     },
                 ],
+                0,
                 None,
                 cx,
             )
@@ -2258,7 +2261,7 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
             ..Default::default()
         },
         tree_sitter_rust::language(),
-        None,
+        vec![],
         |_| Default::default(),
     );
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1420,6 +1420,7 @@ async fn test_empty_diagnostic_ranges(cx: &mut gpui::TestAppContext) {
                         },
                     },
                 ],
+                0,
                 None,
                 cx,
             )

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -303,6 +303,7 @@ async fn test_managing_language_servers(
 
     rust_buffer2.update(cx, |buffer, cx| {
         buffer.update_diagnostics(
+            0,
             DiagnosticSet::from_sorted_entries(
                 vec![DiagnosticEntry {
                     diagnostic: Default::default(),
@@ -1402,6 +1403,8 @@ async fn test_empty_diagnostic_ranges(cx: &mut gpui::TestAppContext) {
         project
             .update_buffer_diagnostics(
                 &buffer,
+                0,
+                None,
                 vec![
                     DiagnosticEntry {
                         range: Unclipped(PointUtf16::new(0, 10))..Unclipped(PointUtf16::new(0, 10)),
@@ -1420,8 +1423,6 @@ async fn test_empty_diagnostic_ranges(cx: &mut gpui::TestAppContext) {
                         },
                     },
                 ],
-                0,
-                None,
                 cx,
             )
             .unwrap();

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -400,7 +400,7 @@ async fn test_managing_language_servers(
             .text_document,
         lsp::TextDocumentItem {
             uri: lsp::Url::from_file_path("/the-root/test.rs").unwrap(),
-            version: 1,
+            version: 0,
             text: rust_buffer.read_with(cx, |buffer, _| buffer.text()),
             language_id: Default::default()
         }
@@ -427,7 +427,7 @@ async fn test_managing_language_servers(
             },
             lsp::TextDocumentItem {
                 uri: lsp::Url::from_file_path("/the-root/test3.json").unwrap(),
-                version: 1,
+                version: 0,
                 text: rust_buffer2.read_with(cx, |buffer, _| buffer.text()),
                 language_id: Default::default()
             }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -536,10 +536,15 @@ impl LocalWorktree {
                 .insert(PathKey(worktree_path.clone()), new_summary);
             let diagnostics_by_server_id =
                 self.diagnostics.entry(worktree_path.clone()).or_default();
-            let ix = match diagnostics_by_server_id.binary_search_by_key(&server_id, |e| e.0) {
-                Ok(ix) | Err(ix) => ix,
-            };
-            diagnostics_by_server_id[ix] = (server_id, diagnostics);
+            match diagnostics_by_server_id.binary_search_by_key(&server_id, |e| e.0) {
+                Ok(ix) => {
+                    diagnostics_by_server_id[ix] = (server_id, diagnostics);
+                }
+
+                Err(ix) => {
+                    diagnostics_by_server_id.insert(ix, (server_id, diagnostics));
+                }
+            }
         }
 
         let updated = !old_summary.is_empty() || !new_summary.is_empty();

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/rope.rs"
 
 [dependencies]
 bromberg_sl2 = { git = "https://github.com/zed-industries/bromberg_sl2", rev = "950bc5482c216c395049ae33ae4501e08975f17f" }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 sum_tree = { path = "../sum_tree" }
 arrayvec = "0.7.1"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -684,9 +684,10 @@ message SearchProjectResponse {
 }
 
 message CodeAction {
-    Anchor start = 1;
-    Anchor end = 2;
-    bytes lsp_action = 3;
+    uint64 server_id = 1;
+    Anchor start = 2;
+    Anchor end = 3;
+    bytes lsp_action = 4;
 }
 
 message ProjectTransaction {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -861,7 +861,8 @@ message IncomingContactRequest {
 message UpdateDiagnostics {
     uint32 replica_id = 1;
     uint32 lamport_timestamp = 2;
-    repeated Diagnostic diagnostics = 3;
+    uint64 server_id = 3;
+    repeated Diagnostic diagnostics = 4;
 }
 
 message Follow {

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 51;
+pub const PROTOCOL_VERSION: u32 = 52;

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -25,7 +25,7 @@ log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 postage = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2"
 
 [dev-dependencies]

--- a/crates/snippet/Cargo.toml
+++ b/crates/snippet/Cargo.toml
@@ -10,4 +10,4 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -17,7 +17,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "a51dbe25d67e84d6ed4261e640d3954fbdd9be45" }
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2.5"
 mio-extras = "2.0.6"
 futures = "0.3"

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -21,7 +21,7 @@ workspace = { path = "../workspace" }
 db = { path = "../db" }
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
 terminal = { path = "../terminal" }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2.5"
 mio-extras = "2.0.6"
 futures = "0.3"

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -24,7 +24,7 @@ log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 parking_lot = "0.11"
 postage = { workspace = true }
 rand = { version = "0.8.3", optional = true }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 util = { path = "../util" }
 regex = "1.5"
 

--- a/crates/theme_testbench/Cargo.toml
+++ b/crates/theme_testbench/Cargo.toml
@@ -16,4 +16,4 @@ settings = { path = "../settings" }
 workspace = { path = "../workspace" }
 project = { path = "../project" }
 
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -47,7 +47,7 @@ postage = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 indoc = "1.0.4"
 uuid = { version = "1.1.2", features = ["v4"] }
 

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -96,7 +96,7 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = "0.1.4"
 simplelog = "0.9"
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { workspace = true }
 smol = "1.2.5"
 tempdir = { version = "0.3.7" }
 thiserror = "1.0.29"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -107,7 +107,7 @@ pub fn init(
             tree_sitter_typescript::language_tsx(),
             vec![
                 adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-                adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
+                // adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),
         (

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -89,23 +89,26 @@ pub fn init(
         (
             "tsx",
             tree_sitter_typescript::language_tsx(),
-            vec![adapter_arc(typescript::TypeScriptLspAdapter::new(
-                node_runtime.clone(),
-            ))],
+            vec![
+                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
+            ],
         ),
         (
             "typescript",
             tree_sitter_typescript::language_typescript(),
-            vec![adapter_arc(typescript::TypeScriptLspAdapter::new(
-                node_runtime.clone(),
-            ))],
+            vec![
+                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
+            ],
         ),
         (
             "javascript",
             tree_sitter_typescript::language_tsx(),
-            vec![adapter_arc(typescript::TypeScriptLspAdapter::new(
-                node_runtime.clone(),
-            ))],
+            vec![
+                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
+            ],
         ),
         (
             "html",
@@ -149,7 +152,7 @@ pub async fn language(
 ) -> Arc<Language> {
     Arc::new(
         Language::new(load_config(name), Some(grammar))
-            .with_lsp_adapters(lsp_adapter)
+            .with_lsp_adapters(lsp_adapter.into_iter().collect())
             .await
             .with_queries(load_queries(name))
             .unwrap(),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -90,7 +90,7 @@ pub fn init(
             "tsx",
             tree_sitter_typescript::language_tsx(),
             vec![
-                // adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
                 adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),
@@ -98,7 +98,7 @@ pub fn init(
             "typescript",
             tree_sitter_typescript::language_typescript(),
             vec![
-                // adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
                 adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),
@@ -106,7 +106,7 @@ pub fn init(
             "javascript",
             tree_sitter_typescript::language_tsx(),
             vec![
-                // adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
                 adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -90,7 +90,7 @@ pub fn init(
             "tsx",
             tree_sitter_typescript::language_tsx(),
             vec![
-                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                // adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
                 adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),
@@ -98,7 +98,7 @@ pub fn init(
             "typescript",
             tree_sitter_typescript::language_typescript(),
             vec![
-                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                // adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
                 adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),
@@ -106,7 +106,7 @@ pub fn init(
             "javascript",
             tree_sitter_typescript::language_tsx(),
             vec![
-                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
+                // adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
                 adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
             ],
         ),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -89,26 +89,23 @@ pub fn init(
         (
             "tsx",
             tree_sitter_typescript::language_tsx(),
-            vec![
-                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-                adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
-            ],
+            vec![adapter_arc(typescript::TypeScriptLspAdapter::new(
+                node_runtime.clone(),
+            ))],
         ),
         (
             "typescript",
             tree_sitter_typescript::language_typescript(),
-            vec![
-                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-                adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
-            ],
+            vec![adapter_arc(typescript::TypeScriptLspAdapter::new(
+                node_runtime.clone(),
+            ))],
         ),
         (
             "javascript",
             tree_sitter_typescript::language_tsx(),
-            vec![
-                adapter_arc(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-                // adapter_arc(typescript::EsLintLspAdapter::new(node_runtime.clone())),
-            ],
+            vec![adapter_arc(typescript::TypeScriptLspAdapter::new(
+                node_runtime.clone(),
+            ))],
         ),
         (
             "html",

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -15,13 +15,17 @@ use std::{
 use util::http::HttpClient;
 use util::ResultExt;
 
-fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
+fn typescript_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![
         server_path.into(),
         "--stdio".into(),
         "--tsserver-path".into(),
         "node_modules/typescript/lib".into(),
     ]
+}
+
+fn eslint_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
+    vec![server_path.into(), "--stdin".into()]
 }
 
 pub struct TypeScriptLspAdapter {
@@ -89,7 +93,7 @@ impl LspAdapter for TypeScriptLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
-            arguments: server_binary_arguments(&server_path),
+            arguments: typescript_server_binary_arguments(&server_path),
         })
     }
 
@@ -101,12 +105,12 @@ impl LspAdapter for TypeScriptLspAdapter {
             if new_server_path.exists() {
                 Ok(LanguageServerBinary {
                     path: self.node.binary_path().await?,
-                    arguments: server_binary_arguments(&new_server_path),
+                    arguments: typescript_server_binary_arguments(&new_server_path),
                 })
             } else if old_server_path.exists() {
                 Ok(LanguageServerBinary {
                     path: self.node.binary_path().await?,
-                    arguments: server_binary_arguments(&old_server_path),
+                    arguments: typescript_server_binary_arguments(&old_server_path),
                 })
             } else {
                 Err(anyhow!(
@@ -169,7 +173,7 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
-    const SERVER_PATH: &'static str = "node_modules/typescript-language-server/lib/cli.mjs";
+    const SERVER_PATH: &'static str = "node_modules/eslint/bin/eslint.js";
 
     pub fn new(node: Arc<NodeRuntime>) -> Self {
         EsLintLspAdapter { node }
@@ -208,7 +212,7 @@ impl LspAdapter for EsLintLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
-            arguments: server_binary_arguments(&server_path),
+            arguments: eslint_server_binary_arguments(&server_path),
         })
     }
 
@@ -218,7 +222,7 @@ impl LspAdapter for EsLintLspAdapter {
             if server_path.exists() {
                 Ok(LanguageServerBinary {
                     path: self.node.binary_path().await?,
-                    arguments: server_binary_arguments(&server_path),
+                    arguments: eslint_server_binary_arguments(&server_path),
                 })
             } else {
                 Err(anyhow!(

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -73,7 +73,6 @@ impl LspAdapter for TypeScriptLspAdapter {
         _: Arc<dyn HttpClient>,
         container_dir: PathBuf,
     ) -> Result<LanguageServerBinary> {
-        dbg!();
         let versions = versions.downcast::<TypeScriptVersions>().unwrap();
         let server_path = container_dir.join(Self::NEW_SERVER_PATH);
 
@@ -99,7 +98,6 @@ impl LspAdapter for TypeScriptLspAdapter {
     }
 
     async fn cached_server_binary(&self, container_dir: PathBuf) -> Option<LanguageServerBinary> {
-        dbg!();
         (|| async move {
             let old_server_path = container_dir.join(Self::OLD_SERVER_PATH);
             let new_server_path = container_dir.join(Self::NEW_SERVER_PATH);

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use futures::{future::BoxFuture, FutureExt, StreamExt};
-use gpui::{AppContext, Task};
+use futures::{future::BoxFuture, FutureExt};
+use gpui::AppContext;
 use language::{LanguageServerBinary, LanguageServerName, LspAdapter};
 use lsp::CodeActionKind;
 use node_runtime::NodeRuntime;
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 use smol::fs;
 use std::{
     any::Any,

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -293,8 +293,8 @@ impl LspAdapter for EsLintLspAdapter {
 
     async fn label_for_completion(
         &self,
-        item: &lsp::CompletionItem,
-        language: &Arc<language::Language>,
+        _item: &lsp::CompletionItem,
+        _language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
         None
     }

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -175,18 +175,11 @@ impl EsLintLspAdapter {
     const SERVER_PATH: &'static str =
         "node_modules/vscode-langservers-extracted/lib/eslint-language-server/eslintServer.js";
 
+    #[allow(unused)]
     pub fn new(node: Arc<NodeRuntime>) -> Self {
         EsLintLspAdapter { node }
     }
 }
-
-// "workspaceFolder": {
-//     "name": "testing_ts",
-//     "uri": "file:///Users/julia/Stuff/testing_ts"
-// },
-// "workingDirectory": "file:///Users/julia/Stuff/testing_ts",
-// "nodePath": "/opt/homebrew/opt/node@18/bin/node",
-// "experimental": {},
 
 #[async_trait]
 impl LspAdapter for EsLintLspAdapter {


### PR DESCRIPTION
This paves the way for supporting ESLint.

Languages can now have multiple LSP adapters, and multiple language servers can provide diagnostics for a given buffer. Other LSP features like completion and formatting are still currently hard-coded to only use the buffer's first language server, so we'll have to generalize those later.

Before merging
* [x] Avoid using a `HashMap` for diagnostic sets on the `BufferSnapshot`, since that struct needs to be very cheap to clone. 