### PR TITLE
Fix issues with syntax highlighting in elixir and heex

### DIFF
--- a/crates/zed/src/languages/elixir/highlights.scm
+++ b/crates/zed/src/languages/elixir/highlights.scm
@@ -36,8 +36,6 @@
 
 (char) @constant
 
-(interpolation "#{" @punctuation.special "}" @punctuation.special) @embedded
-
 (escape_sequence) @string.escape
 
 [
@@ -146,3 +144,10 @@
   "<<"
   ">>"
 ] @punctuation.bracket
+
+(interpolation "#{" @punctuation.special "}" @punctuation.special) @embedded
+
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @embedded)
+ (#eq? @_sigil_name "H"))

--- a/crates/zed/src/languages/heex/highlights.scm
+++ b/crates/zed/src/languages/heex/highlights.scm
@@ -1,17 +1,11 @@
 ; HEEx delimiters
 [
-  "%>"
   "--%>"
   "-->"
   "/>"
   "<!"
   "<!--"
   "<"
-  "<%!--"
-  "<%"
-  "<%#"
-  "<%%="
-  "<%="
   "</"
   "</:"
   "<:"
@@ -19,6 +13,15 @@
   "{"
   "}"
 ] @punctuation.bracket
+
+[
+  "<%!--"
+  "<%"
+  "<%#"
+  "<%%="
+  "<%="
+  "%>"
+] @keyword
 
 ; HEEx operators are highlighted as such
 "=" @operator

--- a/crates/zed/src/languages/heex/injections.scm
+++ b/crates/zed/src/languages/heex/injections.scm
@@ -1,11 +1,13 @@
-((directive (partial_expression_value) @content)
- (#set! language "elixir")
- (#set! include-children)
- (#set! combined))
-
-; Regular expression_values do not need to be combined
-((directive (expression_value) @content)
- (#set! language "elixir"))
+(
+  (directive
+    [
+      (partial_expression_value)
+      (expression_value)
+      (ending_expression_value)
+    ] @content)
+  (#set! language "elixir")
+  (#set! combined)
+)
 
 ; expressions live within HTML tags, and do not need to be combined
 ;     <link href={ Routes.static_path(..) } />


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2391/text-within-h-isnt-highlighted-the-same-as-in-heex-files
Fixes https://linear.app/zed-industries/issue/Z-2415/syntax-highlighting-bug-in-strings

Release Notes:

- Fixed some issues with syntax highlighting in Elixir and Heex.

If the release notes are only intended for a specific release channel only, add `(<release_channel>-only)` to the end of the release note line.
These will be removed by the person making the release.
