### PR TITLE
Remove highlighted rows when confirming outline view

### DIFF
--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -187,6 +187,7 @@ impl PickerDelegate for OutlineViewDelegate {
                 active_editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                     s.select_ranges([position..position])
                 });
+                active_editor.highlight_rows(None);
             }
         });
         cx.emit(PickerEvent::Dismiss);


### PR DESCRIPTION
I think this regressed in https://github.com/zed-industries/zed/pull/2372

We should cherry-pick this onto preview (`v0.84.x`).