### PR TITLE
Add `Sized` bound to `StyleHelpers`

### DIFF
--- a/crates/gpui2/src/style.rs
+++ b/crates/gpui2/src/style.rs
@@ -320,174 +320,114 @@ use crate as gpui2;
 //
 // Example:
 // // Sets the padding to 0.5rem, just like class="p-2" in Tailwind.
-// fn p_2(mut self) -> Self where Self: Sized;
-pub trait StyleHelpers: Styleable<Style = Style> {
+// fn p_2(mut self) -> Self;
+pub trait StyleHelpers: Sized + Styleable<Style = Style> {
     styleable_helpers!();
 
-    fn full(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn full(mut self) -> Self {
         self.declared_style().size.width = Some(relative(1.).into());
         self.declared_style().size.height = Some(relative(1.).into());
         self
     }
 
-    fn relative(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn relative(mut self) -> Self {
         self.declared_style().position = Some(Position::Relative);
         self
     }
 
-    fn absolute(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn absolute(mut self) -> Self {
         self.declared_style().position = Some(Position::Absolute);
         self
     }
 
-    fn block(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn block(mut self) -> Self {
         self.declared_style().display = Some(Display::Block);
         self
     }
 
-    fn flex(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex(mut self) -> Self {
         self.declared_style().display = Some(Display::Flex);
         self
     }
 
-    fn flex_col(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex_col(mut self) -> Self {
         self.declared_style().flex_direction = Some(FlexDirection::Column);
         self
     }
 
-    fn flex_row(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex_row(mut self) -> Self {
         self.declared_style().flex_direction = Some(FlexDirection::Row);
         self
     }
 
-    fn flex_1(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex_1(mut self) -> Self {
         self.declared_style().flex_grow = Some(1.);
         self.declared_style().flex_shrink = Some(1.);
         self.declared_style().flex_basis = Some(relative(0.).into());
         self
     }
 
-    fn flex_auto(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex_auto(mut self) -> Self {
         self.declared_style().flex_grow = Some(1.);
         self.declared_style().flex_shrink = Some(1.);
         self.declared_style().flex_basis = Some(Length::Auto);
         self
     }
 
-    fn flex_initial(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex_initial(mut self) -> Self {
         self.declared_style().flex_grow = Some(0.);
         self.declared_style().flex_shrink = Some(1.);
         self.declared_style().flex_basis = Some(Length::Auto);
         self
     }
 
-    fn flex_none(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn flex_none(mut self) -> Self {
         self.declared_style().flex_grow = Some(0.);
         self.declared_style().flex_shrink = Some(0.);
         self
     }
 
-    fn grow(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn grow(mut self) -> Self {
         self.declared_style().flex_grow = Some(1.);
         self
     }
 
-    fn items_start(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn items_start(mut self) -> Self {
         self.declared_style().align_items = Some(AlignItems::FlexStart);
         self
     }
 
-    fn items_end(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn items_end(mut self) -> Self {
         self.declared_style().align_items = Some(AlignItems::FlexEnd);
         self
     }
 
-    fn items_center(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn items_center(mut self) -> Self {
         self.declared_style().align_items = Some(AlignItems::Center);
         self
     }
 
-    fn justify_between(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn justify_between(mut self) -> Self {
         self.declared_style().justify_content = Some(JustifyContent::SpaceBetween);
         self
     }
 
-    fn justify_center(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn justify_center(mut self) -> Self {
         self.declared_style().justify_content = Some(JustifyContent::Center);
         self
     }
 
-    fn justify_start(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn justify_start(mut self) -> Self {
         self.declared_style().justify_content = Some(JustifyContent::Start);
         self
     }
 
-    fn justify_end(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn justify_end(mut self) -> Self {
         self.declared_style().justify_content = Some(JustifyContent::End);
         self
     }
 
-    fn justify_around(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn justify_around(mut self) -> Self {
         self.declared_style().justify_content = Some(JustifyContent::SpaceAround);
         self
     }
@@ -495,7 +435,6 @@ pub trait StyleHelpers: Styleable<Style = Style> {
     fn fill<F>(mut self, fill: F) -> Self
     where
         F: Into<Fill>,
-        Self: Sized,
     {
         self.declared_style().fill = Some(fill.into());
         self
@@ -504,7 +443,6 @@ pub trait StyleHelpers: Styleable<Style = Style> {
     fn border_color<C>(mut self, border_color: C) -> Self
     where
         C: Into<Hsla>,
-        Self: Sized,
     {
         self.declared_style().border_color = Some(border_color.into());
         self
@@ -513,72 +451,47 @@ pub trait StyleHelpers: Styleable<Style = Style> {
     fn text_color<C>(mut self, color: C) -> Self
     where
         C: Into<Hsla>,
-        Self: Sized,
     {
         self.declared_style().text_color = Some(color.into());
         self
     }
 
-    fn text_xs(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_xs(mut self) -> Self {
         self.declared_style().font_size = Some(0.75);
         self
     }
 
-    fn text_sm(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_sm(mut self) -> Self {
         self.declared_style().font_size = Some(0.875);
         self
     }
 
-    fn text_base(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_base(mut self) -> Self {
         self.declared_style().font_size = Some(1.0);
         self
     }
 
-    fn text_lg(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_lg(mut self) -> Self {
         self.declared_style().font_size = Some(1.125);
         self
     }
 
-    fn text_xl(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_xl(mut self) -> Self {
         self.declared_style().font_size = Some(1.25);
         self
     }
 
-    fn text_2xl(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_2xl(mut self) -> Self {
         self.declared_style().font_size = Some(1.5);
         self
     }
 
-    fn text_3xl(mut self) -> Self
-    where
-        Self: Sized,
-    {
+    fn text_3xl(mut self) -> Self {
         self.declared_style().font_size = Some(1.875);
         self
     }
 
-    fn font(mut self, family_name: impl Into<Arc<str>>) -> Self
-    where
-        Self: Sized,
-    {
+    fn font(mut self, family_name: impl Into<Arc<str>>) -> Self {
         self.declared_style().font_family = Some(family_name.into());
         self
     }


### PR DESCRIPTION
This PR adds a `Sized` bound to the `StyleHelpers` trait.

All of the individual methods on this trait already had a `Self: Sized` bound, so moving it up to the trait level will make it so we don't have to repeat ourselves so much.

There's an open question of whether we can hoist the `Sized` bound to `Styleable`, but it's possible there are cases where we'd want to have a `Styleable` trait object.

Release Notes:

- N/A
