### PR TITLE
Refactor LSP restart logic 

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -369,6 +369,7 @@ mod tests {
             editor::init(cx);
             workspace::init(app_state.clone(), cx);
             init(cx);
+            Project::init_settings(cx);
             app_state
         })
     }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -90,8 +90,7 @@ pub struct LanguageServerName(pub Arc<str>);
 /// once at startup, and caches the results.
 pub struct CachedLspAdapter {
     pub name: LanguageServerName,
-    initialization_options: Option<Value>,
-    initialization_overrides: Mutex<Option<Value>>,
+    pub initialization_options: Option<Value>,
     pub disk_based_diagnostic_sources: Vec<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
     pub language_ids: HashMap<String, String>,
@@ -110,7 +109,6 @@ impl CachedLspAdapter {
         Arc::new(CachedLspAdapter {
             name,
             initialization_options,
-            initialization_overrides: Mutex::new(None),
             disk_based_diagnostic_sources,
             disk_based_diagnostics_progress_token,
             language_ids,
@@ -209,30 +207,6 @@ impl CachedLspAdapter {
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         self.adapter.label_for_symbol(name, kind, language).await
-    }
-
-    pub fn update_initialization_overrides(&self, new: Option<&Value>) -> bool {
-        let mut current = self.initialization_overrides.lock();
-        if current.as_ref() != new {
-            *current = new.cloned();
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn initialization_options(&self) -> Option<Value> {
-        let initialization_options = self.initialization_options.as_ref();
-        let override_options = self.initialization_overrides.lock().clone();
-        match (initialization_options, override_options) {
-            (None, override_options) => override_options,
-            (initialization_options, None) => initialization_options.cloned(),
-            (Some(initialization_options), Some(override_options)) => {
-                let mut initialization_options = initialization_options.clone();
-                merge_json_value_into(override_options, &mut initialization_options);
-                Some(initialization_options)
-            }
-        }
     }
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -50,7 +50,7 @@ use lsp::{
 };
 use lsp_command::*;
 use postage::watch;
-use project_settings::ProjectSettings;
+use project_settings::{LspSettings, ProjectSettings};
 use rand::prelude::*;
 use search::SearchQuery;
 use serde::Serialize;
@@ -149,6 +149,7 @@ pub struct Project {
     _maintain_workspace_config: Task<()>,
     terminals: Terminals,
     copilot_enabled: bool,
+    current_lsp_settings: HashMap<Arc<str>, LspSettings>,
 }
 
 struct DelayedDebounced {
@@ -614,6 +615,7 @@ impl Project {
                     local_handles: Vec::new(),
                 },
                 copilot_enabled: Copilot::global(cx).is_some(),
+                current_lsp_settings: settings::get::<ProjectSettings>(cx).lsp.clone(),
             }
         })
     }
@@ -706,6 +708,7 @@ impl Project {
                     local_handles: Vec::new(),
                 },
                 copilot_enabled: Copilot::global(cx).is_some(),
+                current_lsp_settings: settings::get::<ProjectSettings>(cx).lsp.clone(),
             };
             for worktree in worktrees {
                 let _ = this.add_worktree(&worktree, cx);
@@ -779,7 +782,9 @@ impl Project {
         let mut language_servers_to_stop = Vec::new();
         let mut language_servers_to_restart = Vec::new();
         let languages = self.languages.to_vec();
-        let project_settings = settings::get::<ProjectSettings>(cx).clone();
+
+        let new_lsp_settings = settings::get::<ProjectSettings>(cx).lsp.clone();
+        let current_lsp_settings = &self.current_lsp_settings;
         for (worktree_id, started_lsp_name) in self.language_server_ids.keys() {
             let language = languages.iter().find_map(|l| {
                 let adapter = l
@@ -796,16 +801,25 @@ impl Project {
                 if !language_settings(Some(language), file.as_ref(), cx).enable_language_server {
                     language_servers_to_stop.push((*worktree_id, started_lsp_name.clone()));
                 } else if let Some(worktree) = worktree {
-                    let new_lsp_settings = project_settings
-                        .lsp
-                        .get(&adapter.name.0)
-                        .and_then(|s| s.initialization_options.as_ref());
-                    if adapter.initialization_options.as_ref() != new_lsp_settings {
-                        language_servers_to_restart.push((worktree, Arc::clone(language)));
+                    let server_name = &adapter.name.0;
+                    match (
+                        current_lsp_settings.get(server_name),
+                        new_lsp_settings.get(server_name),
+                    ) {
+                        (None, None) => {}
+                        (Some(_), None) | (None, Some(_)) => {
+                            language_servers_to_restart.push((worktree, Arc::clone(language)));
+                        }
+                        (Some(current_lsp_settings), Some(new_lsp_settings)) => {
+                            if current_lsp_settings != new_lsp_settings {
+                                language_servers_to_restart.push((worktree, Arc::clone(language)));
+                            }
+                        }
                     }
                 }
             }
         }
+        self.current_lsp_settings = new_lsp_settings;
 
         // Stop all newly-disabled language servers.
         for (worktree_id, adapter_name) in language_servers_to_stop {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -907,6 +907,7 @@ mod tests {
         let params = cx.update(AppState::test);
         cx.update(|cx| {
             theme::init((), cx);
+            Project::init_settings(cx);
             language::init(cx);
         });
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2316,6 +2316,7 @@ mod tests {
             cx.set_global(SettingsStore::test(cx));
             theme::init((), cx);
             crate::init_settings(cx);
+            Project::init_settings(cx);
         });
     }
 


### PR DESCRIPTION
Instead of storing `initialization_options` in every LSP adapter as
before, store previous LSP settings in `Project` entirely.

This way, we can later have use multiple different project
configurations per single LSP with its associated adapter.

Release Notes:

- N/A
