### PR TITLE
editor: add select previous command

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -16,6 +16,12 @@
           "replace_newest": true
         }
       ],
+      "ctrl-cmd-g": [
+        "editor::SelectPrevious",
+        {
+          "replace_newest": true
+        }
+      ],
       "ctrl-shift-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::AddSelectionAbove",
       "cmd-shift-backspace": "editor::DeleteToBeginningOfLine",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -250,6 +250,12 @@
           "replace_newest": false
         }
       ],
+      "ctrl-cmd-d": [
+        "editor::SelectNext",
+        {
+          "replace_newest": false
+        }
+      ],
       "cmd-k cmd-d": [
         "editor::SelectNext",
         {

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -262,6 +262,12 @@
           "replace_newest": true
         }
       ],
+      "cmd-k ctrl-cmd-d": [
+        "editor::SelectPrevious",
+        {
+          "replace_newest": true
+        }
+      ],
       "cmd-k cmd-i": "editor::Hover",
       "cmd-/": [
         "editor::ToggleComments",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -251,7 +251,7 @@
         }
       ],
       "ctrl-cmd-d": [
-        "editor::SelectNext",
+        "editor::SelectPrevious",
         {
           "replace_newest": false
         }

--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -26,6 +26,12 @@
           "replace_newest": false
         }
       ],
+      "ctrl-cmd-g": [
+        "editor::SelectPrevious",
+        {
+          "replace_newest": false
+        }
+      ],
       "cmd-/": [
         "editor::ToggleComments",
         {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5181,7 +5181,6 @@ impl Editor {
                         s.insert_range(next_selected_range);
                     });
                 } else {
-                    log::error!("Nothing to do in forward state");
                     select_next_state.done = true;
                 }
             }
