### PR TITLE
Block extra drag events in original drag handlers

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -172,6 +172,10 @@ impl EditorElement {
             .on_drag(MouseButton::Left, {
                 let position_map = position_map.clone();
                 move |event, editor, cx| {
+                    if event.end {
+                        return;
+                    }
+
                     if !Self::mouse_dragged(
                         editor,
                         event.platform_event,
@@ -1235,6 +1239,10 @@ impl EditorElement {
                 })
                 .on_drag(MouseButton::Left, {
                     move |event, editor: &mut Editor, cx| {
+                        if event.end {
+                            return;
+                        }
+
                         let y = event.prev_mouse_position.y();
                         let new_y = event.position.y();
                         if thumb_top < y && y < thumb_bottom {

--- a/crates/gpui/src/elements/resizable.rs
+++ b/crates/gpui/src/elements/resizable.rs
@@ -147,6 +147,9 @@ impl<V: View> Element<V> for Resizable<V> {
                 let max_size = side.relevant_component(constraint.max);
                 let on_resize = self.on_resize.clone();
                 move |event, view: &mut V, cx| {
+                    if event.end {
+                        return;
+                    }
                     let new_size = min_size
                         .max(prev_size + side.compute_delta(event))
                         .min(max_size)

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -78,7 +78,7 @@ lazy_static! {
     // * use more strict regex for `file://` protocol matching: original regex has `file:` inside, but we want to avoid matching `some::file::module` strings.
     static ref URL_REGEX: RegexSearch = RegexSearch::new(r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`]+"#).unwrap();
 
-    static ref WORD_REGEX: RegexSearch = RegexSearch::new("[\\w.:/@-~]+").unwrap();
+    static ref WORD_REGEX: RegexSearch = RegexSearch::new(r#"[\w.:/@\-~]+"#).unwrap();
 }
 
 ///Upward flowing events, for changing the title and such

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -411,6 +411,10 @@ impl TerminalElement {
             })
             // Update drag selections
             .on_drag(MouseButton::Left, move |event, _: &mut TerminalView, cx| {
+                if event.end {
+                    return;
+                }
+
                 if cx.is_self_focused() {
                     if let Some(conn_handle) = connection.upgrade(cx) {
                         conn_handle.update(cx, |terminal, cx| {


### PR DESCRIPTION
In https://github.com/zed-industries/zed/pull/2790 I added an extra drag event on mouse_up which signaled the end of a drag event, as mouse_up event themselves wouldn't reliably fire if users moved their mouse too quickly. This broke the assumptions of the terminal element. This PR adds filters to all current on_drag handlers which removes this new event.

Release Notes:

- Fixed a bug causing terminal links to never open (preview only)
- Fixed a bug in terminal link detection causing it to miss files with a `-` in it