### PR TITLE
Add file and line number information to logs

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -9,6 +9,7 @@ pub mod test;
 use std::{
     cmp::{self, Ordering},
     ops::{AddAssign, Range, RangeInclusive},
+    panic::Location,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -129,11 +130,13 @@ where
 {
     type Ok = T;
 
+    #[track_caller]
     fn log_err(self) -> Option<T> {
         match self {
             Ok(value) => Some(value),
             Err(error) => {
-                log::error!("{:?}", error);
+                let caller = Location::caller();
+                log::error!("{}:{}: {:?}", caller.file(), caller.line(), error);
                 None
             }
         }


### PR DESCRIPTION
This PR adds codegen from rustc to track the file and line number of calls to `log_err()`. I haven't noticed much longer compile times on my machine, and looking at the [implementation](https://rustc-dev-guide.rust-lang.org/backend/implicit-caller-location.html) it essentially adds an extra argument and secret reference pass. However, this will show a lot more data in our logs on user machines. Requesting review from @ForLoveOfCats, who usually knows a bunch about this kind of thing :)