### PR TITLE
Always log panics

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -495,11 +495,11 @@ fn init_panic_hook(app: &App, installation_id: Option<String>) {
             installation_id: installation_id.clone(),
         };
 
-        if is_pty {
-            if let Some(panic_data_json) = serde_json::to_string_pretty(&panic_data).log_err() {
-                eprintln!("{}", panic_data_json);
-            }
-        } else {
+        if let Some(panic_data_json) = serde_json::to_string_pretty(&panic_data).log_err() {
+            log::error!("{}", panic_data_json);
+        }
+
+        if !is_pty {
             if let Some(panic_data_json) = serde_json::to_string(&panic_data).log_err() {
                 let timestamp = chrono::Utc::now().format("%Y_%m_%d %H_%M_%S").to_string();
                 let panic_file_path = paths::LOGS_DIR.join(format!("zed-{}.panic", timestamp));


### PR DESCRIPTION
I just panicked and wanted to see the cause, but forgot that panic files get deleted when Zed uploads them.

Release Notes:

- Panics are now written to `~/Library/Logs/Zed/Zed.log`