### PR TITLE
Make outline queries show more info

### DIFF
--- a/crates/zed/src/languages/javascript/outline.scm
+++ b/crates/zed/src/languages/javascript/outline.scm
@@ -6,6 +6,13 @@
     "enum" @context
     name: (_) @name) @item
 
+(return_statement
+    "return" @context
+    (object
+        "{" @context
+        (pair
+            key: (_) @name) @item))
+
 (function_declaration
     "async"? @context
     "function" @context

--- a/crates/zed/src/languages/rust/outline.scm
+++ b/crates/zed/src/languages/rust/outline.scm
@@ -27,13 +27,27 @@
     (visibility_modifier)? @context
     (function_modifiers)? @context
     "fn" @context
-    name: (_) @name) @item
+    name: (_) @name
+    (parameters
+        "(" @context
+        ((self_parameter) @context ","? @context)?
+        ((parameter pattern: (_) @context) ","? @context)*
+        ")" @context)
+    "->"? @context
+    return_type: (_)? @context) @item
 
 (function_signature_item
     (visibility_modifier)? @context
     (function_modifiers)? @context
     "fn" @context
-    name: (_) @name) @item
+    name: (_) @name
+    (parameters
+        "(" @context
+        ((self_parameter) @context ","? @context)?
+        ((parameter pattern: (_) @context) ","? @context)*
+        ")" @context)
+    "->"? @context
+    return_type: (_)? @context) @item
 
 (macro_definition
     . "macro_rules!" @context
@@ -56,8 +70,12 @@
 (const_item
     (visibility_modifier)? @context
     "const" @context
-    name: (_) @name) @item
+    name: (_) @name
+    ":"? @context
+    type: (_)? @context) @item
 
 (field_declaration
     (visibility_modifier)? @context
-    name: (_) @name) @item
+    name: (_) @name
+    ":"? @context
+    type: (_)? @context) @item

--- a/crates/zed/src/languages/typescript/outline.scm
+++ b/crates/zed/src/languages/typescript/outline.scm
@@ -63,3 +63,13 @@
         (accessibility_modifier)
     ]* @context
     name: (_) @name) @item
+
+(return_statement
+    "return" @context
+    (object
+        "{" @context)) @item
+
+(return_statement
+    (object
+        (pair
+            key: (_) @name) @item))


### PR DESCRIPTION
I use our outline view a lot and I've always wished it had type information included in our rust outlines. I also find it hard to use on our styles repository, as it isn't set up in a way our outlines query knows how to index.  

Rust before/after:

<img width="1020" alt="Screenshot 2023-07-16 at 12 52 31 AM" src="https://github.com/zed-industries/zed/assets/2280405/a35c8eab-81f3-4ea2-b2a0-b86509ac5a6e">

Typescript/Javascript updates:

<img width="477" alt="Screenshot 2023-07-16 at 1 08 53 AM" src="https://github.com/zed-industries/zed/assets/2280405/ffd3f2de-f597-4bcd-8a42-166ea8f71fef">

TODO: 
- [ ] Figure out if spacing issues are solvable
- [ ] Figure out if this looks correct