### PR TITLE
Automatically enable project search filters when using `Search Inside`

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -893,6 +893,7 @@ impl ProjectSearchView {
             search
                 .included_files_editor
                 .update(cx, |editor, cx| editor.set_text(filter_str, cx));
+            search.filters_enabled = true;
             search.focus_query_editor(cx)
         });
     }


### PR DESCRIPTION
Now that the filters are hidden behind a toggle-able setting, running the `Search Inside` action from the project panel feels a bit weird, since the filter being used is hidden. This PR automatically opens that filter section after running a `Search Inside` action.

Release Notes:

- N/A