### PR TITLE
Detect file paths that end with `:`

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -139,6 +139,12 @@ impl<P> PathLikeWithPosition<P> {
                                     column: None,
                                 })
                             } else {
+                                let maybe_col_str =
+                                    if maybe_col_str.ends_with(FILE_ROW_COLUMN_DELIMITER) {
+                                        &maybe_col_str[..maybe_col_str.len() - 1]
+                                    } else {
+                                        maybe_col_str
+                                    };
                                 match maybe_col_str.parse::<u32>() {
                                     Ok(col) => Ok(Self {
                                         path_like: parse_path_like_str(path_like_str)?,
@@ -241,7 +247,6 @@ mod tests {
             "test_file.rs:1::",
             "test_file.rs::1:2",
             "test_file.rs:1::2",
-            "test_file.rs:1:2:",
             "test_file.rs:1:2:3",
         ] {
             let actual = parse_str(input);
@@ -275,6 +280,14 @@ mod tests {
                     path_like: "test_file.rs".to_string(),
                     row: Some(1),
                     column: None,
+                },
+            ),
+            (
+                "crates/file_finder/src/file_finder.rs:1902:13:",
+                PathLikeWithPosition {
+                    path_like: "crates/file_finder/src/file_finder.rs".to_string(),
+                    row: Some(1902),
+                    column: Some(13),
                 },
             ),
         ];


### PR DESCRIPTION
New rustc messages look like

```
thread 'tests::test_history_items_vs_very_good_external_match' panicked at crates/file_finder/src/file_finder.rs:1902:13:
assertion `left == right` failed: Only one history item contains collab_ui, it should be present and others should be filtered out
  left: 0
 right: 1
```

now and we fail to parse that `13:` bit properly, fix that.

One caveat is that we highlight the entire word including the trailing `:`:
<img width="914" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/d653a8ff-3e6e-4e3d-b6ea-dad0c8db0f06">

this is unfortunate, but better than nothing (as now).
This is due to the fact, that we detect words with regex inside the `terminal.rs` and send events to other place that's able to check paths for existence (and whether that's a path at all), currently there's no way to detect a path and sanitize it in `terminal.rs`

Release Notes:

- N/A