### PR TITLE
Improve status integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6688,6 +6688,7 @@ name = "theme"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fs",
  "gpui",
  "indexmap",
  "parking_lot 0.11.2",

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -578,6 +578,15 @@ pub struct ComponentHost<V: View, C: Component<V>> {
     view_type: PhantomData<V>,
 }
 
+impl<V: View, C: Component<V>> ComponentHost<V, C> {
+    pub fn new(c: C) -> Self {
+        Self {
+            component: c,
+            view_type: PhantomData,
+        }
+    }
+}
+
 impl<V: View, C: Component<V>> Deref for ComponentHost<V, C> {
     type Target = C;
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3086,7 +3086,7 @@ impl BackgroundScanner {
                 }
 
                 let git_ptr = local_repo.repo_ptr.lock();
-                git_ptr.worktree_status(&repo_path)?
+                git_ptr.worktree_status(&repo_path)
             };
 
             let work_dir = repo.work_directory(snapshot)?;
@@ -3097,7 +3097,11 @@ impl BackgroundScanner {
                 .update(&work_dir_id, |entry| entry.scan_id = scan_id);
 
             snapshot.repository_entries.update(&work_dir, |entry| {
-                entry.worktree_statuses.insert(repo_path, status)
+                if let Some(status) = status {
+                    entry.worktree_statuses.insert(repo_path, status);
+                } else {
+                    entry.worktree_statuses.remove(&repo_path);
+                }
             });
         }
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -195,10 +195,10 @@ impl RepositoryEntry {
                             (GitFileStatus::Conflict, _) | (_, GitFileStatus::Conflict) => {
                                 &GitFileStatus::Conflict
                             }
-                            (GitFileStatus::Added, _) | (_, GitFileStatus::Added) => {
-                                &GitFileStatus::Added
+                            (GitFileStatus::Modified, _) | (_, GitFileStatus::Modified) => {
+                                &GitFileStatus::Modified
                             }
-                            _ => &GitFileStatus::Modified,
+                            _ => &GitFileStatus::Added,
                         },
                     )
                     .copied()

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 gpui = { path = "../gpui" }
+fs = { path = "../fs" }
 anyhow.workspace = true
 indexmap = "1.6.2"
 parking_lot.workspace = true

--- a/crates/theme/src/ui.rs
+++ b/crates/theme/src/ui.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 
+use fs::repository::GitFileStatus;
 use gpui::{
     color::Color,
     elements::{
-        ConstrainedBox, Container, ContainerStyle, Empty, Flex, KeystrokeLabel, Label,
+        ConstrainedBox, Container, ContainerStyle, Empty, Flex, KeystrokeLabel, Label, LabelStyle,
         MouseEventHandler, ParentElement, Stack, Svg,
     },
     fonts::TextStyle,
@@ -11,11 +12,11 @@ use gpui::{
     platform,
     platform::MouseButton,
     scene::MouseClick,
-    Action, Element, EventContext, MouseState, View, ViewContext,
+    Action, AnyElement, Element, EventContext, MouseState, View, ViewContext,
 };
 use serde::Deserialize;
 
-use crate::{ContainedText, Interactive};
+use crate::{ContainedText, Interactive, Theme};
 
 #[derive(Clone, Deserialize, Default)]
 pub struct CheckboxStyle {
@@ -251,4 +252,54 @@ where
         )
         .constrained()
         .with_height(style.dimensions().y())
+}
+
+pub struct FileName {
+    filename: String,
+    git_status: Option<GitFileStatus>,
+    style: FileNameStyle,
+}
+
+pub struct FileNameStyle {
+    template_style: LabelStyle,
+    git_inserted: Color,
+    git_modified: Color,
+    git_deleted: Color,
+}
+
+impl FileName {
+    pub fn new(filename: String, git_status: Option<GitFileStatus>, style: FileNameStyle) -> Self {
+        FileName {
+            filename,
+            git_status,
+            style,
+        }
+    }
+
+    pub fn style<I: Into<LabelStyle>>(style: I, theme: &Theme) -> FileNameStyle {
+        FileNameStyle {
+            template_style: style.into(),
+            git_inserted: theme.editor.diff.inserted,
+            git_modified: theme.editor.diff.modified,
+            git_deleted: theme.editor.diff.deleted,
+        }
+    }
+}
+
+impl<V: View> gpui::elements::Component<V> for FileName {
+    fn render(&self, _: &mut V, _: &mut ViewContext<V>) -> AnyElement<V> {
+        // Prepare colors for git statuses
+        let mut filename_text_style = self.style.template_style.text.clone();
+        filename_text_style.color = self
+            .git_status
+            .as_ref()
+            .map(|status| match status {
+                GitFileStatus::Added => self.style.git_inserted,
+                GitFileStatus::Modified => self.style.git_modified,
+                GitFileStatus::Conflict => self.style.git_deleted,
+            })
+            .unwrap_or(self.style.template_style.text.color);
+
+        Label::new(self.filename.clone(), filename_text_style).into_any()
+    }
 }


### PR DESCRIPTION
- Adds git status information to the tab titles https://linear.app/zed-industries/issue/Z-1435/show-git-status-in-tabs
- Changes priority of git statuses for folders
- Fixes https://linear.app/zed-industries/issue/Z-1451/file-git-status-is-not-cleared-when-file-state-is-reverted-to-clean

Release Notes:

* No notes, update added before release.

cc: @iamnbutler to get a sign off on the colors in the tabs 

<img width="774" alt="Screenshot 2023-05-13 at 2 47 51 AM" src="https://github.com/zed-industries/zed/assets/2280405/d0de5f7a-614d-425b-901d-ba99848d3e2c">

