### PR TITLE
Detach completion confirmation task when selecting with mouse

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1057,7 +1057,8 @@ impl CompletionsMenu {
                                     item_ix: Some(item_ix),
                                 },
                                 cx,
-                            );
+                            )
+                            .map(|task| task.detach());
                         })
                         .into_any(),
                     );


### PR DESCRIPTION
Otherwise the spawn to resolve the additional edits never runs causing autocomplete to never add imports automatically when clicking with the mouse

Release Notes:

- Fixed auto-complete additional edits, such as auto-import, not applying when selecting a completion with a mouse click.
