### PR TITLE
Avoid assigning NSCursor style when it already is that style

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -786,7 +786,7 @@ impl platform::Platform for MacPlatform {
 
     fn set_cursor_style(&self, style: CursorStyle) {
         unsafe {
-            let cursor: id = match style {
+            let new_cursor: id = match style {
                 CursorStyle::Arrow => msg_send![class!(NSCursor), arrowCursor],
                 CursorStyle::ResizeLeftRight => {
                     msg_send![class!(NSCursor), resizeLeftRightCursor]
@@ -795,7 +795,11 @@ impl platform::Platform for MacPlatform {
                 CursorStyle::PointingHand => msg_send![class!(NSCursor), pointingHandCursor],
                 CursorStyle::IBeam => msg_send![class!(NSCursor), IBeamCursor],
             };
-            let _: () = msg_send![cursor, set];
+
+            let old_cursor: id = msg_send![class!(NSCursor), currentCursor];
+            if new_cursor != old_cursor {
+                let _: () = msg_send![new_cursor, set];
+            }
         }
     }
 


### PR DESCRIPTION
This avoids a high cost which appears to be the system rasterizing the cursor every time we call this, fixes a slowdown when scrolling rapidly while mouse motion continually attempted to assign the style

Fixes https://linear.app/zed-industries/issue/Z-2200/editor-scroll-slowdown

Release Notes:

- Improved the performance of scrolling by avoiding unnecessary cursor changes ([#1597](https://github.com/zed-industries/zed/issues/6164)).