### PR TITLE
Don't apply the 'literal' color to entire markdown code blocks

### DIFF
--- a/crates/zed/src/languages/markdown/highlights.scm
+++ b/crates/zed/src/languages/markdown/highlights.scm
@@ -14,11 +14,11 @@
   (list_marker_parenthesis)
 ] @punctuation.list_marker
 
-[
-  (indented_code_block)
-  (fenced_code_block)
-  (code_span)
-] @text.literal
+(code_span) @text.literal
+
+(fenced_code_block
+  (info_string
+    (language) @text.literal))
 
 (link_destination) @link_uri
 (link_text) @link_text


### PR DESCRIPTION
### Before

![Screen Shot 2023-06-06 at 2 32 46 PM](https://github.com/zed-industries/zed/assets/326587/036f1da3-19c6-4979-adc6-c3133f8d63dc)

### After

![Screen Shot 2023-06-06 at 2 32 08 PM](https://github.com/zed-industries/zed/assets/326587/6d4729db-b76a-4052-847e-fd9de346f194)

Release Notes:

* Improved the syntax highlighting of fenced code blocks in markdown.