### PR TITLE
relative line numbers

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -98,6 +98,7 @@
     // Whether to show selections in the scrollbar.
     "selections": true
   },
+  "relative_line_numbers": false,
   // Inlay hint related settings
   "inlay_hints": {
     // Global switch to toggle hints on and off, switched off by default.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -9,6 +9,7 @@ pub struct EditorSettings {
     pub show_completions_on_input: bool,
     pub use_on_type_format: bool,
     pub scrollbar: Scrollbar,
+    pub relative_line_numbers: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -34,6 +35,7 @@ pub struct EditorSettingsContent {
     pub show_completions_on_input: Option<bool>,
     pub use_on_type_format: Option<bool>,
     pub scrollbar: Option<ScrollbarContent>,
+    pub relative_line_numbers: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2365,6 +2365,7 @@ impl Element<Editor> for EditorElement {
                 editor.cursor_shape,
                 &snapshot.display_snapshot,
                 true,
+                true,
             )
             .head
         });
@@ -3156,7 +3157,7 @@ mod tests {
 
         let relative_rows = editor.update(cx, |editor, cx| {
             let snapshot = editor.snapshot(cx);
-            element.calculate_relative_line_numbers(&snapshot, &(0..6), 3)
+            element.calculate_relative_line_numbers(&snapshot, &(0..6), Some(3))
         });
         assert_eq!(relative_rows[&0], 3);
         assert_eq!(relative_rows[&1], 2);
@@ -3169,7 +3170,7 @@ mod tests {
         let relative_rows = editor.update(cx, |editor, cx| {
             let snapshot = editor.snapshot(cx);
 
-            element.calculate_relative_line_numbers(&snapshot, &(3..6), 1)
+            element.calculate_relative_line_numbers(&snapshot, &(3..6), Some(1))
         });
         assert_eq!(relative_rows.len(), 3);
         assert_eq!(relative_rows[&3], 2);
@@ -3180,7 +3181,7 @@ mod tests {
         let relative_rows = editor.update(cx, |editor, cx| {
             let snapshot = editor.snapshot(cx);
 
-            element.calculate_relative_line_numbers(&snapshot, &(0..3), 6)
+            element.calculate_relative_line_numbers(&snapshot, &(0..3), Some(6))
         });
         assert_eq!(relative_rows.len(), 3);
         assert_eq!(relative_rows[&0], 5);


### PR DESCRIPTION
- Add relative_line_mode
- vim change for wrapped lines

Release Notes:

- Add a `relative_line_numbers` setting ([#988](https://github.com/zed-industries/zed/issues/5958)).
