### PR TITLE
rust: Highlight async functions in completions

### DIFF
--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -377,7 +377,28 @@ mod tests {
                 ],
             })
         );
-
+        assert_eq!(
+            language
+                .label_for_completion(&lsp::CompletionItem {
+                    kind: Some(lsp::CompletionItemKind::FUNCTION),
+                    label: "hello(…)".to_string(),
+                    detail: Some("async fn(&mut Option<T>) -> Vec<T>".to_string()),
+                    ..Default::default()
+                })
+                .await,
+            Some(CodeLabel {
+                text: "hello(&mut Option<T>) -> Vec<T>".to_string(),
+                filter_range: 0..5,
+                runs: vec![
+                    (0..5, highlight_function),
+                    (7..10, highlight_keyword),
+                    (11..17, highlight_type),
+                    (18..19, highlight_type),
+                    (25..28, highlight_type),
+                    (29..30, highlight_type),
+                ],
+            })
+        );
         assert_eq!(
             language
                 .label_for_completion(&lsp::CompletionItem {


### PR DESCRIPTION
Before (code in screenshot is from this branch, `crates/zed/languages/rust.rs:179`):
![image](https://github.com/zed-industries/zed/assets/24362066/6b709f8c-1b80-4aaa-8ddc-8db9dbca5a5e)
Notice how the last 2 entries (that are async functions) are not highlighted properly.
After:
![image](https://github.com/zed-industries/zed/assets/24362066/88337f43-b97f-4257-9c31-54c9023e8dbb)

This is slightly suboptimal, as it's hard to tell that this is an async function - I guess adding an `async` prefix is not really an option, as then we should have a prefix for non-async functions too. Still, at least you can tell that something is a function in the first place. :)

Release Notes:
- Fixed Rust async functions not being highlighted in completions.
