### PR TITLE
Vim toggle case

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -172,6 +172,7 @@
       "^": "vim::FirstNonWhitespace",
       "o": "vim::InsertLineBelow",
       "shift-o": "vim::InsertLineAbove",
+      "~": "vim::ChangeCase",
       "v": [
         "vim::SwitchMode",
         {
@@ -309,6 +310,7 @@
       "y": "vim::VisualYank",
       "p": "vim::VisualPaste",
       "s": "vim::Substitute",
+      "~": "vim::ChangeCase",
       "r": [
         "vim::PushOperator",
         "Replace"

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1,3 +1,4 @@
+mod case;
 mod change;
 mod delete;
 mod substitute;
@@ -24,6 +25,7 @@ use serde::Deserialize;
 use workspace::Workspace;
 
 use self::{
+    case::change_case,
     change::{change_motion, change_object},
     delete::{delete_motion, delete_object},
     substitute::substitute,
@@ -48,6 +50,7 @@ actions!(
         Paste,
         Yank,
         Substitute,
+        ChangeCase,
     ]
 );
 
@@ -59,6 +62,7 @@ pub fn init(cx: &mut AppContext) {
     cx.add_action(insert_end_of_line);
     cx.add_action(insert_line_above);
     cx.add_action(insert_line_below);
+    cx.add_action(change_case);
     cx.add_action(|_: &mut Workspace, _: &Substitute, cx| {
         Vim::update(cx, |vim, cx| {
             let times = vim.pop_number_operator(cx);

--- a/crates/vim/src/normal/case.rs
+++ b/crates/vim/src/normal/case.rs
@@ -1,0 +1,64 @@
+use gpui::ViewContext;
+use language::Point;
+use workspace::Workspace;
+
+use crate::{motion::Motion, normal::ChangeCase, Vim};
+
+pub fn change_case(_: &mut Workspace, _: &ChangeCase, cx: &mut ViewContext<Workspace>) {
+    Vim::update(cx, |vim, cx| {
+        let count = vim.pop_number_operator(cx);
+        vim.update_active_editor(cx, |editor, cx| {
+            editor.set_clip_at_line_ends(false, cx);
+            editor.transact(cx, |editor, cx| {
+                editor.change_selections(None, cx, |s| {
+                    s.move_with(|map, selection| {
+                        if selection.start == selection.end {
+                            Motion::Right.expand_selection(map, selection, count, true);
+                        }
+                    })
+                });
+                let selections = editor.selections.all::<Point>(cx);
+                for selection in selections.into_iter().rev() {
+                    let snapshot = editor.buffer().read(cx).snapshot(cx);
+                    editor.buffer().update(cx, |buffer, cx| {
+                        let range = selection.start..selection.end;
+                        let text = snapshot
+                            .text_for_range(selection.start..selection.end)
+                            .flat_map(|s| s.chars())
+                            .flat_map(|c| {
+                                if c.is_lowercase() {
+                                    c.to_uppercase().collect::<Vec<char>>()
+                                } else {
+                                    c.to_lowercase().collect::<Vec<char>>()
+                                }
+                            })
+                            .collect::<String>();
+
+                        buffer.edit([(range, text)], None, cx)
+                    })
+                }
+            });
+            editor.set_clip_at_line_ends(true, cx);
+        });
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{state::Mode, test::VimTestContext};
+    use indoc::indoc;
+
+    #[gpui::test]
+    async fn test_change_case(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.set_state(indoc! {"ˇabC\n"}, Mode::Normal);
+        cx.simulate_keystrokes(["~"]);
+        cx.assert_editor_state("AˇbC\n");
+        cx.simulate_keystrokes(["2", "~"]);
+        cx.assert_editor_state("ABcˇ\n");
+
+        cx.set_state(indoc! {"a😀C«dÉ1*fˇ»\n"}, Mode::Normal);
+        cx.simulate_keystrokes(["~"]);
+        cx.assert_editor_state("a😀CDé1*Fˇ\n");
+    }
+}


### PR DESCRIPTION
Release Notes:

- vim: Add ~ to toggle case ([#1410](https://github.com/zed-industries/zed/issues/6102))
