### PR TITLE
Show diagnostic source in more places

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -677,7 +677,7 @@ impl Item for ProjectDiagnosticsEditor {
 }
 
 fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
-    let (message, highlights) = highlight_diagnostic_message(&diagnostic.message);
+    let (message, highlights) = highlight_diagnostic_message(Vec::new(), &diagnostic.message);
     Arc::new(move |cx| {
         let settings = cx.global::<Settings>();
         let theme = &settings.theme.editor;

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -697,8 +697,18 @@ fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
                 icon.constrained()
                     .with_width(icon_width)
                     .aligned()
-                    .contained(),
+                    .contained()
+                    .with_margin_right(cx.gutter_padding),
             )
+            .with_children(diagnostic.source.as_ref().map(|source| {
+                Label::new(
+                    format!("{source}: "),
+                    style.source.label.clone().with_font_size(font_size),
+                )
+                .contained()
+                .with_style(style.message.container)
+                .aligned()
+            }))
             .with_child(
                 Label::new(
                     message.clone(),
@@ -707,7 +717,6 @@ fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
                 .with_highlights(highlights.clone())
                 .contained()
                 .with_style(style.message.container)
-                .with_margin_left(cx.gutter_padding)
                 .aligned(),
             )
             .with_children(diagnostic.code.clone().map(|code| {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -659,6 +659,7 @@ pub struct DiagnosticPathHeader {
 pub struct DiagnosticHeader {
     #[serde(flatten)]
     pub container: ContainerStyle,
+    pub source: ContainedLabel,
     pub message: ContainedLabel,
     pub code: ContainedText,
     pub text_scale_factor: f32,

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -176,6 +176,9 @@ export default function editor(colorScheme: ColorScheme) {
                     left: 10,
                 },
             },
+            source: {
+                text: text(colorScheme.middle, "sans", { size: "sm", weight: "bold", }),
+            },
             message: {
                 highlightText: text(colorScheme.middle, "sans", {
                     size: "sm",


### PR DESCRIPTION
Implements the final two locations, diagnostic panel excerpt headers and inline diagnostics

Closes https://linear.app/zed-industries/issue/Z-941/show-which-server-produced-a-diagnostic