### PR TITLE
Add admin APIs for interacting and viewing feature flags

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -41,6 +41,7 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 
 pub use ids::*;
 pub use sea_orm::ConnectOptions;
+pub use tables::feature_flag::Model as FeatureFlag;
 pub use tables::user::Model as User;
 
 pub struct Database {

--- a/crates/collab/src/db/tables/feature_flag.rs
+++ b/crates/collab/src/db/tables/feature_flag.rs
@@ -1,8 +1,9 @@
 use sea_orm::entity::prelude::*;
+use serde_derive::Serialize;
 
 use crate::db::FlagId;
 
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, DeriveEntityModel, Serialize)]
 #[sea_orm(table_name = "feature_flags")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/crates/collab/src/db/tests/feature_flag_tests.rs
+++ b/crates/collab/src/db/tests/feature_flag_tests.rs
@@ -1,16 +1,16 @@
 use crate::{
-    db::{Database, NewUserParams},
+    db::{Database, FeatureFlag, NewUserParams},
     test_both_dbs,
 };
 use std::sync::Arc;
 
 test_both_dbs!(
-    test_get_user_flags,
-    test_get_user_flags_postgres,
-    test_get_user_flags_sqlite
+    test_feature_flags,
+    test_feature_flags_postgres,
+    test_feature_flags_sqlite
 );
 
-async fn test_get_user_flags(db: &Arc<Database>) {
+async fn test_feature_flags(db: &Arc<Database>) {
     let user_1 = db
         .create_user(
             &format!("user1@example.com"),
@@ -42,8 +42,8 @@ async fn test_get_user_flags(db: &Arc<Database>) {
     const CHANNELS_ALPHA: &'static str = "channels-alpha";
     const NEW_SEARCH: &'static str = "new-search";
 
-    let channels_flag = db.create_user_flag(CHANNELS_ALPHA).await.unwrap();
-    let search_flag = db.create_user_flag(NEW_SEARCH).await.unwrap();
+    let channels_flag = db.create_feature_flag(CHANNELS_ALPHA).await.unwrap();
+    let search_flag = db.create_feature_flag(NEW_SEARCH).await.unwrap();
 
     db.add_user_flag(user_1, channels_flag).await.unwrap();
     db.add_user_flag(user_1, search_flag).await.unwrap();
@@ -57,4 +57,29 @@ async fn test_get_user_flags(db: &Arc<Database>) {
     let mut user_2_flags = db.get_user_flags(user_2).await.unwrap();
     user_2_flags.sort();
     assert_eq!(user_2_flags, &[CHANNELS_ALPHA]);
+
+    let flags = db.get_feature_flags().await.unwrap();
+    assert_eq!(
+        flags,
+        vec![
+            FeatureFlag {
+                id: channels_flag,
+                flag: CHANNELS_ALPHA.to_string(),
+            },
+            FeatureFlag {
+                id: search_flag,
+                flag: NEW_SEARCH.to_string(),
+            },
+        ]
+    );
+
+    let users_for_channels_alpha = db
+        .get_flag_users(channels_flag)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|user| user.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(users_for_channels_alpha, vec![user_1, user_2])
 }


### PR DESCRIPTION
This PR adds APIs to the collab server for viewing / editing the server-side feature flags. This will be paired with a PR to zed.dev which restores access to the admin page and uses these APIs.

Release Notes:

- N/A