### PR TITLE
Use nextest instead of test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           rustup set profile minimal
           rustup update stable
           rustup target add wasm32-wasi
+          cargo install cargo-nextest
 
       - name: Install Node
         uses: actions/setup-node@v2
@@ -70,7 +71,7 @@ jobs:
         run: cargo check --workspace
 
       - name: Run tests
-        run: cargo test --workspace --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast
 
       - name: Build collab
         run: cargo build -p collab


### PR DESCRIPTION
This should speed up our test CI by a minute or so. =)

[current best case CI run](https://github.com/zed-industries/zed/actions/runs/5337351944/jobs/9673291188), where we don't rebuild anything (and only run tests) takes about 2m30s
[with nextest](https://github.com/zed-industries/zed/actions/runs/5346819257/jobs/9694617720?pr=2639), that's down to 1m30s.
Release Notes:
- N/A