### PR TITLE
vim: shift-d and shift-x in visual mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -452,6 +452,8 @@
       "shift-o": "vim::OtherEnd",
       "d": "vim::VisualDelete",
       "x": "vim::VisualDelete",
+      "shift-d": "vim::VisualDelete",
+      "shift-x": "vim::VisualDelete",
       "y": "vim::VisualYank",
       "p": "vim::Paste",
       "shift-p": [


### PR DESCRIPTION
Release Notes:

- vim: Support `shift-d` and `shift-x` to delete in visual mode
