### PR TITLE
Ensure chat messages are retrieved in order of id

### DIFF
--- a/crates/collab/src/db/queries.rs
+++ b/crates/collab/src/db/queries.rs
@@ -9,13 +9,3 @@ pub mod projects;
 pub mod rooms;
 pub mod servers;
 pub mod users;
-
-fn max_assign<T: Ord>(max: &mut Option<T>, val: T) {
-    if let Some(max_val) = max {
-        if val > *max_val {
-            *max = Some(val);
-        }
-    } else {
-        *max = Some(val);
-    }
-}


### PR DESCRIPTION
Also, remove logic for implicitly marking chat messages as observed when they are fetched. I think this is unnecessary, because the client always explicitly acknowledges messages when they are shown.

Release Notes:

- Fixed a bug where chat messages were shown out of order (preview only)