### PR TITLE
Add the `local` and `declare` keywords to bash syntax highlighting

### DIFF
--- a/crates/zed/src/languages/bash/highlights.scm
+++ b/crates/zed/src/languages/bash/highlights.scm
@@ -27,6 +27,8 @@
   "unset"
   "until"
   "while"
+  "local"
+  "declare"
 ] @keyword
 
 (comment) @comment


### PR DESCRIPTION
Release Notes:

- Improved Bash / Shell Script syntax highlighting