### PR TITLE
Filter out vim commands when vim mode is disabled

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -84,7 +84,12 @@ pub fn init(cx: &mut AppContext) {
         Vim::active_editor_input_ignored("\n".into(), cx)
     });
 
-    // Any time settings change, update vim mode to match.
+    // Any time settings change, update vim mode to match. The Vim struct
+    // will be initialized as disabled by default, so we filter its commands
+    // out when starting up.
+    cx.update_default_global::<CommandPaletteFilter, _, _>(|filter, _| {
+        filter.filtered_namespaces.insert("vim");
+    });
     cx.update_default_global(|vim: &mut Vim, cx: &mut AppContext| {
         vim.set_enabled(cx.global::<Settings>().vim_mode, cx)
     });


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1183/vim-command-arent-being-filtered-out-from-command-palette

This regressed as part of #2372 where we didn't realize `Vim` will start as disabled when instantiating it during `vim::init`. When calling `Vim::set_enabled(false)` after reading the settings, we wouldn't take care of reflecting that in the command palette because its enabled state wouldn't have changed.

This pull request always inserts a filter for vim commands in the command palette to reflect the `Vim` struct's initial state.