### PR TITLE
workspace: Improve save prompt.

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -41,12 +41,26 @@ pub fn truncate(s: &str, max_chars: usize) -> &str {
     }
 }
 
+/// Removes characters from the end of the string if it's length is greater than `max_chars` and
+/// appends "..." to the string. Returns string unchanged if it's length is smaller than max_chars.
 pub fn truncate_and_trailoff(s: &str, max_chars: usize) -> String {
     debug_assert!(max_chars >= 5);
 
     let truncation_ix = s.char_indices().map(|(i, _)| i).nth(max_chars);
     match truncation_ix {
         Some(length) => s[..length].to_string() + "…",
+        None => s.to_string(),
+    }
+}
+
+/// Removes characters from the front of the string if it's length is greater than `max_chars` and
+/// prepends the string with "...". Returns string unchanged if it's length is smaller than max_chars.
+pub fn truncate_and_remove_front(s: &str, max_chars: usize) -> String {
+    debug_assert!(max_chars >= 5);
+
+    let truncation_ix = s.char_indices().map(|(i, _)| i).nth_back(max_chars);
+    match truncation_ix {
+        Some(length) => "…".to_string() + &s[length..],
         None => s.to_string(),
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2543,12 +2543,14 @@ mod tests {
 
         set_labeled_items(&pane, ["A", "B", "C*", "D", "E"], cx);
 
-        pane.update(cx, |pane, cx| {
-            pane.close_inactive_items(&CloseInactiveItems, cx)
-        })
-        .unwrap()
-        .await
-        .unwrap();
+        let task = pane
+            .update(cx, |pane, cx| {
+                pane.close_inactive_items(&CloseInactiveItems, cx)
+            })
+            .unwrap();
+        cx.foreground().run_until_parked();
+        window.simulate_prompt_answer(2, cx);
+        task.await.unwrap();
         assert_item_labels(&pane, ["C*"], cx);
     }
 
@@ -2569,10 +2571,12 @@ mod tests {
         add_labeled_item(&pane, "E", false, cx);
         assert_item_labels(&pane, ["A^", "B", "C^", "D", "E*"], cx);
 
-        pane.update(cx, |pane, cx| pane.close_clean_items(&CloseCleanItems, cx))
-            .unwrap()
-            .await
+        let task = pane
+            .update(cx, |pane, cx| pane.close_clean_items(&CloseCleanItems, cx))
             .unwrap();
+        cx.foreground().run_until_parked();
+        window.simulate_prompt_answer(2, cx);
+        task.await.unwrap();
         assert_item_labels(&pane, ["A^", "C*^"], cx);
     }
 
@@ -2588,12 +2592,14 @@ mod tests {
 
         set_labeled_items(&pane, ["A", "B", "C*", "D", "E"], cx);
 
-        pane.update(cx, |pane, cx| {
-            pane.close_items_to_the_left(&CloseItemsToTheLeft, cx)
-        })
-        .unwrap()
-        .await
-        .unwrap();
+        let task = pane
+            .update(cx, |pane, cx| {
+                pane.close_items_to_the_left(&CloseItemsToTheLeft, cx)
+            })
+            .unwrap();
+        cx.foreground().run_until_parked();
+        window.simulate_prompt_answer(2, cx);
+        task.await.unwrap();
         assert_item_labels(&pane, ["C*", "D", "E"], cx);
     }
 
@@ -2609,12 +2615,14 @@ mod tests {
 
         set_labeled_items(&pane, ["A", "B", "C*", "D", "E"], cx);
 
-        pane.update(cx, |pane, cx| {
-            pane.close_items_to_the_right(&CloseItemsToTheRight, cx)
-        })
-        .unwrap()
-        .await
-        .unwrap();
+        let task = pane
+            .update(cx, |pane, cx| {
+                pane.close_items_to_the_right(&CloseItemsToTheRight, cx)
+            })
+            .unwrap();
+        cx.foreground().run_until_parked();
+        window.simulate_prompt_answer(2, cx);
+        task.await.unwrap();
         assert_item_labels(&pane, ["A", "B", "C*"], cx);
     }
 
@@ -2633,10 +2641,12 @@ mod tests {
         add_labeled_item(&pane, "C", false, cx);
         assert_item_labels(&pane, ["A", "B", "C*"], cx);
 
-        pane.update(cx, |pane, cx| pane.close_all_items(&CloseAllItems, cx))
-            .unwrap()
-            .await
+        let t = pane
+            .update(cx, |pane, cx| pane.close_all_items(&CloseAllItems, cx))
             .unwrap();
+        cx.foreground().run_until_parked();
+        window.simulate_prompt_answer(2, cx);
+        t.await.unwrap();
         assert_item_labels(&pane, [], cx);
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4339,7 +4339,9 @@ mod tests {
         });
         let task = workspace.update(cx, |w, cx| w.prepare_to_close(false, cx));
         cx.foreground().run_until_parked();
-        window.simulate_prompt_answer(2, cx); // cancel
+        window.simulate_prompt_answer(2, cx); // cancel save all
+        cx.foreground().run_until_parked();
+        window.simulate_prompt_answer(2, cx); // cancel save all
         cx.foreground().run_until_parked();
         assert!(!window.has_pending_prompt(cx));
         assert!(!task.await.unwrap());
@@ -4397,13 +4399,15 @@ mod tests {
         });
         cx.foreground().run_until_parked();
 
+        assert!(window.has_pending_prompt(cx));
+        // Ignore "Save all" prompt
+        window.simulate_prompt_answer(2, cx);
+        cx.foreground().run_until_parked();
         // There's a prompt to save item 1.
         pane.read_with(cx, |pane, _| {
             assert_eq!(pane.items_len(), 4);
             assert_eq!(pane.active_item().unwrap().id(), item1.id());
         });
-        assert!(window.has_pending_prompt(cx));
-
         // Confirm saving item 1.
         window.simulate_prompt_answer(0, cx);
         cx.foreground().run_until_parked();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4536,6 +4536,10 @@ mod tests {
             pane.close_items(cx, SaveBehavior::PromptOnWrite, move |_| true)
         });
         cx.foreground().run_until_parked();
+        // Discard "Save all" prompt
+        window.simulate_prompt_answer(2, cx);
+
+        cx.foreground().run_until_parked();
         left_pane.read_with(cx, |pane, cx| {
             assert_eq!(
                 pane.active_item().unwrap().project_entry_ids(cx).as_slice(),


### PR DESCRIPTION
Add buffer path to the prompt.

Z-2903

Release Notes:
- Added a "Save all/Discard all" prompt when closing a pane with multiple edited buffers.