### PR TITLE
Simplify traits for accessing app state uniformly across different kinds of contexts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2715,7 +2715,7 @@ impl Editor {
         title: String,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
-        let replica_id = this.read_with(&cx, |this, cx| this.replica_id(cx));
+        let replica_id = this.read_with(&cx, |this, cx| this.replica_id(cx))?;
 
         let mut entries = transaction.0.into_iter().collect::<Vec<_>>();
         entries.sort_unstable_by_key(|(buffer, _)| {
@@ -2732,7 +2732,7 @@ impl Editor {
                         .buffer()
                         .read(cx)
                         .excerpt_containing(editor.selections.newest_anchor().head(), cx)
-                });
+                })?;
                 if let Some((_, excerpted_buffer, excerpt_range)) = excerpt {
                     if excerpted_buffer == *buffer {
                         let all_edits_within_excerpt = buffer.read_with(&cx, |buffer, _| {
@@ -5814,7 +5814,7 @@ impl Editor {
                     buffer_highlights
                         .next()
                         .map(|highlight| highlight.start.text_anchor..highlight.end.text_anchor)
-                })
+                })?
             };
             if let Some(rename_range) = rename_range {
                 let rename_buffer_range = rename_range.to_offset(&snapshot);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5673,8 +5673,8 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
         .await
         .unwrap();
     assert_eq!(
-        follower_1.read_with(cx, Editor::text),
-        leader.read_with(cx, Editor::text)
+        follower_1.read_with(cx, |editor, cx| editor.text(cx)),
+        leader.read_with(cx, |editor, cx| editor.text(cx))
     );
     update_message.borrow_mut().take();
 
@@ -5697,8 +5697,8 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
         .await
         .unwrap();
     assert_eq!(
-        follower_2.read_with(cx, Editor::text),
-        leader.read_with(cx, Editor::text)
+        follower_2.read_with(cx, |editor, cx| editor.text(cx)),
+        leader.read_with(cx, |editor, cx| editor.text(cx))
     );
 
     // Remove some excerpts.
@@ -5725,8 +5725,8 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
         .unwrap();
     update_message.borrow_mut().take();
     assert_eq!(
-        follower_1.read_with(cx, Editor::text),
-        leader.read_with(cx, Editor::text)
+        follower_1.read_with(cx, |editor, cx| editor.text(cx)),
+        leader.read_with(cx, |editor, cx| editor.text(cx))
     );
 }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -78,7 +78,7 @@ impl FollowableItem for Editor {
                             == editor.read(cx).buffer.read(cx).as_singleton().as_ref();
                     ids_match || singleton_buffer_matches
                 })
-            });
+            })?;
 
             let editor = if let Some(editor) = editor {
                 editor

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -57,7 +57,7 @@ impl<'a> EditorTestContext<'a> {
 
     pub fn editor<F, T>(&self, read: F) -> T
     where
-        F: FnOnce(&Editor, &AppContext) -> T,
+        F: FnOnce(&Editor, &ViewContext<Editor>) -> T,
     {
         self.editor.read_with(self.cx, read)
     }

--- a/crates/gpui/src/app/test_app_context.rs
+++ b/crates/gpui/src/app/test_app_context.rs
@@ -23,8 +23,8 @@ use crate::{
     platform,
     platform::{Event, InputHandler, KeyDownEvent, Platform},
     Action, AnyViewHandle, AppContext, BorrowAppContext, Entity, FontCache, Handle, ModelContext,
-    ModelHandle, ReadViewWith, Subscription, Task, UpdateModel, UpdateView, View, ViewContext,
-    ViewHandle, WeakHandle, WindowContext,
+    ModelHandle, ReadViewWith, Subscription, Task, UpdateView, View, ViewContext, ViewHandle,
+    WeakHandle, WindowContext,
 };
 use collections::BTreeMap;
 
@@ -388,16 +388,6 @@ impl BorrowAppContext for TestAppContext {
 
     fn update<T, F: FnOnce(&mut AppContext) -> T>(&mut self, f: F) -> T {
         self.cx.borrow_mut().update(f)
-    }
-}
-
-impl UpdateModel for TestAppContext {
-    fn update_model<T: Entity, O>(
-        &mut self,
-        handle: &ModelHandle<T>,
-        update: &mut dyn FnMut(&mut T, &mut ModelContext<T>) -> O,
-    ) -> O {
-        self.cx.borrow_mut().update_model(handle, update)
     }
 }
 

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -15,9 +15,9 @@ use crate::{
     util::post_inc,
     Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle,
     AppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle, MouseRegion,
-    MouseRegionId, ParentId, ReadModel, ReadView, SceneBuilder, Subscription, UpdateModel,
-    UpdateView, UpgradeModelHandle, UpgradeViewHandle, View, ViewContext, ViewHandle,
-    WeakModelHandle, WeakViewHandle, WindowInvalidation,
+    MouseRegionId, ParentId, ReadModel, SceneBuilder, Subscription, UpdateModel, UpdateView,
+    UpgradeModelHandle, UpgradeViewHandle, View, ViewContext, ViewHandle, WeakModelHandle,
+    WeakViewHandle, WindowInvalidation,
 };
 use anyhow::{anyhow, bail, Result};
 use collections::{HashMap, HashSet};
@@ -146,12 +146,6 @@ impl UpdateModel for WindowContext<'_> {
         update: &mut dyn FnMut(&mut T, &mut ModelContext<T>) -> R,
     ) -> R {
         self.app_context.update_model(handle, update)
-    }
-}
-
-impl ReadView for WindowContext<'_> {
-    fn read_view<W: View>(&self, handle: &crate::ViewHandle<W>) -> &W {
-        self.app_context.read_view(handle)
     }
 }
 

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -13,11 +13,11 @@ use crate::{
     },
     text_layout::TextLayoutCache,
     util::post_inc,
