### PR TITLE
Prevent bottom dock from becoming too large or too small

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2836,7 +2836,10 @@ impl Workspace {
                         Vector2F::new(20., constraint.min.y()),
                         Vector2F::new(cx.window_size().x() * 0.8, constraint.max.y()),
                     ),
-                    _ => constraint,
+                    DockPosition::Bottom => SizeConstraint::new(
+                        Vector2F::new(constraint.min.x(), 20.),
+                        Vector2F::new(constraint.max.x(), cx.window_size().y() * 0.8),
+                    ),
                 })
                 .into_any(),
         )


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1834/bottom-dock-can-be-dragged-down-far-enough-such-that-the-tab-bar-is

Release Notes:

- Improved the resize experience for the bottom dock, preventing it from becoming too large or too small. (preview-only)