### PR TITLE
vim: Allow ctrl+[ as an alias for escape

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -99,6 +99,10 @@
         "vim::SwitchMode",
         "Normal"
       ],
+      "ctrl+[": [
+        "vim::SwitchMode",
+        "Normal"
+      ],
       "0": "vim::StartOfLine", // When no number operator present, use start of line motion
       "1": [
         "vim::Number",
@@ -234,10 +238,6 @@
       "h": "editor::Hover",
       "t": "pane::ActivateNextItem",
       "shift-t": "pane::ActivatePrevItem",
-      "escape": [
-        "vim::SwitchMode",
-        "Normal"
-      ],
       "d": "editor::GoToDefinition"
     }
   },
@@ -265,10 +265,6 @@
       "t": "editor::ScrollCursorTop",
       "z": "editor::ScrollCursorCenter",
       "b": "editor::ScrollCursorBottom",
-      "escape": [
-        "vim::SwitchMode",
-        "Normal"
-      ]
     }
   },
   {
@@ -322,7 +318,8 @@
     "context": "Editor && vim_mode == insert",
     "bindings": {
       "escape": "vim::NormalBefore",
-      "ctrl-c": "vim::NormalBefore"
+      "ctrl-c": "vim::NormalBefore",
+      "ctrl-[": "vim::NormalBefore",
     }
   },
   {
@@ -331,6 +328,10 @@
       "tab": "vim::Tab",
       "enter": "vim::Enter",
       "escape": [
+        "vim::SwitchMode",
+        "Normal"
+      ],
+      "ctrl+[": [
         "vim::SwitchMode",
         "Normal"
       ]


### PR DESCRIPTION
Also remove unneeded mappings in `g` and `z` modes

Release Notes:

- Adds `ctrl+[` as an alias for escape ([#538](https://github.com/zed-industries/zed/issues/5206)).