### PR TITLE
Ignore history items' paths when matching search queries

### DIFF
--- a/crates/fuzzy/src/matcher.rs
+++ b/crates/fuzzy/src/matcher.rs
@@ -441,7 +441,7 @@ mod tests {
                 score,
                 worktree_id: 0,
                 positions: Vec::new(),
-                path: candidate.path.clone(),
+                path: Arc::from(candidate.path),
                 path_prefix: "".into(),
                 distance_to_relative_ancestor: usize::MAX,
             },

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct PathMatchCandidate<'a> {
-    pub path: &'a Arc<Path>,
+    pub path: &'a Path,
     pub char_bag: CharBag,
 }
 
@@ -120,7 +120,7 @@ pub fn match_fixed_path_set(
             score,
             worktree_id,
             positions: Vec::new(),
-            path: candidate.path.clone(),
+            path: Arc::from(candidate.path),
             path_prefix: Arc::from(""),
             distance_to_relative_ancestor: usize::MAX,
         },
@@ -195,7 +195,7 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                                     score,
                                     worktree_id,
                                     positions: Vec::new(),
-                                    path: candidate.path.clone(),
+                                    path: Arc::from(candidate.path),
                                     path_prefix: candidate_set.prefix(),
                                     distance_to_relative_ancestor: relative_to.as_ref().map_or(
                                         usize::MAX,


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/3059 

Before: 
![image](https://github.com/zed-industries/zed/assets/2690773/4eb2d2d1-1aa3-40b8-b782-bf2bc5f17b43)

After:
![image](https://github.com/zed-industries/zed/assets/2690773/5587d46b-9198-45fe-9372-114a95d4b7d6)

Release Notes:

- N/A
