### PR TITLE
vim: Fix accidental visual selection when following

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -195,6 +195,9 @@ impl Vim {
             if editor_mode == EditorMode::Full
                 && !newest_selection_empty
                 && self.state().mode == Mode::Normal
+                // if leader_replica_id is set, then you're following someone else's cursor
+                // don't switch vim mode.
+                && editor.leader_replica_id().is_none()
             {
                 self.switch_mode(Mode::Visual, true, cx);
             }


### PR DESCRIPTION
Release Notes:

- vim: Fix a bug where following could put you in visual mode
