### PR TITLE
Add support for folder-specific settings

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -112,6 +112,16 @@ CREATE INDEX "index_worktree_repository_statuses_on_project_id" ON "worktree_rep
 CREATE INDEX "index_worktree_repository_statuses_on_project_id_and_worktree_id" ON "worktree_repository_statuses" ("project_id", "worktree_id");
 CREATE INDEX "index_worktree_repository_statuses_on_project_id_and_worktree_id_and_work_directory_id" ON "worktree_repository_statuses" ("project_id", "worktree_id", "work_directory_id");
 
+CREATE TABLE "worktree_settings_files" (
+    "project_id" INTEGER NOT NULL,
+    "worktree_id" INTEGER NOT NULL,
+    "path" VARCHAR NOT NULL,
+    "content" TEXT,
+    PRIMARY KEY(project_id, worktree_id, path),
+    FOREIGN KEY(project_id, worktree_id) REFERENCES worktrees (project_id, id) ON DELETE CASCADE
+);
+CREATE INDEX "index_worktree_settings_files_on_project_id" ON "worktree_settings_files" ("project_id");
+CREATE INDEX "index_worktree_settings_files_on_project_id_and_worktree_id" ON "worktree_settings_files" ("project_id", "worktree_id");
 
 CREATE TABLE "worktree_diagnostic_summaries" (
     "project_id" INTEGER NOT NULL,

--- a/crates/collab/migrations/20230529164700_add_worktree_settings_files.sql
+++ b/crates/collab/migrations/20230529164700_add_worktree_settings_files.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "worktree_settings_files" (
+    "project_id" INTEGER NOT NULL,
+    "worktree_id" INT8 NOT NULL,
+    "path" VARCHAR NOT NULL,
+    "content" TEXT NOT NULL,
+    PRIMARY KEY(project_id, worktree_id, path),
+    FOREIGN KEY(project_id, worktree_id) REFERENCES worktrees (project_id, id) ON DELETE CASCADE
+);
+CREATE INDEX "index_settings_files_on_project_id" ON "worktree_settings_files" ("project_id");
+CREATE INDEX "index_settings_files_on_project_id_and_wt_id" ON "worktree_settings_files" ("project_id", "worktree_id");

--- a/crates/collab/src/db/worktree_settings_file.rs
+++ b/crates/collab/src/db/worktree_settings_file.rs
@@ -1,0 +1,19 @@
+use super::ProjectId;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "worktree_settings_files")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub project_id: ProjectId,
+    #[sea_orm(primary_key)]
+    pub worktree_id: i64,
+    #[sea_orm(primary_key)]
+    pub path: String,
+    pub content: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -785,11 +785,7 @@ impl Copilot {
         let buffer = buffer.read(cx);
         let uri = registered_buffer.uri.clone();
         let position = position.to_point_utf16(buffer);
-        let settings = language_settings(
-            buffer.language_at(position).map(|l| l.name()).as_deref(),
-            buffer.file(),
-            cx,
-        );
+        let settings = language_settings(buffer.language_at(position).as_ref(), buffer.file(), cx);
         let tab_size = settings.tab_size;
         let hard_tabs = settings.hard_tabs;
         let relative_path = buffer

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -318,7 +318,7 @@ impl Copilot {
     fn enable_or_disable_copilot(&mut self, cx: &mut ModelContext<Copilot>) {
         let http = self.http.clone();
         let node_runtime = self.node_runtime.clone();
-        if all_language_settings(cx).copilot_enabled(None, None) {
+        if all_language_settings(None, cx).copilot_enabled(None, None) {
             if matches!(self.server, CopilotServer::Disabled) {
                 let start_task = cx
                     .spawn({

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -787,6 +787,7 @@ impl Copilot {
         let position = position.to_point_utf16(buffer);
         let settings = language_settings(
             buffer.language_at(position).map(|l| l.name()).as_deref(),
+            buffer.file().map(|f| f.as_ref()),
             cx,
         );
         let tab_size = settings.tab_size;
@@ -1174,6 +1175,10 @@ mod tests {
 
         fn to_proto(&self) -> rpc::proto::File {
             unimplemented!()
+        }
+
+        fn worktree_id(&self) -> usize {
+            0
         }
     }
 

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -787,7 +787,7 @@ impl Copilot {
         let position = position.to_point_utf16(buffer);
         let settings = language_settings(
             buffer.language_at(position).map(|l| l.name()).as_deref(),
-            buffer.file().map(|f| f.as_ref()),
+            buffer.file(),
             cx,
         );
         let tab_size = settings.tab_size;

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -198,7 +198,7 @@ impl CopilotButton {
         if let Some(language) = self.language.clone() {
             let fs = fs.clone();
             let language_enabled =
-                language_settings::language_settings(Some(language.as_ref()), cx)
+                language_settings::language_settings(Some(language.as_ref()), None, cx)
                     .show_copilot_suggestions;
             menu_options.push(ContextMenuItem::handler(
                 format!(

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -285,7 +285,7 @@ impl CopilotButton {
         let file = snapshot.file_at(suggestion_anchor).cloned();
 
         self.editor_enabled = Some(
-            all_language_settings(self.file.as_ref().map(|f| f.as_ref()), cx).copilot_enabled(
+            all_language_settings(self.file.as_ref(), cx).copilot_enabled(
                 language_name.as_deref(),
                 file.as_ref().map(|file| file.path().as_ref()),
             ),

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -272,12 +272,11 @@ impl DisplayMap {
     }
 
     fn tab_size(buffer: &ModelHandle<MultiBuffer>, cx: &mut ModelContext<Self>) -> NonZeroU32 {
-        let language_name = buffer
+        let language = buffer
             .read(cx)
             .as_singleton()
-            .and_then(|buffer| buffer.read(cx).language())
-            .map(|language| language.name());
-        language_settings(language_name.as_deref(), None, cx).tab_size
+            .and_then(|buffer| buffer.read(cx).language());
+        language_settings(language.as_deref(), None, cx).tab_size
     }
 
     #[cfg(test)]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -277,7 +277,7 @@ impl DisplayMap {
             .as_singleton()
             .and_then(|buffer| buffer.read(cx).language())
             .map(|language| language.name());
-        language_settings(language_name.as_deref(), cx).tab_size
+        language_settings(language_name.as_deref(), None, cx).tab_size
     }
 
     #[cfg(test)]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3211,7 +3211,7 @@ impl Editor {
         let language_name = snapshot
             .language_at(location)
             .map(|language| language.name());
-        let settings = all_language_settings(file.map(|f| f.as_ref() as _), cx);
+        let settings = all_language_settings(file, cx);
         settings.copilot_enabled(language_name.as_deref(), file.map(|f| f.path().as_ref()))
     }
 
@@ -7093,8 +7093,7 @@ impl Editor {
             .get("vim_mode")
             == Some(&serde_json::Value::Bool(true));
         let telemetry_settings = *settings::get::<TelemetrySettings>(cx);
-        let copilot_enabled =
-            all_language_settings(file.map(|f| f.as_ref()), cx).copilot_enabled(None, None);
+        let copilot_enabled = all_language_settings(file, cx).copilot_enabled(None, None);
         let copilot_enabled_for_language = self
             .buffer
             .read(cx)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3208,11 +3208,9 @@ impl Editor {
         cx: &mut ViewContext<Self>,
     ) -> bool {
         let file = snapshot.file_at(location);
-        let language_name = snapshot
-            .language_at(location)
-            .map(|language| language.name());
+        let language = snapshot.language_at(location);
         let settings = all_language_settings(file, cx);
-        settings.copilot_enabled(language_name.as_deref(), file.map(|f| f.path().as_ref()))
+        settings.copilot_enabled(language, file.map(|f| f.path().as_ref()))
     }
 
     fn has_active_copilot_suggestion(&self, cx: &AppContext) -> bool {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1231,6 +1231,10 @@ mod tests {
             unimplemented!()
         }
 
+        fn worktree_id(&self) -> usize {
+            0
+        }
+
         fn is_deleted(&self) -> bool {
             unimplemented!()
         }

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1382,7 +1382,7 @@ impl MultiBuffer {
         if let Some((buffer, offset)) = self.point_to_buffer_offset(point, cx) {
             let buffer = buffer.read(cx);
             language = buffer.language_at(offset).map(|l| l.name());
-            file = buffer.file().map(|f| f.as_ref());
+            file = buffer.file();
         }
         language_settings(language.as_deref(), file, cx)
     }
@@ -2795,7 +2795,7 @@ impl MultiBufferSnapshot {
         let mut file = None;
         if let Some((buffer, offset)) = self.point_to_buffer_offset(point) {
             language = buffer.language_at(offset).map(|l| l.name());
-            file = buffer.file().map(|f| f.as_ref());
+            file = buffer.file();
         }
         language_settings(language.as_deref(), file, cx)
     }

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1377,8 +1377,14 @@ impl MultiBuffer {
         point: T,
         cx: &'a AppContext,
     ) -> &'a LanguageSettings {
-        let language = self.language_at(point, cx);
-        language_settings(language.map(|l| l.name()).as_deref(), cx)
+        let mut language = None;
+        let mut file = None;
+        if let Some((buffer, offset)) = self.point_to_buffer_offset(point, cx) {
+            let buffer = buffer.read(cx);
+            language = buffer.language_at(offset).map(|l| l.name());
+            file = buffer.file().map(|f| f.as_ref());
+        }
+        language_settings(language.as_deref(), file, cx)
     }
 
     pub fn for_each_buffer(&self, mut f: impl FnMut(&ModelHandle<Buffer>)) {
@@ -2785,9 +2791,13 @@ impl MultiBufferSnapshot {
         point: T,
         cx: &'a AppContext,
     ) -> &'a LanguageSettings {
-        self.point_to_buffer_offset(point)
-            .map(|(buffer, offset)| buffer.settings_at(offset, cx))
-            .unwrap_or_else(|| language_settings(None, cx))
+        let mut language = None;
+        let mut file = None;
+        if let Some((buffer, offset)) = self.point_to_buffer_offset(point) {
+            language = buffer.language_at(offset).map(|l| l.name());
+            file = buffer.file().map(|f| f.as_ref());
+        }
+        language_settings(language.as_deref(), file, cx)
     }
 
     pub fn language_scope_at<'a, T: ToOffset>(&'a self, point: T) -> Option<LanguageScope> {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1381,10 +1381,10 @@ impl MultiBuffer {
         let mut file = None;
         if let Some((buffer, offset)) = self.point_to_buffer_offset(point, cx) {
             let buffer = buffer.read(cx);
-            language = buffer.language_at(offset).map(|l| l.name());
+            language = buffer.language_at(offset);
             file = buffer.file();
         }
-        language_settings(language.as_deref(), file, cx)
+        language_settings(language.as_ref(), file, cx)
     }
 
     pub fn for_each_buffer(&self, mut f: impl FnMut(&ModelHandle<Buffer>)) {
@@ -2794,10 +2794,10 @@ impl MultiBufferSnapshot {
         let mut language = None;
         let mut file = None;
         if let Some((buffer, offset)) = self.point_to_buffer_offset(point) {
-            language = buffer.language_at(offset).map(|l| l.name());
+            language = buffer.language_at(offset);
             file = buffer.file();
         }
-        language_settings(language.as_deref(), file, cx)
+        language_settings(language, file, cx)
     }
 
     pub fn language_scope_at<'a, T: ToOffset>(&'a self, point: T) -> Option<LanguageScope> {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1808,11 +1808,7 @@ impl BufferSnapshot {
 
     pub fn language_indent_size_at<T: ToOffset>(&self, position: T, cx: &AppContext) -> IndentSize {
         let language_name = self.language_at(position).map(|language| language.name());
-        let settings = language_settings(
-            language_name.as_deref(),
-            self.file().map(|f| f.as_ref()),
-            cx,
-        );
+        let settings = language_settings(language_name.as_deref(), self.file(), cx);
         if settings.hard_tabs {
             IndentSize::tab()
         } else {
@@ -2139,7 +2135,7 @@ impl BufferSnapshot {
         let language = self.language_at(position);
         language_settings(
             language.map(|l| l.name()).as_deref(),
-            self.file.as_ref().map(AsRef::as_ref),
+            self.file.as_ref(),
             cx,
         )
     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1807,8 +1807,7 @@ impl BufferSnapshot {
     }
 
     pub fn language_indent_size_at<T: ToOffset>(&self, position: T, cx: &AppContext) -> IndentSize {
-        let language_name = self.language_at(position).map(|language| language.name());
-        let settings = language_settings(language_name.as_deref(), self.file(), cx);
+        let settings = language_settings(self.language_at(position), self.file(), cx);
         if settings.hard_tabs {
             IndentSize::tab()
         } else {
@@ -2132,12 +2131,7 @@ impl BufferSnapshot {
         position: D,
         cx: &'a AppContext,
     ) -> &'a LanguageSettings {
-        let language = self.language_at(position);
-        language_settings(
-            language.map(|l| l.name()).as_deref(),
-            self.file.as_ref(),
-            cx,
-        )
+        language_settings(self.language_at(position), self.file.as_ref(), cx)
     }
 
     pub fn language_scope_at<D: ToOffset>(&self, position: D) -> Option<LanguageScope> {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -16,7 +16,7 @@ pub fn init(cx: &mut AppContext) {
 
 pub fn language_settings<'a>(
     language: Option<&str>,
-    file: Option<&dyn File>,
+    file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a LanguageSettings {
     settings::get_local::<AllLanguageSettings>(
@@ -27,7 +27,7 @@ pub fn language_settings<'a>(
 }
 
 pub fn all_language_settings<'a>(
-    file: Option<&dyn File>,
+    file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a AllLanguageSettings {
     settings::get_local::<AllLanguageSettings>(

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -26,8 +26,14 @@ pub fn language_settings<'a>(
     .language(language)
 }
 
-pub fn all_language_settings<'a>(cx: &'a AppContext) -> &'a AllLanguageSettings {
-    settings::get::<AllLanguageSettings>(cx)
+pub fn all_language_settings<'a>(
+    file: Option<&dyn File>,
+    cx: &'a AppContext,
+) -> &'a AllLanguageSettings {
+    settings::get_local::<AllLanguageSettings>(
+        file.map(|f| (f.worktree_id(), f.path().as_ref())),
+        cx,
+    )
 }
 
 #[derive(Debug, Clone)]

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1,4 +1,4 @@
-use crate::File;
+use crate::{File, Language};
 use anyhow::Result;
 use collections::HashMap;
 use globset::GlobMatcher;
@@ -15,7 +15,7 @@ pub fn init(cx: &mut AppContext) {
 }
 
 pub fn language_settings<'a>(
-    language: Option<&str>,
+    language: Option<&Arc<Language>>,
     file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a LanguageSettings {
@@ -23,7 +23,7 @@ pub fn language_settings<'a>(
         file.map(|f| (f.worktree_id(), f.path().as_ref())),
         cx,
     )
-    .language(language)
+    .language(language.map(|l| l.name()).as_deref())
 }
 
 pub fn all_language_settings<'a>(
@@ -170,7 +170,7 @@ impl AllLanguageSettings {
             .any(|glob| glob.is_match(path))
     }
 
-    pub fn copilot_enabled(&self, language_name: Option<&str>, path: Option<&Path>) -> bool {
+    pub fn copilot_enabled(&self, language: Option<&Arc<Language>>, path: Option<&Path>) -> bool {
         if !self.copilot.feature_enabled {
             return false;
         }
@@ -181,7 +181,8 @@ impl AllLanguageSettings {
             }
         }
 
-        self.language(language_name).show_copilot_suggestions
+        self.language(language.map(|l| l.name()).as_deref())
+            .show_copilot_suggestions
     }
 }
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1,3 +1,4 @@
+use crate::File;
 use anyhow::Result;
 use collections::HashMap;
 use globset::GlobMatcher;
@@ -13,8 +14,16 @@ pub fn init(cx: &mut AppContext) {
     settings::register::<AllLanguageSettings>(cx);
 }
 
-pub fn language_settings<'a>(language: Option<&str>, cx: &'a AppContext) -> &'a LanguageSettings {
-    settings::get::<AllLanguageSettings>(cx).language(language)
+pub fn language_settings<'a>(
+    language: Option<&str>,
+    file: Option<&dyn File>,
+    cx: &'a AppContext,
+) -> &'a LanguageSettings {
+    settings::get_local::<AllLanguageSettings>(
+        file.map(|f| (f.worktree_id(), f.path().as_ref())),
+        cx,
+    )
+    .language(language)
 }
 
 pub fn all_language_settings<'a>(cx: &'a AppContext) -> &'a AllLanguageSettings {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -19,21 +19,16 @@ pub fn language_settings<'a>(
     file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a LanguageSettings {
-    settings::get_local::<AllLanguageSettings>(
-        file.map(|f| (f.worktree_id(), f.path().as_ref())),
-        cx,
-    )
-    .language(language.map(|l| l.name()).as_deref())
+    let language_name = language.map(|l| l.name());
+    all_language_settings(file, cx).language(language_name.as_deref())
 }
 
 pub fn all_language_settings<'a>(
     file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a AllLanguageSettings {
-    settings::get_local::<AllLanguageSettings>(
-        file.map(|f| (f.worktree_id(), f.path().as_ref())),
-        cx,
-    )
+    let location = file.map(|f| (f.worktree_id(), f.path().as_ref()));
+    settings::get_local(location, cx)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1716,8 +1716,7 @@ impl LspCommand for OnTypeFormatting {
             .await?;
 
         let tab_size = buffer.read_with(&cx, |buffer, cx| {
-            let language_name = buffer.language().map(|language| language.name());
-            language_settings(language_name.as_deref(), buffer.file(), cx).tab_size
+            language_settings(buffer.language(), buffer.file(), cx).tab_size
         });
 
         Ok(Self {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1717,8 +1717,7 @@ impl LspCommand for OnTypeFormatting {
 
         let tab_size = buffer.read_with(&cx, |buffer, cx| {
             let language_name = buffer.language().map(|language| language.name());
-            let file = buffer.file().map(|f| f.as_ref());
-            language_settings(language_name.as_deref(), file, cx).tab_size
+            language_settings(language_name.as_deref(), buffer.file(), cx).tab_size
         });
 
         Ok(Self {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1717,7 +1717,8 @@ impl LspCommand for OnTypeFormatting {
 
         let tab_size = buffer.read_with(&cx, |buffer, cx| {
             let language_name = buffer.language().map(|language| language.name());
-            language_settings(language_name.as_deref(), cx).tab_size
+            let file = buffer.file().map(|f| f.as_ref());
+            language_settings(language_name.as_deref(), file, cx).tab_size
         });
 
         Ok(Self {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -99,18 +99,22 @@ async fn test_managing_project_specific_settings(
 
         let settings_a = language_settings(
             None,
-            Some(&File::for_entry(
-                tree.entry_for_path("a/a.rs").unwrap().clone(),
-                worktree.clone(),
-            )),
+            Some(
+                &(File::for_entry(
+                    tree.entry_for_path("a/a.rs").unwrap().clone(),
+                    worktree.clone(),
+                ) as _),
+            ),
             cx,
         );
         let settings_b = language_settings(
             None,
-            Some(&File::for_entry(
-                tree.entry_for_path("b/b.rs").unwrap().clone(),
-                worktree.clone(),
-            )),
+            Some(
+                &(File::for_entry(
+                    tree.entry_for_path("b/b.rs").unwrap().clone(),
+                    worktree.clone(),
+                ) as _),
+            ),
             cx,
         );
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -64,6 +64,62 @@ async fn test_symlinks(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_managing_project_specific_settings(
+    deterministic: Arc<Deterministic>,
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.background());
+    fs.insert_tree(
+        "/the-root",
+        json!({
+            ".zed": {
+                "settings.json": r#"{ "tab_size": 8 }"#
+            },
+            "a": {
+                "a.rs": "fn a() {\n    A\n}"
+            },
+            "b": {
+                ".zed": {
+                    "settings.json": r#"{ "tab_size": 2 }"#
+                },
+                "b.rs": "fn b() {\n  B\n}"
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/the-root".as_ref()], cx).await;
+    let worktree = project.read_with(cx, |project, cx| project.worktrees(cx).next().unwrap());
+
+    deterministic.run_until_parked();
+    cx.read(|cx| {
+        let tree = worktree.read(cx);
+
+        let settings_a = language_settings(
+            None,
+            Some(&File::for_entry(
+                tree.entry_for_path("a/a.rs").unwrap().clone(),
+                worktree.clone(),
+            )),
+            cx,
+        );
+        let settings_b = language_settings(
+            None,
+            Some(&File::for_entry(
+                tree.entry_for_path("b/b.rs").unwrap().clone(),
+                worktree.clone(),
+            )),
+            cx,
+        );
+
+        assert_eq!(settings_a.tab_size.get(), 8);
+        assert_eq!(settings_b.tab_size.get(), 2);
+    });
+}
+
+#[gpui::test]
 async fn test_managing_language_servers(
     deterministic: Arc<Deterministic>,
     cx: &mut gpui::TestAppContext,

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -679,7 +679,7 @@ impl Worktree {
     }
 
     pub fn root_file(&self, cx: &mut ModelContext<Self>) -> Option<File> {
-        let entry = self.entry_for_path("")?;
+        let entry = self.root_entry()?;
         Some(File {
             worktree: cx.handle(),
             path: entry.path.clone(),

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -678,16 +678,9 @@ impl Worktree {
         }
     }
 
-    pub fn root_file(&self, cx: &mut ModelContext<Self>) -> Option<File> {
+    pub fn root_file(&self, cx: &mut ModelContext<Self>) -> Option<Arc<File>> {
         let entry = self.root_entry()?;
-        Some(File {
-            worktree: cx.handle(),
-            path: entry.path.clone(),
-            mtime: entry.mtime,
-            entry_id: entry.id,
-            is_local: self.is_local(),
-            is_deleted: false,
-        })
+        Some(File::for_entry(entry.clone(), cx.handle()))
     }
 }
 
@@ -2463,15 +2456,15 @@ impl language::LocalFile for File {
 }
 
 impl File {
-    pub fn for_entry(entry: Entry, worktree: ModelHandle<Worktree>) -> Self {
-        Self {
+    pub fn for_entry(entry: Entry, worktree: ModelHandle<Worktree>) -> Arc<Self> {
+        Arc::new(Self {
             worktree,
             path: entry.path.clone(),
             mtime: entry.mtime,
             entry_id: entry.id,
             is_local: true,
             is_deleted: false,
-        }
+        })
     }
 
     pub fn from_proto(

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -677,19 +677,23 @@ impl Worktree {
             Worktree::Remote(worktree) => worktree.abs_path.clone(),
         }
     }
+
+    pub fn root_file(&self, cx: &mut ModelContext<Self>) -> Option<File> {
+        let entry = self.entry_for_path("")?;
+        Some(File {
+            worktree: cx.handle(),
+            path: entry.path.clone(),
+            mtime: entry.mtime,
+            entry_id: entry.id,
+            is_local: self.is_local(),
+            is_deleted: false,
+        })
+    }
 }
 
 impl LocalWorktree {
     pub fn contains_abs_path(&self, path: &Path) -> bool {
         path.starts_with(&self.abs_path)
-    }
-
-    fn absolutize(&self, path: &Path) -> PathBuf {
-        if path.file_name().is_some() {
-            self.abs_path.join(path)
-        } else {
-            self.abs_path.to_path_buf()
-        }
     }
 
     pub(crate) fn load_buffer(
@@ -1544,6 +1548,14 @@ impl Snapshot {
         &self.abs_path
     }
 
+    pub fn absolutize(&self, path: &Path) -> PathBuf {
+        if path.file_name().is_some() {
+            self.abs_path.join(path)
+        } else {
+            self.abs_path.to_path_buf()
+        }
+    }
+
     pub fn contains_entry(&self, entry_id: ProjectEntryId) -> bool {
         self.entries_by_id.get(&entry_id, &()).is_some()
     }
@@ -2383,6 +2395,10 @@ impl language::File for File {
             .unwrap_or_else(|| OsStr::new(&self.worktree.read(cx).root_name))
     }
 
+    fn worktree_id(&self) -> usize {
+        self.worktree.id()
+    }
+
     fn is_deleted(&self) -> bool {
         self.is_deleted
     }
@@ -2447,6 +2463,17 @@ impl language::LocalFile for File {
 }
 
 impl File {
+    pub fn for_entry(entry: Entry, worktree: ModelHandle<Worktree>) -> Self {
+        Self {
+            worktree,
+            path: entry.path.clone(),
+            mtime: entry.mtime,
+            entry_id: entry.id,
+            is_local: true,
+            is_deleted: false,
+        }
+    }
+
     pub fn from_proto(
         proto: rpc::proto::File,
         worktree: ModelHandle<Worktree>,
@@ -2507,7 +2534,7 @@ pub enum EntryKind {
     File(CharBag),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PathChange {
     /// A filesystem entry was was created.
     Added,

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -132,6 +132,8 @@ message Envelope {
 
         OnTypeFormatting on_type_formatting = 111;
         OnTypeFormattingResponse on_type_formatting_response = 112;
+
+        UpdateWorktreeSettings update_worktree_settings = 113;
     }
 }
 
@@ -337,6 +339,13 @@ message UpdateWorktree {
     uint64 scan_id = 8;
     bool is_last_update = 9;
     string abs_path = 10;
+}
+
+message UpdateWorktreeSettings {
+    uint64 project_id = 1;
+    uint64 worktree_id = 2;
+    string path = 3;
+    optional string content = 4;
 }
 
 message CreateProjectEntry {

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -236,6 +236,7 @@ messages!(
     (UpdateProject, Foreground),
     (UpdateProjectCollaborator, Foreground),
     (UpdateWorktree, Foreground),
+    (UpdateWorktreeSettings, Foreground),
     (UpdateDiffBase, Foreground),
     (GetPrivateUserInfo, Foreground),
     (GetPrivateUserInfoResponse, Foreground),
@@ -345,6 +346,7 @@ entity_messages!(
     UpdateProject,
     UpdateProjectCollaborator,
     UpdateWorktree,
+    UpdateWorktreeSettings,
     UpdateDiffBase
 );
 

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 56;
+pub const PROTOCOL_VERSION: u32 = 57;

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -4,7 +4,14 @@ use assets::Assets;
 use fs::Fs;
 use futures::{channel::mpsc, StreamExt};
 use gpui::{executor::Background, AppContext, AssetSource};
-use std::{borrow::Cow, io::ErrorKind, path::PathBuf, str, sync::Arc, time::Duration};
+use std::{
+    borrow::Cow,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    str,
+    sync::Arc,
+    time::Duration,
+};
 use util::{paths, ResultExt};
 
 pub fn register<T: Setting>(cx: &mut AppContext) {
@@ -15,6 +22,10 @@ pub fn register<T: Setting>(cx: &mut AppContext) {
 
 pub fn get<'a, T: Setting>(cx: &'a AppContext) -> &'a T {
     cx.global::<SettingsStore>().get(None)
+}
+
+pub fn get_local<'a, T: Setting>(location: Option<(usize, &Path)>, cx: &'a AppContext) -> &'a T {
+    cx.global::<SettingsStore>().get(location)
 }
 
 pub fn default_settings() -> Cow<'static, str> {

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -359,6 +359,21 @@ impl SettingsStore {
         Ok(())
     }
 
+    /// Add or remove a set of local settings via a JSON string.
+    pub fn clear_local_settings(&mut self, root_id: usize, cx: &AppContext) -> Result<()> {
+        eprintln!("clearing local settings {root_id}");
+        self.local_deserialized_settings
+            .retain(|k, _| k.0 != root_id);
+        self.recompute_values(Some((root_id, "".as_ref())), cx)?;
+        Ok(())
+    }
+
+    pub fn local_settings(&self, root_id: usize) -> impl '_ + Iterator<Item = (Arc<Path>, String)> {
+        self.local_deserialized_settings
+            .range((root_id, Path::new("").into())..(root_id + 1, Path::new("").into()))
+            .map(|((_, path), content)| (path.clone(), serde_json::to_string(content).unwrap()))
+    }
+
     pub fn json_schema(
         &self,
         schema_params: &SettingsJsonSchemaParams,

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -89,14 +89,14 @@ pub struct SettingsStore {
     setting_values: HashMap<TypeId, Box<dyn AnySettingValue>>,
     default_deserialized_settings: Option<serde_json::Value>,
     user_deserialized_settings: Option<serde_json::Value>,
-    local_deserialized_settings: BTreeMap<Arc<Path>, serde_json::Value>,
+    local_deserialized_settings: BTreeMap<(usize, Arc<Path>), serde_json::Value>,
     tab_size_callback: Option<(TypeId, Box<dyn Fn(&dyn Any) -> Option<usize>>)>,
 }
 
 #[derive(Debug)]
 struct SettingValue<T> {
     global_value: Option<T>,
-    local_values: Vec<(Arc<Path>, T)>,
+    local_values: Vec<(usize, Arc<Path>, T)>,
 }
 
 trait AnySettingValue {
@@ -109,9 +109,9 @@ trait AnySettingValue {
         custom: &[DeserializedSetting],
         cx: &AppContext,
     ) -> Result<Box<dyn Any>>;
-    fn value_for_path(&self, path: Option<&Path>) -> &dyn Any;
+    fn value_for_path(&self, path: Option<(usize, &Path)>) -> &dyn Any;
     fn set_global_value(&mut self, value: Box<dyn Any>);
-    fn set_local_value(&mut self, path: Arc<Path>, value: Box<dyn Any>);
+    fn set_local_value(&mut self, root_id: usize, path: Arc<Path>, value: Box<dyn Any>);
     fn json_schema(
         &self,
         generator: &mut SchemaGenerator,
@@ -165,7 +165,7 @@ impl SettingsStore {
     ///
     /// Panics if the given setting type has not been registered, or if there is no
     /// value for this setting.
-    pub fn get<T: Setting>(&self, path: Option<&Path>) -> &T {
+    pub fn get<T: Setting>(&self, path: Option<(usize, &Path)>) -> &T {
         self.setting_values
             .get(&TypeId::of::<T>())
             .unwrap_or_else(|| panic!("unregistered setting type {}", type_name::<T>()))
@@ -343,17 +343,19 @@ impl SettingsStore {
     /// Add or remove a set of local settings via a JSON string.
     pub fn set_local_settings(
         &mut self,
+        root_id: usize,
         path: Arc<Path>,
         settings_content: Option<&str>,
         cx: &AppContext,
     ) -> Result<()> {
         if let Some(content) = settings_content {
             self.local_deserialized_settings
-                .insert(path.clone(), parse_json_with_comments(content)?);
+                .insert((root_id, path.clone()), parse_json_with_comments(content)?);
         } else {
-            self.local_deserialized_settings.remove(&path);
+            self.local_deserialized_settings
+                .remove(&(root_id, path.clone()));
         }
-        self.recompute_values(Some(&path), cx)?;
+        self.recompute_values(Some((root_id, &path)), cx)?;
         Ok(())
     }
 
@@ -436,12 +438,12 @@ impl SettingsStore {
 
     fn recompute_values(
         &mut self,
-        changed_local_path: Option<&Path>,
+        changed_local_path: Option<(usize, &Path)>,
         cx: &AppContext,
     ) -> Result<()> {
         // Reload the global and local values for every setting.
         let mut user_settings_stack = Vec::<DeserializedSetting>::new();
-        let mut paths_stack = Vec::<Option<&Path>>::new();
+        let mut paths_stack = Vec::<Option<(usize, &Path)>>::new();
         for setting_value in self.setting_values.values_mut() {
             if let Some(default_settings) = &self.default_deserialized_settings {
                 let default_settings = setting_value.deserialize_setting(default_settings)?;
@@ -469,11 +471,11 @@ impl SettingsStore {
                 }
 
                 // Reload the local values for the setting.
-                for (path, local_settings) in &self.local_deserialized_settings {
+                for ((root_id, path), local_settings) in &self.local_deserialized_settings {
                     // Build a stack of all of the local values for that setting.
-                    while let Some(prev_path) = paths_stack.last() {
-                        if let Some(prev_path) = prev_path {
-                            if !path.starts_with(prev_path) {
+                    while let Some(prev_entry) = paths_stack.last() {
+                        if let Some((prev_root_id, prev_path)) = prev_entry {
+                            if root_id != prev_root_id || !path.starts_with(prev_path) {
                                 paths_stack.pop();
                                 user_settings_stack.pop();
                                 continue;
@@ -485,14 +487,17 @@ impl SettingsStore {
                     if let Some(local_settings) =
                         setting_value.deserialize_setting(&local_settings).log_err()
                     {
-                        paths_stack.push(Some(path.as_ref()));
+                        paths_stack.push(Some((*root_id, path.as_ref())));
                         user_settings_stack.push(local_settings);
 
                         // If a local settings file changed, then avoid recomputing local
                         // settings for any path outside of that directory.
-                        if changed_local_path.map_or(false, |changed_local_path| {
-                            !path.starts_with(changed_local_path)
-                        }) {
+                        if changed_local_path.map_or(
+                            false,
+                            |(changed_root_id, changed_local_path)| {
+                                *root_id != changed_root_id || !path.starts_with(changed_local_path)
+                            },
+                        ) {
                             continue;
                         }
 
@@ -500,13 +505,31 @@ impl SettingsStore {
                             .load_setting(&default_settings, &user_settings_stack, cx)
                             .log_err()
                         {
-                            setting_value.set_local_value(path.clone(), value);
+                            setting_value.set_local_value(*root_id, path.clone(), value);
                         }
                     }
                 }
             }
         }
         Ok(())
+    }
+}
+
+impl Debug for SettingsStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SettingsStore")
+            .field(
+                "types",
+                &self
+                    .setting_values
+                    .values()
+                    .map(|value| value.setting_type_name())
+                    .collect::<Vec<_>>(),
+            )
+            .field("default_settings", &self.default_deserialized_settings)
+            .field("user_settings", &self.user_deserialized_settings)
+            .field("local_settings", &self.local_deserialized_settings)
+            .finish_non_exhaustive()
     }
 }
 
@@ -546,10 +569,10 @@ impl<T: Setting> AnySettingValue for SettingValue<T> {
         Ok(DeserializedSetting(Box::new(value)))
     }
 
-    fn value_for_path(&self, path: Option<&Path>) -> &dyn Any {
-        if let Some(path) = path {
-            for (settings_path, value) in self.local_values.iter().rev() {
-                if path.starts_with(&settings_path) {
+    fn value_for_path(&self, path: Option<(usize, &Path)>) -> &dyn Any {
+        if let Some((root_id, path)) = path {
+            for (settings_root_id, settings_path, value) in self.local_values.iter().rev() {
+                if root_id == *settings_root_id && path.starts_with(&settings_path) {
                     return value;
                 }
             }
@@ -563,11 +586,14 @@ impl<T: Setting> AnySettingValue for SettingValue<T> {
         self.global_value = Some(*value.downcast().unwrap());
     }
 
-    fn set_local_value(&mut self, path: Arc<Path>, value: Box<dyn Any>) {
+    fn set_local_value(&mut self, root_id: usize, path: Arc<Path>, value: Box<dyn Any>) {
         let value = *value.downcast().unwrap();
-        match self.local_values.binary_search_by_key(&&path, |e| &e.0) {
-            Ok(ix) => self.local_values[ix].1 = value,
-            Err(ix) => self.local_values.insert(ix, (path, value)),
+        match self
+            .local_values
+            .binary_search_by_key(&(root_id, &path), |e| (e.0, &e.1))
+        {
+            Ok(ix) => self.local_values[ix].2 = value,
+            Err(ix) => self.local_values.insert(ix, (root_id, path, value)),
         }
     }
 
@@ -884,6 +910,7 @@ mod tests {
 
         store
             .set_local_settings(
+                1,
                 Path::new("/root1").into(),
                 Some(r#"{ "user": { "staff": true } }"#),
                 cx,
@@ -891,6 +918,7 @@ mod tests {
             .unwrap();
         store
             .set_local_settings(
+                1,
                 Path::new("/root1/subdir").into(),
                 Some(r#"{ "user": { "name": "Jane Doe" } }"#),
                 cx,
@@ -899,6 +927,7 @@ mod tests {
 
         store
             .set_local_settings(
+                1,
                 Path::new("/root2").into(),
                 Some(r#"{ "user": { "age": 42 }, "key2": "b" }"#),
                 cx,
@@ -906,7 +935,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            store.get::<UserSettings>(Some(Path::new("/root1/something"))),
+            store.get::<UserSettings>(Some((1, Path::new("/root1/something")))),
             &UserSettings {
                 name: "John Doe".to_string(),
                 age: 31,
@@ -914,7 +943,7 @@ mod tests {
             }
         );
         assert_eq!(
-            store.get::<UserSettings>(Some(Path::new("/root1/subdir/something"))),
+            store.get::<UserSettings>(Some((1, Path::new("/root1/subdir/something")))),
             &UserSettings {
                 name: "Jane Doe".to_string(),
                 age: 31,
@@ -922,7 +951,7 @@ mod tests {
             }
         );
         assert_eq!(
-            store.get::<UserSettings>(Some(Path::new("/root2/something"))),
+            store.get::<UserSettings>(Some((1, Path::new("/root2/something")))),
             &UserSettings {
                 name: "John Doe".to_string(),
                 age: 42,
@@ -930,7 +959,7 @@ mod tests {
             }
         );
         assert_eq!(
-            store.get::<MultiKeySettings>(Some(Path::new("/root2/something"))),
+            store.get::<MultiKeySettings>(Some((1, Path::new("/root2/something")))),
             &MultiKeySettings {
                 key1: "a".to_string(),
                 key2: "b".to_string(),

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -905,7 +905,10 @@ mod tests {
         cx: &mut TestAppContext,
     ) -> (ModelHandle<Project>, ViewHandle<Workspace>) {
         let params = cx.update(AppState::test);
-        cx.update(|cx| theme::init((), cx));
+        cx.update(|cx| {
+            theme::init((), cx);
+            language::init(cx);
+        });
 
         let project = Project::test(params.fs.clone(), [], cx).await;
         let (_, workspace) = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -15,6 +15,7 @@ lazy_static::lazy_static! {
     pub static ref LAST_USERNAME: PathBuf = CONFIG_DIR.join("last-username.txt");
     pub static ref LOG: PathBuf = LOGS_DIR.join("Zed.log");
     pub static ref OLD_LOG: PathBuf = LOGS_DIR.join("Zed.log.old");
+    pub static ref LOCAL_SETTINGS_RELATIVE_PATH: &'static Path = Path::new(".zed/settings.json");
 }
 
 pub mod legacy {

--- a/crates/zed/src/languages/json.rs
+++ b/crates/zed/src/languages/json.rs
@@ -135,7 +135,10 @@ impl LspAdapter for JsonLspAdapter {
                     },
                     "schemas": [
                         {
-                            "fileMatch": [schema_file_match(&paths::SETTINGS)],
+                            "fileMatch": [
+                                schema_file_match(&paths::SETTINGS),
+                                &*paths::LOCAL_SETTINGS_RELATIVE_PATH,
+                            ],
                             "schema": settings_schema,
                         },
                         {

--- a/crates/zed/src/languages/yaml.rs
+++ b/crates/zed/src/languages/yaml.rs
@@ -107,7 +107,7 @@ impl LspAdapter for YamlLspAdapter {
                     "keyOrdering": false
                 },
                 "[yaml]": {
-                    "editor.tabSize": language_settings(Some("YAML"), cx).tab_size,
+                    "editor.tabSize": language_settings(Some("YAML"), None, cx).tab_size,
                 }
             }))
             .boxed(),

--- a/crates/zed/src/languages/yaml.rs
+++ b/crates/zed/src/languages/yaml.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use gpui::AppContext;
 use language::{
-    language_settings::language_settings, LanguageServerBinary, LanguageServerName, LspAdapter,
+    language_settings::all_language_settings, LanguageServerBinary, LanguageServerName, LspAdapter,
 };
 use node_runtime::NodeRuntime;
 use serde_json::Value;
@@ -101,13 +101,16 @@ impl LspAdapter for YamlLspAdapter {
     }
 
     fn workspace_configuration(&self, cx: &mut AppContext) -> Option<BoxFuture<'static, Value>> {
+        let tab_size = all_language_settings(None, cx)
+            .language(Some("YAML"))
+            .tab_size;
         Some(
             future::ready(serde_json::json!({
                 "yaml": {
                     "keyOrdering": false
                 },
                 "[yaml]": {
-                    "editor.tabSize": language_settings(Some("YAML"), None, cx).tab_size,
+                    "editor.tabSize": tab_size,
                 }
             }))
             .boxed(),


### PR DESCRIPTION
This PR allows you to customize Zed's settings within a particular folder by creating a `.zed/settings.json` file within that folder.

Todo

* [x] respect folder-specific settings for local projects
* [x] respect folder-specific settings in remote projects
* [x] pass a path when retrieving editor/language settings
* [x] pass a path when retrieving copilot settings
* [ ] update the `Setting` trait to make it clear which types of settings are locally overridable

Release Notes:

* Added support for folder-specific settings. You can customize Zed's settings within a particular folder by creating a `.zed` directory and a `.zed/settings.json` file within that folder.