### PR TITLE
Select all matches

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -221,7 +221,8 @@
       "escape": "buffer_search::Dismiss",
       "tab": "buffer_search::FocusEditor",
       "enter": "search::SelectNextMatch",
-      "shift-enter": "search::SelectPrevMatch"
+      "shift-enter": "search::SelectPrevMatch",
+      "cmd-shift-k": "search::CaretsToAllMatches"
     }
   },
   {
@@ -242,6 +243,7 @@
       "cmd-f": "project_search::ToggleFocus",
       "cmd-g": "search::SelectNextMatch",
       "cmd-shift-g": "search::SelectPrevMatch",
+      "cmd-shift-k": "search::CaretsToAllMatches",
       "alt-cmd-c": "search::ToggleCaseSensitive",
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-cmd-r": "search::ToggleRegex"

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -194,8 +194,8 @@
   {
     "context": "Editor && mode == auto_height",
     "bindings": {
-      "alt-enter": "editor::Newline",
-      "cmd-alt-enter": "editor::NewlineBelow"
+      "shift-enter": "editor::Newline",
+      "cmd-shift-enter": "editor::NewlineBelow"
     }
   },
   {
@@ -222,7 +222,7 @@
       "tab": "buffer_search::FocusEditor",
       "enter": "search::SelectNextMatch",
       "shift-enter": "search::SelectPrevMatch",
-      "cmd-shift-k": "search::CaretsToAllMatches"
+      "alt-enter": "search::CaretsToAllMatches"
     }
   },
   {
@@ -243,7 +243,7 @@
       "cmd-f": "project_search::ToggleFocus",
       "cmd-g": "search::SelectNextMatch",
       "cmd-shift-g": "search::SelectPrevMatch",
-      "cmd-shift-k": "search::CaretsToAllMatches",
+      "alt-enter": "search::CaretsToAllMatches",
       "alt-cmd-c": "search::ToggleCaseSensitive",
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-cmd-r": "search::ToggleRegex"

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -222,7 +222,7 @@
       "tab": "buffer_search::FocusEditor",
       "enter": "search::SelectNextMatch",
       "shift-enter": "search::SelectPrevMatch",
-      "alt-enter": "search::CaretsToAllMatches"
+      "alt-enter": "search::SelectAllMatches"
     }
   },
   {
@@ -243,7 +243,7 @@
       "cmd-f": "project_search::ToggleFocus",
       "cmd-g": "search::SelectNextMatch",
       "cmd-shift-g": "search::SelectPrevMatch",
-      "alt-enter": "search::CaretsToAllMatches",
+      "alt-enter": "search::SelectAllMatches",
       "alt-cmd-c": "search::ToggleCaseSensitive",
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-cmd-r": "search::ToggleRegex"

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -941,6 +941,11 @@ impl SearchableItem for Editor {
         });
     }
 
