### PR TITLE
Make toggle dock actions appear in the command palette

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -105,16 +105,19 @@ pub struct RemoveWorktreeFromProject(pub WorktreeId);
 
 #[derive(Copy, Clone, Default, Deserialize, PartialEq)]
 pub struct ToggleLeftDock {
+    #[serde(default = "default_true")]
     pub focus: bool,
 }
 
 #[derive(Copy, Clone, Default, Deserialize, PartialEq)]
 pub struct ToggleBottomDock {
+    #[serde(default = "default_true")]
     pub focus: bool,
 }
 
 #[derive(Copy, Clone, Default, Deserialize, PartialEq)]
 pub struct ToggleRightDock {
+    #[serde(default = "default_true")]
     pub focus: bool,
 }
 
@@ -3376,6 +3379,10 @@ fn parse_pixel_position_env_var(value: &str) -> Option<Vector2F> {
     let width: usize = parts.next()?.parse().ok()?;
     let height: usize = parts.next()?.parse().ok()?;
     Some(vec2f(width as f32, height as f32))
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This makes the `Toggle{Left,Right,Bottom}Dock` actions deserializable from empty JSON, so that they can be constructed for the command palette. It also fixes a bug in GPUI's `available_actions` method, in which we'd include key bindings for actions of the same type but different values.

Note that, for now, the command palette will perform the *focusing* version of the actions. I'm not totally sure this is the right behavior, but it seems more useful to me.

Release Notes:

N/A