### PR TITLE
Move `debug_elements` to `AsyncAppContext`

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -43,6 +43,7 @@ use window_input_handler::WindowInputHandler;
 use crate::{
     elements::{AnyElement, AnyRootElement, RootElement},
     executor::{self, Task},
+    json,
     keymap_matcher::{self, Binding, KeymapContext, KeymapMatcher, Keystroke, MatchResult},
     platform::{
         self, FontSystem, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton,
@@ -307,6 +308,14 @@ impl AsyncAppContext {
         callback: F,
     ) -> Option<T> {
         self.0.borrow_mut().update_window(window_id, callback)
+    }
+
+    pub fn debug_elements(&self, window_id: usize) -> Option<json::Value> {
+        self.0.borrow().read_window(window_id, |cx| {
+            let root_view = cx.window.root_view();
+            let root_element = cx.window.rendered_views.get(&root_view.id())?;
+            root_element.debug(cx).log_err()
+        })?
     }
 
     pub fn dispatch_action(

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -1,7 +1,7 @@
 use crate::{
     elements::AnyRootElement,
     geometry::rect::RectF,
-    json::{self, ToJson},
+    json::ToJson,
     keymap_matcher::{Binding, Keystroke, MatchResult},
     platform::{
         self, Appearance, CursorStyle, Event, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent,
@@ -975,17 +975,6 @@ impl<'a> WindowContext<'a> {
             .flatten()
     }
 
-    pub fn debug_elements(&self) -> Option<json::Value> {
-        let view = self.window.root_view();
-        Some(json!({
-            "root_view": view.debug_json(self),
-            "root_element": self.window.rendered_views.get(&view.id())
-                .and_then(|root_element| {
-                    root_element.debug(self).log_err()
-                })
-        }))
-    }
-
     pub fn set_window_title(&mut self, title: &str) {
         self.window.platform_window.set_title(title);
     }
@@ -1454,13 +1443,7 @@ impl<V: View> Element<V> for ChildView {
     ) -> serde_json::Value {
         json!({
             "type": "ChildView",
-            "view_id": self.view_id,
             "bounds": bounds.to_json(),
-            "view": if let Some(view) = cx.views.get(&(cx.window_id, self.view_id))  {
-                view.debug_json(cx)
-            } else {
-                json!(null)
-            },
             "child": if let Some(element) = cx.window.rendered_views.get(&self.view_id) {
                 element.debug(&cx.window_context).log_err().unwrap_or_else(|| json!(null))
             } else {

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -45,7 +45,6 @@ use std::{
     mem,
     ops::{Deref, DerefMut, Range},
 };
-use util::ResultExt;
 
 pub trait Element<V: View>: 'static {
     type LayoutState;
@@ -714,63 +713,6 @@ impl<V: View> AnyRootElement for RootElement<V> {
 
     fn name(&self) -> Option<&str> {
         self.element.name()
-    }
-}
-
-impl<V: View, R: View> Element<V> for RootElement<R> {
-    type LayoutState = ();
-    type PaintState = ();
-
-    fn layout(
-        &mut self,
-        constraint: SizeConstraint,
-        _view: &mut V,
-        cx: &mut ViewContext<V>,
-    ) -> (Vector2F, ()) {
-        let size = AnyRootElement::layout(self, constraint, cx)
-            .log_err()
-            .unwrap_or_else(|| Vector2F::zero());
-        (size, ())
-    }
-
-    fn paint(
-        &mut self,
-        scene: &mut SceneBuilder,
-        bounds: RectF,
-        visible_bounds: RectF,
-        _layout: &mut Self::LayoutState,
-        _view: &mut V,
-        cx: &mut ViewContext<V>,
-    ) {
-        AnyRootElement::paint(self, scene, bounds.origin(), visible_bounds, cx).log_err();
-    }
-
-    fn rect_for_text_range(
-        &self,
-        range_utf16: Range<usize>,
-        _bounds: RectF,
-        _visible_bounds: RectF,
-        _layout: &Self::LayoutState,
-        _paint: &Self::PaintState,
-        _view: &V,
-        cx: &ViewContext<V>,
-    ) -> Option<RectF> {
-        AnyRootElement::rect_for_text_range(self, range_utf16, cx)
-            .log_err()
-            .flatten()
-    }
-
-    fn debug(
-        &self,
-        _bounds: RectF,
-        _layout: &Self::LayoutState,
-        _paint: &Self::PaintState,
-        _view: &V,
-        cx: &ViewContext<V>,
-    ) -> serde_json::Value {
-        AnyRootElement::debug(self, cx)
-            .log_err()
-            .unwrap_or_default()
     }
 }
 

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -708,7 +708,12 @@ impl<V: View> AnyRootElement for RootElement<V> {
             .ok_or_else(|| anyhow!("debug called on a root element for a dropped view"))?;
         let view = view.read(cx);
         let view_context = ViewContext::immutable(cx, self.view.id());
-        Ok(self.element.debug(view, &view_context))
+        Ok(serde_json::json!({
+            "view_id": self.view.id(),
+            "view_name": V::ui_name(),
+            "view": view.debug_json(cx),
+            "element": self.element.debug(view, &view_context)
+        }))
     }
 
     fn name(&self) -> Option<&str> {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -11,6 +11,7 @@ use collections::VecDeque;
 pub use editor;
 use editor::{Editor, MultiBuffer};
 
+use anyhow::anyhow;
 use feedback::{
     feedback_info_text::FeedbackInfoText, submit_feedback_button::SubmitFeedbackButton,
 };
@@ -215,9 +216,14 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut gpui::AppContext) {
         move |workspace: &mut Workspace, _: &DebugElements, cx: &mut ViewContext<Workspace>| {
             let app_state = workspace.app_state().clone();
             let markdown = app_state.languages.language_for_name("JSON");
-            let content = to_string_pretty(&cx.debug_elements()).unwrap();
+            let window_id = cx.window_id();
             cx.spawn(|workspace, mut cx| async move {
                 let markdown = markdown.await.log_err();
+                let content = to_string_pretty(
+                    &cx.debug_elements(window_id)
+                        .ok_or_else(|| anyhow!("could not debug elements for {window_id}"))?,
+                )
+                .unwrap();
                 workspace
                     .update(&mut cx, |workspace, cx| {
                         workspace.with_local_workspace(cx, move |workspace, cx| {


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1119/thread-main-panicked-at-circular-view-reference-for-type

Previously, `debug_elements` was available on `WindowContext`. If that method was called while having a borrow out to a view, it would panic because the view would already have been borrowed.

By moving it to an `AsyncAppContext` we ensure the method can't be called while a view is being used.