### PR TITLE
Add open file in project finder via space

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -529,6 +529,7 @@
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
+      "space": "project_panel::Open",
       "backspace": "project_panel::Delete",
       "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2389,7 +2389,7 @@ mod tests {
 
         toggle_expand_dir(&panel, "src/test", cx);
         select_path(&panel, "src/test/first.rs", cx);
-        panel.update(cx, |panel, cx| panel.confirm(&Confirm, cx));
+        panel.update(cx, |panel, cx| panel.open_file(&Open, cx));
         cx.foreground().run_until_parked();
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),
@@ -2417,7 +2417,7 @@ mod tests {
         ensure_no_open_items_and_panes(window_id, &workspace, cx);
 
         select_path(&panel, "src/test/second.rs", cx);
-        panel.update(cx, |panel, cx| panel.confirm(&Confirm, cx));
+        panel.update(cx, |panel, cx| panel.open_file(&Open, cx));
         cx.foreground().run_until_parked();
         assert_eq!(
             visible_entries_as_strings(&panel, 0..10, cx),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -125,6 +125,7 @@ actions!(
         Paste,
         Delete,
         Rename,
+        Open,
         ToggleFocus,
         NewSearchInDirectory,
     ]
@@ -146,6 +147,7 @@ pub fn init(assets: impl AssetSource, cx: &mut AppContext) {
     cx.add_action(ProjectPanel::rename);
     cx.add_async_action(ProjectPanel::delete);
     cx.add_async_action(ProjectPanel::confirm);
+    cx.add_async_action(ProjectPanel::open_file);
     cx.add_action(ProjectPanel::cancel);
     cx.add_action(ProjectPanel::cut);
     cx.add_action(ProjectPanel::copy);
@@ -560,15 +562,20 @@ impl ProjectPanel {
 
     fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) -> Option<Task<Result<()>>> {
         if let Some(task) = self.confirm_edit(cx) {
-            Some(task)
-        } else if let Some((_, entry)) = self.selected_entry(cx) {
+            return Some(task);
+        }
+
+        None
+    }
+
+    fn open_file(&mut self, _: &Open, cx: &mut ViewContext<Self>) -> Option<Task<Result<()>>> {
+        if let Some((_, entry)) = self.selected_entry(cx) {
             if entry.is_file() {
                 self.open_entry(entry.id, true, cx);
             }
-            None
-        } else {
-            None
         }
+
+        None
     }
 
     fn confirm_edit(&mut self, cx: &mut ViewContext<Self>) -> Option<Task<Result<()>>> {


### PR DESCRIPTION
@mikayla-maki for 👀 

[This PR added in the ability to rename a file via `enter`](https://github.com/zed-industries/zed/pull/2784). Previously, `enter` was used to both open a file and confirm a rename, so this PR changes the opening of a file to use `space`, which is what VS Code uses.  It also makes a bit more sense because now `enter` is just used to start a rename and confirm the rename, vs being used for 2 different actions.

N/A on the release notes, as I adjusted the release note in the previously-tagged PR.

Release Notes:

- N/A