### PR TITLE
Fix script/start-local-collaboration

### DIFF
--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -32,7 +32,8 @@ fi
 
 # Make each Zed instance take up half of the screen.
 output=$(system_profiler SPDisplaysDataType -json)
-resolution=$(echo "$output" | jq -r '.SPDisplaysDataType[0].spdisplays_ndrvs[] | select(.spdisplays_online == "spdisplays_yes") | ._spdisplays_resolution')
+main_display=$(echo "$output" | jq '.SPDisplaysDataType[].spdisplays_ndrvs[] | select(.spdisplays_main == "spdisplays_yes")')
+resolution=$(echo "$main_display" | jq -r '._spdisplays_resolution')
 width=$(echo "$resolution" | jq -Rr 'match("(\\d+) x (\\d+)").captures[0].string')
 half_width=$(($width / 2))
 height=$(echo "$resolution" | jq -Rr 'match("(\\d+) x (\\d+)").captures[1].string')

--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -33,9 +33,9 @@ fi
 # Make each Zed instance take up half of the screen.
 output=$(system_profiler SPDisplaysDataType -json)
 resolution=$(echo "$output" | jq -r '.SPDisplaysDataType[0].spdisplays_ndrvs[] | select(.spdisplays_online == "spdisplays_yes") | ._spdisplays_resolution')
-width=$(echo "$resolution" | jq -Rr 'split(" x ")[0]')
+width=$(echo "$resolution" | jq -Rr 'match("(\\d+) x (\\d+)").captures[0].string')
 half_width=$(($width / 2))
-height=$(echo "$resolution" | jq -Rr 'split(" x ")[1]')
+height=$(echo "$resolution" | jq -Rr 'match("(\\d+) x (\\d+)").captures[1].string')
 y=0
 
 echo "Width: $width"

--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -38,10 +38,6 @@ half_width=$(($width / 2))
 height=$(echo "$resolution" | jq -Rr 'match("(\\d+) x (\\d+)").captures[1].string')
 y=0
 
-echo "Width: $width"
-echo "Half-width: $half_width"
-echo "Height: $height"
-
 position_1=0,${y}
 position_2=${half_width},${y}
 

--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -17,6 +17,12 @@ MESSAGE
   exit 1
 fi
 
+# Install jq if it's not installed
+if ! command -v jq &> /dev/null; then
+    echo "Installing jq..."
+    brew install jq
+fi
+
 # Start one Zed instance as the current user and a second instance with a different user.
 username_1=$(curl -sH "Authorization: bearer $GITHUB_TOKEN" https://api.github.com/user | jq -r .login)
 username_2=nathansobo
@@ -25,7 +31,6 @@ if [[ $username_1 == $username_2 ]]; then
 fi
 
 # Make each Zed instance take up half of the screen.
-
 output=$(system_profiler SPDisplaysDataType -json)
 resolution=$(echo "$output" | jq -r '.SPDisplaysDataType[0].spdisplays_ndrvs[] | select(.spdisplays_online == "spdisplays_yes") | ._spdisplays_resolution')
 width=$(echo "$resolution" | jq -Rr 'split(" x ")[0]')

--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -25,33 +25,26 @@ if [[ $username_1 == $username_2 ]]; then
 fi
 
 # Make each Zed instance take up half of the screen.
-resolution_line=$(system_profiler SPDisplaysDataType | grep Resolution | head -n1)
-screen_size=($(echo $resolution_line | egrep -o '\s*(\d+)\s*x\s*(\d+).*)' | egrep -o '[0-9]+'))
-scale_factor=1
-if [[ $resolution_line =~ Retina ]]; then scale_factor=2; fi
-width=$(expr ${screen_size[0]} / 2 / $scale_factor)
-height=${screen_size[1] / $scale_factor}
+
+output=$(system_profiler SPDisplaysDataType -json)
+resolution=$(echo "$output" | jq -r '.SPDisplaysDataType[0].spdisplays_ndrvs[] | select(.spdisplays_online == "spdisplays_yes") | ._spdisplays_resolution')
+width=$(echo "$resolution" | jq -Rr 'split(" x ")[0]')
+half_width=$(($width / 2))
+height=$(echo "$resolution" | jq -Rr 'split(" x ")[1]')
 y=0
 
-position_1=0,${y}
-position_2=${width},${y}
+echo "Width: $width"
+echo "Half-width: $half_width"
+echo "Height: $height"
 
-# Uncomment the following for debugging purposes.
-# echo "Resolution line: $resolution_line"
-# echo "Screen size: $screen_size"
-# echo "Screen size 0: ${screen_size[0]}"
-# echo "Screen size 1: ${screen_size[1]}"
-# echo "Scale factor: $scale_factor"
-# echo "Width: $width"
-# echo "Height: $height"
-# echo "Position 1: $position_1"
-# echo "Position 2: $position_2"
+position_1=0,${y}
+position_2=${half_width},${y}
 
 # Authenticate using the collab server's admin secret.
 export ZED_STATELESS=1
 export ZED_ADMIN_API_TOKEN=secret
 export ZED_SERVER_URL=http://localhost:8080
-export ZED_WINDOW_SIZE=${width},${height}
+export ZED_WINDOW_SIZE=${half_width},${height}
 
 cargo build
 sleep 0.5

--- a/script/start-local-collaboration
+++ b/script/start-local-collaboration
@@ -26,7 +26,7 @@ fi
 
 # Make each Zed instance take up half of the screen.
 resolution_line=$(system_profiler SPDisplaysDataType | grep Resolution | head -n1)
-screen_size=($(echo $resolution_line | egrep -o '[0-9]+'))
+screen_size=($(echo $resolution_line | egrep -o '\s*(\d+)\s*x\s*(\d+).*)' | egrep -o '[0-9]+'))
 scale_factor=1
 if [[ $resolution_line =~ Retina ]]; then scale_factor=2; fi
 width=$(expr ${screen_size[0]} / 2 / $scale_factor)
@@ -35,6 +35,17 @@ y=0
 
 position_1=0,${y}
 position_2=${width},${y}
+
+# Uncomment the following for debugging purposes.
+# echo "Resolution line: $resolution_line"
+# echo "Screen size: $screen_size"
+# echo "Screen size 0: ${screen_size[0]}"
+# echo "Screen size 1: ${screen_size[1]}"
+# echo "Scale factor: $scale_factor"
+# echo "Width: $width"
+# echo "Height: $height"
+# echo "Position 1: $position_1"
+# echo "Position 2: $position_2"
 
 # Authenticate using the collab server's admin secret.
 export ZED_STATELESS=1


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-77/the-start-local-collaboration-script-no-longer-puts-the-two-windows

The first commit, does the minimum to fix the issue. The rest of this PR tries to make this a bit more reliable. Instead of relying on a string might change between macOS versions or in the future, we get the `json` output and use `jq` to query it.

In theory, this should also work on a setup with multiple monitors. Meaning it will open the windows on the active monitor. I don't have such a setup though, so we may need to test my theory.