### PR TITLE
Start indexing right away when project was already indexed before

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -867,7 +867,7 @@ impl ProjectSearchView {
         SemanticIndex::global(cx)
             .map(|semantic| {
                 let project = self.model.read(cx).project.clone();
-                semantic.update(cx, |this, cx| this.project_previously_indexed(project, cx))
+                semantic.update(cx, |this, cx| this.project_previously_indexed(&project, cx))
             })
             .unwrap_or(Task::ready(Ok(false)))
     }

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -18,7 +18,7 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
-    time::{Instant, SystemTime},
+    time::SystemTime,
 };
 use util::TryFutureExt;
 
@@ -232,7 +232,6 @@ impl VectorDatabase {
 
             let file_id = db.last_insert_rowid();
 
-            let t0 = Instant::now();
             let mut query = db.prepare(
                 "
                 INSERT INTO spans
@@ -240,10 +239,6 @@ impl VectorDatabase {
                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
                 ",
             )?;
-            log::trace!(
-                "Preparing Query Took: {:?} milliseconds",
-                t0.elapsed().as_millis()
-            );
 
             for span in spans {
                 query.execute(params![


### PR DESCRIPTION
Release notes:
- Improved semantic search indexing to start in the background if the project was already indexed before.
