### PR TITLE
Remove methods taking `&mut Workspace` from `Pane`

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6608,7 +6608,7 @@ async fn test_basic_following(
     // When client A navigates back and forth, client B does so as well.
     workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace::Pane::go_back(workspace, None, cx)
+            workspace.go_back(workspace.active_pane().downgrade(), cx)
         })
         .await
         .unwrap();
@@ -6619,7 +6619,7 @@ async fn test_basic_following(
 
     workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace::Pane::go_back(workspace, None, cx)
+            workspace.go_back(workspace.active_pane().downgrade(), cx)
         })
         .await
         .unwrap();
@@ -6630,7 +6630,7 @@ async fn test_basic_following(
 
     workspace_a
         .update(cx_a, |workspace, cx| {
-            workspace::Pane::go_forward(workspace, None, cx)
+            workspace.go_forward(workspace.active_pane().downgrade(), cx)
         })
         .await
         .unwrap();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4931,12 +4931,12 @@ impl Editor {
     }
 
     fn push_to_nav_history(
-        &self,
+        &mut self,
         cursor_anchor: Anchor,
         new_position: Option<Point>,
         cx: &mut ViewContext<Self>,
     ) {
-        if let Some(nav_history) = &self.nav_history {
+        if let Some(nav_history) = self.nav_history.as_mut() {
             let buffer = self.buffer.read(cx).read(cx);
             let cursor_position = cursor_anchor.to_point(&buffer);
             let scroll_state = self.scroll_manager.anchor();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5264,6 +5264,20 @@ impl Project {
         Some(ProjectPath { worktree_id, path })
     }
 
+    pub fn absolute_path(&self, project_path: &ProjectPath, cx: &AppContext) -> Option<PathBuf> {
+        let workspace_root = self
+            .worktree_for_id(project_path.worktree_id, cx)?
+            .read(cx)
+            .abs_path();
+        let project_path = project_path.path.as_ref();
+
+        Some(if project_path == Path::new("") {
+            workspace_root.to_path_buf()
+        } else {
+            workspace_root.join(project_path)
+        })
+    }
+
     // RPC message handlers
 
     async fn handle_unshare_project(

--- a/crates/workspace/src/pane/dragged_item_receiver.rs
+++ b/crates/workspace/src/pane/dragged_item_receiver.rs
@@ -183,7 +183,7 @@ pub fn handle_dropped_item<V: View>(
                             .zip(pane.upgrade(cx))
                         {
                             workspace.update(cx, |workspace, cx| {
-                                Pane::move_item(workspace, from, to, item_id, index, cx);
+                                workspace.move_item(from, to, item_id, index, cx);
                             })
                         }
                     });

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -99,7 +99,7 @@ impl Item for SharedScreen {
         Some(format!("{}'s screen", self.user.github_login).into())
     }
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
-        if let Some(nav_history) = self.nav_history.as_ref() {
+        if let Some(nav_history) = self.nav_history.as_mut() {
             nav_history.push::<()>(None, cx);
         }
     }

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -153,14 +153,13 @@ impl View for Toolbar {
                             let pane = pane.clone();
                             cx.window_context().defer(move |cx| {
                                 workspace.update(cx, |workspace, cx| {
-                                    Pane::go_back(workspace, Some(pane.clone()), cx)
-                                        .detach_and_log_err(cx);
+                                    workspace.go_back(pane.clone(), cx).detach_and_log_err(cx);
                                 });
                             })
                         }
                     }
                 },
-                super::GoBack { pane: None },
+                super::GoBack,
                 "Go Back",
                 cx,
             ));
@@ -182,14 +181,15 @@ impl View for Toolbar {
                             let pane = pane.clone();
                             cx.window_context().defer(move |cx| {
                                 workspace.update(cx, |workspace, cx| {
-                                    Pane::go_forward(workspace, Some(pane.clone()), cx)
+                                    workspace
+                                        .go_forward(pane.clone(), cx)
                                         .detach_and_log_err(cx);
                                 });
                             });
                         }
                     }
                 },
