### PR TITLE
Set default tab_size for JSON to 2 and apply new formatting

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -1,548 +1,548 @@
 [
-    // Standard macOS bindings
-    {
-        "bindings": {
-            "up": "menu::SelectPrev",
-            "pageup": "menu::SelectFirst",
-            "shift-pageup": "menu::SelectFirst",
-            "ctrl-p": "menu::SelectPrev",
-            "down": "menu::SelectNext",
-            "pagedown": "menu::SelectLast",
-            "shift-pagedown": "menu::SelectFirst",
-            "ctrl-n": "menu::SelectNext",
-            "cmd-up": "menu::SelectFirst",
-            "cmd-down": "menu::SelectLast",
-            "enter": "menu::Confirm",
-            "escape": "menu::Cancel",
-            "ctrl-c": "menu::Cancel",
-            "cmd-{": "pane::ActivatePrevItem",
-            "cmd-}": "pane::ActivateNextItem",
-            "alt-cmd-left": "pane::ActivatePrevItem",
-            "alt-cmd-right": "pane::ActivateNextItem",
-            "cmd-w": "pane::CloseActiveItem",
-            "alt-cmd-t": "pane::CloseInactiveItems",
-            "cmd-k u": "pane::CloseCleanItems",
-            "cmd-k cmd-w": "pane::CloseAllItems",
-            "cmd-shift-w": "workspace::CloseWindow",
-            "cmd-s": "workspace::Save",
-            "cmd-shift-s": "workspace::SaveAs",
-            "cmd-=": "zed::IncreaseBufferFontSize",
-            "cmd--": "zed::DecreaseBufferFontSize",
-            "cmd-0": "zed::ResetBufferFontSize",
-            "cmd-,": "zed::OpenSettings",
-            "cmd-q": "zed::Quit",
-            "cmd-h": "zed::Hide",
-            "alt-cmd-h": "zed::HideOthers",
-            "cmd-m": "zed::Minimize",
-            "ctrl-cmd-f": "zed::ToggleFullScreen",
-            "cmd-n": "workspace::NewFile",
-            "cmd-shift-n": "workspace::NewWindow",
-            "cmd-o": "workspace::Open",
-            "alt-cmd-o": "projects::OpenRecent",
-            "ctrl-`": "workspace::NewTerminal"
-        }
-    },
-    {
-        "context": "Editor",
-        "bindings": {
-            "escape": "editor::Cancel",
-            "backspace": "editor::Backspace",
-            "shift-backspace": "editor::Backspace",
-            "ctrl-h": "editor::Backspace",
-            "delete": "editor::Delete",
-            "ctrl-d": "editor::Delete",
-            "tab": "editor::Tab",
-            "shift-tab": "editor::TabPrev",
-            "ctrl-k": "editor::CutToEndOfLine",
-            "ctrl-t": "editor::Transpose",
-            "cmd-backspace": "editor::DeleteToBeginningOfLine",
-            "cmd-delete": "editor::DeleteToEndOfLine",
-            "alt-backspace": "editor::DeleteToPreviousWordStart",
-            "alt-delete": "editor::DeleteToNextWordEnd",
-            "alt-h": "editor::DeleteToPreviousWordStart",
-            "alt-d": "editor::DeleteToNextWordEnd",
-            "cmd-x": "editor::Cut",
-            "cmd-c": "editor::Copy",
-            "cmd-v": "editor::Paste",
-            "cmd-z": "editor::Undo",
-            "cmd-shift-z": "editor::Redo",
-            "up": "editor::MoveUp",
-            "pageup": "editor::PageUp",
-            "shift-pageup": "editor::MovePageUp",
-            "home": "editor::MoveToBeginningOfLine",
-            "down": "editor::MoveDown",
-            "pagedown": "editor::PageDown",
-            "shift-pagedown": "editor::MovePageDown",
-            "end": "editor::MoveToEndOfLine",
-            "left": "editor::MoveLeft",
-            "right": "editor::MoveRight",
-            "ctrl-p": "editor::MoveUp",
-            "ctrl-n": "editor::MoveDown",
-            "ctrl-b": "editor::MoveLeft",
-            "ctrl-f": "editor::MoveRight",
-            "ctrl-l": "editor::NextScreen",
-            "alt-left": "editor::MoveToPreviousWordStart",
-            "alt-b": "editor::MoveToPreviousWordStart",
-            "alt-right": "editor::MoveToNextWordEnd",
-            "alt-f": "editor::MoveToNextWordEnd",
-            "cmd-left": "editor::MoveToBeginningOfLine",
-            "ctrl-a": "editor::MoveToBeginningOfLine",
-            "cmd-right": "editor::MoveToEndOfLine",
-            "ctrl-e": "editor::MoveToEndOfLine",
-            "cmd-up": "editor::MoveToBeginning",
-            "cmd-down": "editor::MoveToEnd",
-            "shift-up": "editor::SelectUp",
-            "ctrl-shift-p": "editor::SelectUp",
-            "shift-down": "editor::SelectDown",
-            "ctrl-shift-n": "editor::SelectDown",
-            "shift-left": "editor::SelectLeft",
-            "ctrl-shift-b": "editor::SelectLeft",
-            "shift-right": "editor::SelectRight",
-            "ctrl-shift-f": "editor::SelectRight",
-            "alt-shift-left": "editor::SelectToPreviousWordStart",
-            "alt-shift-b": "editor::SelectToPreviousWordStart",
-            "alt-shift-right": "editor::SelectToNextWordEnd",
-            "alt-shift-f": "editor::SelectToNextWordEnd",
-            "cmd-shift-up": "editor::SelectToBeginning",
-            "cmd-shift-down": "editor::SelectToEnd",
-            "cmd-a": "editor::SelectAll",
-            "cmd-l": "editor::SelectLine",
-            "cmd-shift-i": "editor::Format",
-            "cmd-shift-left": [
-                "editor::SelectToBeginningOfLine",
-                {
-                    "stop_at_soft_wraps": true
-                }
-            ],
-            "shift-home": [
-                "editor::SelectToBeginningOfLine",
-                {
-                    "stop_at_soft_wraps": true
-                }
-            ],
-            "ctrl-shift-a": [
-                "editor::SelectToBeginningOfLine",
-                {
-                    "stop_at_soft_wraps": true
-                }
-            ],
-            "cmd-shift-right": [
-                "editor::SelectToEndOfLine",
-                {
-                    "stop_at_soft_wraps": true
-                }
-            ],
-            "shift-end": [
-                "editor::SelectToEndOfLine",
-                {
-                    "stop_at_soft_wraps": true
-                }
-            ],
-            "ctrl-shift-e": [
-                "editor::SelectToEndOfLine",
-                {
-                    "stop_at_soft_wraps": true
-                }
-            ],
-            "ctrl-v": [
-                "editor::MovePageDown",
-                {
-                    "center_cursor": true
-                }
-            ],
-            "alt-v": [
-                "editor::MovePageUp",
-                {
-                    "center_cursor": true
-                }
-            ],
-            "ctrl-cmd-space": "editor::ShowCharacterPalette"
-        }
-    },
-    {
-        "context": "Editor && mode == full",
-        "bindings": {
-            "enter": "editor::Newline",
-            "cmd-shift-enter": "editor::NewlineAbove",
-            "cmd-enter": "editor::NewlineBelow",
-            "alt-z": "editor::ToggleSoftWrap",
-            "cmd-f": [
-                "buffer_search::Deploy",
-                {
-                    "focus": true
-                }
-            ],
-            "cmd-e": [
-                "buffer_search::Deploy",
-                {
-                    "focus": false
-                }
-            ],
-            "alt-\\": "copilot::Suggest",
-            "alt-]": "copilot::NextSuggestion",
-            "alt-[": "copilot::PreviousSuggestion"
-        }
-    },
-    {
-        "context": "Editor && mode == auto_height",
-        "bindings": {
-            "alt-enter": "editor::Newline",
-            "cmd-alt-enter": "editor::NewlineBelow"
-        }
-    },
-    {
-        "context": "BufferSearchBar > Editor",
-        "bindings": {
-            "escape": "buffer_search::Dismiss",
-            "tab": "buffer_search::FocusEditor",
-            "enter": "search::SelectNextMatch",
-            "shift-enter": "search::SelectPrevMatch"
-        }
-    },
-    {
-        "context": "Pane",
-        "bindings": {
-            "cmd-f": "project_search::ToggleFocus",
-            "cmd-g": "search::SelectNextMatch",
-            "cmd-shift-g": "search::SelectPrevMatch",
-            "alt-cmd-c": "search::ToggleCaseSensitive",
-            "alt-cmd-w": "search::ToggleWholeWord",
-            "alt-cmd-r": "search::ToggleRegex"
-        }
-    },
-    // Bindings from VS Code
-    {
-        "context": "Editor",
-        "bindings": {
-            "cmd-[": "editor::Outdent",
-            "cmd-]": "editor::Indent",
-            "cmd-alt-up": "editor::AddSelectionAbove",
-            "cmd-ctrl-p": "editor::AddSelectionAbove",
-            "cmd-alt-down": "editor::AddSelectionBelow",
-            "cmd-ctrl-n": "editor::AddSelectionBelow",
-            "cmd-d": [
-                "editor::SelectNext",
-                {
-                    "replace_newest": false
-                }
-            ],
-            "cmd-k cmd-d": [
-                "editor::SelectNext",
-                {
-                    "replace_newest": true
-                }
-            ],
-            "cmd-k cmd-i": "editor::Hover",
-            "cmd-/": [
-                "editor::ToggleComments",
-                {
-                    "advance_downwards": false
-                }
-            ],
-            "alt-up": "editor::SelectLargerSyntaxNode",
-            "alt-down": "editor::SelectSmallerSyntaxNode",
-            "cmd-u": "editor::UndoSelection",
-            "cmd-shift-u": "editor::RedoSelection",
-            "f8": "editor::GoToDiagnostic",
-            "shift-f8": "editor::GoToPrevDiagnostic",
-            "f2": "editor::Rename",
-            "f12": "editor::GoToDefinition",
-            "cmd-f12": "editor::GoToTypeDefinition",
-            "alt-shift-f12": "editor::FindAllReferences",
-            "ctrl-m": "editor::MoveToEnclosingBracket",
-            "alt-cmd-[": "editor::Fold",
-            "alt-cmd-]": "editor::UnfoldLines",
-            "ctrl-space": "editor::ShowCompletions",
-            "cmd-.": "editor::ToggleCodeActions",
-            "alt-cmd-r": "editor::RevealInFinder"
-        }
-    },
-    {
-        "context": "Editor && mode == full",
-        "bindings": {
-            "cmd-shift-o": "outline::Toggle",
-            "ctrl-g": "go_to_line::Toggle"
-        }
-    },
-    {
-        "context": "Pane",
-        "bindings": {
-            "ctrl-1": [
-                "pane::ActivateItem",
-                0
-            ],
-            "ctrl-2": [
-                "pane::ActivateItem",
-                1
-            ],
-            "ctrl-3": [
-                "pane::ActivateItem",
-                2
-            ],
-            "ctrl-4": [
-                "pane::ActivateItem",
-                3
-            ],
-            "ctrl-5": [
-                "pane::ActivateItem",
-                4
-            ],
-            "ctrl-6": [
-                "pane::ActivateItem",
-                5
-            ],
-            "ctrl-7": [
-                "pane::ActivateItem",
-                6
-            ],
-            "ctrl-8": [
-                "pane::ActivateItem",
-                7
-            ],
-            "ctrl-9": [
-                "pane::ActivateItem",
-                8
-            ],
-            "ctrl-0": "pane::ActivateLastItem",
-            "ctrl--": "pane::GoBack",
-            "ctrl-_": "pane::GoForward",
-            "cmd-shift-t": "pane::ReopenClosedItem",
-            "cmd-shift-f": "project_search::ToggleFocus"
-        }
-    },
-    {
-        "context": "Workspace",
-        "bindings": {
-            "cmd-1": [
-                "workspace::ActivatePane",
-                0
-            ],
-            "cmd-2": [
-                "workspace::ActivatePane",
-                1
-            ],
-            "cmd-3": [
-                "workspace::ActivatePane",
-                2
-            ],
-            "cmd-4": [
-                "workspace::ActivatePane",
-                3
-            ],
-            "cmd-5": [
-                "workspace::ActivatePane",
-                4
-            ],
-            "cmd-6": [
-                "workspace::ActivatePane",
-                5
-            ],
-            "cmd-7": [
-                "workspace::ActivatePane",
-                6
-            ],
-            "cmd-8": [
-                "workspace::ActivatePane",
-                7
-            ],
-            "cmd-9": [
-                "workspace::ActivatePane",
-                8
-            ],
-            "cmd-b": "workspace::ToggleLeftSidebar",
-            "cmd-shift-f": "workspace::NewSearch",
-            "cmd-k cmd-t": "theme_selector::Toggle",
-            "cmd-k cmd-s": "zed::OpenKeymap",
-            "cmd-t": "project_symbols::Toggle",
-            "cmd-p": "file_finder::Toggle",
-            "cmd-shift-p": "command_palette::Toggle",
-            "cmd-shift-m": "diagnostics::Deploy",
-            "cmd-shift-e": "project_panel::ToggleFocus",
-            "cmd-alt-s": "workspace::SaveAll",
-            "cmd-k m": "language_selector::Toggle"
-        }
-    },
-    // Bindings from Sublime Text
-    {
-        "context": "Editor",
-        "bindings": {
-            "ctrl-shift-k": "editor::DeleteLine",
-            "cmd-shift-d": "editor::DuplicateLine",
-            "cmd-shift-l": "editor::SplitSelectionIntoLines",
-            "ctrl-cmd-up": "editor::MoveLineUp",
-            "ctrl-cmd-down": "editor::MoveLineDown",
-            "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
-            "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
-            "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
-            "ctrl-alt-d": "editor::DeleteToNextSubwordEnd",
-            "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
-            "ctrl-alt-b": "editor::MoveToPreviousSubwordStart",
-            "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
-            "ctrl-alt-f": "editor::MoveToNextSubwordEnd",
-            "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
-            "ctrl-alt-shift-b": "editor::SelectToPreviousSubwordStart",
-            "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
-            "ctrl-alt-shift-f": "editor::SelectToNextSubwordEnd"
-        }
-    },
-    {
-        "bindings": {
-            "cmd-k cmd-left": "workspace::ActivatePreviousPane",
-            "cmd-k cmd-right": "workspace::ActivateNextPane"
-        }
-    },
-    // Bindings from Atom
-    {
-        "context": "Pane",
-        "bindings": {
-            "cmd-k up": "pane::SplitUp",
-            "cmd-k down": "pane::SplitDown",
-            "cmd-k left": "pane::SplitLeft",
-            "cmd-k right": "pane::SplitRight"
-        }
-    },
-    // Bindings that should be unified with bindings for more general actions
-    {
-        "context": "Editor && renaming",
-        "bindings": {
-            "enter": "editor::ConfirmRename"
-        }
-    },
-    {
-        "context": "Editor && showing_completions",
-        "bindings": {
-            "enter": "editor::ConfirmCompletion",
-            "tab": "editor::ConfirmCompletion"
-        }
-    },
-    {
-        "context": "Editor && showing_code_actions",
-        "bindings": {
-            "enter": "editor::ConfirmCodeAction"
-        }
-    },
-    // Custom bindings
-    {
-        "bindings": {
-            "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
-            "cmd-shift-c": "collab::ToggleContactsMenu",
-            "cmd-alt-i": "zed::DebugElements"
-        }
-    },
-    {
-        "context": "Editor",
-        "bindings": {
-            "alt-enter": "editor::OpenExcerpts",
-            "cmd-f8": "editor::GoToHunk",
-            "cmd-shift-f8": "editor::GoToPrevHunk"
-        }
-    },
-    {
-        "context": "ProjectSearchBar",
-        "bindings": {
-            "cmd-enter": "project_search::SearchInNew"
-        }
-    },
-    {
-        "context": "Workspace",
-        "bindings": {
-            "shift-escape": "dock::FocusDock"
-        }
-    },
-    {
-        "bindings": {
-            "cmd-shift-k cmd-shift-right": "dock::AnchorDockRight",
-            "cmd-shift-k cmd-shift-down": "dock::AnchorDockBottom",
-            "cmd-shift-k cmd-shift-up": "dock::ExpandDock"
-        }
-    },
-    {
-        "context": "Pane",
-        "bindings": {
-            "cmd-escape": "dock::AddTabToDock"
-        }
-    },
-    {
-        "context": "Pane && docked",
-        "bindings": {
-            "shift-escape": "dock::HideDock",
-            "cmd-escape": "dock::RemoveTabFromDock"
-        }
-    },
-    {
-        "context": "ProjectPanel",
-        "bindings": {
-            "left": "project_panel::CollapseSelectedEntry",
-            "right": "project_panel::ExpandSelectedEntry",
-            "cmd-x": "project_panel::Cut",
-            "cmd-c": "project_panel::Copy",
-            "cmd-v": "project_panel::Paste",
-            "cmd-alt-c": "project_panel::CopyPath",
-            "alt-cmd-shift-c": "project_panel::CopyRelativePath",
-            "f2": "project_panel::Rename",
-            "backspace": "project_panel::Delete",
-            "alt-cmd-r": "project_panel::RevealInFinder"
-        }
-    },
-    {
-        "context": "Terminal",
-        "bindings": {
-            "ctrl-cmd-space": "terminal::ShowCharacterPalette",
-            "cmd-c": "terminal::Copy",
-            "cmd-v": "terminal::Paste",
-            "cmd-k": "terminal::Clear",
-            // Some nice conveniences
-            "cmd-backspace": [
-                "terminal::SendText",
-                "\u0015"
-            ],
-            "cmd-right": [
-                "terminal::SendText",
-                "\u0005"
-            ],
-            "cmd-left": [
-                "terminal::SendText",
-                "\u0001"
-            ],
-            // Terminal.app compatability
-            "alt-left": [
-                "terminal::SendText",
-                "\u001bb"
-            ],
-            "alt-right": [
-                "terminal::SendText",
-                "\u001bf"
-            ],
-            // There are conflicting bindings for these keys in the global context.
-            // these bindings override them, remove at your own risk:
-            "up": [
-                "terminal::SendKeystroke",
-                "up"
-            ],
-            "pageup": [
-                "terminal::SendKeystroke",
-                "pageup"
-            ],
-            "down": [
-                "terminal::SendKeystroke",
-                "down"
-            ],
-            "pagedown": [
-                "terminal::SendKeystroke",
-                "pagedown"
-            ],
-            "escape": [
-                "terminal::SendKeystroke",
-                "escape"
-            ],
-            "enter": [
-                "terminal::SendKeystroke",
-                "enter"
-            ],
-            "ctrl-c": [
-                "terminal::SendKeystroke",
-                "ctrl-c"
-            ]
-        }
+  // Standard macOS bindings
+  {
+    "bindings": {
+      "up": "menu::SelectPrev",
+      "pageup": "menu::SelectFirst",
+      "shift-pageup": "menu::SelectFirst",
+      "ctrl-p": "menu::SelectPrev",
+      "down": "menu::SelectNext",
+      "pagedown": "menu::SelectLast",
+      "shift-pagedown": "menu::SelectFirst",
+      "ctrl-n": "menu::SelectNext",
+      "cmd-up": "menu::SelectFirst",
+      "cmd-down": "menu::SelectLast",
+      "enter": "menu::Confirm",
+      "escape": "menu::Cancel",
+      "ctrl-c": "menu::Cancel",
+      "cmd-{": "pane::ActivatePrevItem",
+      "cmd-}": "pane::ActivateNextItem",
+      "alt-cmd-left": "pane::ActivatePrevItem",
+      "alt-cmd-right": "pane::ActivateNextItem",
+      "cmd-w": "pane::CloseActiveItem",
+      "alt-cmd-t": "pane::CloseInactiveItems",
+      "cmd-k u": "pane::CloseCleanItems",
+      "cmd-k cmd-w": "pane::CloseAllItems",
+      "cmd-shift-w": "workspace::CloseWindow",
+      "cmd-s": "workspace::Save",
+      "cmd-shift-s": "workspace::SaveAs",
+      "cmd-=": "zed::IncreaseBufferFontSize",
+      "cmd--": "zed::DecreaseBufferFontSize",
+      "cmd-0": "zed::ResetBufferFontSize",
+      "cmd-,": "zed::OpenSettings",
+      "cmd-q": "zed::Quit",
+      "cmd-h": "zed::Hide",
+      "alt-cmd-h": "zed::HideOthers",
+      "cmd-m": "zed::Minimize",
+      "ctrl-cmd-f": "zed::ToggleFullScreen",
+      "cmd-n": "workspace::NewFile",
+      "cmd-shift-n": "workspace::NewWindow",
+      "cmd-o": "workspace::Open",
+      "alt-cmd-o": "projects::OpenRecent",
+      "ctrl-`": "workspace::NewTerminal"
     }
+  },
+  {
+    "context": "Editor",
+    "bindings": {
+      "escape": "editor::Cancel",
+      "backspace": "editor::Backspace",
+      "shift-backspace": "editor::Backspace",
+      "ctrl-h": "editor::Backspace",
+      "delete": "editor::Delete",
+      "ctrl-d": "editor::Delete",
+      "tab": "editor::Tab",
+      "shift-tab": "editor::TabPrev",
+      "ctrl-k": "editor::CutToEndOfLine",
+      "ctrl-t": "editor::Transpose",
+      "cmd-backspace": "editor::DeleteToBeginningOfLine",
+      "cmd-delete": "editor::DeleteToEndOfLine",
+      "alt-backspace": "editor::DeleteToPreviousWordStart",
+      "alt-delete": "editor::DeleteToNextWordEnd",
+      "alt-h": "editor::DeleteToPreviousWordStart",
+      "alt-d": "editor::DeleteToNextWordEnd",
+      "cmd-x": "editor::Cut",
+      "cmd-c": "editor::Copy",
+      "cmd-v": "editor::Paste",
+      "cmd-z": "editor::Undo",
+      "cmd-shift-z": "editor::Redo",
+      "up": "editor::MoveUp",
+      "pageup": "editor::PageUp",
+      "shift-pageup": "editor::MovePageUp",
+      "home": "editor::MoveToBeginningOfLine",
+      "down": "editor::MoveDown",
+      "pagedown": "editor::PageDown",
+      "shift-pagedown": "editor::MovePageDown",
+      "end": "editor::MoveToEndOfLine",
+      "left": "editor::MoveLeft",
+      "right": "editor::MoveRight",
+      "ctrl-p": "editor::MoveUp",
+      "ctrl-n": "editor::MoveDown",
+      "ctrl-b": "editor::MoveLeft",
+      "ctrl-f": "editor::MoveRight",
+      "ctrl-l": "editor::NextScreen",
+      "alt-left": "editor::MoveToPreviousWordStart",
+      "alt-b": "editor::MoveToPreviousWordStart",
+      "alt-right": "editor::MoveToNextWordEnd",
+      "alt-f": "editor::MoveToNextWordEnd",
+      "cmd-left": "editor::MoveToBeginningOfLine",
+      "ctrl-a": "editor::MoveToBeginningOfLine",
+      "cmd-right": "editor::MoveToEndOfLine",
+      "ctrl-e": "editor::MoveToEndOfLine",
+      "cmd-up": "editor::MoveToBeginning",
+      "cmd-down": "editor::MoveToEnd",
+      "shift-up": "editor::SelectUp",
+      "ctrl-shift-p": "editor::SelectUp",
+      "shift-down": "editor::SelectDown",
+      "ctrl-shift-n": "editor::SelectDown",
+      "shift-left": "editor::SelectLeft",
+      "ctrl-shift-b": "editor::SelectLeft",
+      "shift-right": "editor::SelectRight",
+      "ctrl-shift-f": "editor::SelectRight",
+      "alt-shift-left": "editor::SelectToPreviousWordStart",
+      "alt-shift-b": "editor::SelectToPreviousWordStart",
+      "alt-shift-right": "editor::SelectToNextWordEnd",
+      "alt-shift-f": "editor::SelectToNextWordEnd",
+      "cmd-shift-up": "editor::SelectToBeginning",
+      "cmd-shift-down": "editor::SelectToEnd",
+      "cmd-a": "editor::SelectAll",
+      "cmd-l": "editor::SelectLine",
+      "cmd-shift-i": "editor::Format",
+      "cmd-shift-left": [
+        "editor::SelectToBeginningOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "shift-home": [
+        "editor::SelectToBeginningOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "ctrl-shift-a": [
+        "editor::SelectToBeginningOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "cmd-shift-right": [
+        "editor::SelectToEndOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "shift-end": [
+        "editor::SelectToEndOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "ctrl-shift-e": [
+        "editor::SelectToEndOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "ctrl-v": [
+        "editor::MovePageDown",
+        {
+          "center_cursor": true
+        }
+      ],
+      "alt-v": [
+        "editor::MovePageUp",
+        {
+          "center_cursor": true
+        }
+      ],
+      "ctrl-cmd-space": "editor::ShowCharacterPalette"
+    }
+  },
+  {
+    "context": "Editor && mode == full",
+    "bindings": {
+      "enter": "editor::Newline",
+      "cmd-shift-enter": "editor::NewlineAbove",
+      "cmd-enter": "editor::NewlineBelow",
+      "alt-z": "editor::ToggleSoftWrap",
+      "cmd-f": [
+        "buffer_search::Deploy",
+        {
+          "focus": true
+        }
+      ],
+      "cmd-e": [
+        "buffer_search::Deploy",
+        {
+          "focus": false
+        }
+      ],
+      "alt-\\": "copilot::Suggest",
+      "alt-]": "copilot::NextSuggestion",
+      "alt-[": "copilot::PreviousSuggestion"
+    }
+  },
+  {
+    "context": "Editor && mode == auto_height",
+    "bindings": {
+      "alt-enter": "editor::Newline",
+      "cmd-alt-enter": "editor::NewlineBelow"
+    }
+  },
+  {
+    "context": "BufferSearchBar > Editor",
+    "bindings": {
+      "escape": "buffer_search::Dismiss",
+      "tab": "buffer_search::FocusEditor",
+      "enter": "search::SelectNextMatch",
+      "shift-enter": "search::SelectPrevMatch"
+    }
+  },
+  {
+    "context": "Pane",
+    "bindings": {
+      "cmd-f": "project_search::ToggleFocus",
+      "cmd-g": "search::SelectNextMatch",
+      "cmd-shift-g": "search::SelectPrevMatch",
+      "alt-cmd-c": "search::ToggleCaseSensitive",
+      "alt-cmd-w": "search::ToggleWholeWord",
+      "alt-cmd-r": "search::ToggleRegex"
+    }
+  },
+  // Bindings from VS Code
+  {
+    "context": "Editor",
+    "bindings": {
+      "cmd-[": "editor::Outdent",
+      "cmd-]": "editor::Indent",
+      "cmd-alt-up": "editor::AddSelectionAbove",
+      "cmd-ctrl-p": "editor::AddSelectionAbove",
+      "cmd-alt-down": "editor::AddSelectionBelow",
+      "cmd-ctrl-n": "editor::AddSelectionBelow",
+      "cmd-d": [
+        "editor::SelectNext",
+        {
+          "replace_newest": false
+        }
+      ],
+      "cmd-k cmd-d": [
+        "editor::SelectNext",
+        {
+          "replace_newest": true
+        }
+      ],
+      "cmd-k cmd-i": "editor::Hover",
+      "cmd-/": [
+        "editor::ToggleComments",
+        {
+          "advance_downwards": false
+        }
+      ],
+      "alt-up": "editor::SelectLargerSyntaxNode",
+      "alt-down": "editor::SelectSmallerSyntaxNode",
+      "cmd-u": "editor::UndoSelection",
+      "cmd-shift-u": "editor::RedoSelection",
+      "f8": "editor::GoToDiagnostic",
+      "shift-f8": "editor::GoToPrevDiagnostic",
+      "f2": "editor::Rename",
+      "f12": "editor::GoToDefinition",
+      "cmd-f12": "editor::GoToTypeDefinition",
+      "alt-shift-f12": "editor::FindAllReferences",
+      "ctrl-m": "editor::MoveToEnclosingBracket",
+      "alt-cmd-[": "editor::Fold",
+      "alt-cmd-]": "editor::UnfoldLines",
+      "ctrl-space": "editor::ShowCompletions",
+      "cmd-.": "editor::ToggleCodeActions",
+      "alt-cmd-r": "editor::RevealInFinder"
+    }
+  },
+  {
+    "context": "Editor && mode == full",
+    "bindings": {
+      "cmd-shift-o": "outline::Toggle",
+      "ctrl-g": "go_to_line::Toggle"
+    }
+  },
+  {
+    "context": "Pane",
+    "bindings": {
+      "ctrl-1": [
+        "pane::ActivateItem",
+        0
+      ],
+      "ctrl-2": [
+        "pane::ActivateItem",
+        1
+      ],
+      "ctrl-3": [
+        "pane::ActivateItem",
+        2
+      ],
+      "ctrl-4": [
+        "pane::ActivateItem",
+        3
+      ],
+      "ctrl-5": [
+        "pane::ActivateItem",
+        4
+      ],
+      "ctrl-6": [
+        "pane::ActivateItem",
+        5
+      ],
+      "ctrl-7": [
+        "pane::ActivateItem",
+        6
+      ],
+      "ctrl-8": [
+        "pane::ActivateItem",
+        7
+      ],
+      "ctrl-9": [
+        "pane::ActivateItem",
+        8
+      ],
+      "ctrl-0": "pane::ActivateLastItem",
+      "ctrl--": "pane::GoBack",
+      "ctrl-_": "pane::GoForward",
+      "cmd-shift-t": "pane::ReopenClosedItem",
+      "cmd-shift-f": "project_search::ToggleFocus"
+    }
+  },
+  {
+    "context": "Workspace",
+    "bindings": {
+      "cmd-1": [
+        "workspace::ActivatePane",
+        0
+      ],
+      "cmd-2": [
+        "workspace::ActivatePane",
+        1
+      ],
+      "cmd-3": [
+        "workspace::ActivatePane",
+        2
+      ],
+      "cmd-4": [
+        "workspace::ActivatePane",
+        3
+      ],
+      "cmd-5": [
+        "workspace::ActivatePane",
+        4
+      ],
+      "cmd-6": [
+        "workspace::ActivatePane",
+        5
+      ],
+      "cmd-7": [
+        "workspace::ActivatePane",
+        6
+      ],
+      "cmd-8": [
+        "workspace::ActivatePane",
+        7
+      ],
+      "cmd-9": [
+        "workspace::ActivatePane",
+        8
+      ],
+      "cmd-b": "workspace::ToggleLeftSidebar",
+      "cmd-shift-f": "workspace::NewSearch",
+      "cmd-k cmd-t": "theme_selector::Toggle",
+      "cmd-k cmd-s": "zed::OpenKeymap",
+      "cmd-t": "project_symbols::Toggle",
+      "cmd-p": "file_finder::Toggle",
+      "cmd-shift-p": "command_palette::Toggle",
+      "cmd-shift-m": "diagnostics::Deploy",
+      "cmd-shift-e": "project_panel::ToggleFocus",
+      "cmd-alt-s": "workspace::SaveAll",
+      "cmd-k m": "language_selector::Toggle"
+    }
+  },
+  // Bindings from Sublime Text
+  {
+    "context": "Editor",
+    "bindings": {
+      "ctrl-shift-k": "editor::DeleteLine",
+      "cmd-shift-d": "editor::DuplicateLine",
+      "cmd-shift-l": "editor::SplitSelectionIntoLines",
+      "ctrl-cmd-up": "editor::MoveLineUp",
+      "ctrl-cmd-down": "editor::MoveLineDown",
+      "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
+      "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
+      "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
+      "ctrl-alt-d": "editor::DeleteToNextSubwordEnd",
+      "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
+      "ctrl-alt-b": "editor::MoveToPreviousSubwordStart",
+      "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
+      "ctrl-alt-f": "editor::MoveToNextSubwordEnd",
+      "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
+      "ctrl-alt-shift-b": "editor::SelectToPreviousSubwordStart",
+      "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
+      "ctrl-alt-shift-f": "editor::SelectToNextSubwordEnd"
+    }
+  },
+  {
+    "bindings": {
+      "cmd-k cmd-left": "workspace::ActivatePreviousPane",
+      "cmd-k cmd-right": "workspace::ActivateNextPane"
+    }
+  },
+  // Bindings from Atom
+  {
+    "context": "Pane",
+    "bindings": {
+      "cmd-k up": "pane::SplitUp",
+      "cmd-k down": "pane::SplitDown",
+      "cmd-k left": "pane::SplitLeft",
+      "cmd-k right": "pane::SplitRight"
+    }
+  },
+  // Bindings that should be unified with bindings for more general actions
+  {
+    "context": "Editor && renaming",
+    "bindings": {
+      "enter": "editor::ConfirmRename"
+    }
+  },
+  {
+    "context": "Editor && showing_completions",
+    "bindings": {
+      "enter": "editor::ConfirmCompletion",
+      "tab": "editor::ConfirmCompletion"
+    }
+  },
+  {
+    "context": "Editor && showing_code_actions",
+    "bindings": {
+      "enter": "editor::ConfirmCodeAction"
+    }
+  },
+  // Custom bindings
+  {
+    "bindings": {
+      "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
+      "cmd-shift-c": "collab::ToggleContactsMenu",
+      "cmd-alt-i": "zed::DebugElements"
+    }
+  },
+  {
+    "context": "Editor",
+    "bindings": {
+      "alt-enter": "editor::OpenExcerpts",
+      "cmd-f8": "editor::GoToHunk",
+      "cmd-shift-f8": "editor::GoToPrevHunk"
+    }
+  },
+  {
+    "context": "ProjectSearchBar",
+    "bindings": {
+      "cmd-enter": "project_search::SearchInNew"
+    }
+  },
+  {
+    "context": "Workspace",
+    "bindings": {
+      "shift-escape": "dock::FocusDock"
+    }
+  },
+  {
+    "bindings": {
+      "cmd-shift-k cmd-shift-right": "dock::AnchorDockRight",
+      "cmd-shift-k cmd-shift-down": "dock::AnchorDockBottom",
+      "cmd-shift-k cmd-shift-up": "dock::ExpandDock"
+    }
+  },
+  {
+    "context": "Pane",
+    "bindings": {
+      "cmd-escape": "dock::AddTabToDock"
+    }
+  },
+  {
+    "context": "Pane && docked",
+    "bindings": {
+      "shift-escape": "dock::HideDock",
+      "cmd-escape": "dock::RemoveTabFromDock"
+    }
+  },
+  {
+    "context": "ProjectPanel",
+    "bindings": {
+      "left": "project_panel::CollapseSelectedEntry",
+      "right": "project_panel::ExpandSelectedEntry",
+      "cmd-x": "project_panel::Cut",
+      "cmd-c": "project_panel::Copy",
+      "cmd-v": "project_panel::Paste",
+      "cmd-alt-c": "project_panel::CopyPath",
+      "alt-cmd-shift-c": "project_panel::CopyRelativePath",
+      "f2": "project_panel::Rename",
+      "backspace": "project_panel::Delete",
+      "alt-cmd-r": "project_panel::RevealInFinder"
+    }
+  },
+  {
+    "context": "Terminal",
+    "bindings": {
+      "ctrl-cmd-space": "terminal::ShowCharacterPalette",
+      "cmd-c": "terminal::Copy",
+      "cmd-v": "terminal::Paste",
+      "cmd-k": "terminal::Clear",
+      // Some nice conveniences
+      "cmd-backspace": [
+        "terminal::SendText",
+        "\u0015"
+      ],
+      "cmd-right": [
+        "terminal::SendText",
+        "\u0005"
+      ],
+      "cmd-left": [
+        "terminal::SendText",
+        "\u0001"
+      ],
+      // Terminal.app compatability
+      "alt-left": [
+        "terminal::SendText",
+        "\u001bb"
+      ],
+      "alt-right": [
+        "terminal::SendText",
+        "\u001bf"
+      ],
+      // There are conflicting bindings for these keys in the global context.
+      // these bindings override them, remove at your own risk:
+      "up": [
+        "terminal::SendKeystroke",
+        "up"
+      ],
+      "pageup": [
+        "terminal::SendKeystroke",
+        "pageup"
+      ],
+      "down": [
+        "terminal::SendKeystroke",
+        "down"
+      ],
+      "pagedown": [
+        "terminal::SendKeystroke",
+        "pagedown"
+      ],
+      "escape": [
+        "terminal::SendKeystroke",
+        "escape"
+      ],
+      "enter": [
+        "terminal::SendKeystroke",
+        "enter"
+      ],
+      "ctrl-c": [
+        "terminal::SendKeystroke",
+        "ctrl-c"
+      ]
+    }
+  }
 ]

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,325 +1,325 @@
 [
-    {
-        "context": "Editor && VimControl && !VimWaiting",
-        "bindings": {
-            "g": [
-                "vim::PushOperator",
-                {
-                    "Namespace": "G"
-                }
-            ],
-            "i": [
-                "vim::PushOperator",
-                {
-                    "Object": {
-                        "around": false
-                    }
-                }
-            ],
-            "a": [
-                "vim::PushOperator",
-                {
-                    "Object": {
-                        "around": true
-                    }
-                }
-            ],
-            "h": "vim::Left",
-            "backspace": "vim::Backspace",
-            "j": "vim::Down",
-            "enter": "vim::NextLineStart",
-            "k": "vim::Up",
-            "l": "vim::Right",
-            "$": "vim::EndOfLine",
-            "shift-g": "vim::EndOfDocument",
-            "w": "vim::NextWordStart",
-            "shift-w": [
-                "vim::NextWordStart",
-                {
-                    "ignorePunctuation": true
-                }
-            ],
-            "e": "vim::NextWordEnd",
-            "shift-e": [
-                "vim::NextWordEnd",
-                {
-                    "ignorePunctuation": true
-                }
-            ],
-            "b": "vim::PreviousWordStart",
-            "shift-b": [
-                "vim::PreviousWordStart",
-                {
-                    "ignorePunctuation": true
-                }
-            ],
-            "%": "vim::Matching",
-            "ctrl-y": [
-                "vim::Scroll",
-                "LineUp"
-            ],
-            "f": [
-                "vim::PushOperator",
-                {
-                    "FindForward": {
-                        "before": false
-                    }
-                }
-            ],
-            "t": [
-                "vim::PushOperator",
-                {
-                    "FindForward": {
-                        "before": true
-                    }
-                }
-            ],
-            "shift-f": [
-                "vim::PushOperator",
-                {
-                    "FindBackward": {
-                        "after": false
-                    }
-                }
-            ],
-            "shift-t": [
-                "vim::PushOperator",
-                {
-                    "FindBackward": {
-                        "after": true
-                    }
-                }
-            ],
-            "escape": "editor::Cancel",
-            "0": "vim::StartOfLine", // When no number operator present, use start of line motion
-            "1": [
-                "vim::Number",
-                1
-            ],
-            "2": [
-                "vim::Number",
-                2
-            ],
-            "3": [
-                "vim::Number",
-                3
-            ],
-            "4": [
-                "vim::Number",
-                4
-            ],
-            "5": [
-                "vim::Number",
-                5
-            ],
-            "6": [
-                "vim::Number",
-                6
-            ],
-            "7": [
-                "vim::Number",
-                7
-            ],
-            "8": [
-                "vim::Number",
-                8
-            ],
-            "9": [
-                "vim::Number",
-                9
-            ]
+  {
+    "context": "Editor && VimControl && !VimWaiting",
+    "bindings": {
+      "g": [
+        "vim::PushOperator",
+        {
+          "Namespace": "G"
         }
-    },
-    {
-        "context": "Editor && vim_mode == normal && vim_operator == none && !VimWaiting",
-        "bindings": {
-            "c": [
-                "vim::PushOperator",
-                "Change"
-            ],
-            "shift-c": "vim::ChangeToEndOfLine",
-            "d": [
-                "vim::PushOperator",
-                "Delete"
-            ],
-            "shift-d": "vim::DeleteToEndOfLine",
-            "y": [
-                "vim::PushOperator",
-                "Yank"
-            ],
-            "z": [
-                "vim::PushOperator",
-                {
-                    "Namespace": "Z"
-                }
-            ],
-            "i": [
-                "vim::SwitchMode",
-                "Insert"
-            ],
-            "shift-i": "vim::InsertFirstNonWhitespace",
-            "a": "vim::InsertAfter",
-            "shift-a": "vim::InsertEndOfLine",
-            "x": "vim::DeleteRight",
-            "shift-x": "vim::DeleteLeft",
-            "^": "vim::FirstNonWhitespace",
-            "o": "vim::InsertLineBelow",
-            "shift-o": "vim::InsertLineAbove",
-            "v": [
-                "vim::SwitchMode",
-                {
-                    "Visual": {
-                        "line": false
-                    }
-                }
-            ],
-            "shift-v": [
-                "vim::SwitchMode",
-                {
-                    "Visual": {
-                        "line": true
-                    }
-                }
-            ],
-            "p": "vim::Paste",
-            "u": "editor::Undo",
-            "ctrl-r": "editor::Redo",
-            "ctrl-o": "pane::GoBack",
-            "/": [
-                "buffer_search::Deploy",
-                {
-                    "focus": true
-                }
-            ],
-            "ctrl-f": [
-                "vim::Scroll",
-                "PageDown"
-            ],
-            "ctrl-b": [
-                "vim::Scroll",
-                "PageUp"
-            ],
-            "ctrl-d": [
-                "vim::Scroll",
-                "HalfPageDown"
-            ],
-            "ctrl-u": [
-                "vim::Scroll",
-                "HalfPageUp"
-            ],
-            "ctrl-e": [
-                "vim::Scroll",
-                "LineDown"
-            ],
-            "r": [
-                "vim::PushOperator",
-                "Replace"
-            ]
+      ],
+      "i": [
+        "vim::PushOperator",
+        {
+          "Object": {
+            "around": false
+          }
         }
-    },
-    {
-        "context": "Editor && vim_operator == n",
-        "bindings": {
-            "0": [
-                "vim::Number",
-                0
-            ]
+      ],
+      "a": [
+        "vim::PushOperator",
+        {
+          "Object": {
+            "around": true
+          }
         }
-    },
-    {
-        "context": "Editor && vim_operator == g",
-        "bindings": {
-            "g": "vim::StartOfDocument",
-            "h": "editor::Hover",
-            "escape": [
-                "vim::SwitchMode",
-                "Normal"
-            ],
-            "d": "editor::GoToDefinition"
+      ],
+      "h": "vim::Left",
+      "backspace": "vim::Backspace",
+      "j": "vim::Down",
+      "enter": "vim::NextLineStart",
+      "k": "vim::Up",
+      "l": "vim::Right",
+      "$": "vim::EndOfLine",
+      "shift-g": "vim::EndOfDocument",
+      "w": "vim::NextWordStart",
+      "shift-w": [
+        "vim::NextWordStart",
+        {
+          "ignorePunctuation": true
         }
-    },
-    {
-        "context": "Editor && vim_operator == c",
-        "bindings": {
-            "c": "vim::CurrentLine"
+      ],
+      "e": "vim::NextWordEnd",
+      "shift-e": [
+        "vim::NextWordEnd",
+        {
+          "ignorePunctuation": true
         }
-    },
-    {
-        "context": "Editor && vim_operator == d",
-        "bindings": {
-            "d": "vim::CurrentLine"
+      ],
+      "b": "vim::PreviousWordStart",
+      "shift-b": [
+        "vim::PreviousWordStart",
+        {
+          "ignorePunctuation": true
         }
-    },
-    {
-        "context": "Editor && vim_operator == y",
-        "bindings": {
-            "y": "vim::CurrentLine"
+      ],
+      "%": "vim::Matching",
+      "ctrl-y": [
+        "vim::Scroll",
+        "LineUp"
+      ],
+      "f": [
+        "vim::PushOperator",
+        {
+          "FindForward": {
+            "before": false
+          }
         }
-    },
-    {
-        "context": "Editor && vim_operator == z",
-        "bindings": {
-            "t": "editor::ScrollCursorTop",
-            "z": "editor::ScrollCursorCenter",
-            "b": "editor::ScrollCursorBottom",
-            "escape": [
-                "vim::SwitchMode",
-                "Normal"
-            ]
+      ],
+      "t": [
+        "vim::PushOperator",
+        {
+          "FindForward": {
+            "before": true
+          }
         }
-    },
-    {
-        "context": "Editor && VimObject",
-        "bindings": {
-            "w": "vim::Word",
-            "shift-w": [
-                "vim::Word",
-                {
-                    "ignorePunctuation": true
-                }
-            ],
-            "s": "vim::Sentence",
-            "'": "vim::Quotes",
-            "`": "vim::BackQuotes",
-            "\"": "vim::DoubleQuotes",
-            "(": "vim::Parentheses",
-            ")": "vim::Parentheses",
-            "[": "vim::SquareBrackets",
-            "]": "vim::SquareBrackets",
-            "{": "vim::CurlyBrackets",
-            "}": "vim::CurlyBrackets",
-            "<": "vim::AngleBrackets",
-            ">": "vim::AngleBrackets"
+      ],
+      "shift-f": [
+        "vim::PushOperator",
+        {
+          "FindBackward": {
+            "after": false
+          }
         }
-    },
-    {
-        "context": "Editor && vim_mode == visual && !VimWaiting",
-        "bindings": {
-            "u": "editor::Undo",
-            "c": "vim::VisualChange",
-            "d": "vim::VisualDelete",
-            "x": "vim::VisualDelete",
-            "y": "vim::VisualYank",
-            "p": "vim::VisualPaste",
-            "r": [
-                "vim::PushOperator",
-                "Replace"
-            ]
+      ],
+      "shift-t": [
+        "vim::PushOperator",
+        {
+          "FindBackward": {
+            "after": true
+          }
         }
-    },
-    {
-        "context": "Editor && vim_mode == insert",
-        "bindings": {
-            "escape": "vim::NormalBefore",
-            "ctrl-c": "vim::NormalBefore"
-        }
-    },
-    {
-        "context": "Editor && VimWaiting",
-        "bindings": {
-            "tab": "vim::Tab",
-            "enter": "vim::Enter",
-            "escape": "editor::Cancel"
-        }
+      ],
+      "escape": "editor::Cancel",
+      "0": "vim::StartOfLine", // When no number operator present, use start of line motion
+      "1": [
+        "vim::Number",
+        1
+      ],
+      "2": [
+        "vim::Number",
+        2
+      ],
+      "3": [
+        "vim::Number",
+        3
+      ],
+      "4": [
+        "vim::Number",
+        4
+      ],
+      "5": [
+        "vim::Number",
+        5
+      ],
+      "6": [
+        "vim::Number",
+        6
+      ],
+      "7": [
+        "vim::Number",
+        7
+      ],
+      "8": [
+        "vim::Number",
+        8
+      ],
+      "9": [
+        "vim::Number",
+        9
+      ]
     }
+  },
+  {
+    "context": "Editor && vim_mode == normal && vim_operator == none && !VimWaiting",
+    "bindings": {
+      "c": [
+        "vim::PushOperator",
+        "Change"
+      ],
+      "shift-c": "vim::ChangeToEndOfLine",
+      "d": [
+        "vim::PushOperator",
+        "Delete"
+      ],
+      "shift-d": "vim::DeleteToEndOfLine",
+      "y": [
+        "vim::PushOperator",
+        "Yank"
+      ],
+      "z": [
+        "vim::PushOperator",
+        {
+          "Namespace": "Z"
+        }
+      ],
+      "i": [
+        "vim::SwitchMode",
+        "Insert"
+      ],
+      "shift-i": "vim::InsertFirstNonWhitespace",
+      "a": "vim::InsertAfter",
+      "shift-a": "vim::InsertEndOfLine",
+      "x": "vim::DeleteRight",
+      "shift-x": "vim::DeleteLeft",
+      "^": "vim::FirstNonWhitespace",
+      "o": "vim::InsertLineBelow",
+      "shift-o": "vim::InsertLineAbove",
+      "v": [
+        "vim::SwitchMode",
+        {
+          "Visual": {
+            "line": false
+          }
+        }
+      ],
+      "shift-v": [
+        "vim::SwitchMode",
+        {
+          "Visual": {
+            "line": true
+          }
+        }
+      ],
+      "p": "vim::Paste",
+      "u": "editor::Undo",
+      "ctrl-r": "editor::Redo",
+      "ctrl-o": "pane::GoBack",
+      "/": [
+        "buffer_search::Deploy",
+        {
+          "focus": true
+        }
+      ],
+      "ctrl-f": [
+        "vim::Scroll",
+        "PageDown"
+      ],
+      "ctrl-b": [
+        "vim::Scroll",
+        "PageUp"
+      ],
+      "ctrl-d": [
+        "vim::Scroll",
+        "HalfPageDown"
+      ],
+      "ctrl-u": [
+        "vim::Scroll",
+        "HalfPageUp"
+      ],
+      "ctrl-e": [
+        "vim::Scroll",
+        "LineDown"
+      ],
+      "r": [
+        "vim::PushOperator",
+        "Replace"
+      ]
+    }
+  },
+  {
+    "context": "Editor && vim_operator == n",
+    "bindings": {
+      "0": [
+        "vim::Number",
+        0
+      ]
+    }
+  },
+  {
+    "context": "Editor && vim_operator == g",
+    "bindings": {
+      "g": "vim::StartOfDocument",
+      "h": "editor::Hover",
+      "escape": [
+        "vim::SwitchMode",
+        "Normal"
+      ],
+      "d": "editor::GoToDefinition"
+    }
+  },
+  {
+    "context": "Editor && vim_operator == c",
+    "bindings": {
+      "c": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "Editor && vim_operator == d",
+    "bindings": {
+      "d": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "Editor && vim_operator == y",
+    "bindings": {
+      "y": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "Editor && vim_operator == z",
+    "bindings": {
+      "t": "editor::ScrollCursorTop",
+      "z": "editor::ScrollCursorCenter",
+      "b": "editor::ScrollCursorBottom",
+      "escape": [
+        "vim::SwitchMode",
+        "Normal"
+      ]
+    }
+  },
+  {
+    "context": "Editor && VimObject",
+    "bindings": {
+      "w": "vim::Word",
+      "shift-w": [
+        "vim::Word",
+        {
+          "ignorePunctuation": true
+        }
+      ],
+      "s": "vim::Sentence",
+      "'": "vim::Quotes",
+      "`": "vim::BackQuotes",
+      "\"": "vim::DoubleQuotes",
+      "(": "vim::Parentheses",
+      ")": "vim::Parentheses",
+      "[": "vim::SquareBrackets",
+      "]": "vim::SquareBrackets",
+      "{": "vim::CurlyBrackets",
+      "}": "vim::CurlyBrackets",
+      "<": "vim::AngleBrackets",
+      ">": "vim::AngleBrackets"
+    }
+  },
+  {
+    "context": "Editor && vim_mode == visual && !VimWaiting",
+    "bindings": {
+      "u": "editor::Undo",
+      "c": "vim::VisualChange",
+      "d": "vim::VisualDelete",
+      "x": "vim::VisualDelete",
+      "y": "vim::VisualYank",
+      "p": "vim::VisualPaste",
+      "r": [
+        "vim::PushOperator",
+        "Replace"
+      ]
+    }
+  },
+  {
+    "context": "Editor && vim_mode == insert",
+    "bindings": {
+      "escape": "vim::NormalBefore",
+      "ctrl-c": "vim::NormalBefore"
+    }
+  },
+  {
+    "context": "Editor && VimWaiting",
+    "bindings": {
+      "tab": "vim::Tab",
+      "enter": "vim::Enter",
+      "escape": "editor::Cancel"
+    }
+  }
 ]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1,257 +1,257 @@
 {
-    // The name of the Zed theme to use for the UI
-    "theme": "One Dark",
-    // Features that can be globally enabled or disabled
-    "features": {
-        // Show Copilot icon in status bar
-        "copilot": true
-    },
-    // The name of a font to use for rendering text in the editor
-    "buffer_font_family": "Zed Mono",
-    // The OpenType features to enable for text in the editor.
-    "buffer_font_features": {
-        // Disable ligatures:
-        // "calt": false
-    },
-    // The default font size for text in the editor
-    "buffer_font_size": 15,
-    // The factor to grow the active pane by. Defaults to 1.0
-    // which gives the same size as all other panes.
-    "active_pane_magnification": 1.0,
-    // Whether to enable vim modes and key bindings
-    "vim_mode": false,
-    // Whether to show the informational hover box when moving the mouse
-    // over symbols in the editor.
-    "hover_popover_enabled": true,
-    // Whether to confirm before quitting Zed.
-    "confirm_quit": false,
-    // Whether the cursor blinks in the editor.
-    "cursor_blink": true,
-    // Whether to pop the completions menu while typing in an editor without
-    // explicitly requesting it.
-    "show_completions_on_input": true,
-    // Controls whether copilot provides suggestion immediately
-    // or waits for a `copilot::Toggle`
-    "show_copilot_suggestions": true,
-    // Whether the screen sharing icon is shown in the os status bar.
-    "show_call_status_icon": true,
-    // Whether to use language servers to provide code intelligence.
-    "enable_language_server": true,
-    // When to automatically save edited buffers. This setting can
-    // take four values.
-    //
-    // 1. Never automatically save:
-    //     "autosave": "off",
-    // 2. Save when changing focus away from the Zed window:
-    //     "autosave": "on_window_change",
-    // 3. Save when changing focus away from a specific buffer:
-    //     "autosave": "on_focus_change",
-    // 4. Save when idle for a certain amount of time:
-    //     "autosave": { "after_delay": {"milliseconds": 500} },
-    "autosave": "off",
-    // Where to place the dock by default. This setting can take three
-    // values:
-    //
-    // 1. Position the dock attached to the bottom of the workspace
-    //     "default_dock_anchor": "bottom"
-    // 2. Position the dock to the right of the workspace like a side panel
-    //     "default_dock_anchor": "right"
-    // 3. Position the dock full screen over the entire workspace"
-    //     "default_dock_anchor": "expanded"
-    "default_dock_anchor": "bottom",
-    // Whether or not to remove any trailing whitespace from lines of a buffer
-    // before saving it.
-    "remove_trailing_whitespace_on_save": true,
-    // Whether or not to ensure there's a single newline at the end of a buffer
-    // when saving it.
-    "ensure_final_newline_on_save": true,
-    // Whether or not to perform a buffer format before saving
-    "format_on_save": "on",
-    // How to perform a buffer format. This setting can take two values:
-    //
-    // 1. Format code using the current language server:
-    //     "format_on_save": "language_server"
-    // 2. Format code using an external command:
-    //     "format_on_save": {
-    //       "external": {
-    //         "command": "prettier",
-    //         "arguments": ["--stdin-filepath", "{buffer_path}"]
-    //       }
+  // The name of the Zed theme to use for the UI
+  "theme": "One Dark",
+  // Features that can be globally enabled or disabled
+  "features": {
+    // Show Copilot icon in status bar
+    "copilot": true
+  },
+  // The name of a font to use for rendering text in the editor
+  "buffer_font_family": "Zed Mono",
+  // The OpenType features to enable for text in the editor.
+  "buffer_font_features": {
+    // Disable ligatures:
+    // "calt": false
+  },
+  // The default font size for text in the editor
+  "buffer_font_size": 15,
+  // The factor to grow the active pane by. Defaults to 1.0
+  // which gives the same size as all other panes.
+  "active_pane_magnification": 1.0,
+  // Whether to enable vim modes and key bindings
+  "vim_mode": false,
+  // Whether to show the informational hover box when moving the mouse
+  // over symbols in the editor.
+  "hover_popover_enabled": true,
+  // Whether to confirm before quitting Zed.
+  "confirm_quit": false,
+  // Whether the cursor blinks in the editor.
+  "cursor_blink": true,
+  // Whether to pop the completions menu while typing in an editor without
+  // explicitly requesting it.
+  "show_completions_on_input": true,
+  // Controls whether copilot provides suggestion immediately
+  // or waits for a `copilot::Toggle`
+  "show_copilot_suggestions": true,
+  // Whether the screen sharing icon is shown in the os status bar.
+  "show_call_status_icon": true,
+  // Whether to use language servers to provide code intelligence.
+  "enable_language_server": true,
+  // When to automatically save edited buffers. This setting can
+  // take four values.
+  //
+  // 1. Never automatically save:
+  //     "autosave": "off",
+  // 2. Save when changing focus away from the Zed window:
+  //     "autosave": "on_window_change",
+  // 3. Save when changing focus away from a specific buffer:
+  //     "autosave": "on_focus_change",
+  // 4. Save when idle for a certain amount of time:
+  //     "autosave": { "after_delay": {"milliseconds": 500} },
+  "autosave": "off",
+  // Where to place the dock by default. This setting can take three
+  // values:
+  //
+  // 1. Position the dock attached to the bottom of the workspace
+  //     "default_dock_anchor": "bottom"
+  // 2. Position the dock to the right of the workspace like a side panel
+  //     "default_dock_anchor": "right"
+  // 3. Position the dock full screen over the entire workspace"
+  //     "default_dock_anchor": "expanded"
+  "default_dock_anchor": "bottom",
+  // Whether or not to remove any trailing whitespace from lines of a buffer
+  // before saving it.
+  "remove_trailing_whitespace_on_save": true,
+  // Whether or not to ensure there's a single newline at the end of a buffer
+  // when saving it.
+  "ensure_final_newline_on_save": true,
+  // Whether or not to perform a buffer format before saving
+  "format_on_save": "on",
+  // How to perform a buffer format. This setting can take two values:
+  //
+  // 1. Format code using the current language server:
+  //     "format_on_save": "language_server"
+  // 2. Format code using an external command:
+  //     "format_on_save": {
+  //       "external": {
+  //         "command": "prettier",
+  //         "arguments": ["--stdin-filepath", "{buffer_path}"]
+  //       }
+  //     }
+  "formatter": "language_server",
+  // How to soft-wrap long lines of text. This setting can take
+  // three values:
+  //
+  // 1. Do not soft wrap.
+  //      "soft_wrap": "none",
+  // 2. Soft wrap lines that overflow the editor:
+  //      "soft_wrap": "editor_width",
+  // 3. Soft wrap lines at the preferred line length
+  //      "soft_wrap": "preferred_line_length",
+  "soft_wrap": "none",
+  // The column at which to soft-wrap lines, for buffers where soft-wrap
+  // is enabled.
+  "preferred_line_length": 80,
+  // Whether to indent lines using tab characters, as opposed to multiple
+  // spaces.
+  "hard_tabs": false,
+  // How many columns a tab should occupy.
+  "tab_size": 4,
+  // Control what info is collected by Zed.
+  "telemetry": {
+    // Send debug info like crash reports.
+    "diagnostics": true,
+    // Send anonymized usage data like what languages you're using Zed with.
+    "metrics": true
+  },
+  // Automatically update Zed
+  "auto_update": true,
+  // Git gutter behavior configuration.
+  "git": {
+    // Control whether the git gutter is shown. May take 2 values:
+    // 1. Show the gutter
+    //      "git_gutter": "tracked_files"
+    // 2. Hide the gutter
+    //      "git_gutter": "hide"
+    "git_gutter": "tracked_files"
+  },
+  // Settings specific to journaling
+  "journal": {
+    // The path of the directory where journal entries are stored
+    "path": "~",
+    // What format to display the hours in
+    // May take 2 values:
+    // 1. hour12
+    // 2. hour24
+    "hour_format": "hour12"
+  },
+  // Settings specific to the terminal
+  "terminal": {
+    // What shell to use when opening a terminal. May take 3 values:
+    // 1. Use the system's default terminal configuration in /etc/passwd
+    //      "shell": "system"
+    // 2. A program:
+    //      "shell": {
+    //        "program": "sh"
+    //      }
+    // 3. A program with arguments:
+    //     "shell": {
+    //         "with_arguments": {
+    //           "program": "/bin/bash",
+    //           "arguments": ["--login"]
+    //         }
     //     }
-    "formatter": "language_server",
-    // How to soft-wrap long lines of text. This setting can take
-    // three values:
+    "shell": "system",
+    // What working directory to use when launching the terminal.
+    // May take 4 values:
+    // 1. Use the current file's project directory.  Will Fallback to the
+    //    first project directory strategy if unsuccessful
+    //      "working_directory": "current_project_directory"
+    // 2. Use the first project in this workspace's directory
+    //      "working_directory": "first_project_directory"
+    // 3. Always use this platform's home directory (if we can find it)
+    //     "working_directory": "always_home"
+    // 4. Always use a specific directory. This value will be shell expanded.
+    //    If this path is not a valid directory the terminal will default to
+    //    this platform's home directory  (if we can find it)
+    //      "working_directory": {
+    //        "always": {
+    //          "directory": "~/zed/projects/"
+    //        }
+    //      }
     //
-    // 1. Do not soft wrap.
-    //      "soft_wrap": "none",
-    // 2. Soft wrap lines that overflow the editor:
-    //      "soft_wrap": "editor_width",
-    // 3. Soft wrap lines at the preferred line length
-    //      "soft_wrap": "preferred_line_length",
-    "soft_wrap": "none",
-    // The column at which to soft-wrap lines, for buffers where soft-wrap
-    // is enabled.
-    "preferred_line_length": 80,
-    // Whether to indent lines using tab characters, as opposed to multiple
-    // spaces.
-    "hard_tabs": false,
-    // How many columns a tab should occupy.
-    "tab_size": 4,
-    // Control what info is collected by Zed.
-    "telemetry": {
-        // Send debug info like crash reports.
-        "diagnostics": true,
-        // Send anonymized usage data like what languages you're using Zed with.
-        "metrics": true
-    },
-    // Automatically update Zed
-    "auto_update": true,
-    // Git gutter behavior configuration.
-    "git": {
-        // Control whether the git gutter is shown. May take 2 values:
-        // 1. Show the gutter
-        //      "git_gutter": "tracked_files"
-        // 2. Hide the gutter
-        //      "git_gutter": "hide"
-        "git_gutter": "tracked_files"
-    },
-    // Settings specific to journaling
-    "journal": {
-        // The path of the directory where journal entries are stored
-        "path": "~",
-        // What format to display the hours in
-        // May take 2 values:
-        // 1. hour12
-        // 2. hour24
-        "hour_format": "hour12"
-    },
-    // Settings specific to the terminal
-    "terminal": {
-        // What shell to use when opening a terminal. May take 3 values:
-        // 1. Use the system's default terminal configuration in /etc/passwd
-        //      "shell": "system"
-        // 2. A program:
-        //      "shell": {
-        //        "program": "sh"
-        //      }
-        // 3. A program with arguments:
-        //     "shell": {
-        //         "with_arguments": {
-        //           "program": "/bin/bash",
-        //           "arguments": ["--login"]
-        //         }
-        //     }
-        "shell": "system",
-        // What working directory to use when launching the terminal.
-        // May take 4 values:
-        // 1. Use the current file's project directory.  Will Fallback to the
-        //    first project directory strategy if unsuccessful
-        //      "working_directory": "current_project_directory"
-        // 2. Use the first project in this workspace's directory
-        //      "working_directory": "first_project_directory"
-        // 3. Always use this platform's home directory (if we can find it)
-        //     "working_directory": "always_home"
-        // 4. Always use a specific directory. This value will be shell expanded.
-        //    If this path is not a valid directory the terminal will default to
-        //    this platform's home directory  (if we can find it)
-        //      "working_directory": {
-        //        "always": {
-        //          "directory": "~/zed/projects/"
-        //        }
-        //      }
-        //
-        //
-        "working_directory": "current_project_directory",
-        // Set the cursor blinking behavior in the terminal.
-        // May take 4 values:
-        //  1. Never blink the cursor, ignoring the terminal mode
-        //         "blinking": "off",
-        //  2. Default the cursor blink to off, but allow the terminal to
-        //     set blinking
-        //         "blinking": "terminal_controlled",
-        //  3. Always blink the cursor, ignoring the terminal mode
-        //         "blinking": "on",
-        "blinking": "terminal_controlled",
-        // Set whether Alternate Scroll mode (code: ?1007) is active by default.
-        // Alternate Scroll mode converts mouse scroll events into up / down key
-        // presses when in the alternate screen (e.g. when running applications
-        // like vim or  less). The terminal can still set and unset this mode.
-        // May take 2 values:
-        //  1. Default alternate scroll mode to on
-        //         "alternate_scroll": "on",
-        //  2. Default alternate scroll mode to off
-        //         "alternate_scroll": "off",
-        "alternate_scroll": "off",
-        // Set whether the option key behaves as the meta key.
-        // May take 2 values:
-        //  1. Rely on default platform handling of option key, on macOS
-        //     this means generating certain unicode characters
-        //         "option_to_meta": false,
-        //  2. Make the option keys behave as a 'meta' key, e.g. for emacs
-        //         "option_to_meta": true,
-        "option_as_meta": false,
-        // Whether or not selecting text in the terminal will automatically
-        // copy to the system clipboard.
-        "copy_on_select": false,
-        // Any key-value pairs added to this list will be added to the terminal's
-        // enviroment. Use `:` to seperate multiple values.
-        "env": {
-            // "KEY": "value1:value2"
-        }
-        // Set the terminal's font size. If this option is not included,
-        // the terminal will default to matching the buffer's font size.
-        // "font_size": "15"
-        // Set the terminal's font family. If this option is not included,
-        // the terminal will default to matching the buffer's font family.
-        // "font_family": "Zed Mono"
-    },
-    // Different settings for specific languages.
-    "languages": {
-        "Plain Text": {
-            "soft_wrap": "preferred_line_length"
-        },
-        "Elixir": {
-            "tab_size": 2
-        },
-        "Go": {
-            "tab_size": 4,
-            "hard_tabs": true
-        },
-        "Markdown": {
-            "soft_wrap": "preferred_line_length"
-        },
-        "JavaScript": {
-            "tab_size": 2
-        },
-        "TypeScript": {
-            "tab_size": 2
-        },
-        "TSX": {
-            "tab_size": 2
-        },
-        "YAML": {
-            "tab_size": 2
-        },
-        "JSON": {
-            "tab_size": 2
-        }
-    },
-    // LSP Specific settings.
-    "lsp": {
-        // Specify the LSP name as a key here.
-        // As of 8/10/22, supported LSPs are:
-        // pyright
-        // gopls
-        // rust-analyzer
-        // typescript-language-server
-        // vscode-json-languageserver
-        // "rust-analyzer": {
-        //     //These initialization options are merged into Zed's defaults
-        //     "initialization_options": {
-        //         "checkOnSave": {
-        //             "command": "clippy"
-        //         }
-        //     }
-        // }
+    //
+    "working_directory": "current_project_directory",
+    // Set the cursor blinking behavior in the terminal.
+    // May take 4 values:
+    //  1. Never blink the cursor, ignoring the terminal mode
+    //         "blinking": "off",
+    //  2. Default the cursor blink to off, but allow the terminal to
+    //     set blinking
+    //         "blinking": "terminal_controlled",
+    //  3. Always blink the cursor, ignoring the terminal mode
+    //         "blinking": "on",
+    "blinking": "terminal_controlled",
+    // Set whether Alternate Scroll mode (code: ?1007) is active by default.
+    // Alternate Scroll mode converts mouse scroll events into up / down key
+    // presses when in the alternate screen (e.g. when running applications
+    // like vim or  less). The terminal can still set and unset this mode.
+    // May take 2 values:
+    //  1. Default alternate scroll mode to on
+    //         "alternate_scroll": "on",
+    //  2. Default alternate scroll mode to off
+    //         "alternate_scroll": "off",
+    "alternate_scroll": "off",
+    // Set whether the option key behaves as the meta key.
+    // May take 2 values:
+    //  1. Rely on default platform handling of option key, on macOS
+    //     this means generating certain unicode characters
+    //         "option_to_meta": false,
+    //  2. Make the option keys behave as a 'meta' key, e.g. for emacs
+    //         "option_to_meta": true,
+    "option_as_meta": false,
+    // Whether or not selecting text in the terminal will automatically
+    // copy to the system clipboard.
+    "copy_on_select": false,
+    // Any key-value pairs added to this list will be added to the terminal's
+    // enviroment. Use `:` to seperate multiple values.
+    "env": {
+      // "KEY": "value1:value2"
     }
+    // Set the terminal's font size. If this option is not included,
+    // the terminal will default to matching the buffer's font size.
+    // "font_size": "15"
+    // Set the terminal's font family. If this option is not included,
+    // the terminal will default to matching the buffer's font family.
+    // "font_family": "Zed Mono"
+  },
+  // Different settings for specific languages.
+  "languages": {
+    "Plain Text": {
+      "soft_wrap": "preferred_line_length"
+    },
+    "Elixir": {
+      "tab_size": 2
+    },
+    "Go": {
+      "tab_size": 4,
+      "hard_tabs": true
+    },
+    "Markdown": {
+      "soft_wrap": "preferred_line_length"
+    },
+    "JavaScript": {
+      "tab_size": 2
+    },
+    "TypeScript": {
+      "tab_size": 2
+    },
+    "TSX": {
+      "tab_size": 2
+    },
+    "YAML": {
+      "tab_size": 2
+    },
+    "JSON": {
+      "tab_size": 2
+    }
+  },
+  // LSP Specific settings.
+  "lsp": {
+    // Specify the LSP name as a key here.
+    // As of 8/10/22, supported LSPs are:
+    // pyright
+    // gopls
+    // rust-analyzer
+    // typescript-language-server
+    // vscode-json-languageserver
+    // "rust-analyzer": {
+    //     //These initialization options are merged into Zed's defaults
+    //     "initialization_options": {
+    //         "checkOnSave": {
+    //             "command": "clippy"
+    //         }
+    //     }
+    // }
+  }
 }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -231,6 +231,9 @@
         },
         "YAML": {
             "tab_size": 2
+        },
+        "JSON": {
+            "tab_size": 2
         }
     },
     // LSP Specific settings.

--- a/assets/settings/initial_user_settings.json
+++ b/assets/settings/initial_user_settings.json
@@ -7,5 +7,5 @@
 // custom settings, run the `open default settings` command
 // from the command palette or from `Zed` application menu.
 {
-    "buffer_font_size": 15
+  "buffer_font_size": 15
 }


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-804/change-default-settings-for-json-to-2-spaces

@maxbrunsfeld and I noticed an inconsistency in `assets/keymaps` and `assets/settings` `.json` configuration files. Some were using two spaces and some four spaces.

We noticed we hadn't defined a `JSON` `tab_size` in `assets/settings/default.json`, which meant it was using a `tab_size` of four by default.

The consensus for `JSON` is two spaces, so I went ahead and added that to our default settings.

I then formatted all files under `assets/keymaps` and `assets/settings` to use the new default setting.

I didn't touch any `json` files used as test data (see the vim crate).

And I didn't touch anything under styles, cause there are some inconsistencies in some `package.json` files, but I didn't want to mess with that as I know @iamnbutler is using prettier, and I will let that handle this.

For context, the reason I noticed the inconsistencies was the work we did in #2390.