### PR TITLE
add scheme for full parseable files in semantic index

### DIFF
--- a/crates/semantic_index/src/parsing.rs
+++ b/crates/semantic_index/src/parsing.rs
@@ -61,8 +61,9 @@ const CODE_CONTEXT_TEMPLATE: &str =
 const ENTIRE_FILE_TEMPLATE: &str =
     "The below snippet is from file '<path>'\n\n```<language>\n<item>\n```";
 const MARKDOWN_CONTEXT_TEMPLATE: &str = "The below file contents is from file '<path>'\n\n<item>";
-pub const PARSEABLE_ENTIRE_FILE_TYPES: &[&str] =
-    &["TOML", "YAML", "CSS", "HEEX", "ERB", "SVELTE", "HTML"];
+pub const PARSEABLE_ENTIRE_FILE_TYPES: &[&str] = &[
+    "TOML", "YAML", "CSS", "HEEX", "ERB", "SVELTE", "HTML", "Scheme",
+];
 
 pub struct CodeContextRetriever {
     pub parser: Parser,


### PR DESCRIPTION
add scheme as a parseable file type in semantic index.
Each file will operate as a single embedding, in which no real scheme syntax or tree-sitter level data is stored.

Release Notes:

- Added scheme to Semantic Index