### PR TITLE
Fix panic when opening multiple definitions in a multibuffer

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5680,28 +5680,30 @@ impl Editor {
             }
         } else if !definitions.is_empty() {
             let replica_id = self.replica_id(cx);
-            let title = definitions
-                .iter()
-                .find(|definition| definition.origin.is_some())
-                .and_then(|definition| {
-                    definition.origin.as_ref().map(|origin| {
-                        let buffer = origin.buffer.read(cx);
-                        format!(
-                            "Definitions for {}",
-                            buffer
-                                .text_for_range(origin.range.clone())
-                                .collect::<String>()
-                        )
+            cx.window_context().defer(move |cx| {
+                let title = definitions
+                    .iter()
+                    .find(|definition| definition.origin.is_some())
+                    .and_then(|definition| {
+                        definition.origin.as_ref().map(|origin| {
+                            let buffer = origin.buffer.read(cx);
+                            format!(
+                                "Definitions for {}",
+                                buffer
+                                    .text_for_range(origin.range.clone())
+                                    .collect::<String>()
+                            )
+                        })
                     })
-                })
-                .unwrap_or("Definitions".to_owned());
-            let locations = definitions
-                .into_iter()
-                .map(|definition| definition.target)
-                .collect();
-            workspace.update(cx, |workspace, cx| {
-                Self::open_locations_in_multibuffer(workspace, locations, replica_id, title, cx)
-            })
+                    .unwrap_or("Definitions".to_owned());
+                let locations = definitions
+                    .into_iter()
+                    .map(|definition| definition.target)
+                    .collect();
+                workspace.update(cx, |workspace, cx| {
+                    Self::open_locations_in_multibuffer(workspace, locations, replica_id, title, cx)
+                });
+            });
         }
     }
 


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1177/thread-main-panicked-at-circular-view-reference-for-type-editoreditor

The editor is on the stack, so adding an item to the `Pane` containing the editor will cause a double borrow and a consequent panic. This pull request fixes the issue by deferring the opening of the definitions.