### PR TITLE
Make mode indicator follow vim enabled state

### DIFF
--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -44,7 +44,11 @@ impl ModeIndicator {
         // Vim doesn't exist in some tests
         let mode = cx
             .has_global::<Vim>()
-            .then(|| cx.global::<Vim>().state.mode);
+            .then(|| {
+                let vim = cx.global::<Vim>();
+                vim.enabled.then(|| vim.state.mode)
+            })
+            .flatten();
 
         Self {
             mode,


### PR DESCRIPTION
There was a minor visual bug introduced in https://github.com/zed-industries/zed/pull/2801, this PR corrects it.

Release Notes:

- N/A
