### PR TITLE
buffer_search: Discard empty search suggestions.

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -537,6 +537,7 @@ impl BufferSearchBar {
         self.active_searchable_item
             .as_ref()
             .map(|searchable_item| searchable_item.query_suggestion(cx))
+            .filter(|suggestion| !suggestion.is_empty())
     }
 
     pub fn set_replacement(&mut self, replacement: Option<&str>, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Now when buffer_search::Deploy action is triggered (with cmd-f), we'll keep the previous query in query_editor (if there was one) instead of replacing it with empty query.

This addresses this bit of feedback from Jose:
> If no text is selected, `cmd + f` should not delete the text in the search bar when refocusing

Release Notes:
- Improved buffer search by not clearing out query editor when no text is selected and "buffer search: deploy" (default keybind: cmd-f) is triggered.
