### PR TITLE
workspace: Do not scan for .gitignore files if a .git directory is encountered along the way

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -2027,11 +2027,16 @@ impl LocalSnapshot {
 
     fn ignore_stack_for_abs_path(&self, abs_path: &Path, is_dir: bool) -> Arc<IgnoreStack> {
         let mut new_ignores = Vec::new();
-        for ancestor in abs_path.ancestors().skip(1) {
-            if let Some((ignore, _)) = self.ignores_by_parent_abs_path.get(ancestor) {
-                new_ignores.push((ancestor, Some(ignore.clone())));
-            } else {
-                new_ignores.push((ancestor, None));
+        for (index, ancestor) in abs_path.ancestors().enumerate() {
+            if index > 0 {
+                if let Some((ignore, _)) = self.ignores_by_parent_abs_path.get(ancestor) {
+                    new_ignores.push((ancestor, Some(ignore.clone())));
+                } else {
+                    new_ignores.push((ancestor, None));
+                }
+            }
+            if ancestor.join(&*DOT_GIT).is_dir() {
+                break;
             }
         }
 
@@ -2048,7 +2053,6 @@ impl LocalSnapshot {
         if ignore_stack.is_abs_path_ignored(abs_path, is_dir) {
             ignore_stack = IgnoreStack::all();
         }
-
         ignore_stack
     }
 
@@ -3064,7 +3068,6 @@ impl BackgroundScanner {
 
         // Populate ignores above the root.
         let root_abs_path = self.state.lock().snapshot.abs_path.clone();
-
         for (index, ancestor) in root_abs_path.ancestors().enumerate() {
             if index != 0 {
                 if let Ok(ignore) =


### PR DESCRIPTION
Partially fixes zed-industries/zed#5749

This PR will see one more fix to the case I've spotted while working on this: namely, if a project has several nested repositories, e.g for a structure:
/a
/a/.git/
/a/.gitignore
/a/b/
/a/b/.git/
/a/b/.gitignore

/b/ should not account for a's .gitignore at all - which is sort of similar to the fix in commit #c416fbb, but for the paths in the project.

The release note is kinda bad, I'll try to reword it too.
- [x] Improve release note.
- [x] Address the same bug for project files.

Release Notes:
- Fixed handling of nested .git repositories, where files of inner repository could be marked as ignored if they matched .gitignore of outer repository (zed-industries/zed#5749).
