### PR TITLE
WIP: Add the ability to make new directories by adding slashes to a file name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5033,6 +5033,7 @@ dependencies = [
  "language",
  "menu",
  "postage",
+ "pretty_assertions",
  "project",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ time = { version = "0.3", features = ["serde", "serde-well-known"] }
 toml = { version = "0.5" }
 tree-sitter = "0.20"
 unindent = { version = "0.1.7" }
+pretty_assertions = "1.3.0"
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "49226023693107fba9a1191136a4f47f38cdca73" }

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -67,7 +67,7 @@ fs = { path = "../fs", features = ["test-support"] }
 git = { path = "../git", features = ["test-support"] }
 live_kit_client = { path = "../live_kit_client", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
-pretty_assertions = "*"
+pretty_assertions.workspace = true
 project = { path = "../project", features = ["test-support"] }
 rpc = { path = "../rpc", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -67,7 +67,7 @@ fs = { path = "../fs", features = ["test-support"] }
 git = { path = "../git", features = ["test-support"] }
 live_kit_client = { path = "../live_kit_client", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
-pretty_assertions = "1.3.0"
+pretty_assertions = "*"
 project = { path = "../project", features = ["test-support"] }
 rpc = { path = "../rpc", features = ["test-support"] }
 settings = { path = "../settings", features = ["test-support"] }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -279,6 +279,9 @@ impl Fs for RealFs {
 
     async fn save(&self, path: &Path, text: &Rope, line_ending: LineEnding) -> Result<()> {
         let buffer_size = text.summary().len.min(10 * 1024);
+        if let Some(path) = path.parent() {
+            self.create_dir(path).await?;
+        }
         let file = smol::fs::File::create(path).await?;
         let mut writer = smol::io::BufWriter::with_capacity(buffer_size, file);
         for chunk in chunks(text, line_ending) {
@@ -1077,6 +1080,9 @@ impl Fs for FakeFs {
         self.simulate_random_delay().await;
         let path = normalize_path(path);
         let content = chunks(text, line_ending).collect();
+        if let Some(path) = path.parent() {
+            self.create_dir(path).await?;
+        }
         self.write_file_internal(path, content)?;
         Ok(())
     }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.10"
 [dev-dependencies]
 ctor.workspace = true
 env_logger.workspace = true
-pretty_assertions = "1.3.0"
+pretty_assertions = "*"
 client = { path = "../client", features = ["test-support"] }
 collections = { path = "../collections", features = ["test-support"] }
 db = { path = "../db", features = ["test-support"] }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.10"
 [dev-dependencies]
 ctor.workspace = true
 env_logger.workspace = true
-pretty_assertions = "*"
+pretty_assertions.workspace = true
 client = { path = "../client", features = ["test-support"] }
 collections = { path = "../collections", features = ["test-support"] }
 db = { path = "../db", features = ["test-support"] }

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -1016,13 +1016,14 @@ impl LocalWorktree {
         cx.spawn(|this, mut cx| async move {
             write.await?;
             let (result, refreshes) = this.update(&mut cx, |this, cx| {
-                let mut refreshes = Vec::new();
+                let mut refreshes = Vec::<Task<anyhow::Result<Entry>>>::new();
                 let refresh_paths = path.strip_prefix(&lowest_ancestor).unwrap();
                 for refresh_path in refresh_paths.ancestors() {
-                    let refresh_full_path = lowest_ancestor.join(refresh_path);
-                    if refresh_full_path.as_path() == path.deref() {
+                    if refresh_path == Path::new("") {
                         continue;
                     }
+                    let refresh_full_path = lowest_ancestor.join(refresh_path);
+
                     refreshes.push(this.as_local_mut().unwrap().refresh_entry(
                         refresh_full_path.into(),
                         None,

--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -982,7 +982,7 @@ impl LocalWorktree {
     }
 
     /// Find the lowest path in the worktree's datastructures that is an ancestor
-    pub fn lowest_ancestor(&self, path: &Path) -> PathBuf {
+    fn lowest_ancestor(&self, path: &Path) -> PathBuf {
         let mut lowest_ancestor = None;
         for path in path.ancestors() {
             if self.entry_for_path(path).is_some() {

--- a/crates/project/src/worktree_tests.rs
+++ b/crates/project/src/worktree_tests.rs
@@ -941,13 +941,14 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
     let client_fake = cx.read(|cx| Client::new(FakeHttpClient::with_404_response(), cx));
 
     let fs_fake = FakeFs::new(cx.background());
-    fs_fake.insert_tree(
-        "/root",
-        json!({
-            "a": {},
-        }),
-    )
-    .await;
+    fs_fake
+        .insert_tree(
+            "/root",
+            json!({
+                "a": {},
+            }),
+        )
+        .await;
 
     let tree_fake = Worktree::local(
         client_fake,

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -27,6 +27,7 @@ serde_derive.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 schemars.workspace = true
+pretty_assertions.workspace = true
 unicase = "2.6"
 
 [dev-dependencies]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -981,7 +981,6 @@ impl ProjectPanel {
             }
         }
 
-
         Some(())
     }
 
@@ -1158,7 +1157,6 @@ impl ProjectPanel {
                 let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
                 for entry in visible_worktree_entries[entry_range].iter() {
                     let status = git_status_setting.then(|| entry.git_status).flatten();
-
 
                     let mut details = EntryDetails {
                         filename: entry
@@ -2107,7 +2105,6 @@ mod tests {
                 "    > e",
             ]
         );
-
 
         let confirm = panel.update(cx, |panel, cx| {
             panel.filename_editor.update(cx, |editor, cx| {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -547,7 +547,7 @@ impl ProjectPanel {
                 worktree_id,
                 entry_id: NEW_ENTRY_ID,
             });
-            let new_path = entry.path.join(&filename);
+            let new_path = entry.path.join(&filename.trim_start_matches("/"));
             if path_already_exists(new_path.as_path()) {
                 return None;
             }
@@ -2111,7 +2111,7 @@ mod tests {
 
         let confirm = panel.update(cx, |panel, cx| {
             panel.filename_editor.update(cx, |editor, cx| {
-                editor.set_text("bdir1/dir2/the-new-filename", cx)
+                editor.set_text("/bdir1/dir2/the-new-filename", cx)
             });
             panel.confirm(&Confirm, cx).unwrap()
         });
@@ -2124,7 +2124,7 @@ mod tests {
                 "    > a",
                 "    > b",
                 "    > C",
-                "      [PROCESSING: 'bdir1/dir2/the-new-filename']  <== selected",
+                "      [PROCESSING: '/bdir1/dir2/the-new-filename']  <== selected",
                 "      .dockerignore",
                 "v root2",
                 "    > d",

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -38,5 +38,5 @@ tree-sitter-json = "*"
 gpui = { path = "../gpui", features = ["test-support"] }
 fs = { path = "../fs", features = ["test-support"] }
 indoc.workspace = true
-pretty_assertions = "1.3.0"
+pretty_assertions = "*"
 unindent.workspace = true

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -38,5 +38,5 @@ tree-sitter-json = "*"
 gpui = { path = "../gpui", features = ["test-support"] }
 fs = { path = "../fs", features = ["test-support"] }
 indoc.workspace = true
-pretty_assertions = "*"
+pretty_assertions.workspace = true
 unindent.workspace = true


### PR DESCRIPTION
This PR adds a new way to make files / directories in the project panel, by writing a path instead of a file. 

TODO:
- [x] Solve a race condition that sometimes causes the newly created file to not be selected / expanded correctly.
- [x] Change file refreshes to be minimal

Release Notes:

- Adds the ability to create new folders in the create-file action ([743](https://github.com/zed-industries/zed/issues/5101))