### PR TITLE
enabled truncation for messages that extend over the models limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "tiktoken-rs 0.5.4",
+ "tiktoken-rs",
  "util",
 ]
 
@@ -326,7 +326,7 @@ dependencies = [
  "settings",
  "smol",
  "theme",
- "tiktoken-rs 0.4.5",
+ "tiktoken-rs",
  "util",
  "uuid 1.4.1",
  "workspace",
@@ -6797,7 +6797,7 @@ dependencies = [
  "smol",
  "tempdir",
  "theme",
- "tiktoken-rs 0.5.4",
+ "tiktoken-rs",
  "tree-sitter",
  "tree-sitter-cpp",
  "tree-sitter-elixir",
@@ -7872,21 +7872,6 @@ dependencies = [
  "jpeg-decoder",
  "miniz_oxide 0.4.4",
  "weezl",
-]
-
-[[package]]
-name = "tiktoken-rs"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52aacc1cff93ba9d5f198c62c49c77fa0355025c729eed3326beaf7f33bc8614"
-dependencies = [
- "anyhow",
- "base64 0.21.4",
- "bstr",
- "fancy-regex",
- "lazy_static",
- "parking_lot 0.12.1",
- "rustc-hash",
 ]
 
 [[package]]

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -32,3 +32,4 @@ bincode = "1.3.3"
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }
+util = { path = "../util", features = ["test-support"] }

--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use std::fmt::{self, Display};
 
 use serde::{Deserialize, Serialize};

--- a/crates/ai/src/ai.rs
+++ b/crates/ai/src/ai.rs
@@ -1,2 +1,152 @@
+use anyhow::anyhow;
+use std::fmt::{self, Display};
+
+use serde::{Deserialize, Serialize};
+use tiktoken_rs::{
+    get_bpe_from_model, get_chat_completion_max_tokens, ChatCompletionRequestMessage,
+};
+
 pub mod completion;
 pub mod embedding;
+
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    User,
+    Assistant,
+    System,
+}
+
+impl Role {
+    pub fn cycle(&mut self) {
+        *self = match self {
+            Role::User => Role::Assistant,
+            Role::Assistant => Role::System,
+            Role::System => Role::User,
+        }
+    }
+}
+
+impl Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::User => write!(f, "User"),
+            Role::Assistant => write!(f, "Assistant"),
+            Role::System => write!(f, "System"),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct RequestMessage {
+    pub role: Role,
+    pub content: String,
+}
+
+impl RequestMessage {
+    pub fn to_tiktoken_message(&self) -> ChatCompletionRequestMessage {
+        ChatCompletionRequestMessage {
+            content: Some(self.content.clone()),
+            role: self.role.to_string(),
+            name: None,
+            function_call: None,
+        }
+    }
+}
+
+pub fn truncate_messages(
+    messages: &Vec<RequestMessage>,
+    model: &str,
+    reserved_tokens: usize,
+) -> anyhow::Result<Vec<RequestMessage>> {
+    let mut tiktoken_messages = Vec::new();
+    let mut valid_messages = Vec::new();
+    for message in messages.into_iter().rev() {
+        tiktoken_messages.push(message.to_tiktoken_message());
+
+        let remaining_token_count =
+            get_chat_completion_max_tokens(model, tiktoken_messages.as_slice())?;
+        if remaining_token_count > reserved_tokens {
+            valid_messages.insert(0, message.clone());
+        } else {
+            let cut_tokens = reserved_tokens - remaining_token_count;
+            let bpe = get_bpe_from_model(model)?;
+            let encoding = bpe.encode_with_special_tokens(message.content.as_str());
+            let content = bpe.decode(encoding[cut_tokens..].to_vec())?;
+            let new_message = RequestMessage {
+                content,
+                role: message.role,
+            };
+            valid_messages.insert(0, new_message);
+            break;
+        }
+    }
+
+    Ok(valid_messages)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{distributions::Alphanumeric, thread_rng, Rng};
+    use tiktoken_rs::{get_chat_completion_max_tokens, ChatCompletionRequestMessage};
+
+    use crate::{truncate_messages, RequestMessage, Role};
+
+    fn generate_test_string(token_count: usize, model: &str) -> String {
+        let rand_string: String = thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(token_count * 5)
+            .map(char::from)
+            .collect();
+
+        let bpe = tiktoken_rs::get_bpe_from_model(model).unwrap();
+        let encoding = bpe.encode_with_special_tokens(rand_string.as_str());
+        let test_string = bpe.decode(encoding[..token_count].to_vec()).unwrap();
+
+        test_string
+    }
+
+    fn tokens_remaining_in_conversation(messages: Vec<RequestMessage>, model: &str) -> usize {
+        let messages = messages
+            .into_iter()
+            .map(|message| message.to_tiktoken_message())
+            .collect::<Vec<ChatCompletionRequestMessage>>();
+
+        get_chat_completion_max_tokens(model, messages.as_slice()).unwrap()
+    }
+
+    #[test]
+    fn test_truncate_messages() {
+        // GPT-4s user limit is 8189, reserved is 1k, pf 7189 of valid room
+        let model = "gpt-4";
+
+        let mut messages = Vec::new();
+        // Should be at least 9010 tokens.
+        // As such, when truncated we should return 10 messages, with the first one truncated.
+        for _ in 0..10 {
+            messages.push(RequestMessage {
+                content: generate_test_string(901, model),
+                role: Role::User,
+            })
+        }
+
+        let truncated_messages = truncate_messages(&messages, model, 1000).unwrap();
+        assert_eq!(
+            tokens_remaining_in_conversation(truncated_messages, model),
+            1000
+        );
+
+        // Should be at least 9010 tokens.
+        // As such, when truncated we should return 10 messages, with the first one truncated.
+        let mut messages = Vec::new();
+        for _ in 0..10 {
+            messages.push(RequestMessage {
+                content: generate_test_string(101, model),
+                role: Role::User,
+            })
+        }
+
+        let truncated_messages = truncate_messages(&messages, model, 1000).unwrap();
+        assert_eq!(messages, truncated_messages);
+    }
+}

