### PR TITLE
Add support for the experimental Next LS for Elixir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9868,6 +9868,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "settings",
+ "shellexpand",
  "simplelog",
  "smallvec",
  "smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9861,6 +9861,7 @@ dependencies = [
  "rpc",
  "rsa",
  "rust-embed",
+ "schemars",
  "search",
  "semantic_index",
  "serde",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -373,6 +373,27 @@
     "enabled": false,
     "reindexing_delay_seconds": 600
   },
+  // Settings specific to our elixir integration
+  "elixir": {
+    // Set Zed to use the experimental Next LS LSP server.
+    // Note that changing this setting requires a restart of Zed
+    // to take effect.
+    //
+    // May take 3 values:
+    //  1. Use the standard elixir-ls LSP server
+    //         "next": "off"
+    //  2. Use a bundled version of the next Next LS LSP server
+    //         "next": "on",
+    //  3. Use a locally running version of the next Next LS LSP server,
+    //     on a specific port:
+    //         "next": {
+    //           "local": {
+    //             "port": 4000
+    //            }
+    //          },
+    //
+    "next": "off"
+  },
   // Different settings for specific languages.
   "languages": {
     "Plain Text": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -384,11 +384,11 @@
     //         "next": "off"
     //  2. Use a bundled version of the next Next LS LSP server
     //         "next": "on",
-    //  3. Use a locally running version of the next Next LS LSP server,
-    //     on a specific port:
+    //  3. Use a local build of the next Next LS LSP server:
     //         "next": {
     //           "local": {
-    //             "port": 4000
+    //             "path": "~/next-ls/bin/start",
+    //             "arguments": ["--stdio"]
     //            }
     //          },
     //

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -712,11 +712,11 @@ impl LanguageServer {
         }
     }
 
-    pub fn name<'a>(self: &'a Arc<Self>) -> &'a str {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
-    pub fn capabilities<'a>(self: &'a Arc<Self>) -> &'a ServerCapabilities {
+    pub fn capabilities(&self) -> &ServerCapabilities {
         &self.capabilities
     }
 

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -69,7 +69,7 @@ impl ProjectSymbolsDelegate {
             &self.external_match_candidates,
             query,
             false,
-            MAX_MATCHES - visible_matches.len(),
+            MAX_MATCHES - visible_matches.len().min(MAX_MATCHES),
             &Default::default(),
             cx.background().clone(),
         ));

