### PR TITLE
Allow disabling the tab close button

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -132,8 +132,8 @@
   "tabs": {
     // Show git status colors in the editor tabs.
     "git_status": false,
-    // Position of the close button on the editor tabs.
-    "close_position": "right"
+    // Position or presence of the close button on the editor tabs.
+    "close_button": "right"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -33,30 +33,22 @@ use theme::Theme;
 #[derive(Deserialize)]
 pub struct ItemSettings {
     pub git_status: bool,
-    pub close_position: ClosePosition,
+    pub close_button: CloseButton,
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
-pub enum ClosePosition {
+pub enum CloseButton {
     Left,
     #[default]
     Right,
+    Off,
 }
 
-impl ClosePosition {
-    pub fn right(&self) -> bool {
-        match self {
-            ClosePosition::Left => false,
-            ClosePosition::Right => true,
-        }
-    }
-}
-
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ItemSettingsContent {
     git_status: Option<bool>,
-    close_position: Option<ClosePosition>,
+    close_button: Option<CloseButton>,
 }
 
 impl Setting for ItemSettings {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1440,18 +1440,21 @@ impl Pane {
         .with_width(tab_style.close_icon_width)
         .aligned();
 
-        let close_right = settings::get::<ItemSettings>(cx).close_position.right();
+        let close_button = settings::get::<ItemSettings>(cx).close_button;
+        match close_button {
+            crate::item::CloseButton::Left => Flex::row()
+                .with_child(close_element)
+                .with_child(title_element)
+                .with_child(buffer_jewel_element),
 
-        if close_right {
-            Flex::row()
+            crate::item::CloseButton::Right => Flex::row()
                 .with_child(buffer_jewel_element)
                 .with_child(title_element)
-                .with_child(close_element)
-        } else {
-            Flex::row()
-                .with_child(close_element)
-                .with_child(title_element)
+                .with_child(close_element),
+
+            crate::item::CloseButton::Off => Flex::row()
                 .with_child(buffer_jewel_element)
+                .with_child(title_element),
         }
         .contained()
         .with_style(container)


### PR DESCRIPTION
I was looking at tab rendering to fix an icon cut off issue, saw the newly added logic for the left/right close button, and thought why not lol

Release Notes:
- Added the ability to disable the close button on editor tabs.