### PR TITLE
auto-update: Link to the current release's changelog, not the latest one

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -115,13 +115,15 @@ pub fn check(_: &Check, cx: &mut AppContext) {
 
 fn view_release_notes(_: &ViewReleaseNotes, cx: &mut AppContext) {
     if let Some(auto_updater) = AutoUpdater::get(cx) {
-        let server_url = &auto_updater.read(cx).server_url;
+        let auto_updater = auto_updater.read(cx);
+        let server_url = &auto_updater.server_url;
+        let current_version = auto_updater.current_version;
         let latest_release_url = if cx.has_global::<ReleaseChannel>()
             && *cx.global::<ReleaseChannel>() == ReleaseChannel::Preview
         {
-            format!("{server_url}/releases/preview/latest")
+            format!("{server_url}/releases/preview/{current_version}")
         } else {
-            format!("{server_url}/releases/stable/latest")
+            format!("{server_url}/releases/stable/{current_version}")
         };
         cx.platform().open_url(&latest_release_url);
     }


### PR DESCRIPTION

An user complained in zed-industries/zed#6320 that we always link to the latest release changelog, not the one that they've just updated to.


Release Notes:
- Fixed changelog link in update notification always leading to the latest release changelog, not the one that was updated to. Fixes zed-industries/zed#6320.
