### PR TITLE
Keyboard navigation and setting persistence for project search

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -248,7 +248,10 @@
     "context": "ProjectSearchBar",
     "bindings": {
       "escape": "project_search::ToggleFocus",
-      "alt-tab": "search::CycleMode"
+      "alt-tab": "search::CycleMode",
+      "alt-cmd-g": "search::ActivateRegexMode",
+      "alt-cmd-s": "search::ActivateSemanticMode",
+      "alt-cmd-x": "search::ActivateTextMode"
     }
   },
   {
@@ -262,7 +265,10 @@
     "context": "ProjectSearchView",
     "bindings": {
       "escape": "project_search::ToggleFocus",
-      "alt-tab": "search::CycleMode"
+      "alt-tab": "search::CycleMode",
+      "alt-cmd-g": "search::ActivateRegexMode",
+      "alt-cmd-s": "search::ActivateSemanticMode",
+      "alt-cmd-x": "search::ActivateTextMode"
     }
   },
   {
@@ -275,7 +281,10 @@
       "alt-cmd-c": "search::ToggleCaseSensitive",
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-tab": "search::CycleMode",
-      "alt-cmd-f": "project_search::ToggleFilters"
+      "alt-cmd-f": "project_search::ToggleFilters",
+      "alt-cmd-g": "search::ActivateRegexMode",
+      "alt-cmd-s": "search::ActivateSemanticMode",
+      "alt-cmd-x": "search::ActivateTextMode"
     }
   },
   // Bindings from VS Code

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -370,8 +370,7 @@
   },
   // Difference settings for semantic_index
   "semantic_index": {
-    "enabled": false,
-    "reindexing_delay_seconds": 600
+    "enabled": false
   },
   // Different settings for specific languages.
   "languages": {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -71,9 +71,9 @@ pub fn init(cx: &mut AppContext) {
     cx.add_action(ProjectSearchBar::activate_text_mode);
 
     // This action should only be registered if the semantic index is enabled
-    if SemanticIndex::enabled(cx) {
-        cx.add_action(ProjectSearchBar::activate_semantic_mode);
-    }
+    // We are registering it all the time, as I dont want to introduce a dependency
+    // for Semantic Index Settings globally whenever search is tested.
+    cx.add_action(ProjectSearchBar::activate_semantic_mode);
 
     cx.capture_action(ProjectSearchBar::tab);
     cx.capture_action(ProjectSearchBar::tab_previous);
@@ -1449,15 +1449,17 @@ impl ProjectSearchBar {
         _: &ActivateSemanticMode,
         cx: &mut ViewContext<Pane>,
     ) {
-        if let Some(search_view) = pane
-            .active_item()
-            .and_then(|item| item.downcast::<ProjectSearchView>())
-        {
-            search_view.update(cx, |view, cx| {
-                view.activate_search_mode(SearchMode::Semantic, cx)
-            });
-        } else {
-            cx.propagate_action();
+        if SemanticIndex::enabled(cx) {
+            if let Some(search_view) = pane
+                .active_item()
+                .and_then(|item| item.downcast::<ProjectSearchView>())
+            {
+                search_view.update(cx, |view, cx| {
+                    view.activate_search_mode(SearchMode::Semantic, cx)
+                });
+            } else {
+                cx.propagate_action();
+            }
         }
     }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2,8 +2,9 @@ use crate::{
     history::SearchHistory,
     mode::{SearchMode, Side},
     search_bar::{render_nav_button, render_option_button_icon, render_search_mode_button},
-    ActivateRegexMode, ActivateSemanticMode, CycleMode, NextHistoryQuery, PreviousHistoryQuery,
-    SearchOptions, SelectNextMatch, SelectPrevMatch, ToggleCaseSensitive, ToggleWholeWord,
+    ActivateRegexMode, ActivateSemanticMode, ActivateTextMode, CycleMode, NextHistoryQuery,
+    PreviousHistoryQuery, SearchOptions, SelectNextMatch, SelectPrevMatch, ToggleCaseSensitive,
+    ToggleWholeWord,
 };
 use anyhow::{Context, Result};
 use collections::HashMap;
@@ -63,6 +64,7 @@ pub fn init(cx: &mut AppContext) {
     cx.add_action(ProjectSearchBar::next_history_query);
     cx.add_action(ProjectSearchBar::previous_history_query);
     cx.add_action(ProjectSearchBar::activate_regex_mode);
+    cx.add_action(ProjectSearchBar::activate_text_mode);
 
     // This action should only be registered if the semantic index is enabled
     if SemanticIndex::enabled(cx) {
@@ -1338,6 +1340,19 @@ impl ProjectSearchBar {
             true
         } else {
             false
+        }
+    }
+
+    fn activate_text_mode(pane: &mut Pane, _: &ActivateTextMode, cx: &mut ViewContext<Pane>) {
+        if let Some(search_view) = pane
+            .active_item()
+            .and_then(|item| item.downcast::<ProjectSearchView>())
+        {
+            search_view.update(cx, |view, cx| {
+                view.activate_search_mode(SearchMode::Text, cx)
+            });
+        } else {
+            cx.propagate_action();
         }
     }
 

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -39,7 +39,7 @@ actions!(
         ActivateSemanticMode,
         ActivateRegexMode,
         ReplaceAll,
-        ReplaceNext
+        ReplaceNext,
     ]
 );
 

--- a/crates/semantic_index/src/semantic_index_settings.rs
+++ b/crates/semantic_index/src/semantic_index_settings.rs
@@ -6,13 +6,11 @@ use settings::Setting;
 #[derive(Deserialize, Debug)]
 pub struct SemanticIndexSettings {
     pub enabled: bool,
-    pub reindexing_delay_seconds: usize,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct SemanticIndexSettingsContent {
     pub enabled: Option<bool>,
-    pub reindexing_delay_seconds: Option<usize>,
 }
 
 impl Setting for SemanticIndexSettings {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -156,8 +156,8 @@ fn main() {
         project_panel::init(Assets, cx);
         channel::init(&client);
         diagnostics::init(cx);
-        semantic_index::init(fs.clone(), http.clone(), languages.clone(), cx);
         search::init(cx);
+        semantic_index::init(fs.clone(), http.clone(), languages.clone(), cx);
         vim::init(cx);
         terminal_view::init(cx);
         copilot::init(copilot_language_server_id, http.clone(), node_runtime, cx);

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -156,8 +156,8 @@ fn main() {
         project_panel::init(Assets, cx);
         channel::init(&client);
         diagnostics::init(cx);
-        search::init(cx);
         semantic_index::init(fs.clone(), http.clone(), languages.clone(), cx);
+        search::init(cx);
         vim::init(cx);
         terminal_view::init(cx);
         copilot::init(copilot_language_server_id, http.clone(), node_runtime, cx);


### PR DESCRIPTION
Enable keyboard shortcuts for Project Search modes, and ensure project search settings are persisted search to search.

Release Notes:

- Added alt-cmd-s to Toggle Semantic Search Mode
- Added alt-cmd-g to Toggle Regex Search Mode
- Added alt-cmd-x to Toggle Text Search Mode
- Defaulted new project searches to using last used search mode and settings.
