### PR TITLE
Enable semantic_index by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -370,7 +370,7 @@
   },
   // Difference settings for semantic_index
   "semantic_index": {
-    "enabled": false
+    "enabled": true
   },
   // Settings specific to our elixir integration
   "elixir": {


### PR DESCRIPTION
Release Notes:

- Enabled the `semantic_index` setting by default.