### PR TITLE
Fix shift-enter in search

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -195,8 +195,8 @@
   {
     "context": "Editor && mode == auto_height",
     "bindings": {
-      "shift-enter": "editor::Newline",
-      "cmd-shift-enter": "editor::NewlineBelow"
+      "ctrl-enter": "editor::Newline",
+      "ctrl-shift-enter": "editor::NewlineBelow"
     }
   },
   {

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -296,5 +296,7 @@ mod test {
         cx.assert_editor_state("«oneˇ» one one one");
         cx.simulate_keystrokes(["enter"]);
         cx.assert_editor_state("one «oneˇ» one one");
+        cx.simulate_keystrokes(["shift-enter"]);
+        cx.assert_editor_state("«oneˇ» one one one");
     }
 }


### PR DESCRIPTION
Fixes shift-enter to go to previous result.

Release Notes:

- To type a newline in search use `ctrl-enter` (or `ctrl-shift-enter` for a newline below).
