### PR TITLE
Display external paths in history

### DIFF
--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -240,7 +240,7 @@ impl Assistant {
             .assist_stacks
             .entry(cx.view_id())
             .or_default()
-            .push((dbg!(assist_id), assist_task));
+            .push((assist_id, assist_task));
 
         Ok(())
     }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -101,11 +101,11 @@ fn toggle_file_finder(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContex
             });
 
         // if exists, bubble the currently opened path to the top
-        let history_items = dbg!(dbg!(currently_opened_path.clone())
+        let history_items = currently_opened_path
+            .clone()
             .into_iter()
             .chain(
                 workspace
-                    // TODO kb history contains empty paths
                     .recent_navigation_history(Some(MAX_RECENT_SELECTIONS), cx)
                     .into_iter()
                     .filter(|(history_path, _)| {
@@ -116,7 +116,7 @@ fn toggle_file_finder(workspace: &mut Workspace, _: &Toggle, cx: &mut ViewContex
                     })
                     .map(|(history_path, abs_path)| FoundPath::new(history_path, abs_path)),
             )
-            .collect());
+            .collect();
 
         let project = workspace.project().clone();
         let workspace = cx.handle().downgrade();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3218,7 +3218,7 @@ impl Project {
     ) -> Result<(), anyhow::Error> {
         let (worktree, relative_path) = self
             .find_local_worktree(&abs_path, cx)
-            .ok_or_else(|| anyhow!("no worktree found for diagnostics"))?;
+            .ok_or_else(|| anyhow!("no worktree found for diagnostics path {abs_path:?}"))?;
 
         let project_path = ProjectPath {
             worktree_id: worktree.read(cx).id(),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1018,9 +1018,11 @@ impl Pane {
 
         if let Some(path) = item.project_path(cx) {
             let abs_path = self
-                .workspace()
-                .upgrade(cx)
-                .and_then(|workspace| workspace.read(cx).absolute_path(&path, cx));
+                .nav_history
+                .borrow()
+                .paths_by_item
+                .get(&item.id())
+                .and_then(|(_, abs_path)| abs_path.clone());
             self.nav_history
                 .borrow_mut()
                 .paths_by_item


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-1793/file-finder-external-recent-paths-are-not-rendered-properly

Long paths get trimmed, but same do many of our other elements, such as type definitions, so I think it's ok for now:
![image](https://github.com/zed-industries/zed/assets/2690773/b8b6588d-6d6b-42db-9085-c741a40b7adb)

Also, we seem to do a lot of odd diagnostics handling on every external stdlib file opened:
![image](https://github.com/zed-industries/zed/assets/2690773/cd82c54e-7849-46fe-a01c-79bfc5402b7b)
Other external files also emit similar messages, but not that much.
@\mikayla-maki mentioned, that this was happening before, so can be fixed separately.
The PR adds path printing to these logs.

Release Notes:

* Fixed external files not being displayed properly in the recently opened list in the file finder panel