### PR TITLE
chore(deps): bump tree-sitter-elixir rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-elixir"
 version = "0.1.0"
-source = "git+https://github.com/elixir-lang/tree-sitter-elixir?rev=4ba9dab6e2602960d95b2b625f3386c27e08084e#4ba9dab6e2602960d95b2b625f3386c27e08084e"
+source = "git+https://github.com/elixir-lang/tree-sitter-elixir?rev=2616034f78ffa83ca6a521ebd7eee1868cb5c14c#2616034f78ffa83ca6a521ebd7eee1868cb5c14c"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ pretty_assertions = "1.3.0"
 tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
 tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }
-tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "4ba9dab6e2602960d95b2b625f3386c27e08084e" }
+tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "2616034f78ffa83ca6a521ebd7eee1868cb5c14c" }
 tree-sitter-embedded-template = "0.20.0"
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/6214

Not sure what's the policy for updating dependencies here, I did at least the basics and tried to build the project, which was good as I discovered the `tree-sitter-elixir` crate [couldn't be built](https://github.com/elixir-lang/tree-sitter-elixir/issues/58) on [my patch](https://github.com/elixir-lang/tree-sitter-elixir/pull/57) rev but now that's fixed and the project builds fine

the big commit that would probably need some checking before merging this would be https://github.com/elixir-lang/tree-sitter-elixir/commit/f74a75dadf724e3b896f85c4a82ec519821e430d

I've checked and the software licenses now correctly point to the correct repo for the elixir treesitter

Release Notes:

- N/A