### PR TITLE
Split ContextMenu actions

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -515,6 +515,17 @@
       "enter": "editor::ConfirmCodeAction"
     }
   },
+  {
+    "context": "Editor && (showing_code_actions || showing_completions)",
+    "bindings": {
+      "up": "editor::ContextMenuPrev",
+      "ctrl-p": "editor::ContextMenuPrev",
+      "down": "editor::ContextMenuNext",
+      "ctrl-n": "editor::ContextMenuNext",
+      "pageup": "editor::ContextMenuFirst",
+      "pagedown": "editor::ContextMenuLast"
+    }
+  },
   // Custom bindings
   {
     "bindings": {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5340,7 +5340,7 @@ async fn test_completion(cx: &mut gpui::TestAppContext) {
     cx.condition(|editor, _| editor.context_menu_visible())
         .await;
     let apply_additional_edits = cx.update_editor(|editor, cx| {
-        editor.move_down(&MoveDown, cx);
+        editor.context_menu_next(&Default::default(), cx);
         editor
             .confirm_completion(&ConfirmCompletion::default(), cx)
             .unwrap()

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -378,10 +378,6 @@ impl Editor {
             return;
         }
 
-        if amount.move_context_menu_selection(self, cx) {
-            return;
-        }
-
         let cur_position = self.scroll_position(cx);
         let new_pos = cur_position + vec2f(0., amount.lines(self));
         self.set_scroll_position(new_pos, cx);

--- a/crates/editor/src/scroll/scroll_amount.rs
+++ b/crates/editor/src/scroll/scroll_amount.rs
@@ -1,8 +1,5 @@
-use gpui::ViewContext;
-use serde::Deserialize;
-use util::iife;
-
 use crate::Editor;
+use serde::Deserialize;
 
 #[derive(Clone, PartialEq, Deserialize)]
 pub enum ScrollAmount {
@@ -13,25 +10,6 @@ pub enum ScrollAmount {
 }
 
 impl ScrollAmount {
-    pub fn move_context_menu_selection(
-        &self,
-        editor: &mut Editor,
-        cx: &mut ViewContext<Editor>,
-    ) -> bool {
-        iife!({
-            let context_menu = editor.context_menu.as_mut()?;
-
-            match self {
-                Self::Line(c) if *c > 0. => context_menu.select_next(cx),
-                Self::Line(_) => context_menu.select_prev(cx),
-                Self::Page(c) if *c > 0. => context_menu.select_last(cx),
-                Self::Page(_) => context_menu.select_first(cx),
-            }
-            .then_some(())
-        })
-        .is_some()
-    }
-
     pub fn lines(&self, editor: &mut Editor) -> f32 {
         match self {
             Self::Line(count) => *count,


### PR DESCRIPTION
This should have no user-visible impact.

For vim `.` to repeat it's important that actions are replayable.
Currently editor::MoveDown *sometimes* moves the cursor down, and
*sometimes* selects the next completion.

For replay we need to be able to separate the two.
