### PR TITLE
Specify more dependencies at the cargo workspace level, to avoid repeating versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,6 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arrayref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,27 @@ default-members = ["crates/zed"]
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = { version = "1.0.57" }
+async-trait = { version = "0.1" }
+ctor = { version = "0.1" }
+env_logger = { version = "0.9" }
+futures = { version = "0.3" }
+lazy_static = { version = "1.4.0" }
+log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+ordered-float = { version = "2.1.1" }
+parking_lot = { version = "0.11.1" }
+postage = { version = "0.5", features = ["futures-traits"] }
+rand = { version = "0.8.5" }
+regex = { version = "1.5" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_derive = { version = "1.0", features = ["deserialize_in_place"] }
 serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
-rand = { version = "0.8" }
-postage = { version = "0.5", features = ["futures-traits"] }
 smallvec = { version = "1.6", features = ["union"] }
-futures = { version = "0.3" }
+smol = { version = "1.2" }
+tempdir = { version = "0.3.7" }
+thiserror = { version = "1.0.29" }
+time = { version = "0.3", features = ["serde", "serde-well-known"] }
+unindent = { version = "0.1.7" }
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14" }

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -17,5 +17,5 @@ project = { path = "../project" }
 settings = { path = "../settings" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-futures = { workspace = true }
-smallvec = { workspace = true }
+futures.workspace = true
+smallvec.workspace = true

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -10,6 +10,5 @@ doctest = false
 
 [dependencies]
 gpui = { path = "../gpui" }
-anyhow = "1.0.38"
+anyhow.workspace = true
 rust-embed = { version = "6.3", features = ["include-exclude"] }
-

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -18,12 +18,12 @@ settings = { path = "../settings" }
 theme = { path = "../theme" }
 workspace = { path = "../workspace" }
 util = { path = "../util" }
-anyhow = "1.0.38"
+anyhow.workspace = true
 isahc = "1.7"
-lazy_static = "1.4"
-log = "0.4"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-smol = "1.2.5"
-tempdir = "0.3.7"
+lazy_static.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+smol.workspace = true
+tempdir.workspace = true

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -22,7 +22,7 @@ test-support = [
 client = { path = "../client" }
 collections = { path = "../collections" }
 gpui = { path = "../gpui" }
-log = "0.4"
+log.workspace = true
 live_kit_client = { path = "../live_kit_client" }
 fs = { path = "../fs" }
 language = { path = "../language" }
@@ -31,10 +31,10 @@ project = { path = "../project" }
 settings = { path = "../settings" }
 util = { path = "../util" }
 
-anyhow = "1.0.38"
+anyhow.workspace = true
 async-broadcast = "0.4"
-futures = { workspace = true }
-postage = { workspace = true }
+futures.workspace = true
+postage.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,12 +13,12 @@ name = "cli"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 clap = { version = "3.1", features = ["derive"] }
 dirs = "3.0"
 ipc-channel = "0.16"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -17,27 +17,28 @@ db = { path = "../db" }
 gpui = { path = "../gpui" }
 util = { path = "../util" }
 rpc = { path = "../rpc" }
+settings = { path = "../settings" }
 staff_mode = { path = "../staff_mode" }
 sum_tree = { path = "../sum_tree" }
-anyhow = "1.0.38"
+
+anyhow.workspace = true
 async-recursion = "0.3"
 async-tungstenite = { version = "0.16", features = ["async-tls"] }
-futures = { workspace = true }
+futures.workspace = true
 image = "0.23"
-lazy_static = "1.4.0"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-postage = { workspace = true }
-rand = "0.8.3"
-smol = "1.2.5"
-thiserror = "1.0.29"
-time = { version = "0.3", features = ["serde", "serde-well-known"] }
+lazy_static.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
+rand.workspace = true
+smol.workspace = true
+thiserror.workspace = true
+time.workspace = true
 tiny_http = "0.8"
 uuid = { version = "1.1.2", features = ["v4"] }
 url = "2.2"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-settings = { path = "../settings" }
+serde.workspace = true
+serde_derive.workspace = true
 tempfile = "3"
 
 [dev-dependencies]

--- a/crates/clock/Cargo.toml
+++ b/crates/clock/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/clock.rs"
 doctest = false
 
 [dependencies]
-smallvec = { workspace = true }
+smallvec.workspace = true

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -19,7 +19,7 @@ live_kit_server = { path = "../live_kit_server" }
 rpc = { path = "../rpc" }
 util = { path = "../util" }
 
-anyhow = "1.0.40"
+anyhow.workspace = true
 async-tungstenite = "0.16"
 axum = { version = "0.5", features = ["json", "headers", "ws"] }
 axum-extra = { version = "0.3", features = ["erased-json"] }
@@ -27,26 +27,26 @@ base64 = "0.13"
 clap = { version = "3.1", features = ["derive"], optional = true }
 dashmap = "5.4"
 envy = "0.4.2"
-futures = { workspace = true }
+futures.workspace = true
 hyper = "0.14"
-lazy_static = "1.4"
+lazy_static.workspace = true
 lipsum = { version = "0.8", optional = true }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 nanoid = "0.4"
-parking_lot = "0.11.1"
+parking_lot.workspace = true
 prometheus = "0.13"
-rand = "0.8"
+rand.workspace = true
 reqwest = { version = "0.11", features = ["json"], optional = true }
 scrypt = "0.7"
 # Remove fork dependency when a version with https://github.com/SeaQL/sea-orm/pull/1283 is released.
 sea-orm = { git = "https://github.com/zed-industries/sea-orm", rev = "18f4c691085712ad014a51792af75a9044bacee6", features = ["sqlx-postgres", "postgres-array", "runtime-tokio-rustls"] }
 sea-query = "0.27"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 sha-1 = "0.9"
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "any"] }
-time = { version = "0.3", features = ["serde", "serde-well-known"] }
+time.workspace = true
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.17"
 tonic = "0.6"
@@ -55,7 +55,6 @@ toml = "0.5.8"
 tracing = "0.1.34"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
-indoc = "1.0.4"
 
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
@@ -75,14 +74,15 @@ settings = { path = "../settings", features = ["test-support"] }
 theme = { path = "../theme" }
 workspace = { path = "../workspace", features = ["test-support"] }
 
-ctor = "0.1"
-env_logger = "0.9"
+ctor.workspace = true
+env_logger.workspace = true
+indoc = "1.0.4"
 util = { path = "../util" }
-lazy_static = "1.4"
+lazy_static.workspace = true
 sea-orm = { git = "https://github.com/zed-industries/sea-orm", rev = "18f4c691085712ad014a51792af75a9044bacee6", features = ["sqlx-sqlite"] }
-serde_json = { workspace = true }
+serde_json.workspace = true
 sqlx = { version = "0.6", features = ["sqlite"] }
-unindent = "0.1"
+unindent.workspace = true
 
 [features]
 seed-support = ["clap", "lipsum", "reqwest"]

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -39,12 +39,13 @@ settings = { path = "../settings" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-anyhow = "1.0"
-futures = { workspace = true }
-log = "0.4"
-postage = { workspace = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
+
+anyhow.workspace = true
+futures.workspace = true
+log.workspace = true
+postage.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -24,7 +24,7 @@ workspace = { path = "../workspace" }
 gpui = { path = "../gpui", features = ["test-support"] }
 editor = { path = "../editor", features = ["test-support"] }
 project = { path = "../project", features = ["test-support"] }
-serde_json = { workspace = true }
+serde_json.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }
-ctor = "0.1"
-env_logger = "0.9"
+ctor.workspace = true
+env_logger.workspace = true

--- a/crates/context_menu/Cargo.toml
+++ b/crates/context_menu/Cargo.toml
@@ -13,4 +13,4 @@ gpui = { path = "../gpui" }
 menu = { path = "../menu" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
-smallvec = { workspace = true }
+smallvec.workspace = true

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -30,12 +30,12 @@ node_runtime = { path = "../node_runtime"}
 util = { path = "../util" }
 async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
 async-tar = "0.4.2"
-anyhow = "1.0"
-log = "0.4"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-smol = "1.2.5"
-futures = { workspace = true }
+anyhow.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+smol.workspace = true
+futures.workspace = true
 
 [dev-dependencies]
 clock = { path = "../clock" }

--- a/crates/copilot_button/Cargo.toml
+++ b/crates/copilot_button/Cargo.toml
@@ -17,6 +17,6 @@ settings = { path = "../settings" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-anyhow = "1.0"
-smol = "1.2.5"
-futures = { workspace = true }
+anyhow.workspace = true
+smol.workspace = true
+futures.workspace = true

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -17,17 +17,17 @@ gpui = { path = "../gpui" }
 sqlez = { path = "../sqlez" }
 sqlez_macros = { path = "../sqlez_macros" }
 util = { path = "../util" }
-anyhow = "1.0.57"
+anyhow.workspace = true
 indoc = "1.0.4"
-async-trait = "0.1"
-lazy_static = "1.4.0"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-smol = "1.2"
+async-trait.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+smol.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
-env_logger = "0.9.1"
-tempdir = { version = "0.3.7" }
+env_logger.workspace = true
+tempdir.workspace = true

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -9,26 +9,28 @@ path = "src/diagnostics.rs"
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
-smallvec = { workspace = true }
 collections = { path = "../collections" }
 editor = { path = "../editor" }
+gpui = { path = "../gpui" }
 language = { path = "../language" }
 lsp = { path = "../lsp" }
-gpui = { path = "../gpui" }
 project = { path = "../project" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-postage = { workspace = true }
+
+anyhow.workspace = true
+smallvec.workspace = true
+postage.workspace = true
 
 [dev-dependencies]
-unindent = "0.1"
 client = { path = "../client", features = ["test-support"] }
 editor = { path = "../editor", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
-serde_json = { workspace = true }
+
+serde_json.workspace = true
+unindent.workspace = true

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -46,20 +46,20 @@ sqlez = { path = "../sqlez" }
 workspace = { path = "../workspace" }
 
 aho-corasick = "0.7"
-anyhow = "1.0"
-futures = { workspace = true }
+anyhow.workspace = true
+futures.workspace = true
 indoc = "1.0.4"
 itertools = "0.10"
-lazy_static = "1.4"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-ordered-float = "2.1.1"
-parking_lot = "0.11"
-postage = { workspace = true }
-rand = { version = "0.8.3", optional = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-smallvec = { workspace = true }
-smol = "1.2"
+lazy_static.workspace = true
+log.workspace = true
+ordered-float.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
+rand = { workspace = true, optional = true }
+serde.workspace = true
+serde_derive.workspace = true
+smallvec.workspace = true
+smol.workspace = true
 tree-sitter-rust = { version = "*", optional = true }
 tree-sitter-html = { version = "*", optional = true }
 tree-sitter-javascript = { version = "*", optional = true }
@@ -75,10 +75,11 @@ util = { path = "../util", features = ["test-support"] }
 project = { path = "../project", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
-ctor = "0.1"
-env_logger = "0.9"
-rand = "0.8"
-unindent = "0.1.7"
+
+ctor.workspace = true
+env_logger.workspace = true
+rand.workspace = true
+unindent.workspace = true
 tree-sitter = "0.20"
 tree-sitter-rust = "0.20"
 tree-sitter-html = "0.19"

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -11,21 +11,21 @@ path = "src/feedback.rs"
 test-support = []
 
 [dependencies]
-anyhow = "1.0.38"
+anyhow.workspace = true
 client = { path = "../client" }
 editor = { path = "../editor" }
 language = { path = "../language" }
-log = "0.4"
-futures = { workspace = true }
+log.workspace = true
+futures.workspace = true
 gpui = { path = "../gpui" }
 human_bytes = "0.4.1"
 isahc = "1.7"
-lazy_static = "1.4.0"
-postage = { workspace = true }
+lazy_static.workspace = true
+postage.workspace = true
 project = { path = "../project" }
 search = { path = "../search" }
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 settings = { path = "../settings" }
 sysinfo = "0.27.1"
 theme = { path = "../theme" }

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -19,11 +19,11 @@ settings = { path = "../settings" }
 util = { path = "../util" }
 theme = { path = "../theme" }
 workspace = { path = "../workspace" }
-postage = { workspace = true }
+postage.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
-serde_json = { workspace = true }
+serde_json.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }
-ctor = "0.1"
-env_logger = "0.9"
+ctor.workspace = true
+env_logger.workspace = true

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -13,20 +13,20 @@ gpui = { path = "../gpui" }
 lsp = { path = "../lsp" }
 rope = { path = "../rope" }
 util = { path = "../util" }
-anyhow = "1.0.57"
-async-trait = "0.1"
-futures = { workspace = true }
+anyhow.workspace = true
+async-trait.workspace = true
+futures.workspace = true
 tempfile = "3"
 fsevent = { path = "../fsevent" }
-lazy_static = "1.4.0"
-parking_lot = "0.11.1"
-smol = "1.2.5"
-regex = "1.5"
+lazy_static.workspace = true
+parking_lot.workspace = true
+smol.workspace = true
+regex.workspace = true
 git2 = { version = "0.15", default-features = false }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+log.workspace = true
 libc = "0.2"
 
 [features]

--- a/crates/fsevent/Cargo.toml
+++ b/crates/fsevent/Cargo.toml
@@ -12,10 +12,10 @@ doctest = false
 [dependencies]
 bitflags = "1"
 fsevent-sys = "3.0.2"
-parking_lot = "0.11.1"
+parking_lot.workspace = true
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempdir.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-apple-darwin"]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -8,22 +8,22 @@ publish = false
 path = "src/git.rs"
 
 [dependencies]
-anyhow = "1.0.38"
+anyhow.workspace = true
 clock = { path = "../clock" }
-lazy_static = "1.4.0"
+lazy_static.workspace = true
 sum_tree = { path = "../sum_tree" }
 text = { path = "../text" }
 collections = { path = "../collections" }
 util = { path = "../util" }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-smol = "1.2"
-parking_lot = "0.11.1"
-async-trait = "0.1"
-futures = { workspace = true }
+log.workspace = true
+smol.workspace = true
+parking_lot.workspace = true
+async-trait.workspace = true
+futures.workspace = true
 git2 = { version = "0.15", default-features = false }
 
 [dev-dependencies]
-unindent = "0.1.7"
+unindent.workspace = true
 
 [features]
 test-support = []

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -15,4 +15,4 @@ menu = { path = "../menu" }
 settings = { path = "../settings" }
 text = { path = "../text" }
 workspace = { path = "../workspace" }
-postage = { workspace = true }
+postage.workspace = true

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -21,32 +21,32 @@ sum_tree = { path = "../sum_tree" }
 sqlez = { path = "../sqlez" }
 async-task = "4.0.3"
 backtrace = { version = "0.3", optional = true }
-ctor = "0.1"
+ctor.workspace = true
 dhat = { version = "0.3", optional = true }
 env_logger = { version = "0.9", optional = true }
 etagere = "0.2"
-futures = { workspace = true }
+futures.workspace = true
 image = "0.23"
 itertools = "0.10"
-lazy_static = "1.4.0"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+lazy_static.workspace = true
+log.workspace = true
 num_cpus = "1.13"
-ordered-float = "2.1.1"
+ordered-float.workspace = true
 parking = "2.0.0"
-parking_lot = "0.11.1"
+parking_lot.workspace = true
 pathfinder_color = "0.5"
 pathfinder_geometry = "0.5"
-postage = { workspace = true }
-rand = "0.8.3"
+postage.workspace = true
+rand.workspace = true
 resvg = "0.14"
 schemars = "0.8"
 seahash = "4.1"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-smallvec = { workspace = true }
-smol = "1.2"
-time = { version = "0.3", features = ["serde", "serde-well-known"] }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+smallvec.workspace = true
+smol.workspace = true
+time.workspace = true
 tiny-skia = "0.5"
 usvg = "0.14"
 uuid = { version = "1.1.2", features = ["v4"] }
@@ -60,13 +60,13 @@ cc = "1.0.67"
 backtrace = "0.3"
 collections = { path = "../collections", features = ["test-support"] }
 dhat = "0.3"
-env_logger = "0.9"
+env_logger.workspace = true
 png = "0.16"
 simplelog = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 media = { path = "../media" }
-anyhow = "1"
+anyhow.workspace = true
 block = "0.1"
 cocoa = "0.24"
 core-foundation = { version = "0.9.3", features = ["with-uuid"] }
@@ -74,6 +74,6 @@ core-graphics = "0.22.3"
 core-text = "19.2"
 font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "8eaf7a918eafa28b0a37dc759e2e0e7683fa24f1" }
 foreign-types = "0.3"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 metal = "0.21.0"
 objc = "0.2"

--- a/crates/install_cli/Cargo.toml
+++ b/crates/install_cli/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/install_cli.rs"
 test-support = []
 
 [dependencies]
-smol = "1.2.5"
-anyhow = "1.0.38"
-log = "0.4"
+smol.workspace = true
+anyhow.workspace = true
+log.workspace = true
 gpui = { path = "../gpui" }
 util = { path = "../util" }

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -13,9 +13,9 @@ editor = { path = "../editor" }
 gpui = { path = "../gpui" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-anyhow = "1.0"
+anyhow.workspace = true
 chrono = "0.4"
 dirs = "4.0"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 settings = { path = "../settings" }
 shellexpand = "2.1.0"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -36,22 +36,22 @@ sum_tree = { path = "../sum_tree" }
 text = { path = "../text" }
 theme = { path = "../theme" }
 util = { path = "../util" }
-anyhow = "1.0.38"
+anyhow.workspace = true
 async-broadcast = "0.4"
-async-trait = "0.1"
-futures = { workspace = true }
-lazy_static = "1.4"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-postage = { workspace = true }
-rand = { version = "0.8.3", optional = true }
-regex = "1.5"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+async-trait.workspace = true
+futures.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
+rand = { workspace = true, optional = true }
+regex.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 similar = "1.3"
-smallvec = { workspace = true }
-smol = "1.2"
+smallvec.workspace = true
+smol.workspace = true
 tree-sitter = "0.20"
 tree-sitter-rust = { version = "*", optional = true }
 tree-sitter-typescript = { version = "*", optional = true }
@@ -65,10 +65,10 @@ lsp = { path = "../lsp", features = ["test-support"] }
 text = { path = "../text", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
-ctor = "0.1"
-env_logger = "0.9"
+ctor.workspace = true
+env_logger.workspace = true
 indoc = "1.0.4"
-rand = "0.8.3"
+rand.workspace = true
 tree-sitter-embedded-template = "*"
 tree-sitter-html = "*"
 tree-sitter-javascript = "*"
@@ -78,4 +78,4 @@ tree-sitter-rust = "*"
 tree-sitter-python = "*"
 tree-sitter-typescript = "*"
 tree-sitter-ruby = "*"
-unindent = "0.1.7"
+unindent.workspace = true

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -19,4 +19,4 @@ theme = { path = "../theme" }
 settings = { path = "../settings" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-anyhow = "1.0"
+anyhow.workspace = true

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -28,17 +28,17 @@ gpui = { path = "../gpui", optional = true }
 live_kit_server = { path = "../live_kit_server", optional = true }
 media = { path = "../media" }
 
-anyhow = "1.0.38"
+anyhow.workspace = true
 async-broadcast = "0.4"
 core-foundation = "0.9.3"
 core-graphics = "0.22.3"
-futures = { workspace = true }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-postage = { workspace = true }
+futures.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
 
-async-trait = { version = "0.1", optional = true }
-lazy_static = { version = "1.4", optional = true }
+async-trait = { workspace = true, optional = true }
+lazy_static = { workspace = true, optional = true }
 nanoid = { version ="0.4", optional = true}
 
 [dev-dependencies]
@@ -47,8 +47,8 @@ gpui = { path = "../gpui", features = ["test-support"] }
 live_kit_server = { path = "../live_kit_server" }
 media = { path = "../media" }
 
-anyhow = "1.0.38"
-async-trait = "0.1"
+anyhow.workspace = true
+async-trait.workspace = true
 block = "0.1"
 bytes = "1.2"
 byteorder = "1.4"
@@ -56,18 +56,18 @@ cocoa = "0.24"
 core-foundation = "0.9.3"
 core-graphics = "0.22.3"
 foreign-types = "0.3"
-futures = { workspace = true }
+futures.workspace = true
 hmac = "0.12"
 jwt = "0.16"
-lazy_static = "1.4"
+lazy_static.workspace = true
 objc = "0.2"
-parking_lot = "0.11.1"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+parking_lot.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
 sha2 = "0.10"
 simplelog = "0.9"
 
 [build-dependencies]
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true

--- a/crates/live_kit_server/Cargo.toml
+++ b/crates/live_kit_server/Cargo.toml
@@ -10,17 +10,17 @@ path = "src/live_kit_server.rs"
 doctest = false
 
 [dependencies]
-anyhow = "1.0.38"
-async-trait = "0.1"
-futures = { workspace = true }
+anyhow.workspace = true
+async-trait.workspace = true
+futures.workspace = true
 hmac = "0.12"
-log = "0.4"
+log.workspace = true
 jwt = "0.16"
 prost = "0.8"
 prost-types = "0.8"
 reqwest = "0.11"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 sha2 = "0.10"
 
 [build-dependencies]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -15,22 +15,24 @@ test-support = ["async-pipe"]
 collections = { path = "../collections" }
 gpui = { path = "../gpui" }
 util = { path = "../util" }
-anyhow = "1.0"
+
+anyhow.workspace = true
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553", optional = true }
-futures = { workspace = true }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+futures.workspace = true
+log.workspace = true
 lsp-types = "0.91"
-parking_lot = "0.11"
-postage = { workspace = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-smol = "1.2"
+parking_lot.workspace = true
+postage.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+smol.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
+
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
-ctor = "0.1"
-env_logger = "0.9"
-unindent = "0.1.7"
+ctor.workspace = true
+env_logger.workspace = true
+unindent.workspace = true

--- a/crates/lsp_log/Cargo.toml
+++ b/crates/lsp_log/Cargo.toml
@@ -19,11 +19,11 @@ workspace = { path = "../workspace" }
 gpui = { path = "../gpui" }
 util = { path = "../util" }
 lsp = { path = "../lsp" }
-futures = { workspace = true }
-serde = { workspace = true }
-anyhow = "1.0"
+futures.workspace = true
+serde.workspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
-unindent = "0.1.7"
+unindent.workspace = true

--- a/crates/media/Cargo.toml
+++ b/crates/media/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/media.rs"
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 block = "0.1"
 bytes = "1.2"
 core-foundation = "0.9.3"

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -13,10 +13,10 @@ gpui = { path = "../gpui" }
 util = { path = "../util" }
 async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
 async-tar = "0.4.2"
-futures = { workspace = true }
-anyhow = "1.0.38"
-parking_lot = "0.11.1"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-smol = "1.2.5"
+futures.workspace = true
+anyhow.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+smol.workspace = true

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -17,6 +17,6 @@ picker = { path = "../picker" }
 settings = { path = "../settings" }
 text = { path = "../text" }
 workspace = { path = "../workspace" }
-ordered-float = "2.1.1"
-postage = { workspace = true }
-smol = "1.2"
+ordered-float.workspace = true
+postage.workspace = true
+smol.workspace = true

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -17,11 +17,11 @@ util = { path = "../util" }
 theme = { path = "../theme" }
 workspace = { path = "../workspace" }
 
-parking_lot = "0.11.1"
+parking_lot.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
-serde_json = { workspace = true }
+serde_json.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }
-ctor = "0.1"
-env_logger = "0.9"
+ctor.workspace = true
+env_logger.workspace = true

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 bincode = "1.3"
 plugin_macros = { path = "../plugin_macros" }

--- a/crates/plugin_macros/Cargo.toml
+++ b/crates/plugin_macros/Cargo.toml
@@ -11,6 +11,6 @@ proc-macro = true
 syn = { version = "1.0", features = ["full",  "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 bincode = "1.3"

--- a/crates/plugin_runtime/Cargo.toml
+++ b/crates/plugin_runtime/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 wasmtime = "0.38"
 wasmtime-wasi = "0.38"
 wasi-common = "0.38"
-anyhow = { version = "1.0", features = ["std"] }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+anyhow.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 bincode = "1.3"
 pollster = "0.2.5"
-smol = "1.2.5"
+smol.workspace = true
 
 [build-dependencies]
 wasmtime = { version = "0.38", features = ["all-arch"] }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -38,30 +38,30 @@ sum_tree = { path = "../sum_tree" }
 terminal = { path = "../terminal" }
 util = { path = "../util" }
 aho-corasick = "0.7"
-anyhow = "1.0.57"
-async-trait = "0.1"
+anyhow.workspace = true
+async-trait.workspace = true
 backtrace = "0.3"
-futures = { workspace = true }
+futures.workspace = true
 ignore = "0.4"
-lazy_static = "1.4.0"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-postage = { workspace = true }
+lazy_static.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
 pulldown-cmark = { version = "0.9.1", default-features = false }
-rand = "0.8.3"
-regex = "1.5"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+rand.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 sha2 = "0.10"
 similar = "1.3"
-smol = "1.2.5"
-thiserror = "1.0.29"
+smol.workspace = true
+thiserror.workspace = true
 toml = "0.5"
 
 [dev-dependencies]
-ctor = "0.1"
-env_logger = "0.9"
+ctor.workspace = true
+env_logger.workspace = true
 pretty_assertions = "1.3.0"
 client = { path = "../client", features = ["test-support"] }
 collections = { path = "../collections", features = ["test-support"] }
@@ -73,5 +73,5 @@ lsp = { path = "../lsp", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 rpc = { path = "../rpc", features = ["test-support"] }
-tempdir = { version = "0.3.7" }
-unindent = "0.1.7"
+tempdir.workspace = true
+unindent.workspace = true

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -19,12 +19,12 @@ settings = { path = "../settings" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-postage = { workspace = true }
-futures = { workspace = true }
+postage.workspace = true
+futures.workspace = true
 unicase = "2.6"
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
-serde_json = { workspace = true }
+serde_json.workspace = true

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -18,13 +18,13 @@ text = { path = "../text" }
 settings = { path = "../settings" }
 workspace = { path = "../workspace" }
 util = { path = "../util" }
-anyhow = "1.0.38"
-ordered-float = "2.1.1"
-postage = { workspace = true }
-smol = "1.2"
+anyhow.workspace = true
+ordered-float.workspace = true
+postage.workspace = true
+smol.workspace = true
 
 [dev-dependencies]
-futures = { workspace = true }
+futures.workspace = true
 settings = { path = "../settings", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -17,8 +17,9 @@ language = { path = "../language" }
 picker = { path = "../picker" }
 settings = { path = "../settings" }
 text = { path = "../text" }
-workspace = { path = "../workspace" }
-ordered-float = "2.1.1"
-postage = { workspace = true }
-smol = "1.2"
 util = { path = "../util"}
+workspace = { path = "../workspace" }
+
+ordered-float.workspace = true
+postage.workspace = true
+smol.workspace = true

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -9,13 +9,13 @@ path = "src/rope.rs"
 
 [dependencies]
 bromberg_sl2 = { git = "https://github.com/zed-industries/bromberg_sl2", rev = "950bc5482c216c395049ae33ae4501e08975f17f" }
-smallvec = { workspace = true }
+smallvec.workspace = true
 sum_tree = { path = "../sum_tree" }
 arrayvec = "0.7.1"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 util = { path = "../util" }
 
 [dev-dependencies]
-rand = "0.8.3"
+rand.workspace = true
 util = { path = "../util", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"]  }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -17,17 +17,17 @@ clock = { path = "../clock" }
 collections = { path = "../collections" }
 gpui = { path = "../gpui", optional = true }
 util = { path = "../util" }
-anyhow = "1.0"
+anyhow.workspace = true
 async-lock = "2.4"
 async-tungstenite = "0.16"
 base64 = "0.13"
-futures = { workspace = true }
-parking_lot = "0.11.1"
+futures.workspace = true
+parking_lot.workspace = true
 prost = "0.8"
-rand = "0.8"
+rand.workspace = true
 rsa = "0.4"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 smol-timeout = "0.6"
 tracing = { version = "0.1.34", features = ["log"] }
 zstd = "0.11"
@@ -38,7 +38,7 @@ prost-build = "0.9"
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
-smol = "1.2.5"
-tempdir = "0.3.7"
-ctor = "0.1"
-env_logger = "0.9"
+smol.workspace = true
+tempdir.workspace = true
+ctor.workspace = true
+env_logger.workspace = true

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -240,13 +240,13 @@ message ParticipantLocation {
         UnsharedProject unshared_project = 2;
         External external = 3;
     }
-    
+
     message SharedProject {
         uint64 id = 1;
     }
-    
+
     message UnsharedProject {}
-    
+
     message External {}
 }
 

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -19,18 +19,18 @@ settings = { path = "../settings" }
 theme = { path = "../theme" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
-anyhow = "1.0"
-futures = { workspace = true }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-postage = { workspace = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-smallvec = { workspace = true }
-smol = "1.2"
+anyhow.workspace = true
+futures.workspace = true
+log.workspace = true
+postage.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+smallvec.workspace = true
+smol.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
-serde_json = { workspace = true }
+serde_json.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }
-unindent = "0.1"
+unindent.workspace = true

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -17,24 +17,26 @@ collections = { path = "../collections" }
 gpui = { path = "../gpui" }
 sqlez = { path = "../sqlez" }
 fs = { path = "../fs" }
-anyhow = "1.0.38"
-futures = { workspace = true }
+anyhow.workspace = true
+futures.workspace = true
 theme = { path = "../theme" }
 staff_mode = { path = "../staff_mode" }
 util = { path = "../util" }
+
 json_comments = "0.2"
-postage = { workspace = true }
+postage.workspace = true
 schemars = "0.8"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 serde_path_to_error = "0.1.4"
 toml = "0.5"
 tree-sitter = "*"
 tree-sitter-json = "*"
 
 [dev-dependencies]
-unindent = "0.1"
 gpui = { path = "../gpui", features = ["test-support"] }
 fs = { path = "../fs", features = ["test-support"] }
+
 pretty_assertions = "1.3.0"
+unindent.workspace = true

--- a/crates/snippet/Cargo.toml
+++ b/crates/snippet/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/snippet.rs"
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
-smallvec = { workspace = true }
+anyhow.workspace = true
+smallvec.workspace = true

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -4,15 +4,13 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow = { version = "1.0.38", features = ["backtrace"] }
+anyhow.workspace = true
 indoc = "1.0.7"
 libsqlite3-sys = { version = "0.24", features = ["bundled"] }
-smol = "1.2"
+smol.workspace = true
 thread_local = "1.1.4"
-lazy_static = "1.4"
-parking_lot = "0.11.1"
-futures = { workspace = true }
+lazy_static.workspace = true
+parking_lot.workspace = true
+futures.workspace = true
 uuid = { version = "1.1.2", features = ["v4"] }

--- a/crates/sqlez_macros/Cargo.toml
+++ b/crates/sqlez_macros/Cargo.toml
@@ -13,6 +13,6 @@ doctest = false
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-lazy_static = "1.4"
+lazy_static.workspace = true
 sqlez = { path = "../sqlez" }
 sqlformat = "0.2"

--- a/crates/staff_mode/Cargo.toml
+++ b/crates/staff_mode/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/staff_mode.rs"
 
 [dependencies]
 gpui = { path = "../gpui" }
-anyhow = "1.0.38"
+anyhow.workspace = true

--- a/crates/sum_tree/Cargo.toml
+++ b/crates/sum_tree/Cargo.toml
@@ -10,9 +10,9 @@ doctest = false
 
 [dependencies]
 arrayvec = "0.7.1"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 
 [dev-dependencies]
-ctor = "0.1"
-env_logger = "0.9"
-rand = "0.8.3"
+ctor.workspace = true
+env_logger.workspace = true
+rand.workspace = true

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -17,20 +17,20 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "a51dbe25d67e84d6ed4261e640d3954fbdd9be45" }
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
-smallvec = { workspace = true }
-smol = "1.2.5"
+smallvec.workspace = true
+smol.workspace = true
 mio-extras = "2.0.6"
-futures = { workspace = true }
-ordered-float = "2.1.1"
+futures.workspace = true
+ordered-float.workspace = true
 itertools = "0.10"
 dirs = "4.0.0"
 shellexpand = "2.1.0"
 libc = "0.2"
-anyhow = "1"
-thiserror = "1.0"
-lazy_static = "1.4.0"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+anyhow.workspace = true
+thiserror.workspace = true
+lazy_static.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
+rand.workspace = true

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -21,20 +21,20 @@ workspace = { path = "../workspace" }
 db = { path = "../db" }
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
 terminal = { path = "../terminal" }
-smallvec = { workspace = true }
-smol = "1.2.5"
+smallvec.workspace = true
+smol.workspace = true
 mio-extras = "2.0.6"
-futures = { workspace = true }
-ordered-float = "2.1.1"
+futures.workspace = true
+ordered-float.workspace = true
 itertools = "0.10"
 dirs = "4.0.0"
 shellexpand = "2.1.0"
 libc = "0.2"
-anyhow = "1"
-thiserror = "1.0"
-lazy_static = "1.4.0"
-serde = { workspace = true }
-serde_derive = { workspace = true }
+anyhow.workspace = true
+thiserror.workspace = true
+lazy_static.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
 
 
 
@@ -43,4 +43,4 @@ gpui = { path = "../gpui", features = ["test-support"] }
 client = { path = "../client", features = ["test-support"]}
 project = { path = "../project", features = ["test-support"]}
 workspace = { path = "../workspace", features = ["test-support"] }
-rand = "0.8.5"
+rand.workspace = true

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -17,21 +17,21 @@ collections = { path = "../collections" }
 fs = { path = "../fs" }
 rope = { path = "../rope" }
 sum_tree = { path = "../sum_tree" }
-anyhow = "1.0.38"
-digest = { version = "0.9", features = ["std"] }
-lazy_static = "1.4"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11"
-postage = { workspace = true }
-rand = { version = "0.8.3", optional = true }
-smallvec = { workspace = true }
 util = { path = "../util" }
-regex = "1.5"
 
+anyhow.workspace = true
+digest = { version = "0.9", features = ["std"] }
+lazy_static.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
+rand = { workspace = true, optional = true }
+smallvec.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
-ctor = "0.1"
-env_logger = "0.9"
-rand = "0.8.3"
+ctor.workspace = true
+env_logger.workspace = true
+rand.workspace = true

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -10,11 +10,11 @@ doctest = false
 
 [dependencies]
 gpui = { path = "../gpui" }
-anyhow = "1.0.38"
+anyhow.workspace = true
 indexmap = "1.6.2"
-parking_lot = "0.11.1"
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+parking_lot.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 serde_path_to_error = "0.1.4"
 toml = "0.5"

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -18,7 +18,7 @@ settings = { path = "../settings" }
 staff_mode = { path = "../staff_mode" }
 workspace = { path = "../workspace" }
 util = { path = "../util" }
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-postage = { workspace = true }
-smol = "1.2.5"
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
+smol.workspace = true

--- a/crates/theme_testbench/Cargo.toml
+++ b/crates/theme_testbench/Cargo.toml
@@ -16,4 +16,4 @@ settings = { path = "../settings" }
 workspace = { path = "../workspace" }
 project = { path = "../project" }
 
-smallvec = { workspace = true }
+smallvec.workspace = true

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -12,21 +12,21 @@ doctest = true
 test-support = ["tempdir", "git2"]
 
 [dependencies]
-anyhow = "1.0.38"
+anyhow.workspace = true
 backtrace = "0.3"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-lazy_static = "1.4.0"
-futures = { workspace = true }
+log.workspace = true
+lazy_static.workspace = true
+futures.workspace = true
 isahc = "1.7"
-smol = "1.2.5"
+smol.workspace = true
 url = "2.2"
-rand = { workspace = true }
-tempdir = { version = "0.3.7", optional = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
+rand.workspace = true
+tempdir = { workspace = true, optional = true }
+serde.workspace = true
+serde_json.workspace = true
 git2 = { version = "0.15", default-features = false, optional = true }
 dirs = "3.0"
 
 [dev-dependencies]
-tempdir = { version = "0.3.7" }
+tempdir.workspace = true
 git2 = { version = "0.15", default-features = false }

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -12,16 +12,16 @@ doctest = false
 neovim = ["nvim-rs", "async-compat", "async-trait", "tokio"]
 
 [dependencies]
-serde = { workspace = true }
-serde_derive = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
 itertools = "0.10"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 
 async-compat = { version = "0.2.1", "optional" = true }
-async-trait = { version = "0.1", "optional" = true }
+async-trait = { workspace = true, "optional" = true }
 nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"], optional = true }
 tokio = { version = "1.15", "optional" = true }
-serde_json = { workspace = true }
+serde_json.workspace = true
 
 assets = { path = "../assets" }
 collections = { path = "../collections" }
@@ -35,8 +35,8 @@ workspace = { path = "../workspace" }
 
 [dev-dependencies]
 indoc = "1.0.4"
-parking_lot = "0.11.1"
-lazy_static = "1.4"
+parking_lot.workspace = true
+lazy_static.workspace = true
 
 editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/welcome.rs"
 test-support = []
 
 [dependencies]
-anyhow = "1.0.38"
-log = "0.4"
+anyhow.workspace = true
+log.workspace = true
 editor = { path = "../editor" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -35,20 +35,19 @@ settings = { path = "../settings" }
 terminal = { path = "../terminal" }
 theme = { path = "../theme" }
 util = { path = "../util" }
+
 async-recursion = "1.0.0"
 bincode = "1.2.1"
-anyhow = "1.0.38"
-futures = { workspace = true }
-lazy_static = "1.4"
-env_logger = "0.9.1"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
-parking_lot = "0.11.1"
-postage = { workspace = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-smallvec = { workspace = true }
-indoc = "1.0.4"
+anyhow.workspace = true
+futures.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+postage.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+smallvec.workspace = true
 uuid = { version = "1.1.2", features = ["v4"] }
 
 [dev-dependencies]
@@ -59,3 +58,6 @@ project = { path = "../project", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }
 fs = { path = "../fs", features = ["test-support"] }
 db = { path = "../db", features = ["test-support"] }
+
+indoc = "1.0.4"
+env_logger.workspace = true

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2784,9 +2784,7 @@ fn notify_if_database_failed(workspace: &ViewHandle<Workspace>, cx: &mut AsyncAp
             workspace.show_notification_once(0, cx, |cx| {
                 cx.add_view(|_| {
                     MessageNotification::new(
-                        indoc::indoc! {"
-                            Failed to load any database file :(
-                        "},
+                        "Failed to load any database file.",
                         OsOpen::new("https://github.com/zed-industries/community/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml".to_string()),
                         "Click to let us know about this error"
                     )
@@ -2800,11 +2798,7 @@ fn notify_if_database_failed(workspace: &ViewHandle<Workspace>, cx: &mut AsyncAp
                         let backup_path = backup_path.to_string_lossy();
                         MessageNotification::new(
                             format!(
-                                indoc::indoc! {"
-                                Database file was corrupted :(
-                                Old database backed up to:
-                                {}
-                                "},
+                                "Database file was corrupted. Old database backed up to {}",
                                 backup_path
                             ),
                             OsOpen::new(backup_path.to_string()),

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -67,40 +67,41 @@ util = { path = "../util" }
 vim = { path = "../vim" }
 workspace = { path = "../workspace" }
 welcome = { path = "../welcome" }
-anyhow = "1.0.38"
+
+anyhow.workspace = true
 async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
 async-tar = "0.4.2"
 async-recursion = "0.3"
-async-trait = "0.1"
+async-trait.workspace = true
 backtrace = "0.3"
 chrono = "0.4"
 ctor = "0.1.20"
 easy-parallel = "3.1.0"
-env_logger = "0.9"
-futures = { workspace = true }
+env_logger.workspace = true
+futures.workspace = true
 ignore = "0.4"
 image = "0.23"
 indexmap = "1.6.2"
 isahc = "1.7"
-lazy_static = "1.4.0"
+lazy_static.workspace = true
 libc = "0.2"
-log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+log.workspace = true
 num_cpus = "1.13.0"
-parking_lot = "0.11.1"
-postage = { workspace = true }
-rand = "0.8.3"
-regex = "1.5"
+parking_lot.workspace = true
+postage.workspace = true
+rand.workspace = true
+regex.workspace = true
 rsa = "0.4"
 rust-embed = { version = "6.3", features = ["include-exclude"] }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
 serde_path_to_error = "0.1.4"
 simplelog = "0.9"
-smallvec = { workspace = true }
-smol = "1.2.5"
-tempdir = { version = "0.3.7" }
-thiserror = "1.0.29"
+smallvec.workspace = true
+smol.workspace = true
+tempdir.workspace = true
+thiserror.workspace = true
 tiny_http = "0.8"
 toml = "0.5"
 tree-sitter = "0.20"
@@ -116,7 +117,6 @@ tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown",
 tree-sitter-python = "0.20.2"
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259" }
-
 tree-sitter-ruby = "0.20.0"
 tree-sitter-html = "0.19.0"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9"}
@@ -141,9 +141,7 @@ text = { path = "../text", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
 
-env_logger = "0.9"
-serde_json = { workspace = true }
-unindent = "0.1.7"
+unindent.workspace = true
 
 [package.metadata.bundle-dev]
 icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]


### PR DESCRIPTION
This PR just removes a lot of duplicated specification of dependency crates' versions and features, by specifying them at the workspace level.