### PR TITLE
Downgrade tree sitter elm to 5.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8070,9 +8070,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-elm"
-version = "5.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95236155fa1cd5fcf92123e7e6aa7b6e8c6756b54b5d39afd792a23bd6c9eb7b"
+version = "5.6.4"
+source = "git+https://github.com/elm-tooling/tree-sitter-elm?rev=692c50c0b961364c40299e73c1306aecb5d20f40#692c50c0b961364c40299e73c1306aecb5d20f40"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tree-sitter-c = "0.20.1"
 tree-sitter-cpp = "0.20.0"
 tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }
 tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "4ba9dab6e2602960d95b2b625f3386c27e08084e" }
-tree-sitter-elm = "5.6.4"
+tree-sitter-elm = { git = "https://github.com/elm-tooling/tree-sitter-elm", rev = "692c50c0b961364c40299e73c1306aecb5d20f40"}
 tree-sitter-embedded-template = "0.20.0"
 tree-sitter-glsl = { git = "https://github.com/theHamsta/tree-sitter-glsl", rev = "2a56fb7bc8bb03a1892b4741279dd0a8758b7fb3" }
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }


### PR DESCRIPTION
In 5.6.5, The tree sitter elm parser added a c symbol which collides with other linked symbols. And then even though we had set the version to 5.6.4, cargo silently updated it to 5.6.6. This PR downgrades the tree sitter elm parser to a version which doesn't have this problem.

Release Notes:
- Fixed crash when parsing elm files