### PR TITLE
Prevent some cases of clipping icons due to pixel coord rounding

### DIFF
--- a/crates/drag_and_drop/src/drag_and_drop.rs
+++ b/crates/drag_and_drop/src/drag_and_drop.rs
@@ -199,7 +199,7 @@ impl<V: View> DragAndDrop<V> {
                             return None;
                         }
 
-                        let position = position - region_offset;
+                        let position = (position - region_offset).round();
                         Some(
                             Overlay::new(
                                 MouseEventHandler::<DraggedElementHandler, V>::new(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1609,7 +1609,8 @@ impl Element<Editor> for EditorElement {
         let gutter_width;
         let gutter_margin;
         if snapshot.mode == EditorMode::Full {
-            gutter_padding = style.text.em_width(cx.font_cache()) * style.gutter_padding_factor;
+            let em_width = style.text.em_width(cx.font_cache());
+            gutter_padding = (em_width * style.gutter_padding_factor).round();
             gutter_width = self.max_line_number_width(&snapshot, cx) + gutter_padding * 2.0;
             gutter_margin = -style.text.descent(cx.font_cache());
         } else {


### PR DESCRIPTION
Regards https://linear.app/zed-industries/issue/Z-1050/tab-icons-cut-off

We generally assume fractional coords are valid throughout the UI system but this can cause issues when flooring/rounding/ceiling these coords near boundaries, with these icons getting cut off by their layer boundaries. This patch fixes up the problematic icons I could track down but I feel there's probably a more complete solution hiding somewhere. Maybe disallowing fractional coords altogether? This feels like an unfortunate footgun especially since it seems it will only repro under specific conditions (probably related to display scaling factor?).

Pre-round the coordinate of the drag-and-drop render item at the top level, this has the added benefit that text jitters around less when moving under lower DPI

Round the gutter padding after performing the padding factor multiplication. On my display this has the same results as changing the padding factor from `3.5` to `3.0` but should be more in line with the original intent of that value on higher DPI display/scaling factors

I was unable to repro the tab icons cutting off so this does not affect that issue, once I can repro I'll come back and figure that one out. My guess is that it's probably related to tab bar layout when a tab has a fractional width, we'll see