### PR TITLE
Add outline support for Ruby singleton methods

### DIFF
--- a/crates/zed/src/languages/ruby/outline.scm
+++ b/crates/zed/src/languages/ruby/outline.scm
@@ -6,6 +6,12 @@
     "def" @context
     name: (_) @name) @item
 
+(singleton_method
+    "def" @context
+    object: (_) @context
+    "." @context
+    name: (_) @name) @item
+
 (module
     "module" @context
     name: (_) @name) @item


### PR DESCRIPTION
This pull request add support for Ruby singleton methods in the document outline.

**Before**

<img width="1490" alt="outline-before" src="https://github.com/zed-industries/zed/assets/503025/e90afd4c-bcdd-477b-92cf-fe34cec54980">

**After**

<img width="1493" alt="outline-after" src="https://github.com/zed-industries/zed/assets/503025/067cc80b-7718-4395-9079-4677a689b9be">

Release Notes:

- Added support for singleton methods in Ruby outline view. Fixed [#1442](https://github.com/zed-industries/zed/issues/6111).
