### PR TITLE
Fix file icon bug

### DIFF
--- a/crates/project_panel/src/file_associations.rs
+++ b/crates/project_panel/src/file_associations.rs
@@ -48,14 +48,19 @@ impl FileAssociations {
             // FIXME: Associate a type with the languages and have the file's langauge
             //        override these associations
             iife!({
-                let suffix = path
-                    .file_name()
-                    .and_then(|os_str| os_str.to_str())
-                    .and_then(|file_name| {
-                        file_name
-                            .find('.')
-                            .and_then(|dot_index| file_name.get(dot_index + 1..))
-                    })?;
+                let suffix = match path.extension() {
+                    Some(extension) => extension.to_str()?,
+                    None => {
+                        // Fall back to custom logic to handle cases that the built-in `extension()` doesn't handle, such as `.gitignore`
+                        path.file_name()
+                            .and_then(|os_str| os_str.to_str())
+                            .and_then(|file_name| {
+                                file_name
+                                    .find('.')
+                                    .and_then(|dot_index| file_name.get(dot_index + 1..))
+                            })?
+                    }
+                };
 
                 this.suffixes
                     .get(suffix)


### PR DESCRIPTION
Use the built-in extension() method as first line of defense when trying to obtain file extensions.  Use custom logic after that for edge cases where the extension() method fails, such as for files like `.gitignore`.

Release Notes:

- Fixed a bug where file icons would not be registered for files with with multiple `.` characters in their name ([#1877](https://github.com/zed-industries/zed/issues/6250)).