### PR TITLE
Allow CLI to start Zed from local sources

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -20,3 +20,7 @@ pub enum CliResponse {
     Stderr { message: String },
     Exit { status: i32 },
 }
+
+/// When Zed started not as an *.app but as a binary (e.g. local development),
+/// there's a possibility to tell it to behave "regularly".
+pub const FORCE_CLI_MODE_ENV_VAR_NAME: &str = "ZED_FORCE_CLI_MODE";

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
-use cli::{CliRequest, CliResponse, IpcHandshake};
+use cli::{CliRequest, CliResponse, IpcHandshake, FORCE_CLI_MODE_ENV_VAR_NAME};
 use core_foundation::{
     array::{CFArray, CFIndex},
     string::kCFStringEncodingUTF8,
@@ -43,20 +43,10 @@ struct InfoPlist {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let bundle_path = if let Some(bundle_path) = args.bundle_path {
-        bundle_path.canonicalize()?
-    } else {
-        locate_bundle()?
-    };
+    let bundle = Bundle::detect(args.bundle_path.as_deref()).context("Bundle detection")?;
 
     if args.version {
-        let plist_path = bundle_path.join("Contents/Info.plist");
-        let plist = plist::from_file::<_, InfoPlist>(plist_path)?;
-        println!(
-            "Zed {} – {}",
-            plist.bundle_short_version_string,
-            bundle_path.to_string_lossy()
-        );
+        println!("{}", bundle.zed_version_string());
         return Ok(());
     }
 
@@ -66,7 +56,7 @@ fn main() -> Result<()> {
         }
     }
 
-    let (tx, rx) = launch_app(bundle_path)?;
+    let (tx, rx) = bundle.launch()?;
 
     tx.send(CliRequest::Open {
         paths: args
@@ -89,6 +79,148 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+enum Bundle {
+    App {
+        app_bundle: PathBuf,
+        plist: InfoPlist,
+    },
+    LocalPath {
+        executable: PathBuf,
+        plist: InfoPlist,
+    },
+}
+
+impl Bundle {
+    fn detect(args_bundle_path: Option<&Path>) -> anyhow::Result<Self> {
+        let bundle_path = if let Some(bundle_path) = args_bundle_path {
+            bundle_path
+                .canonicalize()
+                .with_context(|| format!("Args bundle path {bundle_path:?} canonicalization"))?
+        } else {
+            locate_bundle().context("bundle autodiscovery")?
+        };
+
+        match bundle_path.extension().and_then(|ext| ext.to_str()) {
+            Some("app") => {
+                let plist_path = bundle_path.join("Contents/Info.plist");
+                let plist = plist::from_file::<_, InfoPlist>(&plist_path).with_context(|| {
+                    format!("Reading *.app bundle plist file at {plist_path:?}")
+                })?;
+                Ok(Self::App {
+                    app_bundle: bundle_path,
+                    plist,
+                })
+            }
+            _ => {
+                println!("Bundle path {bundle_path:?} has no *.app extension, attempting to locate a dev build");
+                let plist_path = bundle_path
+                    .parent()
+                    .with_context(|| format!("Bundle path {bundle_path:?} has no parent"))?
+                    .join("WebRTC.framework/Resources/Info.plist");
+                let plist = plist::from_file::<_, InfoPlist>(&plist_path)
+                    .with_context(|| format!("Reading dev bundle plist file at {plist_path:?}"))?;
+                Ok(Self::LocalPath {
+                    executable: bundle_path,
+                    plist,
+                })
+            }
+        }
+    }
+
+    fn plist(&self) -> &InfoPlist {
+        match self {
+            Self::App { plist, .. } => plist,
+            Self::LocalPath { plist, .. } => plist,
+        }
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            Self::App { app_bundle, .. } => app_bundle,
+            Self::LocalPath {
+                executable: excutable,
+                ..
+            } => excutable,
+        }
+    }
+
+    fn launch(&self) -> anyhow::Result<(IpcSender<CliRequest>, IpcReceiver<CliResponse>)> {
+        let (server, server_name) =
+            IpcOneShotServer::<IpcHandshake>::new().context("Handshake before Zed spawn")?;
+        let url = format!("zed-cli://{server_name}");
+
+        match self {
+            Self::App { app_bundle, .. } => {
+                let app_path = app_bundle;
+
+                let status = unsafe {
+                    let app_url = CFURL::from_path(app_path, true)
+                        .with_context(|| format!("invalid app path {app_path:?}"))?;
+                    let url_to_open = CFURL::wrap_under_create_rule(CFURLCreateWithBytes(
+                        ptr::null(),
+                        url.as_ptr(),
+                        url.len() as CFIndex,
+                        kCFStringEncodingUTF8,
+                        ptr::null(),
+                    ));
+                    let urls_to_open = CFArray::from_copyable(&[url_to_open.as_concrete_TypeRef()]);
+                    LSOpenFromURLSpec(
+                        &LSLaunchURLSpec {
+                            appURL: app_url.as_concrete_TypeRef(),
+                            itemURLs: urls_to_open.as_concrete_TypeRef(),
+                            passThruParams: ptr::null(),
+                            launchFlags: kLSLaunchDefaults,
+                            asyncRefCon: ptr::null_mut(),
+                        },
+                        ptr::null_mut(),
+                    )
+                };
+
+                anyhow::ensure!(
+                    status == 0,
+                    "cannot start app bundle {}",
+                    self.zed_version_string()
+                );
+            }
+            Self::LocalPath { executable, .. } => {
+                let executable_parent = executable
+                    .parent()
+                    .with_context(|| format!("Executable {executable:?} path has no parent"))?;
+                let subprocess_stdout_file =
+                    fs::File::create(executable_parent.join("zed_dev.log"))
+                        .with_context(|| format!("Log file creation in {executable_parent:?}"))?;
+                let subprocess_stdin_file =
+                    subprocess_stdout_file.try_clone().with_context(|| {
+                        format!("Cloning descriptor for file {subprocess_stdout_file:?}")
+                    })?;
+                let mut command = std::process::Command::new(executable);
+                let command = command
+                    .env(FORCE_CLI_MODE_ENV_VAR_NAME, "")
+                    .stderr(subprocess_stdout_file)
+                    .stdout(subprocess_stdin_file)
+                    .arg(url);
+
+                command
+                    .spawn()
+                    .with_context(|| format!("Spawning {command:?}"))?;
+            }
+        }
+
+        let (_, handshake) = server.accept().context("Handshake after Zed spawn")?;
+        Ok((handshake.requests, handshake.responses))
+    }
+
+    fn zed_version_string(&self) -> String {
+        let is_dev = matches!(self, Self::LocalPath { .. });
+        format!(
+            "Zed {}{} – {}",
+            self.plist().bundle_short_version_string,
+            if is_dev { " (dev)" } else { "" },
+            self.path().display(),
+        )
+    }
+}
+
 fn touch(path: &Path) -> io::Result<()> {
     match OpenOptions::new().create(true).write(true).open(path) {
         Ok(_) => Ok(()),
@@ -105,39 +237,4 @@ fn locate_bundle() -> Result<PathBuf> {
         }
     }
     Ok(app_path)
-}
-
-fn launch_app(app_path: PathBuf) -> Result<(IpcSender<CliRequest>, IpcReceiver<CliResponse>)> {
-    let (server, server_name) = IpcOneShotServer::<IpcHandshake>::new()?;
-    let url = format!("zed-cli://{server_name}");
-
-    let status = unsafe {
-        let app_url =
-            CFURL::from_path(&app_path, true).ok_or_else(|| anyhow!("invalid app path"))?;
-        let url_to_open = CFURL::wrap_under_create_rule(CFURLCreateWithBytes(
-            ptr::null(),
-            url.as_ptr(),
-            url.len() as CFIndex,
-            kCFStringEncodingUTF8,
-            ptr::null(),
-        ));
-        let urls_to_open = CFArray::from_copyable(&[url_to_open.as_concrete_TypeRef()]);
-        LSOpenFromURLSpec(
-            &LSLaunchURLSpec {
-                appURL: app_url.as_concrete_TypeRef(),
-                itemURLs: urls_to_open.as_concrete_TypeRef(),
-                passThruParams: ptr::null(),
-                launchFlags: kLSLaunchDefaults,
-                asyncRefCon: ptr::null_mut(),
-            },
-            ptr::null_mut(),
-        )
-    };
-
-    if status == 0 {
-        let (_, handshake) = server.accept()?;
-        Ok((handshake.requests, handshake.responses))
-    } else {
-        Err(anyhow!("cannot start {:?}", app_path))
-    }
 }


### PR DESCRIPTION
Before, you could've only run `zed -b $BUNDLE_PATH` with `BUNDLE_PATH` pointing at an *.app file.
If you are changing both CLI and Zed and want to test their interop (new Zed CLI should start new Zed with specific parameters), the only available way would be to build *.dmg file (we have a bundling script, but that builds for both aarch64 and x86_64 platforms and in --release) which was very long even for incremental builds.

The PR tries to address that and make CLI's `-b` to accept regular binaries also, since we're already perfectly able to do `cargo run -- ..some args` to start Zed.
To achieve that, two modifications were made:

* Zed now is able to behave as if it's being started from CLI (`ZED_FORCE_CLI_MODE` env var)

This var forces Zed to check its args as if they were the `zed://` protocol ones and generally imitate the cli pty-less start.

* Zed CLI accepts regular binary file path into `-b` parameter (only *.app before), and tries to start it as Zed editor with `ZED_FORCE_CLI_MODE` env var and other params needed.

New CLI logic to validate the file given and use the new env var and corresponding parameters to actually start a non-app Zed.

The PR does not change any documentation or comments around the `-b` parameter, since the change is dev-only.
Also, the started binary does not get a focus and the terminal window I start it from gets killed, but it seems fine for a dev feature either: the editor still works and is way faster to iterate on.