### PR TITLE
branch_list: Ensure index is within list bounds.

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -182,7 +182,9 @@ impl PickerDelegate for BranchListDelegate {
 
     fn confirm(&mut self, cx: &mut ViewContext<Picker<Self>>) {
         let current_pick = self.selected_index();
-        let current_pick = self.matches[current_pick].string.clone();
+        let Some(current_pick) = self.matches.get(current_pick).map(|pick| pick.string.clone()) else {
+            return;
+        };
         cx.spawn(|picker, mut cx| async move {
             picker
                 .update(&mut cx, |this, cx| {


### PR DESCRIPTION
Z-2630


Release Notes:
- Fixed a crash in branch list that occurred when confirming a match in empty list.