### PR TITLE
Upgrade Tree-sitter for error recovery bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter"
 version = "0.20.10"
-source = "git+https://github.com/tree-sitter/tree-sitter?rev=1c65ca24bc9a734ab70115188f465e12eecf224e#1c65ca24bc9a734ab70115188f465e12eecf224e"
+source = "git+https://github.com/tree-sitter/tree-sitter?rev=35a6052fbcafc5e5fc0f9415b8652be7dcaf7222#35a6052fbcafc5e5fc0f9415b8652be7dcaf7222"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ tree-sitter-lua = "0.0.14"
 tree-sitter-nix = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "66e3e9ce9180ae08fc57372061006ef83f0abde7" }
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "1c65ca24bc9a734ab70115188f465e12eecf224e" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "35a6052fbcafc5e5fc0f9415b8652be7dcaf7222" }
 async-task = { git = "https://github.com/zed-industries/async-task", rev = "341b57d6de98cdfd7b418567b8de2022ca993a6e" }
 
 # TODO - Remove when a version is released with this PR: https://github.com/servo/core-foundation-rs/pull/457


### PR DESCRIPTION
Bumps Tree-sitter for https://github.com/tree-sitter/tree-sitter/pull/2526.

Release Notes:

- Fixed a bug where small syntax errors would mess up syntax highlighting more than necessary when editing certain languages, like Scheme and PHP.
