### PR TITLE
Maintain recently opened files history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8676,6 +8676,7 @@ dependencies = [
  "gpui",
  "indoc",
  "install_cli",
+ "itertools",
  "language",
  "lazy_static",
  "log",

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -12,13 +12,14 @@ mod project_tests;
 use anyhow::{anyhow, Context, Result};
 use client::{proto, Client, TypedEnvelope, UserStore};
 use clock::ReplicaId;
-use collections::{hash_map, BTreeMap, HashMap, HashSet};
+use collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque};
 use copilot::Copilot;
 use futures::{
     channel::mpsc::{self, UnboundedReceiver},
     future::{try_join_all, Shared},
     AsyncWriteExt, Future, FutureExt, StreamExt, TryFutureExt,
 };
+use fuzzy::PathMatch;
 use gpui::{
     AnyModelHandle, AppContext, AsyncAppContext, BorrowAppContext, Entity, ModelContext,
     ModelHandle, Task, WeakModelHandle,
@@ -135,6 +136,7 @@ pub struct Project {
     _maintain_workspace_config: Task<()>,
     terminals: Terminals,
     copilot_enabled: bool,
+    search_panel_state: SearchPanelState,
 }
 
 struct LspBufferSnapshot {
@@ -388,6 +390,42 @@ impl FormatTrigger {
     }
 }
 
+const MAX_RECENT_SELECTIONS: usize = 20;
+
+#[derive(Debug, Default)]
+pub struct SearchPanelState {
+    recent_selections: VecDeque<PathMatch>,
+}
+
+impl SearchPanelState {
+    pub fn recent_selections(&self) -> impl Iterator<Item = &PathMatch> {
+        self.recent_selections.iter().rev()
+    }
+
+    pub fn add_selection(&mut self, mut new_selection: PathMatch) {
+        let old_len = self.recent_selections.len();
+
+        // remove `new_selection` element, if it's in the list
+        self.recent_selections.retain(|old_selection| {
+            old_selection.worktree_id != new_selection.worktree_id
+                || old_selection.path != new_selection.path
+        });
+        // if `new_selection` was not present and we're adding a new element,
+        // ensure we do not exceed max allowed elements
+        if self.recent_selections.len() == old_len {
+            if self.recent_selections.len() >= MAX_RECENT_SELECTIONS {
+                self.recent_selections.pop_front();
+            }
+        }
+
+        // do not highlight query matches in the selection
+        new_selection.positions.clear();
+        // always re-add the element even if it exists to the back
+        // this way, it gets to the top as the most recently selected element
+        self.recent_selections.push_back(new_selection);
+    }
+}
+
 impl Project {
     pub fn init_settings(cx: &mut AppContext) {
         settings::register::<ProjectSettings>(cx);
@@ -487,6 +525,7 @@ impl Project {
                     local_handles: Vec::new(),
                 },
                 copilot_enabled: Copilot::global(cx).is_some(),
+                search_panel_state: SearchPanelState::default(),
             }
         })
     }
@@ -577,6 +616,7 @@ impl Project {
                     local_handles: Vec::new(),
                 },
                 copilot_enabled: Copilot::global(cx).is_some(),
+                search_panel_state: SearchPanelState::default(),
             };
             for worktree in worktrees {
                 let _ = this.add_worktree(&worktree, cx);
@@ -6433,6 +6473,14 @@ impl Project {
                     None
                 }
             })
+    }
+
+    pub fn search_panel_state(&self) -> &SearchPanelState {
+        &self.search_panel_state
+    }
+
+    pub fn update_search_panel_state(&mut self) -> &mut SearchPanelState {
+        &mut self.search_panel_state
     }
 
     fn primary_language_servers_for_buffer(

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -58,7 +58,7 @@ use sum_tree::{Bias, Edit, SeekTarget, SumTree, TreeMap, TreeSet};
 use util::{paths::HOME, ResultExt, TakeUntilExt, TryFutureExt};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
-pub struct WorktreeId(usize);
+pub struct WorktreeId(pub usize);
 
 pub enum Worktree {
     Local(LocalWorktree),

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -38,6 +38,7 @@ theme = { path = "../theme" }
 util = { path = "../util" }
 
 async-recursion = "1.0.0"
+itertools = "0.10"
 bincode = "1.2.1"
 anyhow.workspace = true
 futures.workspace = true

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -12,6 +12,7 @@ use gpui::{
     platform::{CursorStyle, MouseButton},
     AnyElement, AppContext, Border, Element, SizeConstraint, ViewContext, ViewHandle,
 };
+use std::sync::{atomic::AtomicUsize, Arc};
 use theme::Theme;
 pub use toggle_dock_button::ToggleDockButton;
 
@@ -170,13 +171,21 @@ impl Dock {
     pub fn new(
         default_item_factory: DockDefaultItemFactory,
         background_actions: BackgroundActions,
+        pane_history_timestamp: Arc<AtomicUsize>,
         cx: &mut ViewContext<Workspace>,
     ) -> Self {
         let position =
             DockPosition::Hidden(settings::get::<WorkspaceSettings>(cx).default_dock_anchor);
         let workspace = cx.weak_handle();
-        let pane =
-            cx.add_view(|cx| Pane::new(workspace, Some(position.anchor()), background_actions, cx));
+        let pane = cx.add_view(|cx| {
+            Pane::new(
+                workspace,
+                Some(position.anchor()),
+                background_actions,
+                pane_history_timestamp,
+                cx,
+            )
+        });
         pane.update(cx, |pane, cx| {
             pane.set_active(false, cx);
         });


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/5620 and https://github.com/zed-industries/zed/issues/4931

Adds history to the search file dialogue:

![image](https://github.com/zed-industries/zed/assets/2690773/01a1d3ea-1328-425a-ac95-2ebdbfcc07ab)

The history is only shown on empty query and gets replaced by the query results after an input.
Currently, history gets lost between the project restarts.

Release Notes:

* Added a recently opened file list to search file dialogue
