### PR TITLE
Disable usvg's text feature flags to include less dependency code

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -48,7 +48,7 @@ smallvec.workspace = true
 smol.workspace = true
 time.workspace = true
 tiny-skia = "0.5"
-usvg = "0.14"
+usvg = { version = "0.14", features = [] }
 uuid = { version = "1.1.2", features = ["v4"] }
 waker-fn = "1.1.0"
 


### PR DESCRIPTION
Noticed while attempting to debug faulty backtraces, only takes a few seconds off a release build but still worth having less code
