### PR TITLE
chore: Enable ThinLTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,4 +116,4 @@ split-debuginfo = "unpacked"
 
 [profile.release]
 debug = true
-lto = "fat"
+lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,4 @@ split-debuginfo = "unpacked"
 
 [profile.release]
 debug = true
+lto = "fat"


### PR DESCRIPTION
Per conversation with Antonio, I've suggested enabling full LTO; right now we use a crate-local ThinLTO, which does not inline function calls across crates. 

| Configuration    | Current main (788f97e) | Thin LTO  | Full LTO  |
|------------------|------------------------|-----------|-----------|
| Size in bytes    | 158806721              | 155868753 | 111115553 |
| % of `main` size | 100%                   | 98.14%    | 69.96%    |
| Size in bytes (no debug info) | 129186657 | 127942929 | 108281345 |