### PR TITLE
Rework terminal highlight mechanism

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1915,7 +1915,9 @@ impl Project {
                 return;
             }
 
-            let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
+            let abs_path = file.abs_path(cx);
+            let uri = lsp::Url::from_file_path(&abs_path)
+                .unwrap_or_else(|()| panic!("Failed to register file {abs_path:?}"));
             let initial_snapshot = buffer.text_snapshot();
             let language = buffer.language().cloned();
             let worktree_id = file.worktree_id(cx);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -72,9 +72,10 @@ const DEBUG_TERMINAL_HEIGHT: f32 = 30.;
 const DEBUG_CELL_WIDTH: f32 = 5.;
 const DEBUG_LINE_HEIGHT: f32 = 5.;
 
-// Regex Copied from alacritty's ui_config.rs
-
 lazy_static! {
+    // Regex Copied from alacritty's ui_config.rs
+    pub static ref URL_REGEX: RegexSearch = RegexSearch::new("(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+").unwrap();
+
     static ref WORD_REGEX: RegexSearch = RegexSearch::new("[\\w.:/@-]+").unwrap();
 }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -838,7 +838,7 @@ impl Terminal {
                     self.last_content.size,
                     term.grid().display_offset(),
                 )
-                .grid_clamp(term, alacritty_terminal::index::Boundary::Cursor);
+                .grid_clamp(term, alacritty_terminal::index::Boundary::Grid);
 
                 let link = term.grid().index(point).hyperlink();
                 let found_word = if link.is_some() {

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -392,10 +392,6 @@ impl TerminalElement {
 
         let mut region = MouseRegion::new::<Self>(cx.view_id(), 0, visible_bounds);
 
-        // 1. Get file:linenumber syntax working ✔️
-        // 2. Switch terminal to look for word boundaries, on cmd-hover
-        // 3. Send those query strings to the resolver thing above
-
         // Terminal Emulator controlled behavior:
         region = region
             // Start selections

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -392,6 +392,10 @@ impl TerminalElement {
 
         let mut region = MouseRegion::new::<Self>(cx.view_id(), 0, visible_bounds);
 
+        // 1. Get file:linenumber syntax working ✔️
+        // 2. Switch terminal to look for word boundaries, on cmd-hover
+        // 3. Send those query strings to the resolver thing above
+
         // Terminal Emulator controlled behavior:
         region = region
             // Start selections

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -583,17 +583,23 @@ impl Element<TerminalView> for TerminalElement {
         let last_hovered_hyperlink = terminal_handle.update(cx, |terminal, cx| {
             terminal.set_size(dimensions);
             terminal.try_sync(cx);
-            terminal.last_content.last_hovered_hyperlink.clone()
+            terminal.last_content.last_hovered_word.clone()
         });
 
-        let hyperlink_tooltip = last_hovered_hyperlink.map(|(uri, _, id)| {
+        let hyperlink_tooltip = last_hovered_hyperlink.map(|hovered_word| {
             let mut tooltip = Overlay::new(
                 Empty::new()
                     .contained()
                     .constrained()
                     .with_width(dimensions.width())
                     .with_height(dimensions.height())
-                    .with_tooltip::<TerminalElement>(id, uri, None, tooltip_style, cx),
+                    .with_tooltip::<TerminalElement>(
+                        hovered_word.id,
+                        hovered_word.word,
+                        None,
+                        tooltip_style,
+                        cx,
+                    ),
             )
             .with_position_mode(gpui::elements::OverlayPositionMode::Local)
             .into_any();
@@ -613,7 +619,7 @@ impl Element<TerminalView> for TerminalElement {
             cursor_char,
             selection,
             cursor,
-            last_hovered_hyperlink,
+            last_hovered_word,
             ..
         } = { &terminal_handle.read(cx).last_content };
 
@@ -634,9 +640,9 @@ impl Element<TerminalView> for TerminalElement {
             &terminal_theme,
             cx.text_layout_cache(),
             cx.font_cache(),
-            last_hovered_hyperlink
+            last_hovered_word
                 .as_ref()
-                .map(|(_, range, _)| (link_style, range)),
+                .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
         );
 
         //Layout cursor. Rectangle is used for IME, so we should lay it out even

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -261,10 +261,14 @@ impl TerminalPanel {
                         .create_terminal(working_directory, window_id, cx)
                         .log_err()
                 }) {
-                    let terminal =
-                        Box::new(cx.add_view(|cx| {
-                            TerminalView::new(terminal, workspace.database_id(), cx)
-                        }));
+                    let terminal = Box::new(cx.add_view(|cx| {
+                        TerminalView::new(
+                            terminal,
+                            workspace.weak_handle(),
+                            workspace.database_id(),
+                            cx,
+                        )
+                    }));
                     pane.update(cx, |pane, cx| {
                         let focus = pane.has_focus();
                         pane.add_item(terminal, true, focus, None, cx);

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -172,10 +172,11 @@ impl TerminalView {
             }
             Event::NewNavigationTarget(maybe_navigation_target) => {
                 this.can_navigate_to_selected_word = match maybe_navigation_target {
-                    MaybeNavigationTarget::Url(_) => true,
-                    MaybeNavigationTarget::PathLike(maybe_path) => {
+                    Some(MaybeNavigationTarget::Url(_)) => true,
+                    Some(MaybeNavigationTarget::PathLike(maybe_path)) => {
                         !possible_open_targets(&workspace, maybe_path, cx).is_empty()
                     }
+                    None => false,
                 }
             }
             Event::Open(maybe_navigation_target) => match maybe_navigation_target {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -166,10 +166,11 @@ impl TerminalView {
                         .detach();
                 }
             }
-            Event::Open(maybe_url_or_path) => {
-                // TODO kb, what is the API for this?
-                // terminal::URL_REGEX.matches(maybe_url_or_path)
-                if maybe_url_or_path.starts_with("http") {
+            Event::Open {
+                is_url,
+                maybe_url_or_path,
+            } => {
+                if *is_url {
                     cx.platform().open_url(maybe_url_or_path);
                 } else if let Some(workspace) = workspace.upgrade(cx) {
                     let path_like =
@@ -180,10 +181,11 @@ impl TerminalView {
                     let maybe_path = path_like.path_like;
                     workspace.update(cx, |workspace, cx| {
                         if false { //&& workspace.contains_path() {
-                             //
+                             // TODO kb
                         } else if maybe_path.exists() {
+                            let visible = maybe_path.is_dir();
                             workspace
-                                .open_abs_path(maybe_path, true, cx)
+                                .open_abs_path(maybe_path, visible, cx)
                                 .detach_and_log_err(cx);
                         }
                     });

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -158,7 +158,13 @@ impl TerminalView {
                         .detach();
                 }
             }
-            _ => cx.emit(*event),
+            Event::Open(url) => {
+                // Get a workspace pointer from the new() function above
+                // Guess for project path or url
+                // Either run open buffer action OR platform open depending on whatever happens
+                cx.platform().open_url(url);
+            }
+            _ => cx.emit(event.clone()),
         })
         .detach();
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -11,7 +11,7 @@ use gpui::{
     geometry::vector::Vector2F,
     impl_actions,
     keymap_matcher::{KeymapContext, Keystroke},
-    platform::KeyDownEvent,
+    platform::{KeyDownEvent, ModifiersChangedEvent},
     AnyElement, AnyViewHandle, AppContext, Element, Entity, ModelHandle, Task, View, ViewContext,
     ViewHandle, WeakViewHandle,
 };
@@ -159,6 +159,7 @@ impl TerminalView {
                 }
             }
             Event::Open(url) => {
+                // TODO kb
                 // Get a workspace pointer from the new() function above
                 // Guess for project path or url
                 // Either run open buffer action OR platform open depending on whatever happens
@@ -397,6 +398,20 @@ impl View for TerminalView {
             terminal.focus_out();
         });
         cx.notify();
+    }
+
+    fn modifiers_changed(
+        &mut self,
+        event: &ModifiersChangedEvent,
+        cx: &mut ViewContext<Self>,
+    ) -> bool {
+        let handled = self
+            .terminal()
+            .update(cx, |term, _| term.try_modifiers_change(&event.modifiers));
+        if handled {
+            cx.notify();
+        }
+        handled
     }
 
     fn key_down(&mut self, event: &KeyDownEvent, cx: &mut ViewContext<Self>) -> bool {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -895,7 +895,14 @@ pub fn dock_default_item_factory(
         })
         .notify_err(workspace, cx)?;
 
-    let terminal_view = cx.add_view(|cx| TerminalView::new(terminal, workspace.database_id(), cx));
+    let terminal_view = cx.add_view(|cx| {
+        TerminalView::new(
+            terminal,
+            workspace.weak_handle(),
+            workspace.database_id(),
+            cx,
+        )
+    });
 
     Some(Box::new(terminal_view))
 }


### PR DESCRIPTION
<img width="807" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/ef3bfeef-28f5-458f-abe6-7c19bf820106">

Closes https://github.com/zed-industries/zed/issues/5404
Closes https://github.com/zed-industries/zed/issues/5740

Initial version of improved terminal highlights and "open link" functionality: drops old behavior where URLs were highlighted on hover.
Now, Cmd + hover is needed to highlight the links and click opens both URLs and files that exist (either abs paths, or anything relative to the project workspace worktree roots).
Only paths eligible for opening are highlighted.

Release Notes:

- Improved terminal highlights and selections: Cmd+Click opens local files and links
