### PR TITLE
During CI, clear the target directory if it gets larger than a maximum size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
           clean: false
           submodules: 'recursive'
 
+      - name: Limit target directory size
+        run: script/clear-target-dir-if-larger-than 70
+
       - name: Run check
         run: cargo check --workspace
 
@@ -109,6 +112,9 @@ jobs:
         with:
           clean: false
           submodules: 'recursive'
+
+      - name: Limit target directory size
+        run: script/clear-target-dir-if-larger-than 70
 
       - name: Determine version and release channel
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/script/clear-target-dir-if-larger-than
+++ b/script/clear-target-dir-if-larger-than
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+if [[ $# < 1 ]]; then
+    echo "usage: $0 <MAX_SIZE_IN_GB>"
+    exit 1
+fi
+
+max_size_gb=$1
+
+current_size=$(du -s target | cut -f1)
+current_size_gb=$(expr ${current_size} / 1024 / 1024)
+
+echo "target directory size: ${current_size_gb}gb. max size: ${max_size_gb}gb"
+
+if [[ ${current_size_gb} -gt ${max_size_gb} ]]; then
+    echo "clearing target directory"
+    rm -rf target
+fi


### PR DESCRIPTION
Our CI boxes periodically run out of disk space. This PR adds a CI step that checks the size of the `target` directory and removes it if it gets too big. This should prevent us from having to manually delete the `target` directories to free up space.