### PR TITLE
ui: Fix glyph used for option key in `Keybinding`

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -92,7 +92,7 @@ impl ModifierKey {
     pub fn glyph(&self) -> char {
         match self {
             Self::Control => '^',
-            Self::Alt => '⎇',
+            Self::Alt => '⌥',
             Self::Command => '⌘',
             Self::Shift => '⇧',
         }


### PR DESCRIPTION
This PR fixes the glyph used for the option key in the new `Keybinding` component.

Same fix as in #3065, but applied to the new `Keybinding` component so that we don't regress when switching to GPUI2.

<img width="750" alt="Screenshot 2023-09-29 at 10 50 15 AM" src="https://github.com/zed-industries/zed/assets/1486634/8c6147e9-fa05-4804-954c-b8e3b98cbdf0">

Release Notes:

- N/A

