### PR TITLE
decrease temperature for inline assist on code content

### DIFF
--- a/crates/ai/src/completion.rs
+++ b/crates/ai/src/completion.rs
@@ -53,6 +53,8 @@ pub struct OpenAIRequest {
     pub model: String,
     pub messages: Vec<RequestMessage>,
     pub stream: bool,
+    pub stop: Vec<String>,
+    pub temperature: f32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]

--- a/crates/ai/src/templates/generate.rs
+++ b/crates/ai/src/templates/generate.rs
@@ -78,7 +78,7 @@ impl PromptTemplate for GenerateInlineContent {
 
         match file_type {
             PromptFileType::Code => {
-                writeln!(prompt, "Always wrap your code in a Markdown block.").unwrap();
+                // writeln!(prompt, "Always wrap your code in a Markdown block.").unwrap();
             }
             _ => {}
         }


### PR DESCRIPTION
"Temperature" is a parameter in OpenAI GPT models, to control for randomess in the generated content. To decrease the probability of either escaping the markdown blocks and creating invalid code, we decreased temperature for all Non-Prose files. For Markdown or Plain Text, in which more creativity may be a good thing, we increase the temperature to allow for more randomness. Along with this, we ask the generate inline prompt to include only the code and not markdown blocks, as it appears that lower temperature may decrease the probability of introducing random markdown blocks.

Release Notes (Internal Only):
- Decrease temperature for inline assist on code content.
