### PR TITLE
Determine view ancestry during layout

### DIFF
--- a/crates/collab/src/tests.rs
+++ b/crates/collab/src/tests.rs
@@ -462,8 +462,8 @@ impl TestClient {
         project: &ModelHandle<Project>,
         cx: &mut TestAppContext,
     ) -> ViewHandle<Workspace> {
-        let (_, root_view) = cx.add_window(|_| EmptyView);
-        cx.add_view(&root_view, |cx| Workspace::test_new(project.clone(), cx))
+        let (window_id, _) = cx.add_window(|_| EmptyView);
+        cx.add_view(window_id, |cx| Workspace::test_new(project.clone(), cx))
     }
 }
 

--- a/crates/collab/src/tests.rs
+++ b/crates/collab/src/tests.rs
@@ -12,7 +12,10 @@ use client::{
 use collections::{HashMap, HashSet};
 use fs::FakeFs;
 use futures::{channel::oneshot, StreamExt as _};
-use gpui::{executor::Deterministic, test::EmptyView, ModelHandle, TestAppContext, ViewHandle};
+use gpui::{
+    elements::*, executor::Deterministic, AnyElement, Entity, ModelHandle, TestAppContext, View,
+    ViewContext, ViewHandle, WeakViewHandle,
+};
 use language::LanguageRegistry;
 use parking_lot::Mutex;
 use project::{Project, WorktreeId};
@@ -462,8 +465,41 @@ impl TestClient {
         project: &ModelHandle<Project>,
         cx: &mut TestAppContext,
     ) -> ViewHandle<Workspace> {
-        let (window_id, _) = cx.add_window(|_| EmptyView);
-        cx.add_view(window_id, |cx| Workspace::test_new(project.clone(), cx))
+        struct WorkspaceContainer {
+            workspace: Option<WeakViewHandle<Workspace>>,
+        }
+
+        impl Entity for WorkspaceContainer {
+            type Event = ();
+        }
+
+        impl View for WorkspaceContainer {
+            fn ui_name() -> &'static str {
+                "WorkspaceContainer"
+            }
+
+            fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
+                if let Some(workspace) = self
+                    .workspace
+                    .as_ref()
+                    .and_then(|workspace| workspace.upgrade(cx))
+                {
+                    ChildView::new(&workspace, cx).into_any()
+                } else {
+                    Empty::new().into_any()
+                }
+            }
+        }
+
+        // We use a workspace container so that we don't need to remove the window in order to
+        // drop the workspace and we can use a ViewHandle instead.
+        let (window_id, container) = cx.add_window(|_| WorkspaceContainer { workspace: None });
+        let workspace = cx.add_view(window_id, |cx| Workspace::test_new(project.clone(), cx));
+        container.update(cx, |container, cx| {
+            container.workspace = Some(workspace.downgrade());
+            cx.notify();
+        });
+        workspace
     }
 }
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -1202,7 +1202,7 @@ async fn test_share_project(
     cx_c: &mut TestAppContext,
 ) {
     deterministic.forbid_parking();
-    let (_, window_b) = cx_b.add_window(|_| EmptyView);
+    let (window_b, _) = cx_b.add_window(|_| EmptyView);
     let mut server = TestServer::start(&deterministic).await;
     let client_a = server.create_client(cx_a, "user_a").await;
     let client_b = server.create_client(cx_b, "user_b").await;
@@ -1289,7 +1289,7 @@ async fn test_share_project(
         .await
         .unwrap();
 
-    let editor_b = cx_b.add_view(&window_b, |cx| Editor::for_buffer(buffer_b, None, cx));
+    let editor_b = cx_b.add_view(window_b, |cx| Editor::for_buffer(buffer_b, None, cx));
 
     // Client A sees client B's selection
     deterministic.run_until_parked();
@@ -3076,13 +3076,13 @@ async fn test_newline_above_or_below_does_not_move_guest_cursor(
         .update(cx_a, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
         .await
         .unwrap();
-    let (_, window_a) = cx_a.add_window(|_| EmptyView);
-    let editor_a = cx_a.add_view(&window_a, |cx| {
+    let (window_a, _) = cx_a.add_window(|_| EmptyView);
+    let editor_a = cx_a.add_view(window_a, |cx| {
         Editor::for_buffer(buffer_a, Some(project_a), cx)
     });
     let mut editor_cx_a = EditorTestContext {
         cx: cx_a,
-        window_id: window_a.id(),
+        window_id: window_a,
         editor: editor_a,
     };
 
@@ -3091,13 +3091,13 @@ async fn test_newline_above_or_below_does_not_move_guest_cursor(
         .update(cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
         .await
         .unwrap();
-    let (_, window_b) = cx_b.add_window(|_| EmptyView);
-    let editor_b = cx_b.add_view(&window_b, |cx| {
+    let (window_b, _) = cx_b.add_window(|_| EmptyView);
+    let editor_b = cx_b.add_view(window_b, |cx| {
         Editor::for_buffer(buffer_b, Some(project_b), cx)
     });
     let mut editor_cx_b = EditorTestContext {
         cx: cx_b,
-        window_id: window_b.id(),
+        window_id: window_b,
         editor: editor_b,
     };
 
@@ -3832,8 +3832,8 @@ async fn test_collaborating_with_completion(
         .update(cx_b, |p, cx| p.open_buffer((worktree_id, "main.rs"), cx))
         .await
         .unwrap();
-    let (_, window_b) = cx_b.add_window(|_| EmptyView);
-    let editor_b = cx_b.add_view(&window_b, |cx| {
+    let (window_b, _) = cx_b.add_window(|_| EmptyView);
+    let editor_b = cx_b.add_view(window_b, |cx| {
         Editor::for_buffer(buffer_b.clone(), Some(project_b.clone()), cx)
     });
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6804,13 +6804,10 @@ async fn test_peers_following_each_other(
     // Clients A and B follow each other in split panes
     workspace_a.update(cx_a, |workspace, cx| {
         workspace.split_pane(workspace.active_pane().clone(), SplitDirection::Right, cx);
-        let pane_a1 = pane_a1.clone();
-        cx.defer(move |workspace, _| {
-            assert_ne!(*workspace.active_pane(), pane_a1);
-        });
     });
     workspace_a
         .update(cx_a, |workspace, cx| {
+            assert_ne!(*workspace.active_pane(), pane_a1);
             let leader_id = *project_a.read(cx).collaborators().keys().next().unwrap();
             workspace.toggle_follow(leader_id, cx).unwrap()
         })
@@ -6818,13 +6815,10 @@ async fn test_peers_following_each_other(
         .unwrap();
     workspace_b.update(cx_b, |workspace, cx| {
         workspace.split_pane(workspace.active_pane().clone(), SplitDirection::Right, cx);
-        let pane_b1 = pane_b1.clone();
-        cx.defer(move |workspace, _| {
-            assert_ne!(*workspace.active_pane(), pane_b1);
-        });
     });
     workspace_b
         .update(cx_b, |workspace, cx| {
+            assert_ne!(*workspace.active_pane(), pane_b1);
             let leader_id = *project_b.read(cx).collaborators().keys().next().unwrap();
             workspace.toggle_follow(leader_id, cx).unwrap()
         })

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -14,8 +14,8 @@ use gpui::{
     geometry::{rect::RectF, vector::vec2f, PathBuilder},
     json::{self, ToJson},
     platform::{CursorStyle, MouseButton},
-    AppContext, Entity, ImageData, ModelHandle, SceneBuilder, Subscription, View, ViewContext,
-    ViewHandle, WeakViewHandle,
+    AppContext, Entity, ImageData, LayoutContext, ModelHandle, SceneBuilder, Subscription, View,
+    ViewContext, ViewHandle, WeakViewHandle,
 };
 use project::Project;
 use settings::Settings;
@@ -865,7 +865,7 @@ impl Element<CollabTitlebarItem> for AvatarRibbon {
         &mut self,
         constraint: gpui::SizeConstraint,
         _: &mut CollabTitlebarItem,
-        _: &mut ViewContext<CollabTitlebarItem>,
+        _: &mut LayoutContext<CollabTitlebarItem>,
     ) -> (gpui::geometry::vector::Vector2F, Self::LayoutState) {
         (constraint.max, ())
     }

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -165,6 +165,7 @@ impl CollabTitlebarItem {
             }),
         );
 
+        let view_id = cx.view_id();
         Self {
             workspace: workspace.weak_handle(),
             project,
@@ -172,7 +173,7 @@ impl CollabTitlebarItem {
             client,
             contacts_popover: None,
             user_menu: cx.add_view(|cx| {
-                let mut menu = ContextMenu::new(cx);
+                let mut menu = ContextMenu::new(view_id, cx);
                 menu.set_position_mode(OverlayPositionMode::Local);
                 menu
             }),

--- a/crates/collab_ui/src/face_pile.rs
+++ b/crates/collab_ui/src/face_pile.rs
@@ -7,7 +7,7 @@ use gpui::{
     },
     json::ToJson,
     serde_json::{self, json},
-    AnyElement, Axis, Element, SceneBuilder, ViewContext,
+    AnyElement, Axis, Element, LayoutContext, SceneBuilder, ViewContext,
 };
 
 use crate::CollabTitlebarItem;
@@ -34,7 +34,7 @@ impl Element<CollabTitlebarItem> for FacePile {
         &mut self,
         constraint: gpui::SizeConstraint,
         view: &mut CollabTitlebarItem,
-        cx: &mut ViewContext<CollabTitlebarItem>,
+        cx: &mut LayoutContext<CollabTitlebarItem>,
     ) -> (Vector2F, Self::LayoutState) {
         debug_assert!(constraint.max_along(Axis::Horizontal) == f32::INFINITY);
 

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -304,8 +304,8 @@ mod tests {
         });
 
         let project = Project::test(app_state.fs.clone(), [], cx).await;
-        let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
-        let editor = cx.add_view(&workspace, |cx| {
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+        let editor = cx.add_view(window_id, |cx| {
             let mut editor = Editor::single_line(None, cx);
             editor.set_text("abc", cx);
             editor

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -2,7 +2,7 @@ use collections::CommandPaletteFilter;
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     actions, elements::*, keymap_matcher::Keystroke, Action, AppContext, Element, MouseState,
-    ViewContext, WindowContext,
+    ViewContext,
 };
 use picker::{Picker, PickerDelegate, PickerEvent};
 use settings::Settings;
@@ -41,47 +41,17 @@ struct Command {
     keystrokes: Vec<Keystroke>,
 }
 
-fn toggle_command_palette(_: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
-    let workspace = cx.handle();
-    let focused_view_id = cx.focused_view_id().unwrap_or_else(|| workspace.id());
-
-    cx.window_context().defer(move |cx| {
-        // Build the delegate before the workspace is put on the stack so we can find it when
-        // computing the actions. We should really not allow available_actions to be called
-        // if it's not reliable however.
-        let delegate = CommandPaletteDelegate::new(focused_view_id, cx);
-        workspace.update(cx, |workspace, cx| {
-            workspace.toggle_modal(cx, |_, cx| cx.add_view(|cx| Picker::new(delegate, cx)));
-        })
+fn toggle_command_palette(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContext<Workspace>) {
+    let focused_view_id = cx.focused_view_id().unwrap_or_else(|| cx.view_id());
+    workspace.toggle_modal(cx, |_, cx| {
+        cx.add_view(|cx| Picker::new(CommandPaletteDelegate::new(focused_view_id), cx))
     });
 }
 
 impl CommandPaletteDelegate {
-    pub fn new(focused_view_id: usize, cx: &mut WindowContext) -> Self {
-        let actions = cx
-            .available_actions(focused_view_id)
-            .filter_map(|(name, action, bindings)| {
-                if cx.has_global::<CommandPaletteFilter>() {
-                    let filter = cx.global::<CommandPaletteFilter>();
-                    if filter.filtered_namespaces.contains(action.namespace()) {
-                        return None;
-                    }
-                }
-
-                Some(Command {
-                    name: humanize_action_name(name),
-                    action,
-                    keystrokes: bindings
-                        .iter()
-                        .map(|binding| binding.keystrokes())
-                        .last()
-                        .map_or(Vec::new(), |keystrokes| keystrokes.to_vec()),
-                })
-            })
-            .collect();
-
+    pub fn new(focused_view_id: usize) -> Self {
         Self {
-            actions,
+            actions: Default::default(),
             matches: vec![],
             selected_ix: 0,
             focused_view_id,
@@ -111,17 +81,46 @@ impl PickerDelegate for CommandPaletteDelegate {
         query: String,
         cx: &mut ViewContext<Picker<Self>>,
     ) -> gpui::Task<()> {
-        let candidates = self
-            .actions
-            .iter()
-            .enumerate()
-            .map(|(ix, command)| StringMatchCandidate {
-                id: ix,
-                string: command.name.to_string(),
-                char_bag: command.name.chars().collect(),
-            })
-            .collect::<Vec<_>>();
+        let window_id = cx.window_id();
+        let view_id = self.focused_view_id;
         cx.spawn(move |picker, mut cx| async move {
+            let actions = cx
+                .available_actions(window_id, view_id)
+                .into_iter()
+                .filter_map(|(name, action, bindings)| {
+                    let filtered = cx.read(|cx| {
+                        if cx.has_global::<CommandPaletteFilter>() {
+                            let filter = cx.global::<CommandPaletteFilter>();
+                            filter.filtered_namespaces.contains(action.namespace())
+                        } else {
+                            false
+                        }
+                    });
+
+                    if filtered {
+                        None
+                    } else {
+                        Some(Command {
+                            name: humanize_action_name(name),
+                            action,
+                            keystrokes: bindings
+                                .iter()
+                                .map(|binding| binding.keystrokes())
+                                .last()
+                                .map_or(Vec::new(), |keystrokes| keystrokes.to_vec()),
+                        })
+                    }
+                })
+                .collect::<Vec<_>>();
+            let candidates = actions
+                .iter()
+                .enumerate()
+                .map(|(ix, command)| StringMatchCandidate {
+                    id: ix,
+                    string: command.name.to_string(),
+                    char_bag: command.name.chars().collect(),
+                })
+                .collect::<Vec<_>>();
             let matches = if query.is_empty() {
                 candidates
                     .into_iter()
@@ -147,6 +146,7 @@ impl PickerDelegate for CommandPaletteDelegate {
             picker
                 .update(&mut cx, |picker, _| {
                     let delegate = picker.delegate_mut();
+                    delegate.actions = actions;
                     delegate.matches = matches;
                     if delegate.matches.is_empty() {
                         delegate.selected_ix = 0;

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -127,7 +127,7 @@ pub struct ContextMenu {
     visible: bool,
     previously_focused_view_id: Option<usize>,
     clicked: bool,
-    view_id: usize,
+    parent_view_id: usize,
     _actions_observation: Subscription,
 }
 
@@ -177,7 +177,7 @@ impl View for ContextMenu {
 }
 
 impl ContextMenu {
-    pub fn new(view_id: usize, cx: &mut ViewContext<Self>) -> Self {
+    pub fn new(parent_view_id: usize, cx: &mut ViewContext<Self>) -> Self {
         Self {
             show_count: 0,
             anchor_position: Default::default(),
@@ -188,7 +188,7 @@ impl ContextMenu {
             visible: Default::default(),
             previously_focused_view_id: Default::default(),
             clicked: false,
-            view_id,
+            parent_view_id,
             _actions_observation: cx.observe_actions(Self::action_dispatched),
         }
     }
@@ -224,7 +224,7 @@ impl ContextMenu {
                 match action {
                     ContextMenuItemAction::Action(action) => {
                         let window_id = cx.window_id();
-                        let view_id = self.view_id;
+                        let view_id = self.parent_view_id;
                         let action = action.boxed_clone();
                         cx.app_context()
                             .spawn(|mut cx| async move {
@@ -378,7 +378,7 @@ impl ContextMenu {
 
                                 match action {
                                     ContextMenuItemAction::Action(action) => KeystrokeLabel::new(
-                                        self.view_id,
+                                        self.parent_view_id,
                                         action.boxed_clone(),
                                         style.keystroke.container,
                                         style.keystroke.text.clone(),
@@ -418,7 +418,7 @@ impl ContextMenu {
                     match item {
                         ContextMenuItem::Item { label, action } => {
                             let action = action.clone();
-                            let view_id = self.view_id;
+                            let view_id = self.parent_view_id;
                             MouseEventHandler::<MenuItem, ContextMenu>::new(ix, cx, |state, _| {
                                 let style =
                                     style.item.style_for(state, Some(ix) == self.selected_index);

--- a/crates/context_menu/src/context_menu.rs
+++ b/crates/context_menu/src/context_menu.rs
@@ -127,7 +127,7 @@ pub struct ContextMenu {
     visible: bool,
     previously_focused_view_id: Option<usize>,
     clicked: bool,
-    parent_view_id: usize,
+    view_id: usize,
     _actions_observation: Subscription,
 }
 
@@ -178,9 +178,7 @@ impl View for ContextMenu {
 }
 
 impl ContextMenu {
-    pub fn new(cx: &mut ViewContext<Self>) -> Self {
-        let parent_view_id = cx.parent().unwrap();
-
+    pub fn new(view_id: usize, cx: &mut ViewContext<Self>) -> Self {
         Self {
             show_count: 0,
             anchor_position: Default::default(),
@@ -191,7 +189,7 @@ impl ContextMenu {
             visible: Default::default(),
             previously_focused_view_id: Default::default(),
             clicked: false,
-            parent_view_id,
+            view_id,
             _actions_observation: cx.observe_actions(Self::action_dispatched),
         }
     }
@@ -227,7 +225,7 @@ impl ContextMenu {
                 match action {
                     ContextMenuItemAction::Action(action) => {
                         let window_id = cx.window_id();
-                        let view_id = self.parent_view_id;
+                        let view_id = self.view_id;
                         let action = action.boxed_clone();
                         cx.app_context()
                             .spawn(|mut cx| async move {
@@ -381,7 +379,7 @@ impl ContextMenu {
 
                                 match action {
                                     ContextMenuItemAction::Action(action) => KeystrokeLabel::new(
-                                        self.parent_view_id,
+                                        self.view_id,
                                         action.boxed_clone(),
                                         style.keystroke.container,
                                         style.keystroke.text.clone(),
@@ -421,7 +419,7 @@ impl ContextMenu {
                     match item {
                         ContextMenuItem::Item { label, action } => {
                             let action = action.clone();
-                            let view_id = self.parent_view_id;
+                            let view_id = self.view_id;
                             MouseEventHandler::<MenuItem, ContextMenu>::new(ix, cx, |state, _| {
                                 let style =
                                     style.item.style_for(state, Some(ix) == self.selected_index);

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -142,8 +142,9 @@ impl View for CopilotButton {
 
 impl CopilotButton {
     pub fn new(cx: &mut ViewContext<Self>) -> Self {
+        let button_view_id = cx.view_id();
         let menu = cx.add_view(|cx| {
-            let mut menu = ContextMenu::new(cx);
+            let mut menu = ContextMenu::new(button_view_id, cx);
             menu.set_position_mode(OverlayPositionMode::Local);
             menu
         });

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -852,7 +852,7 @@ mod tests {
 
         let language_server_id = LanguageServerId(0);
         let project = Project::test(fs.clone(), ["/test".as_ref()], cx).await;
-        let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
 
         // Create some diagnostics
         project.update(cx, |project, cx| {
@@ -939,7 +939,7 @@ mod tests {
         });
 
         // Open the project diagnostics view while there are already diagnostics.
-        let view = cx.add_view(&workspace, |cx| {
+        let view = cx.add_view(window_id, |cx| {
             ProjectDiagnosticsEditor::new(project.clone(), workspace.downgrade(), cx)
         });
 
@@ -1244,9 +1244,9 @@ mod tests {
         let server_id_1 = LanguageServerId(100);
         let server_id_2 = LanguageServerId(101);
         let project = Project::test(fs.clone(), ["/test".as_ref()], cx).await;
-        let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
 
-        let view = cx.add_view(&workspace, |cx| {
+        let view = cx.add_view(window_id, |cx| {
             ProjectDiagnosticsEditor::new(project.clone(), workspace.downgrade(), cx)
         });
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1227,6 +1227,7 @@ impl Editor {
         get_field_editor_theme: Option<Arc<GetFieldEditorTheme>>,
         cx: &mut ViewContext<Self>,
     ) -> Self {
+        let editor_view_id = cx.view_id();
         let display_map = cx.add_model(|cx| {
             let settings = cx.global::<Settings>();
             let style = build_style(&*settings, get_field_editor_theme.as_deref(), None, cx);
@@ -1274,7 +1275,8 @@ impl Editor {
             background_highlights: Default::default(),
             nav_history: None,
             context_menu: None,
-            mouse_context_menu: cx.add_view(context_menu::ContextMenu::new),
+            mouse_context_menu: cx
+                .add_view(|cx| context_menu::ContextMenu::new(editor_view_id, cx)),
             completion_tasks: Default::default(),
             next_completion_id: 0,
             available_code_actions: Default::default(),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -493,9 +493,9 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
 
     let fs = FakeFs::new(cx.background());
     let project = Project::test(fs, [], cx).await;
-    let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project, cx));
+    let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project, cx));
     let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
-    cx.add_view(&pane, |cx| {
+    cx.add_view(window_id, |cx| {
         let buffer = MultiBuffer::build_simple(&sample_text(300, 5, 'a'), cx);
         let mut editor = build_editor(buffer.clone(), cx);
         let handle = cx.handle();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -30,8 +30,8 @@ use gpui::{
     json::{self, ToJson},
     platform::{CursorStyle, Modifiers, MouseButton, MouseButtonEvent, MouseMovedEvent},
     text_layout::{self, Line, RunStyle, TextLayoutCache},
-    AnyElement, Axis, Border, CursorRegion, Element, EventContext, MouseRegion, Quad, SceneBuilder,
-    SizeConstraint, ViewContext, WindowContext,
+    AnyElement, Axis, Border, CursorRegion, Element, EventContext, LayoutContext, MouseRegion,
+    Quad, SceneBuilder, SizeConstraint, ViewContext, WindowContext,
 };
 use itertools::Itertools;
 use json::json;
@@ -1388,7 +1388,7 @@ impl EditorElement {
         line_layouts: &[text_layout::Line],
         include_root: bool,
         editor: &mut Editor,
-        cx: &mut ViewContext<Editor>,
+        cx: &mut LayoutContext<Editor>,
     ) -> (f32, Vec<BlockLayout>) {
         let tooltip_style = cx.global::<Settings>().theme.tooltip.clone();
         let scroll_x = snapshot.scroll_anchor.offset.x();
@@ -1594,7 +1594,7 @@ impl Element<Editor> for EditorElement {
         &mut self,
         constraint: SizeConstraint,
         editor: &mut Editor,
-        cx: &mut ViewContext<Editor>,
+        cx: &mut LayoutContext<Editor>,
     ) -> (Vector2F, Self::LayoutState) {
         let mut size = constraint.max;
         if size.x().is_infinite() {
@@ -2565,10 +2565,18 @@ mod tests {
 
         let mut element = EditorElement::new(editor.read_with(cx, |editor, cx| editor.style(cx)));
         let (size, mut state) = editor.update(cx, |editor, cx| {
+            let mut new_parents = Default::default();
+            let mut notify_views_if_parents_change = Default::default();
+            let mut layout_cx = LayoutContext::new(
+                cx,
+                &mut new_parents,
+                &mut notify_views_if_parents_change,
+                false,
+            );
             element.layout(
                 SizeConstraint::new(vec2f(500., 500.), vec2f(500., 500.)),
                 editor,
-                cx,
+                &mut layout_cx,
             )
         });
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -25,6 +25,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use parking_lot::Mutex;
 use postage::oneshot;
+use smallvec::SmallVec;
 use smol::prelude::*;
 use util::ResultExt;
 use uuid::Uuid;
@@ -3198,7 +3199,7 @@ impl<V> BorrowWindowContext for ViewContext<'_, '_, V> {
 pub struct LayoutContext<'a, 'b, 'c, V: View> {
     view_context: &'c mut ViewContext<'a, 'b, V>,
     new_parents: &'c mut HashMap<usize, usize>,
-    views_to_notify_if_ancestors_change: &'c mut HashSet<usize>,
+    views_to_notify_if_ancestors_change: &'c mut HashMap<usize, SmallVec<[usize; 2]>>,
     pub refreshing: bool,
 }
 
@@ -3206,7 +3207,7 @@ impl<'a, 'b, 'c, V: View> LayoutContext<'a, 'b, 'c, V> {
     pub fn new(
         view_context: &'c mut ViewContext<'a, 'b, V>,
         new_parents: &'c mut HashMap<usize, usize>,
-        views_to_notify_if_ancestors_change: &'c mut HashSet<usize>,
+        views_to_notify_if_ancestors_change: &'c mut HashMap<usize, SmallVec<[usize; 2]>>,
         refreshing: bool,
     ) -> Self {
         Self {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2859,14 +2859,6 @@ impl<'a, 'b, V: View> ViewContext<'a, 'b, V> {
         self.window.focused_view_id == Some(self.view_id)
     }
 
-    pub fn is_parent_view_focused(&self) -> bool {
-        if let Some(parent_view_id) = self.ancestors(self.view_id).next().clone() {
-            self.focused_view_id() == Some(parent_view_id)
-        } else {
-            false
-        }
-    }
-
     pub fn focus_parent(&mut self) {
         let window_id = self.window_id;
         let view_id = self.view_id;

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2767,10 +2767,6 @@ impl<'a, 'b, V: View> ViewContext<'a, 'b, V> {
         WeakViewHandle::new(self.window_id, self.view_id)
     }
 
-    pub fn parent(&self) -> Option<usize> {
-        self.window_context.parent(self.view_id)
-    }
-
     pub fn window_id(&self) -> usize {
         self.window_id
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -5360,10 +5360,6 @@ mod tests {
             cx.focus(&view_2);
         });
 
-        cx.read_window(window_id, |cx| {
-            assert!(cx.is_child_focused(&view_1));
-            assert!(!cx.is_child_focused(&view_2));
-        });
         assert_eq!(
             mem::take(&mut *view_events.lock()),
             ["view 1 blurred", "view 2 focused"],
@@ -5377,10 +5373,6 @@ mod tests {
         );
 
         view_1.update(cx, |_, cx| cx.focus(&view_1));
-        cx.read_window(window_id, |cx| {
-            assert!(!cx.is_child_focused(&view_1));
-            assert!(!cx.is_child_focused(&view_2));
-        });
         assert_eq!(
             mem::take(&mut *view_events.lock()),
             ["view 2 blurred", "view 1 focused"],

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2833,16 +2833,6 @@ impl<'a, 'b, V: View> ViewContext<'a, 'b, V> {
         }
     }
 
-    pub fn is_child(&self, view: impl Into<AnyViewHandle>) -> bool {
-        let view = view.into();
-        if self.window_id != view.window_id {
-            return false;
-        }
-        self.ancestors(view.view_id)
-            .skip(1) // Skip self id
-            .any(|parent| parent == self.view_id)
-    }
-
     pub fn blur(&mut self) {
         let window_id = self.window_id;
         self.window_context.focus(window_id, None);

--- a/crates/gpui/src/app/menu.rs
+++ b/crates/gpui/src/app/menu.rs
@@ -81,7 +81,7 @@ pub(crate) fn setup_menu_handlers(foreground_platform: &dyn ForegroundPlatform, 
                 let dispatched = cx
                     .update_window(main_window_id, |cx| {
                         if let Some(view_id) = cx.focused_view_id() {
-                            cx.handle_dispatch_action_from_effect(Some(view_id), action);
+                            cx.dispatch_action(Some(view_id), action);
                             true
                         } else {
                             false

--- a/crates/gpui/src/app/test_app_context.rs
+++ b/crates/gpui/src/app/test_app_context.rs
@@ -4,9 +4,9 @@ use crate::{
     keymap_matcher::Keystroke,
     platform,
     platform::{Event, InputHandler, KeyDownEvent, Platform},
-    Action, AnyViewHandle, AppContext, BorrowAppContext, BorrowWindowContext, Entity, FontCache,
-    Handle, ModelContext, ModelHandle, Subscription, Task, View, ViewContext, ViewHandle,
-    WeakHandle, WindowContext,
+    Action, AppContext, BorrowAppContext, BorrowWindowContext, Entity, FontCache, Handle,
+    ModelContext, ModelHandle, Subscription, Task, View, ViewContext, ViewHandle, WeakHandle,
+    WindowContext,
 };
 use collections::BTreeMap;
 use futures::Future;
@@ -75,7 +75,7 @@ impl TestAppContext {
         self.cx
             .borrow_mut()
             .update_window(window_id, |window| {
-                window.handle_dispatch_action_from_effect(window.focused_view_id(), &action);
+                window.dispatch_action(window.focused_view_id(), &action);
             })
             .expect("window not found");
     }
@@ -153,12 +153,13 @@ impl TestAppContext {
         (window_id, view)
     }
 
-    pub fn add_view<T, F>(&mut self, parent_handle: &AnyViewHandle, build_view: F) -> ViewHandle<T>
+    pub fn add_view<T, F>(&mut self, window_id: usize, build_view: F) -> ViewHandle<T>
     where
         T: View,
         F: FnOnce(&mut ViewContext<T>) -> T,
     {
-        self.cx.borrow_mut().add_view(parent_handle, build_view)
+        self.update_window(window_id, |cx| cx.add_view(build_view))
+            .expect("window not found")
     }
 
     pub fn observe_global<E, F>(&mut self, callback: F) -> Subscription

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -449,7 +449,7 @@ impl<'a> WindowContext<'a> {
             })
     }
 
-    pub fn dispatch_keystroke(&mut self, keystroke: &Keystroke) -> bool {
+    pub(crate) fn dispatch_keystroke(&mut self, keystroke: &Keystroke) -> bool {
         let window_id = self.window_id;
         if let Some(focused_view_id) = self.focused_view_id() {
             let dispatch_path = self

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -1085,16 +1085,6 @@ impl<'a> WindowContext<'a> {
         self.window.focused_view_id
     }
 
-    pub fn is_child_focused(&self, view: &AnyViewHandle) -> bool {
-        if let Some(focused_view_id) = self.focused_view_id() {
-            self.ancestors(focused_view_id)
-                .skip(1) // Skip self id
-                .any(|parent| parent == view.view_id)
-        } else {
-            false
-        }
-    }
-
     pub fn window_bounds(&self) -> WindowBounds {
         self.window.platform_window.bounds()
     }

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -1073,16 +1073,6 @@ impl<'a> WindowContext<'a> {
             }))
     }
 
-    /// Returns the id of the parent of the given view, or none if the given
-    /// view is the root.
-    pub(crate) fn parent(&self, view_id: usize) -> Option<usize> {
-        if let Some(view_id) = self.window.parents.get(&view_id) {
-            Some(*view_id)
-        } else {
-            None
-        }
-    }
-
     // Traverses the parent tree. Walks down the tree toward the passed
     // view calling visit with true. Then walks back up the tree calling visit with false.
     // If `visit` returns false this function will immediately return.

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -1003,7 +1003,6 @@ impl<'a> WindowContext<'a> {
         if let Some(view_id) = view_id {
             self.halt_action_dispatch = false;
             self.visit_dispatch_path(view_id, |view_id, capture_phase, cx| {
-                dbg!(view_id);
                 cx.update_any_view(view_id, |view, cx| {
                     let type_id = view.as_any().type_id();
                     if let Some((name, mut handlers)) = cx

--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -457,7 +457,7 @@ impl<'a> WindowContext<'a> {
         }
     }
 
-    pub fn dispatch_event(&mut self, event: Event, event_reused: bool) -> bool {
+    pub(crate) fn dispatch_event(&mut self, event: Event, event_reused: bool) -> bool {
         let mut mouse_events = SmallVec::<[_; 2]>::new();
         let mut notified_views: HashSet<usize> = Default::default();
         let window_id = self.window_id;
@@ -793,7 +793,7 @@ impl<'a> WindowContext<'a> {
         any_event_handled
     }
 
-    pub fn dispatch_key_down(&mut self, event: &KeyDownEvent) -> bool {
+    pub(crate) fn dispatch_key_down(&mut self, event: &KeyDownEvent) -> bool {
         let window_id = self.window_id;
         if let Some(focused_view_id) = self.window.focused_view_id {
             for view_id in self.ancestors(focused_view_id).collect::<Vec<_>>() {
@@ -812,7 +812,7 @@ impl<'a> WindowContext<'a> {
         false
     }
 
-    pub fn dispatch_key_up(&mut self, event: &KeyUpEvent) -> bool {
+    pub(crate) fn dispatch_key_up(&mut self, event: &KeyUpEvent) -> bool {
         let window_id = self.window_id;
         if let Some(focused_view_id) = self.window.focused_view_id {
             for view_id in self.ancestors(focused_view_id).collect::<Vec<_>>() {
@@ -831,7 +831,7 @@ impl<'a> WindowContext<'a> {
         false
     }
 
-    pub fn dispatch_modifiers_changed(&mut self, event: &ModifiersChangedEvent) -> bool {
+    pub(crate) fn dispatch_modifiers_changed(&mut self, event: &ModifiersChangedEvent) -> bool {
         let window_id = self.window_id;
         if let Some(focused_view_id) = self.window.focused_view_id {
             for view_id in self.ancestors(focused_view_id).collect::<Vec<_>>() {

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -33,9 +33,11 @@ use crate::{
         rect::RectF,
         vector::{vec2f, Vector2F},
     },
-    json, Action, SceneBuilder, SizeConstraint, View, ViewContext, WeakViewHandle, WindowContext,
+    json, Action, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext, WeakViewHandle,
+    WindowContext,
 };
 use anyhow::{anyhow, Result};
+use collections::{HashMap, HashSet};
 use core::panic;
 use json::ToJson;
 use std::{
@@ -54,7 +56,7 @@ pub trait Element<V: View>: 'static {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState);
 
     fn paint(
@@ -211,7 +213,7 @@ trait AnyElementState<V: View> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> Vector2F;
 
     fn paint(
@@ -263,7 +265,7 @@ impl<V: View, E: Element<V>> AnyElementState<V> for ElementState<V, E> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> Vector2F {
         let result;
         *self = match mem::take(self) {
@@ -444,7 +446,7 @@ impl<V: View> AnyElement<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> Vector2F {
         self.state.layout(constraint, view, cx)
     }
@@ -505,7 +507,7 @@ impl<V: View> Element<V> for AnyElement<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let size = self.layout(constraint, view, cx);
         (size, ())
@@ -597,7 +599,7 @@ impl<V: View, C: Component<V>> Element<V> for ComponentHost<V, C> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, AnyElement<V>) {
         let mut element = self.component.render(view, cx);
         let size = element.layout(constraint, view, cx);
@@ -642,7 +644,14 @@ impl<V: View, C: Component<V>> Element<V> for ComponentHost<V, C> {
 }
 
 pub trait AnyRootElement {
-    fn layout(&mut self, constraint: SizeConstraint, cx: &mut WindowContext) -> Result<Vector2F>;
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        new_parents: &mut HashMap<usize, usize>,
+        views_to_notify_if_ancestors_change: &mut HashSet<usize>,
+        refreshing: bool,
+        cx: &mut WindowContext,
+    ) -> Result<Vector2F>;
     fn paint(
         &mut self,
         scene: &mut SceneBuilder,
@@ -660,12 +669,27 @@ pub trait AnyRootElement {
 }
 
 impl<V: View> AnyRootElement for RootElement<V> {
-    fn layout(&mut self, constraint: SizeConstraint, cx: &mut WindowContext) -> Result<Vector2F> {
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        new_parents: &mut HashMap<usize, usize>,
+        views_to_notify_if_ancestors_change: &mut HashSet<usize>,
+        refreshing: bool,
+        cx: &mut WindowContext,
+    ) -> Result<Vector2F> {
         let view = self
             .view
             .upgrade(cx)
             .ok_or_else(|| anyhow!("layout called on a root element for a dropped view"))?;
-        view.update(cx, |view, cx| Ok(self.element.layout(constraint, view, cx)))
+        view.update(cx, |view, cx| {
+            let mut cx = LayoutContext::new(
+                cx,
+                new_parents,
+                views_to_notify_if_ancestors_change,
+                refreshing,
+            );
+            Ok(self.element.layout(constraint, view, &mut cx))
+        })
     }
 
     fn paint(

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -37,9 +37,10 @@ use crate::{
     WindowContext,
 };
 use anyhow::{anyhow, Result};
-use collections::{HashMap, HashSet};
+use collections::HashMap;
 use core::panic;
 use json::ToJson;
+use smallvec::SmallVec;
 use std::{
     any::Any,
     borrow::Cow,
@@ -648,7 +649,7 @@ pub trait AnyRootElement {
         &mut self,
         constraint: SizeConstraint,
         new_parents: &mut HashMap<usize, usize>,
-        views_to_notify_if_ancestors_change: &mut HashSet<usize>,
+        views_to_notify_if_ancestors_change: &mut HashMap<usize, SmallVec<[usize; 2]>>,
         refreshing: bool,
         cx: &mut WindowContext,
     ) -> Result<Vector2F>;
@@ -673,7 +674,7 @@ impl<V: View> AnyRootElement for RootElement<V> {
         &mut self,
         constraint: SizeConstraint,
         new_parents: &mut HashMap<usize, usize>,
-        views_to_notify_if_ancestors_change: &mut HashSet<usize>,
+        views_to_notify_if_ancestors_change: &mut HashMap<usize, SmallVec<[usize; 2]>>,
         refreshing: bool,
         cx: &mut WindowContext,
     ) -> Result<Vector2F> {

--- a/crates/gpui/src/elements/align.rs
+++ b/crates/gpui/src/elements/align.rs
@@ -1,6 +1,6 @@
 use crate::{
     geometry::{rect::RectF, vector::Vector2F},
-    json, AnyElement, Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    json, AnyElement, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 use json::ToJson;
 
@@ -48,7 +48,7 @@ impl<V: View> Element<V> for Align<V> {
         &mut self,
         mut constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let mut size = constraint.max;
         constraint.min = Vector2F::zero();

--- a/crates/gpui/src/elements/canvas.rs
+++ b/crates/gpui/src/elements/canvas.rs
@@ -34,7 +34,7 @@ where
         &mut self,
         constraint: crate::SizeConstraint,
         _: &mut V,
-        _: &mut crate::ViewContext<V>,
+        _: &mut crate::LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let x = if constraint.max.x().is_finite() {
             constraint.max.x()

--- a/crates/gpui/src/elements/clipped.rs
+++ b/crates/gpui/src/elements/clipped.rs
@@ -3,7 +3,9 @@ use std::ops::Range;
 use pathfinder_geometry::{rect::RectF, vector::Vector2F};
 use serde_json::json;
 
-use crate::{json, AnyElement, Element, SceneBuilder, SizeConstraint, View, ViewContext};
+use crate::{
+    json, AnyElement, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
+};
 
 pub struct Clipped<V: View> {
     child: AnyElement<V>,
@@ -23,7 +25,7 @@ impl<V: View> Element<V> for Clipped<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         (self.child.layout(constraint, view, cx), ())
     }

--- a/crates/gpui/src/elements/container.rs
+++ b/crates/gpui/src/elements/container.rs
@@ -10,7 +10,7 @@ use crate::{
     json::ToJson,
     platform::CursorStyle,
     scene::{self, Border, CursorRegion, Quad},
-    AnyElement, Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    AnyElement, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -192,7 +192,7 @@ impl<V: View> Element<V> for Container<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let mut size_buffer = self.margin_size() + self.padding_size();
         if !self.style.border.overlay {

--- a/crates/gpui/src/elements/empty.rs
+++ b/crates/gpui/src/elements/empty.rs
@@ -6,7 +6,7 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     json::{json, ToJson},
-    SceneBuilder, View, ViewContext,
+    LayoutContext, SceneBuilder, View, ViewContext,
 };
 use crate::{Element, SizeConstraint};
 
@@ -34,7 +34,7 @@ impl<V: View> Element<V> for Empty {
         &mut self,
         constraint: SizeConstraint,
         _: &mut V,
-        _: &mut ViewContext<V>,
+        _: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let x = if constraint.max.x().is_finite() && !self.collapsed {
             constraint.max.x()

--- a/crates/gpui/src/elements/expanded.rs
+++ b/crates/gpui/src/elements/expanded.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use crate::{
     geometry::{rect::RectF, vector::Vector2F},
-    json, AnyElement, Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    json, AnyElement, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 use serde_json::json;
 
@@ -42,7 +42,7 @@ impl<V: View> Element<V> for Expanded<V> {
         &mut self,
         mut constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         if self.full_width {
             constraint.min.set_x(constraint.max.x());

--- a/crates/gpui/src/elements/flex.rs
+++ b/crates/gpui/src/elements/flex.rs
@@ -2,8 +2,8 @@ use std::{any::Any, cell::Cell, f32::INFINITY, ops::Range, rc::Rc};
 
 use crate::{
     json::{self, ToJson, Value},
-    AnyElement, Axis, Element, ElementStateHandle, SceneBuilder, SizeConstraint, Vector2FExt, View,
-    ViewContext,
+    AnyElement, Axis, Element, ElementStateHandle, LayoutContext, SceneBuilder, SizeConstraint,
+    Vector2FExt, View, ViewContext,
 };
 use pathfinder_geometry::{
     rect::RectF,
@@ -74,7 +74,7 @@ impl<V: View> Flex<V> {
         remaining_flex: &mut f32,
         cross_axis_max: &mut f32,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) {
         let cross_axis = self.axis.invert();
         for child in &mut self.children {
@@ -125,7 +125,7 @@ impl<V: View> Element<V> for Flex<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let mut total_flex = None;
         let mut fixed_space = 0.0;
@@ -214,7 +214,7 @@ impl<V: View> Element<V> for Flex<V> {
         }
 
         if let Some(scroll_state) = self.scroll_state.as_ref() {
-            scroll_state.0.update(cx, |scroll_state, _| {
+            scroll_state.0.update(cx.view_context(), |scroll_state, _| {
                 if let Some(scroll_to) = scroll_state.scroll_to.take() {
                     let visible_start = scroll_state.scroll_position.get();
                     let visible_end = visible_start + size.along(self.axis);
@@ -432,7 +432,7 @@ impl<V: View> Element<V> for FlexItem<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let size = self.child.layout(constraint, view, cx);
         (size, ())

--- a/crates/gpui/src/elements/hook.rs
+++ b/crates/gpui/src/elements/hook.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::{
     geometry::{rect::RectF, vector::Vector2F},
     json::json,
-    AnyElement, Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    AnyElement, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 
 pub struct Hook<V: View> {
@@ -36,7 +36,7 @@ impl<V: View> Element<V> for Hook<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let size = self.child.layout(constraint, view, cx);
         if let Some(handler) = self.after_layout.as_mut() {

--- a/crates/gpui/src/elements/image.rs
+++ b/crates/gpui/src/elements/image.rs
@@ -5,7 +5,8 @@ use crate::{
         vector::{vec2f, Vector2F},
     },
     json::{json, ToJson},
-    scene, Border, Element, ImageData, SceneBuilder, SizeConstraint, View, ViewContext,
+    scene, Border, Element, ImageData, LayoutContext, SceneBuilder, SizeConstraint, View,
+    ViewContext,
 };
 use serde::Deserialize;
 use std::{ops::Range, sync::Arc};
@@ -63,7 +64,7 @@ impl<V: View> Element<V> for Image {
         &mut self,
         constraint: SizeConstraint,
         _: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let data = match &self.source {
             ImageSource::Path(path) => match cx.asset_cache.png(path) {

--- a/crates/gpui/src/elements/keystroke_label.rs
+++ b/crates/gpui/src/elements/keystroke_label.rs
@@ -42,7 +42,7 @@ impl<V: View> Element<V> for KeystrokeLabel {
         cx: &mut LayoutContext<V>,
     ) -> (Vector2F, AnyElement<V>) {
         let mut element = if let Some(keystrokes) =
-            cx.keystrokes_for_action(self.view_id, self.action.as_ref())
+            cx.keystrokes_for_action(view, self.view_id, self.action.as_ref())
         {
             Flex::row()
                 .with_children(keystrokes.iter().map(|keystroke| {

--- a/crates/gpui/src/elements/keystroke_label.rs
+++ b/crates/gpui/src/elements/keystroke_label.rs
@@ -39,7 +39,7 @@ impl<V: View> Element<V> for KeystrokeLabel {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, AnyElement<V>) {
         let mut element = if let Some(keystrokes) =
             cx.keystrokes_for_action(self.view_id, self.action.as_ref())

--- a/crates/gpui/src/elements/label.rs
+++ b/crates/gpui/src/elements/label.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     json::{ToJson, Value},
     text_layout::{Line, RunStyle},
-    Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -135,7 +135,7 @@ impl<V: View> Element<V> for Label {
         &mut self,
         constraint: SizeConstraint,
         _: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let runs = self.compute_runs();
         let line = cx.text_layout_cache().layout_str(

--- a/crates/gpui/src/elements/mouse_event_handler.rs
+++ b/crates/gpui/src/elements/mouse_event_handler.rs
@@ -10,8 +10,8 @@ use crate::{
         CursorRegion, HandlerSet, MouseClick, MouseDown, MouseDownOut, MouseDrag, MouseHover,
         MouseMove, MouseMoveOut, MouseScrollWheel, MouseUp, MouseUpOut,
     },
-    AnyElement, Element, EventContext, MouseRegion, MouseState, SceneBuilder, SizeConstraint, View,
-    ViewContext,
+    AnyElement, Element, EventContext, LayoutContext, MouseRegion, MouseState, SceneBuilder,
+    SizeConstraint, View, ViewContext,
 };
 use serde_json::json;
 use std::{marker::PhantomData, ops::Range};
@@ -220,7 +220,7 @@ impl<Tag, V: View> Element<V> for MouseEventHandler<Tag, V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         (self.child.layout(constraint, view, cx), ())
     }

--- a/crates/gpui/src/elements/overlay.rs
+++ b/crates/gpui/src/elements/overlay.rs
@@ -3,7 +3,8 @@ use std::ops::Range;
 use crate::{
     geometry::{rect::RectF, vector::Vector2F},
     json::ToJson,
-    AnyElement, Axis, Element, MouseRegion, SceneBuilder, SizeConstraint, View, ViewContext,
+    AnyElement, Axis, Element, LayoutContext, MouseRegion, SceneBuilder, SizeConstraint, View,
+    ViewContext,
 };
 use serde_json::json;
 
@@ -124,7 +125,7 @@ impl<V: View> Element<V> for Overlay<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let constraint = if self.anchor_position.is_some() {
             SizeConstraint::new(Vector2F::zero(), cx.window_size())

--- a/crates/gpui/src/elements/resizable.rs
+++ b/crates/gpui/src/elements/resizable.rs
@@ -7,7 +7,8 @@ use crate::{
     geometry::rect::RectF,
     platform::{CursorStyle, MouseButton},
     scene::MouseDrag,
-    AnyElement, Axis, Element, ElementStateHandle, MouseRegion, SceneBuilder, View, ViewContext,
+    AnyElement, Axis, Element, ElementStateHandle, LayoutContext, MouseRegion, SceneBuilder, View,
+    ViewContext,
 };
 
 use super::{ConstrainedBox, Hook};
@@ -139,7 +140,7 @@ impl<V: View> Element<V> for Resizable<V> {
         &mut self,
         constraint: crate::SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         (self.child.layout(constraint, view, cx), ())
     }

--- a/crates/gpui/src/elements/stack.rs
+++ b/crates/gpui/src/elements/stack.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::{
     geometry::{rect::RectF, vector::Vector2F},
     json::{self, json, ToJson},
-    AnyElement, Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    AnyElement, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 
 /// Element which renders it's children in a stack on top of each other.
@@ -34,7 +34,7 @@ impl<V: View> Element<V> for Stack<V> {
         &mut self,
         mut constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let mut size = constraint.min;
         let mut children = self.children.iter_mut();

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -8,7 +8,7 @@ use crate::{
         rect::RectF,
         vector::{vec2f, Vector2F},
     },
-    scene, Element, SceneBuilder, SizeConstraint, View, ViewContext,
+    scene, Element, LayoutContext, SceneBuilder, SizeConstraint, View, ViewContext,
 };
 
 pub struct Svg {
@@ -38,7 +38,7 @@ impl<V: View> Element<V> for Svg {
         &mut self,
         constraint: SizeConstraint,
         _: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         match cx.asset_cache.svg(&self.path) {
             Ok(tree) => {

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -7,8 +7,8 @@ use crate::{
     },
     json::{ToJson, Value},
     text_layout::{Line, RunStyle, ShapedBoundary},
-    AppContext, Element, FontCache, SceneBuilder, SizeConstraint, TextLayoutCache, View,
-    ViewContext,
+    AppContext, Element, FontCache, LayoutContext, SceneBuilder, SizeConstraint, TextLayoutCache,
+    View, ViewContext,
 };
 use log::warn;
 use serde_json::json;
@@ -78,7 +78,7 @@ impl<V: View> Element<V> for Text {
         &mut self,
         constraint: SizeConstraint,
         _: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         // Convert the string and highlight ranges into an iterator of highlighted chunks.
 
@@ -411,10 +411,18 @@ mod tests {
             let mut view = TestView;
             fonts::with_font_cache(cx.font_cache().clone(), || {
                 let mut text = Text::new("Hello\r\n", Default::default()).with_soft_wrap(true);
+                let mut new_parents = Default::default();
+                let mut notify_views_if_parents_change = Default::default();
+                let mut layout_cx = LayoutContext::new(
+                    cx,
+                    &mut new_parents,
+                    &mut notify_views_if_parents_change,
+                    false,
+                );
                 let (_, state) = text.layout(
                     SizeConstraint::new(Default::default(), vec2f(f32::INFINITY, f32::INFINITY)),
                     &mut view,
-                    cx,
+                    &mut layout_cx,
                 );
                 assert_eq!(state.shaped_lines.len(), 2);
                 assert_eq!(state.wrap_boundaries.len(), 2);

--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -6,7 +6,8 @@ use crate::{
     fonts::TextStyle,
     geometry::{rect::RectF, vector::Vector2F},
     json::json,
-    Action, Axis, ElementStateHandle, SceneBuilder, SizeConstraint, Task, View, ViewContext,
+    Action, Axis, ElementStateHandle, LayoutContext, SceneBuilder, SizeConstraint, Task, View,
+    ViewContext,
 };
 use serde::Deserialize;
 use std::{
@@ -172,7 +173,7 @@ impl<V: View> Element<V> for Tooltip<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let size = self.child.layout(constraint, view, cx);
         if let Some(tooltip) = self.tooltip.as_mut() {

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     json::{self, json},
     platform::ScrollWheelEvent,
-    AnyElement, MouseRegion, SceneBuilder, View, ViewContext,
+    AnyElement, LayoutContext, MouseRegion, SceneBuilder, View, ViewContext,
 };
 use json::ToJson;
 use std::{cell::RefCell, cmp, ops::Range, rc::Rc};
@@ -159,7 +159,7 @@ impl<V: View> Element<V> for UniformList<V> {
         &mut self,
         constraint: SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         if constraint.max.y().is_infinite() {
             unimplemented!(

--- a/crates/gpui/src/keymap_matcher/binding.rs
+++ b/crates/gpui/src/keymap_matcher/binding.rs
@@ -11,6 +11,16 @@ pub struct Binding {
     context_predicate: Option<KeymapContextPredicate>,
 }
 
+impl Clone for Binding {
+    fn clone(&self) -> Self {
+        Self {
+            action: self.action.boxed_clone(),
+            keystrokes: self.keystrokes.clone(),
+            context_predicate: self.context_predicate.clone(),
+        }
+    }
+}
+
 impl Binding {
     pub fn new<A: Action>(keystrokes: &str, action: A, context: Option<&str>) -> Self {
         Self::load(keystrokes, Box::new(action), context).unwrap()

--- a/crates/gpui/src/keymap_matcher/keymap_context.rs
+++ b/crates/gpui/src/keymap_matcher/keymap_context.rs
@@ -39,7 +39,7 @@ impl KeymapContext {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum KeymapContextPredicate {
     Identifier(String),
     Equal(String, String),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -196,6 +196,7 @@ impl ProjectPanel {
             })
             .detach();
 
+            let view_id = cx.view_id();
             let mut this = Self {
                 project: project.clone(),
                 list: Default::default(),
@@ -206,7 +207,7 @@ impl ProjectPanel {
                 edit_state: None,
                 filename_editor,
                 clipboard_entry: None,
-                context_menu: cx.add_view(ContextMenu::new),
+                context_menu: cx.add_view(|cx| ContextMenu::new(view_id, cx)),
                 dragged_entry_destination: None,
                 workspace: workspace.weak_handle(),
             };

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -318,10 +318,10 @@ mod tests {
             },
         );
 
-        let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
 
         // Create the project symbols view.
-        let symbols = cx.add_view(&workspace, |cx| {
+        let symbols = cx.add_view(window_id, |cx| {
             ProjectSymbols::new(
                 ProjectSymbolsDelegate::new(workspace.downgrade(), project.clone()),
                 cx,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -670,13 +670,11 @@ mod tests {
                 cx,
             )
         });
-        let (_, root_view) = cx.add_window(|_| EmptyView);
+        let (window_id, _root_view) = cx.add_window(|_| EmptyView);
 
-        let editor = cx.add_view(&root_view, |cx| {
-            Editor::for_buffer(buffer.clone(), None, cx)
-        });
+        let editor = cx.add_view(window_id, |cx| Editor::for_buffer(buffer.clone(), None, cx));
 
-        let search_bar = cx.add_view(&root_view, |cx| {
+        let search_bar = cx.add_view(window_id, |cx| {
             let mut search_bar = BufferSearchBar::new(cx);
             search_bar.set_active_pane_item(Some(&editor), cx);
             search_bar.show(false, true, cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -200,7 +200,7 @@ impl View for ProjectSearchView {
                     .flex(1., true)
             })
             .on_down(MouseButton::Left, |_, _, cx| {
-                cx.focus_parent_view();
+                cx.focus_parent();
             })
             .into_any_named("project search view")
         } else {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -939,8 +939,6 @@ impl ToolbarItemView for ProjectSearchBar {
         self.subscription = None;
         self.active_project_search = None;
         if let Some(search) = active_pane_item.and_then(|i| i.downcast::<ProjectSearchView>()) {
-            let query_editor = search.read(cx).query_editor.clone();
-            cx.reparent(&query_editor);
             self.subscription = Some(cx.observe(&search, |_, _, cx| cx.notify()));
             self.active_project_search = Some(search);
             ToolbarItemLocation::PrimaryLeft {

--- a/crates/terminal_view/src/terminal_button.rs
+++ b/crates/terminal_view/src/terminal_button.rs
@@ -107,11 +107,12 @@ impl View for TerminalButton {
 
 impl TerminalButton {
     pub fn new(workspace: ViewHandle<Workspace>, cx: &mut ViewContext<Self>) -> Self {
+        let button_view_id = cx.view_id();
         cx.observe(&workspace, |_, _, cx| cx.notify()).detach();
         Self {
             workspace: workspace.downgrade(),
             popup_menu: cx.add_view(|cx| {
-                let mut menu = ContextMenu::new(cx);
+                let mut menu = ContextMenu::new(button_view_id, cx);
                 menu.set_position_mode(OverlayPositionMode::Local);
                 menu
             }),

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -408,7 +408,7 @@ impl TerminalElement {
             )
             // Update drag selections
             .on_drag(MouseButton::Left, move |event, _: &mut TerminalView, cx| {
-                if cx.is_parent_view_focused() {
+                if cx.is_self_focused() {
                     if let Some(conn_handle) = connection.upgrade(cx) {
                         conn_handle.update(cx, |terminal, cx| {
                             terminal.mouse_drag(event, origin);
@@ -444,7 +444,7 @@ impl TerminalElement {
                 },
             )
             .on_move(move |event, _: &mut TerminalView, cx| {
-                if cx.is_parent_view_focused() {
+                if cx.is_self_focused() {
                     if let Some(conn_handle) = connection.upgrade(cx) {
                         conn_handle.update(cx, |terminal, cx| {
                             terminal.mouse_move(&event, origin);

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -10,8 +10,8 @@ use gpui::{
     platform::{CursorStyle, MouseButton},
     serde_json::json,
     text_layout::{Line, RunStyle},
-    AnyElement, Element, EventContext, FontCache, ModelContext, MouseRegion, Quad, SceneBuilder,
-    SizeConstraint, TextLayoutCache, ViewContext, WeakModelHandle,
+    AnyElement, Element, EventContext, FontCache, LayoutContext, ModelContext, MouseRegion, Quad,
+    SceneBuilder, SizeConstraint, TextLayoutCache, ViewContext, WeakModelHandle,
 };
 use itertools::Itertools;
 use language::CursorShape;
@@ -561,7 +561,7 @@ impl Element<TerminalView> for TerminalElement {
         &mut self,
         constraint: gpui::SizeConstraint,
         view: &mut TerminalView,
-        cx: &mut ViewContext<TerminalView>,
+        cx: &mut LayoutContext<TerminalView>,
     ) -> (gpui::geometry::vector::Vector2F, Self::LayoutState) {
         let settings = cx.global::<Settings>();
         let font_cache = cx.font_cache();

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -370,7 +370,7 @@ impl TerminalElement {
         f: impl Fn(&mut Terminal, Vector2F, E, &mut ModelContext<Terminal>),
     ) -> impl Fn(E, &mut TerminalView, &mut EventContext<TerminalView>) {
         move |event, _: &mut TerminalView, cx| {
-            cx.focus_parent_view();
+            cx.focus_parent();
             if let Some(conn_handle) = connection.upgrade(cx) {
                 conn_handle.update(cx, |terminal, cx| {
                     f(terminal, origin, event, cx);

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -124,6 +124,7 @@ impl TerminalView {
         workspace_id: WorkspaceId,
         cx: &mut ViewContext<Self>,
     ) -> Self {
+        let view_id = cx.view_id();
         cx.observe(&terminal, |_, _, cx| cx.notify()).detach();
         cx.subscribe(&terminal, |this, _, event, cx| match event {
             Event::Wakeup => {
@@ -162,7 +163,7 @@ impl TerminalView {
             terminal,
             has_new_content: true,
             has_bell: false,
-            context_menu: cx.add_view(ContextMenu::new),
+            context_menu: cx.add_view(|cx| ContextMenu::new(view_id, cx)),
             blink_state: true,
             blinking_on: false,
             blinking_paused: false,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2,7 +2,6 @@ mod persistence;
 pub mod terminal_button;
 pub mod terminal_element;
 
-use anyhow::anyhow;
 use context_menu::{ContextMenu, ContextMenuItem};
 use dirs::home_dir;
 use gpui::{
@@ -628,16 +627,12 @@ impl Item for TerminalView {
                     })
                 });
 
-            let pane = pane
-                .upgrade(&cx)
-                .ok_or_else(|| anyhow!("pane was dropped"))?;
-            cx.update(|cx| {
-                let terminal = project.update(cx, |project, cx| {
-                    project.create_terminal(cwd, window_id, cx)
-                })?;
-
-                Ok(cx.add_view(&pane, |cx| TerminalView::new(terminal, workspace_id, cx)))
-            })
+            let terminal = project.update(&mut cx, |project, cx| {
+                project.create_terminal(cwd, window_id, cx)
+            })?;
+            Ok(pane.update(&mut cx, |_, cx| {
+                cx.add_view(|cx| TerminalView::new(terminal, workspace_id, cx))
+            })?)
         })
     }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -178,11 +178,7 @@ impl Dock {
         pane.update(cx, |pane, cx| {
             pane.set_active(false, cx);
         });
-        let pane_id = pane.id();
-        cx.subscribe(&pane, move |workspace, _, event, cx| {
-            workspace.handle_pane_event(pane_id, event, cx);
-        })
-        .detach();
+        cx.subscribe(&pane, Workspace::handle_pane_event).detach();
 
         Self {
             pane,

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -726,7 +726,7 @@ mod tests {
             self.update_workspace(|workspace, cx| Dock::move_dock(workspace, anchor, true, cx));
         }
 
-        pub fn hide_dock(&self) {
+        pub fn hide_dock(&mut self) {
             self.cx.dispatch_action(self.window_id, HideDock);
         }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -24,8 +24,8 @@ use gpui::{
     keymap_matcher::KeymapContext,
     platform::{CursorStyle, MouseButton, NavigationDirection, PromptLevel},
     Action, AnyViewHandle, AnyWeakViewHandle, AppContext, AsyncAppContext, Entity, EventContext,
-    ModelHandle, MouseRegion, Quad, Task, View, ViewContext, ViewHandle, WeakViewHandle,
-    WindowContext,
+    LayoutContext, ModelHandle, MouseRegion, Quad, Task, View, ViewContext, ViewHandle,
+    WeakViewHandle, WindowContext,
 };
 use project::{Project, ProjectEntryId, ProjectPath};
 use serde::Deserialize;
@@ -1999,7 +1999,7 @@ impl<V: View> Element<V> for PaneBackdrop<V> {
         &mut self,
         constraint: gpui::SizeConstraint,
         view: &mut V,
-        cx: &mut ViewContext<V>,
+        cx: &mut LayoutContext<V>,
     ) -> (Vector2F, Self::LayoutState) {
         let size = self.child.layout(constraint, view, cx);
         (size, ())

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -226,8 +226,9 @@ impl Pane {
         background_actions: BackgroundActions,
         cx: &mut ViewContext<Self>,
     ) -> Self {
+        let pane_view_id = cx.view_id();
         let handle = cx.weak_handle();
-        let context_menu = cx.add_view(ContextMenu::new);
+        let context_menu = cx.add_view(|cx| ContextMenu::new(pane_view_id, cx));
         context_menu.update(cx, |menu, _| {
             menu.set_position_mode(OverlayPositionMode::Local)
         });
@@ -252,7 +253,7 @@ impl Pane {
                 kind: TabBarContextMenuKind::New,
                 handle: context_menu,
             },
-            tab_context_menu: cx.add_view(ContextMenu::new),
+            tab_context_menu: cx.add_view(|cx| ContextMenu::new(pane_view_id, cx)),
             docked,
             _background_actions: background_actions,
             workspace,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1770,7 +1770,7 @@ impl View for Pane {
                     self.render_blank_pane(&theme, cx)
                 })
                 .on_down(MouseButton::Left, |_, _, cx| {
-                    cx.focus_parent_view();
+                    cx.focus_parent();
                 })
                 .into_any()
             }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -537,7 +537,6 @@ impl Pane {
             // If the item already exists, move it to the desired destination and activate it
             pane.update(cx, |pane, cx| {
                 if existing_item_index != insertion_index {
-                    cx.reparent(item.as_any());
                     let existing_item_is_active = existing_item_index == pane.active_item_index;
 
                     // If the caller didn't specify a destination and the added item is already
@@ -567,7 +566,6 @@ impl Pane {
             });
         } else {
             pane.update(cx, |pane, cx| {
-                cx.reparent(item.as_any());
                 pane.items.insert(insertion_index, item);
                 if insertion_index <= pane.active_item_index {
                     pane.active_item_index += 1;

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -151,6 +151,7 @@ pub struct Pane {
     docked: Option<DockAnchor>,
     _background_actions: BackgroundActions,
     workspace: WeakViewHandle<Workspace>,
+    has_focus: bool,
 }
 
 pub struct ItemNavHistory {
@@ -258,6 +259,7 @@ impl Pane {
             docked,
             _background_actions: background_actions,
             workspace,
+            has_focus: false,
         }
     }
 
@@ -272,6 +274,10 @@ impl Pane {
     pub fn set_active(&mut self, is_active: bool, cx: &mut ViewContext<Self>) {
         self.is_active = is_active;
         cx.notify();
+    }
+
+    pub fn has_focus(&self) -> bool {
+        self.has_focus
     }
 
     pub fn set_docked(&mut self, docked: Option<DockAnchor>, cx: &mut ViewContext<Self>) {
@@ -1798,7 +1804,7 @@ impl View for Pane {
     }
 
     fn focus_in(&mut self, focused: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        cx.emit(Event::Focus);
+        self.has_focus = true;
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.pane_focus_update(true, cx);
         });
@@ -1824,9 +1830,12 @@ impl View for Pane {
                     .insert(active_item.id(), focused.downgrade());
             }
         }
+
+        cx.emit(Event::Focus);
     }
 
     fn focus_out(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
+        self.has_focus = false;
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.pane_focus_update(false, cx);
         });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -134,6 +134,7 @@ pub enum Event {
     RemoveItem { item_id: usize },
     Split(SplitDirection),
     ChangeItemTitle,
+    Focus,
 }
 
 pub struct Pane {
@@ -1797,6 +1798,7 @@ impl View for Pane {
     }
 
     fn focus_in(&mut self, focused: AnyViewHandle, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::Focus);
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.pane_focus_update(true, cx);
         });

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -90,7 +90,7 @@ impl View for SharedScreen {
             .contained()
             .with_style(cx.global::<Settings>().theme.shared_screen)
         })
-        .on_down(MouseButton::Left, |_, _, cx| cx.focus_parent_view())
+        .on_down(MouseButton::Left, |_, _, cx| cx.focus_parent())
         .into_any()
     }
 }

--- a/crates/workspace/src/sidebar.rs
+++ b/crates/workspace/src/sidebar.rs
@@ -146,7 +146,7 @@ impl Sidebar {
                 }
             }),
         ];
-        cx.reparent(&view);
+
         self.items.push(Item {
             icon_path,
             tooltip,

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -93,7 +93,6 @@ impl StatusBar {
     where
         T: 'static + StatusItemView,
     {
-        cx.reparent(item.as_any());
         self.left_items.push(Box::new(item));
         cx.notify();
     }
@@ -102,7 +101,6 @@ impl StatusBar {
     where
         T: 'static + StatusItemView,
     {
-        cx.reparent(item.as_any());
         self.right_items.push(Box::new(item));
         cx.notify();
     }

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -8,8 +8,8 @@ use gpui::{
         vector::{vec2f, Vector2F},
     },
     json::{json, ToJson},
-    AnyElement, AnyViewHandle, Entity, SceneBuilder, SizeConstraint, Subscription, View,
-    ViewContext, ViewHandle, WindowContext,
+    AnyElement, AnyViewHandle, Entity, LayoutContext, SceneBuilder, SizeConstraint, Subscription,
+    View, ViewContext, ViewHandle, WindowContext,
 };
 use settings::Settings;
 
@@ -157,7 +157,7 @@ impl Element<StatusBar> for StatusBarElement {
         &mut self,
         mut constraint: SizeConstraint,
         view: &mut StatusBar,
-        cx: &mut ViewContext<StatusBar>,
+        cx: &mut LayoutContext<StatusBar>,
     ) -> (Vector2F, Self::LayoutState) {
         let max_width = constraint.max.x();
         constraint.min = vec2f(0., constraint.min.y());

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3118,10 +3118,10 @@ mod tests {
 
         let fs = FakeFs::new(cx.background());
         let project = Project::test(fs, [], cx).await;
-        let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
 
         // Adding an item with no ambiguity renders the tab without detail.
-        let item1 = cx.add_view(&workspace, |_| {
+        let item1 = cx.add_view(window_id, |_| {
             let mut item = TestItem::new();
             item.tab_descriptions = Some(vec!["c", "b1/c", "a/b1/c"]);
             item
@@ -3133,7 +3133,7 @@ mod tests {
 
         // Adding an item that creates ambiguity increases the level of detail on
         // both tabs.
-        let item2 = cx.add_view(&workspace, |_| {
+        let item2 = cx.add_view(window_id, |_| {
             let mut item = TestItem::new();
             item.tab_descriptions = Some(vec!["c", "b2/c", "a/b2/c"]);
             item
@@ -3147,7 +3147,7 @@ mod tests {
         // Adding an item that creates ambiguity increases the level of detail only
         // on the ambiguous tabs. In this case, the ambiguity can't be resolved so
         // we stop at the highest detail available.
-        let item3 = cx.add_view(&workspace, |_| {
+        let item3 = cx.add_view(window_id, |_| {
             let mut item = TestItem::new();
             item.tab_descriptions = Some(vec!["c", "b2/c", "a/b2/c"]);
             item
@@ -3187,10 +3187,10 @@ mod tests {
             project.worktrees(cx).next().unwrap().read(cx).id()
         });
 
-        let item1 = cx.add_view(&workspace, |cx| {
+        let item1 = cx.add_view(window_id, |cx| {
             TestItem::new().with_project_items(&[TestProjectItem::new(1, "one.txt", cx)])
         });
-        let item2 = cx.add_view(&workspace, |cx| {
+        let item2 = cx.add_view(window_id, |cx| {
             TestItem::new().with_project_items(&[TestProjectItem::new(2, "two.txt", cx)])
         });
 
@@ -3275,15 +3275,15 @@ mod tests {
         let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
 
         // When there are no dirty items, there's nothing to do.
-        let item1 = cx.add_view(&workspace, |_| TestItem::new());
+        let item1 = cx.add_view(window_id, |_| TestItem::new());
         workspace.update(cx, |w, cx| w.add_item(Box::new(item1.clone()), cx));
         let task = workspace.update(cx, |w, cx| w.prepare_to_close(false, cx));
         assert!(task.await.unwrap());
 
         // When there are dirty untitled items, prompt to save each one. If the user
         // cancels any prompt, then abort.
-        let item2 = cx.add_view(&workspace, |_| TestItem::new().with_dirty(true));
-        let item3 = cx.add_view(&workspace, |cx| {
+        let item2 = cx.add_view(window_id, |_| TestItem::new().with_dirty(true));
+        let item3 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
@@ -3309,24 +3309,24 @@ mod tests {
         let project = Project::test(fs, None, cx).await;
         let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project, cx));
 
-        let item1 = cx.add_view(&workspace, |cx| {
+        let item1 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
         });
-        let item2 = cx.add_view(&workspace, |cx| {
+        let item2 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_conflict(true)
                 .with_project_items(&[TestProjectItem::new(2, "2.txt", cx)])
         });
-        let item3 = cx.add_view(&workspace, |cx| {
+        let item3 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_conflict(true)
                 .with_project_items(&[TestProjectItem::new(3, "3.txt", cx)])
         });
-        let item4 = cx.add_view(&workspace, |cx| {
+        let item4 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_project_items(&[TestProjectItem::new_untitled(cx)])
@@ -3420,7 +3420,7 @@ mod tests {
         // workspace items with multiple project entries.
         let single_entry_items = (0..=4)
             .map(|project_entry_id| {
-                cx.add_view(&workspace, |cx| {
+                cx.add_view(window_id, |cx| {
                     TestItem::new()
                         .with_dirty(true)
                         .with_project_items(&[TestProjectItem::new(
@@ -3431,7 +3431,7 @@ mod tests {
                 })
             })
             .collect::<Vec<_>>();
-        let item_2_3 = cx.add_view(&workspace, |cx| {
+        let item_2_3 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_singleton(false)
@@ -3440,7 +3440,7 @@ mod tests {
                     single_entry_items[3].read(cx).project_items[0].clone(),
                 ])
         });
-        let item_3_4 = cx.add_view(&workspace, |cx| {
+        let item_3_4 = cx.add_view(window_id, |cx| {
             TestItem::new()
                 .with_dirty(true)
                 .with_singleton(false)
@@ -3523,7 +3523,7 @@ mod tests {
         let project = Project::test(fs, [], cx).await;
         let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project, cx));
 
-        let item = cx.add_view(&workspace, |cx| {
+        let item = cx.add_view(window_id, |cx| {
             TestItem::new().with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
         });
         let item_id = item.id();
@@ -3638,9 +3638,9 @@ mod tests {
         let fs = FakeFs::new(cx.background());
 
         let project = Project::test(fs, [], cx).await;
-        let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project, cx));
+        let (window_id, workspace) = cx.add_window(|cx| Workspace::test_new(project, cx));
 
-        let item = cx.add_view(&workspace, |cx| {
+        let item = cx.add_view(window_id, |cx| {
             TestItem::new().with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
         });
         let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2339,19 +2339,14 @@ impl Workspace {
         }
 
         for (pane, item) in items_to_activate {
-            let active_item_was_focused = pane
-                .read(cx)
-                .active_item()
-                .map(|active_item| cx.is_child_focused(active_item.as_any()))
-                .unwrap_or_default();
-
+            let pane_was_focused = pane.read(cx).has_focus();
             if let Some(index) = pane.update(cx, |pane, _| pane.index_for_item(item.as_ref())) {
                 pane.update(cx, |pane, cx| pane.activate_item(index, false, false, cx));
             } else {
                 Pane::add_item(self, &pane, item.boxed_clone(), false, false, None, cx);
             }
 
-            if active_item_was_focused {
+            if pane_was_focused {
                 pane.update(cx, |pane, cx| pane.focus_active_item(cx));
             }
         }


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-862/manage-all-element-ancestry-via-render-and-avoid-explicit-reparenting

TODO:
- [x] Handle window activation effects similar to how we handle focus (do it right before `layout`)
- [x] Remove remaining queries to `ancestors` done via `ViewContext`