### PR TITLE
Supplementary LSP server log improvements

### DIFF
--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -647,6 +647,7 @@ impl View for LspLogToolbarItemView {
                     Overlay::new(
                         MouseEventHandler::new::<Menu, _>(0, cx, move |_, cx| {
                             Flex::column()
+                                .scrollable::<Self>(0, None, cx)
                                 .with_children(menu_rows.into_iter().map(|row| {
                                     Self::render_language_server_menu_item(
                                         row.server_id,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7968,7 +7968,7 @@ impl Project {
     }
 
     pub fn language_server_for_id(&self, id: LanguageServerId) -> Option<Arc<LanguageServer>> {
-        if let LanguageServerState::Running { server, .. } = self.language_servers.get(&id)? {
+        if let Some(LanguageServerState::Running { server, .. }) = self.language_servers.get(&id) {
             Some(server.clone())
         } else if let Some((_, server)) = self.supplementary_language_servers.get(&id) {
             Some(Arc::clone(server))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -8039,11 +8039,9 @@ fn subscribe_for_copilot_events(
         copilot,
         |project, copilot, copilot_event, cx| match copilot_event {
             copilot::Event::CopilotLanguageServerStarted => {
-                if let Some((name, copilot_server)) = copilot.read(cx).language_server() {
-                    let new_server_id = copilot_server.server_id();
-                    if let hash_map::Entry::Vacant(v) =
-                        project.supplementary_language_servers.entry(new_server_id)
-                    {
+                match copilot.read(cx).language_server() {
+                    Some((name, copilot_server)) => {
+                        let new_server_id = copilot_server.server_id();
                         let weak_project = cx.weak_handle();
                         let copilot_log_subscription = copilot_server
                             .on_notification::<copilot::request::LogMessage, _>(
@@ -8058,10 +8056,11 @@ fn subscribe_for_copilot_events(
                                     }
                                 },
                             );
+                        project.supplementary_language_servers.insert(new_server_id, (name.clone(), Arc::clone(copilot_server)));
                         project.copilot_log_subscription = Some(copilot_log_subscription);
-                        v.insert((name.clone(), Arc::clone(copilot_server)));
                         cx.emit(Event::LanguageServerAdded(new_server_id));
                     }
+                    None => debug_panic!("Received Copilot language server started event, but no language server is running"),
                 }
             }
         },


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/2991 improving rough edges around supplementary LSP servers:

* Fixes https://zed-industries.slack.com/archives/C04S6T1T7TQ/p1695281196667609 Copilot init panic
* Makes LSP server list scrollable in the panel
* Shows supplementary servers' RPC logs in the panel

Release Notes:

- N/A
