### PR TITLE
Do not blink the cursor if Zed app is focused away

### DIFF
--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -37,10 +37,7 @@ impl BlinkManager {
     }
 
     pub fn pause_blinking(&mut self, cx: &mut ModelContext<Self>) {
-        if !self.visible {
-            self.visible = true;
-            cx.notify();
-        }
+        self.show_cursor(cx);
 
         let epoch = self.next_blink_epoch();
         let interval = self.blink_interval;
@@ -82,7 +79,13 @@ impl BlinkManager {
                 })
                 .detach();
             }
-        } else if !self.visible {
+        } else {
+            self.show_cursor(cx);
+        }
+    }
+
+    pub fn show_cursor(&mut self, cx: &mut ModelContext<'_, BlinkManager>) {
+        if !self.visible {
             self.visible = true;
             cx.notify();
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1454,6 +1454,16 @@ impl Editor {
                 cx.observe(&display_map, Self::on_display_map_changed),
                 cx.observe(&blink_manager, |_, _, cx| cx.notify()),
                 cx.observe_global::<SettingsStore, _>(Self::settings_changed),
+                cx.observe_window_activation(|editor, active, cx| {
+                    editor.blink_manager.update(cx, |blink_manager, cx| {
+                        if active {
+                            blink_manager.enable(cx);
+                        } else {
+                            blink_manager.show_cursor(cx);
+                            blink_manager.disable(cx);
+                        }
+                    });
+                }),
             ],
         };
 


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/issues/5996
Part of https://github.com/zed-industries/zed/issues/4944

Use Mac platform callbacks to send a global event and enable/disable caret blinking in editors when the app is not focused.

Release Notes:

- Stop blinking caret if Zed app is not focused