### PR TITLE
Instruct the assistant to reply to a specific message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "smol",
  "theme",
  "tiktoken-rs",
  "util",

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -28,6 +28,7 @@ isahc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+smol.workspace = true
 tiktoken-rs = "0.4"
 
 [dev-dependencies]

--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
 // Data types for chat completion requests
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct OpenAIRequest {
     model: String,
     messages: Vec<RequestMessage>,


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-2384/hitting-cmd-enter-in-a-user-or-system-message-should-generate-a

Release Notes:

- Introduced the ability to generate assistant messages for any user/system message, as well as generating multiple assists at the same time, one for each cursor. (preview-only)