### PR TITLE
Focus terminal view on mouse click in terminal

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -400,7 +400,8 @@ impl TerminalElement {
         region = region
             // Start selections
             .on_down(MouseButton::Left, move |event, v: &mut TerminalView, cx| {
-                cx.focus_parent();
+                let terminal_view = cx.handle();
+                cx.focus(&terminal_view);
                 v.context_menu.update(cx, |menu, _cx| menu.delay_cancel());
                 if let Some(conn_handle) = connection.upgrade(cx) {
                     conn_handle.update(cx, |terminal, cx| {


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-2746/terminal-doesnt-gain-focus-when-opening-and-closing-the-terminal, https://linear.app/zed-industries/issue/Z-2292/cant-use-the-mouse-to-select-text-in-the-terminal-while-the-search-bar

Before, terminal view focused the parent (pane) instead and, if terminal's search bar was open and focused, pane transferred the focus back

Release Notes:

- Fixed terminal search focus not switching to terminal on mouse click inside