### PR TITLE
Collab panel touch ups

### DIFF
--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -726,10 +726,10 @@ impl Panel for AssistantPanel {
         }
     }
 
-    fn set_size(&mut self, size: f32, cx: &mut ViewContext<Self>) {
+    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
         match self.position(cx) {
-            DockPosition::Left | DockPosition::Right => self.width = Some(size),
-            DockPosition::Bottom => self.height = Some(size),
+            DockPosition::Left | DockPosition::Right => self.width = size,
+            DockPosition::Bottom => self.height = size,
         }
         cx.notify();
     }

--- a/crates/client/src/channel_store.rs
+++ b/crates/client/src/channel_store.rs
@@ -441,10 +441,12 @@ impl ChannelStore {
 
             for channel in payload.channels {
                 if let Some(existing_channel) = self.channels_by_id.get_mut(&channel.id) {
+                    // FIXME: We may be missing a path for this existing channel in certain cases
                     let existing_channel = Arc::make_mut(existing_channel);
                     existing_channel.name = channel.name;
                     continue;
                 }
+
                 self.channels_by_id.insert(
                     channel.id,
                     Arc::new(Channel {

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -3650,7 +3650,11 @@ impl Database {
         let ancestor_ids = self.get_channel_ancestors(id, tx).await?;
         let user_ids = channel_member::Entity::find()
             .distinct()
-            .filter(channel_member::Column::ChannelId.is_in(ancestor_ids.iter().copied()))
+            .filter(
+                channel_member::Column::ChannelId
+                    .is_in(ancestor_ids.iter().copied())
+                    .and(channel_member::Column::Accepted.eq(true)),
+            )
             .select_only()
             .column(channel_member::Column::UserId)
             .into_values::<_, QueryUserIds>()

--- a/crates/collab/src/tests/channel_tests.rs
+++ b/crates/collab/src/tests/channel_tests.rs
@@ -770,6 +770,19 @@ async fn test_call_from_channel(
     });
 }
 
+#[gpui::test]
+async fn test_lost_channel_creation(
+    deterministic: Arc<Deterministic>,
+    cx_a: &mut TestAppContext,
+    cx_b: &mut TestAppContext,
+) {
+    // Invite a member
+    // Create a new sub channel
+    // Member accepts invite
+    // Make sure that member can see new channel
+    todo!();
+}
+
 #[derive(Debug, PartialEq)]
 struct ExpectedChannel {
     depth: usize,

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -397,7 +397,7 @@ impl CollabPanel {
                 project: workspace.project().clone(),
                 subscriptions: Vec::default(),
                 match_candidates: Vec::default(),
-                collapsed_sections: Vec::default(),
+                collapsed_sections: vec![Section::Offline],
                 workspace: workspace.weak_handle(),
                 client: workspace.app_state().client.clone(),
                 context_menu_on_selected: true,

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2391,8 +2391,8 @@ impl Panel for CollabPanel {
             .unwrap_or_else(|| settings::get::<CollaborationPanelSettings>(cx).default_width)
     }
 
-    fn set_size(&mut self, size: f32, cx: &mut ViewContext<Self>) {
-        self.width = Some(size);
+    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
+        self.width = size;
         self.serialize(cx);
         cx.notify();
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -577,6 +577,14 @@ impl AppContext {
         }
     }
 
+    pub fn optional_global<T: 'static>(&self) -> Option<&T> {
+        if let Some(global) = self.globals.get(&TypeId::of::<T>()) {
+            Some(global.downcast_ref().unwrap())
+        } else {
+            None
+        }
+    }
+
     pub fn upgrade(&self) -> App {
         App(self.weak_self.as_ref().unwrap().upgrade().unwrap())
     }

--- a/crates/gpui/src/elements.rs
+++ b/crates/gpui/src/elements.rs
@@ -186,16 +186,27 @@ pub trait Element<V: View>: 'static {
         Tooltip::new::<Tag>(id, text, action, style, self.into_any(), cx)
     }
 
-    fn resizable(
+    /// Uses the the given element to calculate resizes for the given tag
+    fn provide_resize_bounds<Tag: 'static>(self) -> BoundsProvider<V, Tag>
+    where
+        Self: 'static + Sized,
+    {
+        BoundsProvider::<_, Tag>::new(self.into_any())
+    }
+
+    /// Calls the given closure with the new size of the element whenever the
+    /// handle is dragged. This will be calculated in relation to the bounds
+    /// provided by the given tag
+    fn resizable<Tag: 'static>(
         self,
         side: HandleSide,
         size: f32,
-        on_resize: impl 'static + FnMut(&mut V, f32, &mut ViewContext<V>),
+        on_resize: impl 'static + FnMut(&mut V, Option<f32>, &mut ViewContext<V>),
     ) -> Resizable<V>
     where
         Self: 'static + Sized,
     {
-        Resizable::new(self.into_any(), side, size, on_resize)
+        Resizable::new::<Tag>(self.into_any(), side, size, on_resize)
     }
 
     fn mouse<Tag: 'static>(self, region_id: usize) -> MouseEventHandler<V>

--- a/crates/gpui/src/elements/component.rs
+++ b/crates/gpui/src/elements/component.rs
@@ -82,6 +82,9 @@ impl<V: View, C: Component<V> + 'static> Element<V> for ComponentAdapter<V, C> {
         view: &V,
         cx: &ViewContext<V>,
     ) -> serde_json::Value {
-        element.debug(view, cx)
+        serde_json::json!({
+            "type": "ComponentAdapter",
+            "child": element.debug(view, cx),
+        })
     }
 }

--- a/crates/gpui/src/elements/resizable.rs
+++ b/crates/gpui/src/elements/resizable.rs
@@ -1,14 +1,14 @@
 use std::{cell::RefCell, rc::Rc};
 
+use collections::HashMap;
 use pathfinder_geometry::vector::{vec2f, Vector2F};
 use serde_json::json;
 
 use crate::{
     geometry::rect::RectF,
     platform::{CursorStyle, MouseButton},
-    scene::MouseDrag,
-    AnyElement, Axis, Element, LayoutContext, MouseRegion, PaintContext, SceneBuilder,
-    SizeConstraint, View, ViewContext,
+    AnyElement, AppContext, Axis, Element, LayoutContext, MouseRegion, PaintContext, SceneBuilder,
+    SizeConstraint, TypeTag, View, ViewContext,
 };
 
 #[derive(Copy, Clone, Debug)]
@@ -27,27 +27,10 @@ impl HandleSide {
         }
     }
 
-    /// 'before' is in reference to the standard english document ordering of left-to-right
-    /// then top-to-bottom
-    fn before_content(self) -> bool {
-        match self {
-            HandleSide::Left | HandleSide::Top => true,
-            HandleSide::Right | HandleSide::Bottom => false,
-        }
-    }
-
     fn relevant_component(&self, vector: Vector2F) -> f32 {
         match self.axis() {
             Axis::Horizontal => vector.x(),
             Axis::Vertical => vector.y(),
-        }
-    }
-
-    fn compute_delta(&self, e: MouseDrag) -> f32 {
-        if self.before_content() {
-            self.relevant_component(e.prev_mouse_position) - self.relevant_component(e.position)
-        } else {
-            self.relevant_component(e.position) - self.relevant_component(e.prev_mouse_position)
         }
     }
 
@@ -69,21 +52,29 @@ impl HandleSide {
     }
 }
 
