### PR TITLE
Use json_post() request for update requests

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -273,7 +273,7 @@ impl AutoUpdater {
             telemetry,
         })?);
 
-        let mut response = client.get(&release.url, request_body, true).await?;
+        let mut response = client.post_json(&release.url, request_body, true).await?;
         smol::io::copy(response.body_mut(), &mut dmg_file).await?;
         log::info!("downloaded update. path:{:?}", dmg_path);
 

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -270,7 +270,7 @@ impl Telemetry {
                         }])?;
 
                         this.http_client
-                            .post_json(MIXPANEL_ENGAGE_URL, json_bytes.into())
+                            .post_json(MIXPANEL_ENGAGE_URL, json_bytes.into(), false)
                             .await?;
                         anyhow::Ok(())
                     }
@@ -404,7 +404,7 @@ impl Telemetry {
                         json_bytes.clear();
                         serde_json::to_writer(&mut json_bytes, &events)?;
                         this.http_client
-                            .post_json(MIXPANEL_EVENTS_URL, json_bytes.into())
+                            .post_json(MIXPANEL_EVENTS_URL, json_bytes.into(), false)
                             .await?;
                         anyhow::Ok(())
                     }
@@ -454,7 +454,7 @@ impl Telemetry {
                     }
 
                     this.http_client
-                        .post_json(CLICKHOUSE_EVENTS_URL.as_str(), json_bytes.into())
+                        .post_json(CLICKHOUSE_EVENTS_URL.as_str(), json_bytes.into(), false)
                         .await?;
                     anyhow::Ok(())
                 }

--- a/crates/util/src/http.rs
+++ b/crates/util/src/http.rs
@@ -40,8 +40,14 @@ pub trait HttpClient: Send + Sync {
         &'a self,
         uri: &str,
         body: AsyncBody,
+        follow_redirects: bool,
     ) -> BoxFuture<'a, Result<Response<AsyncBody>, Error>> {
         let request = isahc::Request::builder()
+            .redirect_policy(if follow_redirects {
+                RedirectPolicy::Follow
+            } else {
+                RedirectPolicy::None
+            })
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")


### PR DESCRIPTION
Previously, we were not sending up any data in the body, so the body didn't need to be deserialized on zed.dev.  Now that we are sending up data in the body, I want the body to be deserialized automatically so I can avoid having to put in code like this on zed.dev

```ts
if (typeof body === "string") {
    body = JSON.parse(body)
}
```