### PR TITLE
WIP: Add interactions query language feature

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -38,8 +38,8 @@ use gpui::{
 use itertools::Itertools;
 use json::json;
 use language::{
-    language_settings::ShowWhitespaceSetting, Bias, CursorShape, DiagnosticSeverity, OffsetUtf16,
-    Selection,
+    language_settings::ShowWhitespaceSetting, Bias, CursorShape, DiagnosticSeverity, InteractionId,
+    OffsetUtf16, Selection,
 };
 use project::{
     project_settings::{GitGutterSetting, ProjectSettings},
@@ -1659,6 +1659,7 @@ impl EditorElement {
                         chunk: chunk.text,
                         style: highlight_style,
                         is_tab: chunk.is_tab,
+                        interaction: chunk.interaction_id,
                     }
                 });
 
@@ -1900,6 +1901,7 @@ impl EditorElement {
 struct HighlightedChunk<'a> {
     chunk: &'a str,
     style: Option<HighlightStyle>,
+    interaction: Option<InteractionId>,
     is_tab: bool,
 }
 
@@ -1930,6 +1932,7 @@ impl LineWithInvisibles {
         for highlighted_chunk in chunks.chain([HighlightedChunk {
             chunk: "\n",
             style: None,
+            interaction: None,
             is_tab: false,
         }]) {
             for (ix, mut line_chunk) in highlighted_chunk.chunk.split('\n').enumerate() {
@@ -1958,6 +1961,12 @@ impl LineWithInvisibles {
                             .unwrap_or_else(|_| Cow::Borrowed(text_style))
                     } else {
                         Cow::Borrowed(text_style)
+                    };
+
+                    let interaction = if let Some(interaction) = highlighted_chunk.interaction {
+                        Some(interaction)
+                    } else {
+                        None
                     };
 
                     if line.len() + line_chunk.len() > max_line_len {

--- a/crates/language/src/highlight_map.rs
+++ b/crates/language/src/highlight_map.rs
@@ -2,11 +2,24 @@ use gpui::fonts::HighlightStyle;
 use std::sync::Arc;
 use theme::SyntaxTheme;
 
+use crate::QueryFeatureMap;
+
 #[derive(Clone, Debug)]
 pub struct HighlightMap(Arc<[HighlightId]>);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HighlightId(pub u32);
+
+impl QueryFeatureMap for HighlightMap {
+    type Id = HighlightId;
+
+    fn get(&self, capture_id: u32) -> HighlightId {
+        self.0
+            .get(capture_id as usize)
+            .copied()
+            .unwrap_or(DEFAULT_SYNTAX_HIGHLIGHT_ID)
+    }
+}
 
 const DEFAULT_SYNTAX_HIGHLIGHT_ID: HighlightId = HighlightId(u32::MAX);
 
@@ -40,13 +53,6 @@ impl HighlightMap {
                 })
                 .collect(),
         )
-    }
-
-    pub fn get(&self, capture_id: u32) -> HighlightId {
-        self.0
-            .get(capture_id as usize)
-            .copied()
-            .unwrap_or(DEFAULT_SYNTAX_HIGHLIGHT_ID)
     }
 }
 

