### PR TITLE
Pass a `WeakViewHandle` to `ViewContext::spawn`

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -65,18 +65,14 @@ impl ActivityIndicator {
             let mut status_events = languages.language_server_binary_statuses();
             cx.spawn(|this, mut cx| async move {
                 while let Some((language, event)) = status_events.next().await {
-                    if let Some(this) = this.upgrade(&cx) {
-                        this.update(&mut cx, |this, cx| {
-                            this.statuses.retain(|s| s.name != language.name());
-                            this.statuses.push(LspStatus {
-                                name: language.name(),
-                                status: event,
-                            });
-                            cx.notify();
-                        })?;
-                    } else {
-                        break;
-                    }
+                    this.update(&mut cx, |this, cx| {
+                        this.statuses.retain(|s| s.name != language.name());
+                        this.statuses.push(LspStatus {
+                            name: language.name(),
+                            status: event,
+                        });
+                        cx.notify();
+                    })?;
                 }
                 anyhow::Ok(())
             })

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -63,7 +63,7 @@ impl ActivityIndicator {
         let auto_updater = AutoUpdater::get(cx);
         let this = cx.add_view(|cx: &mut ViewContext<Self>| {
             let mut status_events = languages.language_server_binary_statuses();
-            cx.spawn_weak(|this, mut cx| async move {
+            cx.spawn(|this, mut cx| async move {
                 while let Some((language, event)) = status_events.next().await {
                     if let Some(this) = this.upgrade(&cx) {
                         this.update(&mut cx, |this, cx| {

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -104,17 +104,15 @@ pub fn notify_of_any_new_update(
     cx.spawn(|mut cx| async move {
         let should_show_notification = should_show_notification.await?;
         if should_show_notification {
-            if let Some(workspace) = workspace.upgrade(&cx) {
-                workspace.update(&mut cx, |workspace, cx| {
-                    workspace.show_notification(0, cx, |cx| {
-                        cx.add_view(|_| UpdateNotification::new(version))
-                    });
-                    updater
-                        .read(cx)
-                        .set_should_show_update_notification(false, cx)
-                        .detach_and_log_err(cx);
-                })?;
-            }
+            workspace.update(&mut cx, |workspace, cx| {
+                workspace.show_notification(0, cx, |cx| {
+                    cx.add_view(|_| UpdateNotification::new(version))
+                });
+                updater
+                    .read(cx)
+                    .set_should_show_update_notification(false, cx)
+                    .detach_and_log_err(cx);
+            })?;
         }
         anyhow::Ok(())
     })

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -61,7 +61,7 @@ fn join_project(action: &JoinProject, app_state: Arc<AppState>, cx: &mut AppCont
         });
 
         let workspace = if let Some(existing_workspace) = existing_workspace {
-            existing_workspace
+            existing_workspace.downgrade()
         } else {
             let active_call = cx.read(ActiveCall::global);
             let room = active_call
@@ -93,7 +93,7 @@ fn join_project(action: &JoinProject, app_state: Arc<AppState>, cx: &mut AppCont
                     workspace
                 },
             );
-            workspace
+            workspace.downgrade()
         };
 
         cx.activate_window(workspace.window_id());

--- a/crates/collab_ui/src/incoming_call_notification.rs
+++ b/crates/collab_ui/src/incoming_call_notification.rs
@@ -79,7 +79,7 @@ impl IncomingCallNotification {
             let join = active_call.update(cx, |active_call, cx| active_call.accept_incoming(cx));
             let caller_user_id = self.call.calling_user.id;
             let initial_project_id = self.call.initial_project.as_ref().map(|project| project.id);
-            cx.spawn_weak(|_, mut cx| async move {
+            cx.spawn(|_, mut cx| async move {
                 join.await?;
                 if let Some(project_id) = initial_project_id {
                     cx.update(|cx| {

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -1,4 +1,5 @@
 use gpui::{
+    anyhow,
     elements::*,
     geometry::vector::Vector2F,
     impl_internal_actions,
@@ -209,7 +210,8 @@ impl ContextMenu {
                 cx.notify();
                 cx.spawn(|this, mut cx| async move {
                     cx.background().timer(Duration::from_millis(50)).await;
-                    this.update(&mut cx, |this, cx| this.cancel(&Default::default(), cx))
+                    this.update(&mut cx, |this, cx| this.cancel(&Default::default(), cx))?;
+                    anyhow::Ok(())
                 })
                 .detach_and_log_err(cx);
             }

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -149,7 +149,7 @@ fn show_hover(
         }
     }
 
-    let task = cx.spawn_weak(|this, mut cx| {
+    let task = cx.spawn(|this, mut cx| {
         async move {
             // If we need to delay, delay a set amount initially before making the lsp request
             let delay = if !ignore_timeout {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -201,15 +201,13 @@ fn show_hover(
                     })
             });
 
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, _| {
-                    this.hover_state.diagnostic_popover =
-                        local_diagnostic.map(|local_diagnostic| DiagnosticPopover {
-                            local_diagnostic,
-                            primary_diagnostic,
-                        });
-                })?;
-            }
+            this.update(&mut cx, |this, _| {
+                this.hover_state.diagnostic_popover =
+                    local_diagnostic.map(|local_diagnostic| DiagnosticPopover {
+                        local_diagnostic,
+                        primary_diagnostic,
+                    });
+            })?;
 
             // Construct new hover popover from hover request
             let hover_popover = hover_request.await.ok().flatten().and_then(|hover_result| {
@@ -239,23 +237,22 @@ fn show_hover(
                 })
             });
 
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, cx| {
-                    if let Some(hover_popover) = hover_popover.as_ref() {
-                        // Highlight the selected symbol using a background highlight
-                        this.highlight_background::<HoverState>(
-                            vec![hover_popover.symbol_range.clone()],
-                            |theme| theme.editor.hover_popover.highlight,
-                            cx,
-                        );
-                    } else {
-                        this.clear_background_highlights::<HoverState>(cx);
-                    }
+            this.update(&mut cx, |this, cx| {
+                if let Some(hover_popover) = hover_popover.as_ref() {
+                    // Highlight the selected symbol using a background highlight
+                    this.highlight_background::<HoverState>(
+                        vec![hover_popover.symbol_range.clone()],
+                        |theme| theme.editor.hover_popover.highlight,
+                        cx,
+                    );
+                } else {
+                    this.clear_background_highlights::<HoverState>(cx);
+                }
 
-                    this.hover_state.info_popover = hover_popover;
-                    cx.notify();
-                })?;
-            }
+                this.hover_state.info_popover = hover_popover;
+                cx.notify();
+            })?;
+
             Ok::<_, anyhow::Error>(())
         }
         .log_err()

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -171,7 +171,7 @@ pub fn show_link_definition(
         }
     }
 
-    let task = cx.spawn_weak(|this, mut cx| {
+    let task = cx.spawn(|this, mut cx| {
         async move {
             // query the LSP for definition info
             let definition_request = cx.update(|cx| {

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -245,7 +245,7 @@ impl ScrollManager {
         }
 
         if cx.default_global::<ScrollbarAutoHide>().0 {
-            self.hide_scrollbar_task = Some(cx.spawn_weak(|editor, mut cx| async move {
+            self.hide_scrollbar_task = Some(cx.spawn(|editor, mut cx| async move {
                 cx.background().timer(SCROLLBAR_SHOW_INTERVAL).await;
                 if let Some(editor) = editor.upgrade(&cx) {
                     editor

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -247,14 +247,12 @@ impl ScrollManager {
         if cx.default_global::<ScrollbarAutoHide>().0 {
             self.hide_scrollbar_task = Some(cx.spawn(|editor, mut cx| async move {
                 cx.background().timer(SCROLLBAR_SHOW_INTERVAL).await;
-                if let Some(editor) = editor.upgrade(&cx) {
-                    editor
-                        .update(&mut cx, |editor, cx| {
-                            editor.scroll_manager.show_scrollbars = false;
-                            cx.notify();
-                        })
-                        .log_err();
-                }
+                editor
+                    .update(&mut cx, |editor, cx| {
+                        editor.scroll_manager.show_scrollbars = false;
+                        cx.notify();
+                    })
+                    .log_err();
             }));
         } else {
             self.hide_scrollbar_task = None;

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -124,11 +124,10 @@ impl FeedbackEditor {
             &["Yes, Submit!", "No"],
         );
 
-        let this = cx.handle();
         let client = cx.global::<Arc<Client>>().clone();
         let specs = self.system_specs.clone();
 
-        cx.spawn(|_, mut cx| async move {
+        cx.spawn(|this, mut cx| async move {
             let answer = answer.recv().await;
 
             if answer == Some(0) {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4086,10 +4086,10 @@ impl<V: View> WeakViewHandle<V> {
 
     pub fn read_with<T>(
         &self,
-        cx: &impl BorrowAppContext,
+        cx: &AsyncAppContext,
         read: impl FnOnce(&V, &ViewContext<V>) -> T,
     ) -> Result<T> {
-        cx.read_with(|cx| {
+        cx.read(|cx| {
             let handle = cx
                 .upgrade_view_handle(self)
                 .ok_or_else(|| anyhow!("view {} was dropped", V::ui_name()))?;
@@ -4100,7 +4100,7 @@ impl<V: View> WeakViewHandle<V> {
 
     pub fn update<T>(
         &self,
-        cx: &mut impl BorrowAppContext,
+        cx: &mut AsyncAppContext,
         update: impl FnOnce(&mut V, &mut ViewContext<V>) -> T,
     ) -> Result<T> {
         cx.update(|cx| {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -4156,8 +4156,23 @@ impl AnyWeakViewHandle {
         self.view_id
     }
 
+    fn is<T: 'static>(&self) -> bool {
+        TypeId::of::<T>() == self.view_type
+    }
+
     pub fn upgrade(&self, cx: &impl BorrowAppContext) -> Option<AnyViewHandle> {
         cx.read_with(|cx| cx.upgrade_any_view_handle(self))
+    }
+
+    pub fn downcast<T: View>(self) -> Option<WeakViewHandle<T>> {
+        if self.is::<T>() {
+            Some(WeakViewHandle {
+                any_handle: self,
+                view_type: PhantomData,
+            })
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/gpui/src/app/test_app_context.rs
+++ b/crates/gpui/src/app/test_app_context.rs
@@ -390,8 +390,6 @@ impl BorrowAppContext for TestAppContext {
 }
 
 impl BorrowWindowContext for TestAppContext {
-    type ReturnValue<T> = T;
-
     fn read_with<T, F: FnOnce(&WindowContext) -> T>(&self, window_id: usize, f: F) -> T {
         self.cx
             .borrow()

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -142,8 +142,6 @@ impl BorrowAppContext for WindowContext<'_> {
 }
 
 impl BorrowWindowContext for WindowContext<'_> {
-    type ReturnValue<T> = T;
-
     fn read_with<T, F: FnOnce(&WindowContext) -> T>(&self, window_id: usize, f: F) -> T {
         if self.window_id == window_id {
             f(self)

--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -99,7 +99,7 @@ impl<V: View> Tooltip<V> {
 
                         let mut debounce = state.debounce.borrow_mut();
                         if debounce.is_none() {
-                            *debounce = Some(cx.spawn_weak({
+                            *debounce = Some(cx.spawn({
                                 let state = state.clone();
                                 |view, mut cx| async move {
                                     cx.background().timer(DEBOUNCE_TIMEOUT).await;

--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -104,9 +104,7 @@ impl<V: View> Tooltip<V> {
                                 |view, mut cx| async move {
                                     cx.background().timer(DEBOUNCE_TIMEOUT).await;
                                     state.visible.set(true);
-                                    if let Some(view) = view.upgrade(&cx) {
-                                        view.update(&mut cx, |_, cx| cx.notify()).log_err();
-                                    }
+                                    view.update(&mut cx, |_, cx| cx.notify()).log_err();
                                 }
                             }));
                         }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -56,7 +56,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut AppContext) {
             .await;
 
         if let Some(Some(Ok(item))) = opened.first() {
-            if let Some(editor) = item.downcast::<Editor>() {
+            if let Some(editor) = item.downcast::<Editor>().map(|editor| editor.downgrade()) {
                 editor.update(&mut cx, |editor, cx| {
                     let len = editor.buffer().read(cx).len(cx);
                     editor.change_selections(Some(Autoscroll::center()), cx, |s| {

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -162,17 +162,15 @@ impl PickerDelegate for LanguageSelectorDelegate {
                 .await
             };
 
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, cx| {
-                    let delegate = this.delegate_mut();
-                    delegate.matches = matches;
-                    delegate.selected_index = delegate
-                        .selected_index
-                        .min(delegate.matches.len().saturating_sub(1));
-                    cx.notify();
-                })
-                .log_err();
-            }
+            this.update(&mut cx, |this, cx| {
+                let delegate = this.delegate_mut();
+                delegate.matches = matches;
+                delegate.selected_index = delegate
+                    .selected_index
+                    .min(delegate.matches.len().saturating_sub(1));
+                cx.notify();
+            })
+            .log_err();
         })
     }
 

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -102,7 +102,7 @@ impl PickerDelegate for LanguageSelectorDelegate {
             let language = self.language_registry.language_for_name(language_name);
             let project = self.project.downgrade();
             let buffer = self.buffer.downgrade();
-            cx.spawn_weak(|_, mut cx| async move {
+            cx.spawn(|_, mut cx| async move {
                 let language = language.await?;
                 let project = project
                     .upgrade(&cx)
@@ -138,7 +138,7 @@ impl PickerDelegate for LanguageSelectorDelegate {
     ) -> gpui::Task<()> {
         let background = cx.background().clone();
         let candidates = self.candidates.clone();
-        cx.spawn_weak(|this, mut cx| async move {
+        cx.spawn(|this, mut cx| async move {
             let matches = if query.is_empty() {
                 candidates
                     .into_iter()

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -240,8 +240,7 @@ impl<D: PickerDelegate> Picker<D> {
         self.matches_updated(cx);
         self.pending_update_matches = cx.spawn(|this, mut cx| async move {
             update.await;
-            this.upgrade(&cx)?
-                .update(&mut cx, |this, cx| this.matches_updated(cx))
+            this.update(&mut cx, |this, cx| this.matches_updated(cx))
                 .log_err()
         });
     }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -238,7 +238,7 @@ impl<D: PickerDelegate> Picker<D> {
     pub fn update_matches(&mut self, query: String, cx: &mut ViewContext<Self>) {
         let update = self.delegate.update_matches(query, cx);
         self.matches_updated(cx);
-        self.pending_update_matches = cx.spawn_weak(|this, mut cx| async move {
+        self.pending_update_matches = cx.spawn(|this, mut cx| async move {
             update.await;
             this.upgrade(&cx)?
                 .update(&mut cx, |this, cx| this.matches_updated(cx))

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -117,7 +117,7 @@ impl PickerDelegate for ProjectSymbolsDelegate {
             });
             let symbol = symbol.clone();
             let workspace = self.workspace.clone();
-            cx.spawn_weak(|_, mut cx| async move {
+            cx.spawn(|_, mut cx| async move {
                 let buffer = buffer.await?;
                 let workspace = workspace
                     .upgrade(&cx)
@@ -161,7 +161,7 @@ impl PickerDelegate for ProjectSymbolsDelegate {
         let symbols = self
             .project
             .update(cx, |project, cx| project.symbols(&query, cx));
-        cx.spawn_weak(|this, mut cx| async move {
+        cx.spawn(|this, mut cx| async move {
             let symbols = symbols.await.log_err();
             if let Some(this) = this.upgrade(&cx) {
                 if let Some(symbols) = symbols {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -201,10 +201,11 @@ impl ToolbarItemView for BufferSearchBar {
                 Some(searchable_item_handle.subscribe_to_search_events(
                     cx,
                     Box::new(move |search_event, cx| {
-                        this.update(cx, |this, cx| {
-                            this.on_active_searchable_item_event(search_event, cx)
-                        })
-                        .log_err();
+                        if let Some(this) = this.upgrade(cx) {
+                            this.update(cx, |this, cx| {
+                                this.on_active_searchable_item_event(search_event, cx)
+                            });
+                        }
                     }),
                 ));
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -582,7 +582,7 @@ impl BufferSearchBar {
                 let matches = active_searchable_item.find_matches(query, cx);
 
                 let active_searchable_item = active_searchable_item.downgrade();
-                self.pending_search = Some(cx.spawn_weak(|this, mut cx| async move {
+                self.pending_search = Some(cx.spawn(|this, mut cx| async move {
                     let matches = matches.await;
                     if let Some(this) = this.upgrade(&cx) {
                         this.update(&mut cx, |this, cx| {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -196,16 +196,15 @@ impl ToolbarItemView for BufferSearchBar {
         if let Some(searchable_item_handle) =
             item.and_then(|item| item.to_searchable_item_handle(cx))
         {
-            let handle = cx.weak_handle();
+            let this = cx.weak_handle();
             self.active_searchable_item_subscription =
                 Some(searchable_item_handle.subscribe_to_search_events(
                     cx,
                     Box::new(move |search_event, cx| {
-                        if let Some(this) = handle.upgrade(cx) {
-                            this.update(cx, |this, cx| {
-                                this.on_active_searchable_item_event(search_event, cx)
-                            });
-                        }
+                        this.update(cx, |this, cx| {
+                            this.on_active_searchable_item_event(search_event, cx)
+                        })
+                        .log_err();
                     }),
                 ));
 
@@ -584,34 +583,31 @@ impl BufferSearchBar {
                 let active_searchable_item = active_searchable_item.downgrade();
                 self.pending_search = Some(cx.spawn(|this, mut cx| async move {
                     let matches = matches.await;
-                    if let Some(this) = this.upgrade(&cx) {
-                        this.update(&mut cx, |this, cx| {
-                            if let Some(active_searchable_item) = WeakSearchableItemHandle::upgrade(
-                                active_searchable_item.as_ref(),
-                                cx,
-                            ) {
-                                this.seachable_items_with_matches
-                                    .insert(active_searchable_item.downgrade(), matches);
+                    this.update(&mut cx, |this, cx| {
+                        if let Some(active_searchable_item) =
+                            WeakSearchableItemHandle::upgrade(active_searchable_item.as_ref(), cx)
+                        {
+                            this.seachable_items_with_matches
+                                .insert(active_searchable_item.downgrade(), matches);
 
-                                this.update_match_index(cx);
-                                if !this.dismissed {
-                                    let matches = this
-                                        .seachable_items_with_matches
-                                        .get(&active_searchable_item.downgrade())
-                                        .unwrap();
-                                    active_searchable_item.update_matches(matches, cx);
-                                    if select_closest_match {
-                                        if let Some(match_ix) = this.active_match_index {
-                                            active_searchable_item
-                                                .activate_match(match_ix, matches, cx);
-                                        }
+                            this.update_match_index(cx);
+                            if !this.dismissed {
+                                let matches = this
+                                    .seachable_items_with_matches
+                                    .get(&active_searchable_item.downgrade())
+                                    .unwrap();
+                                active_searchable_item.update_matches(matches, cx);
+                                if select_closest_match {
+                                    if let Some(match_ix) = this.active_match_index {
+                                        active_searchable_item
+                                            .activate_match(match_ix, matches, cx);
                                     }
                                 }
-                                cx.notify();
                             }
-                        })
-                        .log_err();
-                    }
+                            cx.notify();
+                        }
+                    })
+                    .log_err();
                 }));
             }
         }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -277,10 +277,8 @@ impl TerminalView {
             let epoch = self.next_blink_epoch();
             cx.spawn(|this, mut cx| async move {
                 Timer::after(CURSOR_BLINK_INTERVAL).await;
-                if let Some(this) = this.upgrade(&cx) {
-                    this.update(&mut cx, |this, cx| this.blink_cursors(epoch, cx))
-                        .log_err();
-                }
+                this.update(&mut cx, |this, cx| this.blink_cursors(epoch, cx))
+                    .log_err();
             })
             .detach();
         }
@@ -293,10 +291,8 @@ impl TerminalView {
         let epoch = self.next_blink_epoch();
         cx.spawn(|this, mut cx| async move {
             Timer::after(CURSOR_BLINK_INTERVAL).await;
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, cx| this.resume_cursor_blinking(epoch, cx))
-                    .log_err();
-            }
+            this.update(&mut cx, |this, cx| this.resume_cursor_blinking(epoch, cx))
+                .log_err();
         })
         .detach();
     }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -163,7 +163,7 @@ impl PickerDelegate for ThemeSelectorDelegate {
             })
             .collect::<Vec<_>>();
 
-        cx.spawn_weak(|this, mut cx| async move {
+        cx.spawn(|this, mut cx| async move {
             let matches = if query.is_empty() {
                 candidates
                     .into_iter()

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -187,17 +187,15 @@ impl PickerDelegate for ThemeSelectorDelegate {
                 .await
             };
 
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, cx| {
-                    let delegate = this.delegate_mut();
-                    delegate.matches = matches;
-                    delegate.selected_index = delegate
-                        .selected_index
-                        .min(delegate.matches.len().saturating_sub(1));
-                    delegate.show_selected_theme(cx);
-                })
-                .log_err();
-            }
+            this.update(&mut cx, |this, cx| {
+                let delegate = this.delegate_mut();
+                delegate.matches = matches;
+                delegate.selected_index = delegate
+                    .selected_index
+                    .min(delegate.matches.len().saturating_sub(1));
+                delegate.show_selected_theme(cx);
+            })
+            .log_err();
         })
     }
 

--- a/crates/welcome/src/base_keymap_picker.rs
+++ b/crates/welcome/src/base_keymap_picker.rs
@@ -105,16 +105,14 @@ impl PickerDelegate for BaseKeymapSelectorDelegate {
                 .await
             };
 
-            if let Some(this) = this.upgrade(&cx) {
-                this.update(&mut cx, |this, _| {
-                    let delegate = this.delegate_mut();
-                    delegate.matches = matches;
-                    delegate.selected_index = delegate
-                        .selected_index
-                        .min(delegate.matches.len().saturating_sub(1));
-                })
-                .log_err();
-            }
+            this.update(&mut cx, |this, _| {
+                let delegate = this.delegate_mut();
+                delegate.matches = matches;
+                delegate.selected_index = delegate
+                    .selected_index
+                    .min(delegate.matches.len().saturating_sub(1));
+            })
+            .log_err();
         })
     }
 

--- a/crates/welcome/src/base_keymap_picker.rs
+++ b/crates/welcome/src/base_keymap_picker.rs
@@ -81,7 +81,7 @@ impl PickerDelegate for BaseKeymapSelectorDelegate {
             })
             .collect::<Vec<_>>();
 
-        cx.spawn_weak(|this, mut cx| async move {
+        cx.spawn(|this, mut cx| async move {
             let matches = if query.is_empty() {
                 candidates
                     .into_iter()

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -811,8 +811,6 @@ mod tests {
     }
 
     impl BorrowWindowContext for DockTestContext<'_> {
-        type ReturnValue<T> = T;
-
         fn read_with<T, F: FnOnce(&WindowContext) -> T>(&self, window_id: usize, f: F) -> T {
             BorrowWindowContext::read_with(self.cx, window_id, f)
         }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -3,7 +3,7 @@ use crate::{
     FollowableItemBuilders, ItemNavHistory, Pane, ToolbarItemLocation, ViewId, Workspace,
     WorkspaceId,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use client::{proto, Client};
 use gpui::{
     fonts::HighlightStyle, AnyElement, AnyViewHandle, AppContext, ModelHandle, Task, View,
@@ -481,8 +481,6 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
                                 } else {
                                     cx.spawn(|workspace, mut cx| async move {
                                         workspace
-                                            .upgrade(&cx)
-                                            .ok_or_else(|| anyhow!("workspace was dropped"))?
                                             .update(&mut cx, |workspace, cx| {
                                                 item.git_diff_recalc(
                                                     workspace.project().clone(),

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -479,7 +479,7 @@ impl<T: Item> ItemHandle for ViewHandle<T> {
                                         },
                                     );
                                 } else {
-                                    cx.spawn_weak(|workspace, mut cx| async move {
+                                    cx.spawn(|workspace, mut cx| async move {
                                         workspace
                                             .upgrade(&cx)
                                             .ok_or_else(|| anyhow!("workspace was dropped"))?

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2005,9 +2005,11 @@ impl NavHistory {
     }
 
     fn did_update(&self, cx: &mut WindowContext) {
-        if let Some(pane) = self.pane.upgrade(cx) {
-            cx.defer(move |cx| pane.update(cx, |pane, cx| pane.history_updated(cx)));
-        }
+        let pane = self.pane.clone();
+        cx.defer(move |cx| {
+            pane.update(cx, |pane, cx| pane.history_updated(cx))
+                .log_err();
+        });
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2005,11 +2005,11 @@ impl NavHistory {
     }
 
     fn did_update(&self, cx: &mut WindowContext) {
-        let pane = self.pane.clone();
-        cx.defer(move |cx| {
-            pane.update(cx, |pane, cx| pane.history_updated(cx))
-                .log_err();
-        });
+        if let Some(pane) = self.pane.upgrade(cx) {
+            cx.defer(move |cx| {
+                pane.update(cx, |pane, cx| pane.history_updated(cx));
+            });
+        }
     }
 }
 

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -1,27 +1,23 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
+use crate::{
+    dock::DockPosition, ItemDeserializers, Member, Pane, PaneAxis, Workspace, WorkspaceId,
 };
-
-use anyhow::{Context, Result};
-
+use anyhow::{anyhow, Context, Result};
 use async_recursion::async_recursion;
-use gpui::{
-    platform::WindowBounds, AsyncAppContext, Axis, ModelHandle, Task, ViewHandle, WeakViewHandle,
-};
-
 use db::sqlez::{
     bindable::{Bind, Column, StaticColumnCount},
     statement::Statement,
 };
+use gpui::{
+    platform::WindowBounds, AsyncAppContext, Axis, ModelHandle, Task, ViewHandle, WeakViewHandle,
+};
 use project::Project;
 use settings::DockAnchor;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use util::ResultExt;
 use uuid::Uuid;
-
-use crate::{
-    dock::DockPosition, ItemDeserializers, Member, Pane, PaneAxis, Workspace, WorkspaceId,
-};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceLocation(Arc<Vec<PathBuf>>);
@@ -134,7 +130,7 @@ impl SerializedPaneGroup {
             }
             SerializedPaneGroup::Pane(serialized_pane) => {
                 let pane = workspace
-                    .update(cx, |workspace, cx| workspace.add_pane(cx))
+                    .update(cx, |workspace, cx| workspace.add_pane(cx).downgrade())
                     .log_err()?;
                 let active = serialized_pane.active;
                 serialized_pane
@@ -146,8 +142,10 @@ impl SerializedPaneGroup {
                     .read_with(cx, |pane, _| pane.items_len() != 0)
                     .log_err()?
                 {
+                    let pane = pane.upgrade(cx)?;
                     Some((Member::Pane(pane.clone()), active.then(|| pane)))
                 } else {
+                    let pane = pane.upgrade(cx)?;
                     workspace
                         .update(cx, |workspace, cx| workspace.remove_pane(pane, cx))
                         .log_err()?;
@@ -172,7 +170,7 @@ impl SerializedPane {
     pub async fn deserialize_to(
         &self,
         project: &ModelHandle<Project>,
-        pane_handle: &ViewHandle<Pane>,
+        pane_handle: &WeakViewHandle<Pane>,
         workspace_id: WorkspaceId,
         workspace: &WeakViewHandle<Workspace>,
         cx: &mut AsyncAppContext,
@@ -196,8 +194,12 @@ impl SerializedPane {
 
             if let Some(item_handle) = item_handle {
                 workspace.update(cx, |workspace, cx| {
+                    let pane_handle = pane_handle
+                        .upgrade(cx)
+                        .ok_or_else(|| anyhow!("pane was dropped"))?;
                     Pane::add_item(workspace, &pane_handle, item_handle, false, false, None, cx);
-                })?;
+                    anyhow::Ok(())
+                })??;
             }
 
             if item.active {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2219,7 +2219,7 @@ impl Workspace {
     // RPC handlers
 
     async fn handle_follow(
-        this: ViewHandle<Self>,
+        this: WeakViewHandle<Self>,
         envelope: TypedEnvelope<proto::Follow>,
         _: Arc<Client>,
         mut cx: AsyncAppContext,
@@ -2267,7 +2267,7 @@ impl Workspace {
     }
 
     async fn handle_unfollow(
-        this: ViewHandle<Self>,
+        this: WeakViewHandle<Self>,
         envelope: TypedEnvelope<proto::Unfollow>,
         _: Arc<Client>,
         mut cx: AsyncAppContext,
@@ -2282,7 +2282,7 @@ impl Workspace {
     }
 
     async fn handle_update_followers(
-        this: ViewHandle<Self>,
+        this: WeakViewHandle<Self>,
         envelope: TypedEnvelope<proto::UpdateFollowers>,
         _: Arc<Client>,
         cx: AsyncAppContext,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -374,7 +374,14 @@ pub fn build_window_options(
 fn restart(_: &Restart, cx: &mut gpui::AppContext) {
     let mut workspaces = cx
         .window_ids()
-        .filter_map(|window_id| cx.root_view(window_id)?.clone().downcast::<Workspace>())
+        .filter_map(|window_id| {
+            Some(
+                cx.root_view(window_id)?
+                    .clone()
+                    .downcast::<Workspace>()?
+                    .downgrade(),
+            )
+        })
         .collect::<Vec<_>>();
 
     // If multiple windows have unsaved changes, and need a save prompt,
@@ -419,7 +426,14 @@ fn restart(_: &Restart, cx: &mut gpui::AppContext) {
 fn quit(_: &Quit, cx: &mut gpui::AppContext) {
     let mut workspaces = cx
         .window_ids()
-        .filter_map(|window_id| cx.root_view(window_id)?.clone().downcast::<Workspace>())
+        .filter_map(|window_id| {
+            Some(
+                cx.root_view(window_id)?
+                    .clone()
+                    .downcast::<Workspace>()?
+                    .downgrade(),
+            )
+        })
         .collect::<Vec<_>>();
 
     // If multiple windows have unsaved changes, and need a save prompt,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -503,7 +503,7 @@ fn open_log_file(
 
     workspace
         .with_local_workspace(&app_state.clone(), cx, move |_, cx| {
-            cx.spawn_weak(|workspace, mut cx| async move {
+            cx.spawn(|workspace, mut cx| async move {
                 let (old_log, new_log) = futures::join!(
                     app_state.fs.load(&paths::OLD_LOG),
                     app_state.fs.load(&paths::LOG)
@@ -558,7 +558,7 @@ fn open_telemetry_log_file(
     cx: &mut ViewContext<Workspace>,
 ) {
     workspace.with_local_workspace(&app_state.clone(), cx, move |_, cx| {
-        cx.spawn_weak(|workspace, mut cx| async move {
+        cx.spawn(|workspace, mut cx| async move {
             let workspace = workspace.upgrade(&cx)?;
 
             async fn fetch_log_string(app_state: &Arc<AppState>) -> Option<String> {


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-952/replace-viewcontextspawn-with-viewcontextspawn-weak

The aim of this pull this request is to make it harder to accidentally hold strong view handles in asynchronous contexts. This is achieved by:

1. Passing a `WeakViewHandle` instead of a `ViewHandle` to `spawn` closures.
2. Disallowing strong view handles to be read or updated with an `AsyncAppContext`.