### PR TITLE
Avoid redundant FS scans when LSPs changed watched files

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3172,8 +3172,8 @@ impl BackgroundScanner {
                         .map_or(false, |entry| entry.kind == EntryKind::Dir)
                 });
                 if !parent_dir_is_loaded {
+                    log::debug!("ignoring event {relative_path:?} within unloaded directory");
                     unloaded_relative_paths.push(relative_path);
-                    log::debug!("ignoring event {abs_path:?} within unloaded directory");
                     return false;
                 }
 


### PR DESCRIPTION
Release Notes:

- Fixed a performance problem that could occur when a language server requested to watch a set of files (preview only).