### PR TITLE
Skip key down event if preceded by its key equivalent version

### DIFF
--- a/crates/gpui/src/platform/event.rs
+++ b/crates/gpui/src/platform/event.rs
@@ -4,7 +4,7 @@ use pathfinder_geometry::vector::vec2f;
 
 use crate::{geometry::vector::Vector2F, keymap_matcher::Keystroke};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeyDownEvent {
     pub keystroke: Keystroke,
     pub is_held: bool,


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2552/pressing-two-keystrokes-in-rapid-succession-ignores-the-latter

Previously, we would only track whether the previous key down event was a key equivalent. However, this could cause issues when pressing certain keystrokes in rapid succession, e.g.:

- Pressing `shift-right` (to select a character, dispatched as a key equivalent)
- Pressing a character (with or without `shift` held down, dispatched as a key down)

This would cause GPUI to ignore the second event because it was preceded by a key equivalent event. With this commit, we track the last key equivalent event, and skip the key down event only if it matches the last key equivalent event.

Release Notes:

- Fixed a bug that could cause certain keystrokes performed in rapid succession to incorrectly get ignored.