### PR TITLE
storybook: Fix kitchen sink story

### DIFF
--- a/crates/storybook/src/stories/kitchen_sink.rs
+++ b/crates/storybook/src/stories/kitchen_sink.rs
@@ -1,46 +1,23 @@
+use strum::IntoEnumIterator;
 use ui::prelude::*;
 
 use crate::story::Story;
+use crate::story_selector::{ComponentStory, ElementStory};
 
 #[derive(Element, Default)]
 pub struct KitchenSinkStory {}
 
 impl KitchenSinkStory {
     fn render<V: 'static>(&mut self, _: &mut V, cx: &mut ViewContext<V>) -> impl IntoElement<V> {
+        let element_stories = ElementStory::iter().map(|selector| selector.story());
+        let component_stories = ComponentStory::iter().map(|selector| selector.story());
+
         Story::container(cx)
+            .overflow_y_scroll(ScrollState::default())
             .child(Story::title(cx, "Kitchen Sink"))
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .overflow_y_scroll(ScrollState::default())
-                    .child(crate::stories::elements::avatar::AvatarStory::default())
-                    .child(crate::stories::elements::button::ButtonStory::default())
-                    .child(crate::stories::elements::icon::IconStory::default())
-                    .child(crate::stories::elements::input::InputStory::default())
-                    .child(crate::stories::elements::label::LabelStory::default())
-                    .child(
-                        crate::stories::components::assistant_panel::AssistantPanelStory::default(),
-                    )
-                    .child(crate::stories::components::breadcrumb::BreadcrumbStory::default())
-                    .child(crate::stories::components::buffer::BufferStory::default())
-                    .child(crate::stories::components::chat_panel::ChatPanelStory::default())
-                    .child(crate::stories::components::collab_panel::CollabPanelStory::default())
-                    .child(crate::stories::components::facepile::FacepileStory::default())
-                    .child(crate::stories::components::keybinding::KeybindingStory::default())
-                    .child(crate::stories::components::palette::PaletteStory::default())
-                    .child(crate::stories::components::panel::PanelStory::default())
-                    .child(crate::stories::components::project_panel::ProjectPanelStory::default())
-                    .child(crate::stories::components::status_bar::StatusBarStory::default())
-                    .child(crate::stories::components::tab::TabStory::default())
-                    .child(crate::stories::components::tab_bar::TabBarStory::default())
-                    .child(crate::stories::components::terminal::TerminalStory::default())
-                    .child(crate::stories::components::title_bar::TitleBarStory::default())
-                    .child(crate::stories::components::toolbar::ToolbarStory::default())
-                    .child(
-                        crate::stories::components::traffic_lights::TrafficLightsStory::default(),
-                    )
-                    .child(crate::stories::components::context_menu::ContextMenuStory::default()),
-            )
+            .child(Story::label(cx, "Elements"))
+            .child(div().flex().flex_col().children_any(element_stories))
+            .child(Story::label(cx, "Components"))
+            .child(div().flex().flex_col().children_any(component_stories))
     }
 }

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -70,24 +70,11 @@ fn main() {
                 ..Default::default()
             },
             |cx| match args.story {
-                // HACK: Special-case the kitchen sink to fix scrolling.
-                Some(StorySelector::KitchenSink) => view(move |cx| {
-                    render_story(
-                        &mut ViewContext::new(cx),
-                        theme_override.clone(),
-                        crate::stories::kitchen_sink::KitchenSinkStory::default(),
-                    )
-                }),
                 Some(selector) => view(move |cx| {
                     render_story(
                         &mut ViewContext::new(cx),
                         theme_override.clone(),
-                        div()
-                            .flex()
-                            .flex_col()
-                            .w_full()
-                            .h_full()
-                            .children_any(selector.story()),
+                        div().flex().flex_col().h_full().child_any(selector.story()),
                     )
                 }),
                 None => view(move |cx| {

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -71,8 +71,6 @@ fn main() {
             },
             |cx| match args.story {
                 // HACK: Special-case the kitchen sink to fix scrolling.
-                // There is something about going through `children_any` that messes
-                // with the scroll interactions.
                 Some(StorySelector::KitchenSink) => view(move |cx| {
                     render_story(
                         &mut ViewContext::new(cx),
@@ -80,23 +78,16 @@ fn main() {
                         crate::stories::kitchen_sink::KitchenSinkStory::default(),
                     )
                 }),
-                // HACK: Special-case the panel story to fix scrolling.
-                // There is something about going through `children_any` that messes
-                // with the scroll interactions.
-                Some(StorySelector::Component(story_selector::ComponentStory::Panel)) => {
-                    view(move |cx| {
-                        render_story(
-                            &mut ViewContext::new(cx),
-                            theme_override.clone(),
-                            crate::stories::components::panel::PanelStory::default(),
-                        )
-                    })
-                }
                 Some(selector) => view(move |cx| {
                     render_story(
                         &mut ViewContext::new(cx),
                         theme_override.clone(),
-                        div().children_any(selector.story()),
+                        div()
+                            .flex()
+                            .flex_col()
+                            .w_full()
+                            .h_full()
+                            .children_any(selector.story()),
                     )
                 }),
                 None => view(move |cx| {


### PR DESCRIPTION
This PR fixes the kitchen sink story in the storybook.

Included are some additional changes that make it so the kitchen sink is automatically populated by all of the defined stories.

Release Notes:

- N/A
