### PR TITLE
Add select all command to the editor

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -454,7 +454,6 @@
     "context": "Editor",
     "bindings": {
       "ctrl-shift-k": "editor::DeleteLine",
-      // "cmd-shift-d": "editor::DuplicateLine",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",
       "ctrl-j": "editor::JoinLines",
       "ctrl-cmd-up": "editor::MoveLineUp",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -294,7 +294,7 @@
           "replace_newest": false
         }
       ],
-      "cmd-shift-d": "editor::SelectNextAll",
+      "cmd-shift-d": "editor::SelectAllMatches",
       "ctrl-cmd-d": [
         "editor::SelectPrevious",
         {

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -294,6 +294,7 @@
           "replace_newest": false
         }
       ],
+      "cmd-shift-d": "editor::SelectNextAll",
       "ctrl-cmd-d": [
         "editor::SelectPrevious",
         {
@@ -453,7 +454,7 @@
     "context": "Editor",
     "bindings": {
       "ctrl-shift-k": "editor::DeleteLine",
-      "cmd-shift-d": "editor::DuplicateLine",
+      // "cmd-shift-d": "editor::DuplicateLine",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",
       "ctrl-j": "editor::JoinLines",
       "ctrl-cmd-up": "editor::MoveLineUp",

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -100,6 +100,10 @@ impl Selection<usize> {
             reversed: false,
         }
     }
+
+    pub fn equals(&self, offset_range: &Range<usize>) -> bool {
+        self.start == offset_range.start && self.end == offset_range.end
+    }
 }
 
 impl Selection<Anchor> {


### PR DESCRIPTION
Equivalent to hitting cmd-d as many times as possible

cc: @JosephTLyons this PR needs a bit of work on user-facing naming and interactions:
- [x] ~~I thought cmd-shift-d would be nice for this action, but that is already taken by a sublime key binding. Could we use the VSCode binding? I left the sublime text binding in but commented out.~~ Gonna just leave it as is
- [x] ~~I went through 'SelectAllMatches' and 'SelectAll' as names for this action, but ran into conflicts with the buffer search action and the existing SelectAll (`cmd-a`) action. I decided to go with `SelectNextAll`, but could use your help here.~~ Decided to go with 'SelectAllMatches'

Release Notes:
- Added a `editor::SelectAllMatches` command, bound to `cmd-shift-d`, for selecting all matching occurrences under your selection. Note that this has replaced the previous binding for `editor::DuplicateLine`.