### PR TITLE
Put our downloaded copy of Node in the env for every NPM action

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -62,6 +62,14 @@ impl NodeRuntime {
         args: &[&str],
     ) -> Result<Output> {
         let attempt = |installation_path: PathBuf| async move {
+            let mut env_path = installation_path.join("bin").into_os_string();
+            if let Some(existing_path) = std::env::var_os("PATH") {
+                if !existing_path.is_empty() {
+                    env_path.push(":");
+                    env_path.push(&existing_path);
+                }
+            }
+
             let node_binary = installation_path.join("bin/node");
             let npm_file = installation_path.join("bin/npm");
 
@@ -74,6 +82,7 @@ impl NodeRuntime {
             }
 
             let mut command = Command::new(node_binary);
+            command.env("PATH", env_path);
             command.arg(npm_file).arg(subcommand).args(args);
 
             if let Some(directory) = directory {


### PR DESCRIPTION
Intelephense (PHP language server) has a dependency on `protobufjs` which invokes `node` in the `postinstall` script and if the user did not have a system Node runtime installed that would fail. Have this use our downloaded installation too

Fixes https://linear.app/zed-industries/issue/Z-2687/php-language-server-failed

Release Notes:
- Fixed PHP language server installation on systems without a system Node installation.