### PR TITLE
Fix language servers improper restarts

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2916,7 +2916,7 @@ mod tests {
     use super::*;
     use crate::{
         display_map::{BlockDisposition, BlockProperties},
-        editor_tests::{init_test, update_test_settings},
+        editor_tests::{init_test, update_test_language_settings},
         Editor, MultiBuffer,
     };
     use gpui::TestAppContext;
@@ -3113,7 +3113,7 @@ mod tests {
         let resize_step = 10.0;
         let mut editor_width = 200.0;
         while editor_width <= 1000.0 {
-            update_test_settings(cx, |s| {
+            update_test_language_settings(cx, |s| {
                 s.defaults.tab_size = NonZeroU32::new(tab_size);
                 s.defaults.show_whitespaces = Some(ShowWhitespaceSetting::All);
                 s.defaults.preferred_line_length = Some(editor_width as u32);

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -847,7 +847,7 @@ mod tests {
     use text::Point;
     use workspace::Workspace;
 
-    use crate::editor_tests::update_test_settings;
+    use crate::editor_tests::update_test_language_settings;
 
     use super::*;
 
@@ -1476,7 +1476,7 @@ mod tests {
             ),
         ] {
             edits_made += 1;
-            update_test_settings(cx, |settings| {
+            update_test_language_settings(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
                     show_type_hints: new_allowed_hint_kinds.contains(&Some(InlayHintKind::Type)),
@@ -1520,7 +1520,7 @@ mod tests {
 
         edits_made += 1;
         let another_allowed_hint_kinds = HashSet::from_iter([Some(InlayHintKind::Type)]);
-        update_test_settings(cx, |settings| {
+        update_test_language_settings(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettings {
                 enabled: false,
                 show_type_hints: another_allowed_hint_kinds.contains(&Some(InlayHintKind::Type)),
@@ -1577,7 +1577,7 @@ mod tests {
 
         let final_allowed_hint_kinds = HashSet::from_iter([Some(InlayHintKind::Parameter)]);
         edits_made += 1;
-        update_test_settings(cx, |settings| {
+        update_test_language_settings(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettings {
                 enabled: true,
                 show_type_hints: final_allowed_hint_kinds.contains(&Some(InlayHintKind::Type)),
@@ -2269,7 +2269,7 @@ unedited (2nd) buffer should have the same hint");
             crate::init(cx);
         });
 
-        update_test_settings(cx, f);
+        update_test_language_settings(cx, f);
     }
 
     async fn prepare_test_objects(

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -90,7 +90,8 @@ pub struct LanguageServerName(pub Arc<str>);
 /// once at startup, and caches the results.
 pub struct CachedLspAdapter {
     pub name: LanguageServerName,
-    pub initialization_options: Option<Value>,
+    initialization_options: Option<Value>,
+    initialization_overrides: Mutex<Option<Value>>,
     pub disk_based_diagnostic_sources: Vec<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
     pub language_ids: HashMap<String, String>,
@@ -109,6 +110,7 @@ impl CachedLspAdapter {
         Arc::new(CachedLspAdapter {
             name,
             initialization_options,
+            initialization_overrides: Mutex::new(None),
             disk_based_diagnostic_sources,
             disk_based_diagnostics_progress_token,
             language_ids,
@@ -207,6 +209,30 @@ impl CachedLspAdapter {
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         self.adapter.label_for_symbol(name, kind, language).await
+    }
+
+    pub fn update_initialization_overrides(&self, new: Option<&Value>) -> bool {
+        let mut current = self.initialization_overrides.lock();
+        if current.as_ref() != new {
+            *current = new.cloned();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn initialization_options(&self) -> Option<Value> {
+        let initialization_options = self.initialization_options.as_ref();
+        let override_options = self.initialization_overrides.lock().clone();
+        match (initialization_options, override_options) {
+            (None, override_options) => override_options,
+            (initialization_options, None) => initialization_options.cloned(),
+            (Some(initialization_options), Some(override_options)) => {
+                let mut initialization_options = initialization_options.clone();
+                merge_json_value_into(override_options, &mut initialization_options);
+                Some(initialization_options)
+            }
+        }
     }
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -453,6 +453,7 @@ fn deserialize_regex<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Regex>, D
 #[cfg(any(test, feature = "test-support"))]
 pub struct FakeLspAdapter {
     pub name: &'static str,
+    pub initialization_options: Option<Value>,
     pub capabilities: lsp::ServerCapabilities,
     pub initializer: Option<Box<dyn 'static + Send + Sync + Fn(&mut lsp::FakeLanguageServer)>>,
     pub disk_based_diagnostics_progress_token: Option<String>,
@@ -1663,6 +1664,7 @@ impl Default for FakeLspAdapter {
             capabilities: lsp::LanguageServer::full_capabilities(),
             initializer: None,
             disk_based_diagnostics_progress_token: None,
+            initialization_options: None,
             disk_based_diagnostics_sources: Vec::new(),
         }
     }
@@ -1711,6 +1713,10 @@ impl LspAdapter for Arc<FakeLspAdapter> {
 
     async fn disk_based_diagnostics_progress_token(&self) -> Option<String> {
         self.disk_based_diagnostics_progress_token.clone()
+    }
+
+    async fn initialization_options(&self) -> Option<Value> {
+        self.initialization_options.clone()
     }
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -78,8 +78,8 @@ use std::{
 use terminals::Terminals;
 use text::Anchor;
 use util::{
-    debug_panic, defer, http::HttpClient, merge_json_value_into,
-    paths::LOCAL_SETTINGS_RELATIVE_PATH, post_inc, ResultExt, TryFutureExt as _,
+    debug_panic, defer, http::HttpClient, paths::LOCAL_SETTINGS_RELATIVE_PATH, post_inc, ResultExt,
+    TryFutureExt as _,
 };
 
 pub use fs::*;
@@ -800,7 +800,7 @@ impl Project {
                         .lsp
                         .get(&adapter.name.0)
                         .and_then(|s| s.initialization_options.as_ref());
-                    if adapter.initialization_options.as_ref() != new_lsp_settings {
+                    if adapter.update_initialization_overrides(new_lsp_settings) {
                         language_servers_to_restart.push((worktree, Arc::clone(language)));
                     }
                 }
@@ -2545,20 +2545,13 @@ impl Project {
         let project_settings = settings::get::<ProjectSettings>(cx);
         let lsp = project_settings.lsp.get(&adapter.name.0);
         let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
-
-        let mut initialization_options = adapter.initialization_options.clone();
-        match (&mut initialization_options, override_options) {
-            (Some(initialization_options), Some(override_options)) => {
-                merge_json_value_into(override_options, initialization_options);
-            }
-            (None, override_options) => initialization_options = override_options,
-            _ => {}
-        }
+        adapter.update_initialization_overrides(override_options.as_ref());
 
         let server_id = pending_server.server_id;
         let container_dir = pending_server.container_dir.clone();
         let state = LanguageServerState::Starting({
             let adapter = adapter.clone();
+            let initialization_options = adapter.initialization_options();
             let server_name = adapter.name.0.clone();
             let languages = self.languages.clone();
             let language = language.clone();


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2595/language-servers-are-unnecessarily-restarted-when-unrelated-settings

Language servers mixed `initialization_options` from hardcodes and user settings, fix that to ensure we restart servers on their settings changes only.

Release Notes:

- Fixes a bug that caused excessive language server restarts
