### PR TITLE
Bump update notification size back up

### DIFF
--- a/styles/src/style_tree/update_notification.ts
+++ b/styles/src/style_tree/update_notification.ts
@@ -26,10 +26,10 @@ export default function update_notification(): any {
         dismiss_button: interactive({
             base: {
                 color: foreground(theme.middle),
-                icon_width: 8,
-                icon_height: 8,
-                button_width: 8,
-                button_height: 8,
+                icon_width: 14,
+                icon_height: 14,
+                button_width: 14,
+                button_height: 14,
             },
             state: {
                 hovered: {


### PR DESCRIPTION
Regressed:
<img width="422" alt="CleanShot 2023-09-27 at 11 07 37@2x" src="https://github.com/zed-industries/zed/assets/30666851/636d7bec-4518-45e6-87bd-84b45dda28e1">

Fixed:
<img width="424" alt="CleanShot 2023-09-27 at 11 04 13@2x" src="https://github.com/zed-industries/zed/assets/30666851/186a1d49-4daf-4211-891a-dacfd1144311">

Release Notes:

- N/A