@@ -5267,7 +5266,6 @@ impl Editor {
                 }
 
                 if let Some(next_selected_range) = next_selected_range {
-                    log::error!("next selected range: {:?}", next_selected_range);
                     self.unfold_ranges([next_selected_range.clone()], false, true, cx);
                     self.change_selections(Some(Autoscroll::newest()), cx, |s| {
                         if action.replace_newest {
@@ -5277,7 +5275,6 @@ impl Editor {
                     });
                 } else {
                     select_prev_state.done = true;
-                    log::error!("Nothing to do here");
                 }
             }
 
@@ -5298,7 +5295,6 @@ impl Editor {
                     .text_for_range(selection.start..selection.end)
                     .collect::<String>();
                 let query = query.chars().rev().collect::<String>();
-                log::error!("query lololo '{}'", query);
                 let select_state = SelectNextState {
                     query: AhoCorasick::new_auto_configured(&[query]),
                     wordwise: true,
@@ -5314,7 +5310,6 @@ impl Editor {
                     .text_for_range(selection.start..selection.end)
                     .collect::<String>();
                 let query = query.chars().rev().collect::<String>();
-                log::error!("query '{}'", query);
                 self.select_prev_state = Some(SelectNextState {
                     query: AhoCorasick::new_auto_configured(&[query]),
                     wordwise: false,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -548,6 +548,7 @@ pub struct EditorSnapshot {
 struct SelectionHistoryEntry {
     selections: Arc<[Selection<Anchor>]>,
     select_next_state: Option<SelectNextState>,
+    select_prev_state: Option<SelectNextState>,
     add_selections_state: Option<AddSelectionsState>,
 }
 
@@ -5697,6 +5698,7 @@ impl Editor {
         if let Some(entry) = self.selection_history.undo_stack.pop_back() {
             self.change_selections(None, cx, |s| s.select_anchors(entry.selections.to_vec()));
             self.select_next_state = entry.select_next_state;
+            self.select_prev_state = entry.select_prev_state;
             self.add_selections_state = entry.add_selections_state;
             self.request_autoscroll(Autoscroll::newest(), cx);
         }
@@ -5709,6 +5711,7 @@ impl Editor {
         if let Some(entry) = self.selection_history.redo_stack.pop_back() {
             self.change_selections(None, cx, |s| s.select_anchors(entry.selections.to_vec()));
             self.select_next_state = entry.select_next_state;
+            self.select_prev_state = entry.select_prev_state;
             self.add_selections_state = entry.add_selections_state;
             self.request_autoscroll(Autoscroll::newest(), cx);
         }
@@ -6486,6 +6489,7 @@ impl Editor {
         self.selection_history.push(SelectionHistoryEntry {
             selections: self.selections.disjoint_anchors(),
             select_next_state: self.select_next_state.clone(),
+            select_prev_state: self.select_prev_state.clone(),
             add_selections_state: self.add_selections_state.clone(),
         });
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3108,6 +3108,57 @@ async fn test_select_next(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_select_previous_word_boundary(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("abc\nˇabc abc\ndefabc\nabc");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("abc\n«abcˇ» abc\ndefabc\nabc");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\nabc");
+
+    cx.update_editor(|view, cx| view.undo_selection(&UndoSelection, cx));
+    cx.assert_editor_state("abc\n«abcˇ» abc\ndefabc\nabc");
+
+    cx.update_editor(|view, cx| view.redo_selection(&RedoSelection, cx));
+    cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\nabc");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\n«abcˇ»");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«abcˇ» «abcˇ»\ndefabc\n«abcˇ»");
+}
+
+#[gpui::test]
+async fn test_select_previous_selection(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("abc\n«ˇabc» abc\ndefabc\nabc");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\nabc");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\n«abcˇ»");
+
+    cx.update_editor(|view, cx| view.undo_selection(&UndoSelection, cx));
+    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\nabc");
+
+    cx.update_editor(|view, cx| view.redo_selection(&RedoSelection, cx));
+    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\n«abcˇ»");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndef«abcˇ»\n«abcˇ»");
+
+    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+    cx.assert_editor_state("«abcˇ»\n«ˇabc» «abcˇ»\ndef«abcˇ»\n«abcˇ»");
+}
+#[gpui::test]
 async fn test_select_larger_smaller_syntax_node(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3108,56 +3108,56 @@ async fn test_select_next(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_select_previous_word_boundary(cx: &mut gpui::TestAppContext) {
+async fn test_select_previous(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
+    {
+        // `Select previous` without a selection (selects wordwise)
+        let mut cx = EditorTestContext::new(cx).await;
+        cx.set_state("abc\nˇabc abc\ndefabc\nabc");
 
-    let mut cx = EditorTestContext::new(cx).await;
-    cx.set_state("abc\nˇabc abc\ndefabc\nabc");
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("abc\n«abcˇ» abc\ndefabc\nabc");
 
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("abc\n«abcˇ» abc\ndefabc\nabc");
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\nabc");
 
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\nabc");
+        cx.update_editor(|view, cx| view.undo_selection(&UndoSelection, cx));
+        cx.assert_editor_state("abc\n«abcˇ» abc\ndefabc\nabc");
 
-    cx.update_editor(|view, cx| view.undo_selection(&UndoSelection, cx));
-    cx.assert_editor_state("abc\n«abcˇ» abc\ndefabc\nabc");
+        cx.update_editor(|view, cx| view.redo_selection(&RedoSelection, cx));
+        cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\nabc");
 
-    cx.update_editor(|view, cx| view.redo_selection(&RedoSelection, cx));
-    cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\nabc");
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\n«abcˇ»");
 
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«abcˇ» abc\ndefabc\n«abcˇ»");
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«abcˇ» «abcˇ»\ndefabc\n«abcˇ»");
+    }
+    {
+        // `Select previous` with a selection
+        let mut cx = EditorTestContext::new(cx).await;
+        cx.set_state("abc\n«ˇabc» abc\ndefabc\nabc");
 
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«abcˇ» «abcˇ»\ndefabc\n«abcˇ»");
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\nabc");
+
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\n«abcˇ»");
+
+        cx.update_editor(|view, cx| view.undo_selection(&UndoSelection, cx));
+        cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\nabc");
+
+        cx.update_editor(|view, cx| view.redo_selection(&RedoSelection, cx));
+        cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\n«abcˇ»");
+
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndef«abcˇ»\n«abcˇ»");
+
+        cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
+        cx.assert_editor_state("«abcˇ»\n«ˇabc» «abcˇ»\ndef«abcˇ»\n«abcˇ»");
+    }
 }
 
-#[gpui::test]
-async fn test_select_previous_selection(cx: &mut gpui::TestAppContext) {
-    init_test(cx, |_| {});
-
-    let mut cx = EditorTestContext::new(cx).await;
-    cx.set_state("abc\n«ˇabc» abc\ndefabc\nabc");
-
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\nabc");
-
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\n«abcˇ»");
-
-    cx.update_editor(|view, cx| view.undo_selection(&UndoSelection, cx));
-    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\nabc");
-
-    cx.update_editor(|view, cx| view.redo_selection(&RedoSelection, cx));
-    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndefabc\n«abcˇ»");
-
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«ˇabc» abc\ndef«abcˇ»\n«abcˇ»");
-
-    cx.update_editor(|e, cx| e.select_previous(&SelectPrevious::default(), cx));
-    cx.assert_editor_state("«abcˇ»\n«ˇabc» «abcˇ»\ndef«abcˇ»\n«abcˇ»");
-}
 #[gpui::test]
 async fn test_select_larger_smaller_syntax_node(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -3783,9 +3783,9 @@ impl<'a> io::Read for MultiBufferBytes<'a> {
 impl<'a> ReversedMultiBufferBytes<'a> {
     fn consume(&mut self, len: usize) {
         self.range.end -= len;
-        let end_offset = self.chunk.len().checked_sub(len);
+        self.chunk = &self.chunk[..self.chunk.len() - len];
 
-        if !self.range.is_empty() && end_offset == Some(0) {
+        if !self.range.is_empty() && self.chunk.is_empty() {
             if let Some(chunk) = self.excerpt_bytes.as_mut().and_then(|bytes| bytes.next()) {
                 self.chunk = chunk;
             } else {
@@ -3797,10 +3797,6 @@ impl<'a> ReversedMultiBufferBytes<'a> {
                     self.excerpt_bytes = Some(excerpt_bytes);
                 }
             }
-        } else if let Some(end_offset) = end_offset {
-            self.chunk = &self.chunk[..end_offset];
-        } else {
-            unreachable!()
         }
     }
 }

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -603,21 +603,13 @@ impl<'a> Bytes<'a> {
 
     pub fn peek(&self) -> Option<&'a [u8]> {
         let chunk = self.chunks.item()?;
-        log::error!("peeking");
         if self.reversed && self.range.start >= self.chunks.end(&()) {
-            log::error!(
-                "Leaving because we're reversed and {} >= {}",
-                self.range.start,
-                self.chunks.end(&())
-            );
             return None;
         }
-        log::error!("peeking 2");
         let chunk_start = *self.chunks.start();
         if self.range.end <= chunk_start {
             return None;
         }
-        log::error!("peeking3");
         let start = self.range.start.saturating_sub(chunk_start);
         let end = self.range.end - chunk_start;
         Some(&chunk.0.as_bytes()[start..chunk.0.len().min(end)])
@@ -647,11 +639,9 @@ impl<'a> io::Read for Bytes<'a> {
             if self.reversed {
                 buf[..len].copy_from_slice(&chunk[chunk.len() - len..]);
                 buf[..len].reverse();
-                log::error!("buffer contents: {:?}", &buf[..len]);
                 self.range.end -= len;
             } else {
                 buf[..len].copy_from_slice(&chunk[..len]);
-                log::error!("buffer contents: {:?}", &buf[..len]);
                 self.range.start += len;
             }
 

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1749,6 +1749,12 @@ impl BufferSnapshot {
         self.visible_text.bytes_in_range(start..end)
     }
 
+    pub fn reversed_bytes_in_range<T: ToOffset>(&self, range: Range<T>) -> rope::Bytes<'_> {
+        let start = range.start.to_offset(self);
+        let end = range.end.to_offset(self);
+        self.visible_text.reversed_bytes_in_range(start..end)
+    }
+
     pub fn text_for_range<T: ToOffset>(&self, range: Range<T>) -> Chunks<'_> {
         let start = range.start.to_offset(self);
         let end = range.end.to_offset(self);


### PR DESCRIPTION
Ticket number: Z-366
Added a `select previous` command to complement `select next`.
Release Notes:

- Added "Select previous" editor command, mirroring `Select next`.
