### PR TITLE
Add a syntax tree view, for developing and debugging language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7360,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.10"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=a2119cb6914d62e626fcc40684ef900d7fa90d86#a2119cb6914d62e626fcc40684ef900d7fa90d86"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=49226023693107fba9a1191136a4f47f38cdca73#49226023693107fba9a1191136a4f47f38cdca73"
 dependencies = [
  "cc",
  "regex",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-yaml"
 version = "0.0.1"
-source = "git+https://github.com/zed-industries/tree-sitter-yaml?rev=5694b7f290cd9ef998829a0a6d8391a666370886#5694b7f290cd9ef998829a0a6d8391a666370886"
+source = "git+https://github.com/zed-industries/tree-sitter-yaml?rev=f545a41f57502e1b5ddf2a6668896c1b0620f930#f545a41f57502e1b5ddf2a6668896c1b0620f930"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "language_tools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "client",
+ "collections",
+ "editor",
+ "env_logger 0.9.3",
+ "futures 0.3.28",
+ "gpui",
+ "language",
+ "lsp",
+ "project",
+ "serde",
+ "settings",
+ "theme",
+ "tree-sitter",
+ "unindent",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,28 +3780,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
-]
-
-[[package]]
-name = "lsp_log"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "client",
- "collections",
- "editor",
- "env_logger 0.9.3",
- "futures 0.3.28",
- "gpui",
- "language",
- "lsp",
- "project",
- "serde",
- "settings",
- "theme",
- "unindent",
- "util",
- "workspace",
 ]
 
 [[package]]
