### PR TITLE
Add a `default_open_ai_model` setting for the assistant

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -128,7 +128,13 @@
     // Default width when the assistant is docked to the left or right.
     "default_width": 640,
     // Default height when the assistant is docked to the bottom.
-    "default_height": 320
+    "default_height": 320,
+    // The default OpenAI model to use when starting new conversations. This
+    // setting can take two values:
+    //
+    // 1. "gpt-3.5-turbo-0613""
+    // 2. "gpt-4-0613""
+    "default_open_ai_model": "gpt-4-0613"
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
@@ -214,7 +220,9 @@
   "copilot": {
     // The set of glob patterns for which copilot should be disabled
     // in any matching file.
-    "disabled_globs": [".env"]
+    "disabled_globs": [
+      ".env"
+    ]
   },
   // Settings specific to journaling
   "journal": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -134,7 +134,7 @@
     //
     // 1. "gpt-3.5-turbo-0613""
     // 2. "gpt-4-0613""
-    "default_open_ai_model": "gpt-4-0613"
+    "default_open_ai_model": "gpt-4"
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -3,6 +3,7 @@ mod assistant_settings;
 
 use anyhow::Result;
 pub use assistant::AssistantPanel;
+use assistant_settings::OpenAIModel;
 use chrono::{DateTime, Local};
 use collections::HashMap;
 use fs::Fs;
