### PR TITLE
join channels

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -291,10 +291,10 @@ impl ActiveCall {
         &mut self,
         channel_id: u64,
         cx: &mut ModelContext<Self>,
-    ) -> Task<Result<()>> {
+    ) -> Task<Result<ModelHandle<Room>>> {
         if let Some(room) = self.room().cloned() {
             if room.read(cx).channel_id() == Some(channel_id) {
-                return Task::ready(Ok(()));
+                return Task::ready(Ok(room));
             } else {
                 room.update(cx, |room, cx| room.clear_state(cx));
             }
@@ -309,7 +309,7 @@ impl ActiveCall {
             this.update(&mut cx, |this, cx| {
                 this.report_call_event("join channel", cx)
             });
-            Ok(())
+            Ok(room)
         })
     }
 

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -594,6 +594,33 @@ impl Room {
             .map_or(&[], |v| v.as_slice())
     }
 
+    /// projects_to_join returns a list of shared projects sorted such
+    /// that the most 'active' projects appear last.
+    pub fn projects_to_join(&self) -> Vec<(u64, u64)> {
+        let mut projects = HashMap::default();
+        let mut hosts = HashMap::default();
+        for participant in self.remote_participants.values() {
+            match participant.location {
+                ParticipantLocation::SharedProject { project_id } => {
+                    *projects.entry(project_id).or_insert(0) += 1;
+                }
+                ParticipantLocation::External | ParticipantLocation::UnsharedProject => {}
+            }
+            for project in &participant.projects {
+                *projects.entry(project.id).or_insert(0) += 1;
+                hosts.insert(project.id, participant.user.id);
+            }
+        }
+
+        let mut pairs: Vec<(u64, usize)> = projects.into_iter().collect();
+        pairs.sort_by_key(|(_, count)| 0 - *count as i32);
+
+        pairs
+            .into_iter()
+            .map(|(project_id, _)| (project_id, hosts[&project_id]))
+            .collect()
+    }
+
     async fn handle_room_updated(
         this: ModelHandle<Self>,
         envelope: TypedEnvelope<proto::RoomUpdated>,


### PR DESCRIPTION
Release Notes:

- Clicking on a channel in the sidebar will now join the channel and open the notes
- If you join a channel that already shared projects, you will join the projects automatically and follow the host.
- Clicking on the current channel in the sidebar will re-open the notes.
- Chat can now be accessed from the right click menu of channels.


- (probably not worth mentioning) Various improvements to hover states and tooltips in the collab ui; and if you click on a channel while in another call, confirm before switching.
