### PR TITLE
Fix vim escape in normal mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -237,6 +237,14 @@
     }
   },
   {
+    // escape is in its own section so that it cancels a pending count.
+    "context": "Editor && vim_mode == normal && vim_operator == none && !VimWaiting",
+    "bindings": {
+      "escape": "editor::Cancel",
+      "ctrl+[": "editor::Cancel"
+    }
+  },
+  {
     "context": "Editor && vim_mode == normal && (vim_operator == none || vim_operator == n) && !VimWaiting",
     "bindings": {
       "c": [
@@ -386,6 +394,14 @@
         "Replace"
       ],
       "ctrl-c": [
+        "vim::SwitchMode",
+        "Normal"
+      ],
+      "escape": [
+        "vim::SwitchMode",
+        "Normal"
+      ],
+      "ctrl+[": [
         "vim::SwitchMode",
         "Normal"
       ],

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -158,6 +158,16 @@ async fn test_escape_command_palette(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_escape_cancels(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+
+    cx.set_state("aˇbˇc", Mode::Normal);
+    cx.simulate_keystrokes(["escape"]);
+
+    cx.assert_state("aˇbc", Mode::Normal);
+}
+
+#[gpui::test]
 async fn test_selection_on_search(cx: &mut gpui::TestAppContext) {
     let mut cx = VimTestContext::new(cx, true).await;
 


### PR DESCRIPTION
Fixes: zed-industries/zed#6244

- vim: Fix escape in normal mode ([#1857](https://github.com/zed-industries/zed/issues/6244)).

