### PR TITLE
Do not rely on user's system time for telemetry events

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -4,14 +4,7 @@ use gpui::{executor::Background, serde_json, AppContext, Task};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use serde::Serialize;
-use std::{
-    env,
-    io::Write,
-    mem,
-    path::PathBuf,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{env, io::Write, mem, path::PathBuf, sync::Arc, time::Duration};
 use tempfile::NamedTempFile;
 use util::http::HttpClient;
 use util::{channel::ReleaseChannel, TryFutureExt};
@@ -59,7 +52,6 @@ struct ClickhouseEventRequestBody {
 
 #[derive(Serialize, Debug)]
 struct ClickhouseEventWrapper {
-    time: u128,
     signed_in: bool,
     #[serde(flatten)]
     event: ClickhouseEvent,
@@ -193,14 +185,9 @@ impl Telemetry {
 
         let mut state = self.state.lock();
         let signed_in = state.metrics_id.is_some();
-        state.clickhouse_events_queue.push(ClickhouseEventWrapper {
-            time: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-            signed_in,
-            event,
-        });
+        state
+            .clickhouse_events_queue
+            .push(ClickhouseEventWrapper { signed_in, event });
 
         if state.installation_id.is_some() {
             if state.clickhouse_events_queue.len() >= MAX_QUEUE_LEN {


### PR DESCRIPTION
Some user's don't have their system clocks configured right and we are seeing events 10 years into the future.  I'm stripping out the code that adds time via the client and am adding it in on zed.dev. We will lose a little accuracy, as the time will be when the batch hits the server, but I think its negligible (currently, batches send up every 30 seconds, at the max) and worth it to protect our data from user's who wonkily dont set care about their system time.

- https://github.com/zed-industries/zed.dev/pull/332

Release Notes:

- N/A