### PR TITLE
In project search on ESC, reduce multiple carets to one first

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -191,7 +191,7 @@
     }
   },
   {
-    "context": "BufferSearchBar > Editor",
+    "context": "BufferSearchBar",
     "bindings": {
       "escape": "buffer_search::Dismiss",
       "tab": "buffer_search::FocusEditor",
@@ -200,13 +200,13 @@
     }
   },
   {
-    "context": "ProjectSearchBar > Editor",
+    "context": "ProjectSearchBar",
     "bindings": {
       "escape": "project_search::ToggleFocus"
     }
   },
   {
-    "context": "ProjectSearchView > Editor",
+    "context": "ProjectSearchView",
     "bindings": {
       "escape": "project_search::ToggleFocus"
     }

--- a/crates/gpui/src/keymap_matcher/binding.rs
+++ b/crates/gpui/src/keymap_matcher/binding.rs
@@ -11,6 +11,19 @@ pub struct Binding {
     context_predicate: Option<KeymapContextPredicate>,
 }
 
+impl std::fmt::Debug for Binding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Binding {{ keystrokes: {:?}, action: {}::{}, context_predicate: {:?} }}",
+            self.keystrokes,
+            self.action.namespace(),
+            self.action.name(),
+            self.context_predicate
+        )
+    }
+}
+
 impl Clone for Binding {
     fn clone(&self) -> Self {
         Self {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -234,7 +234,6 @@ pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {
         },
     );
     cx.add_action(Workspace::toggle_sidebar_item);
-    cx.add_action(Workspace::focus_center);
     cx.add_action(|workspace: &mut Workspace, _: &ActivatePreviousPane, cx| {
         workspace.activate_previous_pane(cx)
     });
@@ -1412,11 +1411,6 @@ impl Workspace {
 
         self.serialize_workspace(cx);
 
-        cx.notify();
-    }
-
-    pub fn focus_center(&mut self, _: &menu::Cancel, cx: &mut ViewContext<Self>) {
-        cx.focus_self();
         cx.notify();
     }
 


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-1469/hitting-escape-with-multiple-cursors-in-a-project-find-is-focusing-the

Not quite sure how can I write tests for this.