### PR TITLE
Remove unused `color_scheme` field in the theme

### DIFF
--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -65,7 +65,6 @@ pub struct Theme {
     pub assistant: AssistantStyle,
     pub feedback: FeedbackStyle,
     pub welcome: WelcomeStyle,
-    pub color_scheme: ColorScheme,
     pub titlebar: Titlebar,
 }
 

--- a/styles/src/style_tree/app.ts
+++ b/styles/src/style_tree/app.ts
@@ -57,21 +57,6 @@ export default function app(): any {
         tooltip: tooltip(),
         terminal: terminal(),
         assistant: assistant(),
-        feedback: feedback(),
-        color_scheme: {
-            ...theme,
-            players: Object.values(theme.players),
-            ramps: {
-                neutral: theme.ramps.neutral.colors(100, "hex"),
-                red: theme.ramps.red.colors(100, "hex"),
-                orange: theme.ramps.orange.colors(100, "hex"),
-                yellow: theme.ramps.yellow.colors(100, "hex"),
-                green: theme.ramps.green.colors(100, "hex"),
-                cyan: theme.ramps.cyan.colors(100, "hex"),
-                blue: theme.ramps.blue.colors(100, "hex"),
-                violet: theme.ramps.violet.colors(100, "hex"),
-                magenta: theme.ramps.magenta.colors(100, "hex"),
-            },
-        },
+        feedback: feedback()
     }
 }


### PR DESCRIPTION
We removed the `theme_testbench` crate a while back - It seems like that was the only thing using the `color_scheme` field in the exported theme.

Removing this from the theme removes something like 42k lines of generated JSON every time we build the theme (2k lines / 28% of the total lines per generated theme!)

Release Notes:

- N/A (No public facing changes)