### PR TITLE
Remove old code from notes icon click handler

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2086,13 +2086,7 @@ impl CollabPanel {
                         }
                     })
                     .on_click(MouseButton::Left, move |_, this, cx| {
-                        let participants =
-                            this.channel_store.read(cx).channel_participants(channel_id);
-                        if is_active || participants.is_empty() {
-                            this.open_channel_notes(&OpenChannelNotes { channel_id }, cx);
-                        } else {
-                            this.join_channel(channel_id, cx);
-                        };
+                        this.open_channel_notes(&OpenChannelNotes { channel_id }, cx);
                     }),
                 )
                 .align_children_center()


### PR DESCRIPTION
Release Notes:

- Fix clicking the notes icon when people are in the channel (preview only)

