### PR TITLE
bash: Add highlighting of ANSI c string

### DIFF
--- a/crates/zed/src/languages/bash/highlights.scm
+++ b/crates/zed/src/languages/bash/highlights.scm
@@ -3,6 +3,7 @@
   (raw_string)
   (heredoc_body)
   (heredoc_start)
+  (ansi_c_string)
 ] @string
 
 (command_name) @function


### PR DESCRIPTION
Fixes zed-industries/zed#6346

Release Notes:

- Fixed highlighting of ANSI C strings ($'foo') in "Shell script" language buffers.
