### PR TITLE
Build Zed for main and labeled PR commits

### DIFF
--- a/.github/workflows/build_dmg.yml
+++ b/.github/workflows/build_dmg.yml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+defaults:
+  run:
+    shell: bash -euxo pipefail {0}
+
+concurrency:
+  # Allow only one workflow per any non-`main` branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+  COPT: '-Werror'
+
+jobs:
+  build-dmg:
+    if: github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'run-build-dmg')
+    env:
+      SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    runs-on:
+      - self-hosted
+      - test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          clean: false
+          submodules: 'recursive'
+
+      - name: Install Rust
+        run: |
+          rustup set profile minimal
+          rustup update stable
+
+
+      - name: Build dmg bundle
+        run: ./script/bundle
+
+      - name: Upload the build stats
+        uses: actions/upload-artifact@v3
+        with:
+          name: zed-main-$SHA.dmg
+          path: ./target/release/Zed.dmg

--- a/.github/workflows/build_dmg.yml
+++ b/.github/workflows/build_dmg.yml
@@ -1,7 +1,10 @@
+name: Build Zed.dmg
+
 on:
   push:
     branches:
     - main
+    - "v[0-9]+.[0-9]+.x"
   pull_request:
 
 defaults:
@@ -20,8 +23,6 @@ env:
 jobs:
   build-dmg:
     if: github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'run-build-dmg')
-    env:
-      SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     runs-on:
       - self-hosted
       - test
@@ -38,12 +39,16 @@ jobs:
           rustup set profile minimal
           rustup update stable
 
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
       - name: Build dmg bundle
         run: ./script/bundle
 
-      - name: Upload the build stats
+      - name: Upload the build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: zed-main-$SHA.dmg
+          name: Zed_${{ github.event.pull_request.head.sha || github.sha }}.dmg
           path: ./target/release/Zed.dmg


### PR DESCRIPTION
See summary tab of the PR's CI run for the binary:
![image](https://github.com/zed-industries/zed/assets/2690773/b6aef3a8-78a9-4a3a-8223-580b54bcbe41)

Add a job to build Zed images marked with the SHA of the commit it was built from.

The job triggers on every commit to `main` or every PR with `run-build-dmg` label and produces an install-ready *.dmg artifact attached to the corresponding CI run.