### PR TITLE
Stop LiveKitBridge Package.resolved from constantly updating

### DIFF
--- a/crates/live_kit_client/build.rs
+++ b/crates/live_kit_client/build.rs
@@ -63,6 +63,7 @@ fn build_bridge(swift_target: &SwiftTarget) {
     let swift_target_folder = swift_target_folder();
     if !Command::new("swift")
         .arg("build")
+        .arg("--disable-automatic-resolution")
         .args(["--configuration", &env::var("PROFILE").unwrap()])
         .args(["--triple", &swift_target.target.triple])
         .args(["--build-path".into(), swift_target_folder])


### PR DESCRIPTION
Stop that damned LiveKitBridge Package.resolved from continually changing and act more like a lock file

Release Notes:

- N/A
