### PR TITLE
Restore shutdown behavior

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4067,10 +4067,10 @@ pub fn restart(_: &Restart, cx: &mut AppContext) {
 
         // If the user cancels any save prompt, then keep the app open.
         for window in workspace_windows {
-            if let Some(close) = window.update_root(&mut cx, |workspace, cx| {
+            if let Some(should_close) = window.update_root(&mut cx, |workspace, cx| {
                 workspace.prepare_to_close(true, cx)
             }) {
-                if !close.await? {
+                if !should_close.await? {
                     return Ok(());
                 }
             }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -433,10 +433,10 @@ fn quit(_: &Quit, cx: &mut gpui::AppContext) {
 
         // If the user cancels any save prompt, then keep the app open.
         for window in workspace_windows {
-            if let Some(close) = window.update_root(&mut cx, |workspace, cx| {
-                workspace.prepare_to_close(false, cx)
+            if let Some(should_close) = window.update_root(&mut cx, |workspace, cx| {
+                workspace.prepare_to_close(true, cx)
             }) {
-                if close.await? {
+                if !should_close.await? {
                     return Ok(());
                 }
             }


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/issues/6259

Restores original close behavior from https://github.com/zed-industries/zed/pull/2832/files#diff-89af0b4072205c53b518aa977d6be48997e1a51fa4dbf06c7ddd1fec99fc510eL444 (load diff for the last file, zed.rs)

and adds a better name for the variable.

Release Notes:

- Fixes `cmd-q` not working