### PR TITLE
Optimize retrieving repos for entries when rendering the project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1010,14 +1010,11 @@ impl ProjectPanel {
                     .unwrap_or(&[]);
 
                 let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
-                for entry in &visible_worktree_entries[entry_range] {
-                    let path = &entry.path;
+                for (entry, repo) in
+                    snapshot.entries_with_repos(visible_worktree_entries[entry_range].iter())
+                {
                     let status = (entry.path.parent().is_some() && !entry.is_ignored)
-                        .then(|| {
-                            snapshot
-                                .repo_for(path)
-                                .and_then(|entry| entry.status_for_path(&snapshot, path))
-                        })
+                        .then(|| repo.and_then(|repo| repo.status_for_path(&snapshot, &entry.path)))
                         .flatten();
 
                     let mut details = EntryDetails {


### PR DESCRIPTION
This fixes slowness in rendering the project panel due to retrieving the repository for a given entry.

Release Notes:

* Fixed a lag that would occur when lots of files changed on disk while the project panel was open (preview only).
