### PR TITLE
vim: Fix some dw edge cases

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -467,6 +467,22 @@ impl Motion {
 
                 (_, selection.end) = map.next_line_boundary(selection.end.to_point(map));
             } else {
+                // Another special case: When using the "w" motion in combination with an
+                // operator and the last word moved over is at the end of a line, the end of
+                // that word becomes the end of the operated text, not the first word in the
+                // next line.
+                if let Motion::NextWordStart {
+                    ignore_punctuation: _,
+                } = self
+                {
+                    let start_row = selection.start.to_point(&map).row;
+                    if selection.end.to_point(&map).row > start_row {
+                        selection.end =
+                            Point::new(start_row, map.buffer_snapshot.line_len(start_row))
+                                .to_display_point(&map)
+                    }
+                }
+
                 // If the motion is exclusive and the end of the motion is in column 1, the
                 // end of the motion is moved to the end of the previous line and the motion
                 // becomes inclusive. Example: "}" moves to the first line after a paragraph,

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -76,12 +76,6 @@ pub fn change_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Windo
 // word does not include the following white space.  {Vi: "cw" when on a blank
 //     followed by other blanks changes only the first blank; this is probably a
 //     bug, because "dw" deletes all the blanks}
-//
-// NOT HANDLED YET
-// Another special case: When using the "w" motion in combination with an
-// operator and the last word moved over is at the end of a line, the end of
-// that word becomes the end of the operated text, not the first word in the
-// next line.
 fn expand_changed_word_selection(
     map: &DisplaySnapshot,
     selection: &mut Selection<DisplayPoint>,

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -23,8 +23,6 @@ pub enum ExemptionFeatures {
     // MOTIONS
     // When an operator completes at the end of the file, an extra newline is left
     OperatorLastNewlineRemains,
-    // Deleting a word on an empty line doesn't remove the newline
-    DeleteWordOnEmptyLine,
 
     // OBJECTS
     // Resulting position after the operation is slightly incorrect for unintuitive reasons.

--- a/crates/vim/test_data/test_command_replace.json
+++ b/crates/vim/test_data/test_command_replace.json
@@ -20,10 +20,3 @@
 {"Key":"0"}
 {"Key":"enter"}
 {"Get":{"state":"aa\ndd\nˇcc","mode":"Normal"}}
-{"Key":":"}
-{"Key":"%"}
-{"Key":"s"}
-{"Key":"/"}
-{"Key":"/"}
-{"Key":"/"}
-{"Key":"enter"}

--- a/crates/vim/test_data/test_delete_w.json
+++ b/crates/vim/test_data/test_delete_w.json
@@ -1,3 +1,7 @@
+{"Put":{"state":"Test tesˇt\n    test"}}
+{"Key":"d"}
+{"Key":"w"}
+{"Get":{"state":"Test teˇs\n    test","mode":"Normal"}}
 {"Put":{"state":"Teˇst"}}
 {"Key":"d"}
 {"Key":"w"}
@@ -14,6 +18,10 @@
 {"Key":"d"}
 {"Key":"w"}
 {"Get":{"state":"Test teˇs\ntest","mode":"Normal"}}
+{"Put":{"state":"Test test\nˇ\ntest"}}
+{"Key":"d"}
+{"Key":"w"}
+{"Get":{"state":"Test test\nˇtest","mode":"Normal"}}
 {"Put":{"state":"Test teˇst-test test"}}
 {"Key":"d"}
 {"Key":"shift-w"}


### PR DESCRIPTION
Release Notes:

- vim: Fix `dw` on the last word of a line, and on empty lines.
