### PR TITLE
Add Nushell support to venv activation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -361,7 +361,7 @@
           ".venv",
           "venv"
         ],
-        // Can also be 'csh' and 'fish'
+        // Can also be 'csh', 'fish', and `nushell`
         "activate_script": "default"
       }
     }

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -84,6 +84,7 @@ impl Project {
             terminal_settings::ActivateScript::Default => "activate",
             terminal_settings::ActivateScript::Csh => "activate.csh",
             terminal_settings::ActivateScript::Fish => "activate.fish",
+            terminal_settings::ActivateScript::Nushell => "activate.nu",
         };
 
         for virtual_environment_name in settings.directories {

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -69,6 +69,7 @@ pub enum ActivateScript {
     Default,
     Csh,
     Fish,
+    Nushell,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
This PR adds an option to run `activate.nu` in the automatic venv activation code (relevant comment [here](https://github.com/zed-industries/zed/issues/6323))

Release Notes:

- Added a `nushell` option to the `terminal.detect_venv.on.activate_script` setting ([2103](https://github.com/zed-industries/zed/issues/6323)).
