### PR TITLE
chore: use Cow instead of String for tooltips

### DIFF
--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -362,7 +362,7 @@ impl AssistantPanel {
                 this.set_active_editor_index(this.prev_active_editor_index, cx);
             }
         })
-        .with_tooltip::<History>(1, "History".into(), None, tooltip_style, cx)
+        .with_tooltip::<History>(1, "History", None, tooltip_style, cx)
     }
 
     fn render_editor_tools(&self, cx: &mut ViewContext<Self>) -> Vec<AnyElement<Self>> {
@@ -394,7 +394,7 @@ impl AssistantPanel {
         })
         .with_tooltip::<Split>(
             1,
-            "Split Message".into(),
+            "Split Message",
             Some(Box::new(Split)),
             tooltip_style,
             cx,
@@ -416,13 +416,7 @@ impl AssistantPanel {
                 active_editor.update(cx, |editor, cx| editor.assist(&Default::default(), cx));
             }
         })
-        .with_tooltip::<Assist>(
-            1,
-            "Assist".into(),
-            Some(Box::new(Assist)),
-            tooltip_style,
-            cx,
-        )
+        .with_tooltip::<Assist>(1, "Assist", Some(Box::new(Assist)), tooltip_style, cx)
     }
 
     fn render_quote_button(cx: &mut ViewContext<Self>) -> impl Element<Self> {
@@ -446,7 +440,7 @@ impl AssistantPanel {
         })
         .with_tooltip::<QuoteSelection>(
             1,
-            "Quote Selection".into(),
+            "Quote Selection",
             Some(Box::new(QuoteSelection)),
             tooltip_style,
             cx,
@@ -468,7 +462,7 @@ impl AssistantPanel {
         })
         .with_tooltip::<NewConversation>(
             1,
-            "New Conversation".into(),
+            "New Conversation",
             Some(Box::new(NewConversation)),
             tooltip_style,
             cx,
@@ -498,11 +492,7 @@ impl AssistantPanel {
         })
         .with_tooltip::<ToggleZoom>(
             0,
-            if self.zoomed {
-                "Zoom Out".into()
-            } else {
-                "Zoom In".into()
-            },
+            if self.zoomed { "Zoom Out" } else { "Zoom In" },
             Some(Box::new(ToggleZoom)),
             tooltip_style,
             cx,

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -238,7 +238,7 @@ impl CollabTitlebarItem {
                             .left()
                             .with_tooltip::<RecentProjectsTooltip>(
                                 0,
-                                "Recent projects".into(),
+                                "Recent projects",
                                 Some(Box::new(recent_projects::OpenRecent)),
                                 theme.tooltip.clone(),
                                 cx,
@@ -282,7 +282,7 @@ impl CollabTitlebarItem {
                                             .left()
                                             .with_tooltip::<BranchPopoverTooltip>(
                                                 0,
-                                                "Recent branches".into(),
+                                                "Recent branches",
                                                 Some(Box::new(ToggleVcsMenu)),
                                                 theme.tooltip.clone(),
                                                 cx,
@@ -582,7 +582,7 @@ impl CollabTitlebarItem {
                 })
                 .with_tooltip::<ToggleContactsMenu>(
                     0,
-                    "Show contacts menu".into(),
+                    "Show contacts menu",
                     Some(Box::new(ToggleContactsMenu)),
                     theme.tooltip.clone(),
                     cx,
@@ -633,7 +633,7 @@ impl CollabTitlebarItem {
         })
         .with_tooltip::<ToggleScreenSharing>(
             0,
-            tooltip.into(),
+            tooltip,
             Some(Box::new(ToggleScreenSharing)),
             theme.tooltip.clone(),
             cx,
@@ -686,7 +686,7 @@ impl CollabTitlebarItem {
         })
         .with_tooltip::<ToggleMute>(
             0,
-            tooltip.into(),
+            tooltip,
             Some(Box::new(ToggleMute)),
             theme.tooltip.clone(),
             cx,
@@ -734,7 +734,7 @@ impl CollabTitlebarItem {
         })
         .with_tooltip::<ToggleDeafen>(
             0,
-            tooltip.into(),
+            tooltip,
             Some(Box::new(ToggleDeafen)),
             theme.tooltip.clone(),
             cx,
@@ -768,7 +768,7 @@ impl CollabTitlebarItem {
         })
         .with_tooltip::<LeaveCall>(
             0,
-            tooltip.into(),
+            tooltip,
             Some(Box::new(LeaveCall)),
             theme.tooltip.clone(),
             cx,

--- a/crates/collab_ui/src/contact_list.rs
+++ b/crates/collab_ui/src/contact_list.rs
@@ -1345,7 +1345,7 @@ impl View for ContactList {
                         })
                         .with_tooltip::<AddContact>(
                             0,
-                            "Search for new contact".into(),
+                            "Search for new contact",
                             None,
                             theme.tooltip.clone(),
                             cx,

--- a/crates/copilot_button/src/copilot_button.rs
+++ b/crates/copilot_button/src/copilot_button.rs
@@ -140,7 +140,7 @@ impl View for CopilotButton {
                 })
                 .with_tooltip::<Self>(
                     0,
-                    "GitHub Copilot".into(),
+                    "GitHub Copilot",
                     None,
                     theme.tooltip.clone(),
                     cx,

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -173,7 +173,7 @@ impl View for DiagnosticIndicator {
             })
             .with_tooltip::<Summary>(
                 0,
-                "Project Diagnostics".to_string(),
+                "Project Diagnostics",
                 Some(Box::new(crate::Deploy)),
                 tooltip_style,
                 cx,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8685,7 +8685,7 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, is_valid: bool) -> Rend
         // We really need to rethink this ID system...
         .with_tooltip::<BlockContextToolip>(
             cx.block_id,
-            "Copy diagnostic message".to_string(),
+            "Copy diagnostic message",
             None,
             tooltip_style,
             cx,

--- a/crates/feedback/src/deploy_feedback_button.rs
+++ b/crates/feedback/src/deploy_feedback_button.rs
@@ -66,7 +66,7 @@ impl View for DeployFeedbackButton {
                 })
                 .with_tooltip::<Self>(
                     0,
-                    "Send Feedback".into(),
+                    "Send Feedback",
                     Some(Box::new(GiveFeedback)),
                     theme.tooltip.clone(),
                     cx,

--- a/crates/feedback/src/submit_feedback_button.rs
+++ b/crates/feedback/src/submit_feedback_button.rs
@@ -80,7 +80,7 @@ impl View for SubmitFeedbackButton {
         .with_margin_left(theme.feedback.button_margin)
         .with_tooltip::<Self>(
             0,
-            "cmd-s".into(),
+            "cmd-s",
             Some(Box::new(SubmitFeedback)),
             theme.tooltip.clone(),
             cx,

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -170,7 +170,7 @@ pub trait Element<V: View>: 'static {
     fn with_tooltip<Tag: 'static>(
         self,
         id: usize,
-        text: String,
+        text: impl Into<Cow<'static, str>>,
         action: Option<Box<dyn Action>>,
         style: TooltipStyle,
         cx: &mut ViewContext<V>,
@@ -178,7 +178,7 @@ pub trait Element<V: View>: 'static {
     where
         Self: 'static + Sized,
     {
-        Tooltip::new::<Tag, V>(id, text, action, style, self.into_any(), cx)
+        Tooltip::new::<Tag>(id, text, action, style, self.into_any(), cx)
     }
 
     fn resizable(

--- a/crates/gpui/src/elements/tooltip.rs
+++ b/crates/gpui/src/elements/tooltip.rs
@@ -12,6 +12,7 @@ use crate::{
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::{
+    borrow::Cow,
     cell::{Cell, RefCell},
     ops::Range,
     rc::Rc,
@@ -52,9 +53,9 @@ pub struct KeystrokeStyle {
 }
 
 impl<V: View> Tooltip<V> {
-    pub fn new<Tag: 'static, T: View>(
+    pub fn new<Tag: 'static>(
         id: usize,
-        text: String,
+        text: impl Into<Cow<'static, str>>,
         action: Option<Box<dyn Action>>,
         style: TooltipStyle,
         child: AnyElement<V>,
@@ -66,6 +67,8 @@ impl<V: View> Tooltip<V> {
 
         let state_handle = cx.default_element_state::<ElementState<Tag>, Rc<TooltipState>>(id);
         let state = state_handle.read(cx).clone();
+        let text = text.into();
+
         let tooltip = if state.visible.get() {
             let mut collapsed_tooltip = Self::render_tooltip(
                 focused_view_id,
@@ -127,7 +130,7 @@ impl<V: View> Tooltip<V> {
 
     pub fn render_tooltip(
         focused_view_id: Option<usize>,
-        text: String,
+        text: impl Into<Cow<'static, str>>,
         style: TooltipStyle,
         action: Option<Box<dyn Action>>,
         measure: bool,

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -72,10 +72,7 @@ impl TerminalPanel {
                         0,
                         "icons/plus_12.svg",
                         false,
-                        Some((
-                            "New Terminal".into(),
-                            Some(Box::new(workspace::NewTerminal)),
-                        )),
+                        Some(("New Terminal", Some(Box::new(workspace::NewTerminal)))),
                         cx,
                         move |_, cx| {
                             let this = this.clone();

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -303,10 +303,10 @@ impl Pane {
                         let tooltip_label;
                         if pane.is_zoomed() {
                             icon_path = "icons/minimize_8.svg";
-                            tooltip_label = "Zoom In".into();
+                            tooltip_label = "Zoom In";
                         } else {
                             icon_path = "icons/maximize_8.svg";
-                            tooltip_label = "Zoom In".into();
+                            tooltip_label = "Zoom In";
                         }
 
                         Pane::render_tab_bar_button(
@@ -1477,7 +1477,7 @@ impl Pane {
         index: usize,
         icon: &'static str,
         is_active: bool,
-        tooltip: Option<(String, Option<Box<dyn Action>>)>,
+        tooltip: Option<(&'static str, Option<Box<dyn Action>>)>,
         cx: &mut ViewContext<Pane>,
         on_click: F1,
         on_down: F2,

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -220,7 +220,7 @@ fn nav_button<A: Action, F: 'static + Fn(&mut Toolbar, &mut ViewContext<Toolbar>
     spacing: f32,
     on_click: F,
     tooltip_action: A,
-    action_name: &str,
+    action_name: &'static str,
     cx: &mut ViewContext<Toolbar>,
 ) -> AnyElement<Toolbar> {
     MouseEventHandler::<A, _>::new(0, cx, |state, _| {
@@ -252,7 +252,7 @@ fn nav_button<A: Action, F: 'static + Fn(&mut Toolbar, &mut ViewContext<Toolbar>
     })
     .with_tooltip::<A>(
         0,
-        action_name.to_string(),
+        action_name,
         Some(Box::new(tooltip_action)),
         tooltip_style,
         cx,


### PR DESCRIPTION
A QoL change to align `Tooltip` with other elements like `Label`
Release Notes:

- N/A

