### PR TITLE
Polish panel experience

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -367,7 +367,30 @@
         "workspace::ActivatePane",
         8
       ],
-      "cmd-b": "workspace::ToggleLeftDock",
+      "cmd-b": [
+        "workspace::ToggleLeftDock",
+        { "focus": true }
+      ],
+      "cmd-shift-b": [
+        "workspace::ToggleLeftDock",
+        { "focus": false }
+      ],
+      "cmd-r": [
+        "workspace::ToggleRightDock",
+        { "focus": true }
+      ],
+      "cmd-shift-r": [
+        "workspace::ToggleRightDock",
+        { "focus": false }
+      ],
+      "cmd-j": [
+        "workspace::ToggleBottomDock",
+        { "focus": true }
+      ],
+      "cmd-shift-j": [
+        "workspace::ToggleBottomDock",
+        { "focus": false }
+      ],
       "cmd-shift-f": "workspace::NewSearch",
       "cmd-k cmd-t": "theme_selector::Toggle",
       "cmd-k cmd-s": "zed::OpenKeymap",

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -15,8 +15,8 @@ use gpui::{
     geometry::vector::Vector2F,
     keymap_matcher::KeymapContext,
     platform::{CursorStyle, MouseButton, PromptLevel},
-    AnyElement, AppContext, AsyncAppContext, ClipboardItem, Element, Entity, ModelHandle, Task,
-    View, ViewContext, ViewHandle, WeakViewHandle, WindowContext,
+    Action, AnyElement, AppContext, AsyncAppContext, ClipboardItem, Element, Entity, ModelHandle,
+    Task, View, ViewContext, ViewHandle, WeakViewHandle, WindowContext,
 };
 use menu::{Confirm, SelectNext, SelectPrev};
 use project::{
@@ -1507,8 +1507,8 @@ impl workspace::dock::Panel for ProjectPanel {
         "icons/folder_tree_16.svg"
     }
 
-    fn icon_tooltip(&self) -> String {
-        "Project Panel".into()
+    fn icon_tooltip(&self) -> (String, Option<Box<dyn Action>>) {
+        ("Project Panel".into(), Some(Box::new(ToggleFocus)))
     }
 
     fn should_change_position_on_event(event: &Self::Event) -> bool {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -236,7 +236,8 @@ impl TerminalPanel {
                         Box::new(cx.add_view(|cx| {
                             TerminalView::new(terminal, workspace.database_id(), cx)
                         }));
-                    Pane::add_item(workspace, &pane, terminal, true, true, None, cx);
+                    let focus = pane.read(cx).has_focus();
+                    Pane::add_item(workspace, &pane, terminal, true, focus, None, cx);
                 }
             })?;
             this.update(&mut cx, |this, cx| this.serialize(cx))?;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::TerminalView;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
-    actions, anyhow::Result, elements::*, serde_json, AppContext, AsyncAppContext, Entity,
+    actions, anyhow::Result, elements::*, serde_json, Action, AppContext, AsyncAppContext, Entity,
     Subscription, Task, View, ViewContext, ViewHandle, WeakViewHandle, WindowContext,
 };
 use project::Fs;
@@ -365,8 +365,8 @@ impl Panel for TerminalPanel {
         "icons/terminal_12.svg"
     }
 
