### PR TITLE
Make LSP status message match new font size of diagnostic message

### DIFF
--- a/styles/src/style_tree/status_bar.ts
+++ b/styles/src/style_tree/status_bar.ts
@@ -44,7 +44,7 @@ export default function status_bar(): any {
                 icon_spacing: 4,
                 icon_width: 14,
                 height: 18,
-                message: text(layer, "sans"),
+                message: text(layer, "sans", { size: "xs" }),
                 icon_color: foreground(layer),
             },
             state: {


### PR DESCRIPTION
The status bar diagnostic message font size was updated in https://github.com/zed-industries/zed/commit/1f65effe57b85d126fcb5689d6d37ec3f768502e but the LSP status message font size remained the same causing a font size change when swapping between the two

![CleanShot 2023-07-26 at 18 32 13](https://github.com/zed-industries/zed/assets/30666851/8d357f46-3a48-4ed1-9832-d24b4b2be4a8)
![CleanShot 2023-07-26 at 18 30 56](https://github.com/zed-industries/zed/assets/30666851/e4ce9911-f66d-4bc3-b951-78196da44176)

Release Notes:

- Fixed an inconsistency in status bar font size.

