### PR TITLE
Update LSP to the newest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,9 +3744,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.91.1"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
+checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
 dependencies = [
  "bitflags",
  "serde",

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5010,19 +5010,21 @@ async fn test_project_symbols(
         .unwrap();
 
     let fake_language_server = fake_language_servers.next().await.unwrap();
-    fake_language_server.handle_request::<lsp::request::WorkspaceSymbol, _, _>(|_, _| async move {
-        #[allow(deprecated)]
-        Ok(Some(vec![lsp::SymbolInformation {
-            name: "TWO".into(),
-            location: lsp::Location {
-                uri: lsp::Url::from_file_path("/code/crate-2/two.rs").unwrap(),
-                range: lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
+    fake_language_server.handle_request::<lsp::WorkspaceSymbolRequest, _, _>(|_, _| async move {
+        Ok(Some(lsp::WorkspaceSymbolResponse::Flat(vec![
+            #[allow(deprecated)]
+            lsp::SymbolInformation {
+                name: "TWO".into(),
+                location: lsp::Location {
+                    uri: lsp::Url::from_file_path("/code/crate-2/two.rs").unwrap(),
+                    range: lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
+                },
+                kind: lsp::SymbolKind::CONSTANT,
+                tags: None,
+                container_name: None,
+                deprecated: None,
             },
-            kind: lsp::SymbolKind::CONSTANT,
-            tags: None,
-            container_name: None,
-            deprecated: None,
-        }]))
+        ])))
     });
 
     // Request the definition of a symbol as the guest.

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -20,7 +20,7 @@ anyhow.workspace = true
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553", optional = true }
 futures.workspace = true
 log.workspace = true
-lsp-types = "0.91"
+lsp-types = "0.94"
 parking_lot.workspace = true
 postage.workspace = true
 serde.workspace = true

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -361,13 +361,18 @@ impl LanguageServer {
             capabilities: ClientCapabilities {
                 workspace: Some(WorkspaceClientCapabilities {
                     configuration: Some(true),
-                    did_change_watched_files: Some(DynamicRegistrationClientCapabilities {
+                    did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
                         dynamic_registration: Some(true),
+                        relative_pattern_support: Some(true),
                     }),
                     did_change_configuration: Some(DynamicRegistrationClientCapabilities {
                         dynamic_registration: Some(true),
                     }),
                     workspace_folders: Some(true),
+                    symbol: Some(WorkspaceSymbolClientCapabilities {
+                        resolve_support: None,
+                        ..WorkspaceSymbolClientCapabilities::default()
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(TextDocumentClientCapabilities {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1524,6 +1524,7 @@ impl LspCommand for GetCodeActions {
             context: lsp::CodeActionContext {
                 diagnostics: relevant_diagnostics,
                 only: language_server.code_action_kinds(),
+                ..lsp::CodeActionContext::default()
             },
         }
     }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -506,7 +506,9 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
                 register_options: serde_json::to_value(
                     lsp::DidChangeWatchedFilesRegistrationOptions {
                         watchers: vec![lsp::FileSystemWatcher {
-                            glob_pattern: "/the-root/*.{rs,c}".to_string(),
+                            glob_pattern: lsp::GlobPattern::String(
+                                "/the-root/*.{rs,c}".to_string(),
+                            ),
                             kind: None,
                         }],
                     },

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -284,7 +284,7 @@ mod tests {
             symbol("uno", "/dir/test.rs"),
         ];
         let fake_server = fake_servers.next().await.unwrap();
-        fake_server.handle_request::<lsp::request::WorkspaceSymbol, _, _>(
+        fake_server.handle_request::<lsp::WorkspaceSymbolRequest, _, _>(
             move |params: lsp::WorkspaceSymbolParams, cx| {
                 let executor = cx.background();
                 let fake_symbols = fake_symbols.clone();
@@ -308,12 +308,12 @@ mod tests {
                         .await
                     };
 
-                    Ok(Some(
+                    Ok(Some(lsp::WorkspaceSymbolResponse::Flat(
                         matches
                             .into_iter()
                             .map(|mat| fake_symbols[mat.candidate_id].clone())
                             .collect(),
-                    ))
+                    )))
                 }
             },
         );


### PR DESCRIPTION
Current `lsp-types:0.91.1` crate lacks inlay hints' definitions. Crate's changelog is not very descriptive, but it appears that `0.92.1` could be used: https://github.com/gluon-lang/lsp-types/blob/master/CHANGELOG.md#v0921-2022-03-21
The latest is crate version is `0.94.0` (2023-02-08), the PR updates Zed to the latest version.


Notable changes:
* workspace symbols may arrive unresolved if the corresponding client capability is enabled: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#partialResults
Zed has this capability disabled, forcing all symbols to arrive synchronously (?). 

Resolve capabilities are important for inlay hints too, but I've not found any code in Zed for that outside tests, so I'd love to learn more and implement the resolution for workspace symbols separately.

* since LSP `3.17` (current), watch file changes can use relative glob patterns: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles

That seemed just a straightforward extra `match` to use the same Ruse `Glob` to handle the relative path one.

Release Notes:

N/A