### PR TITLE
Fix language detection when file name begins with a `.`

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -45,7 +45,7 @@ use syntax_map::SyntaxSnapshot;
 use theme::{SyntaxTheme, Theme};
 use tree_sitter::{self, Query};
 use unicase::UniCase;
-use util::http::HttpClient;
+use util::{http::HttpClient, paths::PathExt};
 use util::{merge_json_value_into, post_inc, ResultExt, TryFutureExt as _, UnwrapFuture};
 
 #[cfg(any(test, feature = "test-support"))]
@@ -777,7 +777,7 @@ impl LanguageRegistry {
     ) -> UnwrapFuture<oneshot::Receiver<Result<Arc<Language>>>> {
         let path = path.as_ref();
         let filename = path.file_name().and_then(|name| name.to_str());
-        let extension = path.extension().and_then(|name| name.to_str());
+        let extension = path.extension_or_hidden_file_name();
         let path_suffixes = [extension, filename];
         self.get_or_load_language(|config| {
             let path_matches = config

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -33,6 +33,7 @@ pub mod legacy {
 pub trait PathExt {
     fn compact(&self) -> PathBuf;
     fn icon_suffix(&self) -> Option<&str>;
+    fn extension_or_hidden_file_name(&self) -> Option<&str>;
 }
 
 impl<T: AsRef<Path>> PathExt for T {
@@ -60,6 +61,7 @@ impl<T: AsRef<Path>> PathExt for T {
         }
     }
 
+    /// Returns a suffix of the path that is used to determine which file icon to use
     fn icon_suffix(&self) -> Option<&str> {
         let file_name = self.as_ref().file_name()?.to_str()?;
 
@@ -69,8 +71,16 @@ impl<T: AsRef<Path>> PathExt for T {
 
         self.as_ref()
             .extension()
-            .map(|extension| extension.to_str())
-            .flatten()
+            .and_then(|extension| extension.to_str())
+    }
+
+    /// Returns a file's extension or, if the file is hidden, its name without the leading dot
+    fn extension_or_hidden_file_name(&self) -> Option<&str> {
+        if let Some(extension) = self.as_ref().extension() {
+            return extension.to_str();
+        }
+
+        self.as_ref().file_name()?.to_str()?.split('.').last()
     }
 }
 
@@ -314,5 +324,28 @@ mod tests {
         // Hidden file, with extension
         let path = Path::new("/a/b/c/.eslintrc.js");
         assert_eq!(path.icon_suffix(), Some("eslintrc.js"));
+    }
+
+    #[test]
+    fn test_extension_or_hidden_file_name() {
+        // No dots in name
+        let path = Path::new("/a/b/c/file_name.rs");
+        assert_eq!(path.extension_or_hidden_file_name(), Some("rs"));
+
+        // Single dot in name
+        let path = Path::new("/a/b/c/file.name.rs");
+        assert_eq!(path.extension_or_hidden_file_name(), Some("rs"));
+
+        // Multiple dots in name
+        let path = Path::new("/a/b/c/long.file.name.rs");
+        assert_eq!(path.extension_or_hidden_file_name(), Some("rs"));
+
+        // Hidden file, no extension
+        let path = Path::new("/a/b/c/.gitignore");
+        assert_eq!(path.extension_or_hidden_file_name(), Some("gitignore"));
+
+        // Hidden file, with extension
+        let path = Path::new("/a/b/c/.eslintrc.js");
+        assert_eq!(path.extension_or_hidden_file_name(), Some("js"));
     }
 }

--- a/crates/zed/src/languages/bash/config.toml
+++ b/crates/zed/src/languages/bash/config.toml
@@ -1,5 +1,5 @@
 name = "Shell Script"
-path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin"]
+path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile"]
 line_comment = "# "
 first_line_pattern = "^#!.*\\b(?:ba|z)?sh\\b"
 brackets = [


### PR DESCRIPTION
I went to add in `zprofile` to the bash language config to get syntax highlighting for it. After adding it in, Zed was still not highlighting the file.  I checked and saw that we are using `Path::extension()` in `language_for_file()`, which [returns `None` when a file's name begins with a `.`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.extension), such as in the case of `.zprofile`. This PR adds a custom method, with some tests, that just tries to grab the last component in the file name if `Path::extension` returns `None`. Not sure if `ext` is the best name, but I can't use `extension`.

Maybe this method should be called `extension_or_hidden_file_name()`?

Release Notes:

- Fixed a bug where language detection would fail for files starting with `.` in their names.
- Added syntax highlighting for `.zprofile` files