### PR TITLE
Remove the concept of a local clock; use lamport clocks for all per-replica versioning

### DIFF
--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -241,7 +241,6 @@ impl Database {
         result
     }
 
-    #[cfg(debug_assertions)]
     pub async fn create_user_flag(&self, flag: &str) -> Result<FlagId> {
         self.transaction(|tx| async move {
             let flag = feature_flag::Entity::insert(feature_flag::ActiveModel {
@@ -257,7 +256,6 @@ impl Database {
         .await
     }
 
-    #[cfg(debug_assertions)]
     pub async fn add_user_flag(&self, user: UserId, flag: FlagId) -> Result<()> {
         self.transaction(|tx| async move {
             user_feature::Entity::insert(user_feature::ActiveModel {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -439,7 +439,7 @@ impl Buffer {
             operations.extend(
                 text_operations
                     .iter()
-                    .filter(|(_, op)| !since.observed(op.local_timestamp()))
+                    .filter(|(_, op)| !since.observed(op.timestamp()))
                     .map(|(_, op)| proto::serialize_operation(&Operation::Buffer(op.clone()))),
             );
             operations.sort_unstable_by_key(proto::lamport_timestamp_for_operation);
@@ -1304,7 +1304,7 @@ impl Buffer {
 
     pub fn wait_for_edits(
         &mut self,
-        edit_ids: impl IntoIterator<Item = clock::Local>,
+        edit_ids: impl IntoIterator<Item = clock::Lamport>,
     ) -> impl Future<Output = Result<()>> {
         self.text.wait_for_edits(edit_ids)
     }
@@ -1362,7 +1362,7 @@ impl Buffer {
         }
     }
 
-    pub fn set_text<T>(&mut self, text: T, cx: &mut ModelContext<Self>) -> Option<clock::Local>
+    pub fn set_text<T>(&mut self, text: T, cx: &mut ModelContext<Self>) -> Option<clock::Lamport>
     where
         T: Into<Arc<str>>,
     {
@@ -1375,7 +1375,7 @@ impl Buffer {
         edits_iter: I,
         autoindent_mode: Option<AutoindentMode>,
         cx: &mut ModelContext<Self>,
-    ) -> Option<clock::Local>
+    ) -> Option<clock::Lamport>
     where
         I: IntoIterator<Item = (Range<S>, T)>,
         S: ToOffset,
@@ -1412,7 +1412,7 @@ impl Buffer {
             .and_then(|mode| self.language.as_ref().map(|_| (self.snapshot(), mode)));
 
         let edit_operation = self.text.edit(edits.iter().cloned());
-        let edit_id = edit_operation.local_timestamp();
+        let edit_id = edit_operation.timestamp();
 
         if let Some((before_edit, mode)) = autoindent_request {
             let mut delta = 0isize;

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -1324,17 +1324,17 @@ message Operation {
 
     message Edit {
         uint32 replica_id = 1;
-        uint32 lamport_timestamp = 3;
-        repeated VectorClockEntry version = 4;
-        repeated Range ranges = 5;
-        repeated string new_text = 6;
+        uint32 lamport_timestamp = 2;
+        repeated VectorClockEntry version = 3;
+        repeated Range ranges = 4;
+        repeated string new_text = 5;
     }
 
     message Undo {
         uint32 replica_id = 1;
-        uint32 lamport_timestamp = 3;
-        repeated VectorClockEntry version = 4;
-        repeated UndoCount counts = 5;
+        uint32 lamport_timestamp = 2;
+        repeated VectorClockEntry version = 3;
+        repeated UndoCount counts = 4;
     }
 
     message UpdateSelections {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -861,12 +861,12 @@ message ProjectTransaction {
 }
 
 message Transaction {
-    LocalTimestamp id = 1;
-    repeated LocalTimestamp edit_ids = 2;
+    LamportTimestamp id = 1;
+    repeated LamportTimestamp edit_ids = 2;
     repeated VectorClockEntry start = 3;
 }
 
-message LocalTimestamp {
+message LamportTimestamp {
     uint32 replica_id = 1;
     uint32 value = 2;
 }
@@ -1280,7 +1280,7 @@ message Excerpt {
 
 message Anchor {
     uint32 replica_id = 1;
-    uint32 local_timestamp = 2;
+    uint32 timestamp = 2;
     uint64 offset = 3;
     Bias bias = 4;
     optional uint64 buffer_id = 5;
@@ -1324,7 +1324,6 @@ message Operation {
 
     message Edit {
         uint32 replica_id = 1;
-        uint32 local_timestamp = 2;
         uint32 lamport_timestamp = 3;
         repeated VectorClockEntry version = 4;
         repeated Range ranges = 5;
@@ -1333,7 +1332,6 @@ message Operation {
 
     message Undo {
         uint32 replica_id = 1;
-        uint32 local_timestamp = 2;
         uint32 lamport_timestamp = 3;
         repeated VectorClockEntry version = 4;
         repeated UndoCount counts = 5;
@@ -1362,7 +1360,7 @@ message UndoMapEntry {
 
 message UndoCount {
     uint32 replica_id = 1;
-    uint32 local_timestamp = 2;
+    uint32 lamport_timestamp = 2;
     uint32 count = 3;
 }
 

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -6,4 +6,4 @@ pub use conn::Connection;
 pub use peer::*;
 mod macros;
 
-pub const PROTOCOL_VERSION: u32 = 61;
+pub const PROTOCOL_VERSION: u32 = 62;

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -31,6 +31,7 @@ regex.workspace = true
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
+util = { path = "../util", features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
 rand.workspace = true

--- a/crates/text/src/anchor.rs
+++ b/crates/text/src/anchor.rs
@@ -8,7 +8,7 @@ use sum_tree::Bias;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Default)]
 pub struct Anchor {
-    pub timestamp: clock::Local,
+    pub timestamp: clock::Lamport,
     pub offset: usize,
     pub bias: Bias,
     pub buffer_id: Option<u64>,
@@ -16,14 +16,14 @@ pub struct Anchor {
 
 impl Anchor {
     pub const MIN: Self = Self {
-        timestamp: clock::Local::MIN,
+        timestamp: clock::Lamport::MIN,
         offset: usize::MIN,
         bias: Bias::Left,
         buffer_id: None,
     };
 
     pub const MAX: Self = Self {
-        timestamp: clock::Local::MAX,
+        timestamp: clock::Lamport::MAX,
         offset: usize::MAX,
         bias: Bias::Right,
         buffer_id: None,

--- a/crates/text/src/undo_map.rs
+++ b/crates/text/src/undo_map.rs
@@ -26,8 +26,8 @@ impl sum_tree::KeyedItem for UndoMapEntry {
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 struct UndoMapKey {
-    edit_id: clock::Local,
-    undo_id: clock::Local,
+    edit_id: clock::Lamport,
+    undo_id: clock::Lamport,
 }
 
 impl sum_tree::Summary for UndoMapKey {
@@ -50,7 +50,7 @@ impl UndoMap {
                 sum_tree::Edit::Insert(UndoMapEntry {
                     key: UndoMapKey {
                         edit_id: *edit_id,
-                        undo_id: undo.id,
+                        undo_id: undo.timestamp,
                     },
                     undo_count: *count,
                 })
@@ -59,11 +59,11 @@ impl UndoMap {
         self.0.edit(edits, &());
     }
 
-    pub fn is_undone(&self, edit_id: clock::Local) -> bool {
+    pub fn is_undone(&self, edit_id: clock::Lamport) -> bool {
         self.undo_count(edit_id) % 2 == 1
     }
 
-    pub fn was_undone(&self, edit_id: clock::Local, version: &clock::Global) -> bool {
+    pub fn was_undone(&self, edit_id: clock::Lamport, version: &clock::Global) -> bool {
         let mut cursor = self.0.cursor::<UndoMapKey>();
         cursor.seek(
             &UndoMapKey {
@@ -88,7 +88,7 @@ impl UndoMap {
         undo_count % 2 == 1
     }
 
-    pub fn undo_count(&self, edit_id: clock::Local) -> u32 {
+    pub fn undo_count(&self, edit_id: clock::Lamport) -> u32 {
         let mut cursor = self.0.cursor::<UndoMapKey>();
         cursor.seek(
             &UndoMapKey {


### PR DESCRIPTION
### Background

Currently, our CRDT uses three different types of timestamps:

| clock type | representation | purpose |
|-----|----------------|----------|
| `Local` | replica id + u32 | uniquely identifies operations |
| `Lamport` | replica id + u32 | provides a consistent total ordering for all operations |
| `Global` |  N local clocks | fully defines the partial ordering between all concurrent operations |

All text operations include *each* type of timestamp. And every `Fragment` in a buffer's fragment tree contains both a local and a lamport timestamp.

### Change

An operation can be uniquely identified by its lamport timestamp, so we don't really need a concept of a local timestamp. In this PR, I've removed the concept of a local timestamp. Version vectors (`clock::Global`) now store vectors of *lamport* timestamps.

Eliminating local timestamps reduces the memory footprint of a buffer by four bytes per fragment, reduces the size of our `UpdateBuffer` RPC messages, and reduces the amount of data we need to store in our database for channel buffers. It also makes our CRDT a bit easier to understand, IMO, because there is now only one scalar value that we increment per replica.

It's possible I'm missing something here though. @as-cii, @nathansobo it'd be good to get your 👀 