### PR TITLE
Fix Python's cached binary retrieval being borked

### DIFF
--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -262,6 +262,7 @@ impl LspAdapter for RustLspAdapter {
         })
     }
 }
+
 async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServerBinary> {
     (|| async move {
         let mut last = None;


### PR DESCRIPTION
We fixed this while brainstorming a better approach to handle server binaries and if we already have a fix for this one then we might as well have this not be broken while the new mechanism is being built

Release Notes:

- Fixed Python language server not launching without a network connection.
