### PR TITLE
recent_projects: Perform fuzzy search on compacted paths.

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -134,10 +134,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let combined_string = location
                     .paths()
                     .iter()
-                    .map(|path| {
-                        let compact = util::paths::compact(&path);
-                        compact.to_string_lossy().into_owned()
-                    })
+                    .map(|path| util::paths::compact(&path).to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
                     .join("");
                 StringMatchCandidate::new(id, combined_string)

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -134,7 +134,10 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let combined_string = location
                     .paths()
                     .iter()
-                    .map(|path| path.to_string_lossy().to_owned())
+                    .map(|path| {
+                        let compact = util::paths::compact(&path);
+                        compact.to_string_lossy().into_owned()
+                    })
                     .collect::<Vec<_>>()
                     .join("");
                 StringMatchCandidate::new(id, combined_string)


### PR DESCRIPTION
Match highlighting for recent projects picker was off, because the path representation was compacted - for a path '/Users/hiro/Projects/zed' we compact it to use a tilde instead of home directory (`~/Projects/zed`). However, the highlight positions were always calculated for a full path, leading to a mismatch in highlights. This commit addresses this by running fuzzy search on compacted paths instead of using long paths. This might lead to a slight performance hit, but given that recent projects modal shouldn't have that many items in the first place, it should be okay.

Z-2546

Release Notes:

- Fixed result highlighting in "Recent projects" modal.

