### PR TITLE
Improve file finder ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
 name = "file_finder"
 version = "0.1.0"
 dependencies = [
+ "collections",
  "ctor",
  "editor",
  "env_logger 0.9.3",

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 editor = { path = "../editor" }
+collections = { path = "../collections" }
 fuzzy = { path = "../fuzzy" }
 gpui = { path = "../gpui" }
 menu = { path = "../menu" }

--- a/crates/fuzzy/src/fuzzy.rs
+++ b/crates/fuzzy/src/fuzzy.rs
@@ -4,5 +4,7 @@ mod paths;
 mod strings;
 
 pub use char_bag::CharBag;
-pub use paths::{match_path_sets, PathMatch, PathMatchCandidate, PathMatchCandidateSet};
+pub use paths::{
+    match_fixed_path_set, match_path_sets, PathMatch, PathMatchCandidate, PathMatchCandidateSet,
+};
 pub use strings::{match_strings, StringMatch, StringMatchCandidate};


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/issues/4450
Part of https://github.com/zed-industries/zed/issues/5620

Initial:
<img width="585" alt="Screenshot 2023-09-28 at 09 50 05" src="https://github.com/zed-industries/zed/assets/2690773/e0149312-dfe3-4b7c-948c-0f593d6f540c">
First query letter input (only two history items match that, both are preserved on top, with their order preserved also)
<img width="603" alt="Screenshot 2023-09-28 at 09 50 08" src="https://github.com/zed-industries/zed/assets/2690773/85ab2f4c-bb9c-4811-b8b0-b5c14a370ae2">
Second query letter input, no matching history items:
<img width="614" alt="Screenshot 2023-09-28 at 09 50 11" src="https://github.com/zed-industries/zed/assets/2690773/6d380403-a43c-4f00-a05b-88f43f91fefb">
Remove second query letter, history items match again and pop to the top:
<img width="574" alt="Screenshot 2023-09-28 at 09 50 15" src="https://github.com/zed-industries/zed/assets/2690773/5981ca53-6bc8-4305-ae36-27144080e1a2">


* allows `file_finder::Toggle` (cmd-p by default) to cycle through file finder items (ESC closes the modal still)
* on query typing, preserve history items that match the query and keep them on top, with their ordering preserved
* show history items' matched letters

Release Notes:

- Improve file finder ergonomics: allow cycle through items with the toggle action, preserve matching history items on query input
