### PR TITLE
Adjust scrollbar settings to be expandable

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -66,7 +66,7 @@
       //    "always"
       // 4. Never show the scrollbar:
       //    "never"
-      "when_to_show": "auto",
+      "show": "auto",
       // Whether to show git diff indicators in the scrollbar.
       "git_diff": true
   },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -52,19 +52,24 @@
   // 3. Draw all invisible symbols:
   //   "all"
   "show_whitespaces": "selection",
-  // Whether to show the scrollbar in the editor.
-  // This setting can take four values:
-  //
-  // 1. Show the scrollbar if there's important information or
-  //    follow the system's configured behavior (default):
-  //   "auto"
-  // 2. Match the system's configured behavior:
-  //    "system"
-  // 3. Always show the scrollbar:
-  //    "always"
-  // 4. Never show the scrollbar:
-  //    "never"
-  "show_scrollbars": "auto",
+  // Scrollbar related settings
+  "scrollbar": {
+      // When to show the scrollbar in the editor.
+      // This setting can take four values:
+      //
+      // 1. Show the scrollbar if there's important information or
+      //    follow the system's configured behavior (default):
+      //   "auto"
+      // 2. Match the system's configured behavior:
+      //    "system"
+      // 3. Always show the scrollbar:
+      //    "always"
+      // 4. Never show the scrollbar:
+      //    "never"
+      "when_to_show": "auto",
+      // Whether to show git diff indicators in the scrollbar.
+      "git_diff": true
+  },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -533,12 +533,6 @@ pub struct EditorSnapshot {
     ongoing_scroll: OngoingScroll,
 }
 
-impl EditorSnapshot {
-    fn has_scrollbar_info(&self, is_singleton: bool) -> bool {
-        is_singleton && self.buffer_snapshot.has_git_diffs()
-    }
-}
-
 #[derive(Clone, Debug)]
 struct SelectionHistoryEntry {
     selections: Arc<[Selection<Anchor>]>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -12,7 +12,7 @@ pub struct EditorSettings {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Scrollbar {
-    pub when_to_show: ShowScrollbar,
+    pub show: ShowScrollbar,
     pub git_diff: bool,
 }
 
@@ -35,7 +35,7 @@ pub struct EditorSettingsContent {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ScrollbarContent {
-    pub when_to_show: Option<ShowScrollbar>,
+    pub show: Option<ShowScrollbar>,
     pub git_diff: Option<bool>,
 }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -13,7 +13,7 @@ pub struct EditorSettings {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Scrollbar {
     pub when_to_show: ShowScrollbar,
-    pub git_diff: bool
+    pub git_diff: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -36,7 +36,7 @@ pub struct EditorSettingsContent {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ScrollbarContent {
     pub when_to_show: Option<ShowScrollbar>,
-    pub git_diff: Option<bool>
+    pub git_diff: Option<bool>,
 }
 
 impl Setting for EditorSettings {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -7,12 +7,18 @@ pub struct EditorSettings {
     pub cursor_blink: bool,
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
-    pub show_scrollbars: ShowScrollbars,
+    pub scrollbar: Scrollbar,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct Scrollbar {
+    pub when_to_show: ShowScrollbar,
+    pub git_diff: bool
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum ShowScrollbars {
+pub enum ShowScrollbar {
     Auto,
     System,
     Always,
@@ -24,7 +30,13 @@ pub struct EditorSettingsContent {
     pub cursor_blink: Option<bool>,
     pub hover_popover_enabled: Option<bool>,
     pub show_completions_on_input: Option<bool>,
-    pub show_scrollbars: Option<ShowScrollbars>,
+    pub scrollbar: Option<ScrollbarContent>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ScrollbarContent {
+    pub when_to_show: Option<ShowScrollbar>,
+    pub git_diff: Option<bool>
 }
 
 impl Setting for EditorSettings {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2068,7 +2068,7 @@ impl Element<Editor> for EditorElement {
         }
 
         let scrollbar_settings = &settings::get::<EditorSettings>(cx).scrollbar;
-        let show_scrollbars = match scrollbar_settings.when_to_show {
+        let show_scrollbars = match scrollbar_settings.show {
             ShowScrollbar::Auto => {
                 // Git
                 (is_singleton && scrollbar_settings.git_diff && snapshot.buffer_snapshot.has_git_diffs())


### PR DESCRIPTION
Note that this PR cannot be cherrypicked into preview, as it relies on the new settings infrastructure.

Switches settings from `show_scrollbars: "auto"` to `scrollbar: {show: "auto", git_diffs: true}`.

fixes https://linear.app/zed-industries/issue/Z-1650/scroll-bar-feature-settings

Release Notes:

- Changed scrollbar settings from `show_scrollbars: "auto"` to `scrollbar: {show: "auto", git_diffs: true}`. (preview only)