### PR TITLE
Fix some issues found when testing Elixir-LS

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -588,10 +588,7 @@ impl InfoPopover {
                                         MouseRegion::new::<Self>(view_id, region_id, bounds)
                                             .on_click::<Editor, _>(
                                                 MouseButton::Left,
-                                                move |_, _, cx| {
-                                                    println!("clicked link {url}");
-                                                    cx.platform().open_url(&url);
-                                                },
+                                                move |_, _, cx| cx.platform().open_url(&url),
                                             ),
                                     );
                                 }

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -260,9 +260,10 @@ impl LanguageServer {
             buffer.clear();
             stdout.read_until(b'\n', &mut buffer).await?;
             stdout.read_until(b'\n', &mut buffer).await?;
-            let message_len: usize = std::str::from_utf8(&buffer)?
+            let header = std::str::from_utf8(&buffer)?;
+            let message_len: usize = header
                 .strip_prefix(CONTENT_LEN_HEADER)
-                .ok_or_else(|| anyhow!("invalid header"))?
+                .ok_or_else(|| anyhow!("invalid LSP message header {header:?}"))?
                 .trim_end()
                 .parse()?;
 
@@ -301,7 +302,7 @@ impl LanguageServer {
                 }
             } else {
                 warn!(
-                    "Failed to deserialize message:\n{}",
+                    "failed to deserialize LSP message:\n{}",
                     std::str::from_utf8(&buffer)?
                 );
             }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1111,14 +1111,18 @@ impl LspCommand for GetHover {
         cx: AsyncAppContext,
     ) -> Result<Self::Response> {
         Ok(message.and_then(|hover| {
-            let range = hover.range.map(|range| {
-                cx.read(|cx| {
-                    let buffer = buffer.read(cx);
-                    let token_start =
-                        buffer.clip_point_utf16(point_from_lsp(range.start), Bias::Left);
-                    let token_end = buffer.clip_point_utf16(point_from_lsp(range.end), Bias::Left);
-                    buffer.anchor_after(token_start)..buffer.anchor_before(token_end)
-                })
+            let (language, range) = cx.read(|cx| {
+                let buffer = buffer.read(cx);
+                (
+                    buffer.language().cloned(),
+                    hover.range.map(|range| {
+                        let token_start =
+                            buffer.clip_point_utf16(point_from_lsp(range.start), Bias::Left);
+                        let token_end =
+                            buffer.clip_point_utf16(point_from_lsp(range.end), Bias::Left);
+                        buffer.anchor_after(token_start)..buffer.anchor_before(token_end)
+                    }),
+                )
             });
 
             fn hover_blocks_from_marked_string(
@@ -1163,7 +1167,11 @@ impl LspCommand for GetHover {
                 }],
             });
 
-            Some(Hover { contents, range })
+            Some(Hover {
+                contents,
+                range,
+                language,
+            })
         }))
     }
 
@@ -1247,16 +1255,9 @@ impl LspCommand for GetHover {
         self,
         message: proto::GetHoverResponse,
         _: ModelHandle<Project>,
-        _: ModelHandle<Buffer>,
-        _: AsyncAppContext,
+        buffer: ModelHandle<Buffer>,
+        cx: AsyncAppContext,
     ) -> Result<Self::Response> {
-        let range = if let (Some(start), Some(end)) = (message.start, message.end) {
-            language::proto::deserialize_anchor(start)
-                .and_then(|start| language::proto::deserialize_anchor(end).map(|end| start..end))
-        } else {
-            None
-        };
-
         let contents: Vec<_> = message
             .contents
             .into_iter()
@@ -1271,12 +1272,23 @@ impl LspCommand for GetHover {
                 },
             })
             .collect();
+        if contents.is_empty() {
+            return Ok(None);
+        }
 
-        Ok(if contents.is_empty() {
-            None
+        let language = buffer.read_with(&cx, |buffer, _| buffer.language().cloned());
+        let range = if let (Some(start), Some(end)) = (message.start, message.end) {
+            language::proto::deserialize_anchor(start)
+                .and_then(|start| language::proto::deserialize_anchor(end).map(|end| start..end))
         } else {
-            Some(Hover { contents, range })
-        })
+            None
+        };
+
+        Ok(Some(Hover {
+            contents,
+            range,
+            language,
+        }))
     }
 
     fn buffer_id_from_proto(message: &Self::ProtoRequest) -> u64 {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1499,7 +1499,11 @@ impl LspCommand for GetCodeActions {
     type ProtoRequest = proto::GetCodeActions;
 
     fn check_capabilities(&self, capabilities: &ServerCapabilities) -> bool {
-        capabilities.code_action_provider.is_some()
+        match &capabilities.code_action_provider {
+            None => false,
+            Some(lsp::CodeActionProviderCapability::Simple(false)) => false,
+            _ => true,
+        }
     }
 
     fn to_lsp(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -359,6 +359,7 @@ pub enum HoverBlockKind {
 pub struct Hover {
     pub contents: Vec<HoverBlock>,
     pub range: Option<Range<language::Anchor>>,
+    pub language: Option<Arc<Language>>,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-2209/popovers-dont-always-have-syntax-highlighted-code
Closes https://linear.app/zed-industries/issue/Z-2206/highlight-syntax-in-hover-docs

* Fix a ton of errors in our logs due to us not recognizing that `elixir-ls` does not support code actions.
* Syntax-highlight elixir code blocks in hover popovers