### PR TITLE
Remove `dbg!` from `styleable_helpers!`

### DIFF
--- a/crates/gpui2_macros/src/styleable_helpers.rs
+++ b/crates/gpui2_macros/src/styleable_helpers.rs
@@ -135,10 +135,6 @@ fn generate_predefined_setter(
         }
     };
 
-    if negate {
-        dbg!(method.to_string());
-    }
-
     method
 }
 


### PR DESCRIPTION
This PR removes a leftover `dbg!` from `styleable_helpers!`.

We already removed this in the `gpui2-ui` branch, but getting this on `main` since @KCaverly pointed it out.

Release Notes:

- N/A
