### PR TITLE
Reorganize `ui` module exports

### DIFF
--- a/crates/storybook/src/ui.rs
+++ b/crates/storybook/src/ui.rs
@@ -1,23 +1,7 @@
-mod element;
-pub use element::avatar::*;
-pub use element::details::*;
-pub use element::icon::*;
-pub use element::icon_button::*;
-pub use element::indicator::*;
-pub use element::input::*;
-pub use element::label::*;
-pub use element::text_button::*;
-pub use element::tool_divider::*;
-
 mod component;
-pub use component::facepile::*;
-pub use component::follow_group::*;
-pub use component::list_item::*;
-pub use component::tab::*;
-
+mod element;
 mod module;
-pub use module::chat_panel::*;
-pub use module::project_panel::*;
-pub use module::status_bar::*;
-pub use module::tab_bar::*;
-pub use module::title_bar::*;
+
+pub use component::*;
+pub use element::*;
+pub use module::*;

--- a/crates/storybook/src/ui/component.rs
+++ b/crates/storybook/src/ui/component.rs
@@ -1,4 +1,9 @@
-pub(crate) mod facepile;
-pub(crate) mod follow_group;
-pub(crate) mod list_item;
-pub(crate) mod tab;
+mod facepile;
+mod follow_group;
+mod list_item;
+mod tab;
+
+pub use facepile::*;
+pub use follow_group::*;
+pub use list_item::*;
+pub use tab::*;

--- a/crates/storybook/src/ui/element.rs
+++ b/crates/storybook/src/ui/element.rs
@@ -1,9 +1,19 @@
-pub(crate) mod avatar;
-pub(crate) mod details;
-pub(crate) mod icon;
-pub(crate) mod icon_button;
-pub(crate) mod indicator;
-pub(crate) mod input;
-pub(crate) mod label;
-pub(crate) mod text_button;
-pub(crate) mod tool_divider;
+mod avatar;
+mod details;
+mod icon;
+mod icon_button;
+mod indicator;
+mod input;
+mod label;
+mod text_button;
+mod tool_divider;
+
+pub use avatar::*;
+pub use details::*;
+pub use icon::*;
+pub use icon_button::*;
+pub use indicator::*;
+pub use input::*;
+pub use label::*;
+pub use text_button::*;
+pub use tool_divider::*;

--- a/crates/storybook/src/ui/module.rs
+++ b/crates/storybook/src/ui/module.rs
@@ -1,5 +1,11 @@
-pub(crate) mod chat_panel;
-pub(crate) mod project_panel;
-pub(crate) mod status_bar;
-pub(crate) mod tab_bar;
-pub(crate) mod title_bar;
+mod chat_panel;
+mod project_panel;
+mod status_bar;
+mod tab_bar;
+mod title_bar;
+
+pub use chat_panel::*;
+pub use project_panel::*;
+pub use status_bar::*;
+pub use tab_bar::*;
+pub use title_bar::*;


### PR DESCRIPTION
This PR reorganizes the exports for the `ui` module in the `storybook` crate.

### Motivation

Currently we expose each of the various elements/components/modules in two places:

- Through the module itself (e.g., `ui::element::Avatar`)
- Through the `ui` module's re-exports (e.g., `ui::Avatar`)

This means it's possible to import any given item from two spots, which can lead to inconsistencies in the consumers. Additionally, it also means we're shipping the exact module structure underneath `ui` as part of the public API.

### Explanation

To avoid this, we can avoid exposing each of the individual modules underneath `ui::{element, component, module}` and instead export just the module contents themselves.

This makes the `ui` module namespace flat.

Release Notes:

- N/A

