### PR TITLE
vim: Dismiss menu in insert mode with escape

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -421,7 +421,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == insert",
+    "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",


### PR DESCRIPTION
Release Notes:

- vim: Fix escape to dismiss suggestions in insert mode. 