### PR TITLE
Render invisibles in the editor

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -33,6 +33,14 @@
   // Controls whether copilot provides suggestion immediately
   // or waits for a `copilot::Toggle`
   "show_copilot_suggestions": true,
+  // Whether to show tabs and spaces in the editor.
+  // This setting can take two values:
+  //
+  // 1. Do not draw any tabs or spaces (default):
+  //   "none"
+  // 2. Draw all invisible symbols:
+  //   "all"
+  "show_invisibles": "none",
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -36,11 +36,13 @@
   // Whether to show tabs and spaces in the editor.
   // This setting can take two values:
   //
-  // 1. Do not draw any tabs or spaces (default):
+  // 1. Draw tabs and spaces only for the selected text (default):
+  //    "selection"
+  // 2. Do not draw any tabs or spaces:
   //   "none"
-  // 2. Draw all invisible symbols:
+  // 3. Draw all invisible symbols:
   //   "all"
-  "show_invisibles": "none",
+  "show_invisibles": "selection",
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -42,7 +42,7 @@
   //   "none"
   // 3. Draw all invisible symbols:
   //   "all"
-  "show_invisibles": "selection",
+  "show_whitespaces": "selection",
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -833,10 +833,7 @@ impl<'a> Iterator for BlockChunks<'a> {
 
             return Some(Chunk {
                 text: unsafe { std::str::from_utf8_unchecked(&NEWLINES[..line_count as usize]) },
-                syntax_highlight_id: None,
-                highlight_style: None,
-                diagnostic_severity: None,
-                is_unnecessary: false,
+                ..Default::default()
             });
         }
 

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1065,13 +1065,11 @@ impl<'a> Iterator for FoldChunks<'a> {
             self.output_offset += output_text.len();
             return Some(Chunk {
                 text: output_text,
-                syntax_highlight_id: None,
                 highlight_style: self.ellipses_color.map(|color| HighlightStyle {
                     color: Some(color),
                     ..Default::default()
                 }),
-                diagnostic_severity: None,
-                is_unnecessary: false,
+                ..Default::default()
             });
         }
 

--- a/crates/editor/src/display_map/suggestion_map.rs
+++ b/crates/editor/src/display_map/suggestion_map.rs
@@ -531,10 +531,8 @@ impl<'a> Iterator for SuggestionChunks<'a> {
             if let Some(chunk) = chunks.next() {
                 return Some(Chunk {
                     text: chunk,
-                    syntax_highlight_id: None,
                     highlight_style: self.highlight_style,
-                    diagnostic_severity: None,
-                    is_unnecessary: false,
+                    ..Default::default()
                 });
             } else {
                 self.suggestion_chunks = None;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1365,6 +1365,14 @@ impl EditorElement {
                         is_tab: chunk.is_tab,
                     }
                 });
+
+            let settings = cx.global::<Settings>();
+            let show_invisibles = settings
+                .editor_overrides
+                .show_invisibles
+                .or(settings.editor_defaults.show_invisibles)
+                .unwrap_or_default()
+                == settings::ShowInvisibles::All;
             layout_highlighted_chunks(
                 chunks,
                 &style.text,
@@ -1372,6 +1380,7 @@ impl EditorElement {
                 cx.font_cache(),
                 MAX_LINE_LEN,
                 rows.len() as usize,
+                show_invisibles,
             )
         }
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1359,7 +1359,11 @@ impl EditorElement {
                         highlight_style = Some(diagnostic_highlight);
                     }
 
