### PR TITLE
Fix broken styling in contact finder

### DIFF
--- a/crates/collab_ui/src/contact_finder.rs
+++ b/crates/collab_ui/src/contact_finder.rs
@@ -23,6 +23,7 @@ pub fn build_contact_finder(
         },
         cx,
     )
+    .with_theme(|theme| theme.contact_finder.picker.clone())
 }
 
 pub struct ContactFinderDelegate {


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1121/contact-finder-isnt-styled-anymore

This regressed as part of #2372, where we forgot to theme the contact finder picker differently from the rest of the app.