-    fn icon_tooltip(&self) -> String {
-        "Terminal Panel".into()
+    fn icon_tooltip(&self) -> (String, Option<Box<dyn Action>>) {
+        ("Terminal Panel".into(), Some(Box::new(ToggleFocus)))
     }
 
     fn icon_label(&self, cx: &WindowContext) -> Option<String> {

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -32,7 +32,7 @@ pub fn init(cx: &mut AppContext) {
 
 pub fn show_welcome_experience(app_state: &Arc<AppState>, cx: &mut AppContext) {
     open_new(&app_state, cx, |workspace, cx| {
-        workspace.toggle_dock(DockPosition::Left, cx);
+        workspace.toggle_dock(DockPosition::Left, false, cx);
         let welcome_page = cx.add_view(|cx| WelcomePage::new(workspace, cx));
         workspace.add_item_to_center(Box::new(welcome_page.clone()), cx);
         cx.focus(&welcome_page);

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -423,6 +423,16 @@ impl View for Dock {
             Empty::new().into_any()
         }
     }
+
+    fn focus_in(&mut self, _: AnyViewHandle, cx: &mut ViewContext<Self>) {
+        if cx.is_self_focused() {
+            if let Some(active_entry) = self.active_entry() {
+                cx.focus(active_entry.panel.as_any());
+            } else {
+                cx.focus_parent();
+            }
+        }
+    }
 }
 
 impl PanelButtons {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -64,7 +64,7 @@ use crate::{
         DockData, DockStructure, SerializedPane, SerializedPaneGroup, SerializedWorkspace,
     },
 };
-use dock::{Dock, DockPosition, Panel, PanelButtons, PanelHandle, TogglePanel};
+use dock::{Dock, DockPosition, Panel, PanelButtons, PanelHandle};
 use lazy_static::lazy_static;
 use notifications::{NotificationHandle, NotifyResultExt};
 pub use pane::*;
@@ -259,7 +259,6 @@ pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {
             workspace.save_active_item(true, cx).detach_and_log_err(cx);
         },
     );
-    cx.add_action(Workspace::toggle_panel);
     cx.add_action(|workspace: &mut Workspace, _: &ActivatePreviousPane, cx| {
         workspace.activate_previous_pane(cx)
     });
@@ -1497,19 +1496,24 @@ impl Workspace {
         self.serialize_workspace(cx);
     }
 
-    pub fn toggle_panel(&mut self, action: &TogglePanel, cx: &mut ViewContext<Self>) {
-        let dock = match action.dock_position {
+    pub fn toggle_panel(
+        &mut self,
+        position: DockPosition,
+        panel_index: usize,
+        cx: &mut ViewContext<Self>,
+    ) {
+        let dock = match position {
             DockPosition::Left => &mut self.left_dock,
             DockPosition::Bottom => &mut self.bottom_dock,
             DockPosition::Right => &mut self.right_dock,
         };
         let active_item = dock.update(cx, move |dock, cx| {
-            if dock.is_open() && dock.active_panel_index() == action.panel_index {
+            if dock.is_open() && dock.active_panel_index() == panel_index {
                 dock.set_open(false, cx);
                 None
             } else {
                 dock.set_open(true, cx);
-                dock.activate_panel(action.panel_index, cx);
+                dock.activate_panel(panel_index, cx);
                 dock.active_panel().cloned()
             }
         });

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -89,9 +89,18 @@ pub fn menus() -> Vec<Menu<'static>> {
                 MenuItem::action("Zoom Out", super::DecreaseBufferFontSize),
                 MenuItem::action("Reset Zoom", super::ResetBufferFontSize),
                 MenuItem::separator(),
-                MenuItem::action("Toggle Left Dock", workspace::ToggleLeftDock),
-                MenuItem::action("Toggle Right Dock", workspace::ToggleRightDock),
-                MenuItem::action("Toggle Bottom Dock", workspace::ToggleBottomDock),
+                MenuItem::action(
+                    "Toggle Left Dock",
+                    workspace::ToggleLeftDock { focus: false },
+                ),
+                MenuItem::action(
+                    "Toggle Right Dock",
+                    workspace::ToggleRightDock { focus: false },
+                ),
+                MenuItem::action(
+                    "Toggle Bottom Dock",
+                    workspace::ToggleBottomDock { focus: false },
+                ),
                 MenuItem::submenu(Menu {
                     name: "Editor Layout",
                     items: vec![

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -354,7 +354,7 @@ pub fn initialize_workspace(
                             .map_or(false, |entry| entry.is_dir())
                     })
             {
-                workspace.toggle_dock(project_panel_position, cx);
+                workspace.toggle_dock(project_panel_position, false, cx);
             }
 
             workspace.add_panel(terminal_panel, cx)


### PR DESCRIPTION
In this pull request we improved key bindings (as described below) and added tooltips.

Add these release notes to the panels release notes:

- The left, right and bottom dock can be toggled and focused at the same time respectively via `cmd-b`, `cmd-r` and `cmd-j`. Holding `shift` will toggle them without changing the focus.