### PR TITLE
Update terminal panel tooltip

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -347,7 +347,7 @@ impl Panel for TerminalPanel {
     }
 
     fn icon_tooltip(&self) -> String {
-        "Terminals".to_string()
+        "Terminal Panel".into()
     }
 
     fn icon_label(&self, cx: &WindowContext) -> Option<String> {


### PR DESCRIPTION
The actions in Zed now call this the Terminal Panel and the crate is called that as well, so I think the tooltip should be updated to use that same name.

Release Notes:

N/A
