### PR TITLE
Scaffold `Toolbar` and `Breadcrumb` components

### DIFF
--- a/crates/storybook/src/stories/components.rs
+++ b/crates/storybook/src/stories/components.rs
@@ -1,3 +1,4 @@
+pub mod breadcrumb;
 pub mod facepile;
 pub mod toolbar;
 pub mod traffic_lights;

--- a/crates/storybook/src/stories/components.rs
+++ b/crates/storybook/src/stories/components.rs
@@ -1,2 +1,3 @@
 pub mod facepile;
+pub mod toolbar;
 pub mod traffic_lights;

--- a/crates/storybook/src/stories/components/breadcrumb.rs
+++ b/crates/storybook/src/stories/components/breadcrumb.rs
@@ -1,0 +1,16 @@
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
+use ui::breadcrumb;
+
+use crate::story::Story;
+
+#[derive(Element, Default)]
+pub struct BreadcrumbStory {}
+
+impl BreadcrumbStory {
+    fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        Story::container()
+            .child(Story::title_for::<_, ui::Breadcrumb>())
+            .child(Story::label("Default"))
+            .child(breadcrumb())
+    }
+}

--- a/crates/storybook/src/stories/components/toolbar.rs
+++ b/crates/storybook/src/stories/components/toolbar.rs
@@ -1,8 +1,7 @@
 use gpui2::elements::div;
 use gpui2::style::StyleHelpers;
 use gpui2::{Element, IntoElement, ParentElement, ViewContext};
-use ui::prelude::*;
-use ui::{avatar, facepile, theme};
+use ui::{prelude::*, toolbar};
 
 use crate::story::Story;
 
@@ -11,6 +10,8 @@ pub struct ToolbarStory {}
 
 impl ToolbarStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
-        Story::container().child(Story::title_for::<_, ui::Toolbar>())
+        Story::container()
+            .child(Story::title_for::<_, ui::Toolbar>())
+            .child(toolbar())
     }
 }

--- a/crates/storybook/src/stories/components/toolbar.rs
+++ b/crates/storybook/src/stories/components/toolbar.rs
@@ -1,0 +1,16 @@
+use gpui2::elements::div;
+use gpui2::style::StyleHelpers;
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
+use ui::prelude::*;
+use ui::{avatar, facepile, theme};
+
+use crate::story::Story;
+
+#[derive(Element, Default)]
+pub struct ToolbarStory {}
+
+impl ToolbarStory {
+    fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        Story::container().child(Story::title_for::<_, ui::Toolbar>())
+    }
+}

--- a/crates/storybook/src/stories/components/toolbar.rs
+++ b/crates/storybook/src/stories/components/toolbar.rs
@@ -1,7 +1,5 @@
-use gpui2::elements::div;
-use gpui2::style::StyleHelpers;
 use gpui2::{Element, IntoElement, ParentElement, ViewContext};
-use ui::{prelude::*, toolbar};
+use ui::toolbar;
 
 use crate::story::Story;
 
@@ -12,6 +10,7 @@ impl ToolbarStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         Story::container()
             .child(Story::title_for::<_, ui::Toolbar>())
+            .child(Story::label("Default"))
             .child(toolbar())
     }
 }

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -14,6 +14,7 @@ use legacy_theme::ThemeSettings;
 use log::LevelFilter;
 use settings::{default_settings, SettingsStore};
 use simplelog::SimpleLogger;
+use stories::components::breadcrumb::BreadcrumbStory;
 use stories::components::facepile::FacepileStory;
 use stories::components::toolbar::ToolbarStory;
 use stories::components::traffic_lights::TrafficLightsStory;
