### PR TITLE
Remove potential osascript hijacking attack

### DIFF
--- a/crates/install_cli/src/install_cli.rs
+++ b/crates/install_cli/src/install_cli.rs
@@ -29,7 +29,7 @@ pub async fn install_cli(cx: &AsyncAppContext) -> Result<()> {
 
     // The symlink could not be created, so use osascript with admin privileges
     // to create it.
-    let status = smol::process::Command::new("osascript")
+    let status = smol::process::Command::new("/usr/bin/osascript")
         .args([
             "-e",
             &format!(

--- a/crates/zed/resources/zed.entitlements
+++ b/crates/zed/resources/zed.entitlements
@@ -18,11 +18,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
-	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
+	<!-- <key>com.apple.security.cs.disable-library-validation</key>
+	<true/> -->
 </dict>
 </plist>


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2818/security-vulnerability-dylib-injection

Release Notes:

- Fixed a potential local code-injection if a user installs the Zed CLI for the first time with a hijacked `osascript` in their path.