### PR TITLE
chore: Enable v0 symbol mangling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
+
+[build]
+# v0 mangling scheme provides more detailed backtraces around closures
+rustflags = ["-C", "symbol-mangling-version=v0"]


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60705
Due to modification of .cargo/config.toml your `cargo build` should pick this change up automatically. Use `legacy` instead of `v0` if you find yourself in need of old mangling scheme for whatever reason
Release Notes:

- Improved precision of backtraces in application crashes