@@ -7358,8 +7359,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.9"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14#c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14"
+version = "0.20.10"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=a2119cb6914d62e626fcc40684ef900d7fa90d86#a2119cb6914d62e626fcc40684ef900d7fa90d86"
 dependencies = [
  "cc",
  "regex",
@@ -8829,11 +8830,11 @@ dependencies = [
  "journal",
  "language",
  "language_selector",
+ "language_tools",
  "lazy_static",
  "libc",
  "log",
  "lsp",
- "lsp_log",
  "node_runtime",
  "num_cpus",
  "outline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tree-sitter = "0.20"
 unindent = { version = "0.1.7" }
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "a2119cb6914d62e626fcc40684ef900d7fa90d86" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "49226023693107fba9a1191136a4f47f38cdca73" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ members = [
     "crates/journal",
     "crates/language",
     "crates/language_selector",
+    "crates/language_tools",
     "crates/live_kit_client",
     "crates/live_kit_server",
     "crates/lsp",
-    "crates/lsp_log",
     "crates/media",
     "crates/menu",
     "crates/node_runtime",
@@ -98,10 +98,11 @@ tempdir = { version = "0.3.7" }
 thiserror = { version = "1.0.29" }
 time = { version = "0.3", features = ["serde", "serde-well-known"] }
 toml = { version = "0.5" }
+tree-sitter = "0.20"
 unindent = { version = "0.1.7" }
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "a2119cb6914d62e626fcc40684ef900d7fa90d86" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -83,7 +83,7 @@ ctor.workspace = true
 env_logger.workspace = true
 rand.workspace = true
 unindent.workspace = true
-tree-sitter = "0.20"
+tree-sitter.workspace = true
 tree-sitter-rust = "0.20"
 tree-sitter-html = "0.19"
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259" }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7102,7 +7102,7 @@ impl Editor {
 
         let mut new_selections_by_buffer = HashMap::default();
         for selection in editor.selections.all::<usize>(cx) {
-            for (buffer, mut range) in
+            for (buffer, mut range, _) in
                 buffer.range_to_buffer_ranges(selection.start..selection.end, cx)
             {
                 if selection.reversed {

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1118,7 +1118,7 @@ impl MultiBuffer {
         &self,
         point: T,
         cx: &AppContext,
-    ) -> Option<(ModelHandle<Buffer>, usize)> {
+    ) -> Option<(ModelHandle<Buffer>, usize, ExcerptId)> {
         let snapshot = self.read(cx);
         let offset = point.to_offset(&snapshot);
         let mut cursor = snapshot.excerpts.cursor::<usize>();
@@ -1132,7 +1132,7 @@ impl MultiBuffer {
             let buffer_point = excerpt_start + offset - *cursor.start();
             let buffer = self.buffers.borrow()[&excerpt.buffer_id].buffer.clone();
 
-            (buffer, buffer_point)
+            (buffer, buffer_point, excerpt.id)
         })
     }
 
@@ -1387,7 +1387,7 @@ impl MultiBuffer {
         cx: &'a AppContext,
     ) -> Option<Arc<Language>> {
         self.point_to_buffer_offset(point, cx)
-            .and_then(|(buffer, offset)| buffer.read(cx).language_at(offset))
+            .and_then(|(buffer, offset, _)| buffer.read(cx).language_at(offset))
     }
 
     pub fn settings_at<'a, T: ToOffset>(
@@ -1397,7 +1397,7 @@ impl MultiBuffer {
     ) -> &'a LanguageSettings {
         let mut language = None;
         let mut file = None;
-        if let Some((buffer, offset)) = self.point_to_buffer_offset(point, cx) {
+        if let Some((buffer, offset, _)) = self.point_to_buffer_offset(point, cx) {
             let buffer = buffer.read(cx);
             language = buffer.language_at(offset);
             file = buffer.file();

--- a/crates/editor/src/multi_buffer.rs
+++ b/crates/editor/src/multi_buffer.rs
@@ -1140,7 +1140,7 @@ impl MultiBuffer {
         &self,
         range: Range<T>,
         cx: &AppContext,
-    ) -> Vec<(ModelHandle<Buffer>, Range<usize>)> {
+    ) -> Vec<(ModelHandle<Buffer>, Range<usize>, ExcerptId)> {
         let snapshot = self.read(cx);
         let start = range.start.to_offset(&snapshot);
         let end = range.end.to_offset(&snapshot);
@@ -1165,7 +1165,7 @@ impl MultiBuffer {
             let start = excerpt_start + (cmp::max(start, *cursor.start()) - *cursor.start());
             let end = excerpt_start + (cmp::min(end, end_before_newline) - *cursor.start());
             let buffer = self.buffers.borrow()[&excerpt.buffer_id].buffer.clone();
-            result.push((buffer, start..end));
+            result.push((buffer, start..end, excerpt.id));
             cursor.next(&());
         }
 
@@ -5196,7 +5196,7 @@ mod tests {
                     .range_to_buffer_ranges(start_ix..end_ix, cx);
                 let excerpted_buffers_text = excerpted_buffer_ranges
                     .iter()
-                    .map(|(buffer, buffer_range)| {
+                    .map(|(buffer, buffer_range, _)| {
                         buffer
                             .read(cx)
                             .text_for_range(buffer_range.clone())

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -55,7 +55,7 @@ serde_json.workspace = true
 similar = "1.3"
 smallvec.workspace = true
 smol.workspace = true
-tree-sitter = "0.20"
+tree-sitter.workspace = true
 tree-sitter-rust = { version = "*", optional = true }
 tree-sitter-typescript = { version = "*", optional = true }
 unicase = "2.6"

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2117,6 +2117,10 @@ impl BufferSnapshot {
         }
     }
 
+    pub fn syntax_layers(&self) -> impl Iterator<Item = SyntaxLayerInfo> + '_ {
+        self.syntax.layers_for_range(0..self.len(), &self.text)
+    }
+
     pub fn syntax_layer_at<D: ToOffset>(&self, position: D) -> Option<SyntaxLayerInfo> {
         let offset = position.to_offset(self);
         self.syntax

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -8,7 +8,8 @@ use crate::{
     language_settings::{language_settings, LanguageSettings},
     outline::OutlineItem,
     syntax_map::{
-        SyntaxMap, SyntaxMapCapture, SyntaxMapCaptures, SyntaxSnapshot, ToTreeSitterPoint,
+        SyntaxLayerInfo, SyntaxMap, SyntaxMapCapture, SyntaxMapCaptures, SyntaxSnapshot,
+        ToTreeSitterPoint,
     },
     CodeLabel, LanguageScope, Outline,
 };
@@ -2116,12 +2117,16 @@ impl BufferSnapshot {
         }
     }
 
-    pub fn language_at<D: ToOffset>(&self, position: D) -> Option<&Arc<Language>> {
+    pub fn syntax_layer_at<D: ToOffset>(&self, position: D) -> Option<SyntaxLayerInfo> {
         let offset = position.to_offset(self);
         self.syntax
             .layers_for_range(offset..offset, &self.text)
-            .filter(|l| l.node.end_byte() > offset)
+            .filter(|l| l.node().end_byte() > offset)
             .last()
+    }
+
+    pub fn language_at<D: ToOffset>(&self, position: D) -> Option<&Arc<Language>> {
+        self.syntax_layer_at(position)
             .map(|info| info.language)
             .or(self.language.as_ref())
     }
@@ -2140,7 +2145,7 @@ impl BufferSnapshot {
         if let Some(layer_info) = self
             .syntax
             .layers_for_range(offset..offset, &self.text)
-            .filter(|l| l.node.end_byte() > offset)
+            .filter(|l| l.node().end_byte() > offset)
             .last()
         {
             Some(LanguageScope {
@@ -2188,7 +2193,7 @@ impl BufferSnapshot {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let mut result: Option<Range<usize>> = None;
         'outer: for layer in self.syntax.layers_for_range(range.clone(), &self.text) {
-            let mut cursor = layer.node.walk();
+            let mut cursor = layer.node().walk();
 
             // Descend to the first leaf that touches the start of the range,
             // and if the range is non-empty, extends beyond the start.

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2242,7 +2242,7 @@ fn get_tree_sexp(buffer: &ModelHandle<Buffer>, cx: &gpui::TestAppContext) -> Str
     buffer.read_with(cx, |buffer, _| {
         let snapshot = buffer.snapshot();
         let layers = snapshot.syntax.layers(buffer.as_text_snapshot());
-        layers[0].node.to_sexp()
+        layers[0].node().to_sexp()
     })
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -57,6 +57,7 @@ pub use buffer::*;
 pub use diagnostic_set::DiagnosticEntry;
 pub use lsp::LanguageServerId;
 pub use outline::{Outline, OutlineItem};
+pub use syntax_map::{OwnedSyntaxLayerInfo, SyntaxLayerInfo};
 pub use tree_sitter::{Parser, Tree};
 
 pub fn init(cx: &mut AppContext) {

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "lsp_log"
+name = "language_tools"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
 [lib]
-path = "src/lsp_log.rs"
+path = "src/language_tools.rs"
 doctest = false
 
 [dependencies]
@@ -22,6 +22,7 @@ lsp = { path = "../lsp" }
 futures.workspace = true
 serde.workspace = true
 anyhow.workspace = true
+tree-sitter.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/language_tools/src/language_tools.rs
+++ b/crates/language_tools/src/language_tools.rs
@@ -7,7 +7,7 @@ mod lsp_log_tests;
 use gpui::AppContext;
 
 pub use lsp_log::{LogStore, LspLogToolbarItemView, LspLogView};
-pub use syntax_tree_view::SyntaxTreeView;
+pub use syntax_tree_view::{SyntaxTreeToolbarItemView, SyntaxTreeView};
 
 pub fn init(cx: &mut AppContext) {
     lsp_log::init(cx);

--- a/crates/language_tools/src/language_tools.rs
+++ b/crates/language_tools/src/language_tools.rs
@@ -1,0 +1,15 @@
+mod lsp_log;
+mod syntax_tree_view;
+
+#[cfg(test)]
+mod lsp_log_tests;
+
+use gpui::AppContext;
+
+pub use lsp_log::{LogStore, LspLogToolbarItemView, LspLogView};
+pub use syntax_tree_view::SyntaxTreeView;
+
+pub fn init(cx: &mut AppContext) {
+    lsp_log::init(cx);
+    syntax_tree_view::init(cx);
+}

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -541,12 +541,7 @@ impl View for LspLogToolbarItemView {
         let theme = theme::current(cx).clone();
         let Some(log_view) = self.log_view.as_ref() else { return Empty::new().into_any() };
         let log_view = log_view.read(cx);
-
-        let menu_rows = self
-            .log_view
-            .as_ref()
-            .and_then(|view| view.read(cx).menu_items(cx))
-            .unwrap_or_default();
+        let menu_rows = log_view.menu_items(cx).unwrap_or_default();
 
         let current_server_id = log_view.current_server_id;
         let current_server = current_server_id.and_then(|current_server_id| {
@@ -583,7 +578,7 @@ impl View for LspLogToolbarItemView {
                                     )
                                 }))
                                 .contained()
-                                .with_style(theme.lsp_log_menu.container)
+                                .with_style(theme.toolbar_dropdown_menu.container)
                                 .constrained()
                                 .with_width(400.)
                                 .with_height(400.)
@@ -593,6 +588,7 @@ impl View for LspLogToolbarItemView {
                             cx.notify()
                         }),
                     )
+                    .with_hoverable(true)
                     .with_fit_mode(OverlayFitMode::SwitchAnchor)
                     .with_anchor_corner(AnchorCorner::TopLeft)
                     .with_z_index(999)
@@ -685,7 +681,7 @@ impl LspLogToolbarItemView {
                     )
                 })
                 .unwrap_or_else(|| "No server selected".into());
-            let style = theme.lsp_log_menu.header.style_for(state, false);
+            let style = theme.toolbar_dropdown_menu.header.style_for(state, false);
             Label::new(label, style.text.clone())
                 .contained()
                 .with_style(style.container)
@@ -711,7 +707,7 @@ impl LspLogToolbarItemView {
 
         Flex::column()
             .with_child({
-                let style = &theme.lsp_log_menu.server;
+                let style = &theme.toolbar_dropdown_menu.section_header;
                 Label::new(
                     format!("{} ({})", name.0, worktree.read(cx).root_name()),
                     style.text.clone(),
@@ -719,16 +715,19 @@ impl LspLogToolbarItemView {
                 .contained()
                 .with_style(style.container)
                 .constrained()
-                .with_height(theme.lsp_log_menu.row_height)
+                .with_height(theme.toolbar_dropdown_menu.row_height)
             })
             .with_child(
                 MouseEventHandler::<ActivateLog, _>::new(id.0, cx, move |state, _| {
-                    let style = theme.lsp_log_menu.item.style_for(state, logs_selected);
+                    let style = theme
+                        .toolbar_dropdown_menu
+                        .item
+                        .style_for(state, logs_selected);
                     Label::new(SERVER_LOGS, style.text.clone())
                         .contained()
                         .with_style(style.container)
                         .constrained()
-                        .with_height(theme.lsp_log_menu.row_height)
+                        .with_height(theme.toolbar_dropdown_menu.row_height)
                 })
                 .with_cursor_style(CursorStyle::PointingHand)
                 .on_click(MouseButton::Left, move |_, view, cx| {
@@ -737,12 +736,15 @@ impl LspLogToolbarItemView {
             )
             .with_child(
                 MouseEventHandler::<ActivateRpcTrace, _>::new(id.0, cx, move |state, cx| {
-                    let style = theme.lsp_log_menu.item.style_for(state, rpc_trace_selected);
+                    let style = theme
+                        .toolbar_dropdown_menu
+                        .item
+                        .style_for(state, rpc_trace_selected);
                     Flex::row()
                         .with_child(
                             Label::new(RPC_MESSAGES, style.text.clone())
                                 .constrained()
-                                .with_height(theme.lsp_log_menu.row_height),
+                                .with_height(theme.toolbar_dropdown_menu.row_height),
                         )
                         .with_child(
                             ui::checkbox_with_label::<Self, _, Self, _>(
@@ -761,7 +763,7 @@ impl LspLogToolbarItemView {
                         .contained()
                         .with_style(style.container)
                         .constrained()
-                        .with_height(theme.lsp_log_menu.row_height)
+                        .with_height(theme.toolbar_dropdown_menu.row_height)
                 })
                 .with_cursor_style(CursorStyle::PointingHand)
                 .on_click(MouseButton::Left, move |_, view, cx| {

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-mod lsp_log_tests;
-
 use collections::HashMap;
 use editor::Editor;
 use futures::{channel::mpsc, StreamExt};
@@ -27,7 +24,7 @@ use workspace::{
 const SEND_LINE: &str = "// Send:\n";
 const RECEIVE_LINE: &str = "// Receive:\n";
 
-struct LogStore {
+pub struct LogStore {
     projects: HashMap<WeakModelHandle<Project>, ProjectState>,
     io_tx: mpsc::UnboundedSender<(WeakModelHandle<Project>, LanguageServerId, bool, String)>,
 }
@@ -49,10 +46,10 @@ struct LanguageServerRpcState {
 }
 
 pub struct LspLogView {
+    pub(crate) editor: ViewHandle<Editor>,
     log_store: ModelHandle<LogStore>,
     current_server_id: Option<LanguageServerId>,
     is_showing_rpc_trace: bool,
-    editor: ViewHandle<Editor>,
     project: ModelHandle<Project>,
 }
 
@@ -68,13 +65,13 @@ enum MessageKind {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct LogMenuItem {
-    server_id: LanguageServerId,
-    server_name: LanguageServerName,
-    worktree: ModelHandle<Worktree>,
-    rpc_trace_enabled: bool,
-    rpc_trace_selected: bool,
-    logs_selected: bool,
+pub(crate) struct LogMenuItem {
+    pub server_id: LanguageServerId,
+    pub server_name: LanguageServerName,
+    pub worktree: ModelHandle<Worktree>,
+    pub rpc_trace_enabled: bool,
+    pub rpc_trace_selected: bool,
+    pub logs_selected: bool,
 }
 
 actions!(log, [OpenLanguageServerLogs]);
@@ -114,7 +111,7 @@ pub fn init(cx: &mut AppContext) {
 }
 
 impl LogStore {
-    fn new(cx: &mut ModelContext<Self>) -> Self {
+    pub fn new(cx: &mut ModelContext<Self>) -> Self {
         let (io_tx, mut io_rx) = mpsc::unbounded();
         let this = Self {
             projects: HashMap::default(),
@@ -320,7 +317,7 @@ impl LogStore {
 }
 
 impl LspLogView {
-    fn new(
+    pub fn new(
         project: ModelHandle<Project>,
         log_store: ModelHandle<LogStore>,
         cx: &mut ViewContext<Self>,
@@ -360,7 +357,7 @@ impl LspLogView {
         editor
     }
 
-    fn menu_items<'a>(&'a self, cx: &'a AppContext) -> Option<Vec<LogMenuItem>> {
+    pub(crate) fn menu_items<'a>(&'a self, cx: &'a AppContext) -> Option<Vec<LogMenuItem>> {
         let log_store = self.log_store.read(cx);
         let state = log_store.projects.get(&self.project.downgrade())?;
         let mut rows = self

--- a/crates/language_tools/src/lsp_log_tests.rs
+++ b/crates/language_tools/src/lsp_log_tests.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+
+use crate::lsp_log::LogMenuItem;
+
 use super::*;
+use futures::StreamExt;
 use gpui::{serde_json::json, TestAppContext};
-use language::{tree_sitter_rust, FakeLspAdapter, Language, LanguageConfig};
-use project::FakeFs;
+use language::{tree_sitter_rust, FakeLspAdapter, Language, LanguageConfig, LanguageServerName};
+use project::{FakeFs, Project};
 use settings::SettingsStore;
 
 #[gpui::test]

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -1,0 +1,297 @@
+use editor::{scroll::autoscroll::Autoscroll, Anchor, Editor, ExcerptId};
+use gpui::{
+    actions,
+    elements::{Empty, Label, MouseEventHandler, UniformList, UniformListState},
+    fonts::TextStyle,
+    platform::MouseButton,
+    AppContext, Element, Entity, ModelHandle, View, ViewContext, ViewHandle,
+};
+use language::{Buffer, OwnedSyntaxLayerInfo};
+use std::ops::Range;
+use theme::ThemeSettings;
+use workspace::{
+    item::{Item, ItemHandle},
+    Workspace,
+};
+
+actions!(log, [OpenSyntaxTreeView]);
+
+pub fn init(cx: &mut AppContext) {
+    cx.add_action(
+        move |workspace: &mut Workspace, _: &OpenSyntaxTreeView, cx: _| {
+            let syntax_tree_view = cx.add_view(|cx| SyntaxTreeView::new(workspace, cx));
+            workspace.add_item(Box::new(syntax_tree_view), cx);
+        },
+    );
+}
+
+pub struct SyntaxTreeView {
+    editor: Option<(ViewHandle<Editor>, gpui::Subscription)>,
+    buffer: Option<(ModelHandle<Buffer>, usize, ExcerptId)>,
+    layer: Option<OwnedSyntaxLayerInfo>,
+    hover_y: Option<f32>,
+    line_height: Option<f32>,
+    list_state: UniformListState,
+    active_descendant_ix: Option<usize>,
+    highlighted_active_descendant: bool,
+}
+
+impl SyntaxTreeView {
+    pub fn new(workspace: &Workspace, cx: &mut ViewContext<Self>) -> Self {
+        let mut this = Self {
+            list_state: UniformListState::default(),
+            editor: None,
+            buffer: None,
+            layer: None,
+            hover_y: None,
+            line_height: None,
+            active_descendant_ix: None,
+            highlighted_active_descendant: false,
+        };
+
+        this.workspace_updated(workspace.active_item(cx), cx);
+        cx.observe(
+            &workspace.weak_handle().upgrade(cx).unwrap(),
+            |this, workspace, cx| {
+                this.workspace_updated(workspace.read(cx).active_item(cx), cx);
+            },
+        )
+        .detach();
+
+        this
+    }
+
+    fn workspace_updated(
+        &mut self,
+        active_item: Option<Box<dyn ItemHandle>>,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(item) = active_item {
+            if item.id() != cx.view_id() {
+                if let Some(editor) = item.act_as::<Editor>(cx) {
+                    self.set_editor(editor, cx);
+                }
+            }
+        }
+    }
+
+    fn set_editor(&mut self, editor: ViewHandle<Editor>, cx: &mut ViewContext<Self>) {
+        if let Some((current_editor, _)) = &self.editor {
+            if current_editor == &editor {
+                return;
+            }
+            editor.update(cx, |editor, cx| {
+                editor.clear_background_highlights::<Self>(cx);
+            });
+        }
+
+        let subscription = cx.subscribe(&editor, |this, editor, event, cx| {
+            let selection_changed = match event {
+                editor::Event::Reparsed => false,
+                editor::Event::SelectionsChanged { .. } => true,
+                _ => return,
+            };
+            this.editor_updated(&editor, selection_changed, cx);
+        });
+
+        self.editor_updated(&editor, true, cx);
+        self.editor = Some((editor, subscription));
+    }
+
+    fn editor_updated(
+        &mut self,
+        editor: &ViewHandle<Editor>,
+        selection_changed: bool,
+        cx: &mut ViewContext<Self>,
+    ) {
+        let editor = editor.read(cx);
+        if selection_changed {
+            let cursor = editor.selections.last::<usize>(cx).end;
+            self.buffer = editor.buffer().read(cx).point_to_buffer_offset(cursor, cx);
+            self.layer = self.buffer.as_ref().and_then(|(buffer, offset, _)| {
+                buffer
+                    .read(cx)
+                    .snapshot()
+                    .syntax_layer_at(*offset)
+                    .map(|l| l.to_owned())
+            });
+        }
+        cx.notify();
+    }
+
+    fn hover_state_changed(&mut self, cx: &mut ViewContext<SyntaxTreeView>) {
+        if let Some((y, line_height)) = self.hover_y.zip(self.line_height) {
+            let ix = ((self.list_state.scroll_top() + y) / line_height) as usize;
+            if self.active_descendant_ix != Some(ix) {
+                self.active_descendant_ix = Some(ix);
+                self.highlighted_active_descendant = false;
+                cx.notify();
+            }
+        }
+    }
+
+    fn handle_click(&mut self, y: f32, cx: &mut ViewContext<SyntaxTreeView>) {
+        if let Some(line_height) = self.line_height {
+            let ix = ((self.list_state.scroll_top() + y) / line_height) as usize;
+            if let Some(layer) = &self.layer {
+                let mut cursor = layer.node().walk();
+                cursor.goto_descendant(ix);
+                let node = cursor.node();
+                self.update_editor_with_node_range(node, cx, |editor, range, cx| {
+                    editor.change_selections(Some(Autoscroll::newest()), cx, |selections| {
+                        selections.select_ranges(vec![range]);
+                    });
+                });
+            }
+        }
+    }
+
+    fn update_editor_with_node_range(
+        &self,
+        node: tree_sitter::Node,
+        cx: &mut ViewContext<Self>,
+        mut f: impl FnMut(&mut Editor, Range<Anchor>, &mut ViewContext<Editor>),
+    ) {
+        let range = node.byte_range();
+        if let Some((editor, _)) = &self.editor {
+            if let Some((buffer, _, excerpt_id)) = &self.buffer {
+                let buffer = &buffer.read(cx);
+                let multibuffer = editor.read(cx).buffer();
+                let multibuffer = multibuffer.read(cx).snapshot(cx);
+                let start =
+                    multibuffer.anchor_in_excerpt(*excerpt_id, buffer.anchor_before(range.start));
+                let end =
+                    multibuffer.anchor_in_excerpt(*excerpt_id, buffer.anchor_after(range.end));
+                editor.update(cx, |editor, cx| {
+                    f(editor, start..end, cx);
+                });
+            }
+        }
+    }
+
+    fn node_is_active(&mut self, node: tree_sitter::Node, cx: &mut ViewContext<Self>) {
+        if self.highlighted_active_descendant {
+            return;
+        }
+        self.highlighted_active_descendant = true;
+        self.update_editor_with_node_range(node, cx, |editor, range, cx| {
+            editor.clear_background_highlights::<Self>(cx);
+            editor.highlight_background::<Self>(
+                vec![range],
+                |theme| theme.editor.document_highlight_write_background,
+                cx,
+            );
+        });
+    }
+}
+
+impl Entity for SyntaxTreeView {
+    type Event = ();
+}
+
+impl View for SyntaxTreeView {
+    fn ui_name() -> &'static str {
+        "SyntaxTreeView"
+    }
+
+    fn render(&mut self, cx: &mut gpui::ViewContext<'_, '_, Self>) -> gpui::AnyElement<Self> {
+        let settings = settings::get::<ThemeSettings>(cx);
+        let font_family_id = settings.buffer_font_family;
+        let font_family_name = cx.font_cache().family_name(font_family_id).unwrap();
+        let font_properties = Default::default();
+        let font_id = cx
+            .font_cache()
+            .select_font(font_family_id, &font_properties)
+            .unwrap();
+        let font_size = settings.buffer_font_size(cx);
+
+        let editor_theme = settings.theme.editor.clone();
+        let style = TextStyle {
+            color: editor_theme.text_color,
+            font_family_name,
+            font_family_id,
+            font_id,
+            font_size,
+            font_properties: Default::default(),
+            underline: Default::default(),
+        };
+        self.line_height = Some(cx.font_cache().line_height(font_size));
+
+        self.hover_state_changed(cx);
+
+        if let Some(layer) = &self.layer {
+            let layer = layer.clone();
+            return MouseEventHandler::<Self, Self>::new(0, cx, move |_, cx| {
+                UniformList::new(
+                    self.list_state.clone(),
+                    layer.node().descendant_count(),
+                    cx,
+                    move |this, range, items, cx| {
+                        let mut cursor = layer.node().walk();
+                        let mut descendant_ix = range.start as usize;
+                        cursor.goto_descendant(descendant_ix);
+                        let mut depth = cursor.depth();
+                        let mut visited_children = false;
+                        while descendant_ix < range.end {
+                            if visited_children {
+                                if cursor.goto_next_sibling() {
+                                    visited_children = false;
+                                } else if cursor.goto_parent() {
+                                    depth -= 1;
+                                } else {
+                                    break;
+                                }
+                            } else {
+                                let node = cursor.node();
+                                let is_hovered = Some(descendant_ix) == this.active_descendant_ix;
+                                if is_hovered {
+                                    this.node_is_active(node, cx);
+                                }
+                                items.push(
+                                    Label::new(node.kind(), style.clone())
+                                        .contained()
+                                        .with_background_color(if is_hovered {
+                                            editor_theme.active_line_background
+                                        } else {
+                                            Default::default()
+                                        })
+                                        .with_padding_left(depth as f32 * 10.0)
+                                        .into_any(),
+                                );
+                                descendant_ix += 1;
+                                if cursor.goto_first_child() {
+                                    depth += 1;
+                                } else {
+                                    visited_children = true;
+                                }
+                            }
+                        }
+                    },
+                )
+            })
+            .on_move(move |event, this, cx| {
+                let y = event.position.y() - event.region.origin_y();
+                this.hover_y = Some(y);
+                this.hover_state_changed(cx);
+            })
+            .on_click(MouseButton::Left, move |event, this, cx| {
+                let y = event.position.y() - event.region.origin_y();
+                this.handle_click(y, cx);
+            })
+            .into_any();
+        }
+
+        Empty::new().into_any()
+    }
+}
+
+impl Item for SyntaxTreeView {
+    fn tab_content<V: View>(
+        &self,
+        _: Option<usize>,
+        style: &theme::Tab,
+        _: &AppContext,
+    ) -> gpui::AnyElement<V> {
+        Label::new("Syntax Tree", style.label.clone()).into_any()
+    }
+}

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -530,6 +530,7 @@ impl SyntaxTreeToolbarItemView {
             let layer = snapshot.syntax_layers().nth(layer_ix)?;
             buffer_state.active_layer = Some(layer.to_owned());
             view.selected_descendant_ix = None;
+            self.menu_open = false;
             cx.notify();
             Some(())
         })

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -31,7 +31,7 @@ serde_derive.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
 toml.workspace = true
-tree-sitter = "*"
+tree-sitter.workspace = true
 tree-sitter-json = "*"
 
 [dev-dependencies]

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -44,7 +44,7 @@ pub struct Theme {
     pub context_menu: ContextMenu,
     pub contacts_popover: ContactsPopover,
     pub contact_list: ContactList,
-    pub lsp_log_menu: LspLogMenu,
+    pub toolbar_dropdown_menu: DropdownMenu,
     pub copilot: Copilot,
     pub contact_finder: ContactFinder,
     pub project_panel: ProjectPanel,
@@ -246,13 +246,24 @@ pub struct ContactFinder {
 }
 
 #[derive(Deserialize, Default)]
-pub struct LspLogMenu {
+pub struct DropdownMenu {
     #[serde(flatten)]
     pub container: ContainerStyle,
-    pub header: Interactive<ContainedText>,
-    pub server: ContainedText,
-    pub item: Interactive<ContainedText>,
+    pub header: Interactive<DropdownMenuItem>,
+    pub section_header: ContainedText,
+    pub item: Interactive<DropdownMenuItem>,
     pub row_height: f32,
+}
+
+#[derive(Deserialize, Default)]
+pub struct DropdownMenuItem {
+    #[serde(flatten)]
+    pub container: ContainerStyle,
+    #[serde(flatten)]
+    pub text: TextStyle,
+    pub secondary_text: Option<TextStyle>,
+    #[serde(default)]
+    pub secondary_text_spacing: f32,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -45,7 +45,7 @@ journal = { path = "../journal" }
 language = { path = "../language" }
 language_selector = { path = "../language_selector" }
 lsp = { path = "../lsp" }
-lsp_log = { path = "../lsp_log" }
+language_tools = { path = "../language_tools" }
 node_runtime = { path = "../node_runtime" }
 ai = { path = "../ai" }
 outline = { path = "../outline" }
@@ -102,7 +102,7 @@ tempdir.workspace = true
 thiserror.workspace = true
 tiny_http = "0.8"
 toml.workspace = true
-tree-sitter = "0.20"
+tree-sitter.workspace = true
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
 tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -191,7 +191,7 @@ fn main() {
         language_selector::init(cx);
         theme_selector::init(cx);
         activity_indicator::init(cx);
-        lsp_log::init(cx);
+        language_tools::init(cx);
         call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
         collab_ui::init(&app_state, cx);
         feedback::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -312,7 +312,7 @@ pub fn initialize_workspace(
                                 let feedback_info_text = cx.add_view(|_| FeedbackInfoText::new());
                                 toolbar.add_item(feedback_info_text, cx);
                                 let lsp_log_item =
-                                    cx.add_view(|_| lsp_log::LspLogToolbarItemView::new());
+                                    cx.add_view(|_| language_tools::LspLogToolbarItemView::new());
                                 toolbar.add_item(lsp_log_item, cx);
                             })
                         });

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -314,6 +314,9 @@ pub fn initialize_workspace(
                                 let lsp_log_item =
                                     cx.add_view(|_| language_tools::LspLogToolbarItemView::new());
                                 toolbar.add_item(lsp_log_item, cx);
+                                let syntax_tree_item = cx
+                                    .add_view(|_| language_tools::SyntaxTreeToolbarItemView::new());
+                                toolbar.add_item(syntax_tree_item, cx);
                             })
                         });
                     }

--- a/styles/src/styleTree/app.ts
+++ b/styles/src/styleTree/app.ts
@@ -17,7 +17,7 @@ import projectSharedNotification from "./projectSharedNotification"
 import tooltip from "./tooltip"
 import terminal from "./terminal"
 import contactList from "./contactList"
-import lspLogMenu from "./lspLogMenu"
+import toolbarDropdownMenu from "./toolbarDropdownMenu"
 import incomingCallNotification from "./incomingCallNotification"
 import { ColorScheme } from "../theme/colorScheme"
 import feedback from "./feedback"
@@ -46,7 +46,7 @@ export default function app(colorScheme: ColorScheme): Object {
         contactsPopover: contactsPopover(colorScheme),
         contactFinder: contactFinder(colorScheme),
         contactList: contactList(colorScheme),
-        lspLogMenu: lspLogMenu(colorScheme),
+        toolbarDropdownMenu: toolbarDropdownMenu(colorScheme),
         search: search(colorScheme),
         sharedScreen: sharedScreen(colorScheme),
         updateNotification: updateNotification(colorScheme),

--- a/styles/src/styleTree/toolbarDropdownMenu.ts
+++ b/styles/src/styleTree/toolbarDropdownMenu.ts
@@ -1,7 +1,7 @@
 import { ColorScheme } from "../theme/colorScheme"
 import { background, border, text } from "./components"
 
-export default function contactsPanel(colorScheme: ColorScheme) {
+export default function dropdownMenu(colorScheme: ColorScheme) {
     let layer = colorScheme.middle
 
     return {
@@ -11,6 +11,8 @@ export default function contactsPanel(colorScheme: ColorScheme) {
         shadow: colorScheme.popoverShadow,
         header: {
             ...text(layer, "sans", { size: "sm" }),
+            secondaryText: text(layer, "sans", { size: "sm", color: "#aaaaaa" }),
+            secondaryTextSpacing: 10,
             padding: { left: 8, right: 8, top: 2, bottom: 2 },
             cornerRadius: 6,
             background: background(layer, "on"),
@@ -20,12 +22,14 @@ export default function contactsPanel(colorScheme: ColorScheme) {
                 ...text(layer, "sans", "hovered", { size: "sm" }),
             }
         },
-        server: {
+        sectionHeader: {
             ...text(layer, "sans", { size: "sm" }),
             padding: { left: 8, right: 8, top: 8, bottom: 8 },
         },
         item: {
             ...text(layer, "sans", { size: "sm" }),
+            secondaryTextSpacing: 10,
+            secondaryText: text(layer, "sans", { size: "sm" }),
             padding: { left: 18, right: 18, top: 2, bottom: 2 },
             hover: {
                 background: background(layer, "hovered"),


### PR DESCRIPTION
This PR adds a syntax tree view, which lets you view the syntax tree of any layer in the active editor's `SyntaxMap`.

This view uses some new APIs that I added to Tree-sitter, which allow us to efficiently render the syntax tree using a `UniformList`. Tree-sitter PR: https://github.com/tree-sitter/tree-sitter/pull/2316

![Screen Shot 2023-06-12 at 3 33 36 PM](https://github.com/zed-industries/zed/assets/326587/2a27ee7b-bf29-4b3b-bfa8-fb47f97a2785)

Release Notes:

- Added a *syntax tree view* that shows Zed's internal syntax tree(s) for the active editor. You can open it running the `debug: open syntax tree view` command from the command palette.