-    Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle,
-    AppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle, MouseRegion,
-    MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateModel, UpdateView,
-    UpgradeModelHandle, UpgradeViewHandle, View, ViewContext, ViewHandle, WeakModelHandle,
-    WeakViewHandle, WindowInvalidation,
+    AccessAppContext, Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle,
+    AnyWeakViewHandle, AppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle,
+    MouseRegion, MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateModel, UpdateView,
+    UpgradeModelHandle, View, ViewContext, ViewHandle, WeakModelHandle, WeakViewHandle,
+    WindowInvalidation,
 };
 use anyhow::{anyhow, bail, Result};
 use collections::{HashMap, HashSet};
@@ -130,6 +130,16 @@ impl Deref for WindowContext<'_> {
 impl DerefMut for WindowContext<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.app_context
+    }
+}
+
+impl AccessAppContext for WindowContext<'_> {
+    fn read<T, F: FnOnce(&AppContext) -> T>(&self, f: F) -> T {
+        self.app_context.read(f)
+    }
+
+    fn update<T, F: FnOnce(&mut AppContext) -> T>(&mut self, f: F) -> T {
+        self.app_context.update(f)
     }
 }
 

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -13,10 +13,9 @@ use crate::{
     },
     text_layout::TextLayoutCache,
     util::post_inc,
-    Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle, AppContext,
-    BorrowAppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle, MouseRegion,
-    MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateModel, UpdateView,
-    UpgradeModelHandle, View, ViewContext, ViewHandle, WeakModelHandle, WindowInvalidation,
+    Action, AnyView, AnyViewHandle, AppContext, BorrowAppContext, Effect, Element, Entity, Handle,
+    ModelContext, ModelHandle, MouseRegion, MouseRegionId, ParentId, SceneBuilder, Subscription,
+    UpdateModel, UpdateView, View, ViewContext, ViewHandle, WindowInvalidation,
 };
 use anyhow::{anyhow, bail, Result};
 use collections::{HashMap, HashSet};
@@ -173,23 +172,6 @@ impl UpdateView for WindowContext<'_> {
             )
         })
         .expect("view is already on the stack")
-    }
-}
-
-impl UpgradeModelHandle for WindowContext<'_> {
-    fn upgrade_model_handle<T: Entity>(
-        &self,
-        handle: &WeakModelHandle<T>,
-    ) -> Option<ModelHandle<T>> {
-        self.app_context.upgrade_model_handle(handle)
-    }
-
-    fn model_handle_is_upgradable<T: Entity>(&self, handle: &WeakModelHandle<T>) -> bool {
-        self.app_context.model_handle_is_upgradable(handle)
-    }
-
-    fn upgrade_any_model_handle(&self, handle: &AnyWeakModelHandle) -> Option<AnyModelHandle> {
-        self.app_context.upgrade_any_model_handle(handle)
     }
 }
 

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -15,7 +15,7 @@ use crate::{
     util::post_inc,
     Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle, AnyWeakViewHandle,
     AppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle, MouseRegion,
-    MouseRegionId, ParentId, ReadModel, SceneBuilder, Subscription, UpdateModel, UpdateView,
+    MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateModel, UpdateView,
     UpgradeModelHandle, UpgradeViewHandle, View, ViewContext, ViewHandle, WeakModelHandle,
     WeakViewHandle, WindowInvalidation,
 };