-                    (chunk.text, highlight_style)
+                    HighlightedChunk {
+                        chunk: chunk.text,
+                        style: highlight_style,
+                        is_tab: chunk.is_tab,
+                    }
                 });
             layout_highlighted_chunks(
                 chunks,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -37,7 +37,7 @@ use itertools::Itertools;
 use json::json;
 use language::{Bias, CursorShape, DiagnosticSeverity, OffsetUtf16, Selection};
 use project::ProjectPath;
-use settings::{GitGutter, Settings, ShowInvisibles};
+use settings::{GitGutter, Settings, ShowWhitespaces};
 use smallvec::SmallVec;
 use std::{
     borrow::Cow,
@@ -1657,13 +1657,13 @@ fn draw_invisibles(
     let settings = cx.global::<Settings>();
     let regions_to_hit = match settings
         .editor_overrides
-        .show_invisibles
-        .or(settings.editor_defaults.show_invisibles)
+        .show_whitespaces
+        .or(settings.editor_defaults.show_whitespaces)
         .unwrap_or_default()
     {
-        ShowInvisibles::None => return,
-        ShowInvisibles::Selection => Some(selection_ranges),
-        ShowInvisibles::All => None,
+        ShowWhitespaces::None => return,
+        ShowWhitespaces::Selection => Some(selection_ranges),
+        ShowWhitespaces::All => None,
     };
 
     for invisible in &line_with_invisibles.invisibles {
@@ -2894,7 +2894,7 @@ mod tests {
 
         cx.update(|cx| {
             let mut test_settings = Settings::test(cx);
-            test_settings.editor_defaults.show_invisibles = Some(ShowInvisibles::All);
+            test_settings.editor_defaults.show_whitespaces = Some(ShowWhitespaces::All);
             test_settings.editor_defaults.tab_size = Some(NonZeroU32::new(tab_size).unwrap());
             cx.set_global(test_settings);
         });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1283,6 +1283,7 @@ impl EditorElement {
     fn layout_lines(
         &mut self,
         rows: Range<u32>,
+        line_number_layouts: &[Option<Line>],
         snapshot: &EditorSnapshot,
         cx: &ViewContext<Editor>,
     ) -> Vec<LineWithInvisibles> {
@@ -1380,6 +1381,7 @@ impl EditorElement {
                 cx.font_cache(),
                 MAX_LINE_LEN,
                 rows.len() as usize,
+                line_number_layouts,
             )
         }
     }
@@ -1725,6 +1727,7 @@ fn layout_highlighted_chunks<'a>(
     font_cache: &Arc<FontCache>,
     max_line_len: usize,
     max_line_count: usize,
+    line_number_layouts: &[Option<Line>],
 ) -> Vec<LineWithInvisibles> {
     let mut layouts = Vec::with_capacity(max_line_count);
     let mut line = String::new();
@@ -1786,7 +1789,7 @@ fn layout_highlighted_chunks<'a>(
 
                 // Line wrap pads its contents with fake whitespaces,
                 // avoid printing them
-                let inside_wrapped_string = ix > 0;
+                let inside_wrapped_string = line_number_layouts[row].is_none();
                 if highlighted_chunk.is_tab {
                     if non_whitespace_added || !inside_wrapped_string {
                         invisibles.push(Invisible::Tab {
@@ -2040,7 +2043,8 @@ impl Element<Editor> for EditorElement {
         let scrollbar_row_range = scroll_position.y()..(scroll_position.y() + height_in_lines);
 
         let mut max_visible_line_width = 0.0;
-        let line_layouts = self.layout_lines(start_row..end_row, &snapshot, cx);
+        let line_layouts =
+            self.layout_lines(start_row..end_row, &line_number_layouts, &snapshot, cx);
         for line_with_invisibles in &line_layouts {
             if line_with_invisibles.line.width() > max_visible_line_width {
                 max_visible_line_width = line_with_invisibles.line.width();
@@ -2850,43 +2854,32 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_invisible_drawing(cx: &mut TestAppContext) {
+    fn test_both_invisible_kinds_drawing(cx: &mut TestAppContext) {
         let tab_size = 4;
-        let initial_str = "\t\t\t\t\t\t\t\t| | a b c d ";
-        let (input_text, expected_invisibles) = {
-            let mut input_text = String::new();
-            let mut expected_invisibles = Vec::new();
-            let mut offset = 0;
-
-            let mut push_char = |char_symbol| {
-                input_text.push(char_symbol);
-                let new_offset = match char_symbol {
-                    '\t' => {
-                        expected_invisibles.push(Invisible::Tab {
-                            line_start_offset: offset,
-                        });
-                        tab_size as usize
-                    }
-                    ' ' => {
-                        expected_invisibles.push(Invisible::Whitespace {
-                            line_offset: offset,
-                        });
-                        1
-                    }
-                    _ => 1,
-                };
-                offset += new_offset;
-            };
-
-            for input_char in initial_str.chars() {
-                push_char(input_char)
-            }
-
-            (input_text, expected_invisibles)
-        };
+        let input_text = "\t\t\t| | a b";
+        let expected_invisibles = vec![
+            Invisible::Tab {
+                line_start_offset: 0,
+            },
+            Invisible::Tab {
+                line_start_offset: tab_size as usize,
+            },
+            Invisible::Tab {
+                line_start_offset: tab_size as usize * 2,
+            },
+            Invisible::Whitespace {
+                line_offset: tab_size as usize * 3 + 1,
+            },
+            Invisible::Whitespace {
+                line_offset: tab_size as usize * 3 + 3,
+            },
+            Invisible::Whitespace {
+                line_offset: tab_size as usize * 3 + 5,
+            },
+        ];
         assert_eq!(
             expected_invisibles.len(),
-            initial_str
+            input_text
                 .chars()
                 .filter(|initial_char| initial_char.is_whitespace())
                 .count()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2201,7 +2201,7 @@ impl Element<Editor> for EditorElement {
 
         let invisible_symbol_font_size = self.style.text.font_size / 2.0;
         let invisible_symbol_style = RunStyle {
-            color: self.style.line_number,
+            color: self.style.whitespace,
             font_id: self.style.text.font_id,
             underline: Default::default(),
         };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -864,16 +864,16 @@ impl EditorElement {
         }
 
         if let Some(visible_text_bounds) = bounds.intersection(visible_bounds) {
+            let line_height = layout.position_map.line_height;
+
             // Draw glyphs
             for (ix, line_with_invisibles) in layout.position_map.line_layouts.iter().enumerate() {
                 let row = start_row + ix as u32;
+                let line_y = row as f32 * line_height - scroll_top;
+
                 line_with_invisibles.line.paint(
                     scene,
-                    content_origin
-                        + vec2f(
-                            -scroll_left,
-                            row as f32 * layout.position_map.line_height - scroll_top,
-                        ),
+                    content_origin + vec2f(-scroll_left, line_y),
                     visible_text_bounds,
                     layout.position_map.line_height,
                     cx,
@@ -889,38 +889,22 @@ impl EditorElement {
                     ShowInvisibles::None => {}
                     ShowInvisibles::All => {
                         for invisible in &line_with_invisibles.invisibles {
-                            // TODO kb cache, deduplicate
-                            let (token_offset, mut test_svg) = match invisible {
-                                Invisible::Tab { line_start_offset } => (
-                                    *line_start_offset,
-                                    Svg::new("icons/arrow_right_16.svg")
-                                        .with_color(self.style.line_number),
-                                ),
-                                Invisible::Whitespace { line_offset } => (
-                                    *line_offset,
-                                    Svg::new("icons/plus_8.svg").with_color(self.style.line_number),
-                                ),
+                            let (token_offset, invisible_symbol) = match invisible {
+                                Invisible::Tab { line_start_offset } => {
+                                    (*line_start_offset, &layout.tab_invisible)
+                                }
+                                Invisible::Whitespace { line_offset } => {
+                                    (*line_offset, &layout.space_invisible)
+                                }
                             };
 
                             let x_offset = line_with_invisibles.line.x_for_index(token_offset);
-                            let font_size = line_with_invisibles.line.font_size();
-                            let max_size = vec2f(font_size, font_size);
+                            let invisible_offset =
+                                (layout.position_map.em_width - invisible_symbol.width()).max(0.0)
+                                    / 2.0;
                             let origin = content_origin
-                                + vec2f(
-                                    -scroll_left + x_offset,
-                                    row as f32 * layout.position_map.line_height - scroll_top,
-                                );
-
-                            let (_, mut layout_state) =
-                                test_svg.layout(SizeConstraint::new(origin, max_size), editor, cx);
-                            test_svg.paint(
-                                scene,
-                                RectF::new(origin, max_size),
-                                visible_bounds,
-                                &mut layout_state,
-                                editor,
-                                cx,
-                            );
+                                + vec2f(-scroll_left + x_offset + invisible_offset, line_y);
+                            invisible_symbol.paint(scene, origin, visible_bounds, line_height, cx);
                         }
                     }
                 }
@@ -1655,6 +1639,7 @@ pub struct LineWithInvisibles {
     invisibles: Vec<Invisible>,
 }
 
+// TODO kb deduplicate? + tests
 fn layout_highlighted_chunks<'a>(
     chunks: impl Iterator<Item = HighlightedChunk<'a>>,
     text_style: &TextStyle,
@@ -2120,6 +2105,13 @@ impl Element<Editor> for EditorElement {
             }
         }
 
+        let invisible_symbol_font_size = self.style.text.font_size / 2.0;
+        let invisible_symbol_style = RunStyle {
+            color: self.style.line_number,
+            font_id: self.style.text.font_id,
+            underline: Default::default(),
+        };
+
         (
             size,
             LayoutState {
@@ -2152,6 +2144,16 @@ impl Element<Editor> for EditorElement {
                 context_menu,
                 code_actions_indicator,
                 fold_indicators,
+                tab_invisible: cx.text_layout_cache().layout_str(
+                    "→",
+                    invisible_symbol_font_size,
+                    &[("→".len(), invisible_symbol_style)],
+                ),
+                space_invisible: cx.text_layout_cache().layout_str(
+                    "•",
+                    invisible_symbol_font_size,
+                    &[("•".len(), invisible_symbol_style)],
+                ),
                 hover_popovers: hover,
             },
         )
@@ -2289,6 +2291,8 @@ pub struct LayoutState {
     code_actions_indicator: Option<(u32, AnyElement<Editor>)>,
     hover_popovers: Option<(DisplayPoint, Vec<AnyElement<Editor>>)>,
     fold_indicators: Vec<Option<AnyElement<Editor>>>,
+    tab_invisible: Line,
+    space_invisible: Line,
 }
 
 struct PositionMap {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -21,7 +21,7 @@ use git::diff::DiffHunkStatus;
 use gpui::{
     color::Color,
     elements::*,
-    fonts::{HighlightStyle, Underline},
+    fonts::{HighlightStyle, TextStyle, Underline},
     geometry::{
         rect::RectF,
         vector::{vec2f, Vector2F},
@@ -29,17 +29,18 @@ use gpui::{
     },
     json::{self, ToJson},
     platform::{CursorStyle, Modifiers, MouseButton, MouseButtonEvent, MouseMovedEvent},
-    text_layout::{self, Line, RunStyle, TextLayoutCache},
-    AnyElement, Axis, Border, CursorRegion, Element, EventContext, LayoutContext, MouseRegion,
-    Quad, SceneBuilder, SizeConstraint, ViewContext, WindowContext,
+    text_layout::{self, Invisible, Line, RunStyle, TextLayoutCache},
+    AnyElement, Axis, Border, CursorRegion, Element, EventContext, FontCache, LayoutContext,
+    MouseRegion, Quad, SceneBuilder, SizeConstraint, ViewContext, WindowContext,
 };
 use itertools::Itertools;
 use json::json;
 use language::{Bias, CursorShape, DiagnosticSeverity, OffsetUtf16, Selection};
 use project::ProjectPath;
-use settings::{GitGutter, Settings};
+use settings::{GitGutter, Settings, ShowInvisibles};
 use smallvec::SmallVec;
 use std::{
+    borrow::Cow,
     cmp::{self, Ordering},
     fmt::Write,
     iter,
@@ -808,7 +809,8 @@ impl EditorElement {
                         .contains(&cursor_position.row())
                     {
                         let cursor_row_layout = &layout.position_map.line_layouts
-                            [(cursor_position.row() - start_row) as usize];
+                            [(cursor_position.row() - start_row) as usize]
+                            .line;
                         let cursor_column = cursor_position.column() as usize;
 
                         let cursor_character_x = cursor_row_layout.x_for_index(cursor_column);
@@ -863,9 +865,9 @@ impl EditorElement {
 
         if let Some(visible_text_bounds) = bounds.intersection(visible_bounds) {
             // Draw glyphs
-            for (ix, line) in layout.position_map.line_layouts.iter().enumerate() {
+            for (ix, line_with_invisibles) in layout.position_map.line_layouts.iter().enumerate() {
                 let row = start_row + ix as u32;
-                line.paint(
+                line_with_invisibles.line.paint(
                     scene,
                     content_origin
                         + vec2f(
@@ -876,6 +878,53 @@ impl EditorElement {
                     layout.position_map.line_height,
                     cx,
                 );
+
+                let settings = cx.global::<Settings>();
+                match settings
+                    .editor_overrides
+                    .show_invisibles
+                    .or(settings.editor_defaults.show_invisibles)
+                    .unwrap_or_default()
+                {
+                    ShowInvisibles::None => {}
+                    ShowInvisibles::All => {
+                        for invisible in &line_with_invisibles.invisibles {
+                            match invisible {
+                                Invisible::Tab { line_start_offset } => {
+                                    // TODO kb cache, deduplicate
+                                    let x_offset =
+                                        line_with_invisibles.line.x_for_index(*line_start_offset);
+                                    let font_size = line_with_invisibles.line.font_size();
+                                    let max_size = vec2f(font_size, font_size);
+                                    let origin = content_origin
+                                        + vec2f(
+                                            -scroll_left + x_offset,
+                                            row as f32 * layout.position_map.line_height
+                                                - scroll_top,
+                                        );
+
+                                    let mut test_svg = Svg::new("icons/arrow_right_16.svg")
+                                        .with_color(Color::red());
+                                    let (_, mut layout_state) = test_svg.layout(
+                                        SizeConstraint::new(origin, max_size),
+                                        editor,
+                                        cx,
+                                    );
+                                    test_svg.paint(
+                                        scene,
+                                        RectF::new(origin, max_size),
+                                        visible_bounds,
+                                        &mut layout_state,
+                                        editor,
+                                        cx,
+                                    );
+                                }
+                                // TODO kb draw whitespaces too
+                                Invisible::Whitespace { .. } => {}
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -888,7 +937,7 @@ impl EditorElement {
         if let Some((position, context_menu)) = layout.context_menu.as_mut() {
             scene.push_stacking_context(None, None);
             let cursor_row_layout =
-                &layout.position_map.line_layouts[(position.row() - start_row) as usize];
+                &layout.position_map.line_layouts[(position.row() - start_row) as usize].line;
             let x = cursor_row_layout.x_for_index(position.column() as usize) - scroll_left;
             let y = (position.row() + 1) as f32 * layout.position_map.line_height - scroll_top;
             let mut list_origin = content_origin + vec2f(x, y);
@@ -921,7 +970,7 @@ impl EditorElement {
 
             // This is safe because we check on layout whether the required row is available
             let hovered_row_layout =
-                &layout.position_map.line_layouts[(position.row() - start_row) as usize];
+                &layout.position_map.line_layouts[(position.row() - start_row) as usize].line;
 
             // Minimum required size: Take the first popover, and add 1.5 times the minimum popover
             // height. This is the size we will use to decide whether to render popovers above or below
@@ -1118,7 +1167,7 @@ impl EditorElement {
                     .into_iter()
                     .map(|row| {
                         let line_layout =
-                            &layout.position_map.line_layouts[(row - start_row) as usize];
+                            &layout.position_map.line_layouts[(row - start_row) as usize].line;
                         HighlightedRangeLine {
                             start_x: if row == range.start.row() {
                                 content_origin.x()
@@ -1282,7 +1331,7 @@ impl EditorElement {
         rows: Range<u32>,
         snapshot: &EditorSnapshot,
         cx: &ViewContext<Editor>,
-    ) -> Vec<text_layout::Line> {
+    ) -> Vec<LineWithInvisibles> {
         if rows.start >= rows.end {
             return Vec::new();
         }
@@ -1316,6 +1365,10 @@ impl EditorElement {
                             },
                         )],
                     )
+                })
+                .map(|line| LineWithInvisibles {
+                    line,
+                    invisibles: Vec::new(),
                 })
                 .collect()
         } else {
@@ -1366,13 +1419,6 @@ impl EditorElement {
                     }
                 });
 
-            let settings = cx.global::<Settings>();
-            let show_invisibles = settings
-                .editor_overrides
-                .show_invisibles
-                .or(settings.editor_defaults.show_invisibles)
-                .unwrap_or_default()
-                == settings::ShowInvisibles::All;
             layout_highlighted_chunks(
                 chunks,
                 &style.text,
@@ -1380,7 +1426,6 @@ impl EditorElement {
                 cx.font_cache(),
                 MAX_LINE_LEN,
                 rows.len() as usize,
-                show_invisibles,
             )
         }
     }
@@ -1398,7 +1443,7 @@ impl EditorElement {
         text_x: f32,
         line_height: f32,
         style: &EditorStyle,
-        line_layouts: &[text_layout::Line],
+        line_layouts: &[LineWithInvisibles],
         include_root: bool,
         editor: &mut Editor,
         cx: &mut LayoutContext<Editor>,
@@ -1421,6 +1466,7 @@ impl EditorElement {
                     let anchor_x = text_x
                         + if rows.contains(&align_to.row()) {
                             line_layouts[(align_to.row() - rows.start) as usize]
+                                .line
                                 .x_for_index(align_to.column() as usize)
                         } else {
                             layout_line(align_to.row(), snapshot, style, cx.text_layout_cache())
@@ -1597,6 +1643,93 @@ impl EditorElement {
             blocks,
         )
     }
+}
+
+struct HighlightedChunk<'a> {
+    chunk: &'a str,
+    style: Option<HighlightStyle>,
+    is_tab: bool,
+}
+
+pub struct LineWithInvisibles {
+    pub line: Line,
+    invisibles: Vec<Invisible>,
+}
+
+fn layout_highlighted_chunks<'a>(
+    chunks: impl Iterator<Item = HighlightedChunk<'a>>,
+    text_style: &TextStyle,
+    text_layout_cache: &TextLayoutCache,
+    font_cache: &Arc<FontCache>,
+    max_line_len: usize,
+    max_line_count: usize,
+) -> Vec<LineWithInvisibles> {
+    let mut layouts = Vec::with_capacity(max_line_count);
+    let mut line = String::new();
+    let mut invisibles = Vec::new();
+    let mut styles = Vec::new();
+    let mut row = 0;
+    let mut line_exceeded_max_len = false;
+    for highlighted_chunk in chunks.chain([HighlightedChunk {
+        chunk: "\n",
+        style: None,
+        is_tab: false,
+    }]) {
+        for (ix, mut line_chunk) in highlighted_chunk.chunk.split('\n').enumerate() {
+            if ix > 0 {
+                layouts.push(LineWithInvisibles {
+                    line: text_layout_cache.layout_str(&line, text_style.font_size, &styles),
+                    invisibles: invisibles.drain(..).collect(),
+                });
+
+                line.clear();
+                styles.clear();
+                row += 1;
+                line_exceeded_max_len = false;
+                if row == max_line_count {
+                    return layouts;
+                }
+            }
+
+            if !line_chunk.is_empty() && !line_exceeded_max_len {
+                let text_style = if let Some(style) = highlighted_chunk.style {
+                    text_style
+                        .clone()
+                        .highlight(style, font_cache)
+                        .map(Cow::Owned)
+                        .unwrap_or_else(|_| Cow::Borrowed(text_style))
+                } else {
+                    Cow::Borrowed(text_style)
+                };
+
+                if line.len() + line_chunk.len() > max_line_len {
+                    let mut chunk_len = max_line_len - line.len();
+                    while !line_chunk.is_char_boundary(chunk_len) {
+                        chunk_len -= 1;
+                    }
+                    line_chunk = &line_chunk[..chunk_len];
+                    line_exceeded_max_len = true;
+                }
+
+                styles.push((
+                    line_chunk.len(),
+                    RunStyle {
+                        font_id: text_style.font_id,
+                        color: text_style.color,
+                        underline: text_style.underline,
+                    },
+                ));
+                if highlighted_chunk.is_tab {
+                    invisibles.push(Invisible::Tab {
+                        line_start_offset: line.len(),
+                    });
+                }
+                line.push_str(line_chunk);
+            }
+        }
+    }
+
+    layouts
 }
 
 impl Element<Editor> for EditorElement {
@@ -1824,9 +1957,9 @@ impl Element<Editor> for EditorElement {
 
         let mut max_visible_line_width = 0.0;
         let line_layouts = self.layout_lines(start_row..end_row, &snapshot, cx);
-        for line in &line_layouts {
-            if line.width() > max_visible_line_width {
-                max_visible_line_width = line.width();
+        for line_with_invisibles in &line_layouts {
+            if line_with_invisibles.line.width() > max_visible_line_width {
+                max_visible_line_width = line_with_invisibles.line.width();
             }
         }
 
@@ -2086,10 +2219,11 @@ impl Element<Editor> for EditorElement {
             return None;
         }
 
-        let line = layout
+        let line = &layout
             .position_map
             .line_layouts
-            .get((range_start.row() - start_row) as usize)?;
+            .get((range_start.row() - start_row) as usize)?
+            .line;
         let range_start_x = line.x_for_index(range_start.column() as usize);
         let range_start_y = range_start.row() as f32 * layout.position_map.line_height;
         Some(RectF::new(
@@ -2148,13 +2282,13 @@ pub struct LayoutState {
     fold_indicators: Vec<Option<AnyElement<Editor>>>,
 }
 
-pub struct PositionMap {
+struct PositionMap {
     size: Vector2F,
     line_height: f32,
     scroll_max: Vector2F,
     em_width: f32,
     em_advance: f32,
-    line_layouts: Vec<text_layout::Line>,
+    line_layouts: Vec<LineWithInvisibles>,
     snapshot: EditorSnapshot,
 }
 
@@ -2176,6 +2310,7 @@ impl PositionMap {
         let (column, x_overshoot) = if let Some(line) = self
             .line_layouts
             .get(row as usize - scroll_position.y() as usize)
+            .map(|line_with_spaces| &line_with_spaces.line)
         {
             if let Some(ix) = line.index_for_x(x) {
                 (ix as u32, 0.0)
@@ -2444,7 +2579,7 @@ impl HighlightedRange {
     }
 }
 
-pub fn position_to_display_point(
+fn position_to_display_point(
     position: Vector2F,
     text_bounds: RectF,
     position_map: &PositionMap,
@@ -2461,7 +2596,7 @@ pub fn position_to_display_point(
     }
 }
 
-pub fn range_to_bounds(
+fn range_to_bounds(
     range: &Range<DisplayPoint>,
     content_origin: Vector2F,
     scroll_left: f32,
@@ -2489,7 +2624,7 @@ pub fn range_to_bounds(
         content_origin.y() + row_range.start as f32 * position_map.line_height - scroll_top;
 
     for (idx, row) in row_range.enumerate() {
-        let line_layout = &position_map.line_layouts[(row - start_row) as usize];
+        let line_layout = &position_map.line_layouts[(row - start_row) as usize].line;
 
         let start_x = if row == range.start.row() {
             content_origin.x() + line_layout.x_for_index(range.start.column() as usize)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -29,7 +29,7 @@ use gpui::{
     },
     json::{self, ToJson},
     platform::{CursorStyle, Modifiers, MouseButton, MouseButtonEvent, MouseMovedEvent},
-    text_layout::{self, Invisible, Line, RunStyle, TextLayoutCache},
+    text_layout::{self, Line, RunStyle, TextLayoutCache},
     AnyElement, Axis, Border, CursorRegion, Element, EventContext, FontCache, LayoutContext,
     MouseRegion, Quad, SceneBuilder, SizeConstraint, ViewContext, WindowContext,
 };
@@ -1696,12 +1696,28 @@ struct HighlightedChunk<'a> {
     is_tab: bool,
 }
 
+#[derive(Debug)]
 pub struct LineWithInvisibles {
     pub line: Line,
     invisibles: Vec<Invisible>,
 }
 
-// TODO kb deduplicate? + tests
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Invisible {
+    Tab { line_start_offset: usize },
+    Whitespace { line_offset: usize },
+}
+
+impl Invisible {
+    #[cfg(test)]
+    fn offset(&self) -> usize {
+        *match self {
+            Self::Tab { line_start_offset } => line_start_offset,
+            Self::Whitespace { line_offset } => line_offset,
+        }
+    }
+}
+
 fn layout_highlighted_chunks<'a>(
     chunks: impl Iterator<Item = HighlightedChunk<'a>>,
     text_style: &TextStyle,
@@ -1769,7 +1785,7 @@ fn layout_highlighted_chunks<'a>(
                 ));
 
                 // Line wrap pads its contents with fake whitespaces,
-                // avoid printing them.
+                // avoid printing them
                 let inside_wrapped_string = ix > 0;
                 if highlighted_chunk.is_tab {
                     if non_whitespace_added || !inside_wrapped_string {
@@ -2752,7 +2768,7 @@ mod tests {
     };
     use gpui::TestAppContext;
     use settings::Settings;
-    use std::sync::Arc;
+    use std::{num::NonZeroU32, sync::Arc};
     use util::test::sample_text;
 
     #[gpui::test]
@@ -2831,5 +2847,88 @@ mod tests {
         editor.update(cx, |editor, cx| {
             element.paint(&mut scene, bounds, bounds, &mut state, editor, cx);
         });
+    }
+
+    #[gpui::test]
+    fn test_invisible_drawing(cx: &mut TestAppContext) {
+        let tab_size = 4;
+        let initial_str = "\t\t\t\t\t\t\t\t| | a b c d ";
+        let (input_text, expected_invisibles) = {
+            let mut input_text = String::new();
+            let mut expected_invisibles = Vec::new();
+            let mut offset = 0;
+
+            let mut push_char = |char_symbol| {
+                input_text.push(char_symbol);
+                let new_offset = match char_symbol {
+                    '\t' => {
+                        expected_invisibles.push(Invisible::Tab {
+                            line_start_offset: offset,
+                        });
+                        tab_size as usize
+                    }
+                    ' ' => {
+                        expected_invisibles.push(Invisible::Whitespace {
+                            line_offset: offset,
+                        });
+                        1
+                    }
+                    _ => 1,
+                };
+                offset += new_offset;
+            };
+
+            for input_char in initial_str.chars() {
+                push_char(input_char)
+            }
+
+            (input_text, expected_invisibles)
+        };
+        assert_eq!(
+            expected_invisibles.len(),
+            initial_str
+                .chars()
+                .filter(|initial_char| initial_char.is_whitespace())
+                .count()
+        );
+
+        cx.update(|cx| {
+            let mut test_settings = Settings::test(cx);
+            test_settings.editor_defaults.show_invisibles = Some(ShowInvisibles::All);
+            test_settings.editor_defaults.tab_size = Some(NonZeroU32::new(tab_size).unwrap());
+            cx.set_global(test_settings);
+        });
+        let (_, editor) = cx.add_window(|cx| {
+            let buffer = MultiBuffer::build_simple(&input_text, cx);
+            Editor::new(EditorMode::Full, buffer, None, None, cx)
+        });
+
+        let mut element = EditorElement::new(editor.read_with(cx, |editor, cx| editor.style(cx)));
+        let (_, layout_state) = editor.update(cx, |editor, cx| {
+            let mut new_parents = Default::default();
+            let mut notify_views_if_parents_change = Default::default();
+            let mut layout_cx = LayoutContext::new(
+                cx,
+                &mut new_parents,
+                &mut notify_views_if_parents_change,
+                false,
+            );
+            element.layout(
+                SizeConstraint::new(vec2f(500., 500.), vec2f(500., 500.)),
+                editor,
+                &mut layout_cx,
+            )
+        });
+
+        let line_layouts = &layout_state.position_map.line_layouts;
+        let actual_invisibles = line_layouts
+            .iter()
+            .map(|line_with_invisibles| &line_with_invisibles.invisibles)
+            .flatten()
+            .sorted_by(|invisible_1, invisible_2| invisible_1.offset().cmp(&invisible_2.offset()))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(expected_invisibles, actual_invisibles);
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1711,16 +1711,6 @@ enum Invisible {
     Whitespace { line_offset: usize },
 }
 
-impl Invisible {
-    #[cfg(test)]
-    fn offset(&self) -> usize {
-        *match self {
-            Self::Tab { line_start_offset } => line_start_offset,
-            Self::Whitespace { line_offset } => line_offset,
-        }
-    }
-}
-
 fn layout_highlighted_chunks<'a>(
     chunks: impl Iterator<Item = HighlightedChunk<'a>>,
     text_style: &TextStyle,
@@ -2780,6 +2770,7 @@ mod tests {
         Editor, MultiBuffer,
     };
     use gpui::TestAppContext;
+    use log::info;
     use settings::Settings;
     use std::{num::NonZeroU32, sync::Arc};
     use util::test::sample_text;
@@ -2863,18 +2854,21 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_both_invisible_kinds_drawing(cx: &mut TestAppContext) {
+    fn test_all_invisibles_drawing(cx: &mut TestAppContext) {
         let tab_size = 4;
-        let input_text = "\t\t\t| | a b";
+        let input_text = "\t \t|\t| a b";
         let expected_invisibles = vec![
             Invisible::Tab {
                 line_start_offset: 0,
             },
-            Invisible::Tab {
-                line_start_offset: tab_size as usize,
+            Invisible::Whitespace {
+                line_offset: tab_size as usize,
             },
             Invisible::Tab {
-                line_start_offset: tab_size as usize * 2,
+                line_start_offset: tab_size as usize + 1,
+            },
+            Invisible::Tab {
+                line_start_offset: tab_size as usize * 2 + 1,
             },
             Invisible::Whitespace {
                 line_offset: tab_size as usize * 3 + 1,
@@ -2882,16 +2876,14 @@ mod tests {
             Invisible::Whitespace {
                 line_offset: tab_size as usize * 3 + 3,
             },
-            Invisible::Whitespace {
-                line_offset: tab_size as usize * 3 + 5,
-            },
         ];
         assert_eq!(
             expected_invisibles.len(),
             input_text
                 .chars()
                 .filter(|initial_char| initial_char.is_whitespace())
-                .count()
+                .count(),
+            "Hardcoded expected invisibles differ from the actual ones in '{input_text}'"
         );
 
         cx.update(|cx| {
@@ -2900,36 +2892,8 @@ mod tests {
             test_settings.editor_defaults.tab_size = Some(NonZeroU32::new(tab_size).unwrap());
             cx.set_global(test_settings);
         });
-        let (_, editor) = cx.add_window(|cx| {
-            let buffer = MultiBuffer::build_simple(&input_text, cx);
-            Editor::new(EditorMode::Full, buffer, None, None, cx)
-        });
-
-        let mut element = EditorElement::new(editor.read_with(cx, |editor, cx| editor.style(cx)));
-        let (_, layout_state) = editor.update(cx, |editor, cx| {
-            let mut new_parents = Default::default();
-            let mut notify_views_if_parents_change = Default::default();
-            let mut layout_cx = LayoutContext::new(
-                cx,
-                &mut new_parents,
-                &mut notify_views_if_parents_change,
-                false,
-            );
-            element.layout(
-                SizeConstraint::new(vec2f(500., 500.), vec2f(500., 500.)),
-                editor,
-                &mut layout_cx,
-            )
-        });
-
-        let line_layouts = &layout_state.position_map.line_layouts;
-        let actual_invisibles = line_layouts
-            .iter()
-            .map(|line_with_invisibles| &line_with_invisibles.invisibles)
-            .flatten()
-            .sorted_by(|invisible_1, invisible_2| invisible_1.offset().cmp(&invisible_2.offset()))
-            .cloned()
-            .collect::<Vec<_>>();
+        let actual_invisibles =
+            collect_invisibles_from_new_editor(cx, EditorMode::Full, &input_text, 500.0);
 
         assert_eq!(expected_invisibles, actual_invisibles);
     }
@@ -2947,42 +2911,135 @@ mod tests {
             EditorMode::SingleLine,
             EditorMode::AutoHeight { max_lines: 100 },
         ] {
-            let (_, editor) = cx.add_window(|cx| {
-                let buffer = MultiBuffer::build_simple("\t\t\t| | a b", cx);
-                Editor::new(editor_mode_without_invisibles, buffer, None, None, cx)
-            });
-
-            let mut element =
-                EditorElement::new(editor.read_with(cx, |editor, cx| editor.style(cx)));
-            let (_, layout_state) = editor.update(cx, |editor, cx| {
-                let mut new_parents = Default::default();
-                let mut notify_views_if_parents_change = Default::default();
-                let mut layout_cx = LayoutContext::new(
-                    cx,
-                    &mut new_parents,
-                    &mut notify_views_if_parents_change,
-                    false,
-                );
-                element.layout(
-                    SizeConstraint::new(vec2f(500., 500.), vec2f(500., 500.)),
-                    editor,
-                    &mut layout_cx,
-                )
-            });
-
-            let line_layouts = &layout_state.position_map.line_layouts;
-            let invisibles = line_layouts
-                .iter()
-                .map(|line_with_invisibles| &line_with_invisibles.invisibles)
-                .flatten()
-                .sorted_by(|invisible_1, invisible_2| {
-                    invisible_1.offset().cmp(&invisible_2.offset())
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-
+            let invisibles = collect_invisibles_from_new_editor(
+                cx,
+                editor_mode_without_invisibles,
+                "\t\t\t| | a b",
+                500.0,
+            );
             assert!(invisibles.is_empty(),
                 "For editor mode {editor_mode_without_invisibles:?} no invisibles was expected but got {invisibles:?}");
         }
+    }
+
+    #[gpui::test]
+    fn test_wrapped_invisibles_drawing(cx: &mut TestAppContext) {
+        let tab_size = 4;
+        let input_text = "a\tbcd   ".repeat(9);
+        let repeated_invisibles = [
+            Invisible::Tab {
+                line_start_offset: 1,
+            },
+            Invisible::Whitespace {
+                line_offset: tab_size as usize + 3,
+            },
+            Invisible::Whitespace {
+                line_offset: tab_size as usize + 4,
+            },
+            Invisible::Whitespace {
+                line_offset: tab_size as usize + 5,
+            },
+        ];
+        let expected_invisibles = std::iter::once(repeated_invisibles)
+            .cycle()
+            .take(9)
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            expected_invisibles.len(),
+            input_text
+                .chars()
+                .filter(|initial_char| initial_char.is_whitespace())
+                .count(),
+            "Hardcoded expected invisibles differ from the actual ones in '{input_text}'"
+        );
+        info!("Expected invisibles: {expected_invisibles:?}");
+
+        // Put the same string with repeating whitespace pattern into editors of various size,
+        // take deliberately small steps during resizing, to put all whitespace kinds near the wrap point.
+        let resize_step = 10.0;
+        let mut editor_width = 200.0;
+        while editor_width <= 1000.0 {
+            cx.update(|cx| {
+                let mut test_settings = Settings::test(cx);
+                test_settings.editor_defaults.tab_size = Some(NonZeroU32::new(tab_size).unwrap());
+                test_settings.editor_defaults.show_whitespaces = Some(ShowWhitespaces::All);
+                test_settings.editor_defaults.preferred_line_length = Some(editor_width as u32);
+                test_settings.editor_defaults.soft_wrap =
+                    Some(settings::SoftWrap::PreferredLineLength);
+                cx.set_global(test_settings);
+            });
+
+            let actual_invisibles =
+                collect_invisibles_from_new_editor(cx, EditorMode::Full, &input_text, editor_width);
+
+            // Whatever the editor size is, ensure it has the same invisible kinds in the same order
+            // (no good guarantees about the offsets: wrapping could trigger padding and its tests should check the offsets).
+            let mut i = 0;
+            for (actual_index, actual_invisible) in actual_invisibles.iter().enumerate() {
+                i = actual_index;
+                match expected_invisibles.get(i) {
+                    Some(expected_invisible) => match (expected_invisible, actual_invisible) {
+                        (Invisible::Whitespace { .. }, Invisible::Whitespace { .. })
+                        | (Invisible::Tab { .. }, Invisible::Tab { .. }) => {}
+                        _ => {
+                            panic!("At index {i}, expected invisible {expected_invisible:?} does not match actual {actual_invisible:?} by kind. Actual invisibles: {actual_invisibles:?}")
+                        }
+                    },
+                    None => panic!("Unexpected extra invisible {actual_invisible:?} at index {i}"),
+                }
+            }
+            let missing_expected_invisibles = &expected_invisibles[i + 1..];
+            assert!(
+                missing_expected_invisibles.is_empty(),
+                "Missing expected invisibles after index {i}: {missing_expected_invisibles:?}"
+            );
+
+            editor_width += resize_step;
+        }
+    }
+
+    fn collect_invisibles_from_new_editor(
+        cx: &mut TestAppContext,
+        editor_mode: EditorMode,
+        input_text: &str,
+        editor_width: f32,
+    ) -> Vec<Invisible> {
+        info!(
+            "Creating editor with mode {editor_mode:?}, witdh {editor_width} and text '{input_text}'"
+        );
+        let (_, editor) = cx.add_window(|cx| {
+            let buffer = MultiBuffer::build_simple(&input_text, cx);
+            Editor::new(editor_mode, buffer, None, None, cx)
+        });
+
+        let mut element = EditorElement::new(editor.read_with(cx, |editor, cx| editor.style(cx)));
+        let (_, layout_state) = editor.update(cx, |editor, cx| {
+            editor.set_soft_wrap_mode(settings::SoftWrap::EditorWidth, cx);
+            editor.set_wrap_width(Some(editor_width), cx);
+
+            let mut new_parents = Default::default();
+            let mut notify_views_if_parents_change = Default::default();
+            let mut layout_cx = LayoutContext::new(
+                cx,
+                &mut new_parents,
+                &mut notify_views_if_parents_change,
+                false,
+            );
+            element.layout(
+                SizeConstraint::new(vec2f(editor_width, 500.), vec2f(editor_width, 500.)),
+                editor,
+                &mut layout_cx,
+            )
+        });
+
+        layout_state
+            .position_map
+            .line_layouts
+            .iter()
+            .map(|line_with_invisibles| &line_with_invisibles.invisibles)
+            .flatten()
+            .cloned()
+            .collect()
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1382,6 +1382,7 @@ impl EditorElement {
                 MAX_LINE_LEN,
                 rows.len() as usize,
                 line_number_layouts,
+                snapshot.mode,
             )
         }
     }
@@ -1728,6 +1729,7 @@ fn layout_highlighted_chunks<'a>(
     max_line_len: usize,
     max_line_count: usize,
     line_number_layouts: &[Option<Line>],
+    editor_mode: EditorMode,
 ) -> Vec<LineWithInvisibles> {
     let mut layouts = Vec::with_capacity(max_line_count);
     let mut line = String::new();
@@ -1787,30 +1789,37 @@ fn layout_highlighted_chunks<'a>(
                     },
                 ));
 
-                // Line wrap pads its contents with fake whitespaces,
-                // avoid printing them
-                let inside_wrapped_string = line_number_layouts[row].is_none();
-                if highlighted_chunk.is_tab {
-                    if non_whitespace_added || !inside_wrapped_string {
-                        invisibles.push(Invisible::Tab {
-                            line_start_offset: line.len(),
-                        });
+                if editor_mode == EditorMode::Full {
+                    // Line wrap pads its contents with fake whitespaces,
+                    // avoid printing them
+                    let inside_wrapped_string = line_number_layouts
+                        .get(row)
+                        .and_then(|layout| layout.as_ref())
+                        .is_none();
+                    if highlighted_chunk.is_tab {
+                        if non_whitespace_added || !inside_wrapped_string {
+                            invisibles.push(Invisible::Tab {
+                                line_start_offset: line.len(),
+                            });
+                        }
+                    } else {
+                        invisibles.extend(
+                            line_chunk
+                                .chars()
+                                .enumerate()
+                                .filter(|(_, line_char)| {
+                                    let is_whitespace = line_char.is_whitespace();
+                                    non_whitespace_added |= !is_whitespace;
+                                    is_whitespace
+                                        && (non_whitespace_added || !inside_wrapped_string)
+                                })
+                                .map(|(whitespace_index, _)| Invisible::Whitespace {
+                                    line_offset: line.len() + whitespace_index,
+                                }),
+                        )
                     }
-                } else {
-                    invisibles.extend(
-                        line_chunk
-                            .chars()
-                            .enumerate()
-                            .filter(|(_, line_char)| {
-                                let is_whitespace = line_char.is_whitespace();
-                                non_whitespace_added |= !is_whitespace;
-                                is_whitespace && (non_whitespace_added || !inside_wrapped_string)
-                            })
-                            .map(|(whitespace_index, _)| Invisible::Whitespace {
-                                line_offset: line.len() + whitespace_index,
-                            }),
-                    )
                 }
+
                 line.push_str(line_chunk);
             }
         }
@@ -2923,5 +2932,57 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(expected_invisibles, actual_invisibles);
+    }
+
+    #[gpui::test]
+    fn test_invisibles_dont_appear_in_certain_editors(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let mut test_settings = Settings::test(cx);
+            test_settings.editor_defaults.show_whitespaces = Some(ShowWhitespaces::All);
+            test_settings.editor_defaults.tab_size = Some(NonZeroU32::new(4).unwrap());
+            cx.set_global(test_settings);
+        });
+
+        for editor_mode_without_invisibles in [
+            EditorMode::SingleLine,
+            EditorMode::AutoHeight { max_lines: 100 },
+        ] {
+            let (_, editor) = cx.add_window(|cx| {
+                let buffer = MultiBuffer::build_simple("\t\t\t| | a b", cx);
+                Editor::new(editor_mode_without_invisibles, buffer, None, None, cx)
+            });
+
+            let mut element =
+                EditorElement::new(editor.read_with(cx, |editor, cx| editor.style(cx)));
+            let (_, layout_state) = editor.update(cx, |editor, cx| {
+                let mut new_parents = Default::default();
+                let mut notify_views_if_parents_change = Default::default();
+                let mut layout_cx = LayoutContext::new(
+                    cx,
+                    &mut new_parents,
+                    &mut notify_views_if_parents_change,
+                    false,
+                );
+                element.layout(
+                    SizeConstraint::new(vec2f(500., 500.), vec2f(500., 500.)),
+                    editor,
+                    &mut layout_cx,
+                )
+            });
+
+            let line_layouts = &layout_state.position_map.line_layouts;
+            let invisibles = line_layouts
+                .iter()
+                .map(|line_with_invisibles| &line_with_invisibles.invisibles)
+                .flatten()
+                .sorted_by(|invisible_1, invisible_2| {
+                    invisible_1.offset().cmp(&invisible_2.offset())
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            assert!(invisibles.is_empty(),
+                "For editor mode {editor_mode_without_invisibles:?} no invisibles was expected but got {invisibles:?}");
+        }
     }
 }

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -1,9 +1,9 @@
 use std::cmp;
 
-use gpui::{text_layout, ViewContext};
+use gpui::ViewContext;
 use language::Point;
 
-use crate::{display_map::ToDisplayPoint, Editor, EditorMode};
+use crate::{display_map::ToDisplayPoint, Editor, EditorMode, LineWithInvisibles};
 
 #[derive(PartialEq, Eq)]
 pub enum Autoscroll {
@@ -172,7 +172,7 @@ impl Editor {
         viewport_width: f32,
         scroll_width: f32,
         max_glyph_width: f32,
-        layouts: &[text_layout::Line],
+        layouts: &[LineWithInvisibles],
         cx: &mut ViewContext<Self>,
     ) -> bool {
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
@@ -194,10 +194,13 @@ impl Editor {
                     let end_column = cmp::min(display_map.line_len(head.row()), head.column() + 3);
                     target_left = target_left.min(
                         layouts[(head.row() - start_row) as usize]
+                            .line
                             .x_for_index(start_column as usize),
                     );
                     target_right = target_right.max(
-                        layouts[(head.row() - start_row) as usize].x_for_index(end_column as usize)
+                        layouts[(head.row() - start_row) as usize]
+                            .line
+                            .x_for_index(end_column as usize)
                             + max_glyph_width,
                     );
                 }

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -129,6 +129,7 @@ impl<V: View> Element<V> for Text {
             &cx.font_cache,
             usize::MAX,
             self.text.matches('\n').count() + 1,
+            false,
         );
 
         // If line wrapping is enabled, wrap each of the shaped lines.
@@ -365,6 +366,7 @@ pub fn layout_highlighted_chunks<'a>(
     font_cache: &Arc<FontCache>,
     max_line_len: usize,
     max_line_count: usize,
+    show_invisibles: bool,
 ) -> Vec<Line> {
     let mut layouts = Vec::with_capacity(max_line_count);
     let mut line = String::new();
@@ -416,7 +418,7 @@ pub fn layout_highlighted_chunks<'a>(
                         underline: text_style.underline,
                     },
                 ));
-                if highlighted_chunk.is_tab {
+                if show_invisibles && highlighted_chunk.is_tab {
                     invisibles.push(Invisible::Tab {
                         range: line.len()..line.len() + line_chunk.len(),
                     });

--- a/crates/gpui/src/text_layout.rs
+++ b/crates/gpui/src/text_layout.rs
@@ -214,7 +214,7 @@ pub struct Glyph {
 #[derive(Debug, Clone)]
 pub enum Invisible {
     Tab { line_start_offset: usize },
-    Whitespace { line_range: std::ops::Range<usize> },
+    Whitespace { line_offset: usize },
 }
 
 impl Line {

--- a/crates/gpui/src/text_layout.rs
+++ b/crates/gpui/src/text_layout.rs
@@ -211,12 +211,6 @@ pub struct Glyph {
     pub is_emoji: bool,
 }
 
-#[derive(Debug, Clone)]
-pub enum Invisible {
-    Tab { line_start_offset: usize },
-    Whitespace { line_offset: usize },
-}
-
 impl Line {
     fn new(layout: Arc<LineLayout>, runs: &[(usize, RunStyle)]) -> Self {
         let mut style_runs = SmallVec::new();

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -311,6 +311,7 @@ pub struct Chunk<'a> {
     pub highlight_style: Option<HighlightStyle>,
     pub diagnostic_severity: Option<DiagnosticSeverity>,
     pub is_unnecessary: bool,
+    pub is_tab: bool,
 }
 
 pub struct Diff {
@@ -2840,9 +2841,9 @@ impl<'a> Iterator for BufferChunks<'a> {
             Some(Chunk {
                 text: slice,
                 syntax_highlight_id: highlight_id,
-                highlight_style: None,
                 diagnostic_severity: self.current_diagnostic_severity(),
                 is_unnecessary: self.current_code_is_unnecessary(),
+                ..Default::default()
             })
         } else {
             None

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -451,6 +451,7 @@ pub struct FeaturesContent {
 #[serde(rename_all = "snake_case")]
 pub enum ShowInvisibles {
     #[default]
+    Selection,
     None,
     All,
 }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -173,6 +173,7 @@ pub struct EditorSettings {
     pub formatter: Option<Formatter>,
     pub enable_language_server: Option<bool>,
     pub show_copilot_suggestions: Option<bool>,
+    pub show_invisibles: Option<ShowInvisibles>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -446,6 +447,14 @@ pub struct FeaturesContent {
     pub copilot: Option<bool>,
 }
 
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ShowInvisibles {
+    #[default]
+    None,
+    All,
+}
+
 impl Settings {
     pub fn initial_user_settings_content(assets: &'static impl AssetSource) -> Cow<'static, str> {
         match assets.load(INITIAL_USER_SETTINGS_ASSET_PATH).unwrap() {
@@ -507,6 +516,7 @@ impl Settings {
                 formatter: required(defaults.editor.formatter),
                 enable_language_server: required(defaults.editor.enable_language_server),
                 show_copilot_suggestions: required(defaults.editor.show_copilot_suggestions),
+                show_invisibles: required(defaults.editor.show_invisibles),
             },
             editor_overrides: Default::default(),
             copilot: CopilotSettings {
@@ -657,6 +667,10 @@ impl Settings {
         self.language_setting(language, |settings| settings.tab_size)
     }
 
+    pub fn show_invisibles(&self, language: Option<&str>) -> ShowInvisibles {
+        self.language_setting(language, |settings| settings.show_invisibles)
+    }
+
     pub fn hard_tabs(&self, language: Option<&str>) -> bool {
         self.language_setting(language, |settings| settings.hard_tabs)
     }
@@ -793,6 +807,7 @@ impl Settings {
                 formatter: Some(Formatter::LanguageServer),
                 enable_language_server: Some(true),
                 show_copilot_suggestions: Some(true),
+                show_invisibles: Some(ShowInvisibles::None),
             },
             editor_overrides: Default::default(),
             copilot: Default::default(),

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -173,7 +173,7 @@ pub struct EditorSettings {
     pub formatter: Option<Formatter>,
     pub enable_language_server: Option<bool>,
     pub show_copilot_suggestions: Option<bool>,
-    pub show_invisibles: Option<ShowInvisibles>,
+    pub show_whitespaces: Option<ShowWhitespaces>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -449,7 +449,7 @@ pub struct FeaturesContent {
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ShowInvisibles {
+pub enum ShowWhitespaces {
     #[default]
     Selection,
     None,
@@ -517,7 +517,7 @@ impl Settings {
                 formatter: required(defaults.editor.formatter),
                 enable_language_server: required(defaults.editor.enable_language_server),
                 show_copilot_suggestions: required(defaults.editor.show_copilot_suggestions),
-                show_invisibles: required(defaults.editor.show_invisibles),
+                show_whitespaces: required(defaults.editor.show_whitespaces),
             },
             editor_overrides: Default::default(),
             copilot: CopilotSettings {
@@ -668,8 +668,8 @@ impl Settings {
         self.language_setting(language, |settings| settings.tab_size)
     }
 
-    pub fn show_invisibles(&self, language: Option<&str>) -> ShowInvisibles {
-        self.language_setting(language, |settings| settings.show_invisibles)
+    pub fn show_whitespaces(&self, language: Option<&str>) -> ShowWhitespaces {
+        self.language_setting(language, |settings| settings.show_whitespaces)
     }
 
     pub fn hard_tabs(&self, language: Option<&str>) -> bool {
@@ -808,7 +808,7 @@ impl Settings {
                 formatter: Some(Formatter::LanguageServer),
                 enable_language_server: Some(true),
                 show_copilot_suggestions: Some(true),
-                show_invisibles: Some(ShowInvisibles::None),
+                show_whitespaces: Some(ShowWhitespaces::None),
             },
             editor_overrides: Default::default(),
             copilot: Default::default(),

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -636,6 +636,7 @@ pub struct Editor {
     pub composition_mark: HighlightStyle,
     pub jump_icon: Interactive<IconButton>,
     pub scrollbar: Scrollbar,
+    pub whitespace: Color,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/styles/src/styleTree/editor.ts
+++ b/styles/src/styleTree/editor.ts
@@ -3,7 +3,7 @@ import { ColorScheme, Layer, StyleSets } from "../themes/common/colorScheme"
 import { background, border, borderColor, foreground, text } from "./components"
 import hoverPopover from "./hoverPopover"
 
-import { buildSyntax } from "../themes/common/syntax"
+import { SyntaxHighlightStyle, buildSyntax } from "../themes/common/syntax"
 
 export default function editor(colorScheme: ColorScheme) {
     let layer = colorScheme.highest
@@ -123,6 +123,7 @@ export default function editor(colorScheme: ColorScheme) {
         renameFade: 0.6,
         unnecessaryCodeFade: 0.5,
         selection: colorScheme.players[0],
+        whitespace: colorScheme.ramps.neutral(0.5).hex(),
         guestSelections: [
             colorScheme.players[1],
             colorScheme.players[2],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2690773/236447061-53b6e17d-3dfd-41d0-9d08-f5691f89125b.png)


Adds new settings entry, `show_whitespaces` (name taken from other editors' settings), that is by default set to "selection" and also accepts "all" and "none" values.

The impl uses → and • symbols to mark the tab and whitespace, respectively.