### PR TITLE
Trim eslint workspace configuration & remove diagnostic source underline

### DIFF
--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -188,35 +188,10 @@ impl LspAdapter for EsLintLspAdapter {
         Some(
             future::ready(json!({
                 "": {
-                      "validate": "on",
-                      "packageManager": "npm",
-                      "useESLintClass": false,
-                      "experimental": {
-                        "useFlatConfig": false
-                      },
-                      "codeActionOnSave": {
-                        "mode": "all"
-                      },
-                      "format": false,
-                      "quiet": false,
-                      "onIgnoredFiles": "off",
-                      "options": {},
-                      "rulesCustomizations": [],
-                      "run": "onType",
-                      "problems": {
-                        "shortenToSingleLine": false
-                      },
-                      "nodePath": null,
-                      "codeAction": {
-                        "disableRuleComment": {
-                          "enable": true,
-                          "location": "separateLine",
-                          "commentStyle": "line"
-                        },
-                        "showDocumentation": {
-                          "enable": true
-                        }
-                      }
+                    "validate": "on",
+                    "rulesCustomizations": [],
+                    "run": "onType",
+                    "nodePath": null,
                 }
             }))
             .boxed(),

--- a/styles/src/styleTree/hoverPopover.ts
+++ b/styles/src/styleTree/hoverPopover.ts
@@ -40,7 +40,7 @@ export default function HoverPopover(colorScheme: ColorScheme) {
             padding: { top: 4 },
         },
         prose: text(layer, "sans", { size: "sm" }),
-        diagnosticSourceHighlight: { underline: true, color: foreground(layer, "accent") },
+        diagnosticSourceHighlight: { color: foreground(layer, "accent") },
         highlight: colorScheme.ramps.neutral(0.5).alpha(0.2).hex(), // TODO: blend was used here. Replace with something better
     }
 }


### PR DESCRIPTION
The underline made it look like a link, especially with the new hover markdown rendering that is going to land soon

Closes https://linear.app/zed-industries/issue/Z-961/reduce-hardcoded-workspace-configuration-for-eslint-adapter