### PR TITLE
Fix inclusion of spurious views from other projects in FollowResponse

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2878,8 +2878,7 @@ impl Workspace {
                         let cx = &cx;
                         move |item| {
                             let item = item.to_followable_item_handle(cx)?;
-                            if project_id.is_some()
-                                && project_id != follower_project_id
+                            if (project_id.is_none() || project_id != follower_project_id)
                                 && item.is_project_item(cx)
                             {
                                 return None;


### PR DESCRIPTION
A logic error in https://github.com/zed-industries/zed/pull/2993 caused follow responses to sometimes contain extra views for other unshared projects 😱 . These views would generally fail to deserialize on the other end. This would create a broken intermediate state, where the following relationship was registered on the server (and on the leader's client), but the follower didn't have the state necessary for following into certain views.

Release Notes:

- Fixed a bug where following would sometimes fail if the leader had another unshared project open.
