### PR TITLE
feat(workspace): add action for closing inactive editors on all panes

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -22,6 +22,7 @@
       "alt-cmd-right": "pane::ActivateNextItem",
       "cmd-w": "pane::CloseActiveItem",
       "alt-cmd-t": "pane::CloseInactiveItems",
+      "ctrl-alt-cmd-w": "workspace::CloseInactiveEditors",
       "cmd-k u": "pane::CloseCleanItems",
       "cmd-k cmd-w": "pane::CloseAllItems",
       "cmd-shift-w": "workspace::CloseWindow",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -22,7 +22,7 @@
       "alt-cmd-right": "pane::ActivateNextItem",
       "cmd-w": "pane::CloseActiveItem",
       "alt-cmd-t": "pane::CloseInactiveItems",
-      "ctrl-alt-cmd-w": "workspace::CloseInactiveEditors",
+      "ctrl-alt-cmd-w": "workspace::CloseInactiveTabsAndPanes",
       "cmd-k u": "pane::CloseCleanItems",
       "cmd-k cmd-w": "pane::CloseAllItems",
       "cmd-shift-w": "workspace::CloseWindow",

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -746,6 +746,10 @@ impl Pane {
         _: &CloseAllItems,
         cx: &mut ViewContext<Self>,
     ) -> Option<Task<Result<()>>> {
+        if self.items.is_empty() {
+            return None;
+        }
+
         Some(self.close_items(cx, move |_| true))
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -21,7 +21,6 @@ use drag_and_drop::DragAndDrop;
 use futures::{
     channel::{mpsc, oneshot},
     future::try_join_all,
-    stream::FuturesUnordered,
     FutureExt, StreamExt,
 };
 use gpui::{


### PR DESCRIPTION
using zed more and more to develop zed itself I'm finding some small qol features missing, this is one of them
I'm very used to open two or three splits, and sometimes I want to close everything except for the active editor, but that wasn't supported, as the `pane::CloseInactiveItems` action only closes inactive items on the active pane

so I've implemented it really quick, although I'm not sure it's the right way to do this

note: I really don't like the default keybinding I've set it to, I have this action bound to `cmd-shift-w` on all editors, but in zed is taken, so I chose something that's free but without thinking too much about it

Release Notes:

- Added action for closing inactive editors from all panes