### PR TITLE
Do not scroll when selecting all

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5298,7 +5298,7 @@ impl Editor {
 
     pub fn select_all(&mut self, _: &SelectAll, cx: &mut ViewContext<Self>) {
         let end = self.buffer.read(cx).read(cx).len();
-        self.change_selections(Some(Autoscroll::fit()), cx, |s| {
+        self.change_selections(None, cx, |s| {
             s.select_ranges(vec![0..end]);
         });
     }


### PR DESCRIPTION
In big buffers, when I press `cmd-a`, the view gets scrolled to the very bottom.
Usually it's now that I want, I can scroll to bottom with `cmd-down` separately, and selecting all text is used for copy-pasting it somewhere, no need to scroll anywhere for that — I can get back to the same place later.

Release Notes:

- Removed the scroll to the end of the editor after `editor::SelectAll` action