### PR TITLE
Improve syntax highlighting and outline view for Elixir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,8 +7342,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-elixir"
-version = "0.19.0"
-source = "git+https://github.com/elixir-lang/tree-sitter-elixir?rev=05e3631c6a0701c1fa518b0fee7be95a2ceef5e2#05e3631c6a0701c1fa518b0fee7be95a2ceef5e2"
+version = "0.1.0"
+source = "git+https://github.com/elixir-lang/tree-sitter-elixir?rev=4ba9dab6e2602960d95b2b625f3386c27e08084e#4ba9dab6e2602960d95b2b625f3386c27e08084e"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -771,6 +771,7 @@ impl LanguageRegistry {
                                         }
                                     }
                                     Err(err) => {
+                                        log::error!("failed to load language {name} - {err}");
                                         let mut state = this.state.write();
                                         state.mark_language_loaded(id);
                                         if let Some(mut txs) = state.loading_languages.remove(&id) {
@@ -1059,34 +1060,22 @@ impl Language {
 
     pub fn with_queries(mut self, queries: LanguageQueries) -> Result<Self> {
         if let Some(query) = queries.highlights {
-            self = self
-                .with_highlights_query(query.as_ref())
-                .expect("failed to evaluate highlights query");
+            self = self.with_highlights_query(query.as_ref())?;
         }
         if let Some(query) = queries.brackets {
-            self = self
-                .with_brackets_query(query.as_ref())
-                .expect("failed to load brackets query");
+            self = self.with_brackets_query(query.as_ref())?;
         }
         if let Some(query) = queries.indents {
-            self = self
-                .with_indents_query(query.as_ref())
-                .expect("failed to load indents query");
+            self = self.with_indents_query(query.as_ref())?;
         }
         if let Some(query) = queries.outline {
-            self = self
-                .with_outline_query(query.as_ref())
-                .expect("failed to load outline query");
+            self = self.with_outline_query(query.as_ref())?;
         }
         if let Some(query) = queries.injections {
-            self = self
-                .with_injection_query(query.as_ref())
-                .expect("failed to load injection query");
+            self = self.with_injection_query(query.as_ref())?;
         }
         if let Some(query) = queries.overrides {
-            self = self
-                .with_override_query(query.as_ref())
-                .expect("failed to load override query");
+            self = self.with_override_query(query.as_ref())?;
         }
         Ok(self)
     }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -455,6 +455,7 @@ struct OutlineConfig {
     item_capture_ix: u32,
     name_capture_ix: u32,
     context_capture_ix: Option<u32>,
+    extra_context_capture_ix: Option<u32>,
 }
 
 struct InjectionConfig {
@@ -1091,12 +1092,14 @@ impl Language {
         let mut item_capture_ix = None;
         let mut name_capture_ix = None;
         let mut context_capture_ix = None;
+        let mut extra_context_capture_ix = None;
         get_capture_indices(
             &query,
             &mut [
                 ("item", &mut item_capture_ix),
                 ("name", &mut name_capture_ix),
                 ("context", &mut context_capture_ix),
+                ("context.extra", &mut extra_context_capture_ix),
             ],
         );
         if let Some((item_capture_ix, name_capture_ix)) = item_capture_ix.zip(name_capture_ix) {
@@ -1105,6 +1108,7 @@ impl Language {
                 item_capture_ix,
                 name_capture_ix,
                 context_capture_ix,
+                extra_context_capture_ix,
             });
         }
         Ok(self)

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -106,7 +106,7 @@ tree-sitter = "0.20"
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
 tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }
-tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "05e3631c6a0701c1fa518b0fee7be95a2ceef5e2" }
+tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "4ba9dab6e2602960d95b2b625f3386c27e08084e" }
 tree-sitter-embedded-template = "0.20.0"
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }

