### PR TITLE
Use `ctrl-:` instead of `ctrl-shift-:` for inlay hints toggling

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -522,7 +522,7 @@
       // TODO: Move this to a dock open action
       "cmd-shift-c": "collab_panel::ToggleFocus",
       "cmd-alt-i": "zed::DebugElements",
-      "ctrl-shift-:": "editor::ToggleInlayHints",
+      "ctrl-:": "editor::ToggleInlayHints",
     }
   },
   {


### PR DESCRIPTION
The latter is not possible to press in Zed, since `:` is typed as `shift-;` with typical US keyboard layouts.

In the end, it's the same buttons you have to press to toggle the inlay hints, but working this time.

Release Notes:

- N/A