### PR TITLE
Prevent multiple submissions of the same feedback text

### DIFF
--- a/crates/feedback/src/submit_feedback_button.rs
+++ b/crates/feedback/src/submit_feedback_button.rs
@@ -46,10 +46,28 @@ impl View for SubmitFeedbackButton {
 
     fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
         let theme = theme::current(cx).clone();
+        let allow_submission = self
+            .active_item
+            .as_ref()
+            .map_or(true, |i| i.read(cx).allow_submission);
+
         enum SubmitFeedbackButton {}
         MouseEventHandler::<SubmitFeedbackButton, Self>::new(0, cx, |state, _| {
-            let style = theme.feedback.submit_button.style_for(state);
-            Label::new("Submit as Markdown", style.text.clone())
+            let text;
+            let style = if allow_submission {
+                text = "Submit as Markdown";
+                theme.feedback.submit_button.style_for(state)
+            } else {
+                text = "Submitting...";
+                theme
+                    .feedback
+                    .submit_button
+                    .disabled
+                    .as_ref()
+                    .unwrap_or(&theme.feedback.submit_button.default)
+            };
+
+            Label::new(text, style.text.clone())
                 .contained()
                 .with_style(style.container)
         })

--- a/styles/src/style_tree/feedback.ts
+++ b/styles/src/style_tree/feedback.ts
@@ -33,6 +33,11 @@ export default function feedback(): any {
                     background: background(theme.highest, "on", "hovered"),
                     border: border(theme.highest, "on", "hovered"),
                 },
+                disabled: {
+                    ...text(theme.highest, "mono", "on", "disabled"),
+                    background: background(theme.highest, "on", "disabled"),
+                    border: border(theme.highest, "on", "disabled"),
+                }
             },
         }),
         button_margin: 8,


### PR DESCRIPTION
Fixes: https://linear.app/zed-industries/issue/Z-2416/improvements-to-feedback-submission

We get a lot of duplicate messages through our in-app feedback.  My best guess is that because we do not tell the user we are doing anything, and because submission takes awhile, users are hitting the submission button mutliple times.  This PR blocks the submission code, once an initial submission is sent.  If the original submission fails, we unblock the submission code.  The submit button is disabled and enabled accordingly as well.

Release Notes:

- N/A