### PR TITLE
Correct icon_margin_scale for fold indicator

### DIFF
--- a/styles/src/style_tree/editor.ts
+++ b/styles/src/style_tree/editor.ts
@@ -91,7 +91,7 @@ export default function editor(): any {
             vertical_scale: 0.55,
         },
         folds: {
-            icon_margin_scale: 2.5,
+            icon_margin_scale: 4,
             folded_icon: "icons/chevron_right.svg",
             foldable_icon: "icons/chevron_down.svg",
             indicator: toggleable({


### PR DESCRIPTION
Fixes a design regression on Preview where the fold icon became small due to the icon standardization PR. 

Release Notes:

- [Preview] Fixed an issue with the size of the fold line icon.