### PR TITLE
Redraw the terminal on every wakeup

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -133,8 +133,8 @@ impl TerminalView {
             Event::Wakeup => {
                 if !cx.is_self_focused() {
                     this.has_new_content = true;
-                    cx.notify();
                 }
+                cx.notify();
                 cx.emit(Event::Wakeup);
             }
             Event::Bell => {


### PR DESCRIPTION
For whatever reason, the optimizations of panes and workspace have caused the terminal to notify less often then it should. This PR fixes that oversight.