### PR TITLE
Add audio sources

### DIFF
--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -1060,6 +1060,11 @@ impl Room {
         self.live_kit.as_ref().map(|live_kit| live_kit.deafened)
     }
 
+    pub fn test_set_audio(&mut self, _cx: &mut ModelContext<Self>) {
+        let output = live_kit_client::Room::audio_output_sources();
+        dbg!(output.get(2).map(|device| device.set()));
+    }
+
     pub fn share_microphone(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         if self.status.is_offline() {
             return Task::ready(Err(anyhow!("room is offline")));

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -23,7 +23,8 @@ actions!(
         ToggleMute,
         ToggleDeafen,
         LeaveCall,
-        ShareMicrophone
+        ShareMicrophone,
+        SetThirdAudioOutput,
     ]
 );
 
@@ -40,6 +41,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
     cx.add_global_action(toggle_mute);
     cx.add_global_action(toggle_deafen);
     cx.add_global_action(share_microphone);
+    cx.add_global_action(test);
 }
 
 pub fn toggle_screen_sharing(_: &ToggleScreenSharing, cx: &mut AppContext) {
@@ -75,5 +77,11 @@ pub fn share_microphone(_: &ShareMicrophone, cx: &mut AppContext) {
     if let Some(room) = ActiveCall::global(cx).read(cx).room().cloned() {
         room.update(cx, Room::share_microphone)
             .detach_and_log_err(cx)
+    }
+}
+
+pub fn test(_: &SetThirdAudioOutput, cx: &mut AppContext) {
+    if let Some(room) = ActiveCall::global(cx).read(cx).room().cloned() {
+        room.update(cx, Room::test_set_audio)
     }
 }

--- a/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
+++ b/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
@@ -259,6 +259,18 @@ public func LKRemoteAudioTrackGetSid(track: UnsafeRawPointer) -> CFString {
     return track.sid! as CFString
 }
 
+@_cdecl("LKAudioInputSources")
+public func LKAudioInputSources(
+    data: UnsafeRawPointer,
+    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, Bool, UnsafeMutableRawPointer) -> Void
+) -> UnsafeRawPointer {
+    Room.audioDeviceModule.inputDevices.forEach { inputDevice in
+        callback(data, inputDevice.name as CFString, inputDevice.isDefault, Unmanaged.passRetained(inputDevice).toOpaque())
+    }
+    return data
+}
+
+
 @_cdecl("LKDisplaySources")
 public func LKDisplaySources(data: UnsafeRawPointer, callback: @escaping @convention(c) (UnsafeRawPointer, CFArray?, CFString?) -> Void) {
     MacOSScreenCapturer.sources(for: .display, includeCurrentApplication: false, preferredMethod: .legacy).then { displaySources in

--- a/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
+++ b/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
@@ -262,10 +262,21 @@ public func LKRemoteAudioTrackGetSid(track: UnsafeRawPointer) -> CFString {
 @_cdecl("LKAudioInputSources")
 public func LKAudioInputSources(
     data: UnsafeRawPointer,
-    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, Bool, UnsafeMutableRawPointer) -> Void
+    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, CFString, Bool, UnsafeMutableRawPointer) -> Void
 ) -> UnsafeRawPointer {
     Room.audioDeviceModule.inputDevices.forEach { inputDevice in
-        callback(data, inputDevice.name as CFString, inputDevice.isDefault, Unmanaged.passRetained(inputDevice).toOpaque())
+        callback(data, inputDevice.name as CFString, inputDevice.deviceId as CFString, inputDevice.isDefault, Unmanaged.passRetained(inputDevice).toOpaque())
+    }
+    return data
+}
+
+@_cdecl("LKAudioOutputSources")
+public func LKAudioOutputSources(
+    data: UnsafeRawPointer,
+    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, CFString, Bool, UnsafeMutableRawPointer) -> Void
+) -> UnsafeRawPointer {
+    Room.audioDeviceModule.outputDevices.forEach { outputDevice in
+        callback(data, outputDevice.name as CFString, outputDevice.deviceId as CFString, outputDevice.isDefault, Unmanaged.passRetained(outputDevice).toOpaque())
     }
     return data
 }

