### PR TITLE
More inlay hover fixes

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2792,11 +2792,13 @@ impl Editor {
                 }
             }
             InlayHintRefreshReason::ExcerptsRemoved(excerpts_removed) => {
-                let InlaySplice {
+                if let Some(InlaySplice {
                     to_remove,
                     to_insert,
-                } = self.inlay_hint_cache.remove_excerpts(excerpts_removed);
-                self.splice_inlay_hints(to_remove, to_insert, cx);
+                }) = self.inlay_hint_cache.remove_excerpts(excerpts_removed)
+                {
+                    self.splice_inlay_hints(to_remove, to_insert, cx);
+                }
                 return;
             }
             InlayHintRefreshReason::NewLinesShown => (InvalidationStrategy::None, None),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2755,7 +2755,7 @@ impl PointForPosition {
         }
     }
 
-    fn as_valid(&self) -> Option<DisplayPoint> {
+    pub fn as_valid(&self) -> Option<DisplayPoint> {
         if self.previous_valid == self.exact_unclipped && self.next_valid == self.exact_unclipped {
             Some(self.previous_valid)
         } else {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1376,13 +1376,21 @@ mod tests {
             .unwrap();
         let new_type_hint_part_hover_position = cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
+            let previous_valid = inlay_range.start.to_display_point(&snapshot);
+            let next_valid = inlay_range.end.to_display_point(&snapshot);
+            assert_eq!(previous_valid.row(), next_valid.row());
+            assert!(previous_valid.column() < next_valid.column());
+            let exact_unclipped = DisplayPoint::new(
+                previous_valid.row(),
+                previous_valid.column()
+                    + (entire_hint_label.find(new_type_label).unwrap() + new_type_label.len() / 2)
+                        as u32,
+            );
             PointForPosition {
-                previous_valid: inlay_range.start.to_display_point(&snapshot),
-                next_valid: inlay_range.end.to_display_point(&snapshot),
-                exact_unclipped: inlay_range.end.to_display_point(&snapshot),
-                column_overshoot_after_line_end: (entire_hint_label.find(new_type_label).unwrap()
-                    + new_type_label.len() / 2)
-                    as u32,
+                previous_valid,
+                next_valid,
+                exact_unclipped,
+                column_overshoot_after_line_end: 0,
             }
         });
         cx.update_editor(|editor, cx| {
@@ -1504,13 +1512,21 @@ mod tests {
 
         let struct_hint_part_hover_position = cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
+            let previous_valid = inlay_range.start.to_display_point(&snapshot);
+            let next_valid = inlay_range.end.to_display_point(&snapshot);
+            assert_eq!(previous_valid.row(), next_valid.row());
+            assert!(previous_valid.column() < next_valid.column());
+            let exact_unclipped = DisplayPoint::new(
+                previous_valid.row(),
+                previous_valid.column()
+                    + (entire_hint_label.find(struct_label).unwrap() + struct_label.len() / 2)
+                        as u32,
+            );
             PointForPosition {
-                previous_valid: inlay_range.start.to_display_point(&snapshot),
-                next_valid: inlay_range.end.to_display_point(&snapshot),
-                exact_unclipped: inlay_range.end.to_display_point(&snapshot),
-                column_overshoot_after_line_end: (entire_hint_label.find(struct_label).unwrap()
-                    + struct_label.len() / 2)
-                    as u32,
+                previous_valid,
+                next_valid,
+                exact_unclipped,
+                column_overshoot_after_line_end: 0,
             }
         });
         cx.update_editor(|editor, cx| {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -57,8 +57,6 @@ pub struct InlayHover {
 
 pub fn find_hovered_hint_part(
     label_parts: Vec<InlayHintLabelPart>,
-    padding_left: bool,
-    padding_right: bool,
     hint_range: Range<InlayOffset>,
     hovered_offset: InlayOffset,
 ) -> Option<(InlayHintLabelPart, Range<InlayOffset>)> {
@@ -67,19 +65,11 @@ pub fn find_hovered_hint_part(
         let mut part_start = hint_range.start;
         for part in label_parts {
             let part_len = part.value.chars().count();
-            if hovered_character >= part_len {
+            if hovered_character > part_len {
                 hovered_character -= part_len;
                 part_start.0 += part_len;
             } else {
-                let mut part_end = InlayOffset(part_start.0 + part_len);
-                if padding_left {
-                    part_start.0 += 1;
-                    part_end.0 += 1;
-                }
-                if padding_right {
-                    part_start.0 += 1;
-                    part_end.0 += 1;
-                }
+                let part_end = InlayOffset(part_start.0 + part_len);
                 return Some((part, part_start..part_end));
             }
         }

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -104,37 +104,34 @@ impl TasksForRanges {
         invalidate: InvalidationStrategy,
         spawn_task: impl FnOnce(QueryRanges) -> Task<()>,
     ) {
-        let query_ranges = match invalidate {
-            InvalidationStrategy::None => {
-                let mut updated_ranges = query_ranges;
-                updated_ranges.before_visible = updated_ranges
-                    .before_visible
-                    .into_iter()
-                    .flat_map(|query_range| {
-                        self.remove_cached_ranges_from_query(buffer_snapshot, query_range)
-                    })
-                    .collect();
-                updated_ranges.visible = updated_ranges
-                    .visible
-                    .into_iter()
-                    .flat_map(|query_range| {
-                        self.remove_cached_ranges_from_query(buffer_snapshot, query_range)
-                    })
-                    .collect();
-                updated_ranges.after_visible = updated_ranges
-                    .after_visible
-                    .into_iter()
-                    .flat_map(|query_range| {
-                        self.remove_cached_ranges_from_query(buffer_snapshot, query_range)
-                    })
-                    .collect();
-                updated_ranges
-            }
-            InvalidationStrategy::RefreshRequested | InvalidationStrategy::BufferEdited => {
-                self.tasks.clear();
-                self.sorted_ranges.clear();
-                query_ranges
-            }
+        let query_ranges = if invalidate.should_invalidate() {
+            self.tasks.clear();
+            self.sorted_ranges.clear();
+            query_ranges
+        } else {
+            let mut non_cached_query_ranges = query_ranges;
+            non_cached_query_ranges.before_visible = non_cached_query_ranges
+                .before_visible
+                .into_iter()
+                .flat_map(|query_range| {
+                    self.remove_cached_ranges_from_query(buffer_snapshot, query_range)
+                })
+                .collect();
+            non_cached_query_ranges.visible = non_cached_query_ranges
+                .visible
+                .into_iter()
+                .flat_map(|query_range| {
+                    self.remove_cached_ranges_from_query(buffer_snapshot, query_range)
+                })
+                .collect();
+            non_cached_query_ranges.after_visible = non_cached_query_ranges
+                .after_visible
+                .into_iter()
+                .flat_map(|query_range| {
+                    self.remove_cached_ranges_from_query(buffer_snapshot, query_range)
+                })
+                .collect();
+            non_cached_query_ranges
         };
 
         if !query_ranges.is_empty() {
@@ -205,45 +202,31 @@ impl TasksForRanges {
         ranges_to_query
     }
 
-    fn remove_from_cached_ranges(
-        &mut self,
-        buffer: &BufferSnapshot,
-        range_to_remove: &Range<language::Anchor>,
-    ) {
+    fn invalidate_range(&mut self, buffer: &BufferSnapshot, range: &Range<language::Anchor>) {
         self.sorted_ranges = self
             .sorted_ranges
             .drain(..)
             .filter_map(|mut cached_range| {
-                if cached_range.start.cmp(&range_to_remove.end, buffer).is_gt()
-                    || cached_range.end.cmp(&range_to_remove.start, buffer).is_lt()
+                if cached_range.start.cmp(&range.end, buffer).is_gt()
+                    || cached_range.end.cmp(&range.start, buffer).is_lt()
                 {
                     Some(vec![cached_range])
-                } else if cached_range
-                    .start
-                    .cmp(&range_to_remove.start, buffer)
-                    .is_ge()
-                    && cached_range.end.cmp(&range_to_remove.end, buffer).is_le()
+                } else if cached_range.start.cmp(&range.start, buffer).is_ge()
+                    && cached_range.end.cmp(&range.end, buffer).is_le()
                 {
                     None
-                } else if range_to_remove
-                    .start
-                    .cmp(&cached_range.start, buffer)
-                    .is_ge()
-                    && range_to_remove.end.cmp(&cached_range.end, buffer).is_le()
+                } else if range.start.cmp(&cached_range.start, buffer).is_ge()
+                    && range.end.cmp(&cached_range.end, buffer).is_le()
                 {
                     Some(vec![
-                        cached_range.start..range_to_remove.start,
-                        range_to_remove.end..cached_range.end,
+                        cached_range.start..range.start,
+                        range.end..cached_range.end,
                     ])
-                } else if cached_range
-                    .start
-                    .cmp(&range_to_remove.start, buffer)
-                    .is_ge()
-                {
-                    cached_range.start = range_to_remove.end;
+                } else if cached_range.start.cmp(&range.start, buffer).is_ge() {
+                    cached_range.start = range.end;
                     Some(vec![cached_range])
                 } else {
-                    cached_range.end = range_to_remove.start;
+                    cached_range.end = range.start;
                     Some(vec![cached_range])
                 }
             })
@@ -474,7 +457,7 @@ impl InlayHintCache {
         }
     }
 
-    pub fn remove_excerpts(&mut self, excerpts_removed: Vec<ExcerptId>) -> InlaySplice {
+    pub fn remove_excerpts(&mut self, excerpts_removed: Vec<ExcerptId>) -> Option<InlaySplice> {
         let mut to_remove = Vec::new();
         for excerpt_to_remove in excerpts_removed {
             self.update_tasks.remove(&excerpt_to_remove);
@@ -483,17 +466,21 @@ impl InlayHintCache {
                 to_remove.extend(cached_hints.hints.iter().map(|(id, _)| *id));
             }
         }
-        if !to_remove.is_empty() {
+        if to_remove.is_empty() {
+            None
+        } else {
             self.version += 1;
-        }
-        InlaySplice {
-            to_remove,
-            to_insert: Vec::new(),
+            Some(InlaySplice {
+                to_remove,
+                to_insert: Vec::new(),
+            })
         }
     }
 
     pub fn clear(&mut self) {
-        self.version += 1;
+        if !self.update_tasks.is_empty() || !self.hints.is_empty() {
+            self.version += 1;
+        }
         self.update_tasks.clear();
         self.hints.clear();
     }
@@ -818,7 +805,7 @@ fn new_update_task(
                         .update_tasks
                         .get_mut(&query.excerpt_id)
                     {
-                        task_ranges.remove_from_cached_ranges(&buffer_snapshot, &range);
+                        task_ranges.invalidate_range(&buffer_snapshot, &range);
                     }
                 })
                 .ok()
@@ -901,7 +888,7 @@ async fn fetch_and_update_hints(
                         .update_tasks
                         .get_mut(&query.excerpt_id)
                     {
-                        task_ranges.remove_from_cached_ranges(&buffer_snapshot, &fetch_range);
+                        task_ranges.invalidate_range(&buffer_snapshot, &fetch_range);
                     }
                     return None;
                 }

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -596,9 +596,11 @@ fn go_to_fetched_definition_of_kind(
             cx,
         );
 
-        match kind {
-            LinkDefinitionKind::Symbol => editor.go_to_definition(&Default::default(), cx),
-            LinkDefinitionKind::Type => editor.go_to_type_definition(&Default::default(), cx),
+        if point.as_valid().is_some() {
+            match kind {
+                LinkDefinitionKind::Symbol => editor.go_to_definition(&Default::default(), cx),
+                LinkDefinitionKind::Type => editor.go_to_type_definition(&Default::default(), cx),
+            }
         }
     }
 }

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -1170,11 +1170,19 @@ mod tests {
             .unwrap();
         let hint_hover_position = cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
+            let previous_valid = inlay_range.start.to_display_point(&snapshot);
+            let next_valid = inlay_range.end.to_display_point(&snapshot);
+            assert_eq!(previous_valid.row(), next_valid.row());
+            assert!(previous_valid.column() < next_valid.column());
+            let exact_unclipped = DisplayPoint::new(
+                previous_valid.row(),
+                previous_valid.column() + (hint_label.len() / 2) as u32,
+            );
             PointForPosition {
-                previous_valid: inlay_range.start.to_display_point(&snapshot),
-                next_valid: inlay_range.end.to_display_point(&snapshot),
-                exact_unclipped: inlay_range.end.to_display_point(&snapshot),
-                column_overshoot_after_line_end: (hint_label.len() / 2) as u32,
+                previous_valid,
+                next_valid,
+                exact_unclipped,
+                column_overshoot_after_line_end: 0,
             }
         });
         // Press cmd to trigger highlight


### PR DESCRIPTION
Better handle edge cases around cmd+hover around inlays:
* distinguish between same text anchors' trigger: inlay and text triggers can have the same anchor, but are different
* forbid cmd+click on inlay that has no label part with location selected
* properly omit throttled inlays that are outside of the visible range

Release Notes:

- N/A