### PR TITLE
Avoid treating snippet completions' details as their variable types

### DIFF
--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -133,7 +133,8 @@ impl LspAdapter for RustLspAdapter {
                 });
             }
             Some(lsp::CompletionItemKind::CONSTANT | lsp::CompletionItemKind::VARIABLE)
-                if completion.detail.is_some() =>
+                if completion.detail.is_some()
+                    && completion.insert_text_format != Some(lsp::InsertTextFormat::SNIPPET) =>
             {
                 let detail = completion.detail.as_ref().unwrap();
                 let name = &completion.label;


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-578/symbols-are-showing-up-in-autocompletions-dollar0