### PR TITLE
Fix bug preventing the assist command from working in certain keymaps

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -24,9 +24,7 @@
       ],
       "ctrl-shift-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::AddSelectionAbove",
-      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine",
-      "cmd-shift-enter": "editor::NewlineAbove",
-      "cmd-enter": "editor::NewlineBelow"
+      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine"
     }
   },
   {

--- a/assets/keymaps/sublime_text.json
+++ b/assets/keymaps/sublime_text.json
@@ -24,9 +24,7 @@
       "ctrl-.": "editor::GoToHunk",
       "ctrl-,": "editor::GoToPrevHunk",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd",
-      "cmd-shift-enter": "editor::NewlineAbove",
-      "cmd-enter": "editor::NewlineBelow"
+      "ctrl-delete": "editor::DeleteToNextWordEnd"
     }
   },
   {

--- a/assets/keymaps/textmate.json
+++ b/assets/keymaps/textmate.json
@@ -12,8 +12,6 @@
       "ctrl-shift-d": "editor::DuplicateLine",
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
-      "cmd-alt-enter": "editor::NewlineAbove",
-      "cmd-enter": "editor::NewlineBelow",
       "cmd-shift-l": "editor::SelectLine",
       "cmd-shift-t": "outline::Toggle",
       "alt-backspace": "editor::DeleteToPreviousWordStart",
@@ -56,7 +54,9 @@
   },
   {
     "context": "Editor && mode == full",
-    "bindings": {}
+    "bindings": {
+      "cmd-alt-enter": "editor::NewlineAbove"
+    }
   },
   {
     "context": "BufferSearchBar",


### PR DESCRIPTION
Fixes: https://github.com/zed-industries/zed/issues/6191

The keymaps were adding in a `"cmd-enter": "editor::NewlineBelow",` entry in the context of `Editor`, and this was clobbering the assist command in the assistant panel context.  Zed now defines this command in the default keymap under the context of `"context": "Editor && mode == full"`.  All I needed to basically do was remove that command from the keymaps. I also removed the `"cmd-shift-enter": "editor::NewlineAbove"` from the `Editor` context in those keymaps as well, as it is also defined in the default keymap.

Release Notes:

- Fix bug preventing the `assistant: assist` command from working in certain keymaps