### PR TITLE
Don't show vim mode when disabled

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -22,9 +22,11 @@ fn focused(EditorFocused(editor): &EditorFocused, cx: &mut AppContext) {
     editor.window().update(cx, |cx| {
         Vim::update(cx, |vim, cx| {
             vim.set_active_editor(editor.clone(), cx);
-            cx.emit_global(VimEvent::ModeChanged {
-                mode: vim.state().mode,
-            });
+            if vim.enabled {
+                cx.emit_global(VimEvent::ModeChanged {
+                    mode: vim.state().mode,
+                });
+            }
         });
     });
 }


### PR DESCRIPTION
Fixes vim's mode indicator showing up when vim is disabled.