### PR TITLE
Fully remove panes and update internal data structures

### DIFF
--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -147,7 +147,14 @@ impl SerializedPaneGroup {
                 } else {
                     let pane = pane.upgrade(cx)?;
                     workspace
-                        .update(cx, |workspace, cx| workspace.remove_pane(pane, cx))
+                        .update(cx, |workspace, cx| {
+                            workspace.panes.retain(|p| p != &pane);
+                            cx.focus(workspace.panes.last().unwrap());
+                            if workspace.last_active_center_pane == Some(pane.downgrade()) {
+                                workspace.last_active_center_pane = None;
+                            }
+                            cx.notify();
+                        })
                         .log_err()?;
                     None
                 }

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -147,14 +147,7 @@ impl SerializedPaneGroup {
                 } else {
                     let pane = pane.upgrade(cx)?;
                     workspace
-                        .update(cx, |workspace, cx| {
-                            workspace.panes.retain(|p| p != &pane);
-                            cx.focus(workspace.panes.last().unwrap());
-                            if workspace.last_active_center_pane == Some(pane.downgrade()) {
-                                workspace.last_active_center_pane = None;
-                            }
-                            cx.notify();
-                        })
+                        .update(cx, |workspace, cx| workspace.force_remove_pane(&pane, cx))
                         .log_err()?;
                     None
                 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2459,7 +2459,14 @@ impl Workspace {
                     self.remove_panes(child.clone(), cx)
                 }
             }
-            Member::Pane(pane) => self.remove_pane(pane.clone(), cx),
+            Member::Pane(pane) => {
+                self.panes.retain(|p| p != &pane);
+                cx.focus(self.panes.last().unwrap());
+                if self.last_active_center_pane == Some(pane.downgrade()) {
+                    self.last_active_center_pane = None;
+                }
+                cx.notify();
+            },
         }
     }
 


### PR DESCRIPTION
Before https://github.com/zed-industries/zed/pull/2441, the workspace's `focus_in` impl masked a bug in the pane deserialization logic that would leave a mistmatch between what was in the `center` and the`active_pane`. While debugging this I realized there was another memory leak in the pane removal code when there was a *successful* deserialization: the original pane is left behind in the `panes` array even though it's not part of the `center`. Both of these bugs stem from the behavior of `Workspace::remove_pane()`, which won't actually remove anything if there is a non-split pane in the center.  This PR contains a minimal fix to properly preserve the workspace's invariants but I'm unsatisfied with it. I think there are more fundamental problems with the workspace deserialization that might be solved with the new focus approach, but at least main isn't broken now.