@@ -130,12 +130,6 @@ impl Deref for WindowContext<'_> {
 impl DerefMut for WindowContext<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.app_context
-    }
-}
-
-impl ReadModel for WindowContext<'_> {
-    fn read_model<T: Entity>(&self, handle: &ModelHandle<T>) -> &T {
-        self.app_context.read_model(handle)
     }
 }
 

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -14,8 +14,8 @@ use crate::{
     text_layout::TextLayoutCache,
     util::post_inc,
     Action, AnyView, AnyViewHandle, AppContext, BorrowAppContext, Effect, Element, Entity, Handle,
-    ModelContext, ModelHandle, MouseRegion, MouseRegionId, ParentId, SceneBuilder, Subscription,
-    UpdateModel, UpdateView, View, ViewContext, ViewHandle, WindowInvalidation,
+    MouseRegion, MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateView, View,
+    ViewContext, ViewHandle, WindowInvalidation,
 };
 use anyhow::{anyhow, bail, Result};
 use collections::{HashMap, HashSet};
@@ -138,16 +138,6 @@ impl BorrowAppContext for WindowContext<'_> {
 
     fn update<T, F: FnOnce(&mut AppContext) -> T>(&mut self, f: F) -> T {
         self.app_context.update(f)
-    }
-}
-
-impl UpdateModel for WindowContext<'_> {
-    fn update_model<T: Entity, R>(
-        &mut self,
-        handle: &ModelHandle<T>,
-        update: &mut dyn FnMut(&mut T, &mut ModelContext<T>) -> R,
-    ) -> R {
-        self.app_context.update_model(handle, update)
     }
 }
 

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -13,11 +13,10 @@ use crate::{
     },
     text_layout::TextLayoutCache,
     util::post_inc,
-    AccessAppContext, Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle,
-    AnyWeakViewHandle, AppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle,
-    MouseRegion, MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateModel, UpdateView,
-    UpgradeModelHandle, View, ViewContext, ViewHandle, WeakModelHandle, WeakViewHandle,
-    WindowInvalidation,
+    Action, AnyModelHandle, AnyView, AnyViewHandle, AnyWeakModelHandle, AppContext,
+    BorrowAppContext, Effect, Element, Entity, Handle, ModelContext, ModelHandle, MouseRegion,
+    MouseRegionId, ParentId, SceneBuilder, Subscription, UpdateModel, UpdateView,
+    UpgradeModelHandle, View, ViewContext, ViewHandle, WeakModelHandle, WindowInvalidation,
 };
 use anyhow::{anyhow, bail, Result};
 use collections::{HashMap, HashSet};
@@ -133,9 +132,9 @@ impl DerefMut for WindowContext<'_> {
     }
 }
 
