### PR TITLE
vim: Use explicit global, not default

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -40,6 +40,7 @@ fn blurred(EditorBlurred(editor): &EditorBlurred, cx: &mut AppContext) {
             if let Some(previous_editor) = vim.active_editor.clone() {
                 if previous_editor == editor.clone() {
                     vim.active_editor = None;
+                    vim.editor_subscription = None;
                 }
             }
 
@@ -50,10 +51,11 @@ fn blurred(EditorBlurred(editor): &EditorBlurred, cx: &mut AppContext) {
 
 fn released(EditorReleased(editor): &EditorReleased, cx: &mut AppContext) {
     editor.window().update(cx, |cx| {
-        cx.update_default_global(|vim: &mut Vim, _| {
+        Vim::update(cx, |vim, _| {
             if let Some(previous_editor) = vim.active_editor.clone() {
                 if previous_editor == editor.clone() {
                     vim.active_editor = None;
+                    vim.editor_subscription = None;
                 }
             }
             vim.editor_states.remove(&editor.id())

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -54,6 +54,7 @@ enum VimEvent {
 }
 
 pub fn init(cx: &mut AppContext) {
+    cx.set_global(Vim::default());
     settings::register::<VimModeSetting>(cx);
 
     editor_events::init(cx);
@@ -90,11 +91,11 @@ pub fn init(cx: &mut AppContext) {
     cx.update_default_global::<CommandPaletteFilter, _, _>(|filter, _| {
         filter.filtered_namespaces.insert("vim");
     });
-    cx.update_default_global(|vim: &mut Vim, cx: &mut AppContext| {
+    cx.update_global(|vim: &mut Vim, cx: &mut AppContext| {
         vim.set_enabled(settings::get::<VimModeSetting>(cx).0, cx)
     });
     cx.observe_global::<SettingsStore, _>(|cx| {
-        cx.update_default_global(|vim: &mut Vim, cx: &mut AppContext| {
+        cx.update_global(|vim: &mut Vim, cx: &mut AppContext| {
             vim.set_enabled(settings::get::<VimModeSetting>(cx).0, cx)
         });
     })
@@ -159,7 +160,7 @@ impl Vim {
     where
         F: FnOnce(&mut Self, &mut WindowContext) -> S,
     {
-        cx.update_default_global(update)
+        cx.update_global(update)
     }
 
     fn set_active_editor(&mut self, editor: ViewHandle<Editor>, cx: &mut WindowContext) {


### PR DESCRIPTION
This should have no user-visible impact, but tidies up one of the awkwardnesses
of how vim uses global state at the moment.

Co-Authored-By: Max Brunsfeld <maxbrunsfeld@gmail.com>
