### PR TITLE
Put `Theme` behind an `Arc`

### DIFF
--- a/crates/storybook/src/collab_panel.rs
+++ b/crates/storybook/src/collab_panel.rs
@@ -52,12 +52,12 @@ impl<V: 'static> CollabPanelElement<V> {
                             //:: https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state
                             // .group()
                             // List Section Header
-                            .child(self.list_section_header("#CRDB", true, theme))
+                            .child(self.list_section_header("#CRDB", true, &theme))
                             // List Item Large
                             .child(self.list_item(
                                 "http://github.com/maxbrunsfeld.png?s=50",
                                 "maxbrunsfeld",
-                                theme,
+                                &theme,
                             )),
                     )
                     .child(
@@ -65,31 +65,31 @@ impl<V: 'static> CollabPanelElement<V> {
                             .py_2()
                             .flex()
                             .flex_col()
-                            .child(self.list_section_header("CHANNELS", true, theme)),
+                            .child(self.list_section_header("CHANNELS", true, &theme)),
                     )
                     .child(
                         div()
                             .py_2()
                             .flex()
                             .flex_col()
-                            .child(self.list_section_header("CONTACTS", true, theme))
+                            .child(self.list_section_header("CONTACTS", true, &theme))
                             .children(
                                 std::iter::repeat_with(|| {
                                     vec![
                                         self.list_item(
                                             "http://github.com/as-cii.png?s=50",
                                             "as-cii",
-                                            theme,
+                                            &theme,
                                         ),
                                         self.list_item(
                                             "http://github.com/nathansobo.png?s=50",
                                             "nathansobo",
-                                            theme,
+                                            &theme,
                                         ),
                                         self.list_item(
                                             "http://github.com/maxbrunsfeld.png?s=50",
                                             "maxbrunsfeld",
-                                            theme,
+                                            &theme,
                                         ),
                                     ]
                                 })

--- a/crates/ui/src/templates/collab_panel.rs
+++ b/crates/ui/src/templates/collab_panel.rs
@@ -52,12 +52,12 @@ impl<V: 'static> CollabPanelElement<V> {
                             //:: https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state
                             // .group()
                             // List Section Header
-                            .child(self.list_section_header("#CRDB", true, theme))
+                            .child(self.list_section_header("#CRDB", true, &theme))
                             // List Item Large
                             .child(self.list_item(
                                 "http://github.com/maxbrunsfeld.png?s=50",
                                 "maxbrunsfeld",
-                                theme,
+                                &theme,
                             )),
                     )
                     .child(
@@ -65,31 +65,31 @@ impl<V: 'static> CollabPanelElement<V> {
                             .py_2()
                             .flex()
                             .flex_col()
-                            .child(self.list_section_header("CHANNELS", true, theme)),
+                            .child(self.list_section_header("CHANNELS", true, &theme)),
                     )
                     .child(
                         div()
                             .py_2()
                             .flex()
                             .flex_col()
-                            .child(self.list_section_header("CONTACTS", true, theme))
+                            .child(self.list_section_header("CONTACTS", true, &theme))
                             .children(
                                 std::iter::repeat_with(|| {
                                     vec![
                                         self.list_item(
                                             "http://github.com/as-cii.png?s=50",
                                             "as-cii",
-                                            theme,
+                                            &theme,
                                         ),
                                         self.list_item(
                                             "http://github.com/nathansobo.png?s=50",
                                             "nathansobo",
-                                            theme,
+                                            &theme,
                                         ),
                                         self.list_item(
                                             "http://github.com/maxbrunsfeld.png?s=50",
                                             "maxbrunsfeld",
-                                            theme,
+                                            &theme,
                                         ),
                                     ]
                                 })

--- a/crates/ui/src/templates/status_bar.rs
+++ b/crates/ui/src/templates/status_bar.rs
@@ -96,8 +96,8 @@ impl<V: 'static> StatusBar<V> {
             .justify_between()
             .w_full()
             .fill(theme.lowest.base.default.background)
-            .child(self.left_tools(theme))
-            .child(self.right_tools(theme))
+            .child(self.left_tools(&theme))
+            .child(self.right_tools(&theme))
     }
 
     fn left_tools(&self, theme: &Theme) -> impl Element<V> {

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use gpui2::color::Hsla;
 use gpui2::element::Element;
@@ -190,6 +191,6 @@ fn preferred_theme<V: 'static>(cx: &AppContext) -> Theme {
         .clone()
 }
 
-pub fn theme<'a>(cx: &'a WindowContext) -> &'a Theme {
+pub fn theme(cx: &WindowContext) -> Arc<Theme> {
     cx.theme::<Theme>()
 }


### PR DESCRIPTION
This PR puts the `Theme` returned from the `theme` function behind an `Arc`.

### Motivation

While working on wiring up window focus events for the `TitleBar` component we ran into issues where `theme` was holding an immutable borrow to the `ViewContext` for the entirety of the `render` scope, which prevented having mutable borrows in the same scope.

### Explanation

To avoid this, we can make `theme` return an `Arc<Theme>` to allow for cheap clones and avoiding the issues with the borrow checker.

Release Notes:

- N/A