### PR TITLE
Factor story boilerplate out into separate components

### DIFF
--- a/crates/storybook/src/stories/components/facepile.rs
+++ b/crates/storybook/src/stories/components/facepile.rs
@@ -1,6 +1,6 @@
 use gpui2::elements::div;
 use gpui2::style::StyleHelpers;
-use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
 use ui::prelude::*;
 use ui::{avatar, facepile, theme};
 
@@ -13,14 +13,7 @@ impl FacepileStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
-        div()
-            .size_full()
-            .flex()
-            .flex_col()
-            .pt_2()
-            .px_4()
-            .font("Zed Mono Extended")
-            .fill(rgb::<Hsla>(0x282c34))
+        Story::container()
             .child(Story::title(std::any::type_name::<ui::Facepile>()))
             .child(
                 div()

--- a/crates/storybook/src/stories/components/facepile.rs
+++ b/crates/storybook/src/stories/components/facepile.rs
@@ -1,8 +1,10 @@
 use gpui2::elements::div;
 use gpui2::style::StyleHelpers;
 use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
-use ui::{avatar, theme};
-use ui::{facepile, prelude::*};
+use ui::prelude::*;
+use ui::{avatar, facepile, theme};
+
+use crate::story::Story;
 
 #[derive(Element, Default)]
 pub struct FacepileStory {}
@@ -19,12 +21,7 @@ impl FacepileStory {
             .px_4()
             .font("Zed Mono Extended")
             .fill(rgb::<Hsla>(0x282c34))
-            .child(
-                div()
-                    .text_2xl()
-                    .text_color(rgb::<Hsla>(0xffffff))
-                    .child(std::any::type_name::<ui::Facepile>()),
-            )
+            .child(Story::title(std::any::type_name::<ui::Facepile>()))
             .child(
                 div()
                     .flex()

--- a/crates/storybook/src/stories/components/traffic_lights.rs
+++ b/crates/storybook/src/stories/components/traffic_lights.rs
@@ -3,6 +3,8 @@ use gpui2::style::StyleHelpers;
 use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
 use ui::{theme, traffic_lights};
 
+use crate::story::Story;
+
 #[derive(Element, Default)]
 pub struct TrafficLightsStory {}
 
@@ -18,12 +20,7 @@ impl TrafficLightsStory {
             .px_4()
             .font("Zed Mono Extended")
             .fill(rgb::<Hsla>(0x282c34))
-            .child(
-                div()
-                    .text_2xl()
-                    .text_color(rgb::<Hsla>(0xffffff))
-                    .child(std::any::type_name::<ui::TrafficLights>()),
-            )
+            .child(Story::title(std::any::type_name::<ui::TrafficLights>()))
             .child(traffic_lights())
     }
 }

--- a/crates/storybook/src/stories/components/traffic_lights.rs
+++ b/crates/storybook/src/stories/components/traffic_lights.rs
@@ -1,6 +1,4 @@
-use gpui2::elements::div;
-use gpui2::style::StyleHelpers;
-use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
 use ui::{theme, traffic_lights};
 
 use crate::story::Story;
@@ -12,14 +10,7 @@ impl TrafficLightsStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
-        div()
-            .size_full()
-            .flex()
-            .flex_col()
-            .pt_2()
-            .px_4()
-            .font("Zed Mono Extended")
-            .fill(rgb::<Hsla>(0x282c34))
+        Story::container()
             .child(Story::title(std::any::type_name::<ui::TrafficLights>()))
             .child(traffic_lights())
     }

--- a/crates/storybook/src/stories/elements/avatar.rs
+++ b/crates/storybook/src/stories/elements/avatar.rs
@@ -4,6 +4,8 @@ use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
 use ui::prelude::*;
 use ui::{avatar, theme};
 
+use crate::story::Story;
+
 #[derive(Element, Default)]
 pub struct AvatarStory {}
 
@@ -19,12 +21,7 @@ impl AvatarStory {
             .px_4()
             .font("Zed Mono Extended")
             .fill(rgb::<Hsla>(0x282c34))
-            .child(
-                div()
-                    .text_2xl()
-                    .text_color(rgb::<Hsla>(0xffffff))
-                    .child(std::any::type_name::<ui::Avatar>()),
-            )
+            .child(Story::title(std::any::type_name::<ui::Avatar>()))
             .child(
                 div()
                     .flex()

--- a/crates/storybook/src/stories/elements/avatar.rs
+++ b/crates/storybook/src/stories/elements/avatar.rs
@@ -1,6 +1,6 @@
 use gpui2::elements::div;
 use gpui2::style::StyleHelpers;
-use gpui2::{rgb, Element, Hsla, IntoElement, ParentElement, ViewContext};
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
 use ui::prelude::*;
 use ui::{avatar, theme};
 
@@ -13,14 +13,7 @@ impl AvatarStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
-        div()
-            .size_full()
-            .flex()
-            .flex_col()
-            .pt_2()
-            .px_4()
-            .font("Zed Mono Extended")
-            .fill(rgb::<Hsla>(0x282c34))
+        Story::container()
             .child(Story::title(std::any::type_name::<ui::Avatar>()))
             .child(
                 div()

--- a/crates/storybook/src/story.rs
+++ b/crates/storybook/src/story.rs
@@ -1,0 +1,14 @@
+use gpui2::elements::div;
+use gpui2::style::StyleHelpers;
+use gpui2::{rgb, Element, Hsla, ParentElement};
+
+pub struct Story {}
+
+impl Story {
+    pub fn title<V: 'static>(title: &str) -> impl Element<V> {
+        div()
+            .text_2xl()
+            .text_color(rgb::<Hsla>(0xffffff))
+            .child(title.to_owned())
+    }
+}

--- a/crates/storybook/src/story.rs
+++ b/crates/storybook/src/story.rs
@@ -5,6 +5,17 @@ use gpui2::{rgb, Element, Hsla, ParentElement};
 pub struct Story {}
 
 impl Story {
+    pub fn container<V: 'static>() -> div::Div<V> {
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .pt_2()
+            .px_4()
+            .font("Zed Mono Extended")
+            .fill(rgb::<Hsla>(0x282c34))
+    }
+
     pub fn title<V: 'static>(title: &str) -> impl Element<V> {
         div()
             .text_2xl()

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -24,12 +24,12 @@ gpui2::actions! {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum Story {
+enum StorySelector {
     Element(ElementStory),
     Component(ComponentStory),
 }
 
-impl FromStr for Story {
+impl FromStr for StorySelector {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -55,7 +55,7 @@ enum ComponentStory {
 
 #[derive(Parser)]
 struct Args {
-    story: Option<Story>,
+    story: Option<StorySelector>,
 }
 
 fn main() {
@@ -79,13 +79,13 @@ fn main() {
                 ..Default::default()
             },
             |cx| match args.story {
-                Some(Story::Element(ElementStory::Avatar)) => {
+                Some(StorySelector::Element(ElementStory::Avatar)) => {
                     view(|cx| render_story(&mut ViewContext::new(cx), AvatarStory::default()))
                 }
-                Some(Story::Component(ComponentStory::Facepile)) => {
+                Some(StorySelector::Component(ComponentStory::Facepile)) => {
                     view(|cx| render_story(&mut ViewContext::new(cx), FacepileStory::default()))
                 }
-                Some(Story::Component(ComponentStory::TrafficLights)) => view(|cx| {
+                Some(StorySelector::Component(ComponentStory::TrafficLights)) => view(|cx| {
                     render_story(&mut ViewContext::new(cx), TrafficLightsStory::default())
                 }),
                 None => {

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -2,6 +2,7 @@
 
 mod collab_panel;
 mod stories;
+mod story;
 mod workspace;
 
 use std::str::FromStr;


### PR DESCRIPTION
This PR factors out the bulk of the boilerplate required to setup a story in the storybook out into separate components.

The pattern we're using here is adapted from the "[associated component](https://maxdeviant.com/posts/2021/react-associated-components/)" pattern in React.

Release Notes:

- N/A
