### PR TITLE
Construct text buffer in background

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2594,7 +2594,7 @@ impl Editor {
         let old_text = buffer.text_for_range(old_range.clone()).collect::<String>();
 
         let newest_selection = self.selections.newest_anchor();
-        if newest_selection.start.buffer_id != Some(buffer_handle.id()) {
+        if newest_selection.start.buffer_id != Some(buffer_handle.read(cx).remote_id()) {
             return None;
         }
 
@@ -2802,7 +2802,7 @@ impl Editor {
                     ),
                 );
             }
-            multibuffer.push_transaction(entries.iter().map(|(b, t)| (b, t)));
+            multibuffer.push_transaction(entries.iter().map(|(b, t)| (b, t)), cx);
             multibuffer
         });
 
@@ -5764,7 +5764,7 @@ impl Editor {
         cx: &mut ViewContext<Workspace>,
     ) {
         // If there are multiple definitions, open them in a multibuffer
-        locations.sort_by_key(|location| location.buffer.id());
+        locations.sort_by_key(|location| location.buffer.read(cx).remote_id());
         let mut locations = locations.into_iter().peekable();
         let mut ranges_to_highlight = Vec::new();
 
@@ -6059,7 +6059,7 @@ impl Editor {
             buffer.update(&mut cx, |buffer, cx| {
                 if let Some(transaction) = transaction {
                     if !buffer.is_singleton() {
-                        buffer.push_transaction(&transaction.0);
+                        buffer.push_transaction(&transaction.0, cx);
                     }
                 }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -704,10 +704,10 @@ impl Item for Editor {
             this.update(&mut cx, |editor, cx| {
                 editor.request_autoscroll(Autoscroll::fit(), cx)
             })?;
-            buffer.update(&mut cx, |buffer, _| {
+            buffer.update(&mut cx, |buffer, cx| {
                 if let Some(transaction) = transaction {
                     if !buffer.is_singleton() {
-                        buffer.push_transaction(&transaction.0);
+                        buffer.push_transaction(&transaction.0, cx);
                     }
                 }
             });

--- a/crates/editor/src/multi_buffer/anchor.rs
+++ b/crates/editor/src/multi_buffer/anchor.rs
@@ -8,7 +8,7 @@ use sum_tree::Bias;
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
 pub struct Anchor {
-    pub(crate) buffer_id: Option<usize>,
+    pub(crate) buffer_id: Option<u64>,
     pub(crate) excerpt_id: ExcerptId,
     pub(crate) text_anchor: text::Anchor,
 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -357,20 +357,6 @@ impl Buffer {
         )
     }
 
-    pub fn from_file<T: Into<String>>(
-        replica_id: ReplicaId,
-        base_text: T,
-        diff_base: Option<T>,
-        file: Arc<dyn File>,
-        cx: &mut ModelContext<Self>,
-    ) -> Self {
-        Self::build(
-            TextBuffer::new(replica_id, cx.model_id() as u64, base_text.into()),
-            diff_base.map(|h| h.into().into_boxed_str().into()),
-            Some(file),
-        )
-    }
-
     pub fn from_proto(
         replica_id: ReplicaId,
         message: proto::BufferState,
@@ -460,7 +446,11 @@ impl Buffer {
         self
     }
 
-    fn build(buffer: TextBuffer, diff_base: Option<String>, file: Option<Arc<dyn File>>) -> Self {
+    pub fn build(
+        buffer: TextBuffer,
+        diff_base: Option<String>,
+        file: Option<Arc<dyn File>>,
+    ) -> Self {
         let saved_mtime = if let Some(file) = file.as_ref() {
             file.mtime()
         } else {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -109,6 +109,7 @@ pub struct Project {
     collaborators: HashMap<proto::PeerId, Collaborator>,
     client_subscriptions: Vec<client::Subscription>,
     _subscriptions: Vec<gpui::Subscription>,
+    next_buffer_id: u64,
     opened_buffer: (watch::Sender<()>, watch::Receiver<()>),
     shared_buffers: HashMap<proto::PeerId, HashSet<u64>>,
     #[allow(clippy::type_complexity)]
@@ -441,6 +442,7 @@ impl Project {
                 worktrees: Default::default(),
                 buffer_ordered_messages_tx: tx,
                 collaborators: Default::default(),
+                next_buffer_id: 0,
                 opened_buffers: Default::default(),
                 shared_buffers: Default::default(),
                 incomplete_remote_buffers: Default::default(),
@@ -509,6 +511,7 @@ impl Project {
                 worktrees: Vec::new(),
                 buffer_ordered_messages_tx: tx,
                 loading_buffers_by_path: Default::default(),
+                next_buffer_id: 0,
                 opened_buffer: watch::channel(),
                 shared_buffers: Default::default(),
                 incomplete_remote_buffers: Default::default(),
@@ -1401,9 +1404,10 @@ impl Project {
         worktree: &ModelHandle<Worktree>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<ModelHandle<Buffer>>> {
+        let buffer_id = post_inc(&mut self.next_buffer_id);
         let load_buffer = worktree.update(cx, |worktree, cx| {
             let worktree = worktree.as_local_mut().unwrap();
-            worktree.load_buffer(path, cx)
+            worktree.load_buffer(buffer_id, path, cx)
         });
         cx.spawn(|this, mut cx| async move {
             let buffer = load_buffer.await?;

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -90,8 +90,7 @@ impl HistoryEntry {
 }
 
 struct History {
-    // TODO: Turn this into a String or Rope, maybe.
-    base_text: Arc<str>,
+    base_text: Rope,
     operations: TreeMap<clock::Local, Operation>,
     insertion_slices: HashMap<clock::Local, Vec<InsertionSlice>>,
     undo_stack: Vec<HistoryEntry>,
@@ -107,7 +106,7 @@ struct InsertionSlice {
 }
 
 impl History {
-    pub fn new(base_text: Arc<str>) -> Self {
+    pub fn new(base_text: Rope) -> Self {
         Self {
             base_text,
             operations: Default::default(),
@@ -470,7 +469,7 @@ impl Buffer {
         let line_ending = LineEnding::detect(&base_text);
         LineEnding::normalize(&mut base_text);
 
-        let history = History::new(base_text.into());
+        let history = History::new(Rope::from(base_text.as_ref()));
         let mut fragments = SumTree::new();
         let mut insertions = SumTree::new();
 
@@ -478,7 +477,7 @@ impl Buffer {
         let mut lamport_clock = clock::Lamport::new(replica_id);
         let mut version = clock::Global::new();
 
-        let visible_text = Rope::from(history.base_text.as_ref());
+        let visible_text = history.base_text.clone();
         if !visible_text.is_empty() {
             let insertion_timestamp = InsertionTimestamp {
                 replica_id: 0,
@@ -1165,7 +1164,7 @@ impl Buffer {
         self.history.group_until(transaction_id);
     }
 
-    pub fn base_text(&self) -> &Arc<str> {
+    pub fn base_text(&self) -> &Rope {
         &self.history.base_text
     }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -60,7 +60,7 @@ pub trait Item: View {
         style: &theme::Tab,
         cx: &AppContext,
     ) -> AnyElement<V>;
-    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item)) {}
+    fn for_each_project_item(&self, _: &AppContext, _: &mut dyn FnMut(usize, &dyn project::Item)) {} // (model id, Item)
     fn is_singleton(&self, _cx: &AppContext) -> bool {
         false
     }


### PR DESCRIPTION
After enough time spent trying to debug non-obvious async test failures resulting from the changes to how `update_local_worktree_buffers` works I've decided to cut those changes out for the time being and move on to something more useful and importantly, in cycle

The aforementioned changes are still around on the branch `make-project-search-less-blocky-two`

Improves the situation regarding https://linear.app/zed-industries/issue/Z-918/project-search-blocking-ui