### PR TITLE
copilot: Propagate action if suggest_next is not possible.

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3740,7 +3740,10 @@ impl Editor {
         if self.has_active_copilot_suggestion(cx) {
             self.cycle_copilot_suggestions(Direction::Next, cx);
         } else {
-            self.refresh_copilot_suggestions(false, cx);
+            let is_copilot_disabled = self.refresh_copilot_suggestions(false, cx).is_none();
+            if is_copilot_disabled {
+                cx.propagate_action();
+            }
         }
     }
 
@@ -3752,7 +3755,10 @@ impl Editor {
         if self.has_active_copilot_suggestion(cx) {
             self.cycle_copilot_suggestions(Direction::Prev, cx);
         } else {
-            self.refresh_copilot_suggestions(false, cx);
+            let is_copilot_disabled = self.refresh_copilot_suggestions(false, cx).is_none();
+            if is_copilot_disabled {
+                cx.propagate_action();
+            }
         }
     }
 


### PR DESCRIPTION
One of our users ran into an issue where typing "true quote" characters (option-[ for „ and option-] for ‚) was not possible; I've narrowed it down to a collision with Copilot's NextSuggestion and PreviousSuggestion action default keybinds. I explicitly did not want to alter the key bindings, so I've went with a more neutral fix - one that propagates the keystroke if there's no Copilot action to be taken (user is not using Copilot etc). Note however that typing true quotes while using a Copilot is still not possible, as for that we'd have to change a keybind.

Fixes zed-industries/zed#6312


Release Notes:
- Fixed Copilot's "Suggest next" and "Suggest previous" actions colliding with true quotes key bindings (`option-[` and `option-]`). The keystrokes are now propagated if there's no Copilot action to be taken at cursor's position.
