### PR TITLE
Allow completion menus to be cycled

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -966,8 +966,11 @@ impl CompletionsMenu {
     ) {
         if self.selected_item > 0 {
             self.selected_item -= 1;
+        } else {
+            self.selected_item = self.matches.len() - 1;
             self.list.scroll_to(ScrollTarget::Show(self.selected_item));
         }
+        self.list.scroll_to(ScrollTarget::Show(self.selected_item));
         self.attempt_resolve_selected_completion_documentation(project, cx);
         cx.notify();
     }
@@ -979,8 +982,10 @@ impl CompletionsMenu {
     ) {
         if self.selected_item + 1 < self.matches.len() {
             self.selected_item += 1;
-            self.list.scroll_to(ScrollTarget::Show(self.selected_item));
+        } else {
+            self.selected_item = 0;
         }
+        self.list.scroll_to(ScrollTarget::Show(self.selected_item));
         self.attempt_resolve_selected_completion_documentation(project, cx);
         cx.notify();
     }
@@ -1532,17 +1537,23 @@ impl CodeActionsMenu {
     fn select_prev(&mut self, cx: &mut ViewContext<Editor>) {
         if self.selected_item > 0 {
             self.selected_item -= 1;
+        } else {
+            self.selected_item = self.actions.len() - 1;
             self.list.scroll_to(ScrollTarget::Show(self.selected_item));
-            cx.notify()
         }
+        self.list.scroll_to(ScrollTarget::Show(self.selected_item));
+        cx.notify();
     }
 
     fn select_next(&mut self, cx: &mut ViewContext<Editor>) {
         if self.selected_item + 1 < self.actions.len() {
             self.selected_item += 1;
             self.list.scroll_to(ScrollTarget::Show(self.selected_item));
-            cx.notify()
+        } else {
+            self.selected_item = 0;
+            self.list.scroll_to(ScrollTarget::Show(self.selected_item));
         }
+        cx.notify();
     }
 
     fn select_last(&mut self, cx: &mut ViewContext<Editor>) {


### PR DESCRIPTION
Not a huge ask from the community, but something that I run into frequently is not being able to cycle the auto completion menus past the beginning / end, so I quickly added it. This matches VS Code behavior:

https://github.com/zed-industries/zed/assets/19867440/bc4606d7-2076-4036-aedc-f3cf5ba349dc

Release Notes:

- Enhanced popover menus with circular navigation ([#632](https://github.com/zed-industries/zed/issues/5775)).