### PR TITLE
Avoid panic in `get_injections`

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1114,6 +1114,8 @@ fn get_injections(
     let mut query_cursor = QueryCursorHandle::new();
     let mut prev_match = None;
 
+    // Ensure that a `ParseStep` is created for every combined injection language, even
+    // if there currently no matches for that injection.
     combined_injection_ranges.clear();
     for pattern in &config.patterns {
         if let (Some(language_name), true) = (pattern.language.as_ref(), pattern.combined) {
@@ -1174,8 +1176,8 @@ fn get_injections(
                 if let Some(language) = language {
                     if combined {
                         combined_injection_ranges
-                            .get_mut(&language.clone())
-                            .unwrap()
+                            .entry(language.clone())
+                            .or_default()
                             .extend(content_ranges);
                     } else {
                         queue.push(ParseStep {


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-462/thread-background-executor-12-panicked-at-called-optionunwrap-on-a

Old message: Rather than requiring the hashmap to already have a vec for the injection language this patch will add a vec if one does not exist. The prior code looks like it \*should\* have already guaranteed that the unwrap never failed as all things seem to be checked. All I can think of is that perhaps in rare cases on startup where the languages haven't been fully loaded yet the `now_or_never` call in the hashmap setup would fail, allowing the unwrap to panic further down if the problematic language finishes loading by then. At the very least this code is simpler and shorter 🤷‍♀️ 

We did a smaller change because it looks like we should have all patterns' parse steps populated even if we have no ranges for them, so the code doesn't shrink but shouldn't fail at that unwrap. It might still behave weirdly but shouldn't take down the app

Release Notes:

* Avoid a rare panic in syntax highlighting
