### PR TITLE
Add scrollbars setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -43,6 +43,17 @@
   // 3. Draw all invisible symbols:
   //   "all"
   "show_whitespaces": "selection",
+  // Whether to show the scrollbar in the editor.
+  // This setting can take four values:
+  //
+  // 1. Show the scrollbar if there's important information or
+  //    follow the system's configured behavior (default):
+  //   "auto"
+  // 2. Match the system's configured behavior:
+  //    "system"
+  // 3. Always show the scrollbar:
+  //    "always"
+  "show_scrollbars": "auto",
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -53,6 +53,8 @@
   //    "system"
   // 3. Always show the scrollbar:
   //    "always"
+  // 4. Never show the scrollbar:
+  //    "never"
   "show_scrollbars": "auto",
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -516,6 +516,15 @@ pub struct EditorSnapshot {
     ongoing_scroll: OngoingScroll,
 }
 
+impl EditorSnapshot {
+    fn has_scrollbar_info(&self) -> bool {
+        self.buffer_snapshot
+            .git_diff_hunks_in_range(0..self.max_point().row(), false)
+            .next()
+            .is_some()
+    }
+}
+
 #[derive(Clone, Debug)]
 struct SelectionHistoryEntry {
     selections: Arc<[Selection<Anchor>]>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2058,7 +2058,15 @@ impl Element<Editor> for EditorElement {
             ));
         }
 
-        let show_scrollbars = editor.scroll_manager.scrollbars_visible();
+        let show_scrollbars = match cx.global::<Settings>().show_scrollbars {
+            settings::ShowScrollbars::Auto => {
+                snapshot.has_scrollbar_info()
+                    || editor.scroll_manager.scrollbars_visible()
+            }
+            settings::ShowScrollbars::System => editor.scroll_manager.scrollbars_visible(),
+            settings::ShowScrollbars::Always => true,
+        };
+
         let include_root = editor
             .project
             .as_ref()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2064,6 +2064,7 @@ impl Element<Editor> for EditorElement {
             }
             settings::ShowScrollbars::System => editor.scroll_manager.scrollbars_visible(),
             settings::ShowScrollbars::Always => true,
+            settings::ShowScrollbars::Never => false,
         };
 
         let include_root = editor

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2060,8 +2060,7 @@ impl Element<Editor> for EditorElement {
 
         let show_scrollbars = match cx.global::<Settings>().show_scrollbars {
             settings::ShowScrollbars::Auto => {
-                snapshot.has_scrollbar_info()
-                    || editor.scroll_manager.scrollbars_visible()
+                snapshot.has_scrollbar_info() || editor.scroll_manager.scrollbars_visible()
             }
             settings::ShowScrollbars::System => editor.scroll_manager.scrollbars_visible(),
             settings::ShowScrollbars::Always => true,

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -46,6 +46,7 @@ pub struct Settings {
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
     pub show_call_status_icon: bool,
+    pub show_scrollbars: ShowScrollbars,
     pub vim_mode: bool,
     pub autosave: Autosave,
     pub default_dock_anchor: DockAnchor,
@@ -66,6 +67,15 @@ pub struct Settings {
     pub telemetry_overrides: TelemetrySettings,
     pub auto_update: bool,
     pub base_keymap: BaseKeymap,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ShowScrollbars {
+    #[default]
+    Auto,
+    System,
+    Always,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
@@ -390,6 +400,8 @@ pub struct SettingsFileContent {
     #[serde(default)]
     pub active_pane_magnification: Option<f32>,
     #[serde(default)]
+    pub show_scrollbars: Option<ShowScrollbars>,
+    #[serde(default)]
     pub cursor_blink: Option<bool>,
     #[serde(default)]
     pub confirm_quit: Option<bool>,
@@ -547,6 +559,7 @@ impl Settings {
             features: Features {
                 copilot: defaults.features.copilot.unwrap(),
             },
+            show_scrollbars: defaults.show_scrollbars.unwrap(),
         }
     }
 
@@ -598,6 +611,7 @@ impl Settings {
         merge(&mut self.autosave, data.autosave);
         merge(&mut self.default_dock_anchor, data.default_dock_anchor);
         merge(&mut self.base_keymap, data.base_keymap);
+        merge(&mut self.show_scrollbars, data.show_scrollbars);
         merge(&mut self.features.copilot, data.features.copilot);
 
         if let Some(copilot) = data.copilot {
@@ -830,6 +844,7 @@ impl Settings {
             auto_update: true,
             base_keymap: Default::default(),
             features: Features { copilot: true },
+            show_scrollbars: Default::default(),
         }
     }
 

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -76,6 +76,7 @@ pub enum ShowScrollbars {
     Auto,
     System,
     Always,
+    Never,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]


### PR DESCRIPTION
Adds a setting for showing the scrollbar when there's important information and sets it by default.

Release Notes:

* Added setting to configure when the scrollbar should be shown.
