### PR TITLE
Simple cascading split

### DIFF
--- a/crates/gpui/src/app/window.rs
+++ b/crates/gpui/src/app/window.rs
@@ -518,6 +518,18 @@ impl<'a> WindowContext<'a> {
                 // NOTE: The order of event pushes is important! MouseUp events MUST be fired
                 // before click events, and so the MouseUp events need to be pushed before
                 // MouseClick events.
+
+                // Synthesize one last drag event to end the drag
+                mouse_events.push(MouseEvent::Drag(MouseDrag {
+                    region: Default::default(),
+                    prev_mouse_position: self.window.mouse_position,
+                    platform_event: MouseMovedEvent {
+                        position: e.position,
+                        pressed_button: Some(e.button),
+                        modifiers: e.modifiers,
+                    },
+                    end: true,
+                }));
                 mouse_events.push(MouseEvent::Up(MouseUp {
                     region: Default::default(),
                     platform_event: e.clone(),
@@ -565,8 +577,16 @@ impl<'a> WindowContext<'a> {
                             region: Default::default(),
                             prev_mouse_position: self.window.mouse_position,
                             platform_event: e.clone(),
+                            end: false,
                         }));
                     } else if let Some((_, clicked_button)) = self.window.clicked_region {
+                        mouse_events.push(MouseEvent::Drag(MouseDrag {
+                            region: Default::default(),
+                            prev_mouse_position: self.window.mouse_position,
+                            platform_event: e.clone(),
+                            end: true,
+                        }));
+
                         // Mouse up event happened outside the current window. Simulate mouse up button event
                         let button_event = e.to_button_event(clicked_button);
                         mouse_events.push(MouseEvent::Up(MouseUp {

--- a/crates/gpui/src/scene/mouse_event.rs
+++ b/crates/gpui/src/scene/mouse_event.rs
@@ -32,7 +32,7 @@ pub struct MouseDrag {
     pub region: RectF,
     pub prev_mouse_position: Vector2F,
     pub platform_event: MouseMovedEvent,
-    pub end: bool
+    pub end: bool,
 }
 
 impl Deref for MouseDrag {

--- a/crates/gpui/src/scene/mouse_event.rs
+++ b/crates/gpui/src/scene/mouse_event.rs
@@ -32,6 +32,7 @@ pub struct MouseDrag {
     pub region: RectF,
     pub prev_mouse_position: Vector2F,
     pub platform_event: MouseMovedEvent,
+    pub end: bool
 }
 
 impl Deref for MouseDrag {

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -697,7 +697,7 @@ mod element {
 
             move |drag, workspace: &mut Workspace, cx| {
                 if drag.end {
-                    // Clear cascading resize state
+                    // TODO: Clear cascading resize state
                     return;
                 }
                 let min_size = match axis {
@@ -929,9 +929,6 @@ mod element {
                                 visible_bounds.clone(),
                             ),
                         )
-                        .on_down(MouseButton::Left, |_, _: &mut Workspace, _| {
-                            // Save cascading resize state
-                        })
                         .on_click(MouseButton::Left, {
                             let flexes = self.flexes.clone();
                             move |e, v: &mut Workspace, cx| {


### PR DESCRIPTION
This PR cascades the split resizing to adjacent splits, if the current split has already hit the minimum size. This PR also adds support for detecting the end of a drag event to GPUI, via a bool on the dispatched drag.

Release Notes:

- Made split resizing more flexible