### PR TITLE
Remove manual mapping in `FromStr` implementation for `StorySelector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7381,6 +7381,7 @@ dependencies = [
  "serde",
  "settings",
  "simplelog",
+ "strum",
  "theme",
  "ui",
  "util",
@@ -7402,6 +7403,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "subtle"

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -17,6 +17,7 @@ rust-embed.workspace = true
 serde.workspace = true
 settings = { path = "../settings" }
 simplelog = "0.9"
+strum = { version = "0.25.0", features = ["derive"] }
 theme = { path = "../theme" }
 ui = { path = "../ui" }
 util = { path = "../util" }


### PR DESCRIPTION
This PR removes the need for writing manual mappings in the `FromStr` implementation for the `StorySelector` enum used in the storybook CLI.

We are now using the [`EnumString`](https://docs.rs/strum/0.25.0/strum/derive.EnumString.html) trait from `strum` to automatically derive snake_cased names for the enums.

This will cut down on some of the manual work needed to wire up more stories to the storybook.

Release Notes:

- N/A
