### PR TITLE
Add enable vim mode checkbox to welcome screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9665,6 +9665,7 @@ dependencies = [
  "theme",
  "theme_selector",
  "util",
+ "vim",
  "workspace",
 ]
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -33,7 +33,7 @@ use workspace::{self, Workspace};
 
 use crate::state::ReplayableAction;
 
-struct VimModeSetting(bool);
+pub struct VimModeSetting(pub bool);
 
 #[derive(Clone, Deserialize, PartialEq)]
 pub struct SwitchMode(pub Mode);

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -25,6 +25,7 @@ theme_selector = { path = "../theme_selector" }
 util = { path = "../util" }
 picker = { path = "../picker" }
 workspace = { path = "../workspace" }
+vim = { path = "../vim" }
 
 anyhow.workspace = true
 log.workspace = true


### PR DESCRIPTION
Had a user state that they didn't know how to enable vim mode and that it was "almost a non-starter" for them. IMO, it is a big enough feature to warrant being on the welcome screen.

<img width="968" alt="SCR-20231008-rnhj" src="https://github.com/zed-industries/zed/assets/19867440/a189c646-1fa7-497c-b6d9-37cb1caa0492">

Release Notes:

- Added an `Enable vim mode` checkbox to the welcome screen