### PR TITLE
Fix bug with terminal button

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1554,6 +1554,9 @@ impl Workspace {
                 .map(|ix| (pane.clone(), ix))
         });
         if let Some((pane, ix)) = result {
+            if &pane == self.dock_pane() {
+                Dock::show(self, false, cx);
+            }
             pane.update(cx, |pane, cx| pane.activate_item(ix, true, true, cx));
             true
         } else {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/zed-industries/zed/pull/2441, dock showing and hiding depended on the explicit view hierarchy to dispatch focus. Now we activate the dock.