### PR TITLE
Parallel vector db

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -411,7 +411,6 @@
       "cmd-k cmd-t": "theme_selector::Toggle",
       "cmd-k cmd-s": "zed::OpenKeymap",
       "cmd-t": "project_symbols::Toggle",
-      "cmd-ctrl-t": "semantic_search::Toggle",
       "cmd-p": "file_finder::Toggle",
       "cmd-shift-p": "command_palette::Toggle",
       "cmd-shift-m": "diagnostics::Deploy",

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -30,6 +30,7 @@ use std::{
     ops::{Not, Range},
     path::PathBuf,
     sync::Arc,
+    time::Instant,
 };
 use util::ResultExt as _;
 use workspace::{
@@ -192,6 +193,7 @@ impl ProjectSearch {
         exclude_files: Vec<GlobMatcher>,
         cx: &mut ModelContext<Self>,
     ) {
+        let t0 = Instant::now();
         let search = SemanticIndex::global(cx).map(|index| {
             index.update(cx, |semantic_index, cx| {
                 semantic_index.search_project(
@@ -208,6 +210,7 @@ impl ProjectSearch {
         self.match_ranges.clear();
         self.pending_search = Some(cx.spawn(|this, mut cx| async move {
             let results = search?.await.log_err()?;
+            log::trace!("semantic search elapsed: {:?}", t0.elapsed().as_millis());
 
             let (_task, mut match_ranges) = this.update(&mut cx, |this, cx| {
                 this.excerpts.update(cx, |excerpts, cx| {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -193,7 +193,6 @@ impl ProjectSearch {
         exclude_files: Vec<GlobMatcher>,
         cx: &mut ModelContext<Self>,
     ) {
-        let t0 = Instant::now();
         let search = SemanticIndex::global(cx).map(|index| {
             index.update(cx, |semantic_index, cx| {
                 semantic_index.search_project(
@@ -210,7 +209,6 @@ impl ProjectSearch {
         self.match_ranges.clear();
         self.pending_search = Some(cx.spawn(|this, mut cx| async move {
             let results = search?.await.log_err()?;
-            log::trace!("semantic search elapsed: {:?}", t0.elapsed().as_millis());
 
             let (_task, mut match_ranges) = this.update(&mut cx, |this, cx| {
                 this.excerpts.update(cx, |excerpts, cx| {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -30,7 +30,6 @@ use std::{
     ops::{Not, Range},
     path::PathBuf,
     sync::Arc,
-    time::Instant,
 };
 use util::ResultExt as _;
 use workspace::{

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -267,41 +267,56 @@ impl VectorDatabase {
 
     pub fn top_k_search(
         &self,
-        worktree_ids: &[i64],
         query_embedding: &Vec<f32>,
         limit: usize,
-        include_globs: Vec<GlobMatcher>,
-        exclude_globs: Vec<GlobMatcher>,
-    ) -> Result<Vec<(i64, PathBuf, Range<usize>)>> {
+        file_ids: &[i64],
+    ) -> Result<Vec<(i64, f32)>> {
         let mut results = Vec::<(i64, f32)>::with_capacity(limit + 1);
-        self.for_each_document(
-            &worktree_ids,
-            include_globs,
-            exclude_globs,
-            |id, embedding| {
-                let similarity = dot(&embedding, &query_embedding);
-                let ix = match results.binary_search_by(|(_, s)| {
-                    similarity.partial_cmp(&s).unwrap_or(Ordering::Equal)
-                }) {
-                    Ok(ix) => ix,
-                    Err(ix) => ix,
-                };
-                results.insert(ix, (id, similarity));
-                results.truncate(limit);
-            },
-        )?;
+        self.for_each_document(file_ids, |id, embedding| {
+            let similarity = dot(&embedding, &query_embedding);
+            let ix = match results
+                .binary_search_by(|(_, s)| similarity.partial_cmp(&s).unwrap_or(Ordering::Equal))
+            {
+                Ok(ix) => ix,
+                Err(ix) => ix,
+            };
+            results.insert(ix, (id, similarity));
+            results.truncate(limit);
+        })?;
 
-        let ids = results.into_iter().map(|(id, _)| id).collect::<Vec<_>>();
-        self.get_documents_by_ids(&ids)
+        Ok(results)
     }
 
-    fn for_each_document(
+    // pub fn top_k_search(
+    //     &self,
+    //     worktree_ids: &[i64],
+    //     query_embedding: &Vec<f32>,
+    //     limit: usize,
+    //     file_ids: Vec<i64>,
+    // ) -> Result<Vec<(i64, PathBuf, Range<usize>)>> {
+    //     let mut results = Vec::<(i64, f32)>::with_capacity(limit + 1);
+    //     self.for_each_document(&worktree_ids, file_ids, |id, embedding| {
+    //         let similarity = dot(&embedding, &query_embedding);
+    //         let ix = match results
+    //             .binary_search_by(|(_, s)| similarity.partial_cmp(&s).unwrap_or(Ordering::Equal))
+    //         {
+    //             Ok(ix) => ix,
+    //             Err(ix) => ix,
+    //         };
+    //         results.insert(ix, (id, similarity));
+    //         results.truncate(limit);
+    //     })?;
+
+    //     let ids = results.into_iter().map(|(id, _)| id).collect::<Vec<_>>();
+    //     self.get_documents_by_ids(&ids)
+    // }
+
+    pub fn retrieve_included_file_ids(
         &self,
         worktree_ids: &[i64],
         include_globs: Vec<GlobMatcher>,
         exclude_globs: Vec<GlobMatcher>,
-        mut f: impl FnMut(i64, Vec<f32>),
-    ) -> Result<()> {
+    ) -> Result<Vec<i64>> {
         let mut file_query = self.db.prepare(
             "
             SELECT
@@ -315,6 +330,7 @@ impl VectorDatabase {
 
         let mut file_ids = Vec::<i64>::new();
         let mut rows = file_query.query([ids_to_sql(worktree_ids)])?;
+
         while let Some(row) = rows.next()? {
             let file_id = row.get(0)?;
             let relative_path = row.get_ref(1)?.as_str()?;
@@ -330,6 +346,10 @@ impl VectorDatabase {
             }
         }
 
+        Ok(file_ids)
+    }
+
+    fn for_each_document(&self, file_ids: &[i64], mut f: impl FnMut(i64, Vec<f32>)) -> Result<()> {
         let mut query_statement = self.db.prepare(
             "
             SELECT
@@ -350,7 +370,7 @@ impl VectorDatabase {
         Ok(())
     }
 
-    fn get_documents_by_ids(&self, ids: &[i64]) -> Result<Vec<(i64, PathBuf, Range<usize>)>> {
+    pub fn get_documents_by_ids(&self, ids: &[i64]) -> Result<Vec<(i64, PathBuf, Range<usize>)>> {
         let mut statement = self.db.prepare(
             "
                 SELECT

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -287,30 +287,6 @@ impl VectorDatabase {
         Ok(results)
     }
 
-    // pub fn top_k_search(
-    //     &self,
-    //     worktree_ids: &[i64],
-    //     query_embedding: &Vec<f32>,
-    //     limit: usize,
-    //     file_ids: Vec<i64>,
-    // ) -> Result<Vec<(i64, PathBuf, Range<usize>)>> {
-    //     let mut results = Vec::<(i64, f32)>::with_capacity(limit + 1);
-    //     self.for_each_document(&worktree_ids, file_ids, |id, embedding| {
-    //         let similarity = dot(&embedding, &query_embedding);
-    //         let ix = match results
-    //             .binary_search_by(|(_, s)| similarity.partial_cmp(&s).unwrap_or(Ordering::Equal))
-    //         {
-    //             Ok(ix) => ix,
-    //             Err(ix) => ix,
-    //         };
-    //         results.insert(ix, (id, similarity));
-    //         results.truncate(limit);
-    //     })?;
-
-    //     let ids = results.into_iter().map(|(id, _)| id).collect::<Vec<_>>();
-    //     self.get_documents_by_ids(&ids)
-    // }
-
     pub fn retrieve_included_file_ids(
         &self,
         worktree_ids: &[i64],

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -721,7 +721,12 @@ impl SemanticIndex {
             )?;
 
             let batch_n = cx.background().num_cpus();
-            let batch_size = file_ids.clone().len() / batch_n;
+            let ids_len = file_ids.clone().len();
+            let batch_size = if ids_len <= batch_n {
+                ids_len
+            } else {
+                ids_len / batch_n
+            };
 
             let mut result_tasks = Vec::new();
             for batch in file_ids.chunks(batch_size) {


### PR DESCRIPTION
Parallelize Vector Database calls for project semantic search.

Release Notes: (Preview-only)

- Parallelize Vector database calls for project semantic search. Cuts query time by 2/3rds.
- Removed default keymap for old semantic search modal.