### PR TITLE
Optimize update local worktree buffers

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -123,6 +123,7 @@ pub struct Project {
         HashMap<Arc<Path>, Shared<Task<Result<ModelHandle<Worktree>, Arc<anyhow::Error>>>>>,
     opened_buffers: HashMap<u64, OpenBuffer>,
     local_buffer_ids_by_path: HashMap<ProjectPath, u64>,
+    local_buffer_ids_by_entry_id: HashMap<ProjectEntryId, u64>,
     /// A mapping from a buffer ID to None means that we've started waiting for an ID but haven't finished loading it.
     /// Used for re-issuing buffer requests when peers temporarily disconnect
     incomplete_remote_buffers: HashMap<u64, Option<ModelHandle<Buffer>>>,
@@ -451,6 +452,7 @@ impl Project {
                 loading_buffers_by_path: Default::default(),
                 loading_local_worktrees: Default::default(),
                 local_buffer_ids_by_path: Default::default(),
+                local_buffer_ids_by_entry_id: Default::default(),
                 buffer_snapshots: Default::default(),
                 join_project_response_message_id: 0,
                 client_state: None,
@@ -520,6 +522,7 @@ impl Project {
                 incomplete_remote_buffers: Default::default(),
                 loading_local_worktrees: Default::default(),
                 local_buffer_ids_by_path: Default::default(),
+                local_buffer_ids_by_entry_id: Default::default(),
                 active_entry: None,
                 collaborators: Default::default(),
                 join_project_response_message_id: response.message_id,
@@ -1640,6 +1643,9 @@ impl Project {
                     },
                     remote_id,
                 );
+
+                self.local_buffer_ids_by_entry_id
+                    .insert(file.entry_id, remote_id);
             }
         }
 