+    fn select_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>) {
+        self.unfold_ranges(matches.clone(), false, false, cx);
+        self.change_selections(None, cx, |s| s.select_ranges(matches));
+    }
+
     fn match_index_for_direction(
         &mut self,
         matches: &Vec<Range<Anchor>>,

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -16,13 +16,13 @@ use crate::{
     Anchor, DisplayPoint, ExcerptId, MultiBuffer, MultiBufferSnapshot, SelectMode, ToOffset,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PendingSelection {
     pub selection: Selection<Anchor>,
     pub mode: SelectMode,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SelectionsCollection {
     display_map: ModelHandle<DisplayMap>,
     buffer: ModelHandle<MultiBuffer>,

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -391,6 +391,11 @@ impl SearchableItem for FeedbackEditor {
             .update(cx, |editor, cx| editor.activate_match(index, matches, cx))
     }
 
+    fn select_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>) {
+        self.editor
+            .update(cx, |e, cx| e.select_matches(matches, cx))
+    }
+
     fn find_matches(
         &mut self,
         query: project::search::SearchQuery,

--- a/crates/feedback/src/feedback_editor.rs
+++ b/crates/feedback/src/feedback_editor.rs
@@ -362,8 +362,13 @@ impl Item for FeedbackEditor {
 impl SearchableItem for FeedbackEditor {
     type Match = Range<Anchor>;
 
-    fn to_search_event(event: &Self::Event) -> Option<workspace::searchable::SearchEvent> {
-        Editor::to_search_event(event)
+    fn to_search_event(
+        &mut self,
+        event: &Self::Event,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<workspace::searchable::SearchEvent> {
+        self.editor
+            .update(cx, |editor, cx| editor.to_search_event(event, cx))
     }
 
     fn clear_matches(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -494,6 +494,11 @@ impl SearchableItem for LspLogView {
             .update(cx, |e, cx| e.activate_match(index, matches, cx))
     }
 
+    fn select_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>) {
+        self.editor
+            .update(cx, |e, cx| e.select_matches(matches, cx))
+    }
+
     fn find_matches(
         &mut self,
         query: project::search::SearchQuery,

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -467,8 +467,13 @@ impl Item for LspLogView {
 impl SearchableItem for LspLogView {
     type Match = <Editor as SearchableItem>::Match;
 
-    fn to_search_event(event: &Self::Event) -> Option<workspace::searchable::SearchEvent> {
-        Editor::to_search_event(event)
+    fn to_search_event(
+        &mut self,
+        event: &Self::Event,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<workspace::searchable::SearchEvent> {
+        self.editor
+            .update(cx, |editor, cx| editor.to_search_event(event, cx))
     }
 
     fn clear_matches(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CaretsToAllMatches, SearchOption, SelectNextMatch, SelectPrevMatch, ToggleCaseSensitive,
+    SearchOption, SelectAllMatches, SelectNextMatch, SelectPrevMatch, ToggleCaseSensitive,
     ToggleRegex, ToggleWholeWord,
 };
 use collections::HashMap;
@@ -39,10 +39,10 @@ pub fn init(cx: &mut AppContext) {
     cx.add_action(BufferSearchBar::focus_editor);
     cx.add_action(BufferSearchBar::select_next_match);
     cx.add_action(BufferSearchBar::select_prev_match);
-    cx.add_action(BufferSearchBar::carets_to_all_matches);
+    cx.add_action(BufferSearchBar::select_all_matches);
     cx.add_action(BufferSearchBar::select_next_match_on_pane);
     cx.add_action(BufferSearchBar::select_prev_match_on_pane);
-    cx.add_action(BufferSearchBar::carets_to_all_matches_on_pane);
+    cx.add_action(BufferSearchBar::select_all_matches_on_pane);
     cx.add_action(BufferSearchBar::handle_editor_cancel);
     add_toggle_option_action::<ToggleCaseSensitive>(SearchOption::CaseSensitive, cx);
     add_toggle_option_action::<ToggleWholeWord>(SearchOption::WholeWord, cx);
@@ -490,7 +490,7 @@ impl BufferSearchBar {
         self.select_match(Direction::Prev, cx);
     }
 
-    fn carets_to_all_matches(&mut self, _: &CaretsToAllMatches, cx: &mut ViewContext<Self>) {
+    fn select_all_matches(&mut self, _: &SelectAllMatches, cx: &mut ViewContext<Self>) {
         if !self.dismissed {
             if let Some(searchable_item) = self.active_searchable_item.as_ref() {
                 if let Some(matches) = self
@@ -540,13 +540,13 @@ impl BufferSearchBar {
         }
     }
 
-    fn carets_to_all_matches_on_pane(
+    fn select_all_matches_on_pane(
         pane: &mut Pane,
-        action: &CaretsToAllMatches,
+        action: &SelectAllMatches,
         cx: &mut ViewContext<Pane>,
     ) {
         if let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>() {
-            search_bar.update(cx, |bar, cx| bar.carets_to_all_matches(action, cx));
+            search_bar.update(cx, |bar, cx| bar.select_all_matches(action, cx));
         }
     }
 
@@ -994,7 +994,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_search_carets_to_all_matches(cx: &mut TestAppContext) {
+    async fn test_search_select_all_matches(cx: &mut TestAppContext) {
         crate::project_search::tests::init_test(cx);
 
         let buffer_text = r#"
@@ -1038,7 +1038,7 @@ mod tests {
         });
 
         search_bar.update(cx, |search_bar, cx| {
-            search_bar.carets_to_all_matches(&CaretsToAllMatches, cx);
+            search_bar.select_all_matches(&SelectAllMatches, cx);
             let all_selections =
                 editor.update(cx, |editor, cx| editor.selections.display_ranges(cx));
             assert_eq!(

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -148,6 +148,7 @@ impl View for BufferSearchBar {
                         Flex::row()
                             .with_child(self.render_nav_button("<", Direction::Prev, cx))
                             .with_child(self.render_nav_button(">", Direction::Next, cx))
+                            .with_child(self.render_action_button("Select All", cx))
                             .aligned(),
                     )
                     .with_child(
@@ -397,6 +398,37 @@ impl BufferSearchBar {
             direction as usize,
             tooltip.to_string(),
             Some(action),
+            tooltip_style,
+            cx,
+        )
+        .into_any()
+    }
+
+    fn render_action_button(
+        &self,
+        icon: &'static str,
+        cx: &mut ViewContext<Self>,
+    ) -> AnyElement<Self> {
+        let tooltip = "Select All Matches";
+        let tooltip_style = theme::current(cx).tooltip.clone();
+        let action_type_id = 0_usize;
+
+        enum ActionButton {}
+        MouseEventHandler::<ActionButton, _>::new(action_type_id, cx, |state, cx| {
+            let theme = theme::current(cx);
+            let style = theme.search.action_button.style_for(state);
+            Label::new(icon, style.text.clone())
+                .contained()
+                .with_style(style.container)
+        })
+        .on_click(MouseButton::Left, move |_, this, cx| {
+            this.select_all_matches(&SelectAllMatches, cx)
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .with_tooltip::<ActionButton>(
+            action_type_id,
+            tooltip.to_string(),
+            Some(Box::new(SelectAllMatches)),
             tooltip_style,
             cx,
         )

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -17,7 +17,8 @@ actions!(
         ToggleCaseSensitive,
         ToggleRegex,
         SelectNextMatch,
-        SelectPrevMatch
+        SelectPrevMatch,
+        CaretsToAllMatches,
     ]
 );
 

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -18,7 +18,7 @@ actions!(
         ToggleRegex,
         SelectNextMatch,
         SelectPrevMatch,
-        CaretsToAllMatches,
+        SelectAllMatches,
     ]
 );
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -908,6 +908,21 @@ impl Terminal {
         }
     }
 
+    pub fn select_matches(&mut self, matches: Vec<RangeInclusive<Point>>) {
+        let matches_to_select = self
+            .matches
+            .iter()
+            .filter(|self_match| matches.contains(self_match))
+            .cloned()
+            .collect::<Vec<_>>();
+        for match_to_select in matches_to_select {
+            self.set_selection(Some((
+                make_selection(&match_to_select),
+                *match_to_select.end(),
+            )));
+        }
+    }
+
     fn set_selection(&mut self, selection: Option<(Selection, Point)>) {
         self.events
             .push_back(InternalEvent::SetSelection(selection));

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -682,6 +682,13 @@ impl SearchableItem for TerminalView {
         cx.notify();
     }
 
+    /// Add selections for all matches given.
+    fn select_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>) {
+        self.terminal()
+            .update(cx, |term, _| term.select_matches(matches));
+        cx.notify();
+    }
+
     /// Get all of the matches for this query, should be done on the background
     fn find_matches(
         &mut self,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -647,7 +647,11 @@ impl SearchableItem for TerminalView {
     }
 
     /// Convert events raised by this item into search-relevant events (if applicable)
-    fn to_search_event(event: &Self::Event) -> Option<SearchEvent> {
+    fn to_search_event(
+        &mut self,
+        event: &Self::Event,
+        _: &mut ViewContext<Self>,
+    ) -> Option<SearchEvent> {
         match event {
             Event::Wakeup => Some(SearchEvent::MatchesInvalidated),
             Event::SelectionsChanged => Some(SearchEvent::ActiveMatchChanged),

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -379,6 +379,7 @@ pub struct Search {
     pub invalid_include_exclude_editor: ContainerStyle,
     pub include_exclude_inputs: ContainedText,
     pub option_button: Toggleable<Interactive<ContainedText>>,
+    pub action_button: Interactive<ContainedText>,
     pub match_background: Color,
     pub match_index: ContainedText,
     pub results_status: TextStyle,

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -47,6 +47,7 @@ pub trait SearchableItem: Item {
         matches: Vec<Self::Match>,
         cx: &mut ViewContext<Self>,
     );
+    fn select_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>);
     fn match_index_for_direction(
         &mut self,
         matches: &Vec<Self::Match>,
@@ -102,6 +103,7 @@ pub trait SearchableItemHandle: ItemHandle {
         matches: &Vec<Box<dyn Any + Send>>,
         cx: &mut WindowContext,
     );
+    fn select_matches(&self, matches: &Vec<Box<dyn Any + Send>>, cx: &mut WindowContext);
     fn match_index_for_direction(
         &self,
         matches: &Vec<Box<dyn Any + Send>>,
@@ -165,6 +167,12 @@ impl<T: SearchableItem> SearchableItemHandle for ViewHandle<T> {
         let matches = downcast_matches(matches);
         self.update(cx, |this, cx| this.activate_match(index, matches, cx));
     }
+
+    fn select_matches(&self, matches: &Vec<Box<dyn Any + Send>>, cx: &mut WindowContext) {
+        let matches = downcast_matches(matches);
+        self.update(cx, |this, cx| this.select_matches(matches, cx));
+    }
+
     fn match_index_for_direction(
         &self,
         matches: &Vec<Box<dyn Any + Send>>,

--- a/styles/src/style_tree/search.ts
+++ b/styles/src/style_tree/search.ts
@@ -83,6 +83,35 @@ export default function search(): any {
                 },
             },
         }),
+        action_button: interactive({
+            base: {
+                ...text(theme.highest, "mono", "on"),
+                background: background(theme.highest, "on"),
+                corner_radius: 6,
+                border: border(theme.highest, "on"),
+                margin: {
+                    right: 4,
+                },
+                padding: {
+                    bottom: 2,
+                    left: 10,
+                    right: 10,
+                    top: 2,
+                },
+            },
+            state: {
+                hovered: {
+                    ...text(theme.highest, "mono", "on", "hovered"),
+                    background: background(theme.highest, "on", "hovered"),
+                    border: border(theme.highest, "on", "hovered"),
+                },
+                clicked: {
+                    ...text(theme.highest, "mono", "on", "pressed"),
+                    background: background(theme.highest, "on", "pressed"),
+                    border: border(theme.highest, "on", "pressed"),
+                },
+            },
+        }),
         editor,
         invalid_editor: {
             ...editor,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/6208

The PR 

* changes keybindings for `Editor && mode == auto_height` context: before, `alt-enter` and `alt-shift-enter` added new lines in such editors, including the one from buffer search.

New bindings are the same as in `Editor && mode == full` context.

*  adds `search::SelectAllMatches` action and binds it to `Alt + Enter` by default, to select all matches of a buffer search

The behavior mimics VSCode: we do not move the screen even if all selections are out of the visible range (Cmd+G will navigate there) and allow reselecting the results from both pane and search field, as long as the search is not dismissed.

Release Notes:

- Added `search::SelectAllMatches` (`Alt + Enter` default) action to place carets and select all buffer search results ([#1749](https://github.com/zed-industries/zed/issues/6208)).