-impl AccessAppContext for WindowContext<'_> {
-    fn read<T, F: FnOnce(&AppContext) -> T>(&self, f: F) -> T {
-        self.app_context.read(f)
+impl BorrowAppContext for WindowContext<'_> {
+    fn read_with<T, F: FnOnce(&AppContext) -> T>(&self, f: F) -> T {
+        self.app_context.read_with(f)
     }
 
     fn update<T, F: FnOnce(&mut AppContext) -> T>(&mut self, f: F) -> T {
@@ -191,16 +190,6 @@ impl UpgradeModelHandle for WindowContext<'_> {
 
     fn upgrade_any_model_handle(&self, handle: &AnyWeakModelHandle) -> Option<AnyModelHandle> {
         self.app_context.upgrade_any_model_handle(handle)
-    }
-}
-
-impl UpgradeViewHandle for WindowContext<'_> {
-    fn upgrade_view_handle<T: View>(&self, handle: &WeakViewHandle<T>) -> Option<ViewHandle<T>> {
-        self.app_context.upgrade_view_handle(handle)
-    }
-
-    fn upgrade_any_view_handle(&self, handle: &AnyWeakViewHandle) -> Option<AnyViewHandle> {
-        self.app_context.upgrade_any_view_handle(handle)
     }
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -19,8 +19,8 @@ use futures::{
     AsyncWriteExt, Future, FutureExt, StreamExt, TryFutureExt,
 };
 use gpui::{
-    AnyModelHandle, AppContext, AsyncAppContext, Entity, ModelContext, ModelHandle, Task,
-    UpgradeModelHandle, WeakModelHandle,
+    AnyModelHandle, AppContext, AsyncAppContext, BorrowAppContext, Entity, ModelContext,
+    ModelHandle, Task, WeakModelHandle,
 };
 use language::{
     point_to_lsp,
@@ -6356,7 +6356,7 @@ impl WorktreeHandle {
 }
 
 impl OpenBuffer {
-    pub fn upgrade(&self, cx: &impl UpgradeModelHandle) -> Option<ModelHandle<Buffer>> {
+    pub fn upgrade(&self, cx: &impl BorrowAppContext) -> Option<ModelHandle<Buffer>> {
         match self {
             OpenBuffer::Strong(handle) => Some(handle.clone()),
             OpenBuffer::Weak(handle) => handle.upgrade(cx),

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use editor::test::{
     editor_lsp_test_context::EditorLspTestContext, editor_test_context::EditorTestContext,
 };
-use gpui::{AppContext, ContextHandle};
+use gpui::ContextHandle;
 use search::{BufferSearchBar, ProjectSearchBar};
 
 use crate::{state::Operator, *};
@@ -45,7 +45,7 @@ impl<'a> VimTestContext<'a> {
 
     pub fn workspace<F, T>(&mut self, read: F) -> T
     where
-        F: FnOnce(&Workspace, &AppContext) -> T,
+        F: FnOnce(&Workspace, &ViewContext<Workspace>) -> T,
     {
         self.cx.workspace.read_with(self.cx.cx.cx, read)
     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -981,7 +981,7 @@ impl Pane {
                 // was started.
                 let (item_ix, mut project_item_ids) = pane.read_with(&cx, |pane, cx| {
                     (pane.index_for_item(&*item), item.project_item_model_ids(cx))
-                });
+                })?;
                 let item_ix = if let Some(ix) = item_ix {
                     ix
                 } else {
@@ -1001,7 +1001,7 @@ impl Pane {
                             project_item_ids.retain(|id| !other_project_item_ids.contains(id));
                         }
                     }
-                });
+                })?;
                 let should_save = project_item_ids
                     .iter()
                     .any(|id| saved_project_items_ids.insert(*id));

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -140,7 +140,10 @@ impl SerializedPaneGroup {
                     .await
                     .log_err()?;
 
-                if pane.read_with(cx, |pane, _| pane.items_len() != 0) {
+                if pane
+                    .read_with(cx, |pane, _| pane.items_len() != 0)
+                    .log_err()?
+                {
                     Some((Member::Pane(pane.clone()), active.then(|| pane)))
                 } else {
                     workspace

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1226,7 +1226,7 @@ impl Workspace {
                     cx.read(|cx| (item.is_singleton(cx), item.project_entry_ids(cx)));
                 if singleton || !project_entry_ids.is_empty() {
                     if let Some(ix) =
-                        pane.read_with(&cx, |pane, _| pane.index_for_item(item.as_ref()))
+                        pane.read_with(&cx, |pane, _| pane.index_for_item(item.as_ref()))?
                     {
                         if !Pane::save_item(
                             project.clone(),
@@ -2298,7 +2298,7 @@ impl Workspace {
         this.read_with(&cx, |this, _| {
             this.leader_updates_tx
                 .unbounded_send((leader_id, envelope.payload))
-        })?;
+        })??;
         Ok(())
     }
 
@@ -2354,7 +2354,7 @@ impl Workspace {
                         .flat_map(|states_by_pane| states_by_pane.keys())
                         .cloned()
                         .collect()
-                });
+                })?;
                 Self::add_views_from_leader(this.clone(), leader_id, panes, vec![view], cx).await?;
             }
         }
@@ -2369,7 +2369,7 @@ impl Workspace {
         views: Vec<proto::View>,
         cx: &mut AsyncAppContext,
     ) -> Result<()> {
-        let project = this.read_with(cx, |this, _| this.project.clone());
+        let project = this.read_with(cx, |this, _| this.project.clone())?;
         let replica_id = project
             .read_with(cx, |project, _| {
                 project
@@ -2699,7 +2699,7 @@ impl Workspace {
                             workspace.dock_pane().clone(),
                             workspace.last_active_center_pane.clone(),
                         )
-                    });
+                    })?;
 
                 serialized_workspace
                     .dock_pane
@@ -2765,7 +2765,7 @@ impl Workspace {
                 })?;
 
                 // Serialize ourself to make sure our timestamps and any pane / item changes are replicated
-                workspace.read_with(&cx, |workspace, cx| workspace.serialize_workspace(cx))
+                workspace.read_with(&cx, |workspace, cx| workspace.serialize_workspace(cx))?
             }
             anyhow::Ok(())
         })


### PR DESCRIPTION
I'm hoping we can phrase everything in terms of a simple trait that runs a read or update function.

/cc @as-cii 

Closes: https://linear.app/zed-industries/issue/Z-859/try-to-remove-gpui-traits-related-to-entity-access