### PR TITLE
Put LiveKitBridge Swift build directory in `target`

### DIFF
--- a/crates/live_kit_client/build.rs
+++ b/crates/live_kit_client/build.rs
@@ -58,11 +58,14 @@ fn build_bridge(swift_target: &SwiftTarget) {
         "cargo:rerun-if-changed={}/Package.resolved",
         SWIFT_PACKAGE_NAME
     );
+
     let swift_package_root = swift_package_root();
+    let swift_target_folder = swift_target_folder();
     if !Command::new("swift")
         .arg("build")
         .args(["--configuration", &env::var("PROFILE").unwrap()])
         .args(["--triple", &swift_target.target.triple])
+        .args(["--build-path".into(), swift_target_folder])
         .current_dir(&swift_package_root)
         .status()
         .unwrap()
@@ -128,6 +131,12 @@ fn swift_package_root() -> PathBuf {
     env::current_dir().unwrap().join(SWIFT_PACKAGE_NAME)
 }
 
+fn swift_target_folder() -> PathBuf {
+    env::current_dir()
+        .unwrap()
+        .join(format!("../../target/{SWIFT_PACKAGE_NAME}"))
+}
+
 fn copy_dir(source: &Path, destination: &Path) {
     assert!(
         Command::new("rm")
@@ -155,8 +164,7 @@ fn copy_dir(source: &Path, destination: &Path) {
 
 impl SwiftTarget {
     fn out_dir_path(&self) -> PathBuf {
-        swift_package_root()
-            .join(".build")
+        swift_target_folder()
             .join(&self.target.unversioned_triple)
             .join(env::var("PROFILE").unwrap())
     }


### PR DESCRIPTION
Helps it get caught in a cargo clean. Joseph was having trouble building a specific version of the app and deleting the Swift build dir for this package resolved it. He had run cargo clean which would have handled that if the Swift build dir was in `target` which this patch does


Release Notes:

- N/A