### PR TITLE
Update JavaScript outline queries

### DIFF
--- a/crates/zed/src/languages/javascript/outline.scm
+++ b/crates/zed/src/languages/javascript/outline.scm
@@ -19,6 +19,13 @@
     name: (_) @name) @item
 
 (program
+    (export_statement
+        (lexical_declaration
+            ["let" "const"] @context
+            (variable_declarator
+                name: (_) @name) @item)))
+
+(program
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator


### PR DESCRIPTION
Add support for exported const declarations in the outline view. Did not include more context (e.g., whether or not the it's exported or not) because we're not doing that for TypeScript right now. We could do that in a follow up pull request, addressing both JavaScript and TypeScript at once.


**Before**

<img width="1186" alt="outline-before" src="https://github.com/zed-industries/zed/assets/503025/e72b0ed4-52b0-4a7c-af70-b2f4758e3554">

**After**

<img width="1186" alt="outline-after" src="https://github.com/zed-industries/zed/assets/503025/cd91bc7f-8ce3-485f-9b33-d487ad6c718d">


Release Notes:

- Added support for exported const declarations in the JavaScript outline view. Fixed [#1399](https://github.com/zed-industries/zed/issues/6098).