### PR TITLE
Prevent empty panes from being zoomed

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -683,7 +683,7 @@ impl Pane {
     pub fn toggle_zoom(&mut self, _: &ToggleZoom, cx: &mut ViewContext<Self>) {
         if self.zoomed {
             cx.emit(Event::ZoomOut);
-        } else {
+        } else if !self.items.is_empty() {
             cx.emit(Event::ZoomIn);
         }
     }
@@ -981,6 +981,10 @@ impl Pane {
                 .borrow_mut()
                 .paths_by_item
                 .remove(&item.id());
+        }
+
+        if self.items.is_empty() && self.zoomed {
+            cx.emit(Event::ZoomOut);
         }
 
         cx.notify();


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-1789/empty-panes-should-not-be-zoomable