### PR TITLE
Ignore empty hover contents, trim final hover label text

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -425,6 +425,12 @@ pub struct Hover {
     pub language: Option<Arc<Language>>,
 }
 
+impl Hover {
+    pub fn is_empty(&self) -> bool {
+        self.contents.iter().all(|block| block.text.is_empty())
+    }
+}
+
 #[derive(Default)]
 pub struct ProjectTransaction(pub HashMap<ModelHandle<Buffer>, language::Transaction>);
 


### PR DESCRIPTION
Removes empty hovers from appearing:
![image](https://github.com/zed-industries/zed/assets/2690773/b8a8af17-e20f-4d87-8782-465dfbf9b561)

And trims final hover label to ensure no trailing whitespaces are present:
![image](https://github.com/zed-industries/zed/assets/2690773/24aeb0f0-d4f0-4e2b-9265-53694bfec437)


Release Notes:

- Tidies up hover elements by trimming them and removing the empty ones 
