### PR TITLE
Remove expensive-to-clone fields from worktree's LocalSnapshot

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1011,7 +1011,7 @@ impl ProjectPanel {
 
                 let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
                 for (entry, repo) in
-                    snapshot.entries_with_repos(visible_worktree_entries[entry_range].iter())
+                    snapshot.entries_with_repositories(visible_worktree_entries[entry_range].iter())
                 {
                     let status = (entry.path.parent().is_some() && !entry.is_ignored)
                         .then(|| repo.and_then(|repo| repo.status_for_path(&snapshot, &entry.path)))


### PR DESCRIPTION
This fixes performance problems that @nathansobo and I have seen in some cases, when a large number of files changed on disk. A lot of time was being spent in `worktree::LocalSnapshot::clone`. I think this may have been because of needing to clone the `removed_entry_ids` map. This structure is only really used when *mutating* the `LocalSnapshot` in the background scanner, so I moved it off of the snapshots.