### PR TITLE
Add a default binding for toggling inlay hints

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -521,7 +521,8 @@
       "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
       // TODO: Move this to a dock open action
       "cmd-shift-c": "collab_panel::ToggleFocus",
-      "cmd-alt-i": "zed::DebugElements"
+      "cmd-alt-i": "zed::DebugElements",
+      "ctrl-shift-:": "editor::ToggleInlayHints",
     }
   },
   {


### PR DESCRIPTION
Release Notes:

- Add a `"ctrl-shift-:": "editor::ToggleInlayHints"` default binding
