### PR TITLE
Add key binding to close all docks

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -406,6 +406,7 @@
       "cmd-b": "workspace::ToggleLeftDock",
       "cmd-r": "workspace::ToggleRightDock",
       "cmd-j": "workspace::ToggleBottomDock",
+      "alt-cmd-y": "workspace::CloseAllDocks",
       "cmd-shift-f": "workspace::NewSearch",
       "cmd-k cmd-t": "theme_selector::Toggle",
       "cmd-k cmd-s": "zed::OpenKeymap",

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -141,6 +141,7 @@ actions!(
         ToggleLeftDock,
         ToggleRightDock,
         ToggleBottomDock,
+        CloseAllDocks,
     ]
 );
 
@@ -280,6 +281,9 @@ pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {
     });
     cx.add_action(|workspace: &mut Workspace, _: &ToggleBottomDock, cx| {
         workspace.toggle_dock(DockPosition::Bottom, cx);
+    });
+    cx.add_action(|workspace: &mut Workspace, _: &CloseAllDocks, cx| {
+        workspace.close_all_docks(cx);
     });
     cx.add_action(Workspace::activate_pane_at_index);
     cx.add_action(|workspace: &mut Workspace, _: &ReopenClosedItem, cx| {
@@ -1666,6 +1670,20 @@ impl Workspace {
             cx.focus_self();
         }
 
+        cx.notify();
+        self.serialize_workspace(cx);
+    }
+
+    pub fn close_all_docks(&mut self, cx: &mut ViewContext<Self>) {
+        let docks = [&self.left_dock, &self.bottom_dock, &self.right_dock];
+
+        for dock in docks {
+            dock.update(cx, |dock, cx| {
+                dock.set_open(false, cx);
+            });
+        }
+
+        cx.focus_self();
         cx.notify();
         self.serialize_workspace(cx);
     }

--- a/crates/zed/src/menus.rs
+++ b/crates/zed/src/menus.rs
@@ -93,6 +93,7 @@ pub fn menus() -> Vec<Menu<'static>> {
                 MenuItem::action("Toggle Left Dock", workspace::ToggleLeftDock),
                 MenuItem::action("Toggle Right Dock", workspace::ToggleRightDock),
                 MenuItem::action("Toggle Bottom Dock", workspace::ToggleBottomDock),
+                MenuItem::action("Close All Docks", workspace::CloseAllDocks),
                 MenuItem::submenu(Menu {
                     name: "Editor Layout",
                     items: vec![


### PR DESCRIPTION
Fixes: https://linear.app/zed-industries/issue/Z-2680/add-a-close-all-docks-action

I frequently get stuck in this state:

<img width="1608" alt="SCR-20230721-dgvs" src="https://github.com/zed-industries/zed/assets/19867440/13257e6d-f75a-4d1c-9718-153499e90c60">

I could zoom, but I dont want to in this case, I just want to close everything, to get back to a truly decluttered state. Running 3 toggle commands is cumbersome. I'd like to be able to close all docks with one action.

I added an action with the key binding `alt-cmd-y` (similar to`alt-cmd-t`, which is used to close all tabs). My original choice was `alt-cmd-d` (`d` for dock), but that is the default macOS key binding to hide the system dock.


Release Notes:

- Added a `workspace: close all docks` action (deployed via `alt-cmd-y`).