### PR TITLE
Include JS template literal as string type for overrides

### DIFF
--- a/crates/zed/src/languages/javascript/overrides.scm
+++ b/crates/zed/src/languages/javascript/overrides.scm
@@ -1,5 +1,9 @@
 (comment) @comment
-(string) @string
+
+[
+  (string)
+  (template_string)
+] @string
 
 [
   (jsx_element)

--- a/crates/zed/src/languages/tsx/overrides.scm
+++ b/crates/zed/src/languages/tsx/overrides.scm
@@ -1,5 +1,10 @@
 (comment) @comment
-(string) @string
+
+[
+  (string)
+  (template_string)
+] @string
+
 [
   (jsx_element)
   (jsx_fragment)


### PR DESCRIPTION
Allows us to trigger Tailwind completions within template literals in JSX elements

Release Notes:
- Fixed Tailwind autocomplete not appearing in template literals.
