### PR TITLE
Query `rect_for_text_range` on focused view instead of root element

### DIFF
--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -965,10 +965,10 @@ impl<'a> WindowContext<'a> {
     }
 
     pub fn rect_for_text_range(&self, range_utf16: Range<usize>) -> Option<RectF> {
-        let root_view_id = self.window.root_view().id();
+        let focused_view_id = self.window.focused_view_id?;
         self.window
             .rendered_views
-            .get(&root_view_id)?
+            .get(&focused_view_id)?
             .rect_for_text_range(range_utf16, self)
             .log_err()
             .flatten()

--- a/crates/gpui/src/app/window_input_handler.rs
+++ b/crates/gpui/src/app/window_input_handler.rs
@@ -84,8 +84,8 @@ impl InputHandler for WindowInputHandler {
 
     fn rect_for_range(&self, range_utf16: Range<usize>) -> Option<RectF> {
         self.app
-            .borrow_mut()
-            .update_window(self.window_id, |cx| cx.rect_for_text_range(range_utf16))
+            .borrow()
+            .read_window(self.window_id, |cx| cx.rect_for_text_range(range_utf16))
             .flatten()
     }
 }


### PR DESCRIPTION
This was causing IME input to be drawn in the wrong place when there were splits or panels in the window.

Release Notes:

- Fixed a bug that was causing IME input to sometimes be rendered in the wrong position.