### PR TITLE
chore: remove unused features from rodio crate.

### DIFF
--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -13,7 +13,7 @@ gpui = { path = "../gpui" }
 collections = { path = "../collections" }
 util = { path = "../util" }
 
-rodio = "0.17.1"
+rodio ={version = "0.17.1", default-features=false, features = ["wav"]}
 
 log.workspace = true
 


### PR DESCRIPTION
This reduces our dep count by 1% at the expense of not supporting playback of .flac, .mp3 and .vorbis formats. We only use .wav anyways.


Release Notes:
- N/A
