### PR TITLE
Use the same font size for hovered state of LSP status

### DIFF
--- a/styles/src/style_tree/status_bar.ts
+++ b/styles/src/style_tree/status_bar.ts
@@ -49,7 +49,7 @@ export default function status_bar(): any {
             },
             state: {
                 hovered: {
-                    message: text(layer, "sans"),
+                    message: text(layer, "sans", { size: "xs" }),
                     icon_color: foreground(layer),
                     background: background(layer, "hovered"),
                 },


### PR DESCRIPTION
This element is used for the update state as well for some reason so while we don't normally ever see this state, it is used when the status is acting as the restart to update button

Release Notes:

- Fixed an inconsistency in the status bar update button font size.