@@ -65,6 +66,7 @@ enum ElementStory {
 #[derive(Debug, Clone, Copy, EnumString)]
 #[strum(serialize_all = "snake_case")]
 enum ComponentStory {
+    Breadcrumb,
     Facepile,
     Toolbar,
     TrafficLights,
@@ -98,6 +100,9 @@ fn main() {
             |cx| match args.story {
                 Some(StorySelector::Element(ElementStory::Avatar)) => {
                     view(|cx| render_story(&mut ViewContext::new(cx), AvatarStory::default()))
+                }
+                Some(StorySelector::Component(ComponentStory::Breadcrumb)) => {
+                    view(|cx| render_story(&mut ViewContext::new(cx), BreadcrumbStory::default()))
                 }
                 Some(StorySelector::Component(ComponentStory::Facepile)) => {
                     view(|cx| render_story(&mut ViewContext::new(cx), FacepileStory::default()))

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -15,6 +15,7 @@ use log::LevelFilter;
 use settings::{default_settings, SettingsStore};
 use simplelog::SimpleLogger;
 use stories::components::facepile::FacepileStory;
+use stories::components::toolbar::ToolbarStory;
 use stories::components::traffic_lights::TrafficLightsStory;
 use stories::elements::avatar::AvatarStory;
 use strum::EnumString;
@@ -65,6 +66,7 @@ enum ElementStory {
 #[strum(serialize_all = "snake_case")]
 enum ComponentStory {
     Facepile,
+    Toolbar,
     TrafficLights,
 }
 
@@ -99,6 +101,9 @@ fn main() {
                 }
                 Some(StorySelector::Component(ComponentStory::Facepile)) => {
                     view(|cx| render_story(&mut ViewContext::new(cx), FacepileStory::default()))
+                }
+                Some(StorySelector::Component(ComponentStory::Toolbar)) => {
+                    view(|cx| render_story(&mut ViewContext::new(cx), ToolbarStory::default()))
                 }
                 Some(StorySelector::Component(ComponentStory::TrafficLights)) => view(|cx| {
                     render_story(&mut ViewContext::new(cx), TrafficLightsStory::default())

--- a/crates/storybook/src/workspace.rs
+++ b/crates/storybook/src/workspace.rs
@@ -3,7 +3,7 @@ use gpui2::{
     style::StyleHelpers,
     Element, IntoElement, ParentElement, ViewContext,
 };
-use ui::{chat_panel, project_panel, status_bar, tab_bar, theme, title_bar};
+use ui::{chat_panel, project_panel, status_bar, tab_bar, theme, title_bar, toolbar};
 
 #[derive(Element, Default)]
 pub struct WorkspaceElement {
@@ -45,7 +45,8 @@ impl WorkspaceElement {
                                     .flex()
                                     .flex_col()
                                     .flex_1()
-                                    .child(tab_bar(self.tab_bar_scroll_state.clone())),
+                                    .child(tab_bar(self.tab_bar_scroll_state.clone()))
+                                    .child(toolbar()),
                             ),
                     )
                     .child(chat_panel(self.right_scroll_state.clone())),

--- a/crates/ui/src/components.rs
+++ b/crates/ui/src/components.rs
@@ -4,6 +4,7 @@ mod list_item;
 mod list_section_header;
 mod palette_item;
 mod tab;
+mod toolbar;
 mod traffic_lights;
 
 pub use facepile::*;
@@ -12,6 +13,7 @@ pub use list_item::*;
 pub use list_section_header::*;
 pub use palette_item::*;
 pub use tab::*;
+pub use toolbar::*;
 pub use traffic_lights::*;
 
 use std::marker::PhantomData;

--- a/crates/ui/src/components.rs
+++ b/crates/ui/src/components.rs
@@ -1,3 +1,4 @@
+mod breadcrumb;
 mod facepile;
 mod follow_group;
 mod list_item;
@@ -7,6 +8,7 @@ mod tab;
 mod toolbar;
 mod traffic_lights;
 
+pub use breadcrumb::*;
 pub use facepile::*;
 pub use follow_group::*;
 pub use list_item::*;

--- a/crates/ui/src/components/breadcrumb.rs
+++ b/crates/ui/src/components/breadcrumb.rs
@@ -1,5 +1,5 @@
 use gpui2::elements::div;
-use gpui2::style::StyleHelpers;
+use gpui2::style::{StyleHelpers, Styleable};
 use gpui2::{Element, IntoElement, ParentElement, ViewContext};
 
 use crate::theme;
@@ -16,12 +16,16 @@ impl Breadcrumb {
         let theme = theme(cx);
 
         div()
+            .px_1()
             .flex()
             .flex_row()
-            // TODO: Read font from theme.
+            // TODO: Read font from theme (or settings?).
             .font("Zed Mono Extended")
             .text_sm()
             .text_color(theme.middle.base.default.foreground)
+            .rounded_md()
+            .hover()
+            .fill(theme.highest.base.hovered.background)
             // TODO: Replace hardcoded breadcrumbs.
             .child("crates/ui/src/components/toolbar.rs")
             .child(" › ")

--- a/crates/ui/src/components/breadcrumb.rs
+++ b/crates/ui/src/components/breadcrumb.rs
@@ -1,0 +1,32 @@
+use gpui2::elements::div;
+use gpui2::style::StyleHelpers;
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
+
+use crate::theme;
+
+#[derive(Element)]
+pub struct Breadcrumb {}
+
+pub fn breadcrumb() -> Breadcrumb {
+    Breadcrumb {}
+}
+
+impl Breadcrumb {
+    fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        let theme = theme(cx);
+
+        div()
+            .flex()
+            .flex_row()
+            // TODO: Read font from theme.
+            .font("Zed Mono Extended")
+            .text_sm()
+            .text_color(theme.middle.base.default.foreground)
+            // TODO: Replace hardcoded breadcrumbs.
+            .child("crates/ui/src/components/toolbar.rs")
+            .child(" › ")
+            .child("impl Breadcrumb")
+            .child(" › ")
+            .child("fn render")
+    }
+}

--- a/crates/ui/src/components/toolbar.rs
+++ b/crates/ui/src/components/toolbar.rs
@@ -1,15 +1,39 @@
 use gpui2::elements::div;
-use gpui2::{Element, IntoElement, ViewContext};
+use gpui2::style::StyleHelpers;
+use gpui2::{Element, IntoElement, ParentElement, ViewContext};
 
-use crate::theme;
+use crate::{icon, icon_button, theme, IconAsset};
+
+pub struct ToolbarItem {}
 
 #[derive(Element)]
-pub struct Toolbar {}
+pub struct Toolbar {
+    items: Vec<ToolbarItem>,
+}
+
+pub fn toolbar() -> Toolbar {
+    Toolbar { items: Vec::new() }
+}
 
 impl Toolbar {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
         div()
+            .flex()
+            .justify_between()
+            .child(
+                // TODO(maxdeviant): Replace this with real breadcrumbs.
+                div()
+                    .child("crates/ui/src/components/toolbar.rs")
+                    .text_color(theme.middle.base.default.foreground),
+            )
+            .child(
+                div()
+                    .flex()
+                    .child(icon_button("icons/inlay_hint.svg"))
+                    .child(icon_button("icons/magnifying_glass.svg"))
+                    .child(icon_button("icons/magic-wand.svg")),
+            )
     }
 }

--- a/crates/ui/src/components/toolbar.rs
+++ b/crates/ui/src/components/toolbar.rs
@@ -19,12 +19,17 @@ impl Toolbar {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
-        div().flex().justify_between().child(breadcrumb()).child(
-            div()
-                .flex()
-                .child(icon_button("icons/inlay_hint.svg"))
-                .child(icon_button("icons/magnifying_glass.svg"))
-                .child(icon_button("icons/magic-wand.svg")),
-        )
+        div()
+            .p_2()
+            .flex()
+            .justify_between()
+            .child(breadcrumb())
+            .child(
+                div()
+                    .flex()
+                    .child(icon_button("icons/inlay_hint.svg"))
+                    .child(icon_button("icons/magnifying_glass.svg"))
+                    .child(icon_button("icons/magic-wand.svg")),
+            )
     }
 }

--- a/crates/ui/src/components/toolbar.rs
+++ b/crates/ui/src/components/toolbar.rs
@@ -1,0 +1,15 @@
+use gpui2::elements::div;
+use gpui2::{Element, IntoElement, ViewContext};
+
+use crate::theme;
+
+#[derive(Element)]
+pub struct Toolbar {}
+
+impl Toolbar {
+    fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        let theme = theme(cx);
+
+        div()
+    }
+}

--- a/crates/ui/src/components/toolbar.rs
+++ b/crates/ui/src/components/toolbar.rs
@@ -2,7 +2,7 @@ use gpui2::elements::div;
 use gpui2::style::StyleHelpers;
 use gpui2::{Element, IntoElement, ParentElement, ViewContext};
 
-use crate::{icon, icon_button, theme, IconAsset};
+use crate::{breadcrumb, icon_button, theme};
 
 pub struct ToolbarItem {}
 
@@ -19,21 +19,12 @@ impl Toolbar {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
         let theme = theme(cx);
 
-        div()
-            .flex()
-            .justify_between()
-            .child(
-                // TODO(maxdeviant): Replace this with real breadcrumbs.
-                div()
-                    .child("crates/ui/src/components/toolbar.rs")
-                    .text_color(theme.middle.base.default.foreground),
-            )
-            .child(
-                div()
-                    .flex()
-                    .child(icon_button("icons/inlay_hint.svg"))
-                    .child(icon_button("icons/magnifying_glass.svg"))
-                    .child(icon_button("icons/magic-wand.svg")),
-            )
+        div().flex().justify_between().child(breadcrumb()).child(
+            div()
+                .flex()
+                .child(icon_button("icons/inlay_hint.svg"))
+                .child(icon_button("icons/magnifying_glass.svg"))
+                .child(icon_button("icons/magic-wand.svg")),
+        )
     }
 }


### PR DESCRIPTION
This PR scaffolds the `Toolbar` and `Breadcrumb` components.

Right now they both just consist of hardcoded data.

<img width="846" alt="Screenshot 2023-09-22 at 4 54 00 PM" src="https://github.com/zed-industries/zed/assets/1486634/70578df2-7216-42d2-97ef-d38b83fb4a25">

<img width="799" alt="Screenshot 2023-09-22 at 4 46 04 PM" src="https://github.com/zed-industries/zed/assets/1486634/73ca3d8a-baf9-4ed4-b4c4-279c674672a3">

Release Notes:

- N/A
