### PR TITLE
Avoid blocking forever on startup if config files do not exist

### DIFF
--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -66,14 +66,21 @@ pub fn watch_config_file(
         .spawn(async move {
             let events = fs.watch(&path, Duration::from_millis(100)).await;
             futures::pin_mut!(events);
+
+            let contents = fs.load(&path).await.unwrap_or_default();
+            if tx.unbounded_send(contents).is_err() {
+                return;
+            }
+
             loop {
+                if events.next().await.is_none() {
+                    break;
+                }
+
                 if let Ok(contents) = fs.load(&path).await {
                     if !tx.unbounded_send(contents).is_ok() {
                         break;
                     }
-                }
-                if events.next().await.is_none() {
-                    break;
                 }
             }
         })


### PR DESCRIPTION
The files will still get created if the user opens their settings and saves, otherwise everything will transparently work

Release Notes:

- Fixed an issue where a missing settings file would cause a hang on startup ([#1590](https://github.com/zed-industries/zed/issues/6160)).
