### PR TITLE
Fix inlay hint bugs

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -395,9 +395,7 @@ impl EditorElement {
 
         update_go_to_definition_link(
             editor,
-            point
-                .map(GoToDefinitionTrigger::Text)
-                .unwrap_or(GoToDefinitionTrigger::None),
+            point.map(GoToDefinitionTrigger::Text),
             cmd,
             shift,
             cx,
@@ -468,7 +466,7 @@ impl EditorElement {
                 Some(point) => {
                     update_go_to_definition_link(
                         editor,
-                        GoToDefinitionTrigger::Text(point),
+                        Some(GoToDefinitionTrigger::Text(point)),
                         cmd,
                         shift,
                         cx,
@@ -487,7 +485,7 @@ impl EditorElement {
                 }
             }
         } else {
-            update_go_to_definition_link(editor, GoToDefinitionTrigger::None, cmd, shift, cx);
+            update_go_to_definition_link(editor, None, cmd, shift, cx);
             hover_at(editor, None, cx);
         }
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -57,19 +57,30 @@ pub struct InlayHover {
 
 pub fn find_hovered_hint_part(
     label_parts: Vec<InlayHintLabelPart>,
+    padding_left: bool,
+    padding_right: bool,
     hint_range: Range<InlayOffset>,
     hovered_offset: InlayOffset,
 ) -> Option<(InlayHintLabelPart, Range<InlayOffset>)> {
     if hovered_offset >= hint_range.start && hovered_offset <= hint_range.end {
         let mut hovered_character = (hovered_offset - hint_range.start).0;
         let mut part_start = hint_range.start;
-        for part in label_parts {
+        let last_label_part_index = label_parts.len() - 1;
+        for (i, part) in label_parts.into_iter().enumerate() {
             let part_len = part.value.chars().count();
             if hovered_character >= part_len {
                 hovered_character -= part_len;
                 part_start.0 += part_len;
             } else {
-                return Some((part, part_start..InlayOffset(part_start.0 + part_len)));
+                let mut part_end = InlayOffset(part_start.0 + part_len);
+                if padding_left {
+                    part_start.0 += 1;
+                    part_end.0 += 1;
+                }
+                if padding_right && i == last_label_part_index {
+                    part_end.0 -= 1;
+                }
+                return Some((part, part_start..part_end));
             }
         }
     }

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -19,6 +19,7 @@ use project::{InlayHint, ResolveState};
 
 use collections::{hash_map, HashMap, HashSet};
 use language::language_settings::InlayHintSettings;
+use sum_tree::Bias;
 use text::ToOffset;
 use util::post_inc;
 
@@ -632,8 +633,8 @@ fn determine_query_ranges(
         return None;
     } else {
         vec![
-            buffer.anchor_before(excerpt_visible_range.start)
-                ..buffer.anchor_after(excerpt_visible_range.end),
+            buffer.anchor_before(snapshot.clip_offset(excerpt_visible_range.start, Bias::Left))
+                ..buffer.anchor_after(snapshot.clip_offset(excerpt_visible_range.end, Bias::Right)),
         ]
     };
 
@@ -651,8 +652,8 @@ fn determine_query_ranges(
             .min(full_excerpt_range_end_offset)
             .min(buffer.len());
         vec![
-            buffer.anchor_before(after_visible_range_start)
-                ..buffer.anchor_after(after_range_end_offset),
+            buffer.anchor_before(snapshot.clip_offset(after_visible_range_start, Bias::Left))
+                ..buffer.anchor_after(snapshot.clip_offset(after_range_end_offset, Bias::Right)),
         ]
     };
 
@@ -668,8 +669,8 @@ fn determine_query_ranges(
             .saturating_sub(excerpt_visible_len)
             .max(full_excerpt_range_start_offset);
         vec![
-            buffer.anchor_before(before_range_start_offset)
-                ..buffer.anchor_after(before_visible_range_end),
+            buffer.anchor_before(snapshot.clip_offset(before_range_start_offset, Bias::Left))
+                ..buffer.anchor_after(snapshot.clip_offset(before_visible_range_end, Bias::Right)),
         ]
     };
 

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -975,6 +975,7 @@ mod tests {
                 // the cached location instead
                 Ok(Some(lsp::GotoDefinitionResponse::Link(vec![])))
             });
+        cx.foreground().run_until_parked();
         cx.assert_editor_state(indoc! {"
             fn «testˇ»() { do_work(); }
             fn do_work() { test(); }

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -218,6 +218,15 @@ pub fn update_inlay_link_and_hover_points(
                     ResolveState::Resolved => {
                         match cached_hint.label {
                             project::InlayHintLabel::String(_) => {
+                                let mut highlight_start = hint_start_offset;
+                                let mut highlight_end = hint_end_offset;
+                                if cached_hint.padding_left {
+                                    highlight_start.0 += 1;
+                                    highlight_end.0 += 1;
+                                }
+                                if cached_hint.padding_right {
+                                    highlight_end.0 -= 1;
+                                }
                                 if let Some(tooltip) = cached_hint.tooltip {
                                     hover_popover::hover_at_inlay(
                                         editor,
@@ -238,8 +247,8 @@ pub fn update_inlay_link_and_hover_points(
                                             triggered_from: hovered_offset,
                                             range: InlayRange {
                                                 inlay_position: hovered_hint.position,
-                                                highlight_start: hint_start_offset,
-                                                highlight_end: hint_end_offset,
+                                                highlight_start,
+                                                highlight_end,
                                             },
                                         },
                                         cx,
@@ -251,6 +260,8 @@ pub fn update_inlay_link_and_hover_points(
                                 if let Some((hovered_hint_part, part_range)) =
                                     hover_popover::find_hovered_hint_part(
                                         label_parts,
+                                        cached_hint.padding_left,
+                                        cached_hint.padding_right,
                                         hint_start_offset..hint_end_offset,
                                         hovered_offset,
                                     )

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -773,7 +773,10 @@ message InlayHintLabelParts {
 message InlayHintLabelPart {
     string value = 1;
     InlayHintLabelPartTooltip tooltip = 2;
-    Location location = 3;
+    optional string location_url = 3;
+    PointUtf16 location_range_start = 4;
+    PointUtf16 location_range_end = 5;
+    optional uint64 language_server_id = 6;
 }
 
 message InlayHintTooltip {


### PR DESCRIPTION
* https://github.com/zed-industries/zed/pull/2891

Fixes ranges pointing at incorrect positions inside multi-codepoint characters

* https://github.com/zed-industries/zed/pull/2890

Defers hint links' document URL resolution into buffer up until the hover & cmd-click is made by the user.

Release Notes:

- N/A
