### PR TITLE
vim: Fix Y on last line

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -453,6 +453,7 @@
       "d": "vim::VisualDelete",
       "x": "vim::VisualDelete",
       "y": "vim::VisualYank",
+      "shift-y": "vim::VisualYank",
       "p": "vim::Paste",
       "shift-p": [
         "vim::Paste",

--- a/crates/vim/src/utils.rs
+++ b/crates/vim/src/utils.rs
@@ -26,10 +26,11 @@ pub fn copy_selections_content(editor: &mut Editor, linewise: bool, cx: &mut App
             let is_last_line = linewise
                 && end.row == buffer.max_buffer_row()
                 && buffer.max_point().column > 0
+                && start.row < buffer.max_buffer_row()
                 && start == Point::new(start.row, buffer.line_len(start.row));
 
             if is_last_line {
-                start = Point::new(buffer.max_buffer_row(), 0);
+                start = Point::new(start.row + 1, 0);
             }
             for chunk in buffer.text_for_range(start..end) {
                 text.push_str(chunk);

--- a/crates/vim/test_data/test_visual_yank.json
+++ b/crates/vim/test_data/test_visual_yank.json
@@ -27,3 +27,9 @@
 {"Key":"k"}
 {"Key":"y"}
 {"Get":{"state":"ˇThe quick brown\nfox jumps over\nthe lazy dog","mode":"Normal"}}
+{"Put":{"state":"The quick brown\nfox ˇjumps over\nthe lazy dog"}}
+{"Key":"shift-v"}
+{"Key":"shift-g"}
+{"Key":"shift-y"}
+{"Get":{"state":"The quick brown\nˇfox jumps over\nthe lazy dog","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"fox jumps over\nthe lazy dog\n"}}


### PR DESCRIPTION
For zed-industries/zed#6303

Release Notes:

- vim: Fix y in VISUAL LINE mode when last line has no trailing newline ([#2044](https://github.com/zed-industries/zed/issues/6303)).
