### PR TITLE
Add default bindings for new file and directory

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -543,6 +543,8 @@
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",
       "right": "project_panel::ExpandSelectedEntry",
+      "cmd-n": "project_panel::NewFile",
+      "alt-cmd-n": "project_panel::NewDirectory",
       "cmd-x": "project_panel::Cut",
       "cmd-c": "project_panel::Copy",
       "cmd-v": "project_panel::Paste",


### PR DESCRIPTION
Release Notes:

- Added default key bindings for `NewFile` and `NewDirectory` in the project panel (bound to `cmd-n` and `alt-cmd-n`, respectively).