### PR TITLE
Make toolbar horizontal padding more consistent

### DIFF
--- a/crates/feedback/src/feedback_info_text.rs
+++ b/crates/feedback/src/feedback_info_text.rs
@@ -42,14 +42,14 @@ impl View for FeedbackInfoText {
             )
             .with_child(
                 MouseEventHandler::new::<OpenZedCommunityRepo, _>(0, cx, |state, _| {
-                    let contained_text = if state.hovered() {
+                    let style = if state.hovered() {
                         &theme.feedback.link_text_hover
                     } else {
                         &theme.feedback.link_text_default
                     };
-
-                    Label::new("community repo", contained_text.text.clone())
+                    Label::new("community repo", style.text.clone())
                         .contained()
+                        .with_style(style.container)
                         .aligned()
                         .left()
                         .clipped()
@@ -64,6 +64,8 @@ impl View for FeedbackInfoText {
                     .with_soft_wrap(false)
                     .aligned(),
             )
+            .contained()
+            .with_style(theme.feedback.info_text_default.container)
             .aligned()
             .left()
             .clipped()

--- a/styles/src/style_tree/feedback.ts
+++ b/styles/src/style_tree/feedback.ts
@@ -12,9 +12,6 @@ export default function feedback(): any {
                 background: background(theme.highest, "on"),
                 corner_radius: 6,
                 border: border(theme.highest, "on"),
-                margin: {
-                    right: 4,
-                },
                 padding: {
                     bottom: 2,
                     left: 10,
@@ -41,9 +38,15 @@ export default function feedback(): any {
             },
         }),
         button_margin: 8,
-        info_text_default: text(theme.highest, "sans", "default", {
-            size: "xs",
-        }),
+        info_text_default: {
+            padding: {
+                left: 4,
+                right: 4,
+            },
+            ...text(theme.highest, "sans", "default", {
+                size: "xs",
+            })
+        },
         link_text_default: text(theme.highest, "sans", "default", {
             size: "xs",
             underline: true,

--- a/styles/src/style_tree/toolbar.ts
+++ b/styles/src/style_tree/toolbar.ts
@@ -2,14 +2,14 @@ import { useTheme } from "../common"
 import { toggleable_icon_button } from "../component/icon_button"
 import { interactive, toggleable } from "../element"
 import { background, border, foreground, text } from "./components"
-import { text_button } from "../component";
+import { text_button } from "../component"
 
 export const toolbar = () => {
     const theme = useTheme()
 
     return {
         height: 42,
-        padding: { left: 4, right: 4 },
+        padding: { left: 8, right: 8 },
         background: background(theme.highest),
         border: border(theme.highest, { bottom: true }),
         item_spacing: 4,
@@ -24,9 +24,9 @@ export const toolbar = () => {
                 ...text(theme.highest, "sans", "variant"),
                 corner_radius: 6,
                 padding: {
-                    left: 6,
-                    right: 6,
-                },
+                    left: 4,
+                    right: 4,
+                }
             },
             state: {
                 hovered: {


### PR DESCRIPTION
* increase horizontal padding of toolbar itself, remove padding that was added to individual toolbar items like feedback button.
* make feedback info text and breadcrumbs have the same additional padding as quick action buttons.

Release Notes:

- Fixed some inconsistencies in the layout of toolbars.