### PR TITLE
Rework inlay hover model

### DIFF
--- a/crates/ai/src/assistant.rs
+++ b/crates/ai/src/assistant.rs
@@ -702,7 +702,7 @@ impl AssistantPanel {
             }
 
             if foreground_ranges.is_empty() {
-                editor.clear_text_highlights::<PendingInlineAssist>(cx);
+                editor.clear_highlights::<PendingInlineAssist>(cx);
             } else {
                 editor.highlight_text::<PendingInlineAssist>(
                     foreground_ranges,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -5,7 +5,7 @@ mod tab_map;
 mod wrap_map;
 
 use crate::{
-    link_go_to_definition::InlayRange, Anchor, AnchorRangeExt, InlayId, MultiBuffer,
+    link_go_to_definition::InlayHighlight, Anchor, AnchorRangeExt, InlayId, MultiBuffer,
     MultiBufferSnapshot, ToOffset, ToPoint,
 };
 pub use block_map::{BlockMap, BlockPoint};
@@ -44,7 +44,7 @@ pub trait ToDisplayPoint {
 }
 
 type TextHighlights = TreeMap<Option<TypeId>, Arc<(HighlightStyle, Vec<Range<Anchor>>)>>;
-type InlayHighlights = TreeMap<Option<TypeId>, Arc<(HighlightStyle, Vec<InlayRange>)>>;
+type InlayHighlights = TreeMap<Option<TypeId>, Arc<(HighlightStyle, Vec<InlayHighlight>)>>;
 
 pub struct DisplayMap {
     buffer: ModelHandle<MultiBuffer>,
@@ -226,7 +226,7 @@ impl DisplayMap {
     pub fn highlight_inlays(
         &mut self,
         type_id: TypeId,
-        ranges: Vec<InlayRange>,
+        ranges: Vec<InlayHighlight>,
         style: HighlightStyle,
     ) {
         self.inlay_highlights
@@ -308,8 +308,9 @@ impl DisplayMap {
 pub struct Highlights<'a> {
     pub text_highlights: Option<&'a TextHighlights>,
     pub inlay_highlights: Option<&'a InlayHighlights>,
+    // TODO kb remove, backgrounds are not handled in the *Map codegi
     pub inlay_background_highlights:
-        Option<TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayRange])>>>,
+        Option<TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayHighlight])>>>,
     pub inlay_highlight_style: Option<HighlightStyle>,
     pub suggestion_highlight_style: Option<HighlightStyle>,
 }
@@ -482,7 +483,7 @@ impl DisplaySnapshot {
         display_rows: Range<u32>,
         language_aware: bool,
         inlay_background_highlights: Option<
-            TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayRange])>>,
+            TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayHighlight])>>,
         >,
         inlay_highlight_style: Option<HighlightStyle>,
         suggestion_highlight_style: Option<HighlightStyle>,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -761,6 +761,14 @@ impl DisplaySnapshot {
         let type_id = TypeId::of::<Tag>();
         self.text_highlights.get(&Some(type_id)).cloned()
     }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn inlay_highlight_ranges<Tag: ?Sized + 'static>(
+        &self,
+    ) -> Option<Arc<(HighlightStyle, Vec<InlayHighlight>)>> {
+        let type_id = TypeId::of::<Tag>();
+        self.inlay_highlights.get(&Some(type_id)).cloned()
+    }
 }
 
 #[derive(Copy, Clone, Default, Eq, Ord, PartialOrd, PartialEq)]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -5,11 +5,11 @@ mod tab_map;
 mod wrap_map;
 
 use crate::{
-    link_go_to_definition::InlayRange, Anchor, AnchorRangeExt, InlayBackgroundHighlight, InlayId,
-    MultiBuffer, MultiBufferSnapshot, ToOffset, ToPoint,
+    link_go_to_definition::InlayRange, Anchor, AnchorRangeExt, InlayId, MultiBuffer,
+    MultiBufferSnapshot, ToOffset, ToPoint,
 };
 pub use block_map::{BlockMap, BlockPoint};
-use collections::{BTreeMap, HashMap, HashSet};
+use collections::{HashMap, HashSet};
 use fold_map::FoldMap;
 use gpui::{
     color::Color,
@@ -304,6 +304,16 @@ impl DisplayMap {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct Highlights<'a> {
+    pub text_highlights: Option<&'a TextHighlights>,
+    pub inlay_highlights: Option<&'a InlayHighlights>,
+    pub inlay_background_highlights:
+        Option<TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayRange])>>>,
+    pub inlay_highlight_style: Option<HighlightStyle>,
+    pub suggestion_highlight_style: Option<HighlightStyle>,
+}
+
 pub struct DisplaySnapshot {
     pub buffer_snapshot: MultiBufferSnapshot,
     pub fold_snapshot: fold_map::FoldSnapshot,
@@ -314,15 +324,6 @@ pub struct DisplaySnapshot {
     text_highlights: TextHighlights,
     inlay_highlights: InlayHighlights,
     clip_at_line_ends: bool,
-}
-
-#[derive(Debug, Default)]
-pub struct Highlights<'a> {
-    pub text_highlights: Option<&'a TextHighlights>,
-    pub inlay_highlights: Option<&'a InlayHighlights>,
-    pub inlay_background_highlights: Option<&'a BTreeMap<TypeId, InlayBackgroundHighlight>>,
-    pub inlay_highlight_style: Option<HighlightStyle>,
-    pub suggestion_highlight_style: Option<HighlightStyle>,
 }
 
 impl DisplaySnapshot {
@@ -480,7 +481,9 @@ impl DisplaySnapshot {
         &'a self,
         display_rows: Range<u32>,
         language_aware: bool,
-        inlay_background_highlights: Option<&'a BTreeMap<TypeId, InlayBackgroundHighlight>>,
+        inlay_background_highlights: Option<
+            TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayRange])>>,
+        >,
         inlay_highlight_style: Option<HighlightStyle>,
         suggestion_highlight_style: Option<HighlightStyle>,
     ) -> DisplayChunks<'_> {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -308,9 +308,6 @@ impl DisplayMap {
 pub struct Highlights<'a> {
     pub text_highlights: Option<&'a TextHighlights>,
     pub inlay_highlights: Option<&'a InlayHighlights>,
-    // TODO kb remove, backgrounds are not handled in the *Map codegi
-    pub inlay_background_highlights:
-        Option<TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayHighlight])>>>,
     pub inlay_highlight_style: Option<HighlightStyle>,
     pub suggestion_highlight_style: Option<HighlightStyle>,
 }
