### PR TITLE
Don't wrap on paragraphs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,4 @@ xtask = "run --package xtask --"
 
 [build]
 # v0 mangling scheme provides more detailed backtraces around closures
-rustflags = ["-C", "symbol-mangling-version=v0"]
+rustflags = ["-C", "symbol-mangling-version=v0", "-C", "link-arg=-fuse-ld=/opt/homebrew/Cellar/llvm/16.0.6/bin/ld64.lld"]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1333,7 +1333,7 @@ async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut gpui::TestAppCon
 
     cx.update_editor(|editor, cx| editor.move_to_end_of_paragraph(&MoveToEndOfParagraph, cx));
     cx.assert_editor_state(
-        &r#"ˇone
+        &r#"one
         two
 
         three
@@ -1344,9 +1344,22 @@ async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut gpui::TestAppCon
             .unindent(),
     );
 
-    cx.update_editor(|editor, cx| editor.move_to_end_of_paragraph(&MoveToEndOfParagraph, cx));
+    cx.update_editor(|editor, cx| editor.move_to_start_of_paragraph(&MoveToStartOfParagraph, cx));
     cx.assert_editor_state(
-        &r#"ˇone
+        &r#"one
+        two
+
+        three
+        four
+        five
+        ˇ
+        six"#
+            .unindent(),
+    );
+
+    cx.update_editor(|editor, cx| editor.move_to_start_of_paragraph(&MoveToStartOfParagraph, cx));
+    cx.assert_editor_state(
+        &r#"one
         two
         ˇ
         three
@@ -1366,32 +1379,6 @@ async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut gpui::TestAppCon
         four
         five
 
-        sixˇ"#
-            .unindent(),
-    );
-
-    cx.update_editor(|editor, cx| editor.move_to_start_of_paragraph(&MoveToStartOfParagraph, cx));
-    cx.assert_editor_state(
-        &r#"one
-        two
-
-        three
-        four
-        five
-        ˇ
-        sixˇ"#
-            .unindent(),
-    );
-
-    cx.update_editor(|editor, cx| editor.move_to_start_of_paragraph(&MoveToStartOfParagraph, cx));
-    cx.assert_editor_state(
-        &r#"one
-        two
-        ˇ
-        three
-        four
-        five
-        ˇ
         six"#
             .unindent(),
     );

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -234,7 +234,7 @@ pub fn start_of_paragraph(
 ) -> DisplayPoint {
     let point = display_point.to_point(map);
     if point.row == 0 {
-        return map.max_point();
+        return DisplayPoint::zero();
     }
 
     let mut found_non_blank_line = false;
@@ -261,7 +261,7 @@ pub fn end_of_paragraph(
 ) -> DisplayPoint {
     let point = display_point.to_point(map);
     if point.row == map.max_buffer_row() {
-        return DisplayPoint::zero();
+        return map.max_point();
     }
 
     let mut found_non_blank_line = false;

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -652,3 +652,28 @@ async fn test_selection_goal(cx: &mut gpui::TestAppContext) {
         Lorem Ipsum"})
         .await;
 }
+
+#[gpui::test]
+async fn test_paragraphs_dont_wrap(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state(indoc! {"
+        one
+        ˇ
+        two"})
+        .await;
+
+    cx.simulate_shared_keystrokes(["}", "}"]).await;
+    cx.assert_shared_state(indoc! {"
+        one
+
+        twˇo"})
+        .await;
+
+    cx.simulate_shared_keystrokes(["{", "{", "{"]).await;
+    cx.assert_shared_state(indoc! {"
+        ˇone
+
+        two"})
+        .await;
+}

--- a/crates/vim/test_data/test_paragraphs_dont_wrap.json
+++ b/crates/vim/test_data/test_paragraphs_dont_wrap.json
@@ -1,0 +1,8 @@
+{"Put":{"state":"one\nˇ\ntwo"}}
+{"Key":"}"}
+{"Key":"}"}
+{"Get":{"state":"one\n\ntwˇo","mode":"Normal"}}
+{"Key":"{"}
+{"Key":"{"}
+{"Key":"{"}
+{"Get":{"state":"ˇone\n\ntwo","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:

- vim: `{` and `}` will no longer wrap around end of file ([#2116](https://github.com/zed-industries/zed/issues/6326)).
