### PR TITLE
Fix incorrect ThemeAppearance

### DIFF
--- a/styles/src/themes/atelier/atelier-forest-light.ts
+++ b/styles/src/themes/atelier/atelier-forest-light.ts
@@ -30,7 +30,7 @@ const getTheme = (variant: Variant): ThemeConfig => {
     return {
         name: `${meta.name} Forest Light`,
         author: meta.author,
-        appearance: ThemeAppearance.Dark,
+        appearance: ThemeAppearance.Light,
         licenseType: meta.licenseType,
         licenseUrl: meta.licenseUrl,
         licenseFile: `${__dirname}/LICENSE`,


### PR DESCRIPTION
[[PR Description]]

When we updated the way themes were built it looks like we accidentally gave `Atelier Forest Light` the wrong `ThemeAppearance`. This PR fixes that.

Release Notes:

- Fixed the `Atelier Forest Light` theme, which was incorrectly set as a dark theme.