### PR TITLE
Fix ci.yml not pulling in rustfmt properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust
         run: |
           rustup set profile minimal
-          rustup component add rustfmt
+          rustup component add --toolchain stable rustfmt
           rustup update stable
 
       - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Rust
         run: |
           rustup set profile minimal
-          rustup component add --toolchain stable rustfmt
           rustup update stable
+          rustup component add --toolchain stable rustfmt
 
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
It seems like [toolchain bump](https://github.com/zed-industries/zed/commit/c1c91dc2e3133a3de774a3ee01e9047d6dee8320) broke CI somehow, even though CI passed prior to merge. :x
