### PR TITLE
Add text manipulation commands

### DIFF
--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -10,7 +10,6 @@ doctest = false
 
 [features]
 test-support = [
-    "rand",
     "copilot/test-support",
     "text/test-support",
     "language/test-support",
@@ -62,8 +61,8 @@ serde.workspace = true
 serde_derive.workspace = true
 smallvec.workspace = true
 smol.workspace = true
+rand.workspace = true
 
-rand = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-html = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4231,15 +4231,11 @@ impl Editor {
     }
 
     pub fn reverse_lines(&mut self, _: &ReverseLines, cx: &mut ViewContext<Self>) {
-        self.manipulate_lines(cx, |lines| {
-            lines.reverse();
-        })
+        self.manipulate_lines(cx, |lines| lines.reverse())
     }
 
     pub fn shuffle_lines(&mut self, _: &ShuffleLines, cx: &mut ViewContext<Self>) {
-        self.manipulate_lines(cx, |lines| {
-            lines.shuffle(&mut thread_rng());
-        })
+        self.manipulate_lines(cx, |lines| lines.shuffle(&mut thread_rng()))
     }
 
     fn manipulate_lines<Fn>(&mut self, cx: &mut ViewContext<Self>, mut callback: Fn)

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2501,6 +2501,85 @@ fn test_join_lines_with_multi_selection(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_sort_lines_with_single_selection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    cx.add_window(|cx| {
+        let buffer = MultiBuffer::build_simple("dddd\nccc\nbb\na\n\n", cx);
+        let mut editor = build_editor(buffer.clone(), cx);
+        let buffer = buffer.read(cx).as_singleton().unwrap();
+
+        editor.change_selections(None, cx, |s| {
+            s.select_ranges([Point::new(0, 2)..Point::new(0, 2)])
+        });
+        editor.sort_lines_case_sensitive(&SortLinesCaseSensitive, cx);
+        assert_eq!(
+            buffer.read(cx).text(),
+            "dddd\nccc\nbb\na\n\n",
+            "no sorting when single cursor parked on single line"
+        );
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            &[Point::new(0, 2)..Point::new(0, 2)]
+        );
+
+        editor.change_selections(None, cx, |s| {
+            s.select_ranges([Point::new(0, 2)..Point::new(5, 1)])
+        });
+        editor.sort_lines_case_sensitive(&SortLinesCaseSensitive, cx);
+        assert_eq!(
+            buffer.read(cx).text(),
+            "a\nbb\nccc\ndddd\n\n",
+            "single selection is sorted"
+        );
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            &[Point::new(0, 0)..Point::new(5, 1)]
+        );
+
+        editor
+    });
+}
+
+#[gpui::test]
+fn test_sort_lines_with_multi_selection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    cx.add_window(|cx| {
+        let buffer = MultiBuffer::build_simple("dddd\nccc\nbb\na\n\n3\n2\n1\n\n", cx);
+        let mut editor = build_editor(buffer.clone(), cx);
+        let buffer = buffer.read(cx).as_singleton().unwrap();
+
+        editor.change_selections(None, cx, |s| {
+            s.select_ranges([
+                Point::new(0, 2)..Point::new(3, 2),
+                Point::new(5, 0)..Point::new(7, 1),
+            ])
+        });
+
+        editor.sort_lines_case_sensitive(&SortLinesCaseSensitive, cx);
+        assert_eq!(buffer.read(cx).text(), "a\nbb\nccc\ndddd\n\n1\n2\n3\n\n");
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            &[Point::new(0, 5)..Point::new(2, 2)]
+        );
+        assert_eq!(
+            editor.selections.ranges::<Point>(cx),
+            &[Point::new(0, 5)..Point::new(2, 2)]
+        );
+
+        // assert_eq!(
+        //     editor.selections.ranges::<Point>(cx),
+        //     [
+        //         Point::new(0, 7)..Point::new(0, 7),
+        //         Point::new(1, 3)..Point::new(1, 3)
+        //     ]
+        // );
+        editor
+    });
+}
+
+#[gpui::test]
 fn test_duplicate_line(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2501,7 +2501,7 @@ fn test_join_lines_with_multi_selection(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-fn test_sort_lines_with_single_selection(cx: &mut TestAppContext) {
+fn test_manipulate_lines_with_single_selection(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     cx.add_window(|cx| {
@@ -2510,7 +2510,7 @@ fn test_sort_lines_with_single_selection(cx: &mut TestAppContext) {
         let buffer = buffer.read(cx).as_singleton().unwrap();
 
         editor.change_selections(None, cx, |s| {
-            s.select_ranges([Point::new(0, 2)..Point::new(0, 2)])
+            s.select_ranges([Point::new(0, 1)..Point::new(0, 1)])
         });
         editor.sort_lines_case_sensitive(&SortLinesCaseSensitive, cx);
         assert_eq!(
@@ -2520,13 +2520,13 @@ fn test_sort_lines_with_single_selection(cx: &mut TestAppContext) {
         );
         assert_eq!(
             editor.selections.ranges::<Point>(cx),
-            &[Point::new(0, 2)..Point::new(0, 2)]
+            &[Point::new(0, 1)..Point::new(0, 2)]
         );
 
         editor.change_selections(None, cx, |s| {
-            s.select_ranges([Point::new(0, 2)..Point::new(5, 1)])
+            s.select_ranges([Point::new(0, 2)..Point::new(5, 0)])
         });
-        editor.sort_lines_case_sensitive(&SortLinesCaseSensitive, cx);
+        //editor.sort_lines();
         assert_eq!(
             buffer.read(cx).text(),
             "a\nbb\nccc\ndddd\n\n",
@@ -2542,7 +2542,7 @@ fn test_sort_lines_with_single_selection(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-fn test_sort_lines_with_multi_selection(cx: &mut TestAppContext) {
+fn test_manipulate_lines_with_multi_selection(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     cx.add_window(|cx| {

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -138,7 +138,7 @@ impl SelectionsCollection {
         .collect()
     }
 
-    // Returns all of the selections, adjusted to take into account the selection line_mode
+    /// Returns all of the selections, adjusted to take into account the selection line_mode
     pub fn all_adjusted(&self, cx: &mut AppContext) -> Vec<Selection<Point>> {
         let mut selections = self.all::<Point>(cx);
         if self.line_mode {


### PR DESCRIPTION
This PR adds command palette actions for:

- `sort lines case sensitive`
- `sort lines case insensitive`
- `reverse lines`
- `shuffle lines`

Closes out:

- https://github.com/zed-industries/zed/issues/5788

and partially closing out:

- https://github.com/zed-industries/zed/issues/5438 (which is currently a top-ranked issue)

There are issues with dedupe lines and I didn't try to tackle converting variable names between different conventions. I'll likely close out 57 with a note to just upvote the remaining individual issues.

Release Notes:

- Added command palette actions for `sort lines case sensitive`, `sort lines case insensitive`, `reverse lines`, and`shuffle lines` (([#57](https://github.com/zed-industries/zed/issues/5438)), ([#658](https://github.com/zed-industries/zed/issues/5788)))