### PR TITLE
clip FoldPoint earlier

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -541,7 +541,8 @@ fn down(
             .clip_point(FoldPoint::new(new_row, new_col), Bias::Left),
     );
 
-    (point, goal)
+    // clip twice to "clip at end of line"
+    (map.clip_point(point, Bias::Left), goal)
 }
 
 fn down_display(
@@ -581,7 +582,7 @@ pub(crate) fn up(
             .clip_point(FoldPoint::new(new_row, new_col), Bias::Left),
     );
 
-    (point, goal)
+    (map.clip_point(point, Bias::Left), goal)
 }
 
 fn up_display(

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -536,9 +536,12 @@ fn down(
         map.buffer_snapshot.max_point().row,
     );
     let new_col = cmp::min(goal_column, map.fold_snapshot.line_len(new_row));
-    let point = map.fold_point_to_display_point(FoldPoint::new(new_row, new_col));
+    let point = map.fold_point_to_display_point(
+        map.fold_snapshot
+            .clip_point(FoldPoint::new(new_row, new_col), Bias::Left),
+    );
 
-    (map.clip_point(point, Bias::Left), goal)
+    (point, goal)
 }
 
 fn down_display(
@@ -573,9 +576,12 @@ pub(crate) fn up(
 
     let new_row = start.row().saturating_sub(times as u32);
     let new_col = cmp::min(goal_column, map.fold_snapshot.line_len(new_row));
-    let point = map.fold_point_to_display_point(FoldPoint::new(new_row, new_col));
+    let point = map.fold_point_to_display_point(
+        map.fold_snapshot
+            .clip_point(FoldPoint::new(new_row, new_col), Bias::Left),
+    );
 
-    (map.clip_point(point, Bias::Left), goal)
+    (point, goal)
 }
 
 fn up_display(


### PR DESCRIPTION
fold_point_to_display_point calls to_offset on the fold point, which
panics if it hasn't been clipped.

https://zed-industries.slack.com/archives/C04S6T1T7TQ/p1694850156370919

Release Notes:

- vim: Fix a crash when moving up/down in some circumstances.
