### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           rustup update stable
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           submodules: 'recursive'
@@ -54,12 +54,12 @@ jobs:
           cargo install cargo-nextest
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           submodules: 'recursive'
@@ -104,12 +104,12 @@ jobs:
           rustup target add wasm32-wasi
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           submodules: 'recursive'

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -29,12 +29,12 @@ jobs:
           rustup update stable
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           submodules: 'recursive'


### PR DESCRIPTION
Fixes deprecation warnings the CI jobs started to have:

https://github.com/zed-industries/zed/actions/runs/5535503789

<img width="1383" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/a33ecc2a-d6d3-451d-8033-da5754df4731">

Release Notes:

- N/A


