### PR TITLE
`TextStyle::default()` ask system for known existing font family

### DIFF
--- a/crates/gpui/src/fonts.rs
+++ b/crates/gpui/src/fonts.rs
@@ -295,13 +295,14 @@ impl Default for TextStyle {
                 .as_ref()
                 .expect("TextStyle::default can only be called within a call to with_font_cache");
 
-            let font_family_name = Arc::from("Courier");
-            let font_family_id = font_cache
-                .load_family(&[&font_family_name], &Default::default())
-                .unwrap();
+            let font_family_id = font_cache.known_existing_family();
             let font_id = font_cache
                 .select_font(font_family_id, &Default::default())
-                .unwrap();
+                .expect("did not have any font in system-provided family");
+            let font_family_name = font_cache
+                .family_name(font_family_id)
+                .expect("we loaded this family from the font cache, so this should work");
+
             Self {
                 color: Default::default(),
                 font_family_name,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -343,6 +343,7 @@ pub enum RasterizationOptions {
 
 pub trait FontSystem: Send + Sync {
     fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> anyhow::Result<()>;
+    fn all_families(&self) -> Vec<String>;
     fn load_family(&self, name: &str, features: &FontFeatures) -> anyhow::Result<Vec<FontId>>;
     fn select_font(
         &self,

--- a/crates/gpui/src/platform/mac/fonts.rs
+++ b/crates/gpui/src/platform/mac/fonts.rs
@@ -66,6 +66,14 @@ impl platform::FontSystem for FontSystem {
         self.0.write().add_fonts(fonts)
     }
 
+    fn all_families(&self) -> Vec<String> {
+        self.0
+            .read()
+            .system_source
+            .all_families()
+            .expect("core text should never return an error")
+    }
+
     fn load_family(&self, name: &str, features: &Features) -> anyhow::Result<Vec<FontId>> {
         self.0.write().load_family(name, features)
     }


### PR DESCRIPTION
Rather than assuming a specific family exists, try a set of specific names and if they fail, just grab any old font that the system reports as existing

Closes https://linear.app/zed-industries/issue/Z-445/thread-main-panicked-at-called-resultunwrap-on-an-err-value-could-not

Release Notes:

* Fixed crash that could happen if system did not have a specific fallback font
