### PR TITLE
Add cmd-+ as an alias for cmd-=

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -30,6 +30,7 @@
       "cmd-s": "workspace::Save",
       "cmd-shift-s": "workspace::SaveAs",
       "cmd-=": "zed::IncreaseBufferFontSize",
+      "cmd-+": "zed::IncreaseBufferFontSize",
       "cmd--": "zed::DecreaseBufferFontSize",
       "cmd-0": "zed::ResetBufferFontSize",
       "cmd-,": "zed::OpenSettings",


### PR DESCRIPTION
Release Notes:

- Allow cmd-+ in addition to cmd-= for zoom in  ([#1021](https://github.com/zed-industries/zed/issues/4981)).

Although I had initially thought this was something more to do with option key handling, it turns out to be a straightforward and reasonable feature request.