--- a/crates/semantic_index/examples/eval.rs
+++ b/crates/semantic_index/examples/eval.rs
@@ -456,7 +456,7 @@ fn main() {
         let languages = Arc::new(languages);
 
         let node_runtime = RealNodeRuntime::new(http.clone());
-        languages::init(languages.clone(), node_runtime.clone());
+        languages::init(languages.clone(), node_runtime.clone(), cx);
         language::init(cx);
 
         project::Project::init(&client, cx);

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -99,6 +99,7 @@ rust-embed.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
+schemars.workspace = true
 simplelog = "0.9"
 smallvec.workspace = true
 smol.workspace = true

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -62,6 +62,7 @@ rpc = { path = "../rpc" }
 settings = { path = "../settings" }
 feature_flags = { path = "../feature_flags" }
 sum_tree = { path = "../sum_tree" }
+shellexpand = "2.1.0"
 text = { path = "../text" }
 terminal_view = { path = "../terminal_view" }
 theme = { path = "../theme" }

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -78,7 +78,11 @@ pub fn init(
             tree_sitter_elixir::language(),
             vec![Arc::new(elixir::ElixirLspAdapter)],
         ),
-        elixir_next::ElixirNextSetting::On => todo!(),
+        elixir_next::ElixirNextSetting::On => language(
+            "elixir",
+            tree_sitter_elixir::language(),
+            vec![Arc::new(elixir_next::NextLspAdapter)],
+        ),
         elixir_next::ElixirNextSetting::Local { path, arguments } => language(
             "elixir",
             tree_sitter_elixir::language(),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -72,22 +72,20 @@ pub fn init(
         ],
     );
 
-    match settings::get::<ElixirSettings>(cx).next {
+    match &settings::get::<ElixirSettings>(cx).next {
         elixir_next::ElixirNextSetting::Off => language(
             "elixir",
             tree_sitter_elixir::language(),
             vec![Arc::new(elixir::ElixirLspAdapter)],
         ),
-        elixir_next::ElixirNextSetting::On => language(
+        elixir_next::ElixirNextSetting::On => todo!(),
+        elixir_next::ElixirNextSetting::Local { path } => language(
             "elixir",
             tree_sitter_elixir::language(),
-            vec![Arc::new(elixir_next::BundledNextLspAdapter)],
+            vec![Arc::new(elixir_next::LocalNextLspAdapter {
+                path: path.clone(),
+            })],
         ),
-        elixir_next::ElixirNextSetting::Local { port } => unimplemented!(), /*language(
-                                                                            "elixir",
-                                                                            tree_sitter_elixir::language(),
-                                                                            vec![Arc::new(elixir_next::LocalNextLspAdapter { port })],
-                                                                            )*/
     }
 
     language(

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -79,11 +79,12 @@ pub fn init(
             vec![Arc::new(elixir::ElixirLspAdapter)],
         ),
         elixir_next::ElixirNextSetting::On => todo!(),
-        elixir_next::ElixirNextSetting::Local { path } => language(
+        elixir_next::ElixirNextSetting::Local { path, arguments } => language(
             "elixir",
             tree_sitter_elixir::language(),
             vec![Arc::new(elixir_next::LocalNextLspAdapter {
                 path: path.clone(),
+                arguments: arguments.clone(),
             })],
         ),
     }

--- a/crates/zed/src/languages/elixir_next.rs
+++ b/crates/zed/src/languages/elixir_next.rs
@@ -1,13 +1,12 @@
 use anyhow::{anyhow, bail, Result};
-use async_compression::futures::bufread::GzipDecoder;
-use async_tar::Archive;
+
 use async_trait::async_trait;
 pub use language::*;
 use lsp::{LanguageServerBinary, SymbolKind};
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
 use settings::Setting;
-use smol::{fs, io::BufReader, stream::StreamExt};
+use smol::{fs, stream::StreamExt};
 use std::{any::Any, env::consts, ops::Deref, path::PathBuf, sync::Arc};
 use util::{
     async_iife,

--- a/crates/zed/src/languages/elixir_next.rs
+++ b/crates/zed/src/languages/elixir_next.rs
@@ -1,0 +1,178 @@
+use anyhow::Result;
+use async_trait::async_trait;
+pub use language::*;
+use lsp::{CompletionItemKind, LanguageServerBinary, SymbolKind};
+use schemars::JsonSchema;
+use serde_derive::{Deserialize, Serialize};
+use settings::Setting;
+use std::{any::Any, path::PathBuf, sync::Arc};
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ElixirSettings {
+    pub next: ElixirNextSetting,
+}
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ElixirNextSetting {
+    Off,
+    On,
+    Local { path: String },
+}
+
+#[derive(Clone, Serialize, Default, Deserialize, JsonSchema)]
+pub struct ElixirSettingsContent {
+    next: Option<ElixirNextSetting>,
+}
+
+impl Setting for ElixirSettings {
+    const KEY: Option<&'static str> = Some("elixir");
+
+    type FileContent = ElixirSettingsContent;
+
+    fn load(
+        default_value: &Self::FileContent,
+        user_values: &[&Self::FileContent],
+        _: &gpui::AppContext,
+    ) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Self::load_via_json_merge(default_value, user_values)
+    }
+}
+
+pub struct LocalNextLspAdapter {
+    pub path: String,
+}
+
+#[async_trait]
+impl LspAdapter for LocalNextLspAdapter {
+    async fn name(&self) -> LanguageServerName {
+        LanguageServerName("elixir-next-ls".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "next-ls"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        Ok(Box::new(()) as Box<_>)
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _: Box<dyn 'static + Send + Any>,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Ok(LanguageServerBinary {
+            path: self.path.clone().into(),
+            arguments: vec!["--stdio".into()],
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: self.path.clone().into(),
+            arguments: vec!["--stdio".into()],
+        })
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: self.path.clone().into(),
+            arguments: vec!["--stdio".into()],
+        })
+    }
+
+    async fn label_for_completion(
+        &self,
+        completion: &lsp::CompletionItem,
+        language: &Arc<Language>,
+    ) -> Option<CodeLabel> {
+        match completion.kind.zip(completion.detail.as_ref()) {
+            Some((_, detail)) if detail.starts_with("(function)") => {
+                let text = detail.strip_prefix("(function) ")?;
+                let filter_range = 0..text.find('(').unwrap_or(text.len());
+                let source = Rope::from(format!("def {text}").as_str());
+                let runs = language.highlight_text(&source, 4..4 + text.len());
+                return Some(CodeLabel {
+                    text: text.to_string(),
+                    runs,
+                    filter_range,
+                });
+            }
+            Some((_, detail)) if detail.starts_with("(macro)") => {
+                let text = detail.strip_prefix("(macro) ")?;
+                let filter_range = 0..text.find('(').unwrap_or(text.len());
+                let source = Rope::from(format!("defmacro {text}").as_str());
+                let runs = language.highlight_text(&source, 9..9 + text.len());
+                return Some(CodeLabel {
+                    text: text.to_string(),
+                    runs,
+                    filter_range,
+                });
+            }
+            Some((
+                CompletionItemKind::CLASS
+                | CompletionItemKind::MODULE
+                | CompletionItemKind::INTERFACE
+                | CompletionItemKind::STRUCT,
+                _,
+            )) => {
+                let filter_range = 0..completion
+                    .label
+                    .find(" (")
+                    .unwrap_or(completion.label.len());
+                let text = &completion.label[filter_range.clone()];
+                let source = Rope::from(format!("defmodule {text}").as_str());
+                let runs = language.highlight_text(&source, 10..10 + text.len());
+                return Some(CodeLabel {
+                    text: completion.label.clone(),
+                    runs,
+                    filter_range,
+                });
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    async fn label_for_symbol(
+        &self,
+        name: &str,
+        kind: SymbolKind,
+        language: &Arc<Language>,
+    ) -> Option<CodeLabel> {
+        let (text, filter_range, display_range) = match kind {
+            SymbolKind::METHOD | SymbolKind::FUNCTION => {
+                let text = format!("def {}", name);
+                let filter_range = 4..4 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            SymbolKind::CLASS | SymbolKind::MODULE | SymbolKind::INTERFACE | SymbolKind::STRUCT => {
+                let text = format!("defmodule {}", name);
+                let filter_range = 10..10 + name.len();
+                let display_range = 0..filter_range.end;
+                (text, filter_range, display_range)
+            }
+            _ => return None,
+        };
+
+        Some(CodeLabel {
+            runs: language.highlight_text(&text.as_str().into(), display_range.clone()),
+            text: text[display_range].to_string(),
+            filter_range,
+        })
+    }
+}

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -134,7 +134,7 @@ fn main() {
         let languages = Arc::new(languages);
         let node_runtime = RealNodeRuntime::new(http.clone());
 
-        languages::init(languages.clone(), node_runtime.clone());
+        languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
         let channel_store =
             cx.add_model(|cx| ChannelStore::new(client.clone(), user_store.clone(), cx));

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2392,7 +2392,7 @@ mod tests {
         languages.set_executor(cx.background().clone());
         let languages = Arc::new(languages);
         let node_runtime = node_runtime::FakeNodeRuntime::new();
-        languages::init(languages.clone(), node_runtime);
+        languages::init(languages.clone(), node_runtime, cx);
         for name in languages.language_names() {
             languages.language_for_name(&name);
         }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2388,6 +2388,7 @@ mod tests {
 
     #[gpui::test]
     fn test_bundled_languages(cx: &mut AppContext) {
+        cx.set_global(SettingsStore::test(cx));
         let mut languages = LanguageRegistry::test();
         languages.set_executor(cx.background().clone());
         let languages = Arc::new(languages);


### PR DESCRIPTION
This is a PR I built for a friend of a friend at StrangeLoop, who is making a much better LSP for elixir that elixir folks want to experiment with. This PR also improves the our debug log viewer to handle LSP restarts.

TODO:
- [x] Make sure NextLS binary loading works.

Release Notes:

- Added support for the experimental Next LS for Elixir, to enable it add the following field to your settings:

```json
"elixir": {
    "next": "on"
}
```