### PR TITLE
Add initial project panel settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,6 +4886,7 @@ dependencies = [
 name = "project_panel"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "client",
  "context_menu",
  "drag_and_drop",
@@ -4896,6 +4897,9 @@ dependencies = [
  "menu",
  "postage",
  "project",
+ "schemars",
+ "serde",
+ "serde_derive",
  "serde_json",
  "settings",
  "theme",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -70,6 +70,10 @@
       // Whether to show git diff indicators in the scrollbar.
       "git_diff": true
   },
+  "project_panel": {
+      // Whether to show the git status in the project panel.
+      "git_status": true
+  },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -21,6 +21,12 @@ util = { path = "../util" }
 workspace = { path = "../workspace" }
 postage.workspace = true
 futures.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+schemars.workspace = true
+
 unicase = "2.6"
 
 [dev-dependencies]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1018,7 +1018,9 @@ impl ProjectPanel {
                 for (entry, repo) in
                     snapshot.entries_with_repositories(visible_worktree_entries[entry_range].iter())
                 {
-                    let status = (git_status_setting && entry.path.parent().is_some() && !entry.is_ignored)
+                    let status = (git_status_setting
+                        && entry.path.parent().is_some()
+                        && !entry.is_ignored)
                         .then(|| repo.and_then(|repo| repo.status_for_path(&snapshot, &entry.path)))
                         .flatten();
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -113,8 +113,12 @@ actions!(
     ]
 );
 
-pub fn init(cx: &mut AppContext) {
+pub fn init_settings(cx: &mut AppContext) {
     settings::register::<ProjectPanelSettings>(cx);
+}
+
+pub fn init(cx: &mut AppContext) {
+    init_settings(cx);
     cx.add_action(ProjectPanel::expand_selected_entry);
     cx.add_action(ProjectPanel::collapse_selected_entry);
     cx.add_action(ProjectPanel::select_prev);
@@ -2051,6 +2055,7 @@ mod tests {
         cx.foreground().forbid_parking();
         cx.update(|cx| {
             cx.set_global(SettingsStore::test(cx));
+            init_settings(cx);
             theme::init((), cx);
             language::init(cx);
             editor::init_settings(cx);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2068,6 +2068,7 @@ mod tests {
         cx.update(|cx| {
             let app_state = AppState::test(cx);
             theme::init((), cx);
+            init_settings(cx);
             language::init(cx);
             editor::init(cx);
             pane::init(cx);

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -1,0 +1,29 @@
+use serde_derive::{Deserialize, Serialize};
+use anyhow;
+use settings::Setting;
+use schemars::JsonSchema;
+
+
+#[derive(Deserialize, Debug)]
+pub struct ProjectPanelSettings {
+    pub git_status: bool,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+pub struct ProjectPanelSettingsContent {
+    pub git_status: Option<bool>,
+}
+
+impl Setting for ProjectPanelSettings {
+    const KEY: Option<&'static str> = Some("project_panel");
+
+    type FileContent = ProjectPanelSettingsContent;
+
+    fn load(
+        default_value: &Self::FileContent,
+        user_values: &[&Self::FileContent],
+        _: &gpui::AppContext,
+    ) -> anyhow::Result<Self> {
+        Self::load_via_json_merge(default_value, user_values)
+    }
+}

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -1,8 +1,7 @@
-use serde_derive::{Deserialize, Serialize};
 use anyhow;
-use settings::Setting;
 use schemars::JsonSchema;
-
+use serde_derive::{Deserialize, Serialize};
+use settings::Setting;
 
 #[derive(Deserialize, Debug)]
 pub struct ProjectPanelSettings {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2068,6 +2068,7 @@ mod tests {
             workspace::init(app_state.clone(), cx);
             language::init(cx);
             editor::init(cx);
+            project_panel::init_settings(cx);
             pane::init(cx);
             app_state
         })


### PR DESCRIPTION
This PR adds project panel settings for disabling git status.

Release Notes:

- Adds `project_panel: { git_status: bool }` to the settings, for controlling whether git status information appears.