### PR TITLE
Add a way to display unrelated to language support language servers' logs

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -277,7 +277,7 @@ pub struct Copilot {
 }
 
 pub enum Event {
-    CopilotReady,
+    CopilotLanguageServerStarted,
 }
 
 impl Entity for Copilot {
@@ -431,6 +431,7 @@ impl Copilot {
                             sign_in_status: SignInStatus::SignedOut,
                             registered_buffers: Default::default(),
                         });
+                        cx.emit(Event::CopilotLanguageServerStarted);
                         this.update_sign_in_status(status, cx);
                     }
                     Err(error) => {
@@ -873,7 +874,6 @@ impl Copilot {
                             self.register_buffer(&buffer, cx);
                         }
                     }
-                    cx.emit(Event::CopilotReady);
                 }
                 request::SignInStatus::NotAuthorized { .. } => {
                     server.sign_in_status = SignInStatus::Unauthorized;

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -572,6 +572,14 @@ impl Copilot {
         cx.foreground().spawn(start_task)
     }
 
+    pub fn language_server(&self) -> Option<&Arc<LanguageServer>> {
+        if let CopilotServer::Running(server) = &self.server {
+            Some(&server.lsp)
+        } else {
+            None
+        }
+    }
+
     pub fn register_buffer(&mut self, buffer: &ModelHandle<Buffer>, cx: &mut ModelContext<Self>) {
         let weak_buffer = buffer.downgrade();
         self.buffers.insert(weak_buffer.clone());

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -11,8 +11,8 @@ use gpui::{
 };
 use language::{
     language_settings::{all_language_settings, language_settings},
-    point_from_lsp, point_to_lsp, Anchor, Bias, Buffer, BufferSnapshot, Language, PointUtf16,
-    ToPointUtf16,
+    point_from_lsp, point_to_lsp, Anchor, Bias, Buffer, BufferSnapshot, Language,
+    LanguageServerName, PointUtf16, ToPointUtf16,
 };
 use log::{debug, error};
 use lsp::{LanguageServer, LanguageServerBinary, LanguageServerId};
@@ -130,6 +130,7 @@ impl CopilotServer {
 }
 
 struct RunningCopilotServer {
+    name: LanguageServerName,
     lsp: Arc<LanguageServer>,
     sign_in_status: SignInStatus,
     registered_buffers: HashMap<usize, RegisteredBuffer>,
@@ -361,6 +362,7 @@ impl Copilot {
             http: http.clone(),
             node_runtime,
             server: CopilotServer::Running(RunningCopilotServer {
+                name: LanguageServerName(Arc::from("copilot")),
                 lsp: Arc::new(server),
                 sign_in_status: SignInStatus::Authorized,
                 registered_buffers: Default::default(),
@@ -439,6 +441,7 @@ impl Copilot {
                 match server {
                     Ok((server, status)) => {
                         this.server = CopilotServer::Running(RunningCopilotServer {
+                            name: LanguageServerName(Arc::from("copilot")),
                             lsp: server,
                             sign_in_status: SignInStatus::SignedOut,
                             registered_buffers: Default::default(),
@@ -576,9 +579,9 @@ impl Copilot {
         cx.foreground().spawn(start_task)
     }
 
-    pub fn language_server(&self) -> Option<&Arc<LanguageServer>> {
+    pub fn language_server(&self) -> Option<(&LanguageServerName, &Arc<LanguageServer>)> {
         if let CopilotServer::Running(server) = &self.server {
-            Some(&server.lsp)
+            Some((&server.name, &server.lsp))
         } else {
             None
         }

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -14,10 +14,9 @@ use language::{
     point_from_lsp, point_to_lsp, Anchor, Bias, Buffer, BufferSnapshot, Language,
     LanguageServerName, PointUtf16, ToPointUtf16,
 };
-use log::{debug, error};
 use lsp::{LanguageServer, LanguageServerBinary, LanguageServerId};
 use node_runtime::NodeRuntime;
-use request::{LogMessage, StatusNotification};
+use request::StatusNotification;
 use settings::SettingsStore;
 use smol::{fs, io::BufReader, stream::StreamExt};
 use std::{
@@ -390,20 +389,6 @@ impl Copilot {
                 };
                 let server =
                     LanguageServer::new(new_server_id, binary, Path::new("/"), None, cx.clone())?;
-
-                server
-                    .on_notification::<LogMessage, _>(|params, _cx| {
-                        match params.level {
-                            // Copilot is pretty aggressive about logging
-                            0 => debug!("copilot: {}", params.message),
-                            1 => debug!("copilot: {}", params.message),
-                            _ => error!("copilot: {}", params.message),
-                        }
-
-                        debug!("copilot metadata: {}", params.metadata_str);
-                        debug!("copilot extra: {:?}", params.extra);
-                    })
-                    .detach();
 
                 server
                     .on_notification::<StatusNotification, _>(

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -276,8 +276,12 @@ pub struct Copilot {
     server_id: LanguageServerId,
 }
 
+pub enum Event {
+    CopilotReady,
+}
+
 impl Entity for Copilot {
-    type Event = ();
+    type Event = Event;
 
     fn app_will_quit(
         &mut self,
@@ -881,6 +885,7 @@ impl Copilot {
                             self.register_buffer(&buffer, cx);
                         }
                     }
+                    cx.emit(Event::CopilotReady);
                 }
                 request::SignInStatus::NotAuthorized { .. } => {
                     server.sign_in_status = SignInStatus::Unauthorized;

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1018,6 +1018,10 @@ impl LanguageRegistry {
                 .log_err();
         })
     }
+
+    pub fn next_language_server_id(&self) -> LanguageServerId {
+        self.state.write().next_language_server_id()
+    }
 }
 
 impl LanguageRegistryState {

--- a/crates/language_tools/src/lsp_log_tests.rs
+++ b/crates/language_tools/src/lsp_log_tests.rs
@@ -77,7 +77,14 @@ async fn test_lsp_logs(cx: &mut TestAppContext) {
             &[LogMenuItem {
                 server_id: language_server.server.server_id(),
                 server_name: LanguageServerName("the-rust-language-server".into()),
-                worktree: project.read(cx).worktrees(cx).next().unwrap(),
+                worktree_root_name: project
+                    .read(cx)
+                    .worktrees(cx)
+                    .next()
+                    .unwrap()
+                    .read(cx)
+                    .root_name()
+                    .to_string(),
                 rpc_trace_enabled: false,
                 rpc_trace_selected: false,
                 logs_selected: true,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -8038,7 +8038,7 @@ fn subscribe_for_copilot_events(
     cx.subscribe(
         copilot,
         |project, copilot, copilot_event, cx| match copilot_event {
-            copilot::Event::CopilotReady => {
+            copilot::Event::CopilotLanguageServerStarted => {
                 if let Some((name, copilot_server)) = copilot.read(cx).language_server() {
                     let new_server_id = copilot_server.server_id();
                     if let hash_map::Entry::Vacant(v) =

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2790,18 +2790,6 @@ impl Project {
         };
 
         language_server
-            .on_notification::<lsp::notification::LogMessage, _>({
-                move |params, mut cx| {
-                    if let Some(this) = this.upgrade(&cx) {
-                        this.update(&mut cx, |_, cx| {
-                            cx.emit(Event::LanguageServerLog(server_id, params.message))
-                        });
-                    }
-                }
-            })
-            .detach();
-
-        language_server
             .on_notification::<lsp::notification::PublishDiagnostics, _>({
                 let adapter = adapter.clone();
                 move |mut params, mut cx| {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -129,6 +129,7 @@ fn main() {
 
         let client = client::Client::new(http.clone(), cx);
         let mut languages = LanguageRegistry::new(login_shell_env_loaded);
+        let copilot_language_server_id = languages.next_language_server_id();
         languages.set_executor(cx.background().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());
         let languages = Arc::new(languages);
@@ -159,7 +160,7 @@ fn main() {
         semantic_index::init(fs.clone(), http.clone(), languages.clone(), cx);
         vim::init(cx);
         terminal_view::init(cx);
-        copilot::init(http.clone(), node_runtime, cx);
+        copilot::init(copilot_language_server_id, http.clone(), node_runtime, cx);
         ai::init(cx);
         component_test::init(cx);
 


### PR DESCRIPTION
Copilot is being used in every buffer, but we do not see its logs that easily.
In the future, prettier wrapper will pretend to be an LSP server, it is better to log its messages somewhere, so prepare an infrastructure for that.

<img width="1727" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/d31a257c-9608-46fa-8be1-f0a2a2bdbdb7">

Copilot seem to have no rpc messages logged for some reason now, prettier wrapper might be a better case to investigate this, so leaving as is.

Release Notes:

- N/A
