### PR TITLE
Update storybook to support stories for individual components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7390,6 +7390,7 @@ name = "storybook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 3.2.25",
  "gpui2",
  "log",
  "rust-embed",

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -9,8 +9,9 @@ name = "storybook"
 path = "src/storybook.rs"
 
 [dependencies]
-gpui2 = { path = "../gpui2" }
 anyhow.workspace = true
+clap = { version = "3.1", features = ["derive"] }
+gpui2 = { path = "../gpui2" }
 log.workspace = true
 rust-embed.workspace = true
 serde.workspace = true

--- a/crates/storybook/src/stories.rs
+++ b/crates/storybook/src/stories.rs
@@ -1,0 +1,1 @@
+pub mod elements;

--- a/crates/storybook/src/stories.rs
+++ b/crates/storybook/src/stories.rs
@@ -1,1 +1,2 @@
+pub mod components;
 pub mod elements;

--- a/crates/storybook/src/stories/components.rs
+++ b/crates/storybook/src/stories/components.rs
@@ -1,0 +1,1 @@
+pub mod facepile;

--- a/crates/storybook/src/stories/components/facepile.rs
+++ b/crates/storybook/src/stories/components/facepile.rs
@@ -1,0 +1,69 @@
+use gpui2::elements::div;
+use gpui2::style::StyleHelpers;
+use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
+use ui::{avatar, theme};
+use ui::{facepile, prelude::*};
+
+#[derive(Element, Default)]
+pub struct FacepileStory {}
+
+impl FacepileStory {
+    fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        let theme = theme(cx);
+
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .pt_2()
+            .px_4()
+            .font("Zed Mono Extended")
+            .fill(rgb::<Hsla>(0x282c34))
+            .child(
+                div()
+                    .text_2xl()
+                    .text_color(rgb::<Hsla>(0xffffff))
+                    .child(std::any::type_name::<ui::Facepile>()),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(facepile(vec![avatar(
+                        "https://avatars.githubusercontent.com/u/1714999?v=4",
+                    )]))
+                    .child(facepile(vec![
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4"),
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4"),
+                    ]))
+                    .child(facepile(vec![
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4"),
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4"),
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4"),
+                    ])),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(facepile(vec![avatar(
+                        "https://avatars.githubusercontent.com/u/1714999?v=4",
+                    )
+                    .shape(Shape::RoundedRectangle)]))
+                    .child(facepile(vec![
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4")
+                            .shape(Shape::RoundedRectangle),
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4")
+                            .shape(Shape::RoundedRectangle),
+                    ]))
+                    .child(facepile(vec![
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4")
+                            .shape(Shape::RoundedRectangle),
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4")
+                            .shape(Shape::RoundedRectangle),
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4")
+                            .shape(Shape::RoundedRectangle),
+                    ])),
+            )
+    }
+}

--- a/crates/storybook/src/stories/elements.rs
+++ b/crates/storybook/src/stories/elements.rs
@@ -1,0 +1,1 @@
+pub mod avatar;

--- a/crates/storybook/src/stories/elements/avatar.rs
+++ b/crates/storybook/src/stories/elements/avatar.rs
@@ -17,6 +17,8 @@ impl AvatarStory {
             .flex_col()
             .pt_2()
             .px_4()
+            .font("Zed Mono Extended")
+            .fill(rgb::<Hsla>(0x282c34))
             .child(
                 div()
                     .text_2xl()

--- a/crates/storybook/src/stories/elements/avatar.rs
+++ b/crates/storybook/src/stories/elements/avatar.rs
@@ -1,6 +1,7 @@
 use gpui2::elements::div;
 use gpui2::style::StyleHelpers;
-use gpui2::{Element, IntoElement, ParentElement, ViewContext};
+use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
+use ui::prelude::*;
 use ui::{avatar, theme};
 
 #[derive(Element, Default)]
@@ -10,8 +11,29 @@ impl AvatarStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
-        div().size_full().flex().child(avatar(
-            "https://avatars.githubusercontent.com/u/1714999?v=4",
-        ))
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .pt_2()
+            .px_4()
+            .child(
+                div()
+                    .text_2xl()
+                    .text_color(rgb::<Hsla>(0xffffff))
+                    .child(std::any::type_name::<ui::Avatar>()),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(avatar(
+                        "https://avatars.githubusercontent.com/u/1714999?v=4",
+                    ))
+                    .child(
+                        avatar("https://avatars.githubusercontent.com/u/1714999?v=4")
+                            .shape(Shape::RoundedRectangle),
+                    ),
+            )
     }
 }

