### PR TITLE
Add support for joining lines

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -411,6 +411,7 @@
       "ctrl-shift-k": "editor::DeleteLine",
       "cmd-shift-d": "editor::DuplicateLine",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",
+      "ctrl-j": "editor::JoinLines",
       "ctrl-cmd-up": "editor::MoveLineUp",
       "ctrl-cmd-down": "editor::MoveLineDown",
       "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -143,6 +143,7 @@
         "Delete"
       ],
       "shift-d": "vim::DeleteToEndOfLine",
+      "shift-j": "editor::JoinLines",
       "y": [
         "vim::PushOperator",
         "Yank"

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3987,9 +3987,10 @@ impl Editor {
             for row_range in row_ranges.into_iter().rev() {
                 for row in row_range.rev() {
                     let end_of_line = Point::new(row, snapshot.line_len(row));
-                    let start_of_next_line = end_of_line + Point::new(1, 0);
+                    let indent = snapshot.indent_size_for_line(row + 1);
+                    let start_of_next_line = Point::new(row + 1, indent.len);
 
-                    let replace = if snapshot.line_len(row + 1) > 0 {
+                    let replace = if snapshot.line_len(row + 1) > indent.len {
                         " "
                     } else {
                         ""

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3956,7 +3956,7 @@ impl Editor {
 
     pub fn join_lines(&mut self, _: &JoinLines, cx: &mut ViewContext<Self>) {
         let mut row_ranges = Vec::<Range<u32>>::new();
-        for selection in self.selections.ranges::<Point>(cx) {
+        for selection in self.selections.all::<Point>(cx) {
             let start = selection.start.row;
             let end = if selection.start.row == selection.end.row {
                 selection.start.row + 1

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -206,6 +206,7 @@ actions!(
         DuplicateLine,
         MoveLineUp,
         MoveLineDown,
+        JoinLines,
         Transpose,
         Cut,
         Copy,
@@ -321,6 +322,7 @@ pub fn init(cx: &mut AppContext) {
     cx.add_action(Editor::indent);
     cx.add_action(Editor::outdent);
     cx.add_action(Editor::delete_line);
+    cx.add_action(Editor::join_lines);
     cx.add_action(Editor::delete_to_previous_word_start);
     cx.add_action(Editor::delete_to_previous_subword_start);
     cx.add_action(Editor::delete_to_next_word_end);
@@ -3949,6 +3951,17 @@ impl Editor {
             this.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.select(new_selections);
             });
+        });
+    }
+
+    pub fn join_lines(&mut self, _: &JoinLines, cx: &mut ViewContext<Self>) {
+        let cursor_position = self.selections.newest::<Point>(cx).head();
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let end_of_line = Point::new(cursor_position.row, snapshot.line_len(cursor_position.row));
+        let start_of_next_line = end_of_line + Point::new(1, 0);
+
+        self.buffer.update(cx, |buffer, cx| {
+            buffer.edit([(end_of_line..start_of_next_line, " ")], None, cx)
         });
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1,7 +1,10 @@
 use super::*;
-use crate::test::{
-    assert_text_with_selections, build_editor, editor_lsp_test_context::EditorLspTestContext,
-    editor_test_context::EditorTestContext, select_ranges,
+use crate::{
+    test::{
+        assert_text_with_selections, build_editor, editor_lsp_test_context::EditorLspTestContext,
+        editor_test_context::EditorTestContext, select_ranges,
+    },
+    JoinLines,
 };
 use drag_and_drop::DragAndDrop;
 use futures::StreamExt;
@@ -2322,6 +2325,33 @@ fn test_delete_line(cx: &mut TestAppContext) {
             view.selections.display_ranges(cx),
             vec![DisplayPoint::new(0, 1)..DisplayPoint::new(0, 1)]
         );
+    });
+}
+
+#[gpui::test]
+fn test_join_lines(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let (_, editor) = cx.add_window(|cx| {
+        let buffer = MultiBuffer::build_simple("abc\ndef\nghi\n", cx);
+        let mut editor = build_editor(buffer.clone(), cx);
+        let buffer = buffer.read(cx).as_singleton().unwrap();
+
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            &[Point::new(0, 0)..Point::new(0, 0)]
+        );
+
+        editor.join_lines(&JoinLines, cx);
+
+        // assert_eq!(
+        //     editor.selections.ranges::<Point>(cx),
+        //     &[Point::new(0, 0), Point::new(0, 0)]
+        // );
+
+        assert_eq!(buffer.read(cx).text(), "abc def\nghi\n");
+
+        editor
     });
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2396,6 +2396,34 @@ fn test_join_lines_with_single_selection(cx: &mut TestAppContext) {
             [Point::new(2, 3)..Point::new(2, 3)]
         );
 
+        // reset to test indentation
+        editor.buffer.update(cx, |buffer, cx| {
+            buffer.edit(
+                [
+                    (Point::new(1, 0)..Point::new(1, 2), "  "),
+                    (Point::new(2, 0)..Point::new(2, 3), "  \n\td"),
+                ],
+                None,
+                cx,
+            )
+        });
+
+        // We remove any leading spaces
+        assert_eq!(buffer.read(cx).text(), "aaa bbb\n  c\n  \n\td");
+        editor.change_selections(None, cx, |s| {
+            s.select_ranges([Point::new(0, 1)..Point::new(0, 1)])
+        });
+        editor.join_lines(&JoinLines, cx);
+        assert_eq!(buffer.read(cx).text(), "aaa bbb c\n  \n\td");
+
+        // We don't insert a space for a line containing only spaces
+        editor.join_lines(&JoinLines, cx);
+        assert_eq!(buffer.read(cx).text(), "aaa bbb c\n\td");
+
+        // We ignore any leading tabs
+        editor.join_lines(&JoinLines, cx);
+        assert_eq!(buffer.read(cx).text(), "aaa bbb c d");
+
         editor
     });
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2376,6 +2376,20 @@ fn test_join_lines(cx: &mut TestAppContext) {
             [Point::new(2, 3)..Point::new(2, 3)]
         );
 
+        editor.join_lines(&JoinLines, cx);
+        assert_eq!(buffer.read(cx).text(), "aaa bbb\nccc\nddd");
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            [Point::new(2, 3)..Point::new(2, 3)]
+        );
+
+        editor.join_lines(&JoinLines, cx);
+        assert_eq!(buffer.read(cx).text(), "aaa bbb\nccc\nddd");
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            [Point::new(2, 3)..Point::new(2, 3)]
+        );
+
         editor
     });
 }


### PR DESCRIPTION
Release Notes:

You can now join lines with `ctrl-j` or `shift-J` in Vim normal mode. ([#736](https://github.com/zed-industries/zed/issues/5827))

🍐'd with @ConradIrwin 