### PR TITLE
chore: bump MSRV to 1.70, add rust-toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM rust:1.65-bullseye as builder
+FROM rust:1.70-bullseye as builder
 WORKDIR app
 COPY . .
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -10,6 +10,7 @@ use alacritty_terminal::{
     index::{Column, Direction as AlacDirection, Line, Point},
     selection::{Selection, SelectionRange, SelectionType},
     sync::FairMutex,
+
     term::{
         cell::Cell,
         color::Rgb,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -10,7 +10,6 @@ use alacritty_terminal::{
     index::{Column, Direction as AlacDirection, Line, Point},
     selection::{Selection, SelectionRange, SelectionType},
     sync::FairMutex,
-
     term::{
         cell::Cell,
         color::Rgb,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.70"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.70"
+components = [ "rustfmt" ]


### PR DESCRIPTION
This time I've added a `components` section to rust-toolchain.toml file to explicitly require a rustfmt component. Fingers crossed.
