### PR TITLE
vim: Fix code actions menu

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,6 +1,6 @@
 [
   {
-    "context": "Editor && VimControl && !VimWaiting",
+    "context": "Editor && VimControl && !VimWaiting && !menu",
     "bindings": {
       "g": [
         "vim::PushOperator",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7641,8 +7641,14 @@ impl View for Editor {
             keymap.add_identifier("renaming");
         }
         match self.context_menu.as_ref() {
-            Some(ContextMenu::Completions(_)) => keymap.add_identifier("showing_completions"),
-            Some(ContextMenu::CodeActions(_)) => keymap.add_identifier("showing_code_actions"),
+            Some(ContextMenu::Completions(_)) => {
+                keymap.add_identifier("menu");
+                keymap.add_identifier("showing_completions")
+            }
+            Some(ContextMenu::CodeActions(_)) => {
+                keymap.add_identifier("menu");
+                keymap.add_identifier("showing_code_actions")
+            }
             None => {}
         }
         for layer in self.keymap_context_layers.values() {


### PR DESCRIPTION
Fixes: zed-industries/zed#6185

I'm not sure this is the correct way to fix this...
* A simpler approach would be to just say `!showing_code_actions` in the binding file (as `showing_completions` can only happen in insert mode - and `VimControl` will be false). This seemed a little error prone if more menus were added in the future.
* A more complicated approach would be to copy the way this is done from the MouseContextMenu, which registers its own keyboard shortcuts, and as such uses those when it's open. This seems "more correct", but is a major refactoring for a very small reward.

Release Notes:

- vim: Fix code actions menu ([#1690](https://github.com/zed-industries/zed/issues/6185))