### PR TITLE
Diagnostics pane was not focusable with the mouse

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -33,7 +33,7 @@ use theme::ThemeSettings;
 use util::TryFutureExt;
 use workspace::{
     item::{BreadcrumbText, Item, ItemEvent, ItemHandle},
-    ItemNavHistory, Pane, ToolbarItemLocation, Workspace,
+    ItemNavHistory, Pane, ToolbarItemLocation, Workspace, PaneBackdrop,
 };
 
 actions!(diagnostics, [Deploy]);
@@ -90,11 +90,12 @@ impl View for ProjectDiagnosticsEditor {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
         if self.path_states.is_empty() {
             let theme = &theme::current(cx).project_diagnostics;
-            Label::new("No problems in workspace", theme.empty_message.clone())
+            PaneBackdrop::new(cx.view_id(), Label::new("No problems in workspace", theme.empty_message.clone())
                 .aligned()
                 .contained()
                 .with_style(theme.container)
-                .into_any()
+                .into_any()).into_any()
+
         } else {
             ChildView::new(&self.editor, cx).into_any()
         }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -105,8 +105,9 @@ impl View for ProjectDiagnosticsEditor {
     }
 
     fn focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
-        if cx.is_self_focused() && !self.path_states.is_empty() {
-            cx.focus(&self.editor);
+        dbg!("Focus in");
+        if dbg!(cx.is_self_focused()) && dbg!(!self.path_states.is_empty()) {
+            dbg!(cx.focus(&self.editor));
         }
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -33,7 +33,7 @@ use theme::ThemeSettings;
 use util::TryFutureExt;
 use workspace::{
     item::{BreadcrumbText, Item, ItemEvent, ItemHandle},
-    ItemNavHistory, Pane, ToolbarItemLocation, Workspace, PaneBackdrop,
+    ItemNavHistory, Pane, PaneBackdrop, ToolbarItemLocation, Workspace,
 };
 
 actions!(diagnostics, [Deploy]);
@@ -90,12 +90,15 @@ impl View for ProjectDiagnosticsEditor {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
         if self.path_states.is_empty() {
             let theme = &theme::current(cx).project_diagnostics;
-            PaneBackdrop::new(cx.view_id(), Label::new("No problems in workspace", theme.empty_message.clone())
-                .aligned()
-                .contained()
-                .with_style(theme.container)
-                .into_any()).into_any()
-
+            PaneBackdrop::new(
+                cx.view_id(),
+                Label::new("No problems in workspace", theme.empty_message.clone())
+                    .aligned()
+                    .contained()
+                    .with_style(theme.container)
+                    .into_any(),
+            )
+            .into_any()
         } else {
             ChildView::new(&self.editor, cx).into_any()
         }
@@ -162,8 +165,13 @@ impl ProjectDiagnosticsEditor {
             editor.set_vertical_scroll_margin(5, cx);
             editor
         });
-        cx.subscribe(&editor, |_, _, event, cx| cx.emit(event.clone()))
-            .detach();
+        cx.subscribe(&editor, |this, _, event, cx| {
+            cx.emit(event.clone());
+            if event == &editor::Event::Focused && this.path_states.is_empty() {
+                cx.focus_self()
+            }
+        })
+        .detach();
 
         let project = project_handle.read(cx);
         let paths_to_update = project

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7128,6 +7128,7 @@ pub enum Event {
     BufferEdited,
     Edited,
     Reparsed,
+    Focused,
     Blurred,
     DirtyChanged,
     Saved,
@@ -7181,6 +7182,7 @@ impl View for Editor {
     fn focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
         if cx.is_self_focused() {
             let focused_event = EditorFocused(cx.handle());
+            cx.emit(Event::Focused);
             cx.emit_global(focused_event);
         }
         if let Some(rename) = self.pending_rename.as_ref() {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7180,6 +7180,7 @@ impl View for Editor {
     }
 
     fn focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
+        dbg!("Editor Focus in");
         if cx.is_self_focused() {
             let focused_event = EditorFocused(cx.handle());
             cx.emit(Event::Focused);


### PR DESCRIPTION
fixes https://linear.app/zed-industries/issue/Z-1432/cant-cmd-w-an-empty-diagnostics-in-a-split-pane

Release Notes:

* Fixed a bug where the diagnostics pane could not be focused or closed in certain circumstances.
