### PR TITLE
chore: Bump memchr to 2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4269,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
 
 [[package]]
 name = "memfd"


### PR DESCRIPTION
Fresh off the press, memchr 2.6.0 adds vector search routines for aarch64. That directly improves our search performance for both text and regex searches. Per BurntSushi's claims, the simple string searches in ripgrep got ~2 times faster (more details available in https://github.com/BurntSushi/memchr/pull/129).

Release Notes:

- N/A

