### PR TITLE
Make dock not eagerly steal focus from sub items

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -3963,6 +3963,15 @@ impl Drop for AnyViewHandle {
     }
 }
 
+impl Debug for AnyViewHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnyViewHandle")
+            .field("window_id", &self.window_id)
+            .field("view_id", &self.view_id)
+            .finish()
+    }
+}
+
 pub struct AnyModelHandle {
     model_id: usize,
     model_type: TypeId,
@@ -4072,10 +4081,18 @@ impl AnyWeakModelHandle {
     }
 }
 
-#[derive(Debug, Copy)]
+#[derive(Copy)]
 pub struct WeakViewHandle<T> {
     any_handle: AnyWeakViewHandle,
     view_type: PhantomData<T>,
+}
+
+impl<T> Debug for WeakViewHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(&format!("WeakViewHandle<{}>", type_name::<T>()))
+            .field("any_handle", &self.any_handle)
+            .finish()
+    }
 }
 
 impl<T> WeakHandle for WeakViewHandle<T> {

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -197,7 +197,7 @@ impl SerializedPane {
                     let pane_handle = pane_handle
                         .upgrade(cx)
                         .ok_or_else(|| anyhow!("pane was dropped"))?;
-                    Pane::add_item(workspace, &pane_handle, item_handle, false, false, None, cx);
+                    Pane::add_item(workspace, &pane_handle, item_handle, true, true, None, cx);
                     anyhow::Ok(())
                 })??;
             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2610,7 +2610,7 @@ impl Workspace {
                     Dock::set_dock_position(
                         workspace,
                         serialized_workspace.dock_position,
-                        true,
+                        false,
                         cx,
                     );
                 });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1600,7 +1600,6 @@ impl Workspace {
             });
             self.active_item_path_changed(cx);
 
-
             if &pane == self.dock_pane() {
                 Dock::show(self, false, cx);
             } else {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1600,8 +1600,9 @@ impl Workspace {
             });
             self.active_item_path_changed(cx);
 
+
             if &pane == self.dock_pane() {
-                Dock::show(self, true, cx);
+                Dock::show(self, false, cx);
             } else {
                 self.last_active_center_pane = Some(pane.downgrade());
                 if self.dock.is_anchored_at(DockAnchor::Expanded) {


### PR DESCRIPTION
This should fix a bug introduced in https://github.com/zed-industries/zed/pull/2441. Essentially, the panes originally handed focus downward to their active items more aggressively, and the dock relied on this behavior to function during `handle_pane_focused`. This fixes that bug, and a related bug involving the center pane not being focused when there is a dock. But in the process I discovered another problem with the terminal button, where the dock pane will not be opened but the terminal will be focused.

TODO: 
- [x] Fix center not being focused
- [ ] ~~Fix terminal button not focusing the dock properly~~ Out of scope.