### PR TITLE
Magic incantations for Tailwind autocomplete in more languages

### DIFF
--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -76,7 +76,10 @@ pub fn init(
         elixir::ElixirLspSetting::ElixirLs => language(
             "elixir",
             tree_sitter_elixir::language(),
-            vec![Arc::new(elixir::ElixirLspAdapter)],
+            vec![
+                Arc::new(elixir::ElixirLspAdapter),
+                Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
+            ],
         ),
         elixir::ElixirLspSetting::NextLs => language(
             "elixir",
@@ -101,7 +104,10 @@ pub fn init(
     language(
         "heex",
         tree_sitter_heex::language(),
-        vec![Arc::new(elixir::ElixirLspAdapter)],
+        vec![
+            Arc::new(elixir::ElixirLspAdapter),
+            Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
+        ],
     );
     language(
         "json",
@@ -184,9 +190,10 @@ pub fn init(
     language(
         "svelte",
         tree_sitter_svelte::language(),
-        vec![Arc::new(svelte::SvelteLspAdapter::new(
-            node_runtime.clone(),
-        ))],
+        vec![
+            Arc::new(svelte::SvelteLspAdapter::new(node_runtime.clone())),
+            Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
+        ],
     );
     language(
         "php",

--- a/crates/zed/src/languages/elixir/config.toml
+++ b/crates/zed/src/languages/elixir/config.toml
@@ -9,3 +9,8 @@ brackets = [
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
+
+[overrides.string]
+word_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/zed/src/languages/heex/config.toml
+++ b/crates/zed/src/languages/heex/config.toml
@@ -5,3 +5,8 @@ brackets = [
     { start = "<", end = ">", close = true, newline = true },
 ]
 block_comment = ["<%!-- ", " --%>"]
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
+
+[overrides.string]
+word_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/zed/src/languages/heex/overrides.scm
+++ b/crates/zed/src/languages/heex/overrides.scm
@@ -1,0 +1,4 @@
+[
+  (attribute_value)
+  (quoted_attribute_value)
+] @string

--- a/crates/zed/src/languages/svelte/config.toml
+++ b/crates/zed/src/languages/svelte/config.toml
@@ -12,7 +12,8 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false, not_in = ["string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
 
-[overrides.element]
-line_comment = { remove = true }
-block_comment = ["{/* ", " */}"]
+[overrides.string]
+word_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/zed/src/languages/svelte/overrides.scm
+++ b/crates/zed/src/languages/svelte/overrides.scm
@@ -1,0 +1,7 @@
+(comment) @comment
+
+[
+  (raw_text)
+  (attribute_value)
+  (quoted_attribute_value)
+] @string

--- a/crates/zed/src/languages/tailwind.rs
+++ b/crates/zed/src/languages/tailwind.rs
@@ -123,6 +123,9 @@ impl LspAdapter for TailwindLspAdapter {
                 ("CSS".to_string(), "css".to_string()),
                 ("JavaScript".to_string(), "javascript".to_string()),
                 ("TSX".to_string(), "typescriptreact".to_string()),
+                ("Svelte".to_string(), "svelte".to_string()),
+                ("Elixir".to_string(), "phoenix-heex".to_string()),
+                ("HEEX".to_string(), "phoenix-heex".to_string()),
             ]
             .into_iter(),
         )


### PR DESCRIPTION
Release Notes:
- Added Tailwind autocomplete to Svelte files ([#2029](https://github.com/zed-industries/zed/issues/6294)).
- Added Tailwind autocomplete to Phoenix HEEX files ([#2057](https://github.com/zed-industries/zed/issues/6306)).
- Added Tailwind autocomplete to Phoenix ~H sigil in Elixir files ([#2057](https://github.com/zed-industries/zed/issues/6306)).
- Added Tailwind autocomplete to ERB files ([#2153](https://github.com/zed-industries/zed/issues/6340)).
- Added Tailwind autocomplete to PHP files ([#2159](https://github.com/zed-industries/zed/issues/6342)).
- Added Tailwind autocomplete to Laravel Blade files ([#2159](https://github.com/zed-industries/zed/issues/6342)).