--- a/crates/ai/src/completion.rs
+++ b/crates/ai/src/completion.rs
@@ -1,3 +1,4 @@
+use crate::{RequestMessage, Role};
 use anyhow::{anyhow, Result};
 use futures::{
     future::BoxFuture, io::BufReader, stream::BoxStream, AsyncBufReadExt, AsyncReadExt, FutureExt,
@@ -6,47 +7,9 @@ use futures::{
 use gpui::executor::Background;
 use isahc::{http::StatusCode, Request, RequestExt};
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{self, Display},
-    io,
-    sync::Arc,
-};
+use std::{io, sync::Arc};
 
 pub const OPENAI_API_URL: &'static str = "https://api.openai.com/v1";
-
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum Role {
-    User,
-    Assistant,
-    System,
-}
-
-impl Role {
-    pub fn cycle(&mut self) {
-        *self = match self {
-            Role::User => Role::Assistant,
-            Role::Assistant => Role::System,
-            Role::System => Role::User,
-        }
-    }
-}
-
-impl Display for Role {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Role::User => write!(f, "User"),
-            Role::Assistant => write!(f, "Assistant"),
-            Role::System => write!(f, "System"),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub struct RequestMessage {
-    pub role: Role,
-    pub content: String,
-}
 
 #[derive(Debug, Default, Serialize)]
 pub struct OpenAIRequest {

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -36,7 +36,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smol.workspace = true
-tiktoken-rs = "0.4"
+tiktoken-rs = "0.5"
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -3,7 +3,7 @@ mod assistant_settings;
 mod codegen;
 mod streaming_diff;
 
-use ai::completion::Role;
+use ai::Role;
 use anyhow::Result;
 pub use assistant_panel::AssistantPanel;
 use assistant_settings::OpenAIModel;

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -53,7 +53,6 @@ use theme::{
     components::{action_button::Button, ComponentExt},
     AssistantStyle,
 };
-use tiktoken_rs::{get_bpe_from_model, get_chat_completion_max_tokens};
 use util::{paths::CONVERSATIONS_DIR, post_inc, ResultExt, TryFutureExt};
 use uuid::Uuid;
 use workspace::{


### PR DESCRIPTION
This is parked until we can get appropriate UI to illustrate the cutoff.

Enable truncation for assistant conversations which extend over the models limit, with 1000 tokens reserved for completion.

Ie. if you have a conversation with 10000 tokens, and the models limit is 8192, it will truncate your message to 7192 tokens, reserving 1000 for completion. One side effect of this is that it does enforce a reserved token count for completion, essentially reducing the room the user has for completion. On the other hand, it now allows for users to continue long conversations in the same chat panel, truncating the oldest messages first. However, as this channel is still a relatively low level interface, I am unsure how we should treat the token counter at the top. It will reflect negative once you are over the line, however you will still be able to do chat completion. Maybe we just want a counter up. @iamnbutler 

Release Notes:

- enabled message truncation when over the limit in the assistant panel