### PR TITLE
Prevent pane from being erroneously zoomed when toggling the outline pane

### DIFF
--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -100,8 +100,6 @@ pub fn init(cx: &mut AppContext) {
     cx.capture_action({
         let assistant = assistant.clone();
         move |_: &mut Editor, _: &editor::Cancel, cx: &mut ViewContext<Editor>| {
-            dbg!("CANCEL LAST ASSIST");
-
             if !assistant.cancel_last_assist(cx.view_id()) {
                 cx.propagate_action();
             }


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1818/toggling-the-outline-pane-causes-the-pane-to-zoom

Add release note lines here:

- Fixed a bug that could cause panes to be erroneously zoomed when toggling modals. (preview-only)
