### PR TITLE
Change copilot wording to be more explicit

### DIFF
--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -272,10 +272,7 @@ impl CopilotButton {
         let mut menu_options = Vec::with_capacity(2);
 
         menu_options.push(ContextMenuItem::item("Sign In", InitiateSignIn));
-        menu_options.push(ContextMenuItem::item(
-            "Disable Copilot",
-            HideCopilot,
-        ));
+        menu_options.push(ContextMenuItem::item("Disable Copilot", HideCopilot));
 
         self.popup_menu.update(cx, |menu, cx| {
             menu.show(

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -272,7 +272,10 @@ impl CopilotButton {
         let mut menu_options = Vec::with_capacity(2);
 
         menu_options.push(ContextMenuItem::item("Sign In", InitiateSignIn));
-        menu_options.push(ContextMenuItem::item("Hide Copilot", HideCopilot));
+        menu_options.push(ContextMenuItem::item(
+            "Disable Copilot Integration",
+            HideCopilot,
+        ));
 
         self.popup_menu.update(cx, |menu, cx| {
             menu.show(

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -273,7 +273,7 @@ impl CopilotButton {
 
         menu_options.push(ContextMenuItem::item("Sign In", InitiateSignIn));
         menu_options.push(ContextMenuItem::item(
-            "Disable Copilot Integration",
+            "Disable Copilot",
             HideCopilot,
         ));
 


### PR DESCRIPTION
Should probably get a sign off from @iamnbutler at least. 

<img width="285" alt="Screenshot 2023-04-21 at 9 40 46 PM" src="https://user-images.githubusercontent.com/2280405/233762981-c939b2ba-4b38-4ea8-bd25-526a97ce22a3.png">

Also, I'm wondering if we should wait until the first time the user selects 'sign in' to start downloading the copilot server. Right now it gets auto-downloaded to every user's machine on startup whether or not they immediately hide it.
