### PR TITLE
Fix zed-industries/community#1950

### DIFF
--- a/crates/vim/test_data/test_visual_block_mode.json
+++ b/crates/vim/test_data/test_visual_block_mode.json
@@ -30,3 +30,9 @@
 {"Key":"o"}
 {"Key":"escape"}
 {"Get":{"state":"Theˇouick\nbroo\nfoxo\njumo over the\n\nlazy dog\n","mode":"Normal"}}
+{"Put":{"state":"Theˇ quick brown\n\nfox jumps over\nthe lazy dog\n"}}
+{"Key":"l"}
+{"Key":"ctrl-v"}
+{"Key":"j"}
+{"Key":"j"}
+{"Get":{"state":"The «qˇ»uick brown\n\nfox «jˇ»umps over\nthe lazy dog\n","mode":"VisualBlock"}}


### PR DESCRIPTION
Release Notes:

- vim: fix goal preservation of visual block selections ([#1950](https://github.com/zed-industries/zed/issues/6274)).
