### PR TITLE
Remove panic when programatically updating an invalid setting

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7272,7 +7272,7 @@ impl Editor {
 
         let vim_mode = cx
             .global::<SettingsStore>()
-            .untyped_user_settings()
+            .raw_user_settings()
             .get("vim_mode")
             == Some(&serde_json::Value::Bool(true));
         let telemetry_settings = *settings::get::<TelemetrySettings>(cx);


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2170/thread-main-panicked-at-could-not-deserialize-setting-type-welcomebase
Fixes https://linear.app/zed-industries/issue/Z-2228/thread-main-panicked-at-could-not-deserialize-setting-type