### PR TITLE
Add newline shortcuts for popular editors

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -18,7 +18,9 @@
       ],
       "ctrl-shift-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::AddSelectionAbove",
-      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine"
+      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine",
+      "cmd-shift-enter": "editor::NewlineAbove",
+      "cmd-enter": "editor::NewlineBelow"
     }
   },
   {

--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -14,6 +14,7 @@
       "cmd-pagedown": "editor::MovePageDown",
       "cmd-pageup": "editor::MovePageUp",
       "ctrl-alt-shift-b": "editor::SelectToPreviousWordStart",
+      "cmd-alt-enter": "editor::NewlineAbove",
       "shift-enter": "editor::NewlineBelow",
       "cmd--": "editor::Fold",
       "cmd-=": "editor::UnfoldLines",

--- a/assets/keymaps/sublime_text.json
+++ b/assets/keymaps/sublime_text.json
@@ -24,7 +24,9 @@
       "ctrl-.": "editor::GoToHunk",
       "ctrl-,": "editor::GoToPrevHunk",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd"
+      "ctrl-delete": "editor::DeleteToNextWordEnd",
+      "cmd-shift-enter": "editor::NewlineAbove",
+      "cmd-enter": "editor::NewlineBelow"
     }
   },
   {

--- a/assets/keymaps/textmate.json
+++ b/assets/keymaps/textmate.json
@@ -12,6 +12,7 @@
       "ctrl-shift-d": "editor::DuplicateLine",
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
+      "cmd-alt-enter": "editor::NewlineAbove",
       "cmd-enter": "editor::NewlineBelow",
       "cmd-shift-l": "editor::SelectLine",
       "cmd-shift-t": "outline::Toggle",


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-827/copy-the-newline-shortcuts-to-zed-industrieszed

This is related to the work in #2390.

Copied the changes from https://github.com/zed-industries/keymaps/pull/25

cc @JosephTLyons 