--- a/crates/zed/src/languages/elixir/highlights.scm
+++ b/crates/zed/src/languages/elixir/highlights.scm
@@ -1,21 +1,6 @@
 ["when" "and" "or" "not" "in" "not in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
 
 (unary_operator
-  operator: "@" @comment.doc
-  operand: (call
-    target: (identifier) @comment.doc.__attribute__
-    (arguments
-      [
-        (string) @comment.doc
-        (charlist) @comment.doc
-        (sigil
-          quoted_start: _ @comment.doc
-          quoted_end: _ @comment.doc) @comment.doc
-        (boolean) @comment.doc
-      ]))
-  (#match? @comment.doc.__attribute__ "^(moduledoc|typedoc|doc)$"))
-
-(unary_operator
   operator: "&"
   operand: (integer) @operator)
 
@@ -84,6 +69,11 @@
   quoted_start: _ @string.special
   quoted_end: _ @string.special) @string.special
 
+(
+  (identifier) @comment.unused
+  (#match? @comment.unused "^_")
+)
+
 (call
   target: [
     (identifier) @function
@@ -99,15 +89,10 @@
       (binary_operator
         left: (identifier) @function
         operator: "when")
+      (binary_operator
+        operator: "|>"
+        right: (identifier))
     ])
-  (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
-
-(call
-  target: (identifier) @keyword
-  (arguments
-    (binary_operator
-      operator: "|>"
-      right: (identifier)))
   (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
 
 (binary_operator
@@ -127,10 +112,18 @@
   (#match? @constant.builtin "^(__MODULE__|__DIR__|__ENV__|__CALLER__|__STACKTRACE__)$")
 )
 
-(
-  (identifier) @comment.unused
-  (#match? @comment.unused "^_")
-)
+(unary_operator
+  operator: "@" @comment.doc
+  operand: (call
+    target: (identifier) @__attribute__ @comment.doc
+    (arguments
+      [
+        (string)
+        (charlist)
+        (sigil)
+        (boolean)
+      ] @comment.doc))
+  (#match? @__attribute__ "^(moduledoc|typedoc|doc)$"))
 
 (comment) @comment
 

--- a/crates/zed/src/languages/elixir/indents.scm
+++ b/crates/zed/src/languages/elixir/indents.scm
@@ -1,6 +1,4 @@
-[
-    (call)
-] @indent
+(call) @indent
 
 (_ "[" "]" @end) @indent
 (_ "{" "}" @end) @indent

--- a/crates/zed/src/languages/elixir/outline.scm
+++ b/crates/zed/src/languages/elixir/outline.scm
@@ -8,9 +8,19 @@
   (arguments
     [
       (identifier) @name
-      (call target: (identifier) @name)
+      (call
+          target: (identifier) @name
+          (arguments
+              "(" @context.extra
+              _* @context.extra
+              ")" @context.extra))
       (binary_operator
-        left: (call target: (identifier) @name)
+        left: (call
+            target: (identifier) @name
+            (arguments
+                "(" @context.extra
+                _* @context.extra
+                ")" @context.extra))
         operator: "when")
     ])
   (#match? @context "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @item

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -327,10 +327,10 @@ mod tests {
                 .map(|item| (item.text.as_str(), item.depth))
                 .collect::<Vec<_>>(),
             &[
-                ("function a ( )", 0),
-                ("async function a2 ( )", 1),
+                ("function a()", 0),
+                ("async function a2()", 1),
                 ("let b", 0),
-                ("function getB ( )", 0),
+                ("function getB()", 0),
                 ("const d", 0),
             ]
         );


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2208/outline-view-doesnt-differentiate-between-overloaded-functions
Fixes https://linear.app/zed-industries/issue/Z-2205/elixir-syntax-highlighting-not-working-properly-for-doc-attributes-and

This PR improves syntax highlighting and outline view in Elixir. It's common to overload elixir functions, with many different versions of the function for different patterns of parameters, so I updated the outline view to show functions'  parameters in Elixir. But if we showed functions the same way in the *breadcrumbs*, it would take up too much space.

So I added a new capture in languages' `outline` queries called `@context.extra`, which is included in the outline view, but not in breadcrumbs.

Release Notes:

- Improved syntax highlighting of doc attributes and special macros in Elixir
- Updated the outline view in Elixir to display function parameters, to allow differentiating between function overloads.
