### PR TITLE
Enable `"test-support"` feature on editor dependencies for tests

### DIFF
--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -21,3 +21,6 @@ workspace = { path = "../workspace" }
 
 futures.workspace = true
 smallvec.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/copilot_button/Cargo.toml
+++ b/crates/copilot_button/Cargo.toml
@@ -23,3 +23,6 @@ workspace = { path = "../workspace" }
 anyhow.workspace = true
 smol.workspace = true
 futures.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -35,3 +35,6 @@ serde_derive.workspace = true
 sysinfo = "0.27.1"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 urlencoding = "2.1.2"
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -23,6 +23,7 @@ workspace = { path = "../workspace" }
 postage.workspace = true
 
 [dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -18,3 +18,6 @@ workspace = { path = "../workspace" }
 postage.workspace = true
 theme = { path = "../theme" }
 util = { path = "../util" }
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -22,3 +22,6 @@ serde.workspace = true
 schemars.workspace = true
 log.workspace = true
 shellexpand = "2.1.0"
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -20,3 +20,6 @@ settings = { path = "../settings" }
 util = { path = "../util" }
 workspace = { path = "../workspace" }
 anyhow.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/lsp_log/Cargo.toml
+++ b/crates/lsp_log/Cargo.toml
@@ -24,6 +24,7 @@ serde.workspace = true
 anyhow.workspace = true
 
 [dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 unindent.workspace = true

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -22,3 +22,6 @@ workspace = { path = "../workspace" }
 ordered-float.workspace = true
 postage.workspace = true
 smol.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -20,6 +20,7 @@ workspace = { path = "../workspace" }
 parking_lot.workspace = true
 
 [dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 serde_json.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -27,6 +27,7 @@ smol.workspace = true
 
 [dev-dependencies]
 futures.workspace = true
+editor = { path = "../editor", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -24,3 +24,6 @@ workspace = { path = "../workspace" }
 ordered-float.workspace = true
 postage.workspace = true
 smol.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -39,6 +39,7 @@ serde_derive.workspace = true
 
 
 [dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
 client = { path = "../client", features = ["test-support"]}
 project = { path = "../project", features = ["test-support"]}

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -23,3 +23,6 @@ log.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 smol.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -30,3 +30,6 @@ anyhow.workspace = true
 log.workspace = true
 schemars.workspace = true
 serde.workspace = true
+
+[dev-dependencies]
+editor = { path = "../editor", features = ["test-support"] }


### PR DESCRIPTION
Enable the `"test-support"` feature whenever we depend on the `editor` crate in tests.

If we don't do this, we end up depending on `livekit_client` without enabling `"test-support"`, and this causes us to link against `WebRTC.framework` in its build script, which causes a dynamic linker error when starting the tests.

Fixes https://linear.app/zed-industries/issue/Z-1646/cant-run-package-tests-for-activity-monitor-and-auto-update

Release Notes:

* No notes