### PR TITLE
Fix infinite loop in select all

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6542,7 +6542,7 @@ impl Editor {
                     {
                         if selections
                             .iter()
-                            .find(|selection| selection.equals(&offset_range))
+                            .find(|selection| selection.range().overlaps(&offset_range))
                             .is_none()
                         {
                             next_selected_range = Some(offset_range);

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -707,7 +707,9 @@ mod tests {
             let (snapshot, display_points) = marked_display_snapshot(marked_text, cx);
             assert_eq!(
                 surrounding_word(&snapshot, display_points[1]),
-                display_points[0]..display_points[2]
+                display_points[0]..display_points[2],
+                "{}",
+                marked_text.to_string()
             );
         }
 
@@ -717,7 +719,7 @@ mod tests {
         assert("loremˇ ˇ  ˇipsum", cx);
         assert("lorem\nˇˇˇ\nipsum", cx);
         assert("lorem\nˇˇipsumˇ", cx);
-        assert("lorem,ˇˇ ˇipsum", cx);
+        assert("loremˇ,ˇˇ ipsum", cx);
         assert("ˇloremˇˇ, ipsum", cx);
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -373,8 +373,8 @@ pub(crate) struct DiagnosticEndpoint {
 
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub enum CharKind {
-    Punctuation,
     Whitespace,
+    Punctuation,
     Word,
 }
 

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -748,11 +748,10 @@ async fn test_select_all_issue_2170(cx: &mut gpui::TestAppContext) {
         Mode::Normal,
     );
     cx.simulate_keystrokes(["g", "a"]);
-    // TODO: this would be better if it selected the [ not the space.
     cx.assert_state(
         indoc! {"
-        defmodule« ˇ»Test« ˇ»do
-        «    ˇ»def« ˇ»test(a,« ˇ»[_,« ˇ»_]« ˇ»=« ˇ»b),« ˇ»do:« ˇ»IO.puts('hi')
+        defmodule Test do
+            def test(a, «[ˇ»_, _] = b), do: IO.puts('hi')
         end
     "},
         Mode::Visual,

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -734,3 +734,27 @@ async fn test_paragraphs_dont_wrap(cx: &mut gpui::TestAppContext) {
         two"})
         .await;
 }
+
+#[gpui::test]
+async fn test_select_all_issue_2170(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+
+    cx.set_state(
+        indoc! {"
+        defmodule Test do
+            def test(a, ˇ[_, _] = b), do: IO.puts('hi')
+        end
+    "},
+        Mode::Normal,
+    );
+    cx.simulate_keystrokes(["g", "a"]);
+    // TODO: this would be better if it selected the [ not the space.
+    cx.assert_state(
+        indoc! {"
+        defmodule« ˇ»Test« ˇ»do
+        «    ˇ»def« ˇ»test(a,« ˇ»[_,« ˇ»_]« ˇ»=« ˇ»b),« ˇ»do:« ˇ»IO.puts('hi')
+        end
+    "},
+        Mode::Visual,
+    );
+}


### PR DESCRIPTION
[[PR Description]]

Release Notes:

- Fixed an infinite loop in select all matches ([#2170](https://github.com/zed-industries/zed/issues/6347)).