@@ -482,9 +479,6 @@ impl DisplaySnapshot {
         &'a self,
         display_rows: Range<u32>,
         language_aware: bool,
-        inlay_background_highlights: Option<
-            TreeMap<Option<TypeId>, Arc<(HighlightStyle, &'a [InlayHighlight])>>,
-        >,
         inlay_highlight_style: Option<HighlightStyle>,
         suggestion_highlight_style: Option<HighlightStyle>,
     ) -> DisplayChunks<'_> {
@@ -494,7 +488,6 @@ impl DisplaySnapshot {
             Highlights {
                 text_highlights: Some(&self.text_highlights),
                 inlay_highlights: Some(&self.inlay_highlights),
-                inlay_background_highlights,
                 inlay_highlight_style,
                 suggestion_highlight_style,
             },
@@ -1714,7 +1707,7 @@ pub mod tests {
     ) -> Vec<(String, Option<Color>, Option<Color>)> {
         let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
         let mut chunks: Vec<(String, Option<Color>, Option<Color>)> = Vec::new();
-        for chunk in snapshot.chunks(rows, true, None, None, None) {
+        for chunk in snapshot.chunks(rows, true, None, None) {
             let syntax_color = chunk
                 .syntax_highlight_id
                 .and_then(|id| id.style(theme)?.color);

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1,10 +1,10 @@
 use super::{
     wrap_map::{self, WrapEdit, WrapPoint, WrapSnapshot},
-    TextHighlights,
+    Highlights,
 };
 use crate::{Anchor, Editor, ExcerptId, ExcerptRange, ToPoint as _};
 use collections::{Bound, HashMap, HashSet};
-use gpui::{fonts::HighlightStyle, AnyElement, ViewContext};
+use gpui::{AnyElement, ViewContext};
 use language::{BufferSnapshot, Chunk, Patch, Point};
 use parking_lot::Mutex;
 use std::{
@@ -576,9 +576,7 @@ impl BlockSnapshot {
         self.chunks(
             0..self.transforms.summary().output_rows,
             false,
-            None,
-            None,
-            None,
+            Highlights::default(),
         )
         .map(|chunk| chunk.text)
         .collect()
@@ -588,9 +586,7 @@ impl BlockSnapshot {
         &'a self,
         rows: Range<u32>,
         language_aware: bool,
-        text_highlights: Option<&'a TextHighlights>,
-        hint_highlight_style: Option<HighlightStyle>,
-        suggestion_highlight_style: Option<HighlightStyle>,
+        highlights: Highlights<'a>,
     ) -> BlockChunks<'a> {
         let max_output_row = cmp::min(rows.end, self.transforms.summary().output_rows);
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>();
@@ -622,9 +618,7 @@ impl BlockSnapshot {
             input_chunks: self.wrap_snapshot.chunks(
                 input_start..input_end,
                 language_aware,
-                text_highlights,
-                hint_highlight_style,
-                suggestion_highlight_style,
+                highlights,
             ),
             input_chunk: Default::default(),
             transforms: cursor,
@@ -1501,9 +1495,7 @@ mod tests {
                     .chunks(
                         start_row as u32..blocks_snapshot.max_point().row + 1,
                         false,
-                        None,
-                        None,
-                        None,
+                        Highlights::default(),
                     )
                     .map(|chunk| chunk.text)
                     .collect::<String>();

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1,6 +1,6 @@
 use super::{
     inlay_map::{InlayBufferRows, InlayChunks, InlayEdit, InlayOffset, InlayPoint, InlaySnapshot},
-    TextHighlights,
+    Highlights,
 };
 use crate::{Anchor, AnchorRangeExt, MultiBufferSnapshot, ToOffset};
 use gpui::{color::Color, fonts::HighlightStyle};
@@ -475,7 +475,7 @@ pub struct FoldSnapshot {
 impl FoldSnapshot {
     #[cfg(test)]
     pub fn text(&self) -> String {
-        self.chunks(FoldOffset(0)..self.len(), false, None, None, None)
+        self.chunks(FoldOffset(0)..self.len(), false, Highlights::default())
             .map(|c| c.text)
             .collect()
     }
@@ -651,9 +651,7 @@ impl FoldSnapshot {
         &'a self,
         range: Range<FoldOffset>,
         language_aware: bool,
-        text_highlights: Option<&'a TextHighlights>,
-        hint_highlight_style: Option<HighlightStyle>,
-        suggestion_highlight_style: Option<HighlightStyle>,
+        highlights: Highlights<'a>,
     ) -> FoldChunks<'a> {
         let mut transform_cursor = self.transforms.cursor::<(FoldOffset, InlayOffset)>();
 
@@ -674,9 +672,7 @@ impl FoldSnapshot {
             inlay_chunks: self.inlay_snapshot.chunks(
                 inlay_start..inlay_end,
                 language_aware,
-                text_highlights,
-                hint_highlight_style,
-                suggestion_highlight_style,
+                highlights,
             ),
             inlay_chunk: None,
             inlay_offset: inlay_start,
@@ -687,8 +683,12 @@ impl FoldSnapshot {
     }
 
     pub fn chars_at(&self, start: FoldPoint) -> impl '_ + Iterator<Item = char> {
-        self.chunks(start.to_offset(self)..self.len(), false, None, None, None)
-            .flat_map(|chunk| chunk.text.chars())
+        self.chunks(
+            start.to_offset(self)..self.len(),
+            false,
+            Highlights::default(),
+        )
+        .flat_map(|chunk| chunk.text.chars())
     }
 
     #[cfg(test)]
@@ -1496,7 +1496,7 @@ mod tests {
                 let text = &expected_text[start.0..end.0];
                 assert_eq!(
                     snapshot
-                        .chunks(start..end, false, None, None, None)
+                        .chunks(start..end, false, Highlights::default())
                         .map(|c| c.text)
                         .collect::<String>(),
                     text,

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1649,9 +1649,7 @@ mod tests {
                         false,
                         Highlights {
                             text_highlights: Some(&text_highlights),
-                            inlay_highlights: None,
-                            inlay_highlight_style: None,
-                            suggestion_highlight_style: None,
+                            ..Highlights::default()
                         },
                     )
                     .map(|chunk| chunk.text)

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -295,7 +295,6 @@ impl<'a> Iterator for InlayChunks<'a> {
             }
             Transform::Inlay(inlay) => {
                 let mut inlay_style_and_highlight = None;
-                // type InlayHighlights = BTreeMap<TypeId, HashMap<InlayId, (HighlightStyle, InlayHighlight)>>;
                 if let Some(inlay_highlights) = self.highlights.inlay_highlights {
                     for (_, inlay_id_to_data) in inlay_highlights.iter() {
                         let style_and_highlight = inlay_id_to_data.get(&inlay.id);

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1711,7 +1711,6 @@ mod tests {
                     .filter_map(|i| {
                         let (_, inlay) = &inlays[i];
                         let inlay_text_len = inlay.text.len();
-                        // TODO kb gen_range
                         match inlay_text_len {
                             0 => None,
                             1 => Some(InlayHighlight {

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -1,13 +1,11 @@
 use super::{
     fold_map::FoldBufferRows,
     tab_map::{self, TabEdit, TabPoint, TabSnapshot},
-    TextHighlights,
+    Highlights,
 };
 use crate::MultiBufferSnapshot;
 use gpui::{
-    fonts::{FontId, HighlightStyle},
-    text_layout::LineWrapper,
-    AppContext, Entity, ModelContext, ModelHandle, Task,
+    fonts::FontId, text_layout::LineWrapper, AppContext, Entity, ModelContext, ModelHandle, Task,
 };
 use language::{Chunk, Point};
 use lazy_static::lazy_static;
@@ -444,9 +442,7 @@ impl WrapSnapshot {
                 let mut chunks = new_tab_snapshot.chunks(
                     TabPoint::new(edit.new_rows.start, 0)..new_tab_snapshot.max_point(),
                     false,
-                    None,
-                    None,
-                    None,
+                    Highlights::default(),
                 );
                 let mut edit_transforms = Vec::<Transform>::new();
                 for _ in edit.new_rows.start..edit.new_rows.end {
@@ -575,9 +571,7 @@ impl WrapSnapshot {
         &'a self,
         rows: Range<u32>,
         language_aware: bool,
-        text_highlights: Option<&'a TextHighlights>,
-        hint_highlight_style: Option<HighlightStyle>,
-        suggestion_highlight_style: Option<HighlightStyle>,
+        highlights: Highlights<'a>,
     ) -> WrapChunks<'a> {
         let output_start = WrapPoint::new(rows.start, 0);
         let output_end = WrapPoint::new(rows.end, 0);
@@ -594,9 +588,7 @@ impl WrapSnapshot {
             input_chunks: self.tab_snapshot.chunks(
                 input_start..input_end,
                 language_aware,
-                text_highlights,
-                hint_highlight_style,
-                suggestion_highlight_style,
+                highlights,
             ),
             input_chunk: Default::default(),
             output_position: output_start,
@@ -1323,9 +1315,7 @@ mod tests {
             self.chunks(
                 wrap_row..self.max_point().row() + 1,
                 false,
-                None,
-                None,
-                None,
+                Highlights::default(),
             )
             .map(|h| h.text)
         }
@@ -1350,7 +1340,7 @@ mod tests {
                 }
 
                 let actual_text = self
-                    .chunks(start_row..end_row, true, None, None, None)
+                    .chunks(start_row..end_row, true, Highlights::default())
                     .map(|c| c.text)
                     .collect::<String>();
                 assert_eq!(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -99,6 +99,7 @@ use std::{
     time::{Duration, Instant},
 };
 pub use sum_tree::Bias;
+use sum_tree::TreeMap;
 use text::Rope;
 use theme::{DiagnosticStyle, Theme, ThemeSettings};
 use util::{post_inc, RangeExt, ResultExt, TryFutureExt};
@@ -581,7 +582,7 @@ pub struct Editor {
     placeholder_text: Option<Arc<str>>,
     highlighted_rows: Option<Range<u32>>,
     background_highlights: BTreeMap<TypeId, BackgroundHighlight>,
-    inlay_background_highlights: BTreeMap<TypeId, InlayBackgroundHighlight>,
+    inlay_background_highlights: TreeMap<Option<TypeId>, InlayBackgroundHighlight>,
     nav_history: Option<ItemNavHistory>,
     context_menu: Option<ContextMenu>,
     mouse_context_menu: ViewHandle<context_menu::ContextMenu>,
@@ -7823,7 +7824,7 @@ impl Editor {
         cx: &mut ViewContext<Self>,
     ) {
         self.inlay_background_highlights
-            .insert(TypeId::of::<T>(), (color_fetcher, ranges));
+            .insert(Some(TypeId::of::<T>()), (color_fetcher, ranges));
         cx.notify();
     }
 
@@ -7832,7 +7833,9 @@ impl Editor {
         cx: &mut ViewContext<Self>,
     ) -> Option<BackgroundHighlight> {
         let text_highlights = self.background_highlights.remove(&TypeId::of::<T>());
-        let inlay_highlights = self.inlay_background_highlights.remove(&TypeId::of::<T>());
+        let inlay_highlights = self
+            .inlay_background_highlights
+            .remove(&Some(TypeId::of::<T>()));
         if text_highlights.is_some() || inlay_highlights.is_some() {
             cx.notify();
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -66,7 +66,7 @@ use language::{
     TransactionId,
 };
 use link_go_to_definition::{
-    hide_link_definition, show_link_definition, GoToDefinitionLink, InlayRange,
+    hide_link_definition, show_link_definition, GoToDefinitionLink, InlayHighlight,
     LinkGoToDefinitionState,
 };
 use log::error;
@@ -550,7 +550,7 @@ type GetFieldEditorTheme = dyn Fn(&theme::Theme) -> theme::FieldEditor;
 type OverrideTextStyle = dyn Fn(&EditorStyle) -> Option<HighlightStyle>;
 
 type BackgroundHighlight = (fn(&Theme) -> Color, Vec<Range<Anchor>>);
-type InlayBackgroundHighlight = (fn(&Theme) -> Color, Vec<InlayRange>);
+type InlayBackgroundHighlight = (fn(&Theme) -> Color, Vec<InlayHighlight>);
 
 pub struct Editor {
     handle: WeakViewHandle<Self>,
@@ -7819,7 +7819,7 @@ impl Editor {
 
     pub fn highlight_inlay_background<T: 'static>(
         &mut self,
-        ranges: Vec<InlayRange>,
+        ranges: Vec<InlayHighlight>,
         color_fetcher: fn(&Theme) -> Color,
         cx: &mut ViewContext<Self>,
     ) {
@@ -8019,7 +8019,7 @@ impl Editor {
 
     pub fn highlight_inlays<T: 'static>(
         &mut self,
-        ranges: Vec<InlayRange>,
+        ranges: Vec<InlayHighlight>,
         style: HighlightStyle,
         cx: &mut ViewContext<Self>,
     ) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7234,7 +7234,7 @@ impl Editor {
             Some(Autoscroll::fit()),
             cx,
         );
-        self.clear_text_highlights::<Rename>(cx);
+        self.clear_highlights::<Rename>(cx);
         self.show_local_selections = true;
 
         if moving_cursor {
@@ -8038,11 +8038,11 @@ impl Editor {
         self.display_map.read(cx).text_highlights(TypeId::of::<T>())
     }
 
-    pub fn clear_text_highlights<T: 'static>(&mut self, cx: &mut ViewContext<Self>) {
-        let text_highlights = self
+    pub fn clear_highlights<T: 'static>(&mut self, cx: &mut ViewContext<Self>) {
+        let cleared = self
             .display_map
-            .update(cx, |map, _| map.clear_text_highlights(TypeId::of::<T>()));
-        if text_highlights.is_some() {
+            .update(cx, |map, _| map.clear_highlights(TypeId::of::<T>()));
+        if cleared {
             cx.notify();
         }
     }
@@ -8683,7 +8683,7 @@ impl View for Editor {
 
             self.link_go_to_definition_state.task = None;
 
-            self.clear_text_highlights::<LinkGoToDefinitionState>(cx);
+            self.clear_highlights::<LinkGoToDefinitionState>(cx);
         }
 
         false
@@ -8756,7 +8756,7 @@ impl View for Editor {
     }
 
     fn unmark_text(&mut self, cx: &mut ViewContext<Self>) {
-        self.clear_text_highlights::<InputComposition>(cx);
+        self.clear_highlights::<InputComposition>(cx);
         self.ime_transaction.take();
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8020,12 +8020,12 @@ impl Editor {
 
     pub fn highlight_inlays<T: 'static>(
         &mut self,
-        ranges: Vec<InlayHighlight>,
+        highlights: Vec<InlayHighlight>,
         style: HighlightStyle,
         cx: &mut ViewContext<Self>,
     ) {
         self.display_map.update(cx, |map, _| {
-            map.highlight_inlays(TypeId::of::<T>(), ranges, style)
+            map.highlight_inlays(TypeId::of::<T>(), highlights, style)
         });
         cx.notify();
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7823,6 +7823,7 @@ impl Editor {
         color_fetcher: fn(&Theme) -> Color,
         cx: &mut ViewContext<Self>,
     ) {
+        // TODO: no actual highlights happen for inlays currently, find a way to do that
         self.inlay_background_highlights
             .insert(Some(TypeId::of::<T>()), (color_fetcher, ranges));
         cx.notify();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -54,6 +54,7 @@ use std::{
     ops::Range,
     sync::Arc,
 };
+use sum_tree::TreeMap;
 use text::Point;
 use workspace::item::Item;
 
@@ -1592,11 +1593,28 @@ impl EditorElement {
                 .collect()
         } else {
             let style = &self.style;
+            let theme = theme::current(cx);
+            let inlay_background_highlights =
+                TreeMap::from_ordered_entries(editor.inlay_background_highlights.iter().map(
+                    |(type_id, (color_fetcher, ranges))| {
+                        let color = Some(color_fetcher(&theme));
+                        (
+                            *type_id,
+                            Arc::new((
+                                HighlightStyle {
+                                    color,
+                                    ..HighlightStyle::default()
+                                },
+                                ranges.as_slice(),
+                            )),
+                        )
+                    },
+                ));
             let chunks = snapshot
                 .chunks(
                     rows.clone(),
                     true,
-                    Some(&editor.inlay_background_highlights),
+                    Some(inlay_background_highlights),
                     Some(style.theme.hint),
                     Some(style.theme.suggestion),
                 )

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1547,6 +1547,7 @@ impl EditorElement {
         &mut self,
         rows: Range<u32>,
         line_number_layouts: &[Option<Line>],
+        editor: &mut Editor,
         snapshot: &EditorSnapshot,
         cx: &ViewContext<Editor>,
     ) -> Vec<LineWithInvisibles> {
@@ -1595,6 +1596,7 @@ impl EditorElement {
                 .chunks(
                     rows.clone(),
                     true,
+                    Some(&editor.inlay_background_highlights),
                     Some(style.theme.hint),
                     Some(style.theme.suggestion),
                 )
@@ -2355,8 +2357,13 @@ impl Element<Editor> for EditorElement {
         let scrollbar_row_range = scroll_position.y()..(scroll_position.y() + height_in_lines);
 
         let mut max_visible_line_width = 0.0;
-        let line_layouts =
-            self.layout_lines(start_row..end_row, &line_number_layouts, &snapshot, cx);
+        let line_layouts = self.layout_lines(
+            start_row..end_row,
+            &line_number_layouts,
+            editor,
+            &snapshot,
+            cx,
+        );
         for line_with_invisibles in &line_layouts {
             if line_with_invisibles.line.width() > max_visible_line_width {
                 max_visible_line_width = line_with_invisibles.line.width();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -54,7 +54,6 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-use sum_tree::TreeMap;
 use text::Point;
 use workspace::item::Item;
 
@@ -1548,7 +1547,6 @@ impl EditorElement {
         &mut self,
         rows: Range<u32>,
         line_number_layouts: &[Option<Line>],
-        editor: &mut Editor,
         snapshot: &EditorSnapshot,
         cx: &ViewContext<Editor>,
     ) -> Vec<LineWithInvisibles> {
@@ -1593,28 +1591,10 @@ impl EditorElement {
                 .collect()
         } else {
             let style = &self.style;
-            let theme = theme::current(cx);
-            let inlay_background_highlights =
-                TreeMap::from_ordered_entries(editor.inlay_background_highlights.iter().map(
-                    |(type_id, (color_fetcher, ranges))| {
-                        let color = Some(color_fetcher(&theme));
-                        (
-                            *type_id,
-                            Arc::new((
-                                HighlightStyle {
-                                    color,
-                                    ..HighlightStyle::default()
-                                },
-                                ranges.as_slice(),
-                            )),
-                        )
-                    },
-                ));
             let chunks = snapshot
                 .chunks(
                     rows.clone(),
                     true,
-                    Some(inlay_background_highlights),
                     Some(style.theme.hint),
                     Some(style.theme.suggestion),
                 )
@@ -2375,13 +2355,8 @@ impl Element<Editor> for EditorElement {
         let scrollbar_row_range = scroll_position.y()..(scroll_position.y() + height_in_lines);
 
         let mut max_visible_line_width = 0.0;
-        let line_layouts = self.layout_lines(
-            start_row..end_row,
-            &line_number_layouts,
-            editor,
-            &snapshot,
-            cx,
-        );
+        let line_layouts =
+            self.layout_lines(start_row..end_row, &line_number_layouts, &snapshot, cx);
         for line_with_invisibles in &line_layouts {
             if line_with_invisibles.line.width() > max_visible_line_width {
                 max_visible_line_width = line_with_invisibles.line.width();

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -107,7 +107,7 @@ pub fn hover_at_inlay(editor: &mut Editor, inlay_hover: InlayHover, cx: &mut Vie
 
                 let hover_popover = InfoPopover {
                     project: project.clone(),
-                    symbol_range: RangeInEditor::Inlay(inlay_hover.range),
+                    symbol_range: RangeInEditor::Inlay(inlay_hover.range.clone()),
                     blocks: vec![inlay_hover.tooltip],
                     language: None,
                     rendered_content: None,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -796,6 +796,7 @@ mod tests {
         inlay_hint_cache::tests::{cached_hint_labels, visible_hint_labels},
         link_go_to_definition::update_inlay_link_and_hover_points,
         test::editor_lsp_test_context::EditorLspTestContext,
+        InlayId,
     };
     use collections::BTreeSet;
     use gpui::fonts::Weight;
@@ -1462,29 +1463,19 @@ mod tests {
             .advance_clock(Duration::from_millis(HOVER_DELAY_MILLIS + 100));
         cx.foreground().run_until_parked();
         cx.update_editor(|editor, cx| {
-            let snapshot = editor.snapshot(cx);
             let hover_state = &editor.hover_state;
             assert!(hover_state.diagnostic_popover.is_none() && hover_state.info_popover.is_some());
             let popover = hover_state.info_popover.as_ref().unwrap();
             let buffer_snapshot = editor.buffer().update(cx, |buffer, cx| buffer.snapshot(cx));
-            let entire_inlay_start = snapshot.display_point_to_inlay_offset(
-                inlay_range.start.to_display_point(&snapshot),
-                Bias::Left,
+            assert_eq!(
+                popover.symbol_range,
+                RangeInEditor::Inlay(InlayHighlight {
+                    inlay: InlayId::Hint(0),
+                    inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
+                    range: ": ".len()..": ".len() + new_type_label.len(),
+                }),
+                "Popover range should match the new type label part"
             );
-
-            let expected_new_type_label_start = InlayOffset(entire_inlay_start.0 + ": ".len());
-            // TODO kb
-            // assert_eq!(
-            //     popover.symbol_range,
-            //     RangeInEditor::Inlay(InlayRange {
-            //         inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
-            //         highlight_start: expected_new_type_label_start,
-            //         highlight_end: InlayOffset(
-            //             expected_new_type_label_start.0 + new_type_label.len()
-            //         ),
-            //     }),
-            //     "Popover range should match the new type label part"
-            // );
             assert_eq!(
                 popover
                     .rendered_content
@@ -1529,27 +1520,20 @@ mod tests {
             .advance_clock(Duration::from_millis(HOVER_DELAY_MILLIS + 100));
         cx.foreground().run_until_parked();
         cx.update_editor(|editor, cx| {
-            let snapshot = editor.snapshot(cx);
             let hover_state = &editor.hover_state;
             assert!(hover_state.diagnostic_popover.is_none() && hover_state.info_popover.is_some());
             let popover = hover_state.info_popover.as_ref().unwrap();
             let buffer_snapshot = editor.buffer().update(cx, |buffer, cx| buffer.snapshot(cx));
-            let entire_inlay_start = snapshot.display_point_to_inlay_offset(
-                inlay_range.start.to_display_point(&snapshot),
-                Bias::Left,
+            assert_eq!(
+                popover.symbol_range,
+                RangeInEditor::Inlay(InlayHighlight {
+                    inlay: InlayId::Hint(0),
+                    inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
+                    range: ": ".len() + new_type_label.len() + "<".len()
+                        ..": ".len() + new_type_label.len() + "<".len() + struct_label.len(),
+                }),
+                "Popover range should match the struct label part"
             );
-            let expected_struct_label_start =
-                InlayOffset(entire_inlay_start.0 + ": ".len() + new_type_label.len() + "<".len());
-            // TODO kb
-            // assert_eq!(
-            //     popover.symbol_range,
-            //     RangeInEditor::Inlay(InlayRange {
-            //         inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
-            //         highlight_start: expected_struct_label_start,
-            //         highlight_end: InlayOffset(expected_struct_label_start.0 + struct_label.len()),
-            //     }),
-            //     "Popover range should match the struct label part"
-            // );
             assert_eq!(
                 popover
                     .rendered_content

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1,6 +1,6 @@
 use crate::{
     display_map::{InlayOffset, ToDisplayPoint},
-    link_go_to_definition::{InlayRange, RangeInEditor},
+    link_go_to_definition::{InlayHighlight, RangeInEditor},
     Anchor, AnchorRangeExt, DisplayPoint, Editor, EditorSettings, EditorSnapshot, EditorStyle,
     ExcerptId, RangeToAnchorExt,
 };
@@ -50,7 +50,7 @@ pub fn hover_at(editor: &mut Editor, point: Option<DisplayPoint>, cx: &mut ViewC
 
 pub struct InlayHover {
     pub excerpt: ExcerptId,
-    pub range: InlayRange,
+    pub range: InlayHighlight,
     pub tooltip: HoverBlock,
 }
 

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -986,10 +986,7 @@ fn calculate_hint_updates(
                 match cached_excerpt_hints
                     .ordered_hints
                     .binary_search_by(|probe| {
-                        cached_excerpt_hints
-                            .hints_by_id
-                            .get(probe)
-                            .unwrap()
+                        cached_excerpt_hints.hints_by_id[probe]
                             .position
                             .cmp(&new_hint.position, buffer_snapshot)
                     }) {
@@ -1101,6 +1098,9 @@ fn apply_hint_update(
     cached_excerpt_hints
         .ordered_hints
         .retain(|hint_id| !new_update.remove_from_cache.contains(hint_id));
+    cached_excerpt_hints
+        .hints_by_id
+        .retain(|hint_id, _| !new_update.remove_from_cache.contains(hint_id));
     let mut splice = InlaySplice {
         to_remove: new_update.remove_from_visible,
         to_insert: Vec::new(),
@@ -3327,8 +3327,7 @@ all hints should be invalidated and requeried for all of its visible excerpts"
         for (_, excerpt_hints) in &editor.inlay_hint_cache().hints {
             let excerpt_hints = excerpt_hints.read();
             for id in &excerpt_hints.ordered_hints {
-                let inlay = excerpt_hints.hints_by_id.get(id).unwrap();
-                labels.push(inlay.text());
+                labels.push(excerpt_hints.hints_by_id[id].text());
             }
         }
 

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -43,7 +43,8 @@ pub struct CachedExcerptHints {
     version: usize,
     buffer_version: Global,
     buffer_id: u64,
-    hints: Vec<(InlayId, InlayHint)>,
+    ordered_hints: Vec<InlayId>,
+    hints_by_id: HashMap<InlayId, InlayHint>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -316,7 +317,7 @@ impl InlayHintCache {
             self.hints.retain(|cached_excerpt, cached_hints| {
                 let retain = excerpts_to_query.contains_key(cached_excerpt);
                 if !retain {
-                    invalidated_hints.extend(cached_hints.read().hints.iter().map(|&(id, _)| id));
+                    invalidated_hints.extend(cached_hints.read().ordered_hints.iter().copied());
                 }
                 retain
             });
@@ -384,7 +385,7 @@ impl InlayHintCache {
             let shown_excerpt_hints_to_remove =
                 shown_hints_to_remove.entry(*excerpt_id).or_default();
             let excerpt_cached_hints = excerpt_cached_hints.read();
-            let mut excerpt_cache = excerpt_cached_hints.hints.iter().fuse().peekable();
+            let mut excerpt_cache = excerpt_cached_hints.ordered_hints.iter().fuse().peekable();
             shown_excerpt_hints_to_remove.retain(|(shown_anchor, shown_hint_id)| {
                 let Some(buffer) = shown_anchor
                     .buffer_id
@@ -395,7 +396,8 @@ impl InlayHintCache {
                 let buffer_snapshot = buffer.read(cx).snapshot();
                 loop {
                     match excerpt_cache.peek() {
-                        Some((cached_hint_id, cached_hint)) => {
+                        Some(&cached_hint_id) => {
+                            let cached_hint = &excerpt_cached_hints.hints_by_id[cached_hint_id];
                             if cached_hint_id == shown_hint_id {
                                 excerpt_cache.next();
                                 return !new_kinds.contains(&cached_hint.kind);
@@ -428,7 +430,8 @@ impl InlayHintCache {
                 }
             });
 
-            for (cached_hint_id, maybe_missed_cached_hint) in excerpt_cache {
+            for cached_hint_id in excerpt_cache {
+                let maybe_missed_cached_hint = &excerpt_cached_hints.hints_by_id[cached_hint_id];
                 let cached_hint_kind = maybe_missed_cached_hint.kind;
                 if !old_kinds.contains(&cached_hint_kind) && new_kinds.contains(&cached_hint_kind) {
                     to_insert.push(Inlay::hint(
@@ -463,7 +466,7 @@ impl InlayHintCache {
             self.update_tasks.remove(&excerpt_to_remove);
             if let Some(cached_hints) = self.hints.remove(&excerpt_to_remove) {
                 let cached_hints = cached_hints.read();
-                to_remove.extend(cached_hints.hints.iter().map(|(id, _)| *id));
+                to_remove.extend(cached_hints.ordered_hints.iter().copied());
             }
         }
         if to_remove.is_empty() {
@@ -485,15 +488,12 @@ impl InlayHintCache {
         self.hints.clear();
     }
 
-    // TODO kb have a map
     pub fn hint_by_id(&self, excerpt_id: ExcerptId, hint_id: InlayId) -> Option<InlayHint> {
         self.hints
             .get(&excerpt_id)?
             .read()
-            .hints
-            .iter()
-            .find(|&(id, _)| id == &hint_id)
-            .map(|(_, hint)| hint)
+            .hints_by_id
+            .get(&hint_id)
             .cloned()
     }
 
@@ -501,7 +501,13 @@ impl InlayHintCache {
         let mut hints = Vec::new();
         for excerpt_hints in self.hints.values() {
             let excerpt_hints = excerpt_hints.read();
-            hints.extend(excerpt_hints.hints.iter().map(|(_, hint)| hint).cloned());
+            hints.extend(
+                excerpt_hints
+                    .ordered_hints
+                    .iter()
+                    .map(|id| &excerpt_hints.hints_by_id[id])
+                    .cloned(),
+            );
         }
         hints
     }
@@ -519,12 +525,7 @@ impl InlayHintCache {
     ) {
         if let Some(excerpt_hints) = self.hints.get(&excerpt_id) {
             let mut guard = excerpt_hints.write();
-            if let Some(cached_hint) = guard
-                .hints
-                .iter_mut()
-                .find(|(hint_id, _)| hint_id == &id)
-                .map(|(_, hint)| hint)
-            {
+            if let Some(cached_hint) = guard.hints_by_id.get_mut(&id) {
                 if let ResolveState::CanResolve(server_id, _) = &cached_hint.resolve_state {
                     let hint_to_resolve = cached_hint.clone();
                     let server_id = *server_id;
@@ -556,12 +557,7 @@ impl InlayHintCache {
                                     editor.inlay_hint_cache.hints.get(&excerpt_id)
                                 {
                                     let mut guard = excerpt_hints.write();
-                                    if let Some(cached_hint) = guard
-                                        .hints
-                                        .iter_mut()
-                                        .find(|(hint_id, _)| hint_id == &id)
-                                        .map(|(_, hint)| hint)
-                                    {
+                                    if let Some(cached_hint) = guard.hints_by_id.get_mut(&id) {
                                         if cached_hint.resolve_state == ResolveState::Resolving {
                                             resolved_hint.resolve_state = ResolveState::Resolved;
                                             *cached_hint = resolved_hint;
@@ -987,12 +983,20 @@ fn calculate_hint_updates(
         let missing_from_cache = match &cached_excerpt_hints {
             Some(cached_excerpt_hints) => {
                 let cached_excerpt_hints = cached_excerpt_hints.read();
-                match cached_excerpt_hints.hints.binary_search_by(|probe| {
-                    probe.1.position.cmp(&new_hint.position, buffer_snapshot)
-                }) {
+                match cached_excerpt_hints
+                    .ordered_hints
+                    .binary_search_by(|probe| {
+                        cached_excerpt_hints
+                            .hints_by_id
+                            .get(probe)
+                            .unwrap()
+                            .position
+                            .cmp(&new_hint.position, buffer_snapshot)
+                    }) {
                     Ok(ix) => {
                         let mut missing_from_cache = true;
-                        for (cached_inlay_id, cached_hint) in &cached_excerpt_hints.hints[ix..] {
+                        for id in &cached_excerpt_hints.ordered_hints[ix..] {
+                            let cached_hint = &cached_excerpt_hints.hints_by_id[id];
                             if new_hint
                                 .position
                                 .cmp(&cached_hint.position, buffer_snapshot)
@@ -1001,7 +1005,7 @@ fn calculate_hint_updates(
                                 break;
                             }
                             if cached_hint == &new_hint {
-                                excerpt_hints_to_persist.insert(*cached_inlay_id, cached_hint.kind);
+                                excerpt_hints_to_persist.insert(*id, cached_hint.kind);
                                 missing_from_cache = false;
                             }
                         }
@@ -1032,12 +1036,12 @@ fn calculate_hint_updates(
             let cached_excerpt_hints = cached_excerpt_hints.read();
             remove_from_cache.extend(
                 cached_excerpt_hints
-                    .hints
+                    .ordered_hints
                     .iter()
-                    .filter(|(cached_inlay_id, _)| {
+                    .filter(|cached_inlay_id| {
                         !excerpt_hints_to_persist.contains_key(cached_inlay_id)
                     })
-                    .map(|(cached_inlay_id, _)| *cached_inlay_id),
+                    .copied(),
             );
         }
     }
@@ -1081,7 +1085,8 @@ fn apply_hint_update(
                 version: query.cache_version,
                 buffer_version: buffer_snapshot.version().clone(),
                 buffer_id: query.buffer_id,
-                hints: Vec::new(),
+                ordered_hints: Vec::new(),
+                hints_by_id: HashMap::default(),
             }))
         });
     let mut cached_excerpt_hints = cached_excerpt_hints.write();
@@ -1094,20 +1099,24 @@ fn apply_hint_update(
 
     let mut cached_inlays_changed = !new_update.remove_from_cache.is_empty();
     cached_excerpt_hints
-        .hints
-        .retain(|(hint_id, _)| !new_update.remove_from_cache.contains(hint_id));
+        .ordered_hints
+        .retain(|hint_id| !new_update.remove_from_cache.contains(hint_id));
     let mut splice = InlaySplice {
         to_remove: new_update.remove_from_visible,
         to_insert: Vec::new(),
     };
     for new_hint in new_update.add_to_cache {
-        let cached_hints = &mut cached_excerpt_hints.hints;
-        let insert_position = match cached_hints
-            .binary_search_by(|probe| probe.1.position.cmp(&new_hint.position, &buffer_snapshot))
-        {
+        let insert_position = match cached_excerpt_hints
+            .ordered_hints
+            .binary_search_by(|probe| {
+                cached_excerpt_hints.hints_by_id[probe]
+                    .position
+                    .cmp(&new_hint.position, &buffer_snapshot)
+            }) {
             Ok(i) => {
                 let mut insert_position = Some(i);
-                for (_, cached_hint) in &cached_hints[i..] {
+                for id in &cached_excerpt_hints.ordered_hints[i..] {
+                    let cached_hint = &cached_excerpt_hints.hints_by_id[id];
                     if new_hint
                         .position
                         .cmp(&cached_hint.position, &buffer_snapshot)
@@ -1138,7 +1147,11 @@ fn apply_hint_update(
                     .to_insert
                     .push(Inlay::hint(new_inlay_id, new_hint_position, &new_hint));
             }
-            cached_hints.insert(insert_position, (InlayId::Hint(new_inlay_id), new_hint));
+            let new_id = InlayId::Hint(new_inlay_id);
+            cached_excerpt_hints.hints_by_id.insert(new_id, new_hint);
+            cached_excerpt_hints
+                .ordered_hints
+                .insert(insert_position, new_id);
             cached_inlays_changed = true;
         }
     }
@@ -1158,7 +1171,7 @@ fn apply_hint_update(
                 outdated_excerpt_caches.insert(*excerpt_id);
                 splice
                     .to_remove
-                    .extend(excerpt_hints.hints.iter().map(|(id, _)| id));
+                    .extend(excerpt_hints.ordered_hints.iter().copied());
             }
         }
         cached_inlays_changed |= !outdated_excerpt_caches.is_empty();
@@ -3312,7 +3325,9 @@ all hints should be invalidated and requeried for all of its visible excerpts"
     pub fn cached_hint_labels(editor: &Editor) -> Vec<String> {
         let mut labels = Vec::new();
         for (_, excerpt_hints) in &editor.inlay_hint_cache().hints {
-            for (_, inlay) in &excerpt_hints.read().hints {
+            let excerpt_hints = excerpt_hints.read();
+            for id in &excerpt_hints.ordered_hints {
+                let inlay = excerpt_hints.hints_by_id.get(id).unwrap();
                 labels.push(inlay.text());
             }
         }

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -485,6 +485,7 @@ impl InlayHintCache {
         self.hints.clear();
     }
 
+    // TODO kb have a map
     pub fn hint_by_id(&self, excerpt_id: ExcerptId, hint_id: InlayId) -> Option<InlayHint> {
         self.hints
             .get(&excerpt_id)?

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -1196,22 +1196,17 @@ mod tests {
         cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
             let actual_ranges = snapshot
-                .text_highlight_ranges::<LinkGoToDefinitionState>()
+                .inlay_highlight_ranges::<LinkGoToDefinitionState>()
                 .map(|ranges| ranges.as_ref().clone().1)
                 .unwrap_or_default();
 
             let buffer_snapshot = editor.buffer().update(cx, |buffer, cx| buffer.snapshot(cx));
-            let expected_highlight_start = snapshot.display_point_to_inlay_offset(
-                inlay_range.start.to_display_point(&snapshot),
-                Bias::Left,
-            );
-            // TODO kb
-            // let expected_ranges = vec![InlayRange {
-            //     inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
-            //     highlight_start: expected_highlight_start,
-            //     highlight_end: InlayOffset(expected_highlight_start.0 + hint_label.len()),
-            // }];
-            // assert_set_eq!(actual_ranges, expected_ranges);
+            let expected_ranges = vec![InlayHighlight {
+                inlay: InlayId::Hint(0),
+                inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
+                range: 0..hint_label.len(),
+            }];
+            assert_set_eq!(actual_ranges, expected_ranges);
         });
 
         // Unpress cmd causes highlight to go away

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -224,7 +224,6 @@ pub fn update_inlay_link_and_hover_points(
                             extra_shift_left += 1;
                             extra_shift_right += 1;
                         }
-                        // TODO kb is it right for label part cases? for `\n` in hints and fold cases?
                         if cached_hint.padding_right {
                             extra_shift_right += 1;
                         }

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -26,7 +26,7 @@ pub struct LinkGoToDefinitionState {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum RangeInEditor {
     Text(Range<Anchor>),
-    Inlay(InlayRange),
+    Inlay(InlayHighlight),
 }
 
 impl RangeInEditor {
@@ -57,7 +57,7 @@ impl RangeInEditor {
 #[derive(Debug)]
 pub enum GoToDefinitionTrigger {
     Text(DisplayPoint),
-    InlayHint(InlayRange, lsp::Location, LanguageServerId),
+    InlayHint(InlayHighlight, lsp::Location, LanguageServerId),
 }
 
 #[derive(Debug, Clone)]
@@ -67,9 +67,10 @@ pub enum GoToDefinitionLink {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct InlayRange {
+pub struct InlayHighlight {
     pub inlay: InlayId,
     pub inlay_position: Anchor,
+    // TODO kb turn into Range<usize>
     pub highlight_start: usize,
     pub highlight_end: usize,
 }
@@ -77,7 +78,7 @@ pub struct InlayRange {
 #[derive(Debug, Clone)]
 pub enum TriggerPoint {
     Text(Anchor),
-    InlayHint(InlayRange, lsp::Location, LanguageServerId),
+    InlayHint(InlayHighlight, lsp::Location, LanguageServerId),
 }
 
 impl TriggerPoint {
@@ -248,7 +249,7 @@ pub fn update_inlay_link_and_hover_points(
                                                     }
                                                 }
                                             },
-                                            range: InlayRange {
+                                            range: InlayHighlight {
                                                 inlay: hovered_hint.id,
                                                 inlay_position: hovered_hint.position,
                                                 highlight_start: extra_shift_left,
@@ -271,7 +272,7 @@ pub fn update_inlay_link_and_hover_points(
                                         hovered_offset,
                                     )
                                 {
-                                    let range = InlayRange {
+                                    let range = InlayHighlight {
                                         inlay: hovered_hint.id,
                                         inlay_position: hovered_hint.position,
                                         highlight_start: (part_range.start - hint_start).0

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -444,7 +444,7 @@ pub fn show_link_definition(
 
             this.update(&mut cx, |this, cx| {
                 // Clear any existing highlights
-                this.clear_text_highlights::<LinkGoToDefinitionState>(cx);
+                this.clear_highlights::<LinkGoToDefinitionState>(cx);
                 this.link_go_to_definition_state.kind = Some(definition_kind);
                 this.link_go_to_definition_state.symbol_range = result
                     .as_ref()
@@ -545,7 +545,7 @@ pub fn hide_link_definition(editor: &mut Editor, cx: &mut ViewContext<Editor>) {
 
     editor.link_go_to_definition_state.task = None;
 
-    editor.clear_text_highlights::<LinkGoToDefinitionState>(cx);
+    editor.clear_highlights::<LinkGoToDefinitionState>(cx);
 }
 
 pub fn go_to_fetched_definition(
@@ -1198,7 +1198,7 @@ mod tests {
         cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
             let actual_ranges = snapshot
-                .highlight_ranges::<LinkGoToDefinitionState>()
+                .text_highlight_ranges::<LinkGoToDefinitionState>()
                 .map(|ranges| ranges.as_ref().clone().1)
                 .unwrap_or_default();
 
@@ -1233,7 +1233,7 @@ mod tests {
         cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
             let actual_ranges = snapshot
-                .highlight_ranges::<LinkGoToDefinitionState>()
+                .text_highlight_ranges::<LinkGoToDefinitionState>()
                 .map(|ranges| ranges.as_ref().clone().1)
                 .unwrap_or_default();
 

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -1194,18 +1194,19 @@ mod tests {
         cx.foreground().run_until_parked();
         cx.update_editor(|editor, cx| {
             let snapshot = editor.snapshot(cx);
-            let actual_ranges = snapshot
-                .inlay_highlight_ranges::<LinkGoToDefinitionState>()
-                .map(|ranges| ranges.as_ref().clone().1)
-                .unwrap_or_default();
+            let actual_highlights = snapshot
+                .inlay_highlights::<LinkGoToDefinitionState>()
+                .into_iter()
+                .flat_map(|highlights| highlights.values().map(|(_, highlight)| highlight))
+                .collect::<Vec<_>>();
 
             let buffer_snapshot = editor.buffer().update(cx, |buffer, cx| buffer.snapshot(cx));
-            let expected_ranges = vec![InlayHighlight {
+            let expected_highlight = InlayHighlight {
                 inlay: InlayId::Hint(0),
                 inlay_position: buffer_snapshot.anchor_at(inlay_range.start, Bias::Right),
                 range: 0..hint_label.len(),
-            }];
-            assert_set_eq!(actual_ranges, expected_ranges);
+            };
+            assert_set_eq!(actual_highlights, vec![&expected_highlight]);
         });
 
         // Unpress cmd causes highlight to go away

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -188,7 +188,6 @@ pub fn update_inlay_link_and_hover_points(
             Bias::Right,
         );
         if let Some(hovered_hint) = editor
-            // TODO kb look up by position with binary search
             .visible_inlay_hints(cx)
             .into_iter()
             .skip_while(|hint| {

--- a/crates/editor/src/link_go_to_definition.rs
+++ b/crates/editor/src/link_go_to_definition.rs
@@ -69,7 +69,6 @@ pub enum GoToDefinitionLink {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InlayRange {
     pub inlay: InlayId,
-    // TODO kb look up inlays by id instead?
     pub inlay_position: Anchor,
     pub highlight_start: usize,
     pub highlight_end: usize,

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -236,7 +236,7 @@ impl<'a> EditorTestContext<'a> {
         let expected_ranges = self.ranges(marked_text);
         let snapshot = self.update_editor(|editor, cx| editor.snapshot(cx));
         let actual_ranges: Vec<Range<usize>> = snapshot
-            .highlight_ranges::<Tag>()
+            .text_highlight_ranges::<Tag>()
             .map(|ranges| ranges.as_ref().clone().1)
             .unwrap_or_default()
             .into_iter()

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -225,7 +225,6 @@ impl<'a> EditorTestContext<'a> {
                 .map(|h| h.1.clone())
                 .unwrap_or_default()
                 .into_iter()
-                .filter_map(|range| range.as_text_range())
                 .map(|range| range.to_offset(&snapshot.buffer_snapshot))
                 .collect()
         });
@@ -241,7 +240,6 @@ impl<'a> EditorTestContext<'a> {
             .map(|ranges| ranges.as_ref().clone().1)
             .unwrap_or_default()
             .into_iter()
-            .filter_map(|range| range.as_text_range())
             .map(|range| range.to_offset(&snapshot.buffer_snapshot))
             .collect();
         assert_set_eq!(actual_ranges, expected_ranges);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -992,7 +992,7 @@ mod tests {
             .unwrap();
         editor.update(cx, |editor, cx| {
             assert_eq!(
-                editor.all_background_highlights(cx),
+                editor.all_text_background_highlights(cx),
                 &[
                     (
                         DisplayPoint::new(2, 17)..DisplayPoint::new(2, 19),
@@ -1013,7 +1013,7 @@ mod tests {
         editor.next_notification(cx).await;
         editor.update(cx, |editor, cx| {
             assert_eq!(
-                editor.all_background_highlights(cx),
+                editor.all_text_background_highlights(cx),
                 &[(
                     DisplayPoint::new(2, 43)..DisplayPoint::new(2, 45),
                     Color::red(),
@@ -1029,7 +1029,7 @@ mod tests {
             .unwrap();
         editor.update(cx, |editor, cx| {
             assert_eq!(
-                editor.all_background_highlights(cx),
+                editor.all_text_background_highlights(cx),
                 &[
                     (
                         DisplayPoint::new(0, 24)..DisplayPoint::new(0, 26),
@@ -1070,7 +1070,7 @@ mod tests {
         editor.next_notification(cx).await;
         editor.update(cx, |editor, cx| {
             assert_eq!(
-                editor.all_background_highlights(cx),
+                editor.all_text_background_highlights(cx),
                 &[
                     (
                         DisplayPoint::new(0, 41)..DisplayPoint::new(0, 43),
@@ -1281,7 +1281,7 @@ mod tests {
             .unwrap();
         editor.update(cx, |editor, cx| {
             assert_eq!(
-                editor.all_background_highlights(cx),
+                editor.all_text_background_highlights(cx),
                 &[(
                     DisplayPoint::new(2, 43)..DisplayPoint::new(2, 45),
                     Color::red(),
@@ -1308,7 +1308,7 @@ mod tests {
         editor.next_notification(cx).await;
         editor.update(cx, |editor, cx| {
             assert_eq!(
-                editor.all_background_highlights(cx),
+                editor.all_text_background_highlights(cx),
                 &[(
                     DisplayPoint::new(0, 35)..DisplayPoint::new(0, 40),
                     Color::red(),

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1724,7 +1724,7 @@ pub mod tests {
             assert_eq!(
                 search_view
                     .results_editor
-                    .update(cx, |editor, cx| editor.all_background_highlights(cx)),
+                    .update(cx, |editor, cx| editor.all_text_background_highlights(cx)),
                 &[
                     (
                         DisplayPoint::new(2, 32)..DisplayPoint::new(2, 35),

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -227,7 +227,7 @@ mod test {
         deterministic.run_until_parked();
 
         cx.update_editor(|editor, cx| {
-            let highlights = editor.all_background_highlights(cx);
+            let highlights = editor.all_text_background_highlights(cx);
             assert_eq!(3, highlights.len());
             assert_eq!(
                 DisplayPoint::new(2, 0)..DisplayPoint::new(2, 2),

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -186,7 +186,6 @@ impl EditorState {
         if self.active_operator().is_none() && self.pre_count.is_some()
             || self.active_operator().is_some() && self.post_count.is_some()
         {
-            dbg!("VimCount");
             context.add_identifier("VimCount");
         }
 

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -190,7 +190,7 @@ async fn test_selection_on_search(cx: &mut gpui::TestAppContext) {
     search_bar.next_notification(&cx).await;
 
     cx.update_editor(|editor, cx| {
-        let highlights = editor.all_background_highlights(cx);
+        let highlights = editor.all_text_background_highlights(cx);
         assert_eq!(3, highlights.len());
         assert_eq!(
             DisplayPoint::new(2, 0)..DisplayPoint::new(2, 2),


### PR DESCRIPTION
Fixes https://linear.app/zed-industries/issue/Z-2864/thread-main-panicked-at-byte-index-1-is-not-a-char-boundary-it-is
```
thread 'main' panicked at 'byte index 2 is not a char boundary; it is inside '…' (bytes 0..3) of `…)`'
```
panics like https://zed-industries.slack.com/archives/C04S6T1T7TQ/p1694535396473329

by reworking the inlay hover model:
* avoid storing "hardcoded" coordinates of hovered inlay labels (such as `InlayOffset`), instead, remember `inlay_id` and apply required highlights there when hint with the same id is handled
* add randomized tests on inlay highlights
* sped up inlay hint cache lookup by inlay_id

As a downside, background highlights are no long appearing on inlay hints, but Zed does not receive any tooltips for inlays anyway (r-a does not send them for some reason, other LSP seem to have no such feature?), so it does not matter now.
Nontheless, if the logic for displaying hint pop-ups is present and works for harcoded tooltips in r-a, only background highlight is missing now.

Release Notes:

- Fixed inlay hint highlights causing panic for certain cases with "large" characters