### PR TITLE
Adjust chat to allow channel admins to delete all messages

### DIFF
--- a/crates/collab/src/db/queries/messages.rs
+++ b/crates/collab/src/db/queries/messages.rs
@@ -337,8 +337,22 @@ impl Database {
                 .filter(channel_message::Column::SenderId.eq(user_id))
                 .exec(&*tx)
                 .await?;
+
             if result.rows_affected == 0 {
-                Err(anyhow!("no such message"))?;
+                if self
+                    .check_user_is_channel_admin(channel_id, user_id, &*tx)
+                    .await
+                    .is_ok()
+                {
+                    let result = channel_message::Entity::delete_by_id(message_id)
+                        .exec(&*tx)
+                        .await?;
+                    if result.rows_affected == 0 {
+                        Err(anyhow!("no such message"))?;
+                    }
+                } else {
+                    Err(anyhow!("operation could not be completed"))?;
+                }
             }
 
             Ok(participant_connection_ids)

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -355,8 +355,12 @@ impl ChatPanel {
     }
 
     fn render_message(&mut self, ix: usize, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
-        let (message, is_continuation, is_last) = {
+        let (message, is_continuation, is_last, is_admin) = {
             let active_chat = self.active_chat.as_ref().unwrap().0.read(cx);
+            let is_admin = self
+                .channel_store
+                .read(cx)
+                .is_user_admin(active_chat.channel().id);
             let last_message = active_chat.message(ix.saturating_sub(1));
             let this_message = active_chat.message(ix);
             let is_continuation = last_message.id != this_message.id
@@ -366,6 +370,7 @@ impl ChatPanel {
                 active_chat.message(ix).clone(),
                 is_continuation,
                 active_chat.message_count() == ix + 1,
+                is_admin,
             )
         };
 
@@ -386,12 +391,13 @@ impl ChatPanel {
         };
 
         let belongs_to_user = Some(message.sender.id) == self.client.user_id();
-        let message_id_to_remove =
-            if let (ChannelMessageId::Saved(id), true) = (message.id, belongs_to_user) {
-                Some(id)
-            } else {
-                None
-            };
+        let message_id_to_remove = if let (ChannelMessageId::Saved(id), true) =
+            (message.id, belongs_to_user || is_admin)
+        {
+            Some(id)
+        } else {
+            None
+        };
 
         enum MessageBackgroundHighlight {}
         MouseEventHandler::new::<MessageBackgroundHighlight, _>(ix, cx, |state, cx| {


### PR DESCRIPTION
As it says on the tin

Release Notes:

- Changed chat permissions so that admins of a channel can delete any message in a channel.