### PR TITLE
Add additional panic information to panic events

### DIFF
--- a/crates/feedback/src/system_specs.rs
+++ b/crates/feedback/src/system_specs.rs
@@ -6,6 +6,8 @@ use std::{env, fmt::Display};
 use sysinfo::{System, SystemExt};
 use util::channel::ReleaseChannel;
 
+// TODO: Move this file out of feedback and into a more general place
+
 #[derive(Clone, Debug, Serialize)]
 pub struct SystemSpecs {
     #[serde(serialize_with = "serialize_app_version")]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -377,7 +377,7 @@ struct Panic {
     os_name: String,
     os_version: Option<String>,
     architecture: String,
-    time: u128,
+    panicked_on: u128,
 }
 
 #[derive(Serialize)]
@@ -428,7 +428,7 @@ fn init_panic_hook(app: &App) {
                 .ok()
                 .map(|os_version| os_version.to_string()),
             architecture: env::consts::ARCH.into(),
-            time: SystemTime::now()
+            panicked_on: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis(),


### PR DESCRIPTION
Adds the following to the panic event

release_channel
os_name
os_version
architecture

Merge first: https://github.com/zed-industries/zed.dev/pull/322

Release Notes:

- N/A