### PR TITLE
Revert outline summarization

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -578,10 +578,7 @@ impl AssistantPanel {
 
         let codegen_kind = codegen.read(cx).kind().clone();
         let user_prompt = user_prompt.to_string();
-        let prompt = cx.background().spawn(async move {
-            let language_name = language_name.as_deref();
-            generate_content_prompt(user_prompt, language_name, &buffer, range, codegen_kind)
-        });
+
         let mut messages = Vec::new();
         let mut model = settings::get::<AssistantSettings>(cx)
             .default_open_ai_model
@@ -596,6 +593,11 @@ impl AssistantPanel {
             );
             model = conversation.model.clone();
         }
+
+        let prompt = cx.background().spawn(async move {
+            let language_name = language_name.as_deref();
+            generate_content_prompt(user_prompt, language_name, &buffer, range, codegen_kind)
+        });
 
         cx.spawn(|_, mut cx| async move {
             let prompt = prompt.await;

--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -121,6 +121,7 @@ pub fn generate_content_prompt(
     range: Range<impl ToOffset>,
     kind: CodegenKind,
 ) -> String {
+    let range = range.to_offset(buffer);
     let mut prompt = String::new();
 
     // General Preamble
@@ -130,17 +131,29 @@ pub fn generate_content_prompt(
         writeln!(prompt, "You're an expert engineer.\n").unwrap();
     }
 
-    let outline = summarize(buffer, range);
+    let mut content = String::new();
+    content.extend(buffer.text_for_range(0..range.start));
+    if range.start == range.end {
+        content.push_str("<|START|>");
+    } else {
+        content.push_str("<|START|");
+    }
+    content.extend(buffer.text_for_range(range.clone()));
+    if range.start != range.end {
+        content.push_str("|END|>");
+    }
+    content.extend(buffer.text_for_range(range.end..buffer.len()));
+
     writeln!(
         prompt,
-        "The file you are currently working on has the following outline:"
+        "The file you are currently working on has the following content:"
     )
     .unwrap();
     if let Some(language_name) = language_name {
         let language_name = language_name.to_lowercase();
-        writeln!(prompt, "```{language_name}\n{outline}\n```").unwrap();
+        writeln!(prompt, "```{language_name}\n{content}\n```").unwrap();
     } else {
-        writeln!(prompt, "```\n{outline}\n```").unwrap();
+        writeln!(prompt, "```\n{content}\n```").unwrap();
     }
 
     match kind {

--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -4,6 +4,7 @@ use std::cmp::{self, Reverse};
 use std::fmt::Write;
 use std::ops::Range;
 
+#[allow(dead_code)]
 fn summarize(buffer: &BufferSnapshot, selected_range: Range<impl ToOffset>) -> String {
     #[derive(Debug)]
     struct Match {


### PR DESCRIPTION
This pull request essentially reverts #3067: we noticed that only using the function signatures produces far worse results in codegen, and so that feels like a regression compared to before. We should re-enable this once we have a smarter approach to fetching context during codegen, possibly when #3097 lands.

As a drive-by, we also fixed a longstanding bug that caused codegen to include the final line of a selection even if the selection ended at the start of the line.

Ideally, I'd like to hot fix this to preview so that it goes to stable during the weekly release.

/cc: @KCaverly @nathansobo 

Release Notes:

- N/A