### PR TITLE
Debounce code action and document highlight requests

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -111,8 +111,8 @@ const MAX_LINE_LEN: usize = 1024;
 const MIN_NAVIGATION_HISTORY_ROW_DELTA: i64 = 10;
 const MAX_SELECTION_HISTORY_LEN: usize = 1024;
 const COPILOT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
-const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
-const DOCUMENT_HIGHLIGHTS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
+pub const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
+pub const DOCUMENT_HIGHLIGHTS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
 
 pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -171,12 +171,12 @@ impl Peer {
         let this = self.clone();
         let response_channels = connection_state.response_channels.clone();
         let handle_io = async move {
-            tracing::debug!(%connection_id, "handle io future: start");
+            tracing::trace!(%connection_id, "handle io future: start");
 
             let _end_connection = util::defer(|| {
                 response_channels.lock().take();
                 this.connections.write().remove(&connection_id);
-                tracing::debug!(%connection_id, "handle io future: end");
+                tracing::trace!(%connection_id, "handle io future: end");
             });
 
             // Send messages on this frequency so the connection isn't closed.
@@ -188,68 +188,68 @@ impl Peer {
             futures::pin_mut!(receive_timeout);
 
             loop {
-                tracing::debug!(%connection_id, "outer loop iteration start");
+                tracing::trace!(%connection_id, "outer loop iteration start");
                 let read_message = reader.read().fuse();
                 futures::pin_mut!(read_message);
 
                 loop {
-                    tracing::debug!(%connection_id, "inner loop iteration start");
+                    tracing::trace!(%connection_id, "inner loop iteration start");
                     futures::select_biased! {
                         outgoing = outgoing_rx.next().fuse() => match outgoing {
                             Some(outgoing) => {
-                                tracing::debug!(%connection_id, "outgoing rpc message: writing");
+                                tracing::trace!(%connection_id, "outgoing rpc message: writing");
                                 futures::select_biased! {
                                     result = writer.write(outgoing).fuse() => {
-                                        tracing::debug!(%connection_id, "outgoing rpc message: done writing");
+                                        tracing::trace!(%connection_id, "outgoing rpc message: done writing");
                                         result.context("failed to write RPC message")?;
-                                        tracing::debug!(%connection_id, "keepalive interval: resetting after sending message");
+                                        tracing::trace!(%connection_id, "keepalive interval: resetting after sending message");
                                         keepalive_timer.set(create_timer(KEEPALIVE_INTERVAL).fuse());
                                     }
                                     _ = create_timer(WRITE_TIMEOUT).fuse() => {
-                                        tracing::debug!(%connection_id, "outgoing rpc message: writing timed out");
+                                        tracing::trace!(%connection_id, "outgoing rpc message: writing timed out");
                                         Err(anyhow!("timed out writing message"))?;
                                     }
                                 }
                             }
                             None => {
-                                tracing::debug!(%connection_id, "outgoing rpc message: channel closed");
+                                tracing::trace!(%connection_id, "outgoing rpc message: channel closed");
                                 return Ok(())
                             },
                         },
                         _ = keepalive_timer => {
-                            tracing::debug!(%connection_id, "keepalive interval: pinging");
+                            tracing::trace!(%connection_id, "keepalive interval: pinging");
                             futures::select_biased! {
                                 result = writer.write(proto::Message::Ping).fuse() => {
-                                    tracing::debug!(%connection_id, "keepalive interval: done pinging");
+                                    tracing::trace!(%connection_id, "keepalive interval: done pinging");
                                     result.context("failed to send keepalive")?;
-                                    tracing::debug!(%connection_id, "keepalive interval: resetting after pinging");
+                                    tracing::trace!(%connection_id, "keepalive interval: resetting after pinging");
                                     keepalive_timer.set(create_timer(KEEPALIVE_INTERVAL).fuse());
                                 }
                                 _ = create_timer(WRITE_TIMEOUT).fuse() => {
-                                    tracing::debug!(%connection_id, "keepalive interval: pinging timed out");
+                                    tracing::trace!(%connection_id, "keepalive interval: pinging timed out");
                                     Err(anyhow!("timed out sending keepalive"))?;
                                 }
                             }
                         }
                         incoming = read_message => {
                             let incoming = incoming.context("error reading rpc message from socket")?;
-                            tracing::debug!(%connection_id, "incoming rpc message: received");
-                            tracing::debug!(%connection_id, "receive timeout: resetting");
+                            tracing::trace!(%connection_id, "incoming rpc message: received");
+                            tracing::trace!(%connection_id, "receive timeout: resetting");
                             receive_timeout.set(create_timer(RECEIVE_TIMEOUT).fuse());
                             if let proto::Message::Envelope(incoming) = incoming {
-                                tracing::debug!(%connection_id, "incoming rpc message: processing");
+                                tracing::trace!(%connection_id, "incoming rpc message: processing");
                                 futures::select_biased! {
                                     result = incoming_tx.send(incoming).fuse() => match result {
                                         Ok(_) => {
-                                            tracing::debug!(%connection_id, "incoming rpc message: processed");
+                                            tracing::trace!(%connection_id, "incoming rpc message: processed");
                                         }
                                         Err(_) => {
-                                            tracing::debug!(%connection_id, "incoming rpc message: channel closed");
+                                            tracing::trace!(%connection_id, "incoming rpc message: channel closed");
                                             return Ok(())
                                         }
                                     },
                                     _ = create_timer(WRITE_TIMEOUT).fuse() => {
-                                        tracing::debug!(%connection_id, "incoming rpc message: processing timed out");
+                                        tracing::trace!(%connection_id, "incoming rpc message: processing timed out");
                                         Err(anyhow!("timed out processing incoming message"))?
                                     }
                                 }
@@ -257,7 +257,7 @@ impl Peer {
                             break;
                         },
                         _ = receive_timeout => {
-                            tracing::debug!(%connection_id, "receive timeout: delay between messages too long");
+                            tracing::trace!(%connection_id, "receive timeout: delay between messages too long");
                             Err(anyhow!("delay between messages too long"))?
                         }
                     }
@@ -274,13 +274,13 @@ impl Peer {
             let response_channels = response_channels.clone();
             async move {
                 let message_id = incoming.id;
-                tracing::debug!(?incoming, "incoming message future: start");
+                tracing::trace!(?incoming, "incoming message future: start");
                 let _end = util::defer(move || {
-                    tracing::debug!(%connection_id, message_id, "incoming message future: end");
+                    tracing::trace!(%connection_id, message_id, "incoming message future: end");
                 });
 
                 if let Some(responding_to) = incoming.responding_to {
-                    tracing::debug!(
+                    tracing::trace!(
                         %connection_id,
                         message_id,
                         responding_to,
@@ -290,7 +290,7 @@ impl Peer {
                     if let Some(tx) = channel {
                         let requester_resumed = oneshot::channel();
                         if let Err(error) = tx.send((incoming, requester_resumed.0)) {
-                            tracing::debug!(
+                            tracing::trace!(
                                 %connection_id,
                                 message_id,
                                 responding_to = responding_to,
@@ -299,14 +299,14 @@ impl Peer {
                             );
                         }
 
-                        tracing::debug!(
+                        tracing::trace!(
                             %connection_id,
                             message_id,
                             responding_to,
                             "incoming response: waiting to resume requester"
                         );
                         let _ = requester_resumed.1.await;
-                        tracing::debug!(
+                        tracing::trace!(
                             %connection_id,
                             message_id,
                             responding_to,
@@ -323,7 +323,7 @@ impl Peer {
 
                     None
                 } else {
-                    tracing::debug!(%connection_id, message_id, "incoming message: received");
+                    tracing::trace!(%connection_id, message_id, "incoming message: received");
                     proto::build_typed_envelope(connection_id, incoming).or_else(|| {
                         tracing::error!(
                             %connection_id,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1706,6 +1706,8 @@ mod tests {
             .remove_file(Path::new("/root/a/file2"), Default::default())
             .await
             .unwrap();
+        cx.foreground().run_until_parked();
+
         workspace
             .update(cx, |w, cx| w.go_back(w.active_pane().downgrade(), cx))
             .await


### PR DESCRIPTION
Lately, I've been finding Rust-analyzer unusably slow when editing large files (like `editor_tests.rs`, or `integration_tests.rs`). When I profile the Rust-analyzer process, I see that it sometimes saturates up to 10 cores processing a queue of code actions requests.

Additionally, sometimes when collaborating on large files like these, we see long delays in propagating buffer operations. I'm still not sure why this is happening, but whenever I look at the server logs in Datadog, I see that there are remote `CodeActions` and `DocumentHighlights` messages being processed that take upwards of 30 seconds. I think what may be happening is that many such requests are resolving at once, and the responses are taking up too much of the host's bandwidth.

I think that both of these problems are caused by us sending way too many code action and document highlight requests to rust-analyzer. This PR adds a simple debounce between changing selections and making these requests.

From my local testing, this debounce makes Rust-analyzer *much* more responsive when moving the cursor around a large file like `editor_tests.rs`.