### PR TITLE
In terminal, open paths starting with ~ and focus on project panel when opening directories

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -259,6 +259,7 @@ pub enum Event {
     LanguageServerLog(LanguageServerId, String),
     Notification(String),
     ActiveEntryChanged(Option<ProjectEntryId>),
+    ActivateProjectPanel,
     WorktreeAdded,
     WorktreeRemoved(WorktreeId),
     WorktreeUpdatedEntries(WorktreeId, UpdatedEntriesSet),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -174,6 +174,7 @@ pub enum Event {
     NewSearchInDirectory {
         dir_entry: Entry,
     },
+    ActivatePanel,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -199,6 +200,9 @@ impl ProjectPanel {
                         this.autoscroll(cx);
                         cx.notify();
                     }
+                }
+                project::Event::ActivateProjectPanel => {
+                    cx.emit(Event::ActivatePanel);
                 }
                 project::Event::WorktreeRemoved(id) => {
                     this.expanded_dir_ids.remove(id);
@@ -1014,7 +1018,10 @@ impl ProjectPanel {
         None
     }
 
-    fn selected_entry<'a>(&self, cx: &'a AppContext) -> Option<(&'a Worktree, &'a project::Entry)> {
+    pub fn selected_entry<'a>(
+        &self,
+        cx: &'a AppContext,
+    ) -> Option<(&'a Worktree, &'a project::Entry)> {
         let (worktree, entry) = self.selected_entry_handle(cx)?;
         Some((worktree.read(cx), entry))
     }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -73,7 +73,9 @@ const DEBUG_CELL_WIDTH: f32 = 5.;
 const DEBUG_LINE_HEIGHT: f32 = 5.;
 
 lazy_static! {
-    // Regex Copied from alacritty's ui_config.rs
+    // Regex Copied from alacritty's ui_config.rs and modified its declaration slightly:
+    // * avoid Rust-specific escaping.
+    // * use more strict regex for `file://` protocol matching: original regex has `file:` inside, but we want to avoid matching `some::file::module` strings.
     static ref URL_REGEX: RegexSearch = RegexSearch::new(r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`]+"#).unwrap();
 
     static ref WORD_REGEX: RegexSearch = RegexSearch::new("[\\w.:/@-~]+").unwrap();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -76,7 +76,7 @@ lazy_static! {
     // Regex Copied from alacritty's ui_config.rs
     static ref URL_REGEX: RegexSearch = RegexSearch::new(r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`]+"#).unwrap();
 
-    static ref WORD_REGEX: RegexSearch = RegexSearch::new("[\\w.:/@-]+").unwrap();
+    static ref WORD_REGEX: RegexSearch = RegexSearch::new("[\\w.:/@-~]+").unwrap();
 }
 
 ///Upward flowing events, for changing the title and such

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -187,37 +187,56 @@ impl TerminalView {
                     }
                     let potential_abs_paths = possible_open_targets(&workspace, maybe_path, cx);
                     if let Some(path) = potential_abs_paths.into_iter().next() {
-                        let visible = path.path_like.is_dir();
+                        let is_dir = path.path_like.is_dir();
                         let task_workspace = workspace.clone();
                         cx.spawn(|_, mut cx| async move {
-                            let opened_item = task_workspace
+                            let opened_items = task_workspace
                                 .update(&mut cx, |workspace, cx| {
-                                    workspace.open_abs_path(path.path_like, visible, cx)
+                                    workspace.open_paths(vec![path.path_like], is_dir, cx)
                                 })
                                 .context("workspace update")?
-                                .await
-                                .context("workspace update")?;
-                            if let Some(row) = path.row {
-                                let col = path.column.unwrap_or(0);
-                                if let Some(active_editor) = opened_item.downcast::<Editor>() {
-                                    active_editor
-                                        .downgrade()
-                                        .update(&mut cx, |editor, cx| {
-                                            let snapshot = editor.snapshot(cx).display_snapshot;
-                                            let point = snapshot.buffer_snapshot.clip_point(
-                                                language::Point::new(
-                                                    row.saturating_sub(1),
-                                                    col.saturating_sub(1),
-                                                ),
-                                                Bias::Left,
-                                            );
-                                            editor.change_selections(
-                                                Some(Autoscroll::center()),
-                                                cx,
-                                                |s| s.select_ranges([point..point]),
-                                            );
-                                        })
-                                        .log_err();
+                                .await;
+                            anyhow::ensure!(
+                                opened_items.len() == 1,
+                                "For a single path open, expected single opened item"
+                            );
+                            let opened_item = opened_items
+                                .into_iter()
+                                .next()
+                                .unwrap()
+                                .transpose()
+                                .context("path open")?;
+                            if is_dir {
+                                task_workspace.update(&mut cx, |workspace, cx| {
+                                    workspace.project().update(cx, |_, cx| {
+                                        cx.emit(project::Event::ActivateProjectPanel);
+                                    })
+                                })?;
+                            } else {
+                                if let Some(row) = path.row {
+                                    let col = path.column.unwrap_or(0);
+                                    if let Some(active_editor) =
+                                        opened_item.and_then(|item| item.downcast::<Editor>())
+                                    {
+                                        active_editor
+                                            .downgrade()
+                                            .update(&mut cx, |editor, cx| {
+                                                let snapshot = editor.snapshot(cx).display_snapshot;
+                                                let point = snapshot.buffer_snapshot.clip_point(
+                                                    language::Point::new(
+                                                        row.saturating_sub(1),
+                                                        col.saturating_sub(1),
+                                                    ),
+                                                    Bias::Left,
+                                                );
+                                                editor.change_selections(
+                                                    Some(Autoscroll::center()),
+                                                    cx,
+                                                    |s| s.select_ranges([point..point]),
+                                                );
+                                            })
+                                            .log_err();
+                                    }
                                 }
                             }
                             anyhow::Ok(())

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -425,6 +425,16 @@ fn possible_open_targets(
     let maybe_path = path_like.path_like;
     let potential_abs_paths = if maybe_path.is_absolute() {
         vec![maybe_path]
+    } else if maybe_path.starts_with("~") {
+        if let Some(abs_path) = maybe_path
+            .strip_prefix("~")
+            .ok()
+            .and_then(|maybe_path| Some(dirs::home_dir()?.join(maybe_path)))
+        {
+            vec![abs_path]
+        } else {
+            Vec::new()
+        }
     } else if let Some(workspace) = workspace.upgrade(cx) {
         workspace.update(cx, |workspace, cx| {
             workspace

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -899,6 +899,18 @@ impl Workspace {
     where
         T::Event: std::fmt::Debug,
     {
+        self.add_panel_with_extra_event_handler(panel, cx, |_, _, _, _| {})
+    }
+
+    pub fn add_panel_with_extra_event_handler<T: Panel, F>(
+        &mut self,
+        panel: ViewHandle<T>,
+        cx: &mut ViewContext<Self>,
+        handler: F,
+    ) where
+        T::Event: std::fmt::Debug,
+        F: Fn(&mut Self, &ViewHandle<T>, &T::Event, &mut ViewContext<Self>) + 'static,
+    {
         let dock = match panel.position(cx) {
             DockPosition::Left => &self.left_dock,
             DockPosition::Bottom => &self.bottom_dock,
@@ -965,6 +977,8 @@ impl Workspace {
                     }
                     this.update_active_view_for_followers(cx);
                     cx.notify();
+                } else {
+                    handler(this, &panel, event, cx)
                 }
             }
         }));
@@ -1417,45 +1431,65 @@ impl Workspace {
         // Sort the paths to ensure we add worktrees for parents before their children.
         abs_paths.sort_unstable();
         cx.spawn(|this, mut cx| async move {
-            let mut project_paths = Vec::new();
-            for path in &abs_paths {
-                if let Some(project_path) = this
+            let mut tasks = Vec::with_capacity(abs_paths.len());
+            for abs_path in &abs_paths {
+                let project_path = match this
                     .update(&mut cx, |this, cx| {
-                        Workspace::project_path_for_path(this.project.clone(), path, visible, cx)
+                        Workspace::project_path_for_path(
+                            this.project.clone(),
+                            abs_path,
+                            visible,
+                            cx,
+                        )
                     })
                     .log_err()
                 {
-                    project_paths.push(project_path.await.log_err());
-                } else {
-                    project_paths.push(None);
-                }
-            }
+                    Some(project_path) => project_path.await.log_err(),
+                    None => None,
+                };
 
-            let tasks = abs_paths
-                .iter()
-                .cloned()
-                .zip(project_paths.into_iter())
-                .map(|(abs_path, project_path)| {
-                    let this = this.clone();
-                    cx.spawn(|mut cx| {
-                        let fs = fs.clone();
-                        async move {
-                            let (_worktree, project_path) = project_path?;
-                            if fs.is_file(&abs_path).await {
-                                Some(
-                                    this.update(&mut cx, |this, cx| {
-                                        this.open_path(project_path, None, true, cx)
+                let this = this.clone();
+                let task = cx.spawn(|mut cx| {
+                    let fs = fs.clone();
+                    let abs_path = abs_path.clone();
+                    async move {
+                        let (worktree, project_path) = project_path?;
+                        if fs.is_file(&abs_path).await {
+                            Some(
+                                this.update(&mut cx, |this, cx| {
+                                    this.open_path(project_path, None, true, cx)
+                                })
+                                .log_err()?
+                                .await,
+                            )
+                        } else {
+                            this.update(&mut cx, |workspace, cx| {
+                                let worktree = worktree.read(cx);
+                                let worktree_abs_path = worktree.abs_path();
+                                let entry_id = if abs_path == worktree_abs_path.as_ref() {
+                                    worktree.root_entry()
+                                } else {
+                                    abs_path
+                                        .strip_prefix(worktree_abs_path.as_ref())
+                                        .ok()
+                                        .and_then(|relative_path| {
+                                            worktree.entry_for_path(relative_path)
+                                        })
+                                }
+                                .map(|entry| entry.id);
+                                if let Some(entry_id) = entry_id {
+                                    workspace.project().update(cx, |_, cx| {
+                                        cx.emit(project::Event::ActiveEntryChanged(Some(entry_id)));
                                     })
-                                    .log_err()?
-                                    .await,
-                                )
-                            } else {
-                                None
-                            }
+                                }
+                            })
+                            .log_err()?;
+                            None
                         }
-                    })
-                })
-                .collect::<Vec<_>>();
+                    }
+                });
+                tasks.push(task);
+            }
 
             futures::future::join_all(tasks).await
         })
@@ -3007,10 +3041,6 @@ impl Workspace {
 
     pub fn database_id(&self) -> WorkspaceId {
         self.database_id
-    }
-
-    pub fn push_subscription(&mut self, subscription: Subscription) {
-        self.subscriptions.push(subscription)
     }
 
     fn location(&self, cx: &AppContext) -> Option<WorkspaceLocation> {


### PR DESCRIPTION
Further improves terminal navigation with cmd+click, now allowing to open paths starting with `~` (if they are present otherwise) and focusing project panel with highlighted entry for the directories opened.

Release Notes:

- Further improves terminal navigation with cmd+click, now allowing to open paths starting with `~` (if they are present otherwise) and focusing project panel with highlighted entry for the directories opened.