### PR TITLE
Add a simple language server log view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,6 +3613,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp_log"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "collections",
+ "editor",
+ "futures 0.3.25",
+ "gpui",
+ "language",
+ "lsp",
+ "project",
+ "serde",
+ "settings",
+ "theme",
+ "unindent",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8571,6 +8591,7 @@ dependencies = [
  "libc",
  "log",
  "lsp",
+ "lsp_log",
  "node_runtime",
  "num_cpus",
  "outline",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7259,7 +7259,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-json"
 version = "0.20.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-json?rev=137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8#137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8"
+source = "git+https://github.com/tree-sitter/tree-sitter-json?rev=40a81c01a40ac48744e0c8ccabbaba1920441199#40a81c01a40ac48744e0c8ccabbaba1920441199"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
 rand = { version = "0.8" }
 postage = { version = "0.5", features = ["futures-traits"] }
 smallvec = { version = "1.6", features = ["union"] }
+futures = { version = "0.3" }
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crates/live_kit_client",
     "crates/live_kit_server",
     "crates/lsp",
+    "crates/lsp_log",
     "crates/media",
     "crates/menu",
     "crates/node_runtime",

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -17,5 +17,5 @@ project = { path = "../project" }
 settings = { path = "../settings" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-futures = "0.3"
+futures = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -33,7 +33,7 @@ util = { path = "../util" }
 
 anyhow = "1.0.38"
 async-broadcast = "0.4"
-futures = "0.3"
+futures = { workspace = true }
 postage = { workspace = true }
 
 [dev-dependencies]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -22,7 +22,7 @@ sum_tree = { path = "../sum_tree" }
 anyhow = "1.0.38"
 async-recursion = "0.3"
 async-tungstenite = { version = "0.16", features = ["async-tls"] }
-futures = "0.3"
+futures = { workspace = true }
 image = "0.23"
 lazy_static = "1.4.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -27,7 +27,7 @@ base64 = "0.13"
 clap = { version = "3.1", features = ["derive"], optional = true }
 dashmap = "5.4"
 envy = "0.4.2"
-futures = "0.3"
+futures = { workspace = true }
 hyper = "0.14"
 lazy_static = "1.4"
 lipsum = { version = "0.8", optional = true }

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -40,7 +40,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 anyhow = "1.0"
-futures = "0.3"
+futures = { workspace = true }
 log = "0.4"
 postage = { workspace = true }
 serde = { workspace = true }

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4"
 serde = { workspace = true }
 serde_derive = { workspace = true }
 smol = "1.2.5"
-futures = "0.3"
+futures = { workspace = true }
 
 [dev-dependencies]
 clock = { path = "../clock" }

--- a/crates/copilot_button/Cargo.toml
+++ b/crates/copilot_button/Cargo.toml
@@ -19,4 +19,4 @@ util = { path = "../util" }
 workspace = { path = "../workspace" }
 anyhow = "1.0"
 smol = "1.2.5"
-futures = "0.3"
+futures = { workspace = true }

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -47,7 +47,7 @@ workspace = { path = "../workspace" }
 
 aho-corasick = "0.7"
 anyhow = "1.0"
-futures = "0.3"
+futures = { workspace = true }
 indoc = "1.0.4"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -16,7 +16,7 @@ client = { path = "../client" }
 editor = { path = "../editor" }
 language = { path = "../language" }
 log = "0.4"
-futures = "0.3"
+futures = { workspace = true }
 gpui = { path = "../gpui" }
 human_bytes = "0.4.1"
 isahc = "1.7"

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -15,7 +15,7 @@ rope = { path = "../rope" }
 util = { path = "../util" }
 anyhow = "1.0.57"
 async-trait = "0.1"
-futures = "0.3"
+futures = { workspace = true }
 tempfile = "3"
 fsevent = { path = "../fsevent" }
 lazy_static = "1.4.0"

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -19,7 +19,7 @@ log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 smol = "1.2"
 parking_lot = "0.11.1"
 async-trait = "0.1"
-futures = "0.3"
+futures = { workspace = true }
 git2 = { version = "0.15", default-features = false }
 
 [dev-dependencies]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -25,7 +25,7 @@ ctor = "0.1"
 dhat = { version = "0.3", optional = true }
 env_logger = { version = "0.9", optional = true }
 etagere = "0.2"
-futures = "0.3"
+futures = { workspace = true }
 image = "0.23"
 itertools = "0.10"
 lazy_static = "1.4.0"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -39,7 +39,7 @@ util = { path = "../util" }
 anyhow = "1.0.38"
 async-broadcast = "0.4"
 async-trait = "0.1"
-futures = "0.3"
+futures = { workspace = true }
 lazy_static = "1.4"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 parking_lot = "0.11.1"

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.38"
 async-broadcast = "0.4"
 core-foundation = "0.9.3"
 core-graphics = "0.22.3"
-futures = "0.3"
+futures = { workspace = true }
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 parking_lot = "0.11.1"
 postage = { workspace = true }
@@ -56,7 +56,7 @@ cocoa = "0.24"
 core-foundation = "0.9.3"
 core-graphics = "0.22.3"
 foreign-types = "0.3"
-futures = "0.3"
+futures = { workspace = true }
 hmac = "0.12"
 jwt = "0.16"
 lazy_static = "1.4"

--- a/crates/live_kit_server/Cargo.toml
+++ b/crates/live_kit_server/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 anyhow = "1.0.38"
 async-trait = "0.1"
-futures = "0.3"
+futures = { workspace = true }
 hmac = "0.12"
 log = "0.4"
 jwt = "0.16"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -17,7 +17,7 @@ gpui = { path = "../gpui" }
 util = { path = "../util" }
 anyhow = "1.0"
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553", optional = true }
-futures = "0.3"
+futures = { workspace = true }
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 lsp-types = "0.91"
 parking_lot = "0.11"

--- a/crates/lsp_log/Cargo.toml
+++ b/crates/lsp_log/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "lsp_log"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lsp_log.rs"
+doctest = false
+
+[dependencies]
+collections = { path = "../collections" }
+editor = { path = "../editor" }
+settings = { path = "../settings" }
+theme = { path = "../theme" }
+language = { path = "../language" }
+project = { path = "../project" }
+workspace = { path = "../workspace" }
+gpui = { path = "../gpui" }
+util = { path = "../util" }
+lsp = { path = "../lsp" }
+futures = { workspace = true }
+serde = { workspace = true }
+anyhow = "1.0"
+
+[dev-dependencies]
+gpui = { path = "../gpui", features = ["test-support"] }
+util = { path = "../util", features = ["test-support"] }
+unindent = "0.1.7"

--- a/crates/lsp_log/src/lsp_log.rs
+++ b/crates/lsp_log/src/lsp_log.rs
@@ -1,0 +1,374 @@
+use collections::HashMap;
+use editor::Editor;
+use futures::{channel::mpsc, StreamExt};
+use gpui::{
+    actions,
+    elements::{
+        AnchorCorner, ChildView, Empty, Flex, Label, MouseEventHandler, Overlay, OverlayFitMode,
+        ParentElement, Stack,
+    },
+    impl_internal_actions,
+    platform::MouseButton,
+    AppContext, Element, ElementBox, Entity, ModelHandle, RenderContext, View, ViewContext,
+    ViewHandle,
+};
+use language::{Buffer, LanguageServerId, LanguageServerName};
+use project::{Project, WorktreeId};
+use settings::Settings;
+use std::{borrow::Cow, sync::Arc};
+use theme::Theme;
+use workspace::{
+    item::{Item, ItemHandle},
+    ToolbarItemLocation, ToolbarItemView, Workspace,
+};
+
+const SEND_LINE: &str = "// Send:\n";
+const RECEIVE_LINE: &str = "// Receive:\n";
+
+pub struct LspLogView {
+    enabled_logs: HashMap<LanguageServerId, LogState>,
+    current_server_id: Option<LanguageServerId>,
+    project: ModelHandle<Project>,
+    io_tx: mpsc::UnboundedSender<(LanguageServerId, bool, String)>,
+}
+
+pub struct LspLogToolbarItemView {
+    log_view: Option<ViewHandle<LspLogView>>,
+    menu_open: bool,
+    project: ModelHandle<Project>,
+}
+
+struct LogState {
+    buffer: ModelHandle<Buffer>,
+    editor: ViewHandle<Editor>,
+    last_message_kind: Option<MessageKind>,
+    _subscription: lsp::Subscription,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum MessageKind {
+    Send,
+    Receive,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ActivateLog {
+    server_id: LanguageServerId,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ToggleMenu;
+
+impl_internal_actions!(log, [ActivateLog, ToggleMenu]);
+actions!(log, [OpenLanguageServerLogs]);
+
+pub fn init(cx: &mut AppContext) {
+    cx.add_action(LspLogView::deploy);
+    cx.add_action(LspLogToolbarItemView::toggle_menu);
+    cx.add_action(LspLogToolbarItemView::activate_log_for_server);
+}
+
+impl LspLogView {
+    pub fn new(project: ModelHandle<Project>, cx: &mut ViewContext<Self>) -> Self {
+        let (io_tx, mut io_rx) = mpsc::unbounded();
+        let this = Self {
+            enabled_logs: HashMap::default(),
+            current_server_id: None,
+            io_tx,
+            project,
+        };
+        cx.spawn_weak(|this, mut cx| async move {
+            while let Some((language_server_id, is_output, mut message)) = io_rx.next().await {
+                if let Some(this) = this.upgrade(&cx) {
+                    this.update(&mut cx, |this, cx| {
+                        message.push('\n');
+                        this.on_io(language_server_id, is_output, &message, cx);
+                    })
+                }
+            }
+        })
+        .detach();
+        this
+    }
+
+    fn deploy(
+        workspace: &mut Workspace,
+        _: &OpenLanguageServerLogs,
+        cx: &mut ViewContext<Workspace>,
+    ) {
+        let project = workspace.project().read(cx);
+        if project.is_remote() {
+            return;
+        }
+
+        let log_view = cx.add_view(|cx| Self::new(workspace.project().clone(), cx));
+        workspace.add_item(Box::new(log_view), cx);
+    }
+
+    fn activate_log(&mut self, action: &ActivateLog, cx: &mut ViewContext<Self>) {
+        self.enable_logs_for_language_server(action.server_id, cx);
+        self.current_server_id = Some(action.server_id);
+        cx.notify();
+    }
+
+    fn on_io(
+        &mut self,
+        language_server_id: LanguageServerId,
+        is_received: bool,
+        message: &str,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(state) = self.enabled_logs.get_mut(&language_server_id) {
+            state.buffer.update(cx, |buffer, cx| {
+                let kind = if is_received {
+                    MessageKind::Receive
+                } else {
+                    MessageKind::Send
+                };
+                if state.last_message_kind != Some(kind) {
+                    let len = buffer.len();
+                    let line = match kind {
+                        MessageKind::Send => SEND_LINE,
+                        MessageKind::Receive => RECEIVE_LINE,
+                    };
+                    buffer.edit([(len..len, line)], None, cx);
+                    state.last_message_kind = Some(kind);
+                }
+                let len = buffer.len();
+                buffer.edit([(len..len, message)], None, cx);
+            });
+        }
+    }
+
+    pub fn enable_logs_for_language_server(
+        &mut self,
+        server_id: LanguageServerId,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(server) = self.project.read(cx).language_server_for_id(server_id) {
+            self.enabled_logs.entry(server_id).or_insert_with(|| {
+                let project = self.project.read(cx);
+                let io_tx = self.io_tx.clone();
+                let language = project.languages().language_for_name("JSON");
+                let buffer = cx.add_model(|cx| Buffer::new(0, "", cx));
+                cx.spawn({
+                    let buffer = buffer.clone();
+                    |_, mut cx| async move {
+                        let language = language.await.ok();
+                        buffer.update(&mut cx, |buffer, cx| {
+                            buffer.set_language(language, cx);
+                        });
+                    }
+                })
+                .detach();
+                let editor = cx.add_view(|cx| {
+                    let mut editor =
+                        Editor::for_buffer(buffer.clone(), Some(self.project.clone()), cx);
+                    editor.set_read_only(true);
+                    editor
+                });
+
+                LogState {
+                    buffer,
+                    editor,
+                    last_message_kind: None,
+                    _subscription: server.on_io(move |is_received, json| {
+                        io_tx
+                            .unbounded_send((server_id, is_received, json.to_string()))
+                            .ok();
+                    }),
+                }
+            });
+        }
+    }
+}
+
+impl View for LspLogView {
+    fn ui_name() -> &'static str {
+        "LspLogView"
+    }
+
+    fn render(&mut self, cx: &mut gpui::RenderContext<'_, Self>) -> gpui::ElementBox {
+        if let Some(id) = self.current_server_id {
+            if let Some(log) = self.enabled_logs.get_mut(&id) {
+                return ChildView::new(&log.editor, cx).boxed();
+            }
+        }
+        Empty::new().boxed()
+    }
+}
+
+impl Item for LspLogView {
+    fn tab_content(&self, _: Option<usize>, style: &theme::Tab, _: &AppContext) -> ElementBox {
+        Label::new("Logs", style.label.clone()).boxed()
+    }
+}
+
+impl ToolbarItemView for LspLogToolbarItemView {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        cx: &mut ViewContext<Self>,
+    ) -> workspace::ToolbarItemLocation {
+        self.menu_open = false;
+        if let Some(item) = active_pane_item {
+            if let Some(log_view) = item.downcast::<LspLogView>() {
+                self.log_view = Some(log_view.clone());
+                return ToolbarItemLocation::PrimaryLeft {
+                    flex: Some((1., false)),
+                };
+            }
+        }
+        self.log_view = None;
+        ToolbarItemLocation::Hidden
+    }
+}
+
+impl View for LspLogToolbarItemView {
+    fn ui_name() -> &'static str {
+        "LspLogView"
+    }
+
+    fn render(&mut self, cx: &mut RenderContext<'_, Self>) -> ElementBox {
+        let theme = cx.global::<Settings>().theme.clone();
+        let Some(log_view) = self.log_view.as_ref() else { return Empty::new().boxed() };
+        let project = self.project.read(cx);
+        let mut language_servers = project.language_servers().collect::<Vec<_>>();
+        language_servers.sort_by_key(|a| a.0);
+
+        let current_server_id = log_view.read(cx).current_server_id;
+        let current_server = current_server_id.and_then(|current_server_id| {
+            if let Ok(ix) = language_servers.binary_search_by_key(&current_server_id, |e| e.0) {
+                Some(language_servers[ix].clone())
+            } else {
+                None
+            }
+        });
+
+        Stack::new()
+            .with_child(Self::render_language_server_menu_header(
+                current_server,
+                &self.project,
+                &theme,
+                cx,
+            ))
+            .with_children(if self.menu_open {
+                Some(
+                    Overlay::new(
+                        Flex::column()
+                            .with_children(language_servers.into_iter().filter_map(
+                                |(id, name, worktree_id)| {
+                                    Self::render_language_server_menu_item(
+                                        id,
+                                        name,
+                                        worktree_id,
+                                        &self.project,
+                                        &theme,
+                                        cx,
+                                    )
+                                },
+                            ))
+                            .contained()
+                            .with_style(theme.contacts_popover.container)
+                            .constrained()
+                            .with_width(200.)
+                            .with_height(400.)
+                            .boxed(),
+                    )
+                    .with_fit_mode(OverlayFitMode::SwitchAnchor)
+                    .with_anchor_corner(AnchorCorner::TopRight)
+                    .with_z_index(999)
+                    .aligned()
+                    .bottom()
+                    .right()
+                    .boxed(),
+                )
+            } else {
+                None
+            })
+            .boxed()
+    }
+}
+
+impl LspLogToolbarItemView {
+    pub fn new(project: ModelHandle<Project>) -> Self {
+        Self {
+            menu_open: false,
+            log_view: None,
+            project,
+        }
+    }
+
+    fn toggle_menu(&mut self, _: &ToggleMenu, cx: &mut ViewContext<Self>) {
+        self.menu_open = !self.menu_open;
+        cx.notify();
+    }
+
+    fn activate_log_for_server(&mut self, action: &ActivateLog, cx: &mut ViewContext<Self>) {
+        if let Some(log_view) = &self.log_view {
+            log_view.update(cx, |log_view, cx| {
+                log_view.activate_log(action, cx);
+            });
+            self.menu_open = false;
+        }
+        cx.notify();
+    }
+
+    fn render_language_server_menu_header(
+        current_server: Option<(LanguageServerId, LanguageServerName, WorktreeId)>,
+        project: &ModelHandle<Project>,
+        theme: &Arc<Theme>,
+        cx: &mut RenderContext<Self>,
+    ) -> ElementBox {
+        MouseEventHandler::<ToggleMenu>::new(0, cx, move |state, cx| {
+            let project = project.read(cx);
+            let label: Cow<str> = current_server
+                .and_then(|(_, server_name, worktree_id)| {
+                    let worktree = project.worktree_for_id(worktree_id, cx)?;
+                    let worktree = &worktree.read(cx);
+                    Some(format!("{} - ({})", server_name.0, worktree.root_name()).into())
+                })
+                .unwrap_or_else(|| "No server selected".into());
+            Label::new(label, theme.context_menu.item.default.label.clone()).boxed()
+        })
+        .on_click(MouseButton::Left, move |_, cx| {
+            cx.dispatch_action(ToggleMenu);
+        })
+        .boxed()
+    }
+
+    fn render_language_server_menu_item(
+        id: LanguageServerId,
+        name: LanguageServerName,
+        worktree_id: WorktreeId,
+        project: &ModelHandle<Project>,
+        theme: &Arc<Theme>,
+        cx: &mut RenderContext<Self>,
+    ) -> Option<ElementBox> {
+        let project = project.read(cx);
+        let worktree = project.worktree_for_id(worktree_id, cx)?;
+        let worktree = &worktree.read(cx);
+        if !worktree.is_visible() {
+            return None;
+        }
+        let label = format!("{} - ({})", name.0, worktree.root_name());
+
+        Some(
+            MouseEventHandler::<ActivateLog>::new(id.0, cx, move |state, cx| {
+                Label::new(label, theme.context_menu.item.default.label.clone()).boxed()
+            })
+            .on_click(MouseButton::Left, move |_, cx| {
+                cx.dispatch_action(ActivateLog { server_id: id })
+            })
+            .boxed(),
+        )
+    }
+}
+
+impl Entity for LspLogView {
+    type Event = ();
+}
+
+impl Entity for LspLogToolbarItemView {
+    type Event = ();
+}

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -13,7 +13,7 @@ gpui = { path = "../gpui" }
 util = { path = "../util" }
 async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
 async-tar = "0.4.2"
-futures = "0.3"
+futures = { workspace = true }
 anyhow = "1.0.38"
 parking_lot = "0.11.1"
 serde = { workspace = true }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -41,7 +41,7 @@ aho-corasick = "0.7"
 anyhow = "1.0.57"
 async-trait = "0.1"
 backtrace = "0.3"
-futures = "0.3"
+futures = { workspace = true }
 ignore = "0.4"
 lazy_static = "1.4.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -20,7 +20,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 postage = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 unicase = "2.6"
 
 [dev-dependencies]

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -24,7 +24,7 @@ postage = { workspace = true }
 smol = "1.2"
 
 [dev-dependencies]
-futures = "0.3"
+futures = { workspace = true }
 settings = { path = "../settings", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0"
 async-lock = "2.4"
 async-tungstenite = "0.16"
 base64 = "0.13"
-futures = "0.3"
+futures = { workspace = true }
 parking_lot = "0.11.1"
 prost = "0.8"
 rand = "0.8"

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -20,7 +20,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 anyhow = "1.0"
-futures = "0.3"
+futures = { workspace = true }
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 postage = { workspace = true }
 serde = { workspace = true }

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -18,7 +18,7 @@ gpui = { path = "../gpui" }
 sqlez = { path = "../sqlez" }
 fs = { path = "../fs" }
 anyhow = "1.0.38"
-futures = "0.3"
+futures = { workspace = true }
 theme = { path = "../theme" }
 staff_mode = { path = "../staff_mode" }
 util = { path = "../util" }

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -14,5 +14,5 @@ smol = "1.2"
 thread_local = "1.1.4"
 lazy_static = "1.4"
 parking_lot = "0.11.1"
-futures = "0.3"
+futures = { workspace = true }
 uuid = { version = "1.1.2", features = ["v4"] }

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -20,7 +20,7 @@ procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f
 smallvec = { workspace = true }
 smol = "1.2.5"
 mio-extras = "2.0.6"
-futures = "0.3"
+futures = { workspace = true }
 ordered-float = "2.1.1"
 itertools = "0.10"
 dirs = "4.0.0"

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -24,7 +24,7 @@ terminal = { path = "../terminal" }
 smallvec = { workspace = true }
 smol = "1.2.5"
 mio-extras = "2.0.6"
-futures = "0.3"
+futures = { workspace = true }
 ordered-float = "2.1.1"
 itertools = "0.10"
 dirs = "4.0.0"

--- a/crates/theme/src/ui.rs
+++ b/crates/theme/src/ui.rs
@@ -27,28 +27,40 @@ pub struct CheckboxStyle {
     pub hovered_and_checked: ContainerStyle,
 }
 
-pub fn checkbox<Tag: 'static, V: View>(
+pub fn checkbox<Tag, V, F>(
     label: &'static str,
     style: &CheckboxStyle,
     checked: bool,
+    id: usize,
     cx: &mut ViewContext<V>,
-    change: fn(checked: bool, cx: &mut EventContext<V>) -> (),
-) -> MouseEventHandler<Tag, V> {
+    change: F,
+) -> MouseEventHandler<Tag, V>
+where
+    Tag: 'static,
+    V: View,
+    F: 'static + Fn(&mut V, bool, &mut EventContext<V>),
+{
     let label = Label::new(label, style.label.text.clone())
         .contained()
         .with_style(style.label.container);
-
-    checkbox_with_label(label, style, checked, cx, change)
+    checkbox_with_label(label, style, checked, id, cx, change)
 }
 
-pub fn checkbox_with_label<Tag: 'static, D: Element<V>, V: View>(
+pub fn checkbox_with_label<Tag, D, V, F>(
     label: D,
     style: &CheckboxStyle,
     checked: bool,
+    id: usize,
     cx: &mut ViewContext<V>,
-    change: fn(checked: bool, cx: &mut EventContext<V>) -> (),
-) -> MouseEventHandler<Tag, V> {
-    MouseEventHandler::new(0, cx, |state, _| {
+    change: F,
+) -> MouseEventHandler<Tag, V>
+where
+    Tag: 'static,
+    D: Element<V>,
+    V: View,
+    F: 'static + Fn(&mut V, bool, &mut EventContext<V>),
+{
+    MouseEventHandler::new(id, cx, |state, _| {
         let indicator = if checked {
             svg(&style.icon)
         } else {
@@ -75,8 +87,8 @@ pub fn checkbox_with_label<Tag: 'static, D: Element<V>, V: View>(
             .with_child(label)
             .align_children_center()
     })
-    .on_click(platform::MouseButton::Left, move |_, _, cx| {
-        change(!checked, cx)
+    .on_click(platform::MouseButton::Left, move |_, view, cx| {
+        change(view, !checked, cx)
     })
     .with_cursor_style(platform::CursorStyle::PointingHand)
 }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.38"
 backtrace = "0.3"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 lazy_static = "1.4.0"
-futures = "0.3"
+futures = { workspace = true }
 isahc = "1.7"
 smol = "1.2.5"
 url = "2.2"

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -126,7 +126,7 @@ impl View for WelcomePage {
                 .with_child(
                     Flex::column()
                         .with_child(
-                            theme::ui::checkbox_with_label::<Metrics, _, Self>(
+                            theme::ui::checkbox_with_label::<Metrics, _, Self, _>(
                                 Flex::column()
                                     .with_child(
                                         Label::new(
@@ -146,8 +146,9 @@ impl View for WelcomePage {
                                     ),
                                 &theme.welcome.checkbox,
                                 metrics,
+                                0,
                                 cx,
-                                |checked, cx| {
+                                |_, checked, cx| {
                                     SettingsFile::update(cx, move |file| {
                                         file.telemetry.set_metrics(checked)
                                     })
@@ -157,12 +158,13 @@ impl View for WelcomePage {
                             .with_style(theme.welcome.checkbox_container),
                         )
                         .with_child(
-                            theme::ui::checkbox::<Diagnostics, Self>(
+                            theme::ui::checkbox::<Diagnostics, Self, _>(
                                 "Send crash reports",
                                 &theme.welcome.checkbox,
                                 diagnostics,
+                                0,
                                 cx,
-                                |checked, cx| {
+                                |_, checked, cx| {
                                     SettingsFile::update(cx, move |file| {
                                         file.telemetry.set_diagnostics(checked)
                                     })

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -38,7 +38,7 @@ util = { path = "../util" }
 async-recursion = "1.0.0"
 bincode = "1.2.1"
 anyhow = "1.0.38"
-futures = "0.3"
+futures = { workspace = true }
 lazy_static = "1.4"
 env_logger = "0.9.1"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -76,7 +76,7 @@ chrono = "0.4"
 ctor = "0.1.20"
 easy-parallel = "3.1.0"
 env_logger = "0.9"
-futures = "0.3"
+futures = { workspace = true }
 ignore = "0.4"
 image = "0.23"
 indexmap = "1.6.2"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -110,7 +110,7 @@ tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev 
 tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "05e3631c6a0701c1fa518b0fee7be95a2ceef5e2" }
 tree-sitter-embedded-template = "0.20.0"
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
-tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "137e1ce6a02698fc246cdb9c6b886ed1de9a1ed8" }
+tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-rust = "0.20.3"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 tree-sitter-python = "0.20.2"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -46,6 +46,7 @@ journal = { path = "../journal" }
 language = { path = "../language" }
 language_selector = { path = "../language_selector" }
 lsp = { path = "../lsp" }
+lsp_log = { path = "../lsp_log" }
 node_runtime = { path = "../node_runtime" }
 outline = { path = "../outline" }
 plugin_runtime = { path = "../plugin_runtime" }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -262,6 +262,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::AppContext) {
     );
     activity_indicator::init(cx);
     copilot_button::init(cx);
+    lsp_log::init(cx);
     call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
     settings::KeymapFileContent::load_defaults(cx);
 }
@@ -273,7 +274,7 @@ pub fn initialize_workspace(
 ) {
     let workspace_handle = cx.handle();
     cx.subscribe(&workspace_handle, {
-        move |_, _, event, cx| {
+        move |workspace, _, event, cx| {
             if let workspace::Event::PaneAdded(pane) = event {
                 pane.update(cx, |pane, cx| {
                     pane.toolbar().update(cx, |toolbar, cx| {
@@ -287,6 +288,10 @@ pub fn initialize_workspace(
                         toolbar.add_item(submit_feedback_button, cx);
                         let feedback_info_text = cx.add_view(|_| FeedbackInfoText::new());
                         toolbar.add_item(feedback_info_text, cx);
+                        let lsp_log_item = cx.add_view(|_| {
+                            lsp_log::LspLogToolbarItemView::new(workspace.project().clone())
+                        });
+                        toolbar.add_item(lsp_log_item, cx);
                     })
                 });
             }


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-647/allow-language-server-logs-to-be-enabled-at-runtime

This is mainly for internal use, when debugging language server issues. You can run the `open language server logs` action to open a pane item that lets you pick from the running language servers, and display their logs. There is a checkbox for each language server that allows you to start or stop capturing its logs in a buffer. This way, you can switch to viewing another server's logs, but continue capturing the previous server's logs.

This PR also upgrades `tree-sitter-json` for some bug fixes and proper parsing for files with multiple top-level objects (like these logs).

![lsp-logs](https://user-images.githubusercontent.com/326587/233751401-e972726e-466a-4998-98e8-db305f01a96f.gif)
