### PR TITLE
branch_list: Bail in case of missing worktrees.

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -106,12 +106,14 @@ impl PickerDelegate for BranchListDelegate {
                 .read_with(&mut cx, |view, cx| {
                     let delegate = view.delegate();
                     let project = delegate.workspace.read(cx).project().read(&cx);
-                    let mut cwd =
-                    project
+
+                    let Some(worktree) = project
                         .visible_worktrees(cx)
                         .next()
-                        .unwrap()
-                        .read(cx)
+                    else {
+                        bail!("Cannot update branch list as there are no visible worktrees")
+                    };
+                    let mut cwd = worktree .read(cx)
                         .abs_path()
                         .to_path_buf();
                     cwd.push(".git");


### PR DESCRIPTION
Z-2632

Release Notes:
- Fixed a crash that occurred when opening a modal branch picker without a corktree.
