### PR TITLE
Add search in directory action in the project panel

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -529,7 +529,8 @@
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "backspace": "project_panel::Delete",
-      "alt-cmd-r": "project_panel::RevealInFinder"
+      "alt-cmd-r": "project_panel::RevealInFinder",
+      "alt-shift-f": "project_panel::NewSearchInDirectory"
     }
   },
   {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -512,7 +512,7 @@ pub struct Workspace {
     follower_states_by_leader: FollowerStatesByLeader,
     last_leaders_by_pane: HashMap<WeakViewHandle<Pane>, PeerId>,
     window_edited: bool,
-    active_call: Option<(ModelHandle<ActiveCall>, Vec<gpui::Subscription>)>,
+    active_call: Option<(ModelHandle<ActiveCall>, Vec<Subscription>)>,
     leader_updates_tx: mpsc::UnboundedSender<(PeerId, proto::UpdateFollowers)>,
     database_id: WorkspaceId,
     app_state: Arc<AppState>,
@@ -3007,6 +3007,10 @@ impl Workspace {
 
     pub fn database_id(&self) -> WorkspaceId {
         self.database_id
+    }
+
+    pub fn push_subscription(&mut self, subscription: Subscription) {
+        self.subscriptions.push(subscription)
     }
 
     fn location(&self, cx: &AppContext) -> Option<WorkspaceLocation> {


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/1153
Closes https://github.com/zed-industries/zed/issues/6076

<img width="432" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/a50ee073-9d2e-4e5c-ae5e-23312693c540">

Adds an `project_panel::NewSearchInDirectory` action ("alt-shift-f" default) in the project editor context to open a new project search in the selected directory.

Release Notes:

- Adds an action to open project search in the project panel's directory