-                super::GoForward { pane: None },
+                super::GoForward,
                 "Go Forward",
                 cx,
             ));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1926,6 +1926,7 @@ impl Workspace {
         cx: &mut ViewContext<Self>,
     ) {
         match event {
+            pane::Event::AddItem { item } => item.added_to_pane(self, pane, cx),
             pane::Event::Split(direction) => {
                 self.split_pane(pane, *direction, cx);
             }

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -120,8 +120,8 @@ pub fn menus() -> Vec<Menu<'static>> {
         Menu {
             name: "Go",
             items: vec![
-                MenuItem::action("Back", workspace::GoBack { pane: None }),
-                MenuItem::action("Forward", workspace::GoForward { pane: None }),
+                MenuItem::action("Back", workspace::GoBack),
+                MenuItem::action("Forward", workspace::GoForward),
                 MenuItem::separator(),
                 MenuItem::action("Go to File", file_finder::Toggle),
                 MenuItem::action("Go to Symbol in Project", project_symbols::Toggle),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -663,7 +663,7 @@ mod tests {
     use util::http::FakeHttpClient;
     use workspace::{
         item::{Item, ItemHandle},
-        open_new, open_paths, pane, NewFile, Pane, SplitDirection, WorkspaceHandle,
+        open_new, open_paths, pane, NewFile, SplitDirection, WorkspaceHandle,
     };
 
     #[gpui::test]
@@ -1488,7 +1488,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1497,7 +1497,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1506,7 +1506,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1515,7 +1515,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1525,7 +1525,7 @@ mod tests {
 
         // Go back one more time and ensure we don't navigate past the first item in the history.
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1534,7 +1534,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_forward(w, None, cx))
+            .update(cx, |w, cx| w.go_forward(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1543,7 +1543,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_forward(w, None, cx))
+            .update(cx, |w, cx| w.go_forward(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1561,7 +1561,7 @@ mod tests {
         .await
         .unwrap();
         workspace
-            .update(cx, |w, cx| Pane::go_forward(w, None, cx))
+            .update(cx, |w, cx| w.go_forward(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1570,7 +1570,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_forward(w, None, cx))
+            .update(cx, |w, cx| w.go_forward(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1579,7 +1579,7 @@ mod tests {
         );
 
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1601,7 +1601,7 @@ mod tests {
             .await
             .unwrap();
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1609,7 +1609,7 @@ mod tests {
             (file1.clone(), DisplayPoint::new(10, 0), 0.)
         );
         workspace
-            .update(cx, |w, cx| Pane::go_forward(w, None, cx))
+            .update(cx, |w, cx| w.go_forward(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1653,7 +1653,7 @@ mod tests {
             })
         });
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1661,7 +1661,7 @@ mod tests {
             (file1.clone(), DisplayPoint::new(2, 0), 0.)
         );
         workspace
-            .update(cx, |w, cx| Pane::go_back(w, None, cx))
+            .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await
             .unwrap();
         assert_eq!(
@@ -1766,81 +1766,97 @@ mod tests {
         // Reopen all the closed items, ensuring they are reopened in the same order
         // in which they were closed.
         workspace
-            .update(cx, Pane::reopen_closed_item)
+            .update(cx, Workspace::reopen_closed_item)
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file3.clone()));
 
         workspace
-            .update(cx, Pane::reopen_closed_item)
+            .update(cx, Workspace::reopen_closed_item)
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file2.clone()));
 
         workspace
-            .update(cx, Pane::reopen_closed_item)
+            .update(cx, Workspace::reopen_closed_item)
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file4.clone()));
 
         workspace
-            .update(cx, Pane::reopen_closed_item)
+            .update(cx, Workspace::reopen_closed_item)
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file1.clone()));
 
         // Reopening past the last closed item is a no-op.
         workspace
-            .update(cx, Pane::reopen_closed_item)
+            .update(cx, Workspace::reopen_closed_item)
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file1.clone()));
 
         // Reopening closed items doesn't interfere with navigation history.
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file4.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file2.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file3.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file4.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file3.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file2.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file1.clone()));
 
         workspace
-            .update(cx, |workspace, cx| Pane::go_back(workspace, None, cx))
+            .update(cx, |workspace, cx| {
+                workspace.go_back(workspace.active_pane().downgrade(), cx)
+            })
             .await
             .unwrap();
         assert_eq!(active_path(&workspace, cx), Some(file1.clone()));


### PR DESCRIPTION
This pull request simplifies the `Pane` struct by replacing methods like `Pane::add_item` that would previously take a `&mut Workspace` with methods that take a `&mut self`. When access to the workspace is needed, we now either emit an event from the `Pane` or directly move the method to the `Workspace` struct.