### PR TITLE
Support `editor::SelectAll` in Terminal

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -987,6 +987,14 @@ impl Terminal {
         }
     }
 
+    pub fn select_all(&mut self) {
+        let term = self.term.lock();
+        let start = Point::new(term.topmost_line(), Column(0));
+        let end = Point::new(term.bottommost_line(), term.last_column());
+        drop(term);
+        self.set_selection(Some((make_selection(&(start..=end)), end)));
+    }
+
     fn set_selection(&mut self, selection: Option<(Selection, Point)>) {
         self.events
             .push_back(InternalEvent::SetSelection(selection));

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -80,6 +80,7 @@ pub fn init(cx: &mut AppContext) {
     cx.add_action(TerminalView::paste);
     cx.add_action(TerminalView::clear);
     cx.add_action(TerminalView::show_character_palette);
+    cx.add_action(TerminalView::select_all)
 }
 
 ///A terminal view, maintains the PTY's file handles and communicates with the terminal
@@ -310,6 +311,11 @@ impl TerminalView {
                 )
             });
         }
+    }
+
+    fn select_all(&mut self, _: &editor::SelectAll, cx: &mut ViewContext<Self>) {
+        self.terminal.update(cx, |term, _| term.select_all());
+        cx.notify();
     }
 
     fn clear(&mut self, _: &Clear, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
![image](https://github.com/zed-industries/zed/assets/2690773/3aae1e6a-9993-4e65-8ed1-20f2f4b452df)

Allows to use `editor::SelectAll`(`cmd-a` by default) in Terminal to select all text in it, for future copying.
Currently, does not try to be smart and trim the selected whitespaces after the last prompt, and copies them too.

Release Notes:

- Support `editor::SelectAll` in Terminal
