### PR TITLE
Make the LSP log view searchable

### DIFF
--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -312,6 +312,7 @@ mod tests {
         let mut cx = EditorLspTestContext::new_rust(
             lsp::ServerCapabilities {
                 hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                type_definition_provider: Some(lsp::TypeDefinitionProviderCapability::Simple(true)),
                 ..Default::default()
             },
             cx,

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -792,6 +792,8 @@ impl LanguageServer {
             code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
             document_formatting_provider: Some(OneOf::Left(true)),
             document_range_formatting_provider: Some(OneOf::Left(true)),
+            definition_provider: Some(OneOf::Left(true)),
+            type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
             ..Default::default()
         }
     }

--- a/crates/lsp_log/src/lsp_log_tests.rs
+++ b/crates/lsp_log/src/lsp_log_tests.rs
@@ -76,10 +76,7 @@ async fn test_lsp_logs(cx: &mut TestAppContext) {
                 logs_selected: true,
             }]
         );
-        assert_eq!(
-            view.editor.as_ref().unwrap().read(cx).text(cx),
-            "hello from the server\n"
-        );
+        assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");
     });
 }
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -487,6 +487,14 @@ impl LspCommand for GetTypeDefinition {
     type LspRequest = lsp::request::GotoTypeDefinition;
     type ProtoRequest = proto::GetTypeDefinition;
 
+    fn check_capabilities(&self, capabilities: &ServerCapabilities) -> bool {
+        match &capabilities.type_definition_provider {
+            None => false,
+            Some(lsp::TypeDefinitionProviderCapability::Simple(false)) => false,
+            _ => true,
+        }
+    }
+
     fn to_lsp(
         &self,
         path: &Path,


### PR DESCRIPTION
Also, I noticed errors in the logs of the Elixir LSP that we were sending `goToTypeDefinition` requests, which that server does not support. We now respect that server capability.

Release Notes:

- N/A
