### PR TITLE
Z-1074/search default label

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -25,7 +25,7 @@ use std::{
     borrow::Cow,
     collections::HashSet,
     mem,
-    ops::Range,
+    ops::{Not, Range},
     path::PathBuf,
     sync::Arc,
 };
@@ -242,7 +242,13 @@ impl View for ProjectSearchView {
 
 impl Item for ProjectSearchView {
     fn tab_tooltip_text(&self, cx: &AppContext) -> Option<Cow<str>> {
-        Some(self.query_editor.read(cx).text(cx).into())
+        let query_text = self.query_editor.read(cx).text(cx);
+
+        query_text
+            .is_empty()
+            .not()
+            .then(|| query_text.into())
+            .or_else(|| Some("Project search".into()))
     }
 
     fn act_as_type<'a>(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -248,7 +248,7 @@ impl Item for ProjectSearchView {
             .is_empty()
             .not()
             .then(|| query_text.into())
-            .or_else(|| Some("Project search".into()))
+            .or_else(|| Some("Project Search".into()))
     }
 
     fn act_as_type<'a>(


### PR DESCRIPTION
This commit adds a default "Project search" tooltip for empty search panes. Fixes Linear ticket Z-1074
Release Notes:

- Added default tooltip to empty search panes. ([#1533](https://github.com/zed-industries/zed/issues/4749)).