+fn get_bounds(tag: TypeTag, cx: &AppContext) -> Option<&(RectF, RectF)>
+where
+{
+    cx.optional_global::<ProviderMap>()
+        .and_then(|map| map.0.get(&tag))
+}
+
 pub struct Resizable<V: View> {
     child: AnyElement<V>,
+    tag: TypeTag,
     handle_side: HandleSide,
     handle_size: f32,
-    on_resize: Rc<RefCell<dyn FnMut(&mut V, f32, &mut ViewContext<V>)>>,
+    on_resize: Rc<RefCell<dyn FnMut(&mut V, Option<f32>, &mut ViewContext<V>)>>,
 }
 
 const DEFAULT_HANDLE_SIZE: f32 = 4.0;
 
 impl<V: View> Resizable<V> {
-    pub fn new(
+    pub fn new<Tag: 'static>(
         child: AnyElement<V>,
         handle_side: HandleSide,
         size: f32,
-        on_resize: impl 'static + FnMut(&mut V, f32, &mut ViewContext<V>),
+        on_resize: impl 'static + FnMut(&mut V, Option<f32>, &mut ViewContext<V>),
     ) -> Self {
         let child = match handle_side.axis() {
             Axis::Horizontal => child.constrained().with_max_width(size),
@@ -94,6 +85,7 @@ impl<V: View> Resizable<V> {
         Self {
             child,
             handle_side,
+            tag: TypeTag::new::<Tag>(),
             handle_size: DEFAULT_HANDLE_SIZE,
             on_resize: Rc::new(RefCell::new(on_resize)),
         }
@@ -139,6 +131,14 @@ impl<V: View> Element<V> for Resizable<V> {
                 handle_region,
             )
             .on_down(MouseButton::Left, |_, _: &mut V, _| {}) // This prevents the mouse down event from being propagated elsewhere
+            .on_click(MouseButton::Left, {
+                let on_resize = self.on_resize.clone();
+                move |click, v, cx| {
+                    if click.click_count == 2 {
+                        on_resize.borrow_mut()(v, None, cx);
+                    }
+                }
+            })
             .on_drag(MouseButton::Left, {
                 let bounds = bounds.clone();
                 let side = self.handle_side;
@@ -146,16 +146,30 @@ impl<V: View> Element<V> for Resizable<V> {
                 let min_size = side.relevant_component(constraint.min);
                 let max_size = side.relevant_component(constraint.max);
                 let on_resize = self.on_resize.clone();
+                let tag = self.tag;
                 move |event, view: &mut V, cx| {
                     if event.end {
                         return;
                     }
-                    let new_size = min_size
-                        .max(prev_size + side.compute_delta(event))
-                        .min(max_size)
-                        .round();
+
+                    let Some((bounds, _)) = get_bounds(tag, cx) else {
+                        return;
+                    };
+
+                    let new_size_raw = match side {
+                        // Handle on top side of element => Element is on bottom
+                        HandleSide::Top => bounds.height() + bounds.origin_y() - event.position.y(),
+                        // Handle on right side of element => Element is on left
+                        HandleSide::Right => event.position.x() - bounds.lower_left().x(),
+                        // Handle on left side of element => Element is on the right
+                        HandleSide::Left => bounds.width() + bounds.origin_x() - event.position.x(),
+                        // Handle on bottom side of element => Element is on the top
+                        HandleSide::Bottom => event.position.y() - bounds.lower_left().y(),
+                    };
+
+                    let new_size = min_size.max(new_size_raw).min(max_size).round();
                     if new_size != prev_size {
-                        on_resize.borrow_mut()(view, new_size, cx);
+                        on_resize.borrow_mut()(view, Some(new_size), cx);
                     }
                 }
             }),
@@ -197,6 +211,83 @@ impl<V: View> Element<V> for Resizable<V> {
         cx: &ViewContext<V>,
     ) -> serde_json::Value {
         json!({
+            "child": self.child.debug(view, cx),
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct ProviderMap(HashMap<TypeTag, (RectF, RectF)>);
+
+pub struct BoundsProvider<V: View, P> {
+    child: AnyElement<V>,
+    phantom: std::marker::PhantomData<P>,
+}
+
+impl<V: View, P: 'static> BoundsProvider<V, P> {
+    pub fn new(child: AnyElement<V>) -> Self {
+        Self {
+            child,
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<V: View, P: 'static> Element<V> for BoundsProvider<V, P> {
+    type LayoutState = ();
+
+    type PaintState = ();
+
+    fn layout(
+        &mut self,
+        constraint: crate::SizeConstraint,
+        view: &mut V,
+        cx: &mut crate::LayoutContext<V>,
+    ) -> (pathfinder_geometry::vector::Vector2F, Self::LayoutState) {
+        (self.child.layout(constraint, view, cx), ())
+    }
+
+    fn paint(
+        &mut self,
+        scene: &mut crate::SceneBuilder,
+        bounds: pathfinder_geometry::rect::RectF,
+        visible_bounds: pathfinder_geometry::rect::RectF,
+        _: &mut Self::LayoutState,
+        view: &mut V,
+        cx: &mut crate::PaintContext<V>,
+    ) -> Self::PaintState {
+        cx.update_default_global::<ProviderMap, _, _>(|map, _| {
+            map.0.insert(TypeTag::new::<P>(), (bounds, visible_bounds));
+        });
+
+        self.child
+            .paint(scene, bounds.origin(), visible_bounds, view, cx)
+    }
+
+    fn rect_for_text_range(
+        &self,
+        range_utf16: std::ops::Range<usize>,
+        _: pathfinder_geometry::rect::RectF,
+        _: pathfinder_geometry::rect::RectF,
+        _: &Self::LayoutState,
+        _: &Self::PaintState,
+        view: &V,
+        cx: &crate::ViewContext<V>,
+    ) -> Option<pathfinder_geometry::rect::RectF> {
+        self.child.rect_for_text_range(range_utf16, view, cx)
+    }
+
+    fn debug(
+        &self,
+        _: pathfinder_geometry::rect::RectF,
+        _: &Self::LayoutState,
+        _: &Self::PaintState,
+        view: &V,
+        cx: &crate::ViewContext<V>,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "type": "Provider",
+            "providing": format!("{:?}", TypeTag::new::<P>()),
             "child": self.child.debug(view, cx),
         })
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1651,8 +1651,8 @@ impl workspace::dock::Panel for ProjectPanel {
             .unwrap_or_else(|| settings::get::<ProjectPanelSettings>(cx).default_width)
     }
 
-    fn set_size(&mut self, size: f32, cx: &mut ViewContext<Self>) {
-        self.width = Some(size);
+    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
+        self.width = size;
         self.serialize(cx);
         cx.notify();
     }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -362,10 +362,10 @@ impl Panel for TerminalPanel {
         }
     }
 
-    fn set_size(&mut self, size: f32, cx: &mut ViewContext<Self>) {
+    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
         match self.position(cx) {
-            DockPosition::Left | DockPosition::Right => self.width = Some(size),
-            DockPosition::Bottom => self.height = Some(size),
+            DockPosition::Left | DockPosition::Right => self.width = size,
+            DockPosition::Bottom => self.height = size,
         }
         self.serialize(cx);
         cx.notify();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -553,6 +553,8 @@ struct FollowerState {
     items_by_leader_view_id: HashMap<ViewId, Box<dyn FollowableItemHandle>>,
 }
 
+enum WorkspaceBounds {}
+
 impl Workspace {
     pub fn new(
         workspace_id: WorkspaceId,
@@ -3776,6 +3778,7 @@ impl View for Workspace {
                                     }))
                                     .with_children(self.render_notifications(&theme.workspace, cx)),
                             ))
+                            .provide_resize_bounds::<WorkspaceBounds>()
                             .flex(1.0, true),
                     )
                     .with_child(ChildView::new(&self.status_bar, cx))
@@ -4859,7 +4862,9 @@ mod tests {
                 panel_1.size(cx)
             );
 
-            left_dock.update(cx, |left_dock, cx| left_dock.resize_active_panel(1337., cx));
+            left_dock.update(cx, |left_dock, cx| {
+                left_dock.resize_active_panel(Some(1337.), cx)
+            });
             assert_eq!(
                 workspace
                     .right_dock()

--- a/styles/src/style_tree/collab_modals.ts
+++ b/styles/src/style_tree/collab_modals.ts
@@ -76,7 +76,8 @@ export default function channel_modal(): any {
                 },
 
             },
-            max_height: 400,
+            // FIXME: due to a bug in the picker's size calculation, this must be 600
+            max_height: 600,
             max_width: 540,
             title: {
                 ...text(theme.middle, "sans", "on", { size: "lg" }),


### PR DESCRIPTION
This will also fix the bug that @JosephTLyons observed where accepting a channel invite would not show sub channels.

Release Notes:

- Offline section is now collapsed by default
- Manage members now shows full list
- Dragging of docks now follows the mouse exactly, and double clicks reset size. (https://github.com/zed-industries/zed/issues/6233)