--- a/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
+++ b/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
@@ -262,24 +262,38 @@ public func LKRemoteAudioTrackGetSid(track: UnsafeRawPointer) -> CFString {
 @_cdecl("LKAudioInputSources")
 public func LKAudioInputSources(
     data: UnsafeRawPointer,
-    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, CFString, Bool, UnsafeMutableRawPointer) -> Void
+    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, CFString, Bool, Bool, UnsafeMutableRawPointer) -> Void
 ) -> UnsafeRawPointer {
     Room.audioDeviceModule.inputDevices.forEach { inputDevice in
-        callback(data, inputDevice.name as CFString, inputDevice.deviceId as CFString, inputDevice.isDefault, Unmanaged.passRetained(inputDevice).toOpaque())
+        callback(data, inputDevice.name as CFString, inputDevice.deviceId as CFString, false, inputDevice.isDefault, Unmanaged.passRetained(inputDevice).toOpaque())
     }
     return data
+}
+
+@_cdecl("LKSetInputDevice")
+public func LKSetInputDevice(device: UnsafeMutableRawPointer) -> Bool {
+    let device = Unmanaged<RTCAudioDevice>.fromOpaque(device).takeUnretainedValue();
+    return Room.audioDeviceModule.setInputDevice(device)
 }
 
 @_cdecl("LKAudioOutputSources")
 public func LKAudioOutputSources(
     data: UnsafeRawPointer,
-    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, CFString, Bool, UnsafeMutableRawPointer) -> Void
+    callback: @escaping @convention(c) (UnsafeRawPointer, CFString, CFString, Bool, Bool, UnsafeMutableRawPointer) -> Void
 ) -> UnsafeRawPointer {
     Room.audioDeviceModule.outputDevices.forEach { outputDevice in
-        callback(data, outputDevice.name as CFString, outputDevice.deviceId as CFString, outputDevice.isDefault, Unmanaged.passRetained(outputDevice).toOpaque())
+        callback(data, outputDevice.name as CFString, outputDevice.deviceId as CFString, true, outputDevice.isDefault, Unmanaged.passRetained(outputDevice).toOpaque())
     }
     return data
 }
+
+@_cdecl("LKSetOutputDevice")
+public func LKSetOutputDevice(device: UnsafeMutableRawPointer) -> Bool {
+    let device = Unmanaged<RTCAudioDevice>.fromOpaque(device).takeUnretainedValue();
+    print("Got device: ", device.name, device.deviceId, " is output: ", device.type == .output)
+    return Room.audioDeviceModule.setOutputDevice(device)
+}
+
 
 
 @_cdecl("LKDisplaySources")

