### PR TITLE
Allow call events to be logged without a room id

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -273,7 +273,13 @@ impl ActiveCall {
             .borrow_mut()
             .take()
             .ok_or_else(|| anyhow!("no incoming call"))?;
-        Self::report_call_event_for_room("decline incoming", call.room_id, None, &self.client, cx);
+        Self::report_call_event_for_room(
+            "decline incoming",
+            Some(call.room_id),
+            None,
+            &self.client,
+            cx,
+        );
         self.client.send(proto::DeclineCall {
             room_id: call.room_id,
         })?;
@@ -403,22 +409,20 @@ impl ActiveCall {
         &self.pending_invites
     }
 
-    pub fn report_call_event(&self, operation: &'static str, cx: &AppContext) {
-        if let Some(room) = self.room() {
-            let room = room.read(cx);
-            Self::report_call_event_for_room(
-                operation,
-                room.id(),
-                room.channel_id(),
-                &self.client,
-                cx,
-            )
-        }
+    fn report_call_event(&self, operation: &'static str, cx: &AppContext) {
+        let (room_id, channel_id) = match self.room() {
+            Some(room) => {
+                let room = room.read(cx);
+                (Some(room.id()), room.channel_id())
+            }
+            None => (None, None),
+        };
+        Self::report_call_event_for_room(operation, room_id, channel_id, &self.client, cx)
     }
 
     pub fn report_call_event_for_room(
         operation: &'static str,
-        room_id: u64,
+        room_id: Option<u64>,
         channel_id: Option<u64>,
         client: &Arc<Client>,
         cx: &AppContext,

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -73,7 +73,7 @@ pub enum ClickhouseEvent {
     },
     Call {
         operation: &'static str,
-        room_id: u64,
+        room_id: Option<u64>,
         channel_id: Option<u64>,
     },
 }

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -49,7 +49,7 @@ pub fn toggle_screen_sharing(_: &ToggleScreenSharing, cx: &mut AppContext) {
             if room.is_screen_sharing() {
                 ActiveCall::report_call_event_for_room(
                     "disable screen share",
-                    room.id(),
+                    Some(room.id()),
                     room.channel_id(),
                     &client,
                     cx,
@@ -58,7 +58,7 @@ pub fn toggle_screen_sharing(_: &ToggleScreenSharing, cx: &mut AppContext) {
             } else {
                 ActiveCall::report_call_event_for_room(
                     "enable screen share",
-                    room.id(),
+                    Some(room.id()),
                     room.channel_id(),
                     &client,
                     cx,
@@ -78,7 +78,7 @@ pub fn toggle_mute(_: &ToggleMute, cx: &mut AppContext) {
             if room.is_muted(cx) {
                 ActiveCall::report_call_event_for_room(
                     "enable microphone",
-                    room.id(),
+                    Some(room.id()),
                     room.channel_id(),
                     &client,
                     cx,
@@ -86,7 +86,7 @@ pub fn toggle_mute(_: &ToggleMute, cx: &mut AppContext) {
             } else {
                 ActiveCall::report_call_event_for_room(
                     "disable microphone",
-                    room.id(),
+                    Some(room.id()),
                     room.channel_id(),
                     &client,
                     cx,


### PR DESCRIPTION
Prior to this PR, we assumed that all call events needed a room_id, but we now have call-based actions that don't need a room_id - for instance, you can right click a channel and view the notes while not in a call.  In this case, there is no room_id.  We want to be able to track these events, which requires removing the restriction that requires a room_id.

Release Notes:

- N/A