### PR TITLE
Fix panic when saved conversations directory changes

### DIFF
--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -147,8 +147,9 @@ impl AssistantPanel {
                                 .await
                                 .log_err()
                                 .unwrap_or_default();
-                            this.update(&mut cx, |this, _| {
-                                this.saved_conversations = saved_conversations
+                            this.update(&mut cx, |this, cx| {
+                                this.saved_conversations = saved_conversations;
+                                cx.notify();
                             })
                             .ok();
                         }


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2542/deleting-assistant-conversations-with-zed-open-can-cause-a-crash

We were updating the view's state but missed a `notify`, which caused the `UniformList` responsible for rendering the saved conversations to panic when some files were deleted.

Release Notes:

- Fixed a crash that could happen when deleting a saved assistant conversation from the filesystem.