### PR TITLE
Z 1618/extend comments

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2171,60 +2171,60 @@ impl Editor {
                         indent.len = cmp::min(indent.len, start_point.column);
                         let start = selection.start;
                         let end = selection.end;
+                        let is_cursor = start == end;
                         let language_scope = buffer.language_scope_at(start);
-                        let (comment_delimiter, insert_extra_newline) = if let Some(language) =
-                            &language_scope
-                        {
-                            let leading_whitespace_len = buffer
-                                .reversed_chars_at(start)
-                                .take_while(|c| c.is_whitespace() && *c != '\n')
-                                .map(|c| c.len_utf8())
-                                .sum::<usize>();
+                        let (comment_delimiter, insert_extra_newline) =
+                            if let Some(language) = &language_scope {
+                                let leading_whitespace_len = buffer
+                                    .reversed_chars_at(start)
+                                    .take_while(|c| c.is_whitespace() && *c != '\n')
+                                    .map(|c| c.len_utf8())
+                                    .sum::<usize>();
 
-                            let trailing_whitespace_len = buffer
-                                .chars_at(end)
-                                .take_while(|c| c.is_whitespace() && *c != '\n')
-                                .map(|c| c.len_utf8())
-                                .sum::<usize>();
+                                let trailing_whitespace_len = buffer
+                                    .chars_at(end)
+                                    .take_while(|c| c.is_whitespace() && *c != '\n')
+                                    .map(|c| c.len_utf8())
+                                    .sum::<usize>();
 
-                            let insert_extra_newline =
-                                language.brackets().any(|(pair, enabled)| {
-                                    let pair_start = pair.start.trim_end();
-                                    let pair_end = pair.end.trim_start();
+                                let insert_extra_newline =
+                                    language.brackets().any(|(pair, enabled)| {
+                                        let pair_start = pair.start.trim_end();
+                                        let pair_end = pair.end.trim_start();
 
-                                    enabled
-                                        && pair.newline
-                                        && buffer.contains_str_at(
-                                            end + trailing_whitespace_len,
-                                            pair_end,
-                                        )
-                                        && buffer.contains_str_at(
-                                            (start - leading_whitespace_len)
-                                                .saturating_sub(pair_start.len()),
-                                            pair_start,
-                                        )
-                                });
-                            // Comment extension on newline is allowed only for cursor selections
-                            let comment_delimiter =
-                                language.line_comment_prefix().filter(|_| start == end);
-                            let comment_delimiter = if let Some(delimiter) = &comment_delimiter {
-                                buffer
-                                    .buffer_line_for_row(start_point.row)
-                                    .is_some_and(|(snapshot, range)| {
-                                        snapshot
-                                            .chars_for_range(range)
-                                            .skip_while(|c| c.is_whitespace())
-                                            .take(delimiter.len())
-                                            .eq(delimiter.chars())
-                                    })
-                                    .and_then(|_| comment_delimiter.cloned())
+                                        enabled
+                                            && pair.newline
+                                            && buffer.contains_str_at(
+                                                end + trailing_whitespace_len,
+                                                pair_end,
+                                            )
+                                            && buffer.contains_str_at(
+                                                (start - leading_whitespace_len)
+                                                    .saturating_sub(pair_start.len()),
+                                                pair_start,
+                                            )
+                                    });
+                                // Comment extension on newline is allowed only for cursor selections
+                                let comment_delimiter =
+                                    language.line_comment_prefix().filter(|_| is_cursor);
+                                let comment_delimiter = if let Some(delimiter) = comment_delimiter {
+                                    buffer
+                                        .buffer_line_for_row(start_point.row)
+                                        .is_some_and(|(snapshot, range)| {
+                                            snapshot
+                                                .chars_for_range(range)
+                                                .skip_while(|c| c.is_whitespace())
+                                                .take(delimiter.len())
+                                                .eq(delimiter.chars())
+                                        })
+                                        .then(|| delimiter.clone())
+                                } else {
+                                    None
+                                };
+                                (comment_delimiter, insert_extra_newline)
                             } else {
-                                None
+                                (None, false)
                             };
-                            (comment_delimiter, insert_extra_newline)
-                        } else {
-                            (None, false)
-                        };
 
                         let capacity_for_delimiter = comment_delimiter
                             .as_deref()

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1719,6 +1719,33 @@ async fn test_newline_below(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_newline_comments(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4)
+    });
+
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            line_comment: Some("//".into()),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+    cx.set_state(indoc! {"
+        // Fooˇ
+    "});
+
+    cx.update_editor(|e, cx| e.newline(&Newline, cx));
+    cx.assert_editor_state(indoc! {"
+        // Foo
+        //ˇ
+    "});
+}
+
+#[gpui::test]
 fn test_insert_with_old_selections(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Fixes Z-1618. In the current state, this only works for line comments such as `//` (and whatever's set in `{language}.toml` as a line_comment).

Release Notes:

- Comments are now extended on new line.

