### PR TITLE
Fix vim mode crash when active editor changes in inactive window

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -9,11 +9,18 @@ pub fn init(cx: &mut AppContext) {
 }
 
 fn focused(EditorFocused(editor): &EditorFocused, cx: &mut AppContext) {
+    if let Some(previously_active_editor) = Vim::read(cx).active_editor.clone() {
+        cx.update_window(previously_active_editor.window_id(), |cx| {
+            Vim::update(cx, |vim, cx| {
+                vim.update_active_editor(cx, |previously_active_editor, cx| {
+                    Vim::unhook_vim_settings(previously_active_editor, cx);
+                });
+            });
+        });
+    }
+
     cx.update_window(editor.window_id(), |cx| {
         Vim::update(cx, |vim, cx| {
-            vim.update_active_editor(cx, |previously_active_editor, cx| {
-                Vim::unhook_vim_settings(previously_active_editor, cx);
-            });
             vim.set_active_editor(editor.clone(), cx);
         });
     });


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-991/thread-main-panicked-at-update-called-with-id-of-window-that-does-not

After merging this, I'll cherry-pick this onto v0.84.x.