### PR TITLE
Add MacOS standard key binding for file renames

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -528,6 +528,7 @@
       "cmd-alt-c": "project_panel::CopyPath",
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
+      "enter": "project_panel::Rename",
       "backspace": "project_panel::Delete",
       "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"


### PR DESCRIPTION
Release Notes:

- Added a default keybinding for using `enter` to rename files in the project panel. `space` is now the default used to open a file.