--- a/crates/language/src/interaction_map.rs
+++ b/crates/language/src/interaction_map.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct InteractionMap(Arc<[Option<InteractionType>]>);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InteractionId {
+    event_type: InteractionType,
+    capture: u32,
+}
+
+const DEFAULT_INTERACTION_ID: InteractionId = InteractionId {
+    event_type: InteractionType::Click,
+    capture: u32::MAX,
+};
+
+impl super::buffer::QueryFeatureMap for InteractionMap {
+    type Id = InteractionId;
+
+    fn get(&self, capture_id: u32) -> Self::Id {
+        match self.0.get(capture_id as usize) {
+            Some(Some(event)) => InteractionId {
+                event_type: *event,
+                capture: capture_id,
+            },
+            _ => DEFAULT_INTERACTION_ID,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InteractionType {
+    Click,
+}
+
+impl InteractionMap {
+    pub fn new(capture_names: &[String]) -> Self {
+        InteractionMap(
+            capture_names
+                .iter()
+                .map(|capture_name| {
+                    let mut capture_parts = capture_name.split(".").peekable();
+                    if let Some(str) = capture_parts.next() {
+                        if str == "click" && capture_parts.peek().is_some() {
+                            return Some(InteractionType::Click);
+                        }
+                    }
+                    None
+                })
+                .collect(),
+        )
+    }
+}
+
+impl Default for InteractionMap {
+    fn default() -> Self {
+        Self(Arc::new([]))
+    }
+}

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2601,6 +2601,7 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
         },
         tree_sitter_rust::language(),
         vec![],
+        None,
         |_| Default::default(),
     );
 

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -13,6 +13,7 @@ mod json;
 #[cfg(feature = "plugin_runtime")]
 mod language_plugin;
 mod lua;
+mod markdown;
 mod php;
 mod python;
 mod ruby;
@@ -36,36 +37,48 @@ mod yaml;
 struct LanguageDir;
 
 pub fn init(languages: Arc<LanguageRegistry>, node_runtime: Arc<NodeRuntime>) {
-    let language = |name, grammar, adapters| {
-        languages.register(name, load_config(name), grammar, adapters, load_queries)
+    let language = |name, grammar, adapters, interactions| {
+        languages.register(
+            name,
+            load_config(name),
+            grammar,
+            adapters,
+            interactions,
+            load_queries,
+        )
     };
 
-    language("bash", tree_sitter_bash::language(), vec![]);
+    language("bash", tree_sitter_bash::language(), vec![], None);
     language(
         "c",
         tree_sitter_c::language(),
         vec![Arc::new(c::CLspAdapter) as Arc<dyn LspAdapter>],
+        None,
     );
     language(
         "cpp",
         tree_sitter_cpp::language(),
         vec![Arc::new(c::CLspAdapter)],
+        None,
     );
-    language("css", tree_sitter_css::language(), vec![]);
+    language("css", tree_sitter_css::language(), vec![], None);
     language(
         "elixir",
         tree_sitter_elixir::language(),
         vec![Arc::new(elixir::ElixirLspAdapter)],
+        None,
     );
     language(
         "go",
         tree_sitter_go::language(),
         vec![Arc::new(go::GoLspAdapter)],
+        None,
     );
     language(
         "heex",
         tree_sitter_heex::language(),
         vec![Arc::new(elixir::ElixirLspAdapter)],
+        None,
     );
     language(
         "json",
@@ -74,21 +87,29 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: Arc<NodeRuntime>) {
             node_runtime.clone(),
             languages.clone(),
         ))],
+        None,
     );
-    language("markdown", tree_sitter_markdown::language(), vec![]);
+    language(
+        "markdown",
+        tree_sitter_markdown::language(),
+        vec![],
+        Some(Arc::new(MarkdownInteractions)),
+    );
     language(
         "python",
         tree_sitter_python::language(),
         vec![Arc::new(python::PythonLspAdapter::new(
             node_runtime.clone(),
         ))],
+        None,
     );
     language(
         "rust",
         tree_sitter_rust::language(),
         vec![Arc::new(rust::RustLspAdapter)],
+        None,
     );
-    language("toml", tree_sitter_toml::language(), vec![]);
+    language("toml", tree_sitter_toml::language(), vec![], None);
     language(
         "tsx",
         tree_sitter_typescript::language_tsx(),
@@ -96,6 +117,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: Arc<NodeRuntime>) {
             Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
             Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
         ],
+        None,
     );
     language(
         "typescript",
@@ -104,6 +126,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: Arc<NodeRuntime>) {
             Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
             Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
         ],
+        None,
     );
     language(
         "javascript",
@@ -112,33 +135,39 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: Arc<NodeRuntime>) {
             Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
             Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
         ],
+        None,
     );
     language(
         "html",
         tree_sitter_html::language(),
         vec![Arc::new(html::HtmlLspAdapter::new(node_runtime.clone()))],
+        None,
     );
     language(
         "ruby",
         tree_sitter_ruby::language(),
         vec![Arc::new(ruby::RubyLanguageServer)],
+        None,
     );
     language(
         "erb",
         tree_sitter_embedded_template::language(),
         vec![Arc::new(ruby::RubyLanguageServer)],
+        None,
     );