@@ -4574,96 +4580,106 @@ impl Project {
     fn update_local_worktree_buffers(
         &mut self,
         worktree_handle: &ModelHandle<Worktree>,
-        changes: &HashMap<Arc<Path>, PathChange>,
+        changes: &HashMap<(Arc<Path>, ProjectEntryId), PathChange>,
         cx: &mut ModelContext<Self>,
     ) {
         let snapshot = worktree_handle.read(cx).snapshot();
 
         let mut renamed_buffers = Vec::new();
-        for path in changes.keys() {
+        for (path, entry_id) in changes.keys() {
             let worktree_id = worktree_handle.read(cx).id();
             let project_path = ProjectPath {
                 worktree_id,
                 path: path.clone(),
             };
 
-            if let Some(&buffer_id) = self.local_buffer_ids_by_path.get(&project_path) {
-                if let Some(buffer) = self
-                    .opened_buffers
-                    .get(&buffer_id)
-                    .and_then(|buffer| buffer.upgrade(cx))
-                {
-                    buffer.update(cx, |buffer, cx| {
-                        if let Some(old_file) = File::from_dyn(buffer.file()) {
-                            if old_file.worktree != *worktree_handle {
-                                return;
-                            }
+            let buffer_id = match self.local_buffer_ids_by_entry_id.get(entry_id) {
+                Some(&buffer_id) => buffer_id,
+                None => match self.local_buffer_ids_by_path.get(&project_path) {
+                    Some(&buffer_id) => buffer_id,
+                    None => continue,
+                },
+            };
 
-                            let new_file =
-                                if let Some(entry) = snapshot.entry_for_id(old_file.entry_id) {
-                                    File {
-                                        is_local: true,
-                                        entry_id: entry.id,
-                                        mtime: entry.mtime,
-                                        path: entry.path.clone(),
-                                        worktree: worktree_handle.clone(),
-                                        is_deleted: false,
-                                    }
-                                } else if let Some(entry) =
-                                    snapshot.entry_for_path(old_file.path().as_ref())
-                                {
-                                    File {
-                                        is_local: true,
-                                        entry_id: entry.id,
-                                        mtime: entry.mtime,
-                                        path: entry.path.clone(),
-                                        worktree: worktree_handle.clone(),
-                                        is_deleted: false,
-                                    }
-                                } else {
-                                    File {
-                                        is_local: true,
-                                        entry_id: old_file.entry_id,
-                                        path: old_file.path().clone(),
-                                        mtime: old_file.mtime(),
-                                        worktree: worktree_handle.clone(),
-                                        is_deleted: true,
-                                    }
-                                };
+            let open_buffer = self.opened_buffers.get(&buffer_id);
+            let buffer = if let Some(buffer) = open_buffer.and_then(|buffer| buffer.upgrade(cx)) {
+                buffer
+            } else {
+                self.opened_buffers.remove(&buffer_id);
+                self.local_buffer_ids_by_path.remove(&project_path);
+                self.local_buffer_ids_by_entry_id.remove(entry_id);
+                continue;
+            };
 
-                            let old_path = old_file.abs_path(cx);
-                            if new_file.abs_path(cx) != old_path {
-                                renamed_buffers.push((cx.handle(), old_file.clone()));
-                                self.local_buffer_ids_by_path.remove(&project_path);
-                                self.local_buffer_ids_by_path.insert(
-                                    ProjectPath {
-                                        worktree_id,
-                                        path: path.clone(),
-                                    },
-                                    buffer_id,
-                                );
-                            }
+            buffer.update(cx, |buffer, cx| {
+                if let Some(old_file) = File::from_dyn(buffer.file()) {
+                    if old_file.worktree != *worktree_handle {
+                        return;
+                    }
 
-                            if new_file != *old_file {
-                                if let Some(project_id) = self.remote_id() {
-                                    self.client
-                                        .send(proto::UpdateBufferFile {
-                                            project_id,
-                                            buffer_id: buffer_id as u64,
-                                            file: Some(new_file.to_proto()),
-                                        })
-                                        .log_err();
-                                }
-
-                                buffer.file_updated(Arc::new(new_file), cx).detach();
-                            }
+                    let new_file = if let Some(entry) = snapshot.entry_for_id(old_file.entry_id) {
+                        File {
+                            is_local: true,
+                            entry_id: entry.id,
+                            mtime: entry.mtime,
+                            path: entry.path.clone(),
+                            worktree: worktree_handle.clone(),
+                            is_deleted: false,
                         }
-                    });
-                } else {
-                    self.opened_buffers.remove(&buffer_id);
-                    self.local_buffer_ids_by_path.remove(&project_path);
+                    } else if let Some(entry) = snapshot.entry_for_path(old_file.path().as_ref()) {
+                        File {
+                            is_local: true,
+                            entry_id: entry.id,
+                            mtime: entry.mtime,
+                            path: entry.path.clone(),
+                            worktree: worktree_handle.clone(),
+                            is_deleted: false,
+                        }
+                    } else {
+                        File {
+                            is_local: true,
+                            entry_id: old_file.entry_id,
+                            path: old_file.path().clone(),
+                            mtime: old_file.mtime(),
+                            worktree: worktree_handle.clone(),
+                            is_deleted: true,
+                        }
+                    };
+
+                    let old_path = old_file.abs_path(cx);
+                    if new_file.abs_path(cx) != old_path {
+                        renamed_buffers.push((cx.handle(), old_file.clone()));
+                        self.local_buffer_ids_by_path.remove(&project_path);
+                        self.local_buffer_ids_by_path.insert(
+                            ProjectPath {
+                                worktree_id,
+                                path: path.clone(),
+                            },
+                            buffer_id,
+                        );
+                    }
+
+                    if new_file.entry_id != *entry_id {
+                        self.local_buffer_ids_by_entry_id.remove(entry_id);
+                        self.local_buffer_ids_by_entry_id
+                            .insert(new_file.entry_id, buffer_id);
+                    }
+
+                    if new_file != *old_file {
+                        if let Some(project_id) = self.remote_id() {
+                            self.client
+                                .send(proto::UpdateBufferFile {
+                                    project_id,
+                                    buffer_id: buffer_id as u64,
+                                    file: Some(new_file.to_proto()),
+                                })
+                                .log_err();
+                        }
+
+                        buffer.file_updated(Arc::new(new_file), cx).detach();
+                    }
                 }
-            }
+            });
         }
 
         for (buffer, old_file) in renamed_buffers {
@@ -4676,7 +4692,7 @@ impl Project {
     fn update_local_worktree_language_servers(
         &mut self,
         worktree_handle: &ModelHandle<Worktree>,
-        changes: &HashMap<Arc<Path>, PathChange>,
+        changes: &HashMap<(Arc<Path>, ProjectEntryId), PathChange>,
         cx: &mut ModelContext<Self>,
     ) {
         let worktree_id = worktree_handle.read(cx).id();
@@ -4693,7 +4709,7 @@ impl Project {
                         let params = lsp::DidChangeWatchedFilesParams {
                             changes: changes
                                 .iter()
-                                .filter_map(|(path, change)| {
+                                .filter_map(|((path, _), change)| {
                                     let path = abs_path.join(path);
                                     if watched_paths.matches(&path) {
                                         Some(lsp::FileEvent {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -122,6 +122,7 @@ pub struct Project {
     loading_local_worktrees:
         HashMap<Arc<Path>, Shared<Task<Result<ModelHandle<Worktree>, Arc<anyhow::Error>>>>>,
     opened_buffers: HashMap<u64, OpenBuffer>,
+    local_buffer_ids_by_path: HashMap<ProjectPath, u64>,
     /// A mapping from a buffer ID to None means that we've started waiting for an ID but haven't finished loading it.
     /// Used for re-issuing buffer requests when peers temporarily disconnect
     incomplete_remote_buffers: HashMap<u64, Option<ModelHandle<Buffer>>>,
@@ -449,6 +450,7 @@ impl Project {
                 incomplete_remote_buffers: Default::default(),
                 loading_buffers_by_path: Default::default(),
                 loading_local_worktrees: Default::default(),
+                local_buffer_ids_by_path: Default::default(),
                 buffer_snapshots: Default::default(),
                 join_project_response_message_id: 0,
                 client_state: None,
@@ -517,6 +519,7 @@ impl Project {
                 shared_buffers: Default::default(),
                 incomplete_remote_buffers: Default::default(),
                 loading_local_worktrees: Default::default(),
+                local_buffer_ids_by_path: Default::default(),
                 active_entry: None,
                 collaborators: Default::default(),
                 join_project_response_message_id: response.message_id,
@@ -1627,6 +1630,18 @@ impl Project {
             this.on_buffer_event(buffer, event, cx);
         })
         .detach();
+
+        if let Some(file) = File::from_dyn(buffer.read(cx).file()) {
+            if file.is_local {
+                self.local_buffer_ids_by_path.insert(
+                    ProjectPath {
+                        worktree_id: file.worktree_id(cx),
+                        path: file.path.clone(),
+                    },
+                    remote_id,
+                );
+            }
+        }
 
         self.detect_language_for_buffer(buffer, cx);
         self.register_buffer_with_language_servers(buffer, cx);
@@ -4525,7 +4540,7 @@ impl Project {
         if worktree.read(cx).is_local() {
             cx.subscribe(worktree, |this, worktree, event, cx| match event {
                 worktree::Event::UpdatedEntries(changes) => {
-                    this.update_local_worktree_buffers(&worktree, cx);
+                    this.update_local_worktree_buffers(&worktree, &changes, cx);
                     this.update_local_worktree_language_servers(&worktree, changes, cx);
                 }
                 worktree::Event::UpdatedGitRepositories(updated_repos) => {
@@ -4559,80 +4574,96 @@ impl Project {
     fn update_local_worktree_buffers(
         &mut self,
         worktree_handle: &ModelHandle<Worktree>,
+        changes: &HashMap<Arc<Path>, PathChange>,
         cx: &mut ModelContext<Self>,
     ) {
         let snapshot = worktree_handle.read(cx).snapshot();
 
-        let mut buffers_to_delete = Vec::new();
         let mut renamed_buffers = Vec::new();
+        for path in changes.keys() {
+            let worktree_id = worktree_handle.read(cx).id();
+            let project_path = ProjectPath {
+                worktree_id,
+                path: path.clone(),
+            };
 
-        for (buffer_id, buffer) in &self.opened_buffers {
-            if let Some(buffer) = buffer.upgrade(cx) {
-                buffer.update(cx, |buffer, cx| {
-                    if let Some(old_file) = File::from_dyn(buffer.file()) {
-                        if old_file.worktree != *worktree_handle {
-                            return;
+            if let Some(&buffer_id) = self.local_buffer_ids_by_path.get(&project_path) {
+                if let Some(buffer) = self
+                    .opened_buffers
+                    .get(&buffer_id)
+                    .and_then(|buffer| buffer.upgrade(cx))
+                {
+                    buffer.update(cx, |buffer, cx| {
+                        if let Some(old_file) = File::from_dyn(buffer.file()) {
+                            if old_file.worktree != *worktree_handle {
+                                return;
+                            }
+
+                            let new_file =
+                                if let Some(entry) = snapshot.entry_for_id(old_file.entry_id) {
+                                    File {
+                                        is_local: true,
+                                        entry_id: entry.id,
+                                        mtime: entry.mtime,
+                                        path: entry.path.clone(),
+                                        worktree: worktree_handle.clone(),
+                                        is_deleted: false,
+                                    }
+                                } else if let Some(entry) =
+                                    snapshot.entry_for_path(old_file.path().as_ref())
+                                {
+                                    File {
+                                        is_local: true,
+                                        entry_id: entry.id,
+                                        mtime: entry.mtime,
+                                        path: entry.path.clone(),
+                                        worktree: worktree_handle.clone(),
+                                        is_deleted: false,
+                                    }
+                                } else {
+                                    File {
+                                        is_local: true,
+                                        entry_id: old_file.entry_id,
+                                        path: old_file.path().clone(),
+                                        mtime: old_file.mtime(),
+                                        worktree: worktree_handle.clone(),
+                                        is_deleted: true,
+                                    }
+                                };
+
+                            let old_path = old_file.abs_path(cx);
+                            if new_file.abs_path(cx) != old_path {
+                                renamed_buffers.push((cx.handle(), old_file.clone()));
+                                self.local_buffer_ids_by_path.remove(&project_path);
+                                self.local_buffer_ids_by_path.insert(
+                                    ProjectPath {
+                                        worktree_id,
+                                        path: path.clone(),
+                                    },
+                                    buffer_id,
+                                );
+                            }
+
+                            if new_file != *old_file {
+                                if let Some(project_id) = self.remote_id() {
+                                    self.client
+                                        .send(proto::UpdateBufferFile {
+                                            project_id,
+                                            buffer_id: buffer_id as u64,
+                                            file: Some(new_file.to_proto()),
+                                        })
+                                        .log_err();
+                                }
+
+                                buffer.file_updated(Arc::new(new_file), cx).detach();
+                            }
                         }
-
-                        let new_file = if let Some(entry) = snapshot.entry_for_id(old_file.entry_id)
-                        {
-                            File {
-                                is_local: true,
-                                entry_id: entry.id,
-                                mtime: entry.mtime,
-                                path: entry.path.clone(),
-                                worktree: worktree_handle.clone(),
-                                is_deleted: false,
-                            }
-                        } else if let Some(entry) =
-                            snapshot.entry_for_path(old_file.path().as_ref())
-                        {
-                            File {
-                                is_local: true,
-                                entry_id: entry.id,
-                                mtime: entry.mtime,
-                                path: entry.path.clone(),
-                                worktree: worktree_handle.clone(),
-                                is_deleted: false,
-                            }
-                        } else {
-                            File {
-                                is_local: true,
-                                entry_id: old_file.entry_id,
-                                path: old_file.path().clone(),
-                                mtime: old_file.mtime(),
-                                worktree: worktree_handle.clone(),
-                                is_deleted: true,
-                            }
-                        };
-
-                        let old_path = old_file.abs_path(cx);
-                        if new_file.abs_path(cx) != old_path {
-                            renamed_buffers.push((cx.handle(), old_file.clone()));
-                        }
-
-                        if new_file != *old_file {
-                            if let Some(project_id) = self.remote_id() {
-                                self.client
-                                    .send(proto::UpdateBufferFile {
-                                        project_id,
-                                        buffer_id: *buffer_id as u64,
-                                        file: Some(new_file.to_proto()),
-                                    })
-                                    .log_err();
-                            }
-
-                            buffer.file_updated(Arc::new(new_file), cx).detach();
-                        }
-                    }
-                });
-            } else {
-                buffers_to_delete.push(*buffer_id);
+                    });
+                } else {
+                    self.opened_buffers.remove(&buffer_id);
+                    self.local_buffer_ids_by_path.remove(&project_path);
+                }
             }
-        }
-
-        for buffer_id in buffers_to_delete {
-            self.opened_buffers.remove(&buffer_id);
         }
 
         for (buffer, old_file) in renamed_buffers {

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -2523,7 +2523,15 @@ impl BackgroundScanner {
     }
 
     async fn process_refresh_request(&self, paths: Vec<PathBuf>, barrier: barrier::Sender) -> bool {
-        self.reload_entries_for_paths(paths, None).await;
+        if let Some(mut paths) = self.reload_entries_for_paths(paths, None).await {
+            paths.sort_unstable();
+            util::extend_sorted(
+                &mut self.prev_state.lock().event_paths,
+                paths,
+                usize::MAX,
+                Ord::cmp,
+            );
+        }
         self.send_status_update(false, Some(barrier))
     }
 

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3944,6 +3944,7 @@ mod tests {
 
         let mut snapshots = Vec::new();
         let mut mutations_len = operations;
+        fs.as_fake().pause_events().await;
         while mutations_len > 1 {
             randomly_mutate_fs(&fs, root_dir, 1.0, &mut rng).await;
             let buffered_event_count = fs.as_fake().buffered_event_count().await;

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3946,7 +3946,17 @@ mod tests {
         let mut mutations_len = operations;
         fs.as_fake().pause_events().await;
         while mutations_len > 1 {
-            randomly_mutate_fs(&fs, root_dir, 1.0, &mut rng).await;
+            if rng.gen_bool(0.2) {
+                worktree
+                    .update(cx, |worktree, cx| {
+                        randomly_mutate_worktree(worktree, &mut rng, cx)
+                    })
+                    .await
+                    .unwrap();
+            } else {
+                randomly_mutate_fs(&fs, root_dir, 1.0, &mut rng).await;
+            }
+
             let buffered_event_count = fs.as_fake().buffered_event_count().await;
             if buffered_event_count > 0 && rng.gen_bool(0.3) {
                 let len = rng.gen_range(0..=buffered_event_count);


### PR DESCRIPTION
Avoid buffer file updating on every open buffer during worktree scan, could get very slow and block UI in cases of hundreds of thousands of open buffers such as with an especially large project search

Release Notes:

* Improved file tree refresh performance and avoid UI blocking with many buffers open
(Don't know how specific this needs to be, could omit the "file tree refresh")