### PR TITLE
vim keybinding updates

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -95,6 +95,7 @@
         }
       ],
       "ctrl-o": "pane::GoBack",
+      "ctrl-i": "pane::GoForward",
       "ctrl-]": "editor::GoToDefinition",
       "escape": [
         "vim::SwitchMode",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -568,7 +568,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == insert && !menu",
+    "context": "Editor && vim_mode == insert",
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -146,6 +146,7 @@
       "g shift-s": "project_symbols::Toggle",
       "g .": "editor::ToggleCodeActions", // zed specific
       "g shift-a": "editor::FindAllReferences", // zed specific
+      "g space": "editor::OpenExcerpts", // zed specific
       "g *": [
         "vim::MoveToNext",
         {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -572,7 +572,12 @@
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",
-      "ctrl-[": "vim::NormalBefore"
+      "ctrl-[": "vim::NormalBefore",
+      "ctrl-x ctrl-o": "editor::ShowCompletions",
+      "ctrl-x ctrl-a": "assistant::InlineAssist", // zed specific
+      "ctrl-x ctrl-c": "copilot::Suggest", // zed specific
+      "ctrl-x ctrl-l": "editor::ToggleCodeActions", // zed specific
+      "ctrl-x ctrl-z": "editor::Cancel"
     }
   },
   {

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -16,6 +16,7 @@ fn normal_before(_: &mut Workspace, action: &NormalBefore, cx: &mut ViewContext<
         vim.stop_recording_immediately(action.boxed_clone());
         if count <= 1 || vim.workspace_state.replaying {
             vim.update_active_editor(cx, |editor, cx| {
+                editor.cancel(&Default::default(), cx);
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.move_cursors_with(|map, mut cursor, _| {
                         *cursor.column_mut() = cursor.column().saturating_sub(1);


### PR DESCRIPTION
Release Notes:

- vim: Add ctrl-i to go forward ([#1732](https://github.com/zed-industries/zed/issues/6201)). ctrl-o was already supported.
- vim: Add `g <space>` to open the current snippet in its own file.
- vim: Escape will now return to normal mode even if completion menus are open (use `ctrl-x ctrl-z` to hide menus, as in vim).
- vim: Add key bindings for Zed's various completion mechanisms:
- - `ctrl-x ctrl-o` to open the completion menu,
- -  `ctrl-x ctrl-l` to open the LSP action menu,
- - `ctrl-x ctrl-c` to trigger Copilot (requires configuring copilot),
- - `ctrl-x ctrl-a` to trigger the inline Assistant (requires configuring openAI),

NOTE: we should add these to the docs before shipping 0.107 to stable.
