### PR TITLE
Rework prettier tests

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4555,11 +4555,7 @@ async fn test_prettier_formatting_buffer(
         .insert_tree(&directory, json!({ "a.rs": buffer_text }))
         .await;
     let (project_a, worktree_id) = client_a.build_local_project(&directory, cx_a).await;
-    let prettier_format_suffix = project_a.update(cx_a, |project, _| {
-        let suffix = project.enable_test_prettier(&[test_plugin]);
-        project.languages().add(language);
-        suffix
-    });
+    let prettier_format_suffix = project::TEST_PRETTIER_FORMAT_SUFFIX;
     let buffer_a = cx_a
         .background()
         .spawn(project_a.update(cx_a, |p, cx| p.open_buffer((worktree_id, "a.rs"), cx)))

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5117,7 +5117,6 @@ async fn test_document_format_manual_trigger(cx: &mut gpui::TestAppContext) {
 
     let project = Project::test(fs, ["/file.rs".as_ref()], cx).await;
     project.update(cx, |project, _| {
-        project.enable_test_prettier(&[]);
         project.languages().add(Arc::new(language));
     });
     let buffer = project
@@ -7864,10 +7863,9 @@ async fn test_document_format_with_prettier(cx: &mut gpui::TestAppContext) {
     fs.insert_file("/file.rs", Default::default()).await;
 
     let project = Project::test(fs, ["/file.rs".as_ref()], cx).await;
-    let prettier_format_suffix = project.update(cx, |project, _| {
-        let suffix = project.enable_test_prettier(&[test_plugin]);
+    let prettier_format_suffix = project::TEST_PRETTIER_FORMAT_SUFFIX;
+    project.update(cx, |project, _| {
         project.languages().add(Arc::new(language));
-        suffix
     });
     let buffer = project
         .update(cx, |project, cx| project.open_local_buffer("/file.rs", cx))

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -220,96 +220,31 @@ impl NodeRuntime for RealNodeRuntime {
     }
 }
 
-pub struct FakeNodeRuntime(Option<PrettierSupport>);
-
-struct PrettierSupport {
-    plugins: Vec<&'static str>,
-}
+pub struct FakeNodeRuntime;
 
 impl FakeNodeRuntime {
     pub fn new() -> Arc<dyn NodeRuntime> {
-        Arc::new(FakeNodeRuntime(None))
-    }
-
-    pub fn with_prettier_support(plugins: &[&'static str]) -> Arc<dyn NodeRuntime> {
-        Arc::new(FakeNodeRuntime(Some(PrettierSupport::new(plugins))))
+        Arc::new(Self)
     }
 }
 
 #[async_trait::async_trait]
 impl NodeRuntime for FakeNodeRuntime {
     async fn binary_path(&self) -> anyhow::Result<PathBuf> {
-        if let Some(prettier_support) = &self.0 {
-            prettier_support.binary_path().await
-        } else {
-            unreachable!()
-        }
+        unreachable!()
     }
 
     async fn run_npm_subcommand(
         &self,
-        directory: Option<&Path>,
+        _: Option<&Path>,
         subcommand: &str,
         args: &[&str],
     ) -> anyhow::Result<Output> {
-        if let Some(prettier_support) = &self.0 {
-            prettier_support
-                .run_npm_subcommand(directory, subcommand, args)
-                .await
-        } else {
-            unreachable!()
-        }
+        unreachable!("Should not run npm subcommand '{subcommand}' with args {args:?}")
     }
 
     async fn npm_package_latest_version(&self, name: &str) -> anyhow::Result<String> {
-        if let Some(prettier_support) = &self.0 {
-            prettier_support.npm_package_latest_version(name).await
-        } else {
-            unreachable!()
-        }
-    }
-
-    async fn npm_install_packages(
-        &self,
-        directory: &Path,
-        packages: &[(&str, &str)],
-    ) -> anyhow::Result<()> {
-        if let Some(prettier_support) = &self.0 {
-            prettier_support
-                .npm_install_packages(directory, packages)
-                .await
-        } else {
-            unreachable!()
-        }
-    }
-}
-
-impl PrettierSupport {
-    const PACKAGE_VERSION: &str = "0.0.1";
-
-    fn new(plugins: &[&'static str]) -> Self {
-        Self {
-            plugins: plugins.to_vec(),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl NodeRuntime for PrettierSupport {
-    async fn binary_path(&self) -> anyhow::Result<PathBuf> {
-        Ok(PathBuf::from("prettier_fake_node"))
-    }
-
-    async fn run_npm_subcommand(&self, _: Option<&Path>, _: &str, _: &[&str]) -> Result<Output> {
-        unreachable!()
-    }
-
-    async fn npm_package_latest_version(&self, name: &str) -> anyhow::Result<String> {
-        if name == "prettier" || self.plugins.contains(&name) {
-            Ok(Self::PACKAGE_VERSION.to_string())
-        } else {
-            panic!("Unexpected package name: {name}")
-        }
+        unreachable!("Should not query npm package '{name}' for latest version")
     }
 
     async fn npm_install_packages(
@@ -317,32 +252,6 @@ impl NodeRuntime for PrettierSupport {
         _: &Path,
         packages: &[(&str, &str)],
     ) -> anyhow::Result<()> {
-        assert_eq!(
-            packages.len(),
-            self.plugins.len() + 1,
-            "Unexpected packages length to install: {:?}, expected `prettier` + {:?}",
-            packages,
-            self.plugins
-        );
-        for (name, version) in packages {
-            assert!(
-                name == &"prettier" || self.plugins.contains(name),
-                "Unexpected package `{}` to install in packages {:?}, expected {} for `prettier` + {:?}",
-                name,
-                packages,
-                Self::PACKAGE_VERSION,
-                self.plugins
-            );
-            assert_eq!(
-                version,
-                &Self::PACKAGE_VERSION,
-                "Unexpected package version `{}` to install in packages {:?}, expected {} for `prettier` + {:?}",
-                version,
-                packages,
-                Self::PACKAGE_VERSION,
-                self.plugins
-            );
-        }
-        Ok(())
+        unreachable!("Should not install packages {packages:?}")
     }
 }

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -44,6 +44,9 @@ pub const PRETTIER_SERVER_JS: &str = include_str!("./prettier_server.js");
 const PRETTIER_PACKAGE_NAME: &str = "prettier";
 const TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME: &str = "prettier-plugin-tailwindcss";
 
+#[cfg(any(test, feature = "test-support"))]
+pub const FORMAT_SUFFIX: &str = "\nformatted by test prettier";
+
 impl Prettier {
     pub const CONFIG_FILE_NAMES: &'static [&'static str] = &[
         ".prettierrc",
@@ -59,9 +62,6 @@ impl Prettier {
         "prettier.config.cjs",
         ".editorconfig",
     ];
-
-    #[cfg(any(test, feature = "test-support"))]
-    pub const FORMAT_SUFFIX: &str = "\nformatted by test prettier";
 
     pub async fn locate(
         starting_path: Option<LocateStart>,
@@ -349,7 +349,7 @@ impl Prettier {
             #[cfg(any(test, feature = "test-support"))]
             Self::Test(_) => Ok(buffer
                 .read_with(cx, |buffer, cx| {
-                    let formatted_text = buffer.text() + Self::FORMAT_SUFFIX;
+                    let formatted_text = buffer.text() + FORMAT_SUFFIX;
                     buffer.diff(formatted_text, cx)
                 })
                 .await),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -86,6 +86,8 @@ use util::{
 };
 
 pub use fs::*;
+#[cfg(any(test, feature = "test-support"))]
+pub use prettier::FORMAT_SUFFIX as TEST_PRETTIER_FORMAT_SUFFIX;
 pub use worktree::*;
 
 pub trait Item {
@@ -831,16 +833,6 @@ impl Project {
                 .await;
         }
         project
-    }
-
-    /// Enables a prettier mock that avoids interacting with node runtime, prettier LSP wrapper, or any real file changes.
-    /// Instead, if appends the suffix to every input, this suffix is returned by this method.
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn enable_test_prettier(&mut self, plugins: &[&'static str]) -> &'static str {
-        self.node = Some(node_runtime::FakeNodeRuntime::with_prettier_support(
-            plugins,
-        ));
-        Prettier::FORMAT_SUFFIX
     }
 
     fn on_settings_changed(&mut self, cx: &mut ModelContext<Self>) {


### PR DESCRIPTION
Do not infuse `FakeNodeRuntime` with prettier exceptions, rather keep the default formatter installation method as no-op.