### PR TITLE
Multibuffer edit perf

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -1499,6 +1499,7 @@ mod tests {
             language::init(cx);
             client::init_settings(cx);
             workspace::init_settings(cx);
+            Project::init_settings(cx);
         });
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -609,15 +609,6 @@ impl Item for ProjectDiagnosticsEditor {
         unreachable!()
     }
 
-    fn git_diff_recalc(
-        &mut self,
-        project: ModelHandle<Project>,
-        cx: &mut ViewContext<Self>,
-    ) -> Task<Result<()>> {
-        self.editor
-            .update(cx, |editor, cx| editor.git_diff_recalc(project, cx))
-    }
-
     fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         Editor::to_item_events(event)
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6873,6 +6873,7 @@ impl Editor {
             multi_buffer::Event::Saved => cx.emit(Event::Saved),
             multi_buffer::Event::FileHandleChanged => cx.emit(Event::TitleChanged),
             multi_buffer::Event::Reloaded => cx.emit(Event::TitleChanged),
+            multi_buffer::Event::DiffBaseChanged => cx.emit(Event::DiffBaseChanged),
             multi_buffer::Event::Closed => cx.emit(Event::Closed),
             multi_buffer::Event::DiagnosticsUpdated => {
                 self.refresh_active_diagnostics(cx);
@@ -7261,6 +7262,7 @@ pub enum Event {
     DirtyChanged,
     Saved,
     TitleChanged,
+    DiffBaseChanged,
     SelectionsChanged {
         local: bool,
     },

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1246,7 +1246,7 @@ fn test_prev_next_word_bounds_with_soft_wrap(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let line_height = cx.editor(|editor, cx| editor.style(cx).text.line_height(cx.font_cache()));
     cx.simulate_window_resize(cx.window_id, vec2f(100., 4. * line_height));
@@ -1358,7 +1358,7 @@ async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut gpui::TestAppCon
 #[gpui::test]
 async fn test_move_page_up_page_down(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let line_height = cx.editor(|editor, cx| editor.style(cx).text.line_height(cx.font_cache()));
     cx.simulate_window_resize(cx.window_id, vec2f(100., 4. * line_height));
@@ -1473,7 +1473,7 @@ async fn test_move_page_up_page_down(cx: &mut gpui::TestAppContext) {
 #[gpui::test]
 async fn test_delete_to_beginning_of_line(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.set_state("one «two threeˇ» four");
     cx.update_editor(|editor, cx| {
         editor.delete_to_beginning_of_line(&DeleteToBeginningOfLine, cx);
@@ -1637,7 +1637,7 @@ async fn test_newline_above(cx: &mut gpui::TestAppContext) {
         .unwrap(),
     );
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
     cx.set_state(indoc! {"
         const a: ˇA = (
@@ -1685,7 +1685,7 @@ async fn test_newline_below(cx: &mut gpui::TestAppContext) {
         .unwrap(),
     );
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
     cx.set_state(indoc! {"
         const a: ˇA = (
@@ -1751,7 +1751,7 @@ async fn test_tab(cx: &mut gpui::TestAppContext) {
         settings.defaults.tab_size = NonZeroU32::new(3)
     });
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.set_state(indoc! {"
         ˇabˇc
         ˇ🏀ˇ🏀ˇefg
@@ -1779,7 +1779,7 @@ async fn test_tab(cx: &mut gpui::TestAppContext) {
 async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     let language = Arc::new(
         Language::new(
             LanguageConfig::default(),
@@ -1850,7 +1850,7 @@ async fn test_tab_with_mixed_whitespace(cx: &mut gpui::TestAppContext) {
         .unwrap(),
     );
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
     cx.set_state(indoc! {"
         fn a() {
@@ -1876,7 +1876,7 @@ async fn test_indent_outdent(cx: &mut gpui::TestAppContext) {
         settings.defaults.tab_size = NonZeroU32::new(4);
     });
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     cx.set_state(indoc! {"
           «oneˇ» «twoˇ»
@@ -1949,7 +1949,7 @@ async fn test_indent_outdent_with_hard_tabs(cx: &mut gpui::TestAppContext) {
         settings.defaults.hard_tabs = Some(true);
     });
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     // select two ranges on one line
     cx.set_state(indoc! {"
@@ -2156,7 +2156,7 @@ fn test_indent_outdent_with_excerpts(cx: &mut TestAppContext) {
 async fn test_backspace(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     // Basic backspace
     cx.set_state(indoc! {"
@@ -2205,7 +2205,7 @@ async fn test_backspace(cx: &mut gpui::TestAppContext) {
 async fn test_delete(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.set_state(indoc! {"
         onˇe two three
         fou«rˇ» five six
@@ -2559,7 +2559,7 @@ fn test_transpose(cx: &mut TestAppContext) {
 async fn test_clipboard(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     cx.set_state("«one✅ ˇ»two «three ˇ»four «five ˇ»six ");
     cx.update_editor(|e, cx| e.cut(&Cut, cx));
@@ -2641,7 +2641,7 @@ async fn test_clipboard(cx: &mut gpui::TestAppContext) {
 async fn test_paste_multiline(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     let language = Arc::new(Language::new(
         LanguageConfig::default(),
         Some(tree_sitter_rust::language()),
@@ -3085,7 +3085,7 @@ fn test_add_selection_above_below(cx: &mut TestAppContext) {
 async fn test_select_next(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.set_state("abc\nˇabc abc\ndefabc\nabc");
 
     cx.update_editor(|e, cx| e.select_next(&SelectNext::default(), cx));
@@ -3314,7 +3314,7 @@ async fn test_autoindent_selections(cx: &mut gpui::TestAppContext) {
 async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let language = Arc::new(Language::new(
         LanguageConfig {
@@ -3485,7 +3485,7 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
 async fn test_autoclose_with_embedded_language(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let html_language = Arc::new(
         Language::new(
@@ -3721,7 +3721,7 @@ async fn test_autoclose_with_embedded_language(cx: &mut gpui::TestAppContext) {
 async fn test_autoclose_with_overrides(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let rust_language = Arc::new(
         Language::new(
@@ -4938,7 +4938,7 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
     let registry = Arc::new(LanguageRegistry::test());
     registry.add(language.clone());
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| {
         buffer.set_language_registry(registry);
         buffer.set_language(Some(language), cx);
@@ -5060,7 +5060,7 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
 async fn test_toggle_block_comment(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let html_language = Arc::new(
         Language::new(
@@ -5985,7 +5985,7 @@ fn test_combine_syntax_and_fuzzy_match_highlights() {
 async fn go_to_hunk(deterministic: Arc<Deterministic>, cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let mut cx = EditorTestContext::new(cx);
+    let mut cx = EditorTestContext::new(cx).await;
 
     let diff_base = r#"
         use some::mod;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -40,7 +40,10 @@ use language::{
     language_settings::ShowWhitespaceSetting, Bias, CursorShape, DiagnosticSeverity, OffsetUtf16,
     Selection,
 };
-use project::ProjectPath;
+use project::{
+    project_settings::{GitGutterSetting, ProjectSettings},
+    ProjectPath,
+};
 use smallvec::SmallVec;
 use std::{
     borrow::Cow,
@@ -51,7 +54,7 @@ use std::{
     sync::Arc,
 };
 use text::Point;
-use workspace::{item::Item, GitGutterSetting, WorkspaceSettings};
+use workspace::item::Item;
 
 enum FoldMarkers {}
 
@@ -551,11 +554,8 @@ impl EditorElement {
         let scroll_top = scroll_position.y() * line_height;
 
         let show_gutter = matches!(
-            settings::get::<WorkspaceSettings>(cx)
-                .git
-                .git_gutter
-                .unwrap_or_default(),
-            GitGutterSetting::TrackedFiles
+            settings::get::<ProjectSettings>(cx).git.git_gutter,
+            Some(GitGutterSetting::TrackedFiles)
         );
 
         if show_gutter {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -720,17 +720,6 @@ impl Item for Editor {
         })
     }
 
-    fn git_diff_recalc(
-        &mut self,
-        _project: ModelHandle<Project>,
-        cx: &mut ViewContext<Self>,
-    ) -> Task<Result<()>> {
-        self.buffer().update(cx, |multibuffer, cx| {
-            multibuffer.git_diff_recalc(cx);
-        });
-        Task::ready(Ok(()))
-    }
-
     fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         let mut result = SmallVec::new();
         match event {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -343,17 +343,6 @@ impl MultiBuffer {
         self.read(cx).symbols_containing(offset, theme)
     }
 
-    pub fn git_diff_recalc(&mut self, _: &mut ModelContext<Self>) {
-        // let buffers = self.buffers.borrow();
-        // for buffer_state in buffers.values() {
-        //     if buffer_state.buffer.read(cx).needs_git_diff_recalc() {
-        //         buffer_state
-        //             .buffer
-        //             .update(cx, |buffer, cx| buffer.git_diff_recalc(cx))
-        //     }
-        // }
-    }
-
     pub fn edit<I, S, T>(
         &mut self,
         edits: I,

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -343,15 +343,15 @@ impl MultiBuffer {
         self.read(cx).symbols_containing(offset, theme)
     }
 
-    pub fn git_diff_recalc(&mut self, cx: &mut ModelContext<Self>) {
-        let buffers = self.buffers.borrow();
-        for buffer_state in buffers.values() {
-            if buffer_state.buffer.read(cx).needs_git_diff_recalc() {
-                buffer_state
-                    .buffer
-                    .update(cx, |buffer, cx| buffer.git_diff_recalc(cx))
-            }
-        }
+    pub fn git_diff_recalc(&mut self, _: &mut ModelContext<Self>) {
+        // let buffers = self.buffers.borrow();
+        // for buffer_state in buffers.values() {
+        //     if buffer_state.buffer.read(cx).needs_git_diff_recalc() {
+        //         buffer_state
+        //             .buffer
+        //             .update(cx, |buffer, cx| buffer.git_diff_recalc(cx))
+        //     }
+        // }
     }
 
     pub fn edit<I, S, T>(

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1198,6 +1198,7 @@ mod tests {
             super::init(cx);
             editor::init(cx);
             workspace::init_settings(cx);
+            Project::init_settings(cx);
             state
         })
     }

--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -161,13 +161,6 @@ impl BufferDiff {
         self.tree = SumTree::new();
     }
 
-    pub fn needs_update(&self, buffer: &text::BufferSnapshot) -> bool {
-        match &self.last_buffer_version {
-            Some(last) => buffer.version().changed_since(last),
-            None => true,
-        }
-    }
-
     pub async fn update(&mut self, diff_base: &str, buffer: &text::BufferSnapshot) {
         let mut tree = SumTree::new();
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -682,6 +682,20 @@ impl Buffer {
         self.git_diff_status.diff.needs_update(self)
     }
 
+    fn git_diff_recalc_2(&mut self, cx: &mut ModelContext<Self>) -> Option<Task<()>> {
+        let diff_base = &self.diff_base?;
+        let snapshot = self.snapshot();
+        let handle = cx.weak_handle();
+
+        let mut diff = self.git_diff_status.diff.clone();
+        Some(cx.background().spawn(async move {
+            diff.update(&diff_base, &snapshot).await;
+            if let Some(this) = handle.upgrade(cx) {
+                // this.update(cx)
+            }
+        }))
+    }
+
     pub fn git_diff_recalc(&mut self, cx: &mut ModelContext<Self>) {
         if self.git_diff_status.update_in_progress {
             self.git_diff_status.update_requested = true;
@@ -689,6 +703,7 @@ impl Buffer {
         }
 
         if let Some(diff_base) = &self.diff_base {
+            self.git_diff_status.update_in_progress = true;
             let snapshot = self.snapshot();
             let diff_base = diff_base.clone();
 
@@ -706,9 +721,10 @@ impl Buffer {
                         this.git_diff_update_count += 1;
                         cx.notify();
 
-                        this.git_diff_status.update_in_progress = false;
                         if this.git_diff_status.update_requested {
                             this.git_diff_recalc(cx);
+                        } else {
+                            this.git_diff_status.update_in_progress = false;
                         }
                     })
                 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -620,7 +620,6 @@ impl Buffer {
                 cx,
             );
         }
-        self.git_diff_recalc(cx);
         cx.emit(Event::Reloaded);
         cx.notify();
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1977,7 +1977,10 @@ impl Project {
         event: &BufferEvent,
         cx: &mut ModelContext<Self>,
     ) -> Option<()> {
-        if matches!(event, BufferEvent::Edited { .. } | BufferEvent::Reloaded) {
+        if matches!(
+            event,
+            BufferEvent::Edited { .. } | BufferEvent::Reloaded | BufferEvent::DiffBaseChanged
+        ) {
             self.request_buffer_diff_recalculation(&buffer, cx);
         }
 
@@ -2166,7 +2169,7 @@ impl Project {
                     .iter()
                     .filter_map(|buffer| {
                         let buffer = buffer.upgrade(cx)?;
-                        buffer.update(cx, |buffer, cx| buffer.git_diff_recalc_2(cx))
+                        buffer.update(cx, |buffer, cx| buffer.git_diff_recalc(cx))
                     })
                     .collect()
             });

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -8,6 +8,22 @@ use std::sync::Arc;
 pub struct ProjectSettings {
     #[serde(default)]
     pub lsp: HashMap<Arc<str>, LspSettings>,
+    #[serde(default)]
+    pub git: GitSettings,
+}
+
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct GitSettings {
+    pub git_gutter: Option<GitGutterSetting>,
+    pub gutter_debounce: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GitGutterSetting {
+    #[default]
+    TrackedFiles,
+    Hide,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1273,6 +1273,7 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
 
     // The diagnostics have moved down since they were created.
     buffer.next_notification(cx).await;
+    buffer.next_notification(cx).await;
     buffer.read_with(cx, |buffer, _| {
         assert_eq!(
             buffer

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -719,11 +719,7 @@ impl LocalWorktree {
                 .background()
                 .spawn(async move { text::Buffer::new(0, id, contents) })
                 .await;
-            Ok(cx.add_model(|cx| {
-                let mut buffer = Buffer::build(text_buffer, diff_base, Some(Arc::new(file)));
-                buffer.git_diff_recalc(cx);
-                buffer
-            }))
+            Ok(cx.add_model(|_| Buffer::build(text_buffer, diff_base, Some(Arc::new(file)))))
         })
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2229,6 +2229,7 @@ mod tests {
             editor::init_settings(cx);
             crate::init(cx);
             workspace::init_settings(cx);
+            Project::init_settings(cx);
         });
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2244,6 +2244,7 @@ mod tests {
             pane::init(cx);
             crate::init(cx);
             workspace::init(app_state.clone(), cx);
+            Project::init_settings(cx);
         });
     }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -360,15 +360,6 @@ impl Item for ProjectSearchView {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn git_diff_recalc(
-        &mut self,
-        project: ModelHandle<Project>,
-        cx: &mut ViewContext<Self>,
-    ) -> Task<anyhow::Result<()>> {
-        self.results_editor
-            .update(cx, |editor, cx| editor.git_diff_recalc(project, cx))
-    }
-
     fn to_item_events(event: &Self::Event) -> SmallVec<[ItemEvent; 2]> {
         match event {
             ViewEvent::UpdateTab => {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1268,6 +1268,7 @@ pub mod tests {
             client::init_settings(cx);
             editor::init_settings(cx);
             workspace::init_settings(cx);
+            Project::init_settings(cx);
         });
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -442,7 +442,7 @@ impl DelayedDebouncedEditAction {
         }
     }
 
-    fn fire_new<F>(&mut self, delay: Duration, cx: &mut ViewContext<Workspace>, f: F)
+    fn fire_new<F>(&mut self, delay: Duration, cx: &mut ViewContext<Workspace>, func: F)
     where
         F: 'static + FnOnce(&mut Workspace, &mut ViewContext<Workspace>) -> Task<Result<()>>,
     {
@@ -466,7 +466,7 @@ impl DelayedDebouncedEditAction {
             }
 
             if let Some(result) = workspace
-                .update(&mut cx, |workspace, cx| (f)(workspace, cx))
+                .update(&mut cx, |workspace, cx| (func)(workspace, cx))
                 .log_err()
             {
                 result.await.log_err();

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -8,7 +8,6 @@ pub struct WorkspaceSettings {
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
-    pub git: GitSettings,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -17,7 +16,6 @@ pub struct WorkspaceSettingsContent {
     pub confirm_quit: Option<bool>,
     pub show_call_status_icon: Option<bool>,
     pub autosave: Option<AutosaveSetting>,
-    pub git: Option<GitSettings>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2085,6 +2085,7 @@ mod tests {
             theme::init((), cx);
             call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             workspace::init(app_state.clone(), cx);
+            Project::init_settings(cx);
             language::init(cx);
             editor::init(cx);
             project_panel::init_settings(cx);


### PR DESCRIPTION
This took so much longer than I wanted, so glad to finally be rid of this

Closes https://linear.app/zed-industries/issue/Z-616/large-multicursor-edits-in-multibuffers-block-zed-for-a-long-time

Release Notes:
* Improved performance when editing many git-tracked files in a multi-buffer at the same time
