### PR TITLE
Use display name for release channel in panic events

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -479,7 +479,7 @@ fn init_panic_hook(app: &App, installation_id: Option<String>, session_id: Strin
                 line: location.line(),
             }),
             app_version: app_version.clone(),
-            release_channel: RELEASE_CHANNEL.dev_name().into(),
+            release_channel: RELEASE_CHANNEL.display_name().into(),
             os_name: platform.os_name().into(),
             os_version: platform
                 .os_version()


### PR DESCRIPTION
This was a mistake from long ago - something I've been meaning to fix for a long time.  All other events use `display_name()`, but panic events, which leads to mistakes when filtering out `Zed Dev`, which isn't the format that `dev_name()` returns. I'm adding a fix to zed.dev as well:

- https://github.com/zed-industries/zed.dev/pull/393

so that the values are adjusted for all clients, not just ones with this fix.  I will correct the data in clickhouse, and adjust the queries in metabase.

Release Notes:

- N/A