### PR TITLE
language: Add block_comment to CSS

### DIFF
--- a/crates/zed/src/languages/css/config.toml
+++ b/crates/zed/src/languages/css/config.toml
@@ -9,3 +9,4 @@ brackets = [
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]
 word_characters = ["-"]
+block_comment = ["/* ", " */"]


### PR DESCRIPTION
Fixes zed-industries/zed#6316

Release Notes:
- Fixed "toggle comment" action not working in CSS buffers.