--- a/crates/live_kit_client/examples/test_app.rs
+++ b/crates/live_kit_client/examples/test_app.rs
@@ -49,6 +49,10 @@ fn main() {
             let room_a = Room::new();
             room_a.connect(&live_kit_url, &user_a_token).await.unwrap();
 
+            println!("Audio input sources: {:?}", Room::audio_input_sources());
+            // TODO
+            println!("Audio output sources: {:?}", Room::audio_input_sources());
+
             let user2_token = token::create(
                 &live_kit_key,
                 &live_kit_secret,
@@ -57,6 +61,7 @@ fn main() {
             )
             .unwrap();
             let room_b = Room::new();
+
             room_b.connect(&live_kit_url, &user2_token).await.unwrap();
 
             let mut audio_track_updates = room_b.remote_audio_track_updates();

--- a/crates/live_kit_client/examples/test_app.rs
+++ b/crates/live_kit_client/examples/test_app.rs
@@ -50,8 +50,16 @@ fn main() {
             room_a.connect(&live_kit_url, &user_a_token).await.unwrap();
 
             println!("Audio input sources: {:?}", Room::audio_input_sources());
-            // TODO
-            println!("Audio output sources: {:?}", Room::audio_output_sources());
+
+            let output_devices = Room::audio_output_sources();
+            println!("Audio output sources: {:?}", output_devices);
+
+            println!("Setting to third output audio source...");
+            if output_devices[2].set().is_ok() {
+                println!("Sucess!");
+            } else {
+                println!("failure :(");
+            }
 
             let user2_token = token::create(
                 &live_kit_key,
@@ -61,7 +69,6 @@ fn main() {
             )
             .unwrap();
             let room_b = Room::new();
-
             room_b.connect(&live_kit_url, &user2_token).await.unwrap();
 
             let mut audio_track_updates = room_b.remote_audio_track_updates();
@@ -142,6 +149,7 @@ fn main() {
                 .await
                 .unwrap();
 
+            println!("Waiting for video track updates...");
             if let RemoteVideoTrackUpdate::Subscribed(track) =
                 video_track_updates.next().await.unwrap()
             {

--- a/crates/live_kit_client/examples/test_app.rs
+++ b/crates/live_kit_client/examples/test_app.rs
@@ -51,7 +51,7 @@ fn main() {
 
             println!("Audio input sources: {:?}", Room::audio_input_sources());
             // TODO
-            println!("Audio output sources: {:?}", Room::audio_input_sources());
+            println!("Audio output sources: {:?}", Room::audio_output_sources());
 
             let user2_token = token::create(
                 &live_kit_key,

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -366,6 +366,13 @@ impl Room {
         ]
     }
 
+    pub fn audio_output_sources() -> Vec<AudioDevice> {
+        vec![
+            AudioDevice::new("Test Speaker 1".to_string()),
+            AudioDevice::new("Test Speaker 2".to_string()),
+        ]
+    }
+
     pub fn display_sources(self: &Arc<Self>) -> impl Future<Output = Result<Vec<MacOSDisplay>>> {
         let this = self.clone();
         async move {

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -602,12 +602,17 @@ pub enum RemoteAudioTrackUpdate {
 
 #[derive(Debug)]
 pub struct AudioDevice {
-    _name: String,
+    name: String,
 }
 
 impl AudioDevice {
     fn new(name: String) -> Self {
-        Self { _name: name }
+        Self { name }
+    }
+
+    pub fn set(&self) -> Result<()> {
+        println!("Setting audio device {}", self.name);
+        Ok(())
     }
 }
 

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -359,6 +359,13 @@ impl Room {
         }
     }
 
+    pub fn audio_input_sources() -> Vec<AudioDevice> {
+        vec![
+            AudioDevice::new("Test Mic 1".to_string()),
+            AudioDevice::new("Test Mic 2".to_string()),
+        ]
+    }
+
     pub fn display_sources(self: &Arc<Self>) -> impl Future<Output = Result<Vec<MacOSDisplay>>> {
         let this = self.clone();
         async move {
@@ -584,6 +591,17 @@ pub enum RemoteAudioTrackUpdate {
     MuteChanged { track_id: Sid, muted: bool },
     Subscribed(Arc<RemoteAudioTrack>),
     Unsubscribed { publisher_id: Sid, track_id: Sid },
+}
+
+#[derive(Debug)]
+pub struct AudioDevice {
+    _name: String,
+}
+
+impl AudioDevice {
+    fn new(name: String) -> Self {
+        Self { _name: name }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This branch attempted to add audio source information to Zed. I ran into two major problems while working on this:

* For some reason, adding the audio input and output device queries would cause receiving video tracks to fail. As of the first commit, this would be a very long error like: `error LiveKitSDK : [] WebSocket.receive(task:result:) Failed to receive Error Domain=NSURLErrorDomain Code=-999 "cancelled" UserInfo={NSErrorFailingURLStringKey=ws[long websocket url here]`. As of the third commit, this would just cause the video track to never be published.
* For some reason, using the provided APIs as best as I know how simply does not work. Setting the output device form my airpods to my speakers does not seem to cause sound to play, despite the APIs reporting success. 

Given these issues, I am going to cut audio device setting from the scope of this phase of the project. This PR is meant for historical reference.