### PR TITLE
Fix repository initialization bug

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3030,7 +3030,12 @@ impl BackgroundScanner {
         Some(())
     }
 
-    fn reload_repo_for_path(&self, path: &Path, snapshot: &mut LocalSnapshot, fs: &dyn Fs) -> Option<()> {
+    fn reload_repo_for_path(
+        &self,
+        path: &Path,
+        snapshot: &mut LocalSnapshot,
+        fs: &dyn Fs,
+    ) -> Option<()> {
         let scan_id = snapshot.scan_id;
 
         if path


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/5735 / https://linear.app/zed-industries/issue/Z-1317/fix-lack-of-change-tracking-when-repo-is-initialized-after-a-buffer-is

Release Notes:

* Fixed a bug in diff tracking when initializing new git repositories ([553](https://github.com/zed-industries/zed/issues/5735))
