### PR TITLE
Cap every language server logs

### DIFF
--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -24,7 +24,7 @@ use workspace::{
 
 const SEND_LINE: &str = "// Send:";
 const RECEIVE_LINE: &str = "// Receive:";
-const MAX_STORED_LOG_ENTRIES: usize = 5000;
+const MAX_STORED_LOG_ENTRIES: usize = 2000;
 
 pub struct LogStore {
     projects: HashMap<WeakModelHandle<Project>, ProjectState>,
@@ -235,7 +235,7 @@ impl LogStore {
         };
 
         let log_lines = &mut language_server_state.log_messages;
-        if log_lines.len() == MAX_STORED_LOG_ENTRIES {
+        while log_lines.len() >= MAX_STORED_LOG_ENTRIES {
             log_lines.pop_front();
         }
         let message = message.trim();
@@ -335,9 +335,6 @@ impl LogStore {
         };
 
         let rpc_log_lines = &mut state.rpc_messages;
-        if rpc_log_lines.len() == MAX_STORED_LOG_ENTRIES {
-            rpc_log_lines.pop_front();
-        }
         if state.last_message_kind != Some(kind) {
             let line_before_message = match kind {
                 MessageKind::Send => SEND_LINE,
@@ -351,7 +348,7 @@ impl LogStore {
             });
         }
 
-        if rpc_log_lines.len() == MAX_STORED_LOG_ENTRIES {
+        while rpc_log_lines.len() >= MAX_STORED_LOG_ENTRIES {
             rpc_log_lines.pop_front();
         }
         let message = message.trim();


### PR DESCRIPTION
* on opening a language server's logs, a new editor for server logs is now created from `\n`-joined `VecDeque` elements instead of a buffer, as before
* every `VecDeque` entry is a log line we receiver out of stderr or LSP server, and their general amount is capped with `let MAX_STORED_LOG_ENTRIES: usize = 2000;` 
* currently opened editor with logs (`Editor::multi_line`) keeps getting log lines appended and may get over this cap, but only last stored 2000 entries will be restored on reopen
* similarly, cap rpc message logs

Release Notes:

- Improved memory usage by storing less language LSP server and rpc logs