### PR TITLE
ui: Mirror option key in keybindings

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -265,7 +265,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                     .with_children(
                         [
                             (keystroke.ctrl, "^"),
-                            (keystroke.alt, "⎇"),
+                            (keystroke.alt, "⌥"),
                             (keystroke.cmd, "⌘"),
                             (keystroke.shift, "⇧"),
                         ]

--- a/crates/gpui/src/keymap_matcher/keystroke.rs
+++ b/crates/gpui/src/keymap_matcher/keystroke.rs
@@ -112,7 +112,7 @@ impl std::fmt::Display for Keystroke {
             f.write_char('^')?;
         }
         if self.alt {
-            f.write_char('⎇')?;
+            f.write_char('⌥')?;
         }
         if self.cmd {
             f.write_char('⌘')?;


### PR DESCRIPTION
![image](https://github.com/zed-industries/zed/assets/24362066/94731737-a21a-4cef-a445-eb855f1a4d3e)
![image](https://github.com/zed-industries/zed/assets/24362066/e879ec9a-70aa-4989-923f-4cca18d01587)

Release Notes:

- Fixed option key's appearance in keybindings
