### PR TITLE
Fix spurious setting error log messages

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -339,7 +339,7 @@ pub struct TelemetrySettings {
     pub metrics: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TelemetrySettingsContent {
     pub diagnostics: Option<bool>,
     pub metrics: Option<bool>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -10,17 +10,16 @@ pub struct EditorSettings {
     pub show_scrollbars: ShowScrollbars,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ShowScrollbars {
-    #[default]
     Auto,
     System,
     Always,
     Never,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     pub cursor_blink: Option<bool>,
     pub hover_popover_enabled: Option<bool>,

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -49,7 +49,7 @@ pub struct CopilotSettings {
     pub disabled_globs: Vec<GlobMatcher>,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct AllLanguageSettingsContent {
     #[serde(default)]
     pub features: Option<FeaturesContent>,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2870,10 +2870,8 @@ impl Project {
         if let Some(LanguageServerState::Running { watched_paths, .. }) =
             self.language_servers.get_mut(&language_server_id)
         {
-            eprintln!("change watch");
             let mut builders = HashMap::default();
             for watcher in params.watchers {
-                eprintln!("  {}", watcher.glob_pattern);
                 for worktree in &self.worktrees {
                     if let Some(worktree) = worktree.upgrade(cx) {
                         let worktree = worktree.read(cx);

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use settings::Setting;
 use std::sync::Arc;
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ProjectSettings {
     #[serde(default)]
     pub lsp: HashMap<Arc<str>, LspSettings>,

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -830,37 +830,6 @@ mod tests {
         store.register_setting::<UserSettings>(cx);
         store.register_setting::<TurboSetting>(cx);
         store.register_setting::<MultiKeySettings>(cx);
-
-        // error - missing required field in default settings
-        store
-            .set_default_settings(
-                r#"{
-                    "user": {
-                        "name": "John Doe",
-                        "age": 30,
-                        "staff": false
-                    }
-                }"#,
-                cx,
-            )
-            .unwrap_err();
-
-        // error - type error in default settings
-        store
-            .set_default_settings(
-                r#"{
-                    "turbo": "the-wrong-type",
-                    "user": {
-                        "name": "John Doe",
-                        "age": 30,
-                        "staff": false
-                    }
-                }"#,
-                cx,
-            )
-            .unwrap_err();
-
-        // valid default settings.
         store
             .set_default_settings(
                 r#"{

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -17,7 +17,7 @@ pub struct WorkspaceSettings {
     pub git: GitSettings,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct WorkspaceSettingsContent {
     pub active_pane_magnification: Option<f32>,
     pub confirm_quit: Option<bool>,


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/zed-industries/zed/pull/2448, where error messages would be logged if the user config didn't specify certain  fields like `journal` or `telemetry`.