### PR TITLE
Fix vim panic when over-shooting with j

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -533,7 +533,7 @@ fn down(
 
     let new_row = cmp::min(
         start.row() + times as u32,
-        map.buffer_snapshot.max_point().row,
+        map.fold_snapshot.max_point().row(),
     );
     let new_col = cmp::min(goal_column, map.fold_snapshot.line_len(new_row));
     let point = map.fold_point_to_display_point(

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -576,6 +576,26 @@ async fn test_folds(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_folds_panic(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+    cx.set_neovim_option("foldmethod=manual").await;
+
+    cx.set_shared_state(indoc! { "
+        fn boop() {
+          ˇbarp()
+          bazp()
+        }
+    "})
+        .await;
+    cx.simulate_shared_keystrokes(["shift-v", "j", "z", "f"])
+        .await;
+    cx.simulate_shared_keystrokes(["escape"]).await;
+    cx.simulate_shared_keystrokes(["g", "g"]).await;
+    cx.simulate_shared_keystrokes(["5", "d", "j"]).await;
+    cx.assert_shared_state(indoc! { "ˇ"}).await;
+}
+
+#[gpui::test]
 async fn test_clear_counts(cx: &mut gpui::TestAppContext) {
     let mut cx = NeovimBackedTestContext::new(cx).await;
 

--- a/crates/vim/test_data/test_folds_panic.json
+++ b/crates/vim/test_data/test_folds_panic.json
@@ -1,0 +1,12 @@
+{"SetOption":{"value":"foldmethod=manual"}}
+{"Put":{"state":"fn boop() {\n  ˇbarp()\n  bazp()\n}\n"}}
+{"Key":"shift-v"}
+{"Key":"j"}
+{"Key":"z"}
+{"Key":"f"}
+{"Key":"escape"}
+{"Key":"g"}
+{"Key":"g"}
+{"Key":"5"}
+{"Key":"d"}
+{"Key":"j"}

--- a/crates/vim/test_data/test_folds_panic.json
+++ b/crates/vim/test_data/test_folds_panic.json
@@ -10,3 +10,4 @@
 {"Key":"5"}
 {"Key":"d"}
 {"Key":"j"}
+{"Get":{"state":"ˇ","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:

- vim: fix a panic when using `j` to go beyond end of file
