### PR TITLE
Fix possibility of infinite loop in selections_with_autoclose_regions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3286,8 +3286,10 @@ impl Editor {
                     i = 0;
                 } else if pair_state.range.start.to_offset(buffer) > range.end {
                     break;
-                } else if pair_state.selection_id == selection.id {
-                    enclosing = Some(pair_state);
+                } else {
+                    if pair_state.selection_id == selection.id {
+                        enclosing = Some(pair_state);
+                    }
                     i += 1;
                 }
             }


### PR DESCRIPTION
Previously, that method could loop forever if the editor's autoclose regions had unexpected selection ids. @osiewicz and I experienced a hang in Zed 0.108.2 which we believe was due to this code.

Something must have changed recently that allowed this invariant to be violated, but regardless, this code should not have relied on that invariant to terminate like this.

