### PR TITLE
Avoid user menu toggle button overlapping with tab bar top border

### DIFF
--- a/styles/src/style_tree/titlebar.ts
+++ b/styles/src/style_tree/titlebar.ts
@@ -84,7 +84,7 @@ function user_menu() {
                 base: {
                     corner_radius: 6,
                     height: button_height,
-                    width: online ? 37 : 24,
+                    width: 20,
                     padding: {
                         top: 2,
                         bottom: 2,
@@ -153,6 +153,7 @@ function user_menu() {
             },
         }
     }
+
     return {
         user_menu_button_online: build_button({ online: true }),
         user_menu_button_offline: build_button({ online: false }),


### PR DESCRIPTION
Something little I noticed today

| | Normal  | Hovered |
| ------------- | ------------- | - |
| Before  | ![CleanShot 2023-07-11 at 16 57 37](https://github.com/zed-industries/zed/assets/30666851/30769d09-678e-4d66-96de-df51c6d030cc) ![CleanShot 2023-07-12 at 10 17 20](https://github.com/zed-industries/zed/assets/30666851/801e1f26-1cea-45a7-8a50-b620095e2131) | ![CleanShot 2023-07-11 at 16 59 46](https://github.com/zed-industries/zed/assets/30666851/fd1324c2-669f-42f8-96b3-4d65b555fb6e) ![CleanShot 2023-07-12 at 10 17 39](https://github.com/zed-industries/zed/assets/30666851/b286488d-b81e-44d5-a67c-dd816c072f86) |
| After  | ![CleanShot 2023-07-11 at 16 59 25](https://github.com/zed-industries/zed/assets/30666851/9942733f-8129-4854-bbfe-9a292b0e2c0e) ![CleanShot 2023-07-12 at 10 18 52](https://github.com/zed-industries/zed/assets/30666851/0b0f5fec-4c44-4c4f-8921-3b8a2cfff38c) | ![CleanShot 2023-07-11 at 17 02 19](https://github.com/zed-industries/zed/assets/30666851/6ab82b26-0548-4ce7-8fdc-38ae561d26aa) ![CleanShot 2023-07-12 at 10 19 28](https://github.com/zed-industries/zed/assets/30666851/a024f6e8-f0f4-4d81-9f90-38a655a09031) |

Also makes it match the contacts button and seems to more closely resemble the mockups as far as I can tell 

![CleanShot 2023-07-11 at 17 02 55](https://github.com/zed-industries/zed/assets/30666851/07fb1dea-5922-4bdc-9a3b-f7c1b105d017)

Release Notes:

- Fixed the titlebar user menu button obscuring part of the border below it.
