### PR TITLE
Support `assistant: quote selection` on multibuffers

### DIFF
--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -1911,7 +1911,7 @@ impl ConversationEditor {
         let Some(panel) = workspace.panel::<AssistantPanel>(cx) else {
             return;
         };
-        let Some(editor) = workspace.active_item(cx).and_then(|item| item.downcast::<Editor>()) else {
+        let Some(editor) = workspace.active_item(cx).and_then(|item| item.act_as::<Editor>(cx)) else {
             return;
         };
 


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2430/assistant-quote-selection-does-not-work-in-multi-buffer

Release Notes:

- Added support for invoking `assistant: quote selection` (`cmd->`) when editing a multi-buffer.