### PR TITLE
Support go to file_query:row:column syntax in Find File, Go To Line dialogs and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "plist",
  "serde",
  "serde_derive",
+ "util",
 ]
 
 [[package]]
@@ -2675,6 +2676,7 @@ dependencies = [
  "postage",
  "settings",
  "text",
+ "util",
  "workspace",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "project",
  "serde_json",
  "settings",
+ "text",
  "theme",
  "util",
  "workspace",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ dirs = "3.0"
 ipc-channel = "0.16"
 serde.workspace = true
 serde_derive.workspace = true
+util = { path = "../util" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,7 +1,5 @@
 pub use ipc_channel::ipc;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
-use util::paths::PathLikeWithPosition;
 
 #[derive(Serialize, Deserialize)]
 pub struct IpcHandshake {
@@ -11,11 +9,12 @@ pub struct IpcHandshake {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CliRequest {
-    Open {
-        // TODO kb old cli won't be able to communicate to new Zed with this change
-        paths: Vec<PathLikeWithPosition<PathBuf>>,
-        wait: bool,
-    },
+    // The filed is named `path` for compatibility, but now CLI can request
+    // opening a path at a certain row and/or column: `some/path:123` and `some/path:123:456`.
+    //
+    // Since Zed CLI has to be installed separately, there can be situations when old CLI is
+    // querying new Zed editors, support both formats by using `String` here and parsing it on Zed side later.
+    Open { paths: Vec<String>, wait: bool },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,6 +1,7 @@
 pub use ipc_channel::ipc;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use util::paths::PathLikeWithPosition;
 
 #[derive(Serialize, Deserialize)]
 pub struct IpcHandshake {
@@ -10,7 +11,11 @@ pub struct IpcHandshake {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CliRequest {
-    Open { paths: Vec<PathBuf>, wait: bool },
+    Open {
+        // TODO kb old cli won't be able to communicate to new Zed with this change
+        paths: Vec<PathLikeWithPosition<PathBuf>>,
+        wait: bool,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,7 +21,7 @@ use util::paths::PathLikeWithPosition;
 #[derive(Parser)]
 #[clap(name = "zed", global_setting(clap::AppSettings::NoAutoVersion))]
 struct Args {
-    /// Wait for all of the given paths to be closed before exiting.
+    /// Wait for all of the given paths to be opened/closed before exiting.
     #[clap(short, long)]
     wait: bool,
     /// A sequence of space-separated paths that you want to open.
@@ -78,12 +78,13 @@ fn main() -> Result<()> {
         paths: args
             .paths_with_position
             .into_iter()
-            // TODO kb continue sendint path with the position further
-            .map(|path_with_position| path_with_position.path_like)
-            .map(|path| {
-                fs::canonicalize(&path).with_context(|| format!("path {path:?} canonicalization"))
+            .map(|path_with_position| {
+                path_with_position.convert_path(|path| {
+                    fs::canonicalize(&path)
+                        .with_context(|| format!("path {path:?} canonicalization"))
+                })
             })
-            .collect::<Result<Vec<PathBuf>>>()?,
+            .collect::<Result<_>>()?,
         wait: args.wait,
     })?;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -79,10 +79,11 @@ fn main() -> Result<()> {
             .paths_with_position
             .into_iter()
             .map(|path_with_position| {
-                path_with_position.convert_path(|path| {
+                let path_with_position = path_with_position.convert_path(|path| {
                     fs::canonicalize(&path)
                         .with_context(|| format!("path {path:?} canonicalization"))
-                })
+                })?;
+                Ok(path_with_position.to_string(|path| path.display().to_string()))
             })
             .collect::<Result<_>>()?,
         wait: args.wait,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
             .paths_with_position
             .into_iter()
             .map(|path_with_position| {
-                let path_with_position = path_with_position.convert_path(|path| {
+                let path_with_position = path_with_position.map_path_like(|path| {
                     fs::canonicalize(&path)
                         .with_context(|| format!("path {path:?} canonicalization"))
                 })?;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -98,7 +98,6 @@ const MAX_SELECTION_HISTORY_LEN: usize = 1024;
 const COPILOT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
 
 pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
-pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
 #[derive(Clone, Deserialize, PartialEq, Default)]
 pub struct SelectNext {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -98,6 +98,7 @@ const MAX_SELECTION_HISTORY_LEN: usize = 1024;
 const COPILOT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
 
 pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
+pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
 #[derive(Clone, Deserialize, PartialEq, Default)]
 pub struct SelectNext {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1006,8 +1006,7 @@ mod tests {
                     .zip(expected_styles.iter().cloned())
                     .collect::<Vec<_>>();
                 assert_eq!(
-                    rendered.text,
-                    dbg!(expected_text),
+                    rendered.text, expected_text,
                     "wrong text for input {blocks:?}"
                 );
                 assert_eq!(

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -2,6 +2,7 @@ use crate::{
     display_map::ToDisplayPoint, link_go_to_definition::hide_link_definition,
     movement::surrounding_word, persistence::DB, scroll::ScrollAnchor, Anchor, Autoscroll, Editor,
     Event, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot, NavigationData, ToPoint as _,
+    FILE_ROW_COLUMN_DELIMITER,
 };
 use anyhow::{Context, Result};
 use collections::HashSet;
@@ -1112,7 +1113,11 @@ impl View for CursorPosition {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
         if let Some(position) = self.position {
             let theme = &cx.global::<Settings>().theme.workspace.status_bar;
-            let mut text = format!("{},{}", position.row + 1, position.column + 1);
+            let mut text = format!(
+                "{}{FILE_ROW_COLUMN_DELIMITER}{}",
+                position.row + 1,
+                position.column + 1
+            );
             if self.selected_count > 0 {
                 write!(text, " ({} selected)", self.selected_count).unwrap();
             }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -2,7 +2,6 @@ use crate::{
     display_map::ToDisplayPoint, link_go_to_definition::hide_link_definition,
     movement::surrounding_word, persistence::DB, scroll::ScrollAnchor, Anchor, Autoscroll, Editor,
     Event, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot, NavigationData, ToPoint as _,
-    FILE_ROW_COLUMN_DELIMITER,
 };
 use anyhow::{Context, Result};
 use collections::HashSet;
@@ -28,7 +27,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use text::Selection;
-use util::{ResultExt, TryFutureExt};
+use util::{paths::FILE_ROW_COLUMN_DELIMITER, ResultExt, TryFutureExt};
 use workspace::item::{BreadcrumbText, FollowableItemHandle};
 use workspace::{
     item::{FollowableItem, Item, ItemEvent, ItemHandle, ProjectItem},

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -16,6 +16,7 @@ menu = { path = "../menu" }
 picker = { path = "../picker" }
 project = { path = "../project" }
 settings = { path = "../settings" }
+text = { path = "../text" }
 util = { path = "../util" }
 theme = { path = "../theme" }
 workspace = { path = "../workspace" }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1,4 +1,4 @@
-use editor::{scroll::autoscroll::Autoscroll, DisplayPoint, Editor};
+use editor::{scroll::autoscroll::Autoscroll, Bias, DisplayPoint, Editor};
 use fuzzy::PathMatch;
 use gpui::{
     actions, elements::*, AppContext, ModelHandle, MouseState, Task, ViewContext, WeakViewHandle,
@@ -308,41 +308,54 @@ impl PickerDelegate for FileFinderDelegate {
                     path: m.path.clone(),
                 };
 
-                workspace.update(cx, |workspace, cx| {
-                    workspace
-                        .open_path(project_path.clone(), None, true, cx)
-                        .detach_and_log_err(cx);
+                let open_task = workspace.update(cx, |workspace, cx| {
+                    workspace.open_path(project_path.clone(), None, true, cx)
                 });
 
-                workspace.update(cx, |workspace, cx| {
-                    if let Some(query) = &self.latest_search_query {
-                        let row = query.file_row;
-                        let column = query.file_column;
-                        if let Some(row) = row {
-                            if let Some(active_editor) = workspace
-                                .active_item(cx)
-                                .and_then(|active_item| active_item.downcast::<Editor>())
-                            {
-                                // TODO kb does not open proper lines for the first time
-                                active_editor.update(cx, |active_editor, cx| {
-                                    let snapshot = active_editor.snapshot(cx).display_snapshot;
+                let workspace = workspace.downgrade();
+
+                cx.spawn(|file_finder, mut cx| async move {
+                    let item = open_task.await.log_err()?;
+
+                    let (row, col) = file_finder
+                        .read_with(&cx, |file_finder, _| {
+                            file_finder
+                                .delegate()
+                                .latest_search_query
+                                .as_ref()
+                                .map(|query| (query.file_row, query.file_column))
+                        })
+                        .log_err()
+                        .flatten()?;
+
+                    if let Some(row) = row {
+                        if let Some(active_editor) = item.downcast::<Editor>() {
+                            active_editor
+                                .downgrade()
+                                .update(&mut cx, |editor, cx| {
+                                    let snapshot = editor.snapshot(cx).display_snapshot;
                                     let point = DisplayPoint::new(
                                         row.saturating_sub(1),
-                                        column.map(|column| column.saturating_sub(1)).unwrap_or(0),
+                                        col.map(|column| column.saturating_sub(1)).unwrap_or(0),
                                     )
                                     .to_point(&snapshot);
-                                    active_editor.change_selections(
-                                        Some(Autoscroll::center()),
-                                        cx,
-                                        |s| s.select_ranges([point..point]),
-                                    );
+                                    let point =
+                                        snapshot.buffer_snapshot.clip_point(point, Bias::Left);
+                                    editor.change_selections(Some(Autoscroll::center()), cx, |s| {
+                                        s.select_ranges([point..point])
+                                    });
                                 })
-                            }
+                                .log_err();
                         }
                     }
 
-                    workspace.dismiss_modal(cx);
-                });
+                    workspace
+                        .update(&mut cx, |workspace, cx| workspace.dismiss_modal(cx))
+                        .log_err();
+
+                    Some(())
+                })
+                .detach();
             }
         }
     }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -295,8 +295,6 @@ impl PickerDelegate for FileFinderDelegate {
                                     let point = snapshot
                                         .buffer_snapshot
                                         .clip_point(Point::new(row, col), Bias::Left);
-                                    let point =
-                                        snapshot.buffer_snapshot.clip_point(point, Bias::Left);
                                     editor.change_selections(Some(Autoscroll::center()), cx, |s| {
                                         s.select_ranges([point..point])
                                     });

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -16,3 +16,4 @@ settings = { path = "../settings" }
 text = { path = "../text" }
 workspace = { path = "../workspace" }
 postage.workspace = true
+util = { path = "../util" }

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use editor::{
-    display_map::ToDisplayPoint, scroll::autoscroll::Autoscroll, Editor, FILE_ROW_COLUMN_DELIMITER,
-};
+use editor::{display_map::ToDisplayPoint, scroll::autoscroll::Autoscroll, Editor};
 use gpui::{
     actions, elements::*, geometry::vector::Vector2F, AnyViewHandle, AppContext, Axis, Entity,
     View, ViewContext, ViewHandle,
@@ -10,6 +8,7 @@ use gpui::{
 use menu::{Cancel, Confirm};
 use settings::Settings;
 use text::{Bias, Point};
+use util::paths::FILE_ROW_COLUMN_DELIMITER;
 use workspace::{Modal, Workspace};
 
 actions!(go_to_line, [Toggle]);

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -119,4 +119,20 @@ impl<P> PathLikeWithPosition<P> {
             column: self.column,
         })
     }
+
+    pub fn to_string<F>(&self, path_like_to_string: F) -> String
+    where
+        F: Fn(&P) -> String,
+    {
+        let path_like_string = path_like_to_string(&self.path_like);
+        if let Some(row) = self.row {
+            if let Some(column) = self.column {
+                format!("{path_like_string}:{row}:{column}")
+            } else {
+                format!("{path_like_string}:{row}")
+            }
+        } else {
+            path_like_string
+        }
+    }
 }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -73,43 +73,80 @@ pub fn compact(path: &Path) -> PathBuf {
     }
 }
 
+/// A delimiter to use in `path_query:row_number:column_number` strings parsing.
 pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A representation of a path-like string with optional row and column numbers.
+/// Matching values example: `te`, `test.rs:22`, `te:22:5`, etc.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PathLikeWithPosition<P> {
     pub path_like: P,
     pub row: Option<u32>,
+    // Absent if row is absent.
     pub column: Option<u32>,
 }
 
 impl<P> PathLikeWithPosition<P> {
-    pub fn parse_str<F, E>(s: &str, parse_path_like_str: F) -> Result<Self, E>
-    where
-        F: Fn(&str) -> Result<P, E>,
-    {
-        let mut components = s.splitn(3, FILE_ROW_COLUMN_DELIMITER).map(str::trim).fuse();
-        let path_like_str = components.next().filter(|str| !str.is_empty());
-        let row = components.next().and_then(|row| row.parse::<u32>().ok());
-        let column = components
-            .next()
-            .filter(|_| row.is_some())
-            .and_then(|col| col.parse::<u32>().ok());
-
-        Ok(match path_like_str {
-            Some(path_like_str) => Self {
-                path_like: parse_path_like_str(path_like_str)?,
-                row,
-                column,
-            },
-            None => Self {
-                path_like: parse_path_like_str(s)?,
+    /// Parses a string that possibly has `:row:column` suffix.
+    /// Ignores trailing `:`s, so `test.rs:22:` is parsed as `test.rs:22`.
+    /// If any of the row/column component parsing fails, the whole string is then parsed as a path like.
+    pub fn parse_str<E>(
+        s: &str,
+        parse_path_like_str: impl Fn(&str) -> Result<P, E>,
+    ) -> Result<Self, E> {
+        let fallback = |fallback_str| {
+            Ok(Self {
+                path_like: parse_path_like_str(fallback_str)?,
                 row: None,
                 column: None,
-            },
-        })
+            })
+        };
+
+        match s.trim().split_once(FILE_ROW_COLUMN_DELIMITER) {
+            Some((path_like_str, maybe_row_and_col_str)) => {
+                let path_like_str = path_like_str.trim();
+                let maybe_row_and_col_str = maybe_row_and_col_str.trim();
+                if path_like_str.is_empty() {
+                    fallback(s)
+                } else if maybe_row_and_col_str.is_empty() {
+                    fallback(path_like_str)
+                } else {
+                    let (row_parse_result, maybe_col_str) =
+                        match maybe_row_and_col_str.split_once(FILE_ROW_COLUMN_DELIMITER) {
+                            Some((maybe_row_str, maybe_col_str)) => {
+                                (maybe_row_str.parse::<u32>(), maybe_col_str.trim())
+                            }
+                            None => (maybe_row_and_col_str.parse::<u32>(), ""),
+                        };
+
+                    match row_parse_result {
+                        Ok(row) => {
+                            if maybe_col_str.is_empty() {
+                                Ok(Self {
+                                    path_like: parse_path_like_str(path_like_str)?,
+                                    row: Some(row),
+                                    column: None,
+                                })
+                            } else {
+                                match maybe_col_str.parse::<u32>() {
+                                    Ok(col) => Ok(Self {
+                                        path_like: parse_path_like_str(path_like_str)?,
+                                        row: Some(row),
+                                        column: Some(col),
+                                    }),
+                                    Err(_) => fallback(s),
+                                }
+                            }
+                        }
+                        Err(_) => fallback(s),
+                    }
+                }
+            }
+            None => fallback(s),
+        }
     }
 
-    pub fn convert_path<P2, E>(
+    pub fn map_path_like<P2, E>(
         self,
         mapping: impl FnOnce(P) -> Result<P2, E>,
     ) -> Result<PathLikeWithPosition<P2>, E> {
@@ -120,10 +157,7 @@ impl<P> PathLikeWithPosition<P> {
         })
     }
 
-    pub fn to_string<F>(&self, path_like_to_string: F) -> String
-    where
-        F: Fn(&P) -> String,
-    {
+    pub fn to_string(&self, path_like_to_string: impl Fn(&P) -> String) -> String {
         let path_like_string = path_like_to_string(&self.path_like);
         if let Some(row) = self.row {
             if let Some(column) = self.column {
@@ -133,6 +167,113 @@ impl<P> PathLikeWithPosition<P> {
             }
         } else {
             path_like_string
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestPath = PathLikeWithPosition<String>;
+
+    fn parse_str(s: &str) -> TestPath {
+        TestPath::parse_str(s, |s| Ok::<_, std::convert::Infallible>(s.to_string()))
+            .expect("infallible")
+    }
+
+    #[test]
+    fn path_with_position_parsing_positive() {
+        let input_and_expected = [
+            (
+                "test_file.rs",
+                PathLikeWithPosition {
+                    path_like: "test_file.rs".to_string(),
+                    row: None,
+                    column: None,
+                },
+            ),
+            (
+                "test_file.rs:1",
+                PathLikeWithPosition {
+                    path_like: "test_file.rs".to_string(),
+                    row: Some(1),
+                    column: None,
+                },
+            ),
+            (
+                "test_file.rs:1:2",
+                PathLikeWithPosition {
+                    path_like: "test_file.rs".to_string(),
+                    row: Some(1),
+                    column: Some(2),
+                },
+            ),
+        ];
+
+        for (input, expected) in input_and_expected {
+            let actual = parse_str(input);
+            assert_eq!(
+                actual, expected,
+                "For positive case input str '{input}', got a parse mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn path_with_position_parsing_negative() {
+        for input in [
+            "test_file.rs:a",
+            "test_file.rs:a:b",
+            "test_file.rs::",
+            "test_file.rs::1",
+            "test_file.rs:1::",
+            "test_file.rs::1:2",
+            "test_file.rs:1::2",
+            "test_file.rs:1:2:",
+            "test_file.rs:1:2:3",
+        ] {
+            let actual = parse_str(input);
+            assert_eq!(
+                actual,
+                PathLikeWithPosition {
+                    path_like: input.to_string(),
+                    row: None,
+                    column: None,
+                },
+                "For negative case input str '{input}', got a parse mismatch"
+            );
+        }
+    }
+
+    // Trim off trailing `:`s for otherwise valid input.
+    #[test]
+    fn path_with_position_parsing_special() {
+        let input_and_expected = [
+            (
+                "test_file.rs:",
+                PathLikeWithPosition {
+                    path_like: "test_file.rs".to_string(),
+                    row: None,
+                    column: None,
+                },
+            ),
+            (
+                "test_file.rs:1:",
+                PathLikeWithPosition {
+                    path_like: "test_file.rs".to_string(),
+                    row: Some(1),
+                    column: None,
+                },
+            ),
+        ];
+
+        for (input, expected) in input_and_expected {
+            let actual = parse_str(input);
+            assert_eq!(
+                actual, expected,
+                "For special case input str '{input}', got a parse mismatch"
+            );
         }
     }
 }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
 lazy_static::lazy_static! {
     pub static ref HOME: PathBuf = dirs::home_dir().expect("failed to determine home directory");
     pub static ref CONFIG_DIR: PathBuf = HOME.join(".config").join("zed");
@@ -73,7 +75,7 @@ pub fn compact(path: &Path) -> PathBuf {
 
 pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PathLikeWithPosition<P> {
     pub path_like: P,
     pub row: Option<u32>,
@@ -104,6 +106,17 @@ impl<P> PathLikeWithPosition<P> {
                 row: None,
                 column: None,
             },
+        })
+    }
+
+    pub fn convert_path<P2, E>(
+        self,
+        mapping: impl FnOnce(P) -> Result<P2, E>,
+    ) -> Result<PathLikeWithPosition<P2>, E> {
+        Ok(PathLikeWithPosition {
+            path_like: mapping(self.path_like)?,
+            row: self.row,
+            column: self.column,
         })
     }
 }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -462,7 +462,6 @@ mod tests {
 
         let (_, _workspace) = cx.add_window(|cx| {
             Workspace::new(
-                Some(serialized_workspace),
                 0,
                 project.clone(),
                 Arc::new(AppState {
@@ -479,6 +478,11 @@ mod tests {
                 cx,
             )
         });
+
+        cx.update(|cx| {
+            Workspace::load_workspace(_workspace.downgrade(), serialized_workspace, Vec::new(), cx)
+        })
+        .await;
 
         cx.foreground().run_until_parked();
         //Should terminate
@@ -605,7 +609,6 @@ mod tests {
             let project = Project::test(fs, [], cx).await;
             let (window_id, workspace) = cx.add_window(|cx| {
                 Workspace::new(
-                    None,
                     0,
                     project.clone(),
                     Arc::new(AppState {

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -203,8 +203,6 @@ impl SerializedPane {
 
             items.push(item_handle.clone());
 
-            log::info!("ACTUALLY SHOWN ITEMS: {:?}", &item_handle);
-
             if let Some(item_handle) = item_handle {
                 workspace.update(cx, |workspace, cx| {
                     let pane_handle = pane_handle

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -729,19 +729,11 @@ async fn handle_cli_connection(
                         for (item, path) in items.into_iter().zip(&paths) {
                             match item {
                                 Some(Ok(item)) => {
-                                    log::info!("UPDATED ITEMS: {:?}", item);
-                                    log::info!(
-                                        "caret_positions: {caret_positions:?}, path: {path:?}",
-                                    );
                                     if let Some(point) = caret_positions.remove(path) {
-                                        // TODO kb does not work
-                                        log::info!("@@@@@@@@ {path:?}@{point:?}");
                                         if let Some(active_editor) = item.downcast::<Editor>() {
-                                            log::info!("@@@@@@@@ editor");
                                             active_editor
                                                 .downgrade()
                                                 .update(&mut cx, |editor, cx| {
-                                                    log::info!("@@@@@@@@ update");
                                                     let snapshot =
                                                         editor.snapshot(cx).display_snapshot;
                                                     let point = snapshot
@@ -752,7 +744,6 @@ async fn handle_cli_connection(
                                                         cx,
                                                         |s| s.select_ranges([point..point]),
                                                     );
-                                                    log::info!("@@@@@@@@ finished");
                                                 })
                                                 .log_err();
                                         }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -729,6 +729,10 @@ async fn handle_cli_connection(
                         for (item, path) in items.into_iter().zip(&paths) {
                             match item {
                                 Some(Ok(item)) => {
+                                    log::info!("UPDATED ITEMS: {:?}", item);
+                                    log::info!(
+                                        "caret_positions: {caret_positions:?}, path: {path:?}",
+                                    );
                                     if let Some(point) = caret_positions.remove(path) {
                                         // TODO kb does not work
                                         log::info!("@@@@@@@@ {path:?}@{point:?}");


### PR DESCRIPTION
Deals slightly differently with https://github.com/zed-industries/zed/issues/5737
Deals with https://github.com/zed-industries/zed/issues/6026

* Fixes Go To Line not respecting column number when navigating to a place
* Changes a line-row separator from `,` to `:` to show it more uniformly with other tools
* Adjusts file finder dialogue to allow `file_query:row:column` syntax and opens the buffer at the lines given
* Extends CLI with `file_path:row_column` syntax and opens these files similarly