### PR TITLE
Fix select all bugs

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -303,7 +303,7 @@
           "replace_newest": false
         }
       ],
-      "cmd-shift-d": "editor::SelectAllMatches",
+      "cmd-shift-l": "editor::SelectAllMatches",
       "ctrl-cmd-d": [
         "editor::SelectPrevious",
         {
@@ -463,7 +463,7 @@
     "context": "Editor",
     "bindings": {
       "ctrl-shift-k": "editor::DeleteLine",
-      "cmd-shift-l": "editor::SplitSelectionIntoLines",
+      "cmd-shift-d": "editor::DuplicateLine",
       "ctrl-j": "editor::JoinLines",
       "ctrl-cmd-up": "editor::MoveLineUp",
       "ctrl-cmd-down": "editor::MoveLineDown",

--- a/assets/keymaps/sublime_text.json
+++ b/assets/keymaps/sublime_text.json
@@ -17,6 +17,7 @@
       "ctrl-shift-down": "editor::AddSelectionBelow",
       "cmd-shift-space": "editor::SelectAll",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
+      "cmd-shift-l": "editor::SplitSelectionIntoLines",
       "cmd-shift-a": "editor::SelectLargerSyntaxNode",
       "shift-f12": "editor::FindAllReferences",
       "alt-cmd-down": "editor::GoToDefinition",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6048,10 +6048,12 @@ impl Editor {
                 let query = buffer
                     .text_for_range(selection.start..selection.end)
                     .collect::<String>();
+
+                let is_empty = query.is_empty();
                 let select_state = SelectNextState {
                     query: AhoCorasick::new(&[query])?,
                     wordwise: true,
-                    done: false,
+                    done: is_empty,
                 };
                 select_next_match_ranges(
                     self,


### PR DESCRIPTION
Release Notes:

- Restore `cmd-shift-d` as `editor::DuplicateLine` and move `editor::SelectAllMatches` to `cmd-shift-L`, like in VS Code. The previous action for `cmd-shift-l`, `editor::SplitSelectionIntoLines`, has been moved to the sublime base keymap.
- Fixes a panic when using 'editor::SelectAllMatches'  on an empty line.