### PR TITLE
vim: Add multicursor shortcuts

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -125,6 +125,21 @@
       "g shift-t": "pane::ActivatePrevItem",
       "g d": "editor::GoToDefinition",
       "g shift-d": "editor::GoToTypeDefinition",
+      "g n": "vim::SelectNext",
+      "g shift-n": "vim::SelectPrevious",
+      "g >": [
+        "editor::SelectNext",
+        {
+          "replace_newest": true
+        }
+      ],
+      "g <": [
+        "editor::SelectPrevious",
+        {
+          "replace_newest": true
+        }
+      ],
+      "g a": "editor::SelectAllMatches",
       "g s": "outline::Toggle",
       "g shift-s": "project_symbols::Toggle",
       "g .": "editor::ToggleCodeActions", // zed specific


### PR DESCRIPTION
Adding a few bindings to bring first class feeling multiselect to zed's vim emulation.

gn and gN are similar to similar vim bindings, ga is similar to gA (and I doubt we need vim's real ga), g> and g< are just made up.

Release Notes:

- vim: `g n` / `g N` to select next/previous
- vim: `g >` / `g <` to skip current selection and select next/previous
- vim: `g a` to select all
