### PR TITLE
Downgrade our dependency on treesitter-cpp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6513,7 +6513,7 @@ dependencies = [
  "theme",
  "tiktoken-rs 0.5.0",
  "tree-sitter",
- "tree-sitter-cpp",
+ "tree-sitter-cpp 0.20.2",
  "tree-sitter-elixir 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tree-sitter-json 0.19.0",
  "tree-sitter-rust",
@@ -8032,9 +8032,18 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cpp"
-version = "0.20.1"
+version = "0.20.0"
+source = "git+https://github.com/tree-sitter/tree-sitter-cpp?rev=f44509141e7e483323d2ec178f2d2e6c0fc041c1#f44509141e7e483323d2ec178f2d2e6c0fc041c1"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbedbf4066bfab725b3f9e2a21530507419a7d2f98621d3c13213502b734ec0"
+checksum = "1c88fd925d0333e63ac64e521f5bd79c53019e569ffbbccfeef346a326f459e9"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -9622,7 +9631,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
- "tree-sitter-cpp",
+ "tree-sitter-cpp 0.20.0",
  "tree-sitter-css",
  "tree-sitter-elixir 0.1.0 (git+https://github.com/elixir-lang/tree-sitter-elixir?rev=4ba9dab6e2602960d95b2b625f3386c27e08084e)",
  "tree-sitter-elm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ pretty_assertions = "1.3.0"
 
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "1b0321ee85701d5036c334a6f04761cdc672e64c" }
 tree-sitter-c = "0.20.1"
-tree-sitter-cpp = "0.20.0"
+tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev="f44509141e7e483323d2ec178f2d2e6c0fc041c1" }
 tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }
 tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "4ba9dab6e2602960d95b2b625f3386c27e08084e" }
 tree-sitter-elm = { git = "https://github.com/elm-tooling/tree-sitter-elm", rev = "692c50c0b961364c40299e73c1306aecb5d20f40"}

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1188,25 +1188,39 @@ impl Language {
 
     pub fn with_queries(mut self, queries: LanguageQueries) -> Result<Self> {
         if let Some(query) = queries.highlights {
-            self = self.with_highlights_query(query.as_ref()).context("Error loading highlights query")?;
+            self = self
+                .with_highlights_query(query.as_ref())
+                .context("Error loading highlights query")?;
         }
         if let Some(query) = queries.brackets {
-            self = self.with_brackets_query(query.as_ref()).context("Error loading brackets query")?;
+            self = self
+                .with_brackets_query(query.as_ref())
+                .context("Error loading brackets query")?;
         }
         if let Some(query) = queries.indents {
-            self = self.with_indents_query(query.as_ref()).context("Error loading indents query")?;
+            self = self
+                .with_indents_query(query.as_ref())
+                .context("Error loading indents query")?;
         }
         if let Some(query) = queries.outline {
-            self = self.with_outline_query(query.as_ref()).context("Error loading outline query")?;
+            self = self
+                .with_outline_query(query.as_ref())
+                .context("Error loading outline query")?;
         }
         if let Some(query) = queries.embedding {
-            self = self.with_embedding_query(query.as_ref()).context("Error loading embedding query")?;
+            self = self
+                .with_embedding_query(query.as_ref())
+                .context("Error loading embedding query")?;
         }
         if let Some(query) = queries.injections {
-            self = self.with_injection_query(query.as_ref()).context("Error loading injection query")?;
+            self = self
+                .with_injection_query(query.as_ref())
+                .context("Error loading injection query")?;
         }
         if let Some(query) = queries.overrides {
-            self = self.with_override_query(query.as_ref()).context("Error loading override query")?;
+            self = self
+                .with_override_query(query.as_ref())
+                .context("Error loading override query")?;
         }
         Ok(self)
     }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -844,8 +844,8 @@ impl LanguageRegistry {
                                             }
                                         }
                                     }
-                                    Err(err) => {
-                                        log::error!("failed to load language {name} - {err}");
+                                    Err(e) => {
+                                        log::error!("failed to load language {name}:\n{:?}", e);
                                         let mut state = this.state.write();
                                         state.mark_language_loaded(id);
                                         if let Some(mut txs) = state.loading_languages.remove(&id) {
@@ -853,7 +853,7 @@ impl LanguageRegistry {
                                                 let _ = tx.send(Err(anyhow!(
                                                     "failed to load language {}: {}",
                                                     name,
-                                                    err
+                                                    e
                                                 )));
                                             }
                                         }
@@ -1188,25 +1188,25 @@ impl Language {
 
     pub fn with_queries(mut self, queries: LanguageQueries) -> Result<Self> {
         if let Some(query) = queries.highlights {
-            self = self.with_highlights_query(query.as_ref())?;
+            self = self.with_highlights_query(query.as_ref()).context("Error loading highlights query")?;
         }
         if let Some(query) = queries.brackets {
-            self = self.with_brackets_query(query.as_ref())?;
+            self = self.with_brackets_query(query.as_ref()).context("Error loading brackets query")?;
         }
         if let Some(query) = queries.indents {
-            self = self.with_indents_query(query.as_ref())?;
+            self = self.with_indents_query(query.as_ref()).context("Error loading indents query")?;
         }
         if let Some(query) = queries.outline {
-            self = self.with_outline_query(query.as_ref())?;
+            self = self.with_outline_query(query.as_ref()).context("Error loading outline query")?;
         }
         if let Some(query) = queries.embedding {
-            self = self.with_embedding_query(query.as_ref())?;
+            self = self.with_embedding_query(query.as_ref()).context("Error loading embedding query")?;
         }
         if let Some(query) = queries.injections {
-            self = self.with_injection_query(query.as_ref())?;
+            self = self.with_injection_query(query.as_ref()).context("Error loading injection query")?;
         }
         if let Some(query) = queries.overrides {
-            self = self.with_override_query(query.as_ref())?;
+            self = self.with_override_query(query.as_ref()).context("Error loading override query")?;
         }
         Ok(self)
     }


### PR DESCRIPTION
Our dependency on `tree-sitter-cpp` got upgraded to an incompatible version despite semver 'guarantees'. This pins the dependency onto the commit of version 0.20.0

Release Notes:

- Restored language detection for C++ (preview-only)