@@ -60,7 +61,7 @@ struct SavedConversation {
     messages: Vec<SavedMessage>,
     message_metadata: HashMap<MessageId, MessageMetadata>,
     summary: String,
-    model: String,
+    model: OpenAIModel,
 }
 
 impl SavedConversation {

--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -3,7 +3,6 @@ mod assistant_settings;
 
 use anyhow::Result;
 pub use assistant::AssistantPanel;
-use assistant_settings::OpenAIModel;
 use chrono::{DateTime, Local};
 use collections::HashMap;
 use fs::Fs;
@@ -61,7 +60,7 @@ struct SavedConversation {
     messages: Vec<SavedMessage>,
     message_metadata: HashMap<MessageId, MessageMetadata>,
     summary: String,
-    model: OpenAIModel,
+    model: String,
 }
 
 impl SavedConversation {

--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -2238,10 +2238,14 @@ mod tests {
 
     #[gpui::test]
     fn test_inserting_and_removing_messages(cx: &mut AppContext) {
+        cx.set_global(SettingsStore::test(cx));
+        init(cx);
+        dbg!("here1");
         let registry = Arc::new(LanguageRegistry::test());
         let conversation = cx.add_model(|cx| Conversation::new(Default::default(), registry, cx));
         let buffer = conversation.read(cx).buffer.clone();
 
+        dbg!("here2");
         let message_1 = conversation.read(cx).message_anchors[0].clone();
         assert_eq!(
             messages(&conversation, cx),
@@ -2253,6 +2257,7 @@ mod tests {
                 .insert_message_after(message_1.id, Role::Assistant, MessageStatus::Done, cx)
                 .unwrap()
         });
+        dbg!("here3");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2264,6 +2269,7 @@ mod tests {
         buffer.update(cx, |buffer, cx| {
             buffer.edit([(0..0, "1"), (1..1, "2")], None, cx)
         });
+        dbg!("here6");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2277,6 +2283,7 @@ mod tests {
                 .insert_message_after(message_2.id, Role::User, MessageStatus::Done, cx)
                 .unwrap()
         });
+        dbg!("here7");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2291,6 +2298,7 @@ mod tests {
                 .insert_message_after(message_2.id, Role::User, MessageStatus::Done, cx)
                 .unwrap()
         });
+        dbg!("here8");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2304,6 +2312,7 @@ mod tests {
         buffer.update(cx, |buffer, cx| {
             buffer.edit([(4..4, "C"), (5..5, "D")], None, cx)
         });
+        dbg!("here9");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2364,6 +2373,8 @@ mod tests {
 
     #[gpui::test]
     fn test_message_splitting(cx: &mut AppContext) {
+        cx.set_global(SettingsStore::test(cx));
+        init(cx);
         let registry = Arc::new(LanguageRegistry::test());
         let conversation = cx.add_model(|cx| Conversation::new(Default::default(), registry, cx));
         let buffer = conversation.read(cx).buffer.clone();
@@ -2458,6 +2469,8 @@ mod tests {
 
     #[gpui::test]
     fn test_messages_for_offsets(cx: &mut AppContext) {
+        cx.set_global(SettingsStore::test(cx));
+        init(cx);
         let registry = Arc::new(LanguageRegistry::test());
         let conversation = cx.add_model(|cx| Conversation::new(Default::default(), registry, cx));
         let buffer = conversation.read(cx).buffer.clone();
@@ -2538,6 +2551,8 @@ mod tests {
 
     #[gpui::test]
     fn test_serialization(cx: &mut AppContext) {
+        cx.set_global(SettingsStore::test(cx));
+        init(cx);
         let registry = Arc::new(LanguageRegistry::test());
         let conversation =
             cx.add_model(|cx| Conversation::new(Default::default(), registry.clone(), cx));

--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -880,7 +880,7 @@ impl Conversation {
             completion_count: Default::default(),
             pending_completions: Default::default(),
             token_count: None,
-            max_token_count: tiktoken_rs::model::get_context_size(&model.to_string()),
+            max_token_count: tiktoken_rs::model::get_context_size(model.full_name()),
             pending_token_count: Task::ready(None),
             model: model.clone(),
             _subscriptions: vec![cx.subscribe(&buffer, Self::handle_buffer_event)],
@@ -925,7 +925,7 @@ impl Conversation {
                 .as_ref()
                 .map(|summary| summary.text.clone())
                 .unwrap_or_default(),
-            model: self.model.clone(),
+            model: self.model.full_name().to_string(),
         }
     }
 
@@ -936,7 +936,7 @@ impl Conversation {
         language_registry: Arc<LanguageRegistry>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        let model = saved_conversation.model;
+        let model: OpenAIModel = saved_conversation.model.into();
         let markdown = language_registry.language_for_name("Markdown");
         let mut message_anchors = Vec::new();
         let mut next_message_id = MessageId(0);
@@ -976,7 +976,7 @@ impl Conversation {
             completion_count: Default::default(),
             pending_completions: Default::default(),
             token_count: None,
-            max_token_count: tiktoken_rs::model::get_context_size(&model.to_string()),
+            max_token_count: tiktoken_rs::model::get_context_size(model.full_name()),
             pending_token_count: Task::ready(None),
             model,
             _subscriptions: vec![cx.subscribe(&buffer, Self::handle_buffer_event)],
@@ -1031,7 +1031,7 @@ impl Conversation {
                 let token_count = cx
                     .background()
                     .spawn(async move {
-                        tiktoken_rs::num_tokens_from_messages(&model.to_string(), &messages)
+                        tiktoken_rs::num_tokens_from_messages(model.full_name(), &messages)
                     })
                     .await?;
 
@@ -1039,7 +1039,7 @@ impl Conversation {
                     .ok_or_else(|| anyhow!("conversation was dropped"))?
                     .update(&mut cx, |this, cx| {
                         this.max_token_count =
-                            tiktoken_rs::model::get_context_size(&this.model.to_string());
+                            tiktoken_rs::model::get_context_size(this.model.full_name());
                         this.token_count = Some(token_count);
                         cx.notify()
                     });
@@ -1095,7 +1095,7 @@ impl Conversation {
                 }
             } else {
                 let request = OpenAIRequest {
-                    model: self.model.to_string(),
+                    model: self.model.full_name().to_string(),
                     messages: self
                         .messages(cx)
                         .filter(|message| matches!(message.status, MessageStatus::Done))
@@ -1421,7 +1421,7 @@ impl Conversation {
                                 .into(),
                     }));
                 let request = OpenAIRequest {
-                    model: self.model.to_string(),
+                    model: self.model.full_name().to_string(),
                     messages: messages.collect(),
                     stream: true,
                 };
@@ -2048,8 +2048,8 @@ impl ConversationEditor {
 
         MouseEventHandler::<Model, _>::new(0, cx, |state, cx| {
             let style = style.model.style_for(state);
-            let model_display_name = self.conversation.read(cx).model.display_name();
-            Label::new(model_display_name, style.text.clone())
+            let short_name = self.conversation.read(cx).model.short_name();
+            Label::new(short_name, style.text.clone())
                 .contained()
                 .with_style(style.container)
         })

--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -48,6 +48,9 @@ use workspace::{
 
 const OPENAI_API_URL: &'static str = "https://api.openai.com/v1";
 
+const GPT_3_5_TURBO_0613: &'static str = "gpt-3.5-turbo-0613";
+const GPT_4_0613: &'static str = "gpt-4-0613";
+
 actions!(
     assistant,
     [
@@ -850,7 +853,7 @@ impl Conversation {
         language_registry: Arc<LanguageRegistry>,
         cx: &mut ModelContext<Self>,
     ) -> Self {
-        let model = "gpt-3.5-turbo-0613";
+        let model = GPT_3_5_TURBO_0613;
         let markdown = language_registry.language_for_name("Markdown");
         let buffer = cx.add_model(|cx| {
             let mut buffer = Buffer::new(0, "", cx);
@@ -2021,8 +2024,8 @@ impl ConversationEditor {
     fn cycle_model(&mut self, cx: &mut ViewContext<Self>) {
         self.conversation.update(cx, |conversation, cx| {
             let new_model = match conversation.model.as_str() {
-                "gpt-4-0613" => "gpt-3.5-turbo-0613",
-                _ => "gpt-4-0613",
+                GPT_4_0613 => GPT_3_5_TURBO_0613,
+                _ => GPT_4_0613,
             };
             conversation.set_model(new_model.into(), cx);
         });
@@ -2046,7 +2049,13 @@ impl ConversationEditor {
 
         MouseEventHandler::<Model, _>::new(0, cx, |state, cx| {
             let style = style.model.style_for(state);
-            Label::new(self.conversation.read(cx).model.clone(), style.text.clone())
+            let model = self.conversation.read(cx).model.as_ref();
+            let model_display_name = match model {
+                GPT_3_5_TURBO_0613 => "gpt-3.5-turbo",
+                GPT_4_0613 => "gpt-4",
+                _ => panic!("Invalid model name: {}", model),
+            };
+            Label::new(model_display_name, style.text.clone())
                 .contained()
                 .with_style(style.container)
         })

--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -2240,12 +2240,10 @@ mod tests {
     fn test_inserting_and_removing_messages(cx: &mut AppContext) {
         cx.set_global(SettingsStore::test(cx));
         init(cx);
-        dbg!("here1");
         let registry = Arc::new(LanguageRegistry::test());
         let conversation = cx.add_model(|cx| Conversation::new(Default::default(), registry, cx));
         let buffer = conversation.read(cx).buffer.clone();
 
-        dbg!("here2");
         let message_1 = conversation.read(cx).message_anchors[0].clone();
         assert_eq!(
             messages(&conversation, cx),
@@ -2257,7 +2255,6 @@ mod tests {
                 .insert_message_after(message_1.id, Role::Assistant, MessageStatus::Done, cx)
                 .unwrap()
         });
-        dbg!("here3");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2269,7 +2266,6 @@ mod tests {
         buffer.update(cx, |buffer, cx| {
             buffer.edit([(0..0, "1"), (1..1, "2")], None, cx)
         });
-        dbg!("here6");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2283,7 +2279,6 @@ mod tests {
                 .insert_message_after(message_2.id, Role::User, MessageStatus::Done, cx)
                 .unwrap()
         });
-        dbg!("here7");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2298,7 +2293,6 @@ mod tests {
                 .insert_message_after(message_2.id, Role::User, MessageStatus::Done, cx)
                 .unwrap()
         });
-        dbg!("here8");
         assert_eq!(
             messages(&conversation, cx),
             vec![
@@ -2312,7 +2306,6 @@ mod tests {
         buffer.update(cx, |buffer, cx| {
             buffer.edit([(4..4, "C"), (5..5, "D")], None, cx)
         });
-        dbg!("here9");
         assert_eq!(
             messages(&conversation, cx),
             vec![

--- a/crates/ai/src/assistant_settings.rs
+++ b/crates/ai/src/assistant_settings.rs
@@ -5,12 +5,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Setting;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub enum OpenAIModel {
     #[serde(rename = "gpt-3.5-turbo-0613")]
     GptThreeFiveTurbo0613,
     #[serde(rename = "gpt-4-0613")]
-    #[default]
     GptFour0613,
 }
 

--- a/crates/ai/src/assistant_settings.rs
+++ b/crates/ai/src/assistant_settings.rs
@@ -29,13 +29,10 @@ impl OpenAIModel {
     }
 
     pub fn cycle(&mut self) -> Self {
-        let models = [OpenAIModel::GptThreeFiveTurbo0613, OpenAIModel::GptFour0613];
-        let index = models
-            .iter()
-            .position(|model| model == self)
-            .map(|index| (index + 1) % models.len())
-            .unwrap_or_default();
-        models[index].clone()
+        match self {
+            OpenAIModel::GptThreeFiveTurbo0613 => OpenAIModel::GptFour0613,
+            OpenAIModel::GptFour0613 => OpenAIModel::GptThreeFiveTurbo0613,
+        }
     }
 }
 

--- a/crates/ai/src/assistant_settings.rs
+++ b/crates/ai/src/assistant_settings.rs
@@ -15,7 +15,6 @@ pub enum OpenAIModel {
 
 impl Display for OpenAIModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // For some reason, serde_json::to_string() includes the quotes
         let model_name = serde_json::to_string(self).unwrap().replace("\"", "");
         write!(f, "{}", model_name)
     }

--- a/crates/ai/src/assistant_settings.rs
+++ b/crates/ai/src/assistant_settings.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use anyhow;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -7,31 +5,44 @@ use settings::Setting;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub enum OpenAIModel {
-    #[serde(rename = "gpt-3.5-turbo-0613")]
-    GptThreeFiveTurbo0613,
-    #[serde(rename = "gpt-4-0613")]
-    GptFour0613,
+    #[serde(rename = "gpt-3.5")]
+    GptThreePointFive,
+    #[serde(rename = "gpt-4")]
+    GptFour,
 }
 
-impl Display for OpenAIModel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let model_name = serde_json::to_string(self).unwrap().replace("\"", "");
-        write!(f, "{}", model_name)
+impl<T> From<T> for OpenAIModel
+where
+    T: AsRef<str>,
+{
+    fn from(s: T) -> Self {
+        match s.as_ref() {
+            "gpt-3.5-turbo-0613" => OpenAIModel::GptThreePointFive,
+            "gpt-4-0613" => OpenAIModel::GptFour,
+            _ => panic!("Unknown OpenAI model: {}", s.as_ref()),
+        }
     }
 }
 
 impl OpenAIModel {
-    pub fn display_name(&self) -> &'static str {
+    pub fn full_name(&self) -> &'static str {
         match self {
-            OpenAIModel::GptThreeFiveTurbo0613 => "gpt-3.5-turbo",
-            OpenAIModel::GptFour0613 => "gpt-4",
+            OpenAIModel::GptThreePointFive => "gpt-3.5-turbo-0613",
+            OpenAIModel::GptFour => "gpt-4-0613",
+        }
+    }
+
+    pub fn short_name(&self) -> &'static str {
+        match self {
+            OpenAIModel::GptThreePointFive => "gpt-3.5",
+            OpenAIModel::GptFour => "gpt-4",
         }
     }
 
     pub fn cycle(&mut self) -> Self {
         match self {
-            OpenAIModel::GptThreeFiveTurbo0613 => OpenAIModel::GptFour0613,
-            OpenAIModel::GptFour0613 => OpenAIModel::GptThreeFiveTurbo0613,
+            OpenAIModel::GptThreePointFive => OpenAIModel::GptFour,
+            OpenAIModel::GptFour => OpenAIModel::GptThreePointFive,
         }
     }
 }

--- a/crates/ai/src/assistant_settings.rs
+++ b/crates/ai/src/assistant_settings.rs
@@ -1,7 +1,45 @@
+use std::fmt::Display;
+
 use anyhow;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Setting;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub enum OpenAIModel {
+    #[serde(rename = "gpt-3.5-turbo-0613")]
+    GptThreeFiveTurbo0613,
+    #[serde(rename = "gpt-4-0613")]
+    #[default]
+    GptFour0613,
+}
+
+impl Display for OpenAIModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // For some reason, serde_json::to_string() includes the quotes
+        let model_name = serde_json::to_string(self).unwrap().replace("\"", "");
+        write!(f, "{}", model_name)
+    }
+}
+
+impl OpenAIModel {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            OpenAIModel::GptThreeFiveTurbo0613 => "gpt-3.5-turbo",
+            OpenAIModel::GptFour0613 => "gpt-4",
+        }
+    }
+
+    pub fn cycle(&mut self) -> Self {
+        let models = [OpenAIModel::GptThreeFiveTurbo0613, OpenAIModel::GptFour0613];
+        let index = models
+            .iter()
+            .position(|model| model == self)
+            .map(|index| (index + 1) % models.len())
+            .unwrap_or_default();
+        models[index].clone()
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -16,6 +54,7 @@ pub struct AssistantSettings {
     pub dock: AssistantDockPosition,
     pub default_width: f32,
     pub default_height: f32,
+    pub default_open_ai_model: OpenAIModel,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -23,6 +62,7 @@ pub struct AssistantSettingsContent {
     pub dock: Option<AssistantDockPosition>,
     pub default_width: Option<f32>,
     pub default_height: Option<f32>,
+    pub default_open_ai_model: Option<OpenAIModel>,
 }
 
 impl Setting for AssistantSettings {

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use collections::{btree_map, hash_map, BTreeMap, HashMap};
 use gpui::AppContext;
 use lazy_static::lazy_static;
@@ -162,6 +162,7 @@ impl SettingsStore {
 
             if let Some(setting) = setting_value
                 .load_setting(&default_settings, &user_values_stack, cx)
+                .context("A default setting must be added to the `default.json` file")
                 .log_err()
             {
                 setting_value.set_global_value(setting);


### PR DESCRIPTION
This PR adds a `default_open_ai_model` setting for the assistant (defaults to `gpt-4-0613`). Its a bit awkward transforming this these model names into settings, because the setting need to be an enum. Typically, we don't care how the enum serializes and deserializes, as long as it is named nicely, but in this case, the enum variants need to serialize into the model names, which doesn't work because the model names have odd characters, like `.` and numbers. I used the rename functionality of `serde`, but in order to keep things backwards compatible with loading historical conversations, I had to serialize the variable names into hyphenated strings for our settings, which goes against our convention of using underscores.  I think that this is ok because we are then using the exact model name in the settings.json file and not a transformed version of it.

Note: This PR does not add any code that tries to check if the user has access to `gpt-4-0613` - I have that added in another branch and working, but am not happy with how it is at the moment.  Currently, the code is structured in a way that makes it hard to prevent the UI from flickering from `gpt-3.5-turbo-0613` to `gpt-4-0613`, when the fetch completes and finds the user has access. The solution seems to change a few of the fields related to the model into options, then update all of the code accordinlgy, but this has proven to be a bit awkward, so Ive paused on it for now.

Release Notes:

- Added a `default_open_ai_model` setting for the assistant (defaults to `gpt-4`).