### PR TITLE
Expand empty selections to cover full word when doing case conversions and fix bugs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4366,6 +4366,8 @@ impl Editor {
 
         let mut new_selections = Vec::new();
         let mut edits = Vec::new();
+        let mut selection_adjustment = 0i32;
+
         for selection in self.selections.all::<usize>(cx) {
             let selection_is_empty = selection.is_empty();
 
@@ -4382,18 +4384,17 @@ impl Editor {
             };
 
             let text = buffer.text_for_range(start..end).collect::<String>();
+            let old_length = text.len() as i32;
             let text = callback(&text);
 
-            if selection_is_empty {
-                new_selections.push(selection);
-            } else {
-                new_selections.push(Selection {
-                    start,
-                    end: start + text.len(),
-                    goal: SelectionGoal::None,
-                    ..selection
-                });
-            }
+            new_selections.push(Selection {
+                start: (start as i32 - selection_adjustment) as usize,
+                end: ((start + text.len()) as i32 - selection_adjustment) as usize,
+                goal: SelectionGoal::None,
+                ..selection
+            });
+
+            selection_adjustment += old_length - text.len() as i32;
 
             edits.push((start..end, text));
         }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2719,7 +2719,7 @@ async fn test_manipulate_text(cx: &mut TestAppContext) {
         «hello worldˇ»
     "});
 
-    // From here on out, test more complex cases of manipulate_text() with a single driver method: convert_to_upper_case()
+    // From here on out, test more complex cases of manipulate_text()
 
     // Test no selection case - should affect words cursors are in
     // Cursor at beginning, middle, and end of word
@@ -2728,7 +2728,7 @@ async fn test_manipulate_text(cx: &mut TestAppContext) {
     "});
     cx.update_editor(|e, cx| e.convert_to_upper_case(&ConvertToUpperCase, cx));
     cx.assert_editor_state(indoc! {"
-        ˇHELLO big BEAUˇTIFUL WORLDˇ
+        «HELLOˇ» big «BEAUTIFULˇ» «WORLDˇ»
     "});
 
     // Test multiple selections on a single line and across multiple lines
@@ -2751,6 +2751,25 @@ async fn test_manipulate_text(cx: &mut TestAppContext) {
     cx.update_editor(|e, cx| e.convert_to_upper_case(&ConvertToUpperCase, cx));
     cx.assert_editor_state(indoc! {"
         «TSCHÜSSˇ»
+    "});
+
+    // Test to make sure we don't crash when text shrinks
+    cx.set_state(indoc! {"
+        aaa_bbbˇ
+    "});
+    cx.update_editor(|e, cx| e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, cx));
+    cx.assert_editor_state(indoc! {"
+        «aaaBbbˇ»
+    "});
+
+    // Test to make sure we all aware of the fact that each word can grow and shrink
+    // Final selections should be aware of this fact
+    cx.set_state(indoc! {"
+        aaa_bˇbb bbˇb_ccc ˇccc_ddd
+    "});
+    cx.update_editor(|e, cx| e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, cx));
+    cx.assert_editor_state(indoc! {"
+        «aaaBbbˇ» «bbbCccˇ» «cccDddˇ»
     "});
 }
 


### PR DESCRIPTION
When doing case conversions, specifically in the case of an empty selection, in both VS Code and Sublime, the cursor winds up being in a different place relative to where it started. 

In VS Code, the cursor maintains it position in the text, no matter if the text expands or shrinks

https://github.com/zed-industries/zed/assets/19867440/b24f5d86-c315-4a72-9ed4-3732b490ea9a

In Sublime, I have no idea what is going on:

https://github.com/zed-industries/zed/assets/19867440/05f21303-6e42-47b2-b844-7accd0bf05d7

I thought it would be a better experience if, when doing an empty selection transformation, we simply expand the selection and park the cursor at the end of the newly-transformed text.

https://github.com/zed-industries/zed/assets/19867440/833619ef-04e2-47b6-ad4e-e2b43d54fb2b

This feels similar to us expanding the selection when doing line manipulations:

https://github.com/zed-industries/zed/assets/19867440/c30c5332-787d-4cf0-a9ee-e66c3c159956

Selections are adjusted to match however each word expands and shrinks, even when there are multiple:

https://github.com/zed-industries/zed/assets/19867440/d7073aac-8a59-4f2c-b0e5-1df37be1694c

Release Notes:

- Improved behavior of empty-selection case transformations by selecting resulting word.
- Fixed some bugs with overflow