### PR TITLE
Fix bash `path_suffixes `and add `cmd-/` line comment support

### DIFF
--- a/crates/zed/src/languages/bash/config.toml
+++ b/crates/zed/src/languages/bash/config.toml
@@ -1,5 +1,6 @@
 name = "Shell Script"
-path_suffixes = [".sh", ".bash", ".bashrc", ".bash_profile", ".bash_aliases", ".bash_logout", ".profile", ".zsh", ".zshrc", ".zshenv", ".zsh_profile", ".zsh_aliases", ".zsh_histfile", ".zlogin"]
+path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin"]
+line_comment = "# "
 first_line_pattern = "^#!.*\\b(?:ba|z)?sh\\b"
 brackets = [
     { start = "[", end = "]", close = true, newline = false },


### PR DESCRIPTION
<img width="1608" alt="SCR-20230806-cyrg" src="https://github.com/zed-industries/zed/assets/19867440/2491c4bc-5797-4417-9633-08c136b4e8fe">

I noticed we weren't highlghting bash files if the shebang line didn't exist.  After checking, it looks like the `.` were accidentally added to the `path_suffixes` list.  This PR fixes that and adds in support for `cmd-/` to trigger line comments.

<img width="1608" alt="SCR-20230806-czxh" src="https://github.com/zed-industries/zed/assets/19867440/37dd0c8e-c4e7-49e2-9997-9dd8145f460e">


Release Notes:

- Fixed a bug where shell files weren't syntax highlighted if a shebang didn't exist.
- Added support for `cmd-/` to add line comments to shell files.