### PR TITLE
Associate additional file extensions with known languages

### DIFF
--- a/crates/zed/src/languages/cpp/config.toml
+++ b/crates/zed/src/languages/cpp/config.toml
@@ -1,5 +1,5 @@
 name = "C++"
-path_suffixes = ["cc", "cpp", "h", "hpp"]
+path_suffixes = ["cc", "cpp", "h", "hpp", "cxx", "hxx", "inl"]
 line_comment = "// "
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/crates/zed/src/languages/javascript/config.toml
+++ b/crates/zed/src/languages/javascript/config.toml
@@ -1,5 +1,5 @@
 name = "JavaScript"
-path_suffixes = ["js", "jsx", "mjs"]
+path_suffixes = ["js", "jsx", "mjs", "cjs"]
 first_line_pattern = '^#!.*\bnode\b'
 line_comment = "// "
 autoclose_before = ";:.,=}])>"

--- a/crates/zed/src/languages/python/config.toml
+++ b/crates/zed/src/languages/python/config.toml
@@ -1,5 +1,5 @@
 name = "Python"
-path_suffixes = ["py", "pyi"]
+path_suffixes = ["py", "pyi", "mpy"]
 first_line_pattern = '^#!.*\bpython[0-9.]*\b'
 line_comment = "# "
 autoclose_before = ";:.,=}])>"

--- a/crates/zed/src/languages/typescript/config.toml
+++ b/crates/zed/src/languages/typescript/config.toml
@@ -1,5 +1,5 @@
 name = "TypeScript"
-path_suffixes = ["ts"]
+path_suffixes = ["ts", "cts", "d.cts", "d.mts", "mts"]
 line_comment = "// "
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
Going to do these in batches.  Here is the first one.

Release Notes:

- Associated additional file extensions with known languages (([#633](https://github.com/zed-industries/zed/issues/5776)), ([#1822](https://github.com/zed-industries/zed/issues/6236))).
    - C++: `cxx`, `hxx`, `inl`
    - JavaScript: `cjs`
    - Python: `mpy`
    - TypeScript: `cts`, `d.cts`, `d.mts`, `mts`