### PR TITLE
Add a `crate-dep-graph` script, remove a few unnecessary dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,6 @@ dependencies = [
  "parking_lot 0.11.2",
  "regex",
  "rope",
- "rpc",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,6 @@ dependencies = [
  "anyhow",
  "async-broadcast",
  "audio",
- "channel",
  "client",
  "collections",
  "fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9969,7 +9969,6 @@ dependencies = [
  "async-recursion 1.0.5",
  "bincode",
  "call",
- "channel",
  "client",
  "collections",
  "context_menu",

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -20,7 +20,6 @@ test-support = [
 
 [dependencies]
 audio = { path = "../audio" }
-channel = { path = "../channel" }
 client = { path = "../client" }
 collections = { path = "../collections" }
 gpui = { path = "../gpui" }

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -5,7 +5,6 @@ pub mod room;
 use anyhow::{anyhow, Result};
 use audio::Audio;
 use call_settings::CallSettings;
-use channel::ChannelId;
 use client::{
     proto, ClickhouseEvent, Client, TelemetrySettings, TypedEnvelope, User, UserStore,
     ZED_ALWAYS_ACTIVE,
@@ -79,7 +78,7 @@ impl ActiveCall {
         }
     }
 
-    pub fn channel_id(&self, cx: &AppContext) -> Option<ChannelId> {
+    pub fn channel_id(&self, cx: &AppContext) -> Option<u64> {
         self.room()?.read(cx).channel_id()
     }
 

--- a/crates/channel/src/channel.rs
+++ b/crates/channel/src/channel.rs
@@ -2,19 +2,21 @@ mod channel_buffer;
 mod channel_chat;
 mod channel_store;
 
+use client::{Client, UserStore};
+use gpui::{AppContext, ModelHandle};
+use std::sync::Arc;
+
 pub use channel_buffer::{ChannelBuffer, ChannelBufferEvent, ACKNOWLEDGE_DEBOUNCE_INTERVAL};
 pub use channel_chat::{ChannelChat, ChannelChatEvent, ChannelMessage, ChannelMessageId};
 pub use channel_store::{
     Channel, ChannelData, ChannelEvent, ChannelId, ChannelMembership, ChannelPath, ChannelStore,
 };
 
-use client::Client;
-use std::sync::Arc;
-
 #[cfg(test)]
 mod channel_store_tests;
 
-pub fn init(client: &Arc<Client>) {
+pub fn init(client: &Arc<Client>, user_store: ModelHandle<UserStore>, cx: &mut AppContext) {
+    channel_store::init(client, user_store, cx);
     channel_buffer::init(client);
     channel_chat::init(client);
 }

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -2,6 +2,7 @@ mod channel_index;
 
 use crate::{channel_buffer::ChannelBuffer, channel_chat::ChannelChat};
 use anyhow::{anyhow, Result};
+use channel_index::ChannelIndex;
 use client::{Client, Subscription, User, UserId, UserStore};
 use collections::{hash_map, HashMap, HashSet};
 use futures::{channel::mpsc, future::Shared, Future, FutureExt, StreamExt};
@@ -14,7 +15,11 @@ use serde_derive::{Deserialize, Serialize};
 use std::{borrow::Cow, hash::Hash, mem, ops::Deref, sync::Arc, time::Duration};
 use util::ResultExt;
 
-use self::channel_index::ChannelIndex;
+pub fn init(client: &Arc<Client>, user_store: ModelHandle<UserStore>, cx: &mut AppContext) {
+    let channel_store =
+        cx.add_model(|cx| ChannelStore::new(client.clone(), user_store.clone(), cx));
+    cx.set_global(channel_store);
+}
 
 pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -71,6 +76,10 @@ enum OpenedModelHandle<E: Entity> {
 }
 
 impl ChannelStore {
+    pub fn global(cx: &AppContext) -> ModelHandle<Self> {
+        cx.global::<ModelHandle<Self>>().clone()
+    }
+
     pub fn new(
         client: Arc<Client>,
         user_store: ModelHandle<UserStore>,

--- a/crates/channel/src/channel_store_tests.rs
+++ b/crates/channel/src/channel_store_tests.rs
@@ -340,10 +340,10 @@ fn init_test(cx: &mut AppContext) -> ModelHandle<ChannelStore> {
 
     cx.foreground().forbid_parking();
     cx.set_global(SettingsStore::test(cx));
-    crate::init(&client);
     client::init(&client, cx);
+    crate::init(&client, user_store, cx);
 
-    cx.add_model(|cx| ChannelStore::new(client, user_store, cx))
+    ChannelStore::global(cx)
 }
 
 fn update_channels(

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -73,7 +73,7 @@ impl ChannelView {
     ) -> Task<Result<ViewHandle<Self>>> {
         let workspace = workspace.read(cx);
         let project = workspace.project().to_owned();
-        let channel_store = workspace.app_state().channel_store.clone();
+        let channel_store = ChannelStore::global(cx);
         let markdown = workspace
             .app_state()
             .languages

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -81,7 +81,7 @@ impl ChatPanel {
     pub fn new(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) -> ViewHandle<Self> {
         let fs = workspace.app_state().fs.clone();
         let client = workspace.app_state().client.clone();
-        let channel_store = workspace.app_state().channel_store.clone();
+        let channel_store = ChannelStore::global(cx);
         let languages = workspace.app_state().languages.clone();
 
         let input_editor = cx.add_view(|cx| {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -648,7 +648,7 @@ impl CollabPanel {
                 channel_editing_state: None,
                 selection: None,
                 user_store: workspace.user_store().clone(),
-                channel_store: workspace.app_state().channel_store.clone(),
+                channel_store: ChannelStore::global(cx),
                 project: workspace.project().clone(),
                 subscriptions: Vec::default(),
                 match_candidates: Vec::default(),

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -13,7 +13,6 @@ rope = { path = "../rope" }
 text = { path = "../text" }
 util = { path = "../util" }
 sum_tree = { path = "../sum_tree" }
-rpc = { path = "../rpc" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/fs/src/repository.rs
+++ b/crates/fs/src/repository.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use collections::HashMap;
 use git2::{BranchType, StatusShow};
 use parking_lot::Mutex;
-use rpc::proto;
 use serde_derive::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -23,6 +22,7 @@ pub struct Branch {
     /// Timestamp of most recent commit, normalized to Unix Epoch format.
     pub unix_timestamp: Option<i64>,
 }
+
 #[async_trait::async_trait]
 pub trait GitRepository: Send {
     fn reload_index(&self);
@@ -356,24 +356,6 @@ impl GitFileStatus {
                 }
                 _ => None,
             }
-        }
-    }
-
-    pub fn from_proto(git_status: Option<i32>) -> Option<GitFileStatus> {
-        git_status.and_then(|status| {
-            proto::GitStatus::from_i32(status).map(|status| match status {
-                proto::GitStatus::Added => GitFileStatus::Added,
-                proto::GitStatus::Modified => GitFileStatus::Modified,
-                proto::GitStatus::Conflict => GitFileStatus::Conflict,
-            })
-        })
-    }
-
-    pub fn to_proto(self) -> i32 {
-        match self {
-            GitFileStatus::Added => proto::GitStatus::Added as i32,
-            GitFileStatus::Modified => proto::GitStatus::Modified as i32,
-            GitFileStatus::Conflict => proto::GitStatus::Conflict as i32,
         }
     }
 }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -22,7 +22,6 @@ test-support = [
 ]
 
 [dependencies]
-client = { path = "../client" }
 clock = { path = "../clock" }
 collections = { path = "../collections" }
 fuzzy = { path = "../fuzzy" }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -22,7 +22,6 @@ test-support = [
 db = { path = "../db" }
 call = { path = "../call" }
 client = { path = "../client" }
-channel = { path = "../channel" }
 collections = { path = "../collections" }
 context_menu = { path = "../context_menu" }
 drag_and_drop = { path = "../drag_and_drop" }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{anyhow, Context, Result};
 use backtrace::Backtrace;
-use channel::ChannelStore;
 use cli::{
     ipc::{self, IpcSender},
     CliRequest, CliResponse, IpcHandshake, FORCE_CLI_MODE_ENV_VAR_NAME,
@@ -138,8 +137,6 @@ fn main() {
 
         languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.add_model(|cx| UserStore::new(client.clone(), http.clone(), cx));
-        let channel_store =
-            cx.add_model(|cx| ChannelStore::new(client.clone(), user_store.clone(), cx));
         let workspace_store = cx.add_model(|cx| WorkspaceStore::new(client.clone(), cx));
 
         cx.set_global(client.clone());
@@ -156,7 +153,7 @@ fn main() {
         outline::init(cx);
         project_symbols::init(cx);
         project_panel::init(Assets, cx);
-        channel::init(&client);
+        channel::init(&client, user_store.clone(), cx);
         diagnostics::init(cx);
         search::init(cx);
         semantic_index::init(fs.clone(), http.clone(), languages.clone(), cx);
@@ -184,7 +181,6 @@ fn main() {
             languages,
             client: client.clone(),
             user_store,
-            channel_store,
             fs,
             build_window_options,
             initialize_workspace,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2424,6 +2424,7 @@ mod tests {
             state.build_window_options = build_window_options;
             theme::init((), cx);
             audio::init((), cx);
+            channel::init(&app_state.client, app_state.user_store.clone(), cx);
             call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             workspace::init(app_state.clone(), cx);
             Project::init_settings(cx);

--- a/script/crate-dep-graph
+++ b/script/crate-dep-graph
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [[ -x cargo-depgraph ]]; then
+    cargo install cargo-depgraph
+fi
+
+graph_file=target/crate-graph.html
+
+cargo depgraph \
+    --workspace-only \
+    --offline \
+    --root=zed,cli,collab \
+    --dedup-transitive-deps \
+    | dot -Tsvg > $graph_file
+
+echo "open $graph_file"
+open $graph_file


### PR DESCRIPTION
This was motivated by me trying to decide which crate I should put a `NotificationStore` in.

Run `script/crate-dep-graph` to generate an SVG showing the dependency graph of our `crates` folder, and open it in a web browser.

After running this command, I noticed a couple of dependencies that didn't make sense and were easy to remove.

Current dependency graph:

![Screen Shot 2023-10-06 at 1 15 42 PM](https://github.com/zed-industries/zed/assets/326587/b5008235-498a-4562-a826-cc923898c052)