-    language("scheme", tree_sitter_scheme::language(), vec![]);
-    language("racket", tree_sitter_racket::language(), vec![]);
+    language("scheme", tree_sitter_scheme::language(), vec![], None);
+    language("racket", tree_sitter_racket::language(), vec![], None);
     language(
         "lua",
         tree_sitter_lua::language(),
         vec![Arc::new(lua::LuaLspAdapter)],
+        None,
     );
     language(
         "yaml",
         tree_sitter_yaml::language(),
         vec![Arc::new(yaml::YamlLspAdapter::new(node_runtime.clone()))],
+        None,
     );
     language(
         "svelte",
@@ -146,16 +175,18 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: Arc<NodeRuntime>) {
         vec![Arc::new(svelte::SvelteLspAdapter::new(
             node_runtime.clone(),
         ))],
+        None,
     );
     language(
         "php",
         tree_sitter_php::language(),
         vec![Arc::new(php::IntelephenseLspAdapter::new(node_runtime))],
+        None,
     );
 
-    language("elm", tree_sitter_elm::language(), vec![]);
-    language("glsl", tree_sitter_glsl::language(), vec![]);
-    language("nix", tree_sitter_nix::language(), vec![]);
+    language("elm", tree_sitter_elm::language(), vec![], None);
+    language("glsl", tree_sitter_glsl::language(), vec![], None);
+    language("nix", tree_sitter_nix::language(), vec![], None);
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -192,6 +223,7 @@ fn load_queries(name: &str) -> LanguageQueries {
         embedding: load_query(name, "/embedding"),
         injections: load_query(name, "/injections"),
         overrides: load_query(name, "/overrides"),
+        interactions: load_query(name, "/interactions"),
     }
 }
 

--- a/crates/zed/src/languages/markdown.rs
+++ b/crates/zed/src/languages/markdown.rs
@@ -1,0 +1,15 @@
+use language::InteractionProvider;
+
+pub struct MarkdownInteractions;
+
+impl InteractionProvider for MarkdownInteractions {
+    fn on_click(&self, text: &str) -> Option<String> {
+        if text == "[ ]" {
+            return Some("[x]".to_string());
+        } else if text == "[x]" {
+            return Some("[ ]".to_string());
+        } else {
+            return None;
+        }
+    }
+}

--- a/crates/zed/src/languages/markdown/interactions.scm
+++ b/crates/zed/src/languages/markdown/interactions.scm
@@ -1,0 +1,5 @@
+
+(
+    (list_item (paragraph (shortcut_link) @click.toggle_selected))
+    (#matches? @click.toggle_selected "^([ ]|[x])")
+)


### PR DESCRIPTION
This PR is an attempt at wiring in a new language feature, interaction queries and `InteractionProvider`s, for enabling languages to add custom behavior on mouse events. The driving use case is adding a 'cmd-click to toggle checkbox' feature to our Markdown support. 

Unfortunately, I may have made the cut at the wrong place. Problems I have encountered:

1. What should the API be for the `InteractionProvider`? I'd like it to be a pure-data protocol, so this could be turned into a plugin API at some point. I was thinking something like `on_interaction(event, capture_name, capture_text)`, but I couldn't figure out a way to move the capture name up through the `chunks()` methods. I'd like to add an`Arc<str>` field, but the chunks API makes heavy use of cheap copying and is on the hot path. Also, I haven't even considered how to get the `capture_text` back out of the chunks. 
2. Rendering of lines of text is done for us by GPUI in `text_layout.rs`. We'll need to pass some kind of callback into GPUI that knows about this feature, kind of like the API of the `Text` element, except at the sub-element level. This would definitely be doable, and might even be useful, but this is starting to feel like too big of a project for such a small feature.
3. All of the above might be doable, but this means that we need to know the chunk's Language at paint time, in order to pull out it's language's `InteractionProvider`. I don't think we currently have a way of doing that when constructing `LineWithInvisibles`, as the chunks don't carry their location data. I could solve this by attaching a pointer to the `InteractionProvider` when creating the chunks, but I think that has the same problem as the `Arc<str>` problem I mention in problem 1.
4. All of these problems are pretty bad, but what's even worse is that my hypothetical `InteractionProvider` API doesn't provide any way to rewrite the buffer text. I wasn't exactly sure where I would end up with this project (I'm not super familiar with the buffer's maps) and so I was thinking I'd figure that out once I discovered where I would end up. Now I'm there and even if we do make the chunks non-copy, I don't think I could generate edits to the buffers contents due to the lack of coordinates.

All in all, this was probably a good exercise for my own understanding of how the buffer maps work and tree sitter work together, but I don't think this is the right approach :(