### PR TITLE
Avoid calling `update_window` twice in `blurred` event handler

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -35,9 +35,7 @@ fn blurred(EditorBlurred(editor): &EditorBlurred, cx: &mut AppContext) {
                 }
             }
 
-            cx.update_window(editor.window_id(), |cx| {
-                editor.update(cx, |editor, cx| Vim::unhook_vim_settings(editor, cx))
-            });
+            editor.update(cx, |editor, cx| Vim::unhook_vim_settings(editor, cx))
         });
     });
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/6131

This was preventing us from unhooking vim when performing a rename, which prevented typing in the rename editor.