### PR TITLE
Make channel notes act as an editor to enable inline assistant

### DIFF
--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -15,7 +15,7 @@ use gpui::{
     ViewContext, ViewHandle,
 };
 use project::Project;
-use std::any::Any;
+use std::any::{Any, TypeId};
 use workspace::{
     item::{FollowableItem, Item, ItemHandle},
     register_followable_item,
@@ -189,6 +189,21 @@ impl View for ChannelView {
 }
 
 impl Item for ChannelView {
+    fn act_as_type<'a>(
+        &'a self,
+        type_id: TypeId,
+        self_handle: &'a ViewHandle<Self>,
+        _: &'a AppContext,
+    ) -> Option<&'a AnyViewHandle> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self_handle)
+        } else if type_id == TypeId::of::<Editor>() {
+            Some(&self.editor)
+        } else {
+            None
+        }
+    }
+
     fn tab_content<V: 'static>(
         &self,
         _: Option<usize>,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -171,6 +171,7 @@ pub trait Item: View {
             None
         }
     }
+
     fn as_searchable(&self, _: &ViewHandle<Self>) -> Option<Box<dyn SearchableItemHandle>> {
         None
     }


### PR DESCRIPTION
I think it should be fine to make channel notes act as editors, so I'll go ahead and merge this but cc'ing @mikayla-maki and @maxbrunsfeld, in case I'm overlooking something. 

Release Notes:

- Added the inline assistant to channel notes.