### PR TITLE
feat(workspace): add option for moving the tab close button to the left

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -128,9 +128,12 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
-  // Color tab titles based on the git status of the buffer.
+  // Settings related to the editor's tabs
   "tabs": {
-    "git_status": false
+    // Show git status colors in the editor tabs.
+    "git_status": false,
+    // Position of the close button on the editor tabs.
+    "close_position": "right"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -723,12 +723,12 @@ pub struct Scrollbar {
     pub thumb: ContainerStyle,
     pub width: f32,
     pub min_height_factor: f32,
-    pub git: FileGitDiffColors,
+    pub git: BufferGitDiffColors,
     pub selections: Color,
 }
 
 #[derive(Clone, Deserialize, Default, JsonSchema)]
-pub struct FileGitDiffColors {
+pub struct BufferGitDiffColors {
     pub inserted: Color,
     pub modified: Color,
     pub deleted: Color,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -33,11 +33,30 @@ use theme::Theme;
 #[derive(Deserialize)]
 pub struct ItemSettings {
     pub git_status: bool,
+    pub close_position: ClosePosition,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ClosePosition {
+    Left,
+    #[default]
+    Right,
+}
+
+impl ClosePosition {
+    pub fn right(&self) -> bool {
+        match self {
+            ClosePosition::Left => false,
+            ClosePosition::Right => true,
+        }
+    }
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ItemSettingsContent {
     git_status: Option<bool>,
+    close_position: Option<ClosePosition>,
 }
 
 impl Setting for ItemSettings {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/6213

Release Notes:

- Add option for chosing where the close button should be displayed on editor tabs
