### PR TITLE
Show inlay hints on startup for every language server with work events

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3397,6 +3397,7 @@ impl Project {
         cx: &mut ModelContext<Self>,
     ) {
         if let Some(status) = self.language_server_statuses.get_mut(&language_server_id) {
+            cx.emit(Event::RefreshInlays);
             status.pending_work.remove(&token);
             cx.notify();
         }


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-2537/inlay-hint-issues

Language servers such as typescript-language-servers report a single work event, ending right after server's startup.

Other servers might send more similar event, also during startup. The rest of the events are diagnostic-related and we filter them out.

React on such events with /refresh-like hint update, that will check only the visible part of the editor for hints and might be replaced by other /refresh requests, if needed.

Release Notes:

- N/A
