### PR TITLE
Define empty theme for tests regardless of cargo features

### DIFF
--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -26,6 +26,7 @@ postage.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }
+theme = { path = "../theme", features = ["test-support"] }
 
 serde_json.workspace = true
 ctor.workspace = true

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -24,7 +24,6 @@ pub fn default_settings() -> Cow<'static, str> {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
 pub const EMPTY_THEME_NAME: &'static str = "empty-theme";
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/theme/src/theme_registry.rs
+++ b/crates/theme/src/theme_registry.rs
@@ -30,7 +30,6 @@ impl ThemeRegistry {
             font_cache,
         });
 
-        #[cfg(any(test, feature = "test-support"))]
         this.themes.lock().insert(
             settings::EMPTY_THEME_NAME.to_string(),
             gpui::fonts::with_font_cache(this.font_cache.clone(), || {


### PR DESCRIPTION
This fixes some errors that were happening when running a single crate's tests, if the test did not enable the `test-support` feature in the `theme` crate.