--- a/crates/storybook/src/stories/elements/avatar.rs
+++ b/crates/storybook/src/stories/elements/avatar.rs
@@ -1,0 +1,17 @@
+use gpui2::elements::div;
+use gpui2::style::StyleHelpers;
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
+use ui::{avatar, theme};
+
+#[derive(Element, Default)]
+pub struct AvatarStory {}
+
+impl AvatarStory {
+    fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        let theme = theme(cx);
+
+        div().size_full().flex().child(avatar(
+            "https://avatars.githubusercontent.com/u/1714999?v=4",
+        ))
+    }
+}

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -13,6 +13,7 @@ use legacy_theme::ThemeSettings;
 use log::LevelFilter;
 use settings::{default_settings, SettingsStore};
 use simplelog::SimpleLogger;
+use stories::components::facepile::FacepileStory;
 use stories::elements::avatar::AvatarStory;
 use ui::{ElementExt, Theme};
 
@@ -24,6 +25,7 @@ gpui2::actions! {
 #[derive(Debug, Clone, Copy)]
 enum Story {
     Element(ElementStory),
+    Component(ComponentStory),
 }
 
 impl FromStr for Story {
@@ -32,6 +34,7 @@ impl FromStr for Story {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
             "elements/avatar" => Ok(Self::Element(ElementStory::Avatar)),
+            "components/facepile" => Ok(Self::Component(ComponentStory::Facepile)),
             _ => Err(anyhow!("story not found for '{s}'")),
         }
     }
@@ -40,6 +43,11 @@ impl FromStr for Story {
 #[derive(Debug, Clone, Copy)]
 enum ElementStory {
     Avatar,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ComponentStory {
+    Facepile,
 }
 
 #[derive(Parser)]
@@ -70,6 +78,9 @@ fn main() {
             |cx| match args.story {
                 Some(Story::Element(ElementStory::Avatar)) => {
                     view(|cx| render_story(&mut ViewContext::new(cx), AvatarStory::default()))
+                }
+                Some(Story::Component(ComponentStory::Facepile)) => {
+                    view(|cx| render_story(&mut ViewContext::new(cx), FacepileStory::default()))
                 }
                 None => {
                     view(|cx| render_story(&mut ViewContext::new(cx), WorkspaceElement::default()))
@@ -107,7 +118,7 @@ fn current_theme<V: 'static>(cx: &mut ViewContext<V>) -> Theme {
 use anyhow::{anyhow, Result};
 use gpui2::AssetSource;
 use rust_embed::RustEmbed;
-use workspace::{workspace, WorkspaceElement};
+use workspace::WorkspaceElement;
 
 #[derive(RustEmbed)]
 #[folder = "../../assets"]

--- a/crates/storybook/src/workspace.rs
+++ b/crates/storybook/src/workspace.rs
@@ -6,7 +6,7 @@ use gpui2::{
 use ui::{chat_panel, project_panel, status_bar, tab_bar, theme, title_bar};
 
 #[derive(Element, Default)]
-struct WorkspaceElement {
+pub struct WorkspaceElement {
     left_scroll_state: ScrollState,
     right_scroll_state: ScrollState,
     tab_bar_scroll_state: ScrollState,

--- a/crates/storybook/src/workspace.rs
+++ b/crates/storybook/src/workspace.rs
@@ -12,10 +12,6 @@ pub struct WorkspaceElement {
     tab_bar_scroll_state: ScrollState,
 }
 
-pub fn workspace<V: 'static>() -> impl Element<V> {
-    WorkspaceElement::default()
-}
-
 impl WorkspaceElement {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);


### PR DESCRIPTION
This PR updates the `storybook` with support for adding stories for individual components.

### Motivation

Right now we just have one story in the storybook that renders an entire `WorkspaceElement`.

While iterating on the various UI components, it will be helpful to be able to create stories of those components just by themselves.

This is especially true for components that have a number of different states, as we can render the components in all of the various states in a single layout.

### Explanation

We achieve this by adding a simple CLI to the storybook.

The `storybook` binary now accepts an optional `[STORY]` parameter that can be used to indicate which story should be loaded. If this parameter is not provided, it will load the workspace story as it currently does.

Passing a story name will load the corresponding story, if it exists.

For example:

```
cargo run -- elements/avatar
```

<img width="723" alt="Screenshot 2023-09-21 at 10 29 52 PM" src="https://github.com/zed-industries/zed/assets/1486634/5df489ed-8607-4024-9c19-c5f4541f97c9">

```
cargo run -- components/facepile
```

<img width="785" alt="Screenshot 2023-09-21 at 10 30 07 PM" src="https://github.com/zed-industries/zed/assets/1486634/e04a4577-7403-405d-b23c-e765b7a06229">



Release Notes:

- N/A
