### PR TITLE
Update filetype accuracy to include multiple "." in filename

### DIFF
--- a/crates/project_panel/src/file_associations.rs
+++ b/crates/project_panel/src/file_associations.rs
@@ -52,9 +52,7 @@ impl FileAssociations {
                     .file_name()
                     .and_then(|os_str| os_str.to_str())
                     .and_then(|file_name| {
-                        file_name
-                            .find('.')
-                            .and_then(|dot_index| file_name.get(dot_index + 1..))
+                        file_name.rsplit('.').next()
                     })?;
 
                 this.suffixes


### PR DESCRIPTION
Update filename check to take the text after the last period as the suffix

This fixes a bug in the filename suffix check to determine which icon to use for the file. It wasn't supporting multiple periods in the filename. Now it does for better file icon representation accuracy.

<img width="341" alt="image" src="https://github.com/zed-industries/zed/assets/1648941/1d9549e0-fcba-4ba8-9e23-d3cb8b3b498b">
