### PR TITLE
Add a double click to reset resized splits

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -837,64 +837,68 @@ mod element {
                         self.basis + ix,
                         handle_bounds,
                     );
-                    mouse_region = mouse_region.on_drag(
-                        MouseButton::Left,
-                        {
+                    mouse_region = mouse_region
+                        .on_drag(MouseButton::Left, {
                             let flexes = self.flexes.clone();
                             move |drag, workspace: &mut Workspace, cx| {
-                            let min_size = match axis {
-                                Axis::Horizontal => HORIZONTAL_MIN_SIZE,
-                                Axis::Vertical => VERTICAL_MIN_SIZE,
-                            };
-                            // Don't allow resizing to less than the minimum size, if elements are already too small
-                            if min_size - 1. > child_size.along(axis)
-                                || min_size - 1. > next_child_size.along(axis)
-                            {
-                                return;
+                                let min_size = match axis {
+                                    Axis::Horizontal => HORIZONTAL_MIN_SIZE,
+                                    Axis::Vertical => VERTICAL_MIN_SIZE,
+                                };
+                                // Don't allow resizing to less than the minimum size, if elements are already too small
+                                if min_size - 1. > child_size.along(axis)
+                                    || min_size - 1. > next_child_size.along(axis)
+                                {
+                                    return;
+                                }
+
+                                let mut current_target_size =
+                                    (drag.position - child_start).along(axis);
+
+                                let proposed_current_pixel_change =
+                                    current_target_size - child_size.along(axis);
+
+                                if proposed_current_pixel_change < 0. {
+                                    current_target_size = f32::max(current_target_size, min_size);
+                                } else if proposed_current_pixel_change > 0. {
+                                    // TODO: cascade this change to other children if current item is at min size
+                                    let next_target_size = f32::max(
+                                        next_child_size.along(axis) - proposed_current_pixel_change,
+                                        min_size,
+                                    );
+                                    current_target_size = f32::min(
+                                        current_target_size,
+                                        child_size.along(axis) + next_child_size.along(axis)
+                                            - next_target_size,
+                                    );
+                                }
+
+                                let current_pixel_change =
+                                    current_target_size - child_size.along(axis);
+                                let flex_change =
+                                    current_pixel_change / drag_bounds.length_along(axis);
+                                let current_target_flex = current_flex + flex_change;
+                                let next_target_flex = next_flex - flex_change;
+
+                                let mut borrow = flexes.borrow_mut();
+                                *borrow.get_mut(ix).unwrap() = current_target_flex;
+                                *borrow.get_mut(next_ix).unwrap() = next_target_flex;
+
+                                workspace.schedule_serialize(cx);
+                                cx.notify();
                             }
-
-                            let mut current_target_size = (drag.position - child_start).along(axis);
-
-                            let proposed_current_pixel_change =
-                                current_target_size - child_size.along(axis);
-
-                            if proposed_current_pixel_change < 0. {
-                                current_target_size = f32::max(current_target_size, min_size);
-                            } else if proposed_current_pixel_change > 0. {
-                                // TODO: cascade this change to other children if current item is at min size
-                                let next_target_size = f32::max(
-                                    next_child_size.along(axis) - proposed_current_pixel_change,
-                                    min_size,
-                                );
-                                current_target_size = f32::min(
-                                    current_target_size,
-                                    child_size.along(axis) + next_child_size.along(axis)
-                                        - next_target_size,
-                                );
+                        })
+                        .on_click(MouseButton::Left, {
+                            let flexes = self.flexes.clone();
+                            move |e, v: &mut Workspace, cx| {
+                                if e.click_count >= 2 {
+                                    let mut borrow = flexes.borrow_mut();
+                                    *borrow = vec![1.; borrow.len()];
+                                    v.schedule_serialize(cx);
+                                    cx.notify();
+                                }
                             }
-
-                            let current_pixel_change = current_target_size - child_size.along(axis);
-                            let flex_change = current_pixel_change / drag_bounds.length_along(axis);
-                            let current_target_flex = current_flex + flex_change;
-                            let next_target_flex = next_flex - flex_change;
-
-                            let mut borrow = flexes.borrow_mut();
-                            *borrow.get_mut(ix).unwrap() = current_target_flex;
-                            *borrow.get_mut(next_ix).unwrap() = next_target_flex;
-
-                            workspace.schedule_serialize(cx);
-                            cx.notify();
-                        }},
-                    ).on_click(MouseButton::Left, {
-                        let flexes = self.flexes.clone();
-                        move |e, v: &mut Workspace, cx| {
-                        if e.click_count >= 2 {
-                            let mut borrow = flexes.borrow_mut();
-                            *borrow = vec![1.; borrow.len()];
-                            v.schedule_serialize(cx);
-                            cx.notify();
-                        }
-                    }});
+                        });
                     scene.push_mouse_region(mouse_region);
 
                     scene.pop_stacking_context();


### PR DESCRIPTION
fixes https://github.com/zed-industries/zed/issues/6224

Release Notes:

- Double clicking on split resize handles now resets the split's dimensions