### PR TITLE
Revert "Guest roles (#3140)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "settings",
- "smallvec",
  "theme",
  "theme_selector",
  "time",

--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -370,15 +370,42 @@
   {
     "context": "Pane",
     "bindings": {
-      "ctrl-1": ["pane::ActivateItem", 0],
-      "ctrl-2": ["pane::ActivateItem", 1],
-      "ctrl-3": ["pane::ActivateItem", 2],
-      "ctrl-4": ["pane::ActivateItem", 3],
-      "ctrl-5": ["pane::ActivateItem", 4],
-      "ctrl-6": ["pane::ActivateItem", 5],
-      "ctrl-7": ["pane::ActivateItem", 6],
-      "ctrl-8": ["pane::ActivateItem", 7],
-      "ctrl-9": ["pane::ActivateItem", 8],
+      "ctrl-1": [
+        "pane::ActivateItem",
+        0
+      ],
+      "ctrl-2": [
+        "pane::ActivateItem",
+        1
+      ],
+      "ctrl-3": [
+        "pane::ActivateItem",
+        2
+      ],
+      "ctrl-4": [
+        "pane::ActivateItem",
+        3
+      ],
+      "ctrl-5": [
+        "pane::ActivateItem",
+        4
+      ],
+      "ctrl-6": [
+        "pane::ActivateItem",
+        5
+      ],
+      "ctrl-7": [
+        "pane::ActivateItem",
+        6
+      ],
+      "ctrl-8": [
+        "pane::ActivateItem",
+        7
+      ],
+      "ctrl-9": [
+        "pane::ActivateItem",
+        8
+      ],
       "ctrl-0": "pane::ActivateLastItem",
       "ctrl--": "pane::GoBack",
       "ctrl-_": "pane::GoForward",
@@ -389,15 +416,42 @@
   {
     "context": "Workspace",
     "bindings": {
-      "cmd-1": ["workspace::ActivatePane", 0],
-      "cmd-2": ["workspace::ActivatePane", 1],
-      "cmd-3": ["workspace::ActivatePane", 2],
-      "cmd-4": ["workspace::ActivatePane", 3],
-      "cmd-5": ["workspace::ActivatePane", 4],
-      "cmd-6": ["workspace::ActivatePane", 5],
-      "cmd-7": ["workspace::ActivatePane", 6],
-      "cmd-8": ["workspace::ActivatePane", 7],
-      "cmd-9": ["workspace::ActivatePane", 8],
+      "cmd-1": [
+        "workspace::ActivatePane",
+        0
+      ],
+      "cmd-2": [
+        "workspace::ActivatePane",
+        1
+      ],
+      "cmd-3": [
+        "workspace::ActivatePane",
+        2
+      ],
+      "cmd-4": [
+        "workspace::ActivatePane",
+        3
+      ],
+      "cmd-5": [
+        "workspace::ActivatePane",
+        4
+      ],
+      "cmd-6": [
+        "workspace::ActivatePane",
+        5
+      ],
+      "cmd-7": [
+        "workspace::ActivatePane",
+        6
+      ],
+      "cmd-8": [
+        "workspace::ActivatePane",
+        7
+      ],
+      "cmd-9": [
+        "workspace::ActivatePane",
+        8
+      ],
       "cmd-b": "workspace::ToggleLeftDock",
       "cmd-r": "workspace::ToggleRightDock",
       "cmd-j": "workspace::ToggleBottomDock",
@@ -440,14 +494,38 @@
   },
   {
     "bindings": {
-      "cmd-k cmd-left": ["workspace::ActivatePaneInDirection", "Left"],
-      "cmd-k cmd-right": ["workspace::ActivatePaneInDirection", "Right"],
-      "cmd-k cmd-up": ["workspace::ActivatePaneInDirection", "Up"],
-      "cmd-k cmd-down": ["workspace::ActivatePaneInDirection", "Down"],
-      "cmd-k shift-left": ["workspace::SwapPaneInDirection", "Left"],
-      "cmd-k shift-right": ["workspace::SwapPaneInDirection", "Right"],
-      "cmd-k shift-up": ["workspace::SwapPaneInDirection", "Up"],
-      "cmd-k shift-down": ["workspace::SwapPaneInDirection", "Down"]
+      "cmd-k cmd-left": [
+        "workspace::ActivatePaneInDirection",
+        "Left"
+      ],
+      "cmd-k cmd-right": [
+        "workspace::ActivatePaneInDirection",
+        "Right"
+      ],
+      "cmd-k cmd-up": [
+        "workspace::ActivatePaneInDirection",
+        "Up"
+      ],
+      "cmd-k cmd-down": [
+        "workspace::ActivatePaneInDirection",
+        "Down"
+      ],
+      "cmd-k shift-left": [
+        "workspace::SwapPaneInDirection",
+        "Left"
+      ],
+      "cmd-k shift-right": [
+        "workspace::SwapPaneInDirection",
+        "Right"
+      ],
+      "cmd-k shift-up": [
+        "workspace::SwapPaneInDirection",
+        "Up"
+      ],
+      "cmd-k shift-down": [
+        "workspace::SwapPaneInDirection",
+        "Down"
+      ]
     }
   },
   // Bindings from Atom
@@ -550,6 +628,14 @@
     }
   },
   {
+    "context": "(CollabPanel && not_editing) > Editor",
+    "bindings": {
+      "cmd-c": "collab_panel::StartLinkChannel",
+      "cmd-x": "collab_panel::StartMoveChannel",
+      "cmd-v": "collab_panel::MoveOrLinkToSelected"
+    }
+  },
+  {
     "context": "ChannelModal",
     "bindings": {
       "tab": "channel_modal::ToggleMode"
@@ -569,21 +655,57 @@
       "cmd-v": "terminal::Paste",
       "cmd-k": "terminal::Clear",
       // Some nice conveniences
-      "cmd-backspace": ["terminal::SendText", "\u0015"],
-      "cmd-right": ["terminal::SendText", "\u0005"],
-      "cmd-left": ["terminal::SendText", "\u0001"],
+      "cmd-backspace": [
+        "terminal::SendText",
+        "\u0015"
+      ],
+      "cmd-right": [
+        "terminal::SendText",
+        "\u0005"
+      ],
+      "cmd-left": [
+        "terminal::SendText",
+        "\u0001"
+      ],
       // Terminal.app compatibility
-      "alt-left": ["terminal::SendText", "\u001bb"],
-      "alt-right": ["terminal::SendText", "\u001bf"],
+      "alt-left": [
+        "terminal::SendText",
+        "\u001bb"
+      ],
+      "alt-right": [
+        "terminal::SendText",
+        "\u001bf"
+      ],
       // There are conflicting bindings for these keys in the global context.
       // these bindings override them, remove at your own risk:
-      "up": ["terminal::SendKeystroke", "up"],
-      "pageup": ["terminal::SendKeystroke", "pageup"],
-      "down": ["terminal::SendKeystroke", "down"],
-      "pagedown": ["terminal::SendKeystroke", "pagedown"],
-      "escape": ["terminal::SendKeystroke", "escape"],
-      "enter": ["terminal::SendKeystroke", "enter"],
-      "ctrl-c": ["terminal::SendKeystroke", "ctrl-c"]
+      "up": [
+        "terminal::SendKeystroke",
+        "up"
+      ],
+      "pageup": [
+        "terminal::SendKeystroke",
+        "pageup"
+      ],
+      "down": [
+        "terminal::SendKeystroke",
+        "down"
+      ],
+      "pagedown": [
+        "terminal::SendKeystroke",
+        "pagedown"
+      ],
+      "escape": [
+        "terminal::SendKeystroke",
+        "escape"
+      ],
+      "enter": [
+        "terminal::SendKeystroke",
+        "enter"
+      ],
+      "ctrl-c": [
+        "terminal::SendKeystroke",
+        "ctrl-c"
+      ]
     }
   }
 ]

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -54,7 +54,7 @@ pub enum Event {
 
 pub struct Room {
     id: u64,
-    pub channel_id: Option<u64>,
+    channel_id: Option<u64>,
     live_kit: Option<LiveKitRoom>,
     status: RoomStatus,
     shared_projects: HashSet<WeakModelHandle<Project>>,
@@ -121,10 +121,6 @@ impl Room {
         }
     }
 
-    pub fn can_publish(&self) -> bool {
-        self.live_kit.as_ref().is_some_and(|room| room.can_publish)
-    }
-
     fn new(
         id: u64,
         channel_id: Option<u64>,
@@ -184,23 +180,20 @@ impl Room {
             });
 
             let connect = room.connect(&connection_info.server_url, &connection_info.token);
-            if connection_info.can_publish {
-                cx.spawn(|this, mut cx| async move {
-                    connect.await?;
+            cx.spawn(|this, mut cx| async move {
+                connect.await?;
 
-                    if !cx.read(Self::mute_on_join) {
-                        this.update(&mut cx, |this, cx| this.share_microphone(cx))
-                            .await?;
-                    }
+                if !cx.read(Self::mute_on_join) {
+                    this.update(&mut cx, |this, cx| this.share_microphone(cx))
+                        .await?;
+                }
 
-                    anyhow::Ok(())
-                })
-                .detach_and_log_err(cx);
-            }
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
 
             Some(LiveKitRoom {
                 room,
-                can_publish: connection_info.can_publish,
                 screen_track: LocalTrack::None,
                 microphone_track: LocalTrack::None,
                 next_publish_id: 0,
@@ -1499,7 +1492,6 @@ struct LiveKitRoom {
     deafened: bool,
     speaking: bool,
     next_publish_id: usize,
-    can_publish: bool,
     _maintain_room: Task<()>,
     _maintain_tracks: [Task<()>; 2],
 }

--- a/crates/channel/src/channel_store/channel_index.rs
+++ b/crates/channel/src/channel_store/channel_index.rs
@@ -26,8 +26,10 @@ impl ChannelIndex {
     pub fn delete_channels(&mut self, channels: &[ChannelId]) {
         self.channels_by_id
             .retain(|channel_id, _| !channels.contains(channel_id));
-        self.paths
-            .retain(|path| !path.iter().any(|channel_id| channels.contains(channel_id)));
+        self.paths.retain(|path| {
+            path.iter()
+                .all(|channel_id| self.channels_by_id.contains_key(channel_id))
+        });
     }
 
     pub fn bulk_insert(&mut self) -> ChannelPathsInsertGuard {
@@ -119,17 +121,10 @@ impl<'a> ChannelPathsInsertGuard<'a> {
         insert_new_message(&mut self.channels_by_id, channel_id, message_id)
     }
 
-    pub fn insert(&mut self, channel_proto: proto::Channel) -> bool {
-        let mut ret = false;
+    pub fn insert(&mut self, channel_proto: proto::Channel) {
         if let Some(existing_channel) = self.channels_by_id.get_mut(&channel_proto.id) {
             let existing_channel = Arc::make_mut(existing_channel);
-
-            ret = existing_channel.visibility != channel_proto.visibility()
-                || existing_channel.role != channel_proto.role()
-                || existing_channel.name != channel_proto.name;
-
             existing_channel.visibility = channel_proto.visibility();
-            existing_channel.role = channel_proto.role();
             existing_channel.name = channel_proto.name;
         } else {
             self.channels_by_id.insert(
@@ -137,7 +132,6 @@ impl<'a> ChannelPathsInsertGuard<'a> {
                 Arc::new(Channel {
                     id: channel_proto.id,
                     visibility: channel_proto.visibility(),
-                    role: channel_proto.role(),
                     name: channel_proto.name,
                     unseen_note_version: None,
                     unseen_message_id: None,
@@ -145,7 +139,6 @@ impl<'a> ChannelPathsInsertGuard<'a> {
             );
             self.insert_root(channel_proto.id);
         }
-        ret
     }
 
     pub fn insert_edge(&mut self, channel_id: ChannelId, parent_id: ChannelId) {

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -435,103 +435,18 @@ pub struct NewUserResult {
     pub signup_device_id: Option<String>,
 }
 
-#[derive(Debug)]
-pub struct MoveChannelResult {
-    pub participants_to_update: HashMap<UserId, ChannelsForUser>,
-    pub participants_to_remove: HashSet<UserId>,
-    pub moved_channels: HashSet<ChannelId>,
-}
-
-#[derive(Debug)]
-pub struct RenameChannelResult {
-    pub channel: Channel,
-    pub participants_to_update: HashMap<UserId, Channel>,
-}
-
-#[derive(Debug)]
-pub struct CreateChannelResult {
-    pub channel: Channel,
-    pub participants_to_update: Vec<(UserId, ChannelsForUser)>,
-}
-
-#[derive(Debug)]
-pub struct SetChannelVisibilityResult {
-    pub participants_to_update: HashMap<UserId, ChannelsForUser>,
-    pub participants_to_remove: HashSet<UserId>,
-    pub channels_to_remove: Vec<ChannelId>,
-}
-
-#[derive(Debug)]
-pub struct MembershipUpdated {
-    pub channel_id: ChannelId,
-    pub new_channels: ChannelsForUser,
-    pub removed_channels: Vec<ChannelId>,
-}
-
-#[derive(Debug)]
-pub enum SetMemberRoleResult {
-    InviteUpdated(Channel),
-    MembershipUpdated(MembershipUpdated),
-}
-
-#[derive(Debug)]
-pub struct InviteMemberResult {
-    pub channel: Channel,
-    pub notifications: NotificationBatch,
-}
-
-#[derive(Debug)]
-pub struct RespondToChannelInvite {
-    pub membership_update: Option<MembershipUpdated>,
-    pub notifications: NotificationBatch,
-}
-
-#[derive(Debug)]
-pub struct RemoveChannelMemberResult {
-    pub membership_update: MembershipUpdated,
-    pub notification_id: Option<NotificationId>,
-}
-
 #[derive(FromQueryResult, Debug, PartialEq, Eq, Hash)]
 pub struct Channel {
     pub id: ChannelId,
     pub name: String,
     pub visibility: ChannelVisibility,
-    pub role: ChannelRole,
-}
-
-impl Channel {
-    pub fn to_proto(&self) -> proto::Channel {
-        proto::Channel {
-            id: self.id.to_proto(),
-            name: self.name.clone(),
-            visibility: self.visibility.into(),
-            role: self.role.into(),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct ChannelMember {
-    pub role: ChannelRole,
-    pub user_id: UserId,
-    pub kind: proto::channel_member::Kind,
-}
-
-impl ChannelMember {
-    pub fn to_proto(&self) -> proto::ChannelMember {
-        proto::ChannelMember {
-            role: self.role.into(),
-            user_id: self.user_id.to_proto(),
-            kind: self.kind.into(),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ChannelsForUser {
     pub channels: ChannelGraph,
     pub channel_participants: HashMap<ChannelId, Vec<UserId>>,
+    pub channels_with_admin_privileges: HashSet<ChannelId>,
     pub unseen_buffer_changes: Vec<proto::UnseenChannelBufferChange>,
     pub channel_messages: Vec<proto::UnseenChannelMessage>,
 }

--- a/crates/collab/src/db/ids.rs
+++ b/crates/collab/src/db/ids.rs
@@ -84,7 +84,7 @@ id_type!(FlagId);
 id_type!(NotificationId);
 id_type!(NotificationKindId);
 
-#[derive(Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Default, Hash)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Default)]
 #[sea_orm(rs_type = "String", db_type = "String(None)")]
 pub enum ChannelRole {
     #[sea_orm(string_value = "admin")]
@@ -114,22 +114,6 @@ impl ChannelRole {
             *self
         } else {
             other
-        }
-    }
-
-    pub fn can_see_all_descendants(&self) -> bool {
-        use ChannelRole::*;
-        match self {
-            Admin | Member => true,
-            Guest | Banned => false,
-        }
-    }
-
-    pub fn can_only_see_public_descendants(&self) -> bool {
-        use ChannelRole::*;
-        match self {
-            Guest => true,
-            Admin | Member | Banned => false,
         }
     }
 }

--- a/crates/collab/src/db/queries/buffers.rs
+++ b/crates/collab/src/db/queries/buffers.rs
@@ -16,7 +16,7 @@ impl Database {
         connection: ConnectionId,
     ) -> Result<proto::JoinChannelBufferResponse> {
         self.transaction(|tx| async move {
-            self.check_user_is_channel_participant(channel_id, user_id, &tx)
+            self.check_user_is_channel_member(channel_id, user_id, &tx)
                 .await?;
 
             let buffer = channel::Model {
@@ -131,7 +131,7 @@ impl Database {
             for client_buffer in buffers {
                 let channel_id = ChannelId::from_proto(client_buffer.channel_id);
                 if self
-                    .check_user_is_channel_participant(channel_id, user_id, &*tx)
+                    .check_user_is_channel_member(channel_id, user_id, &*tx)
                     .await
                     .is_err()
                 {
@@ -482,7 +482,9 @@ impl Database {
                 )
                 .await?;
 
-                channel_members = self.get_channel_participants(channel_id, &*tx).await?;
+                channel_members = self
+                    .get_channel_participants_internal(channel_id, &*tx)
+                    .await?;
                 let collaborators = self
                     .get_channel_buffer_collaborators_internal(channel_id, &*tx)
                     .await?;

--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -16,39 +16,20 @@ impl Database {
         .await
     }
 
-    #[cfg(test)]
     pub async fn create_root_channel(&self, name: &str, creator_id: UserId) -> Result<ChannelId> {
-        Ok(self
-            .create_channel(name, None, creator_id)
-            .await?
-            .channel
-            .id)
-    }
-
-    #[cfg(test)]
-    pub async fn create_sub_channel(
-        &self,
-        name: &str,
-        parent: ChannelId,
-        creator_id: UserId,
-    ) -> Result<ChannelId> {
-        Ok(self
-            .create_channel(name, Some(parent), creator_id)
-            .await?
-            .channel
-            .id)
+        self.create_channel(name, None, creator_id).await
     }
 
     pub async fn create_channel(
         &self,
         name: &str,
         parent: Option<ChannelId>,
-        admin_id: UserId,
-    ) -> Result<CreateChannelResult> {
+        creator_id: UserId,
+    ) -> Result<ChannelId> {
         let name = Self::sanitize_channel_name(name)?;
         self.transaction(move |tx| async move {
             if let Some(parent) = parent {
-                self.check_user_is_channel_admin(parent, admin_id, &*tx)
+                self.check_user_is_channel_admin(parent, creator_id, &*tx)
                     .await?;
             }
 
@@ -90,34 +71,17 @@ impl Database {
                 .await?;
             }
 
-            if parent.is_none() {
-                channel_member::ActiveModel {
-                    id: ActiveValue::NotSet,
-                    channel_id: ActiveValue::Set(channel.id),
-                    user_id: ActiveValue::Set(admin_id),
-                    accepted: ActiveValue::Set(true),
-                    role: ActiveValue::Set(ChannelRole::Admin),
-                }
-                .insert(&*tx)
-                .await?;
+            channel_member::ActiveModel {
+                id: ActiveValue::NotSet,
+                channel_id: ActiveValue::Set(channel.id),
+                user_id: ActiveValue::Set(creator_id),
+                accepted: ActiveValue::Set(true),
+                role: ActiveValue::Set(ChannelRole::Admin),
             }
+            .insert(&*tx)
+            .await?;
 
-            let participants_to_update = if let Some(parent) = parent {
-                self.participants_to_notify_for_channel_change(parent, &*tx)
-                    .await?
-            } else {
-                vec![]
-            };
-
-            Ok(CreateChannelResult {
-                channel: Channel {
-                    id: channel.id,
-                    visibility: channel.visibility,
-                    name: channel.name,
-                    role: ChannelRole::Admin,
-                },
-                participants_to_update,
-            })
+            Ok(channel.id)
         })
         .await
     }
@@ -128,9 +92,9 @@ impl Database {
         user_id: UserId,
         connection: ConnectionId,
         environment: &str,
-    ) -> Result<(JoinRoom, Option<MembershipUpdated>, ChannelRole)> {
+    ) -> Result<(JoinRoom, Option<ChannelId>)> {
         self.transaction(move |tx| async move {
-            let mut accept_invite_result = None;
+            let mut joined_channel_id = None;
 
             let channel = channel::Entity::find()
                 .filter(channel::Column::Id.eq(channel_id))
@@ -147,18 +111,15 @@ impl Database {
                     .await?
                 {
                     // note, this may be a parent channel
+                    joined_channel_id = Some(invitation.channel_id);
                     role = Some(invitation.role);
+
                     channel_member::Entity::update(channel_member::ActiveModel {
                         accepted: ActiveValue::Set(true),
                         ..invitation.into_active_model()
                     })
                     .exec(&*tx)
                     .await?;
-
-                    accept_invite_result = Some(
-                        self.calculate_membership_updated(channel_id, user_id, &*tx)
-                            .await?,
-                    );
 
                     debug_assert!(
                         self.channel_role_for_user(channel_id, user_id, &*tx)
@@ -170,28 +131,24 @@ impl Database {
             if role.is_none()
                 && channel.as_ref().map(|c| c.visibility) == Some(ChannelVisibility::Public)
             {
-                role = Some(ChannelRole::Guest);
                 let channel_id_to_join = self
-                    .public_path_to_channel(channel_id, &*tx)
+                    .most_public_ancestor_for_channel(channel_id, &*tx)
                     .await?
-                    .first()
-                    .cloned()
                     .unwrap_or(channel_id);
+                // TODO: change this back to Guest.
+                role = Some(ChannelRole::Member);
+                joined_channel_id = Some(channel_id_to_join);
 
                 channel_member::Entity::insert(channel_member::ActiveModel {
                     id: ActiveValue::NotSet,
                     channel_id: ActiveValue::Set(channel_id_to_join),
                     user_id: ActiveValue::Set(user_id),
                     accepted: ActiveValue::Set(true),
-                    role: ActiveValue::Set(ChannelRole::Guest),
+                    // TODO: change this back to Guest.
+                    role: ActiveValue::Set(ChannelRole::Member),
                 })
                 .exec(&*tx)
                 .await?;
-
-                accept_invite_result = Some(
-                    self.calculate_membership_updated(channel_id, user_id, &*tx)
-                        .await?,
-                );
 
                 debug_assert!(
                     self.channel_role_for_user(channel_id, user_id, &*tx)
@@ -211,7 +168,7 @@ impl Database {
 
             self.join_channel_room_internal(channel_id, room_id, user_id, connection, &*tx)
                 .await
-                .map(|jr| (jr, accept_invite_result, role.unwrap()))
+                .map(|jr| (jr, joined_channel_id))
         })
         .await
     }
@@ -220,17 +177,13 @@ impl Database {
         &self,
         channel_id: ChannelId,
         visibility: ChannelVisibility,
-        admin_id: UserId,
-    ) -> Result<SetChannelVisibilityResult> {
+        user_id: UserId,
+    ) -> Result<channel::Model> {
         self.transaction(move |tx| async move {
-            self.check_user_is_channel_admin(channel_id, admin_id, &*tx)
+            self.check_user_is_channel_admin(channel_id, user_id, &*tx)
                 .await?;
 
-            let previous_members = self
-                .get_channel_participant_details_internal(channel_id, &*tx)
-                .await?;
-
-            channel::ActiveModel {
+            let channel = channel::ActiveModel {
                 id: ActiveValue::Unchanged(channel_id),
                 visibility: ActiveValue::Set(visibility),
                 ..Default::default()
@@ -238,62 +191,7 @@ impl Database {
             .update(&*tx)
             .await?;
 
-            let mut participants_to_update: HashMap<UserId, ChannelsForUser> = self
-                .participants_to_notify_for_channel_change(channel_id, &*tx)
-                .await?
-                .into_iter()
-                .collect();
-
-            let mut channels_to_remove: Vec<ChannelId> = vec![];
-            let mut participants_to_remove: HashSet<UserId> = HashSet::default();
-            match visibility {
-                ChannelVisibility::Members => {
-                    let all_descendents: Vec<ChannelId> = self
-                        .get_channel_descendants(vec![channel_id], &*tx)
-                        .await?
-                        .into_iter()
-                        .map(|edge| ChannelId::from_proto(edge.channel_id))
-                        .collect();
-
-                    channels_to_remove = channel::Entity::find()
-                        .filter(
-                            channel::Column::Id
-                                .is_in(all_descendents)
-                                .and(channel::Column::Visibility.eq(ChannelVisibility::Public)),
-                        )
-                        .all(&*tx)
-                        .await?
-                        .into_iter()
-                        .map(|channel| channel.id)
-                        .collect();
-
-                    channels_to_remove.push(channel_id);
-                    for member in previous_members {
-                        if member.role.can_only_see_public_descendants() {
-                            participants_to_remove.insert(member.user_id);
-                        }
-                    }
-                }
-                ChannelVisibility::Public => {
-                    if let Some(public_parent_id) =
-                        self.public_parent_channel_id(channel_id, &*tx).await?
-                    {
-                        let parent_updates = self
-                            .participants_to_notify_for_channel_change(public_parent_id, &*tx)
-                            .await?;
-
-                        for (user_id, channels) in parent_updates {
-                            participants_to_update.insert(user_id, channels);
-                        }
-                    }
-                }
-            }
-
-            Ok(SetChannelVisibilityResult {
-                participants_to_update,
-                participants_to_remove,
-                channels_to_remove,
-            })
+            Ok(channel)
         })
         .await
     }
@@ -373,10 +271,15 @@ impl Database {
         invitee_id: UserId,
         inviter_id: UserId,
         role: ChannelRole,
-    ) -> Result<InviteMemberResult> {
+    ) -> Result<NotificationBatch> {
         self.transaction(move |tx| async move {
             self.check_user_is_channel_admin(channel_id, inviter_id, &*tx)
                 .await?;
+
+            let channel = channel::Entity::find_by_id(channel_id)
+                .one(&*tx)
+                .await?
+                .ok_or_else(|| anyhow!("no such channel"))?;
 
             channel_member::ActiveModel {
                 id: ActiveValue::NotSet,
@@ -388,24 +291,12 @@ impl Database {
             .insert(&*tx)
             .await?;
 
-            let channel = channel::Entity::find_by_id(channel_id)
-                .one(&*tx)
-                .await?
-                .unwrap();
-
-            let channel = Channel {
-                id: channel.id,
-                visibility: channel.visibility,
-                name: channel.name,
-                role,
-            };
-
-            let notifications = self
+            Ok(self
                 .create_notification(
                     invitee_id,
                     rpc::Notification::ChannelInvitation {
                         channel_id: channel_id.to_proto(),
-                        channel_name: channel.name.clone(),
+                        channel_name: channel.name,
                         inviter_id: inviter_id.to_proto(),
                     },
                     true,
@@ -413,12 +304,7 @@ impl Database {
                 )
                 .await?
                 .into_iter()
-                .collect();
-
-            Ok(InviteMemberResult {
-                channel,
-                notifications,
-            })
+                .collect())
         })
         .await
     }
@@ -434,14 +320,13 @@ impl Database {
     pub async fn rename_channel(
         &self,
         channel_id: ChannelId,
-        admin_id: UserId,
+        user_id: UserId,
         new_name: &str,
-    ) -> Result<RenameChannelResult> {
+    ) -> Result<Channel> {
         self.transaction(move |tx| async move {
             let new_name = Self::sanitize_channel_name(new_name)?.to_string();
 
-            let role = self
-                .check_user_is_channel_admin(channel_id, admin_id, &*tx)
+            self.check_user_is_channel_admin(channel_id, user_id, &*tx)
                 .await?;
 
             let channel = channel::ActiveModel {
@@ -452,31 +337,10 @@ impl Database {
             .update(&*tx)
             .await?;
 
-            let participants = self
-                .get_channel_participant_details_internal(channel_id, &*tx)
-                .await?;
-
-            Ok(RenameChannelResult {
-                channel: Channel {
-                    id: channel.id,
-                    name: channel.name,
-                    visibility: channel.visibility,
-                    role,
-                },
-                participants_to_update: participants
-                    .iter()
-                    .map(|participant| {
-                        (
-                            participant.user_id,
-                            Channel {
-                                id: channel.id,
-                                name: new_name.clone(),
-                                visibility: channel.visibility,
-                                role: participant.role,
-                            },
-                        )
-                    })
-                    .collect(),
+            Ok(Channel {
+                id: channel.id,
+                name: channel.name,
+                visibility: channel.visibility,
             })
         })
         .await
@@ -487,10 +351,10 @@ impl Database {
         channel_id: ChannelId,
         user_id: UserId,
         accept: bool,
-    ) -> Result<RespondToChannelInvite> {
+    ) -> Result<NotificationBatch> {
         self.transaction(move |tx| async move {
-            let membership_update = if accept {
-                let rows_affected = channel_member::Entity::update_many()
+            let rows_affected = if accept {
+                channel_member::Entity::update_many()
                     .set(channel_member::ActiveModel {
                         accepted: ActiveValue::Set(accept),
                         ..Default::default()
@@ -503,18 +367,9 @@ impl Database {
                     )
                     .exec(&*tx)
                     .await?
-                    .rows_affected;
-
-                if rows_affected == 0 {
-                    Err(anyhow!("no such invitation"))?;
-                }
-
-                Some(
-                    self.calculate_membership_updated(channel_id, user_id, &*tx)
-                        .await?,
-                )
+                    .rows_affected
             } else {
-                let rows_affected = channel_member::Entity::delete_many()
+                channel_member::Entity::delete_many()
                     .filter(
                         channel_member::Column::ChannelId
                             .eq(channel_id)
@@ -523,87 +378,29 @@ impl Database {
                     )
                     .exec(&*tx)
                     .await?
-                    .rows_affected;
-                if rows_affected == 0 {
-                    Err(anyhow!("no such invitation"))?;
-                }
-
-                None
+                    .rows_affected
             };
 
-            Ok(RespondToChannelInvite {
-                membership_update,
-                notifications: self
-                    .mark_notification_as_read_with_response(
-                        user_id,
-                        &rpc::Notification::ChannelInvitation {
-                            channel_id: channel_id.to_proto(),
-                            channel_name: Default::default(),
-                            inviter_id: Default::default(),
-                        },
-                        accept,
-                        &*tx,
-                    )
-                    .await?
-                    .into_iter()
-                    .collect(),
-            })
-        })
-        .await
-    }
-
-    async fn calculate_membership_updated(
-        &self,
-        channel_id: ChannelId,
-        user_id: UserId,
-        tx: &DatabaseTransaction,
-    ) -> Result<MembershipUpdated> {
-        let mut channel_to_refresh = channel_id;
-        let mut removed_channels: Vec<ChannelId> = Vec::new();
-
-        // if the user was previously a guest of a parent public channel they may have seen this
-        // channel (or its descendants) in the tree already.
-        // Now they have new permissions, the graph of channels needs updating from that point.
-        if let Some(public_parent) = self.public_parent_channel_id(channel_id, &*tx).await? {
-            if self
-                .channel_role_for_user(public_parent, user_id, &*tx)
-                .await?
-                == Some(ChannelRole::Guest)
-            {
-                channel_to_refresh = public_parent;
+            if rows_affected == 0 {
+                Err(anyhow!("no such invitation"))?;
             }
-        }
 
-        // remove all descendant channels from the user's tree
-        removed_channels.append(
-            &mut self
-                .get_channel_descendants(vec![channel_to_refresh], &*tx)
+            Ok(self
+                .mark_notification_as_read_with_response(
+                    user_id,
+                    &rpc::Notification::ChannelInvitation {
+                        channel_id: channel_id.to_proto(),
+                        channel_name: Default::default(),
+                        inviter_id: Default::default(),
+                    },
+                    accept,
+                    &*tx,
+                )
                 .await?
                 .into_iter()
-                .map(|edge| ChannelId::from_proto(edge.channel_id))
-                .collect(),
-        );
-
-        let new_channels = self
-            .get_user_channels(user_id, Some(channel_to_refresh), &*tx)
-            .await?;
-
-        // We only add the current channel to "moved" if the user has lost access,
-        // otherwise it would be made a root channel on the client.
-        if !new_channels
-            .channels
-            .channels
-            .iter()
-            .any(|c| c.id == channel_id)
-        {
-            removed_channels.push(channel_id);
-        }
-
-        Ok(MembershipUpdated {
-            channel_id,
-            new_channels,
-            removed_channels,
+                .collect())
         })
+        .await
     }
 
     pub async fn remove_channel_member(
@@ -611,7 +408,7 @@ impl Database {
         channel_id: ChannelId,
         member_id: UserId,
         admin_id: UserId,
-    ) -> Result<RemoveChannelMemberResult> {
+    ) -> Result<Option<NotificationId>> {
         self.transaction(|tx| async move {
             self.check_user_is_channel_admin(channel_id, admin_id, &*tx)
                 .await?;
@@ -629,30 +426,23 @@ impl Database {
                 Err(anyhow!("no such member"))?;
             }
 
-            Ok(RemoveChannelMemberResult {
-                membership_update: self
-                    .calculate_membership_updated(channel_id, member_id, &*tx)
-                    .await?,
-                notification_id: self
-                    .remove_notification(
-                        member_id,
-                        rpc::Notification::ChannelInvitation {
-                            channel_id: channel_id.to_proto(),
-                            channel_name: Default::default(),
-                            inviter_id: Default::default(),
-                        },
-                        &*tx,
-                    )
-                    .await?,
-            })
+            Ok(self
+                .remove_notification(
+                    member_id,
+                    rpc::Notification::ChannelInvitation {
+                        channel_id: channel_id.to_proto(),
+                        channel_name: Default::default(),
+                        inviter_id: Default::default(),
+                    },
+                    &*tx,
+                )
+                .await?)
         })
         .await
     }
 
     pub async fn get_channel_invites_for_user(&self, user_id: UserId) -> Result<Vec<Channel>> {
         self.transaction(|tx| async move {
-            let mut role_for_channel: HashMap<ChannelId, ChannelRole> = HashMap::default();
-
             let channel_invites = channel_member::Entity::find()
                 .filter(
                     channel_member::Column::UserId
@@ -662,12 +452,14 @@ impl Database {
                 .all(&*tx)
                 .await?;
 
-            for invite in channel_invites {
-                role_for_channel.insert(invite.channel_id, invite.role);
-            }
-
             let channels = channel::Entity::find()
-                .filter(channel::Column::Id.is_in(role_for_channel.keys().copied()))
+                .filter(
+                    channel::Column::Id.is_in(
+                        channel_invites
+                            .into_iter()
+                            .map(|channel_member| channel_member.channel_id),
+                    ),
+                )
                 .all(&*tx)
                 .await?;
 
@@ -677,7 +469,6 @@ impl Database {
                     id: channel.id,
                     name: channel.name,
                     visibility: channel.visibility,
-                    role: role_for_channel[&channel.id],
                 })
                 .collect();
 
@@ -690,7 +481,41 @@ impl Database {
         self.transaction(|tx| async move {
             let tx = tx;
 
-            self.get_user_channels(user_id, None, &tx).await
+            let channel_memberships = channel_member::Entity::find()
+                .filter(
+                    channel_member::Column::UserId
+                        .eq(user_id)
+                        .and(channel_member::Column::Accepted.eq(true)),
+                )
+                .all(&*tx)
+                .await?;
+
+            self.get_user_channels(user_id, channel_memberships, &tx)
+                .await
+        })
+        .await
+    }
+
+    pub async fn get_channel_for_user(
+        &self,
+        channel_id: ChannelId,
+        user_id: UserId,
+    ) -> Result<ChannelsForUser> {
+        self.transaction(|tx| async move {
+            let tx = tx;
+
+            let channel_membership = channel_member::Entity::find()
+                .filter(
+                    channel_member::Column::UserId
+                        .eq(user_id)
+                        .and(channel_member::Column::ChannelId.eq(channel_id))
+                        .and(channel_member::Column::Accepted.eq(true)),
+                )
+                .all(&*tx)
+                .await?;
+
+            self.get_user_channels(user_id, channel_membership, &tx)
+                .await
         })
         .await
     }
@@ -698,34 +523,17 @@ impl Database {
     pub async fn get_user_channels(
         &self,
         user_id: UserId,
-        parent_channel_id: Option<ChannelId>,
+        channel_memberships: Vec<channel_member::Model>,
         tx: &DatabaseTransaction,
     ) -> Result<ChannelsForUser> {
-        // note: we could (maybe) win some efficiency here when parent_channel_id
-        // is set by getting just the role for that channel, then getting descendants
-        // with roles attached; but that's not as straightforward as it sounds
-        // because we need to calculate the path to the channel to make the query
-        // efficient, which currently requires an extra round trip to the database.
-        // Fix this later...
-        let channel_memberships = channel_member::Entity::find()
-            .filter(
-                channel_member::Column::UserId
-                    .eq(user_id)
-                    .and(channel_member::Column::Accepted.eq(true)),
-            )
-            .all(&*tx)
-            .await?;
-
         let mut edges = self
             .get_channel_descendants(channel_memberships.iter().map(|m| m.channel_id), &*tx)
             .await?;
 
-        let mut role_for_channel: HashMap<ChannelId, (ChannelRole, bool)> = HashMap::default();
+        let mut role_for_channel: HashMap<ChannelId, ChannelRole> = HashMap::default();
 
         for membership in channel_memberships.iter() {
-            let included =
-                parent_channel_id.is_none() || membership.channel_id == parent_channel_id.unwrap();
-            role_for_channel.insert(membership.channel_id, (membership.role, included));
+            role_for_channel.insert(membership.channel_id, membership.role);
         }
 
         for ChannelEdge {
@@ -736,27 +544,17 @@ impl Database {
             let parent_id = ChannelId::from_proto(*parent_id);
             let channel_id = ChannelId::from_proto(*channel_id);
             debug_assert!(role_for_channel.get(&parent_id).is_some());
-            let (parent_role, parent_included) = role_for_channel[&parent_id];
-
-            if let Some((existing_role, included)) = role_for_channel.get(&channel_id) {
-                role_for_channel.insert(
-                    channel_id,
-                    (existing_role.max(parent_role), *included || parent_included),
-                );
-            } else {
-                role_for_channel.insert(
-                    channel_id,
-                    (
-                        parent_role,
-                        parent_included
-                            || parent_channel_id.is_none()
-                            || Some(channel_id) == parent_channel_id,
-                    ),
-                );
+            let parent_role = role_for_channel[&parent_id];
+            if let Some(existing_role) = role_for_channel.get(&channel_id) {
+                if existing_role.should_override(parent_role) {
+                    continue;
+                }
             }
+            role_for_channel.insert(channel_id, parent_role);
         }
 
         let mut channels: Vec<Channel> = Vec::new();
+        let mut channels_with_admin_privileges: HashSet<ChannelId> = HashSet::default();
         let mut channels_to_remove: HashSet<u64> = HashSet::default();
 
         let mut rows = channel::Entity::find()
@@ -766,10 +564,9 @@ impl Database {
 
         while let Some(row) = rows.next().await {
             let channel = row?;
-            let (role, included) = role_for_channel[&channel.id];
+            let role = role_for_channel[&channel.id];
 
-            if !included
-                || role == ChannelRole::Banned
+            if role == ChannelRole::Banned
                 || role == ChannelRole::Guest && channel.visibility != ChannelVisibility::Public
             {
                 channels_to_remove.insert(channel.id.0 as u64);
@@ -780,8 +577,11 @@ impl Database {
                 id: channel.id,
                 name: channel.name,
                 visibility: channel.visibility,
-                role,
             });
+
+            if role == ChannelRole::Admin {
+                channels_with_admin_privileges.insert(channel.id);
+            }
         }
         drop(rows);
 
@@ -863,64 +663,15 @@ impl Database {
         Ok(ChannelsForUser {
             channels: ChannelGraph { channels, edges },
             channel_participants,
+            channels_with_admin_privileges,
             unseen_buffer_changes: channel_buffer_changes,
             channel_messages: unseen_messages,
         })
     }
 
-    async fn participants_to_notify_for_channel_change(
-        &self,
-        new_parent: ChannelId,
-        tx: &DatabaseTransaction,
-    ) -> Result<Vec<(UserId, ChannelsForUser)>> {
-        let mut results: Vec<(UserId, ChannelsForUser)> = Vec::new();
-
-        let members = self
-            .get_channel_participant_details_internal(new_parent, &*tx)
-            .await?;
-
-        for member in members.iter() {
-            if !member.role.can_see_all_descendants() {
-                continue;
-            }
-            results.push((
-                member.user_id,
-                self.get_user_channels(member.user_id, Some(new_parent), &*tx)
-                    .await?,
-            ))
-        }
-
-        let public_parent = self
-            .public_path_to_channel(new_parent, &*tx)
-            .await?
-            .last()
-            .copied();
-
-        let Some(public_parent) = public_parent else {
-            return Ok(results);
-        };
-
-        // could save some time in the common case by skipping this if the
-        // new channel is not public and has no public descendants.
-        let public_members = if public_parent == new_parent {
-            members
-        } else {
-            self.get_channel_participant_details_internal(public_parent, &*tx)
-                .await?
-        };
-
-        for member in public_members {
-            if !member.role.can_only_see_public_descendants() {
-                continue;
-            };
-            results.push((
-                member.user_id,
-                self.get_user_channels(member.user_id, Some(public_parent), &*tx)
-                    .await?,
-            ))
-        }
-
-        Ok(results)
+    pub async fn get_channel_members(&self, id: ChannelId) -> Result<Vec<UserId>> {
+        self.transaction(|tx| async move { self.get_channel_participants_internal(id, &*tx).await })
+            .await
     }
 
     pub async fn set_channel_member_role(
@@ -929,7 +680,7 @@ impl Database {
         admin_id: UserId,
         for_user: UserId,
         role: ChannelRole,
-    ) -> Result<SetMemberRoleResult> {
+    ) -> Result<channel_member::Model> {
         self.transaction(|tx| async move {
             self.check_user_is_channel_admin(channel_id, admin_id, &*tx)
                 .await?;
@@ -951,24 +702,7 @@ impl Database {
             update.role = ActiveValue::Set(role);
             let updated = channel_member::Entity::update(update).exec(&*tx).await?;
 
-            if !updated.accepted {
-                let channel = channel::Entity::find_by_id(channel_id)
-                    .one(&*tx)
-                    .await?
-                    .unwrap();
-
-                return Ok(SetMemberRoleResult::InviteUpdated(Channel {
-                    id: channel.id,
-                    visibility: channel.visibility,
-                    name: channel.name,
-                    role,
-                }));
-            }
-
-            Ok(SetMemberRoleResult::MembershipUpdated(
-                self.calculate_membership_updated(channel_id, for_user, &*tx)
-                    .await?,
-            ))
+            Ok(updated)
         })
         .await
     }
@@ -978,146 +712,136 @@ impl Database {
         channel_id: ChannelId,
         user_id: UserId,
     ) -> Result<Vec<proto::ChannelMember>> {
-        let (role, members) = self
-            .transaction(move |tx| async move {
-                let role = self
-                    .check_user_is_channel_participant(channel_id, user_id, &*tx)
-                    .await?;
-                Ok((
-                    role,
-                    self.get_channel_participant_details_internal(channel_id, &*tx)
-                        .await?,
-                ))
-            })
-            .await?;
+        self.transaction(|tx| async move {
+            let user_role = self
+                .check_user_is_channel_member(channel_id, user_id, &*tx)
+                .await?;
 
-        if role == ChannelRole::Admin {
-            Ok(members
-                .into_iter()
-                .map(|channel_member| channel_member.to_proto())
-                .collect())
-        } else {
-            return Ok(members
-                .into_iter()
-                .filter_map(|member| {
-                    if member.kind == proto::channel_member::Kind::Invitee {
-                        return None;
+            let channel_visibility = channel::Entity::find()
+                .filter(channel::Column::Id.eq(channel_id))
+                .one(&*tx)
+                .await?
+                .map(|channel| channel.visibility)
+                .unwrap_or(ChannelVisibility::Members);
+
+            #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
+            enum QueryMemberDetails {
+                UserId,
+                Role,
+                IsDirectMember,
+                Accepted,
+                Visibility,
+            }
+
+            let tx = tx;
+            let ancestor_ids = self.get_channel_ancestors(channel_id, &*tx).await?;
+            let mut stream = channel_member::Entity::find()
+                .left_join(channel::Entity)
+                .filter(channel_member::Column::ChannelId.is_in(ancestor_ids.iter().copied()))
+                .select_only()
+                .column(channel_member::Column::UserId)
+                .column(channel_member::Column::Role)
+                .column_as(
+                    channel_member::Column::ChannelId.eq(channel_id),
+                    QueryMemberDetails::IsDirectMember,
+                )
+                .column(channel_member::Column::Accepted)
+                .column(channel::Column::Visibility)
+                .into_values::<_, QueryMemberDetails>()
+                .stream(&*tx)
+                .await?;
+
+            struct UserDetail {
+                kind: Kind,
+                channel_role: ChannelRole,
+            }
+            let mut user_details: HashMap<UserId, UserDetail> = HashMap::default();
+
+            while let Some(user_membership) = stream.next().await {
+                let (user_id, channel_role, is_direct_member, is_invite_accepted, visibility): (
+                    UserId,
+                    ChannelRole,
+                    bool,
+                    bool,
+                    ChannelVisibility,
+                ) = user_membership?;
+                let kind = match (is_direct_member, is_invite_accepted) {
+                    (true, true) => proto::channel_member::Kind::Member,
+                    (true, false) => proto::channel_member::Kind::Invitee,
+                    (false, true) => proto::channel_member::Kind::AncestorMember,
+                    (false, false) => continue,
+                };
+
+                if channel_role == ChannelRole::Guest
+                    && visibility != ChannelVisibility::Public
+                    && channel_visibility != ChannelVisibility::Public
+                {
+                    continue;
+                }
+
+                if let Some(details_mut) = user_details.get_mut(&user_id) {
+                    if channel_role.should_override(details_mut.channel_role) {
+                        details_mut.channel_role = channel_role;
                     }
-                    Some(ChannelMember {
-                        role: member.role,
-                        user_id: member.user_id,
-                        kind: proto::channel_member::Kind::Member,
+                    if kind == Kind::Member {
+                        details_mut.kind = kind;
+                    // the UI is going to be a bit confusing if you already have permissions
+                    // that are greater than or equal to the ones you're being invited to.
+                    } else if kind == Kind::Invitee && details_mut.kind == Kind::AncestorMember {
+                        details_mut.kind = kind;
+                    }
+                } else {
+                    user_details.insert(user_id, UserDetail { kind, channel_role });
+                }
+            }
+
+            Ok(user_details
+                .into_iter()
+                .filter_map(|(user_id, mut details)| {
+                    // If the user is not an admin, don't give them as much
+                    // information about the other members.
+                    if user_role != ChannelRole::Admin {
+                        if details.kind == Kind::Invitee
+                            || details.channel_role == ChannelRole::Banned
+                        {
+                            return None;
+                        }
+
+                        if details.channel_role == ChannelRole::Admin {
+                            details.channel_role = ChannelRole::Member;
+                        }
+                    }
+
+                    Some(proto::ChannelMember {
+                        user_id: user_id.to_proto(),
+                        kind: details.kind.into(),
+                        role: details.channel_role.into(),
                     })
                 })
-                .map(|channel_member| channel_member.to_proto())
-                .collect());
-        }
+                .collect())
+        })
+        .await
     }
 
-    async fn get_channel_participant_details_internal(
+    pub async fn get_channel_participants_internal(
         &self,
-        channel_id: ChannelId,
-        tx: &DatabaseTransaction,
-    ) -> Result<Vec<ChannelMember>> {
-        let channel_visibility = channel::Entity::find()
-            .filter(channel::Column::Id.eq(channel_id))
-            .one(&*tx)
-            .await?
-            .map(|channel| channel.visibility)
-            .unwrap_or(ChannelVisibility::Members);
-
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryMemberDetails {
-            UserId,
-            Role,
-            IsDirectMember,
-            Accepted,
-            Visibility,
-        }
-
-        let tx = tx;
-        let ancestor_ids = self.get_channel_ancestors(channel_id, &*tx).await?;
-        let mut stream = channel_member::Entity::find()
-            .left_join(channel::Entity)
-            .filter(channel_member::Column::ChannelId.is_in(ancestor_ids.iter().copied()))
-            .select_only()
-            .column(channel_member::Column::UserId)
-            .column(channel_member::Column::Role)
-            .column_as(
-                channel_member::Column::ChannelId.eq(channel_id),
-                QueryMemberDetails::IsDirectMember,
-            )
-            .column(channel_member::Column::Accepted)
-            .column(channel::Column::Visibility)
-            .into_values::<_, QueryMemberDetails>()
-            .stream(&*tx)
-            .await?;
-
-        let mut user_details: HashMap<UserId, ChannelMember> = HashMap::default();
-
-        while let Some(user_membership) = stream.next().await {
-            let (user_id, channel_role, is_direct_member, is_invite_accepted, visibility): (
-                UserId,
-                ChannelRole,
-                bool,
-                bool,
-                ChannelVisibility,
-            ) = user_membership?;
-            let kind = match (is_direct_member, is_invite_accepted) {
-                (true, true) => proto::channel_member::Kind::Member,
-                (true, false) => proto::channel_member::Kind::Invitee,
-                (false, true) => proto::channel_member::Kind::AncestorMember,
-                (false, false) => continue,
-            };
-
-            if channel_role == ChannelRole::Guest
-                && visibility != ChannelVisibility::Public
-                && channel_visibility != ChannelVisibility::Public
-            {
-                continue;
-            }
-
-            if let Some(details_mut) = user_details.get_mut(&user_id) {
-                if channel_role.should_override(details_mut.role) {
-                    details_mut.role = channel_role;
-                }
-                if kind == Kind::Member {
-                    details_mut.kind = kind;
-                // the UI is going to be a bit confusing if you already have permissions
-                // that are greater than or equal to the ones you're being invited to.
-                } else if kind == Kind::Invitee && details_mut.kind == Kind::AncestorMember {
-                    details_mut.kind = kind;
-                }
-            } else {
-                user_details.insert(
-                    user_id,
-                    ChannelMember {
-                        user_id,
-                        kind,
-                        role: channel_role,
-                    },
-                );
-            }
-        }
-
-        Ok(user_details
-            .into_iter()
-            .map(|(_, details)| details)
-            .collect())
-    }
-
-    pub async fn get_channel_participants(
-        &self,
-        channel_id: ChannelId,
+        id: ChannelId,
         tx: &DatabaseTransaction,
     ) -> Result<Vec<UserId>> {
-        let participants = self
-            .get_channel_participant_details_internal(channel_id, &*tx)
+        let ancestor_ids = self.get_channel_ancestors(id, tx).await?;
+        let user_ids = channel_member::Entity::find()
+            .distinct()
+            .filter(
+                channel_member::Column::ChannelId
+                    .is_in(ancestor_ids.iter().copied())
+                    .and(channel_member::Column::Accepted.eq(true)),
+            )
+            .select_only()
+            .column(channel_member::Column::UserId)
+            .into_values::<_, QueryUserIds>()
+            .all(&*tx)
             .await?;
-        Ok(participants
-            .into_iter()
-            .map(|member| member.user_id)
-            .collect())
+        Ok(user_ids)
     }
 
     pub async fn check_user_is_channel_admin(
@@ -1125,10 +849,9 @@ impl Database {
         channel_id: ChannelId,
         user_id: UserId,
         tx: &DatabaseTransaction,
-    ) -> Result<ChannelRole> {
-        let role = self.channel_role_for_user(channel_id, user_id, tx).await?;
-        match role {
-            Some(ChannelRole::Admin) => Ok(role.unwrap()),
+    ) -> Result<()> {
+        match self.channel_role_for_user(channel_id, user_id, tx).await? {
+            Some(ChannelRole::Admin) => Ok(()),
             Some(ChannelRole::Member)
             | Some(ChannelRole::Banned)
             | Some(ChannelRole::Guest)
@@ -1158,11 +881,10 @@ impl Database {
         channel_id: ChannelId,
         user_id: UserId,
         tx: &DatabaseTransaction,
-    ) -> Result<ChannelRole> {
-        let role = self.channel_role_for_user(channel_id, user_id, tx).await?;
-        match role {
+    ) -> Result<()> {
+        match self.channel_role_for_user(channel_id, user_id, tx).await? {
             Some(ChannelRole::Admin) | Some(ChannelRole::Member) | Some(ChannelRole::Guest) => {
-                Ok(role.unwrap())
+                Ok(())
             }
             Some(ChannelRole::Banned) | None => Err(anyhow!(
                 "user is not a channel participant or channel does not exist"
@@ -1188,37 +910,12 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn parent_channel_id(
+    pub async fn most_public_ancestor_for_channel(
         &self,
         channel_id: ChannelId,
         tx: &DatabaseTransaction,
     ) -> Result<Option<ChannelId>> {
-        let path = self.path_to_channel(channel_id, &*tx).await?;
-        if path.len() >= 2 {
-            Ok(Some(path[path.len() - 2]))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub async fn public_parent_channel_id(
-        &self,
-        channel_id: ChannelId,
-        tx: &DatabaseTransaction,
-    ) -> Result<Option<ChannelId>> {
-        let path = self.public_path_to_channel(channel_id, &*tx).await?;
-        if path.len() >= 2 && path.last().copied() == Some(channel_id) {
-            Ok(Some(path[path.len() - 2]))
-        } else {
-            Ok(path.last().copied())
-        }
-    }
-
-    pub async fn path_to_channel(
-        &self,
-        channel_id: ChannelId,
-        tx: &DatabaseTransaction,
-    ) -> Result<Vec<ChannelId>> {
+        // Note: if there are many paths to a channel, this will return just one
         let arbitary_path = channel_path::Entity::find()
             .filter(channel_path::Column::ChannelId.eq(channel_id))
             .order_by(channel_path::Column::IdPath, sea_orm::Order::Desc)
@@ -1226,23 +923,15 @@ impl Database {
             .await?;
 
         let Some(path) = arbitary_path else {
-            return Ok(vec![]);
+            return Ok(None);
         };
 
-        Ok(path
+        let ancestor_ids: Vec<ChannelId> = path
             .id_path
             .trim_matches('/')
             .split('/')
             .map(|id| ChannelId::from_proto(id.parse().unwrap()))
-            .collect())
-    }
-
-    pub async fn public_path_to_channel(
-        &self,
-        channel_id: ChannelId,
-        tx: &DatabaseTransaction,
-    ) -> Result<Vec<ChannelId>> {
-        let ancestor_ids = self.path_to_channel(channel_id, &*tx).await?;
+            .collect();
 
         let rows = channel::Entity::find()
             .filter(channel::Column::Id.is_in(ancestor_ids.iter().copied()))
@@ -1256,10 +945,13 @@ impl Database {
             visible_channels.insert(row.id);
         }
 
-        Ok(ancestor_ids
-            .into_iter()
-            .filter(|id| visible_channels.contains(id))
-            .collect())
+        for ancestor in ancestor_ids {
+            if visible_channels.contains(&ancestor) {
+                return Ok(Some(ancestor));
+            }
+        }
+
+        Ok(None)
     }
 
     pub async fn channel_role_for_user(
@@ -1430,8 +1122,7 @@ impl Database {
     /// Returns the channel with the given ID
     pub async fn get_channel(&self, channel_id: ChannelId, user_id: UserId) -> Result<Channel> {
         self.transaction(|tx| async move {
-            let role = self
-                .check_user_is_channel_participant(channel_id, user_id, &*tx)
+            self.check_user_is_channel_participant(channel_id, user_id, &*tx)
                 .await?;
 
             let channel = channel::Entity::find_by_id(channel_id).one(&*tx).await?;
@@ -1442,7 +1133,6 @@ impl Database {
             Ok(Channel {
                 id: channel.id,
                 visibility: channel.visibility,
-                role,
                 name: channel.name,
             })
         })
@@ -1492,6 +1182,9 @@ impl Database {
         to: ChannelId,
     ) -> Result<ChannelGraph> {
         self.transaction(|tx| async move {
+            // Note that even with these maxed permissions, this linking operation
+            // is still insecure because you can't remove someone's permissions to a
+            // channel if they've linked the channel to one where they're an admin.
             self.check_user_is_channel_admin(channel, user, &*tx)
                 .await?;
 
@@ -1556,7 +1249,16 @@ impl Database {
                 .await?;
         }
 
-        let mut channel_info = self.get_user_channels(user, Some(channel), &*tx).await?;
+        let membership = channel_member::Entity::find()
+            .filter(
+                channel_member::Column::ChannelId
+                    .eq(channel)
+                    .and(channel_member::Column::UserId.eq(user)),
+            )
+            .all(tx)
+            .await?;
+
+        let mut channel_info = self.get_user_channels(user, membership, &*tx).await?;
 
         channel_info.channels.edges.push(ChannelEdge {
             channel_id: channel.to_proto(),
@@ -1575,6 +1277,9 @@ impl Database {
         from: ChannelId,
     ) -> Result<()> {
         self.transaction(|tx| async move {
+            // Note that even with these maxed permissions, this linking operation
+            // is still insecure because you can't remove someone's permissions to a
+            // channel if they've linked the channel to one where they're an admin.
             self.check_user_is_channel_admin(channel, user, &*tx)
                 .await?;
 
@@ -1629,7 +1334,6 @@ impl Database {
                     }
                 })
                 .collect();
-
             channel_path::Entity::insert_many(root_paths)
                 .exec(&*tx)
                 .await?;
@@ -1638,64 +1342,32 @@ impl Database {
         Ok(())
     }
 
-    /// Move a channel from one parent to another
+    /// Move a channel from one parent to another, returns the
+    /// Channels that were moved for notifying clients
     pub async fn move_channel(
         &self,
-        channel_id: ChannelId,
-        old_parent_id: Option<ChannelId>,
-        new_parent_id: ChannelId,
-        admin_id: UserId,
-    ) -> Result<Option<MoveChannelResult>> {
+        user: UserId,
+        channel: ChannelId,
+        from: ChannelId,
+        to: ChannelId,
+    ) -> Result<ChannelGraph> {
+        if from == to {
+            return Ok(ChannelGraph {
+                channels: vec![],
+                edges: vec![],
+            });
+        }
+
         self.transaction(|tx| async move {
-            self.check_user_is_channel_admin(channel_id, admin_id, &*tx)
+            self.check_user_is_channel_admin(channel, user, &*tx)
                 .await?;
 
-            debug_assert_eq!(
-                self.parent_channel_id(channel_id, &*tx).await?,
-                old_parent_id
-            );
+            let moved_channels = self.link_channel_internal(user, channel, to, &*tx).await?;
 
-            if old_parent_id == Some(new_parent_id) {
-                return Ok(None);
-            }
-            let previous_participants = self
-                .get_channel_participant_details_internal(channel_id, &*tx)
+            self.unlink_channel_internal(user, channel, from, &*tx)
                 .await?;
 
-            self.link_channel_internal(admin_id, channel_id, new_parent_id, &*tx)
-                .await?;
-
-            if let Some(from) = old_parent_id {
-                self.unlink_channel_internal(admin_id, channel_id, from, &*tx)
-                    .await?;
-            }
-
-            let participants_to_update: HashMap<UserId, ChannelsForUser> = self
-                .participants_to_notify_for_channel_change(new_parent_id, &*tx)
-                .await?
-                .into_iter()
-                .collect();
-
-            let mut moved_channels: HashSet<ChannelId> = HashSet::default();
-            moved_channels.insert(channel_id);
-            for edge in self.get_channel_descendants([channel_id], &*tx).await? {
-                moved_channels.insert(ChannelId::from_proto(edge.channel_id));
-            }
-
-            let mut participants_to_remove: HashSet<UserId> = HashSet::default();
-            for participant in previous_participants {
-                if participant.kind == proto::channel_member::Kind::AncestorMember {
-                    if !participants_to_update.contains_key(&participant.user_id) {
-                        participants_to_remove.insert(participant.user_id);
-                    }
-                }
-            }
-
-            Ok(Some(MoveChannelResult {
-                participants_to_remove,
-                participants_to_update,
-                moved_channels,
-            }))
+            Ok(moved_channels)
         })
         .await
     }

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -53,7 +53,9 @@ impl Database {
             let (channel_id, room) = self.get_channel_room(room_id, &tx).await?;
             let channel_members;
             if let Some(channel_id) = channel_id {
-                channel_members = self.get_channel_participants(channel_id, &tx).await?;
+                channel_members = self
+                    .get_channel_participants_internal(channel_id, &tx)
+                    .await?;
             } else {
                 channel_members = Vec::new();
 
@@ -421,7 +423,9 @@ impl Database {
         .await?;
 
         let room = self.get_room(room_id, &tx).await?;
-        let channel_members = self.get_channel_participants(channel_id, &tx).await?;
+        let channel_members = self
+            .get_channel_participants_internal(channel_id, &tx)
+            .await?;
         Ok(JoinRoom {
             room,
             channel_id: Some(channel_id),
@@ -720,7 +724,8 @@ impl Database {
 
             let (channel_id, room) = self.get_channel_room(room_id, &tx).await?;
             let channel_members = if let Some(channel_id) = channel_id {
-                self.get_channel_participants(channel_id, &tx).await?
+                self.get_channel_participants_internal(channel_id, &tx)
+                    .await?
             } else {
                 Vec::new()
             };
@@ -878,7 +883,8 @@ impl Database {
                 };
 
                 let channel_members = if let Some(channel_id) = channel_id {
-                    self.get_channel_participants(channel_id, &tx).await?
+                    self.get_channel_participants_internal(channel_id, &tx)
+                        .await?
                 } else {
                     Vec::new()
                 };

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -11,7 +11,7 @@ use rpc::proto::ChannelEdge;
 use sea_orm::ConnectionTrait;
 use sqlx::migrate::MigrateDatabase;
 use std::sync::{
-    atomic::{AtomicI32, AtomicU32, Ordering::SeqCst},
+    atomic::{AtomicI32, Ordering::SeqCst},
     Arc,
 };
 
@@ -154,21 +154,17 @@ impl Drop for TestDb {
 }
 
 /// The second tuples are (channel_id, parent)
-fn graph(
-    channels: &[(ChannelId, &'static str, ChannelRole)],
-    edges: &[(ChannelId, ChannelId)],
-) -> ChannelGraph {
+fn graph(channels: &[(ChannelId, &'static str)], edges: &[(ChannelId, ChannelId)]) -> ChannelGraph {
     let mut graph = ChannelGraph {
         channels: vec![],
         edges: vec![],
     };
 
-    for (id, name, role) in channels {
+    for (id, name) in channels {
         graph.channels.push(Channel {
             id: *id,
             name: name.to_string(),
             visibility: ChannelVisibility::Members,
-            role: *role,
         })
     }
 
@@ -196,12 +192,4 @@ async fn new_test_user(db: &Arc<Database>, email: &str) -> UserId {
     .await
     .unwrap()
     .user_id
-}
-
-static TEST_CONNECTION_ID: AtomicU32 = AtomicU32::new(1);
-fn new_test_connection(server: ServerId) -> ConnectionId {
-    ConnectionId {
-        id: TEST_CONNECTION_ID.fetch_add(1, SeqCst),
-        owner_id: server.0 as u32,
-    }
 }

--- a/crates/collab/src/tests/channel_buffer_tests.rs
+++ b/crates/collab/src/tests/channel_buffer_tests.rs
@@ -410,10 +410,10 @@ async fn test_channel_buffer_disconnect(
     server.disconnect_client(client_a.peer_id().unwrap());
     deterministic.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
 
-    channel_buffer_a.update(cx_a, |buffer, cx| {
+    channel_buffer_a.update(cx_a, |buffer, _| {
         assert_eq!(
-            buffer.channel(cx).unwrap().as_ref(),
-            &channel(channel_id, "the-channel", proto::ChannelRole::Admin)
+            buffer.channel().as_ref(),
+            &channel(channel_id, "the-channel")
         );
         assert!(!buffer.is_connected());
     });
@@ -435,16 +435,18 @@ async fn test_channel_buffer_disconnect(
     deterministic.run_until_parked();
 
     // Channel buffer observed the deletion
-    channel_buffer_b.update(cx_b, |buffer, cx| {
-        assert!(buffer.channel(cx).is_none());
+    channel_buffer_b.update(cx_b, |buffer, _| {
+        assert_eq!(
+            buffer.channel().as_ref(),
+            &channel(channel_id, "the-channel")
+        );
         assert!(!buffer.is_connected());
     });
 }
 
-fn channel(id: u64, name: &'static str, role: proto::ChannelRole) -> Channel {
+fn channel(id: u64, name: &'static str) -> Channel {
     Channel {
         id,
-        role,
         name: name.to_string(),
         visibility: proto::ChannelVisibility::Members,
         unseen_note_version: None,
@@ -696,7 +698,7 @@ async fn test_following_to_channel_notes_without_a_shared_project(
         .await
         .unwrap();
     channel_view_1_a.update(cx_a, |notes, cx| {
-        assert_eq!(notes.channel(cx).unwrap().name, "channel-1");
+        assert_eq!(notes.channel(cx).name, "channel-1");
         notes.editor.update(cx, |editor, cx| {
             editor.insert("Hello from A.", cx);
             editor.change_selections(None, cx, |selections| {
@@ -728,7 +730,7 @@ async fn test_following_to_channel_notes_without_a_shared_project(
             .expect("active item is not a channel view")
     });
     channel_view_1_b.read_with(cx_b, |notes, cx| {
-        assert_eq!(notes.channel(cx).unwrap().name, "channel-1");
+        assert_eq!(notes.channel(cx).name, "channel-1");
         let editor = notes.editor.read(cx);
         assert_eq!(editor.text(cx), "Hello from A.");
         assert_eq!(editor.selections.ranges::<usize>(cx), &[3..4]);
@@ -740,7 +742,7 @@ async fn test_following_to_channel_notes_without_a_shared_project(
         .await
         .unwrap();
     channel_view_2_a.read_with(cx_a, |notes, cx| {
-        assert_eq!(notes.channel(cx).unwrap().name, "channel-2");
+        assert_eq!(notes.channel(cx).name, "channel-2");
     });
 
     // Client B is taken to the notes for channel 2.
@@ -757,7 +759,7 @@ async fn test_following_to_channel_notes_without_a_shared_project(
             .expect("active item is not a channel view")
     });
     channel_view_2_b.read_with(cx_b, |notes, cx| {
-        assert_eq!(notes.channel(cx).unwrap().name, "channel-2");
+        assert_eq!(notes.channel(cx).name, "channel-2");
     });
 }
 

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -611,6 +611,38 @@ impl TestClient {
     ) -> WindowHandle<Workspace> {
         cx.add_window(|cx| Workspace::new(0, project.clone(), self.app_state.clone(), cx))
     }
+
+    pub async fn add_admin_to_channel(
+        &self,
+        user: (&TestClient, &mut TestAppContext),
+        channel: u64,
+        cx_self: &mut TestAppContext,
+    ) {
+        let (other_client, other_cx) = user;
+
+        cx_self
+            .read(ChannelStore::global)
+            .update(cx_self, |channel_store, cx| {
+                channel_store.invite_member(
+                    channel,
+                    other_client.user_id().unwrap(),
+                    ChannelRole::Admin,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        cx_self.foreground().run_until_parked();
+
+        other_cx
+            .read(ChannelStore::global)
+            .update(other_cx, |channel_store, cx| {
+                channel_store.respond_to_channel_invite(channel, true, cx)
+            })
+            .await
+            .unwrap();
+    }
 }
 
 impl Drop for TestClient {

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -61,7 +61,6 @@ postage.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 time.workspace = true
-smallvec.workspace = true
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -263,22 +263,21 @@ impl ChatPanel {
 
     fn set_active_chat(&mut self, chat: ModelHandle<ChannelChat>, cx: &mut ViewContext<Self>) {
         if self.active_chat.as_ref().map(|e| &e.0) != Some(&chat) {
-            let channel_id = chat.read(cx).channel_id;
-            {
-                self.markdown_data.clear();
+            self.markdown_data.clear();
+            let id = {
                 let chat = chat.read(cx);
+                let channel = chat.channel().clone();
                 self.message_list.reset(chat.message_count());
-
-                let channel_name = chat.channel(cx).map(|channel| channel.name.clone());
                 self.input_editor.update(cx, |editor, cx| {
-                    editor.set_channel(channel_id, channel_name, cx);
+                    editor.set_channel(channel.clone(), cx);
                 });
+                channel.id
             };
             let subscription = cx.subscribe(&chat, Self::channel_did_change);
             self.active_chat = Some((chat, subscription));
             self.acknowledge_last_message(cx);
             self.channel_select.update(cx, |select, cx| {
-                if let Some(ix) = self.channel_store.read(cx).index_of_channel(channel_id) {
+                if let Some(ix) = self.channel_store.read(cx).index_of_channel(id) {
                     select.set_selected_index(ix, cx);
                 }
             });
@@ -362,8 +361,7 @@ impl ChatPanel {
                 let is_admin = self
                     .channel_store
                     .read(cx)
-                    .is_channel_admin(active_chat.channel_id);
-
+                    .is_user_admin(active_chat.channel().id);
                 let last_message = active_chat.message(ix.saturating_sub(1));
                 let this_message = active_chat.message(ix).clone();
                 let is_continuation = last_message.id != this_message.id
@@ -678,7 +676,7 @@ impl ChatPanel {
             .active_chat
             .as_ref()
             .and_then(|(chat, _)| {
-                (chat.read(cx).channel_id == selected_channel_id)
+                (chat.read(cx).channel().id == selected_channel_id)
                     .then(|| Task::ready(anyhow::Ok(chat.clone())))
             })
             .unwrap_or_else(|| {
@@ -716,7 +714,7 @@ impl ChatPanel {
 
     fn open_notes(&mut self, _: &OpenChannelNotes, cx: &mut ViewContext<Self>) {
         if let Some((chat, _)) = &self.active_chat {
-            let channel_id = chat.read(cx).channel_id;
+            let channel_id = chat.read(cx).channel().id;
             if let Some(workspace) = self.workspace.upgrade(cx) {
                 ChannelView::open(channel_id, workspace, cx).detach();
             }
@@ -725,7 +723,7 @@ impl ChatPanel {
 
     fn join_call(&mut self, _: &JoinCall, cx: &mut ViewContext<Self>) {
         if let Some((chat, _)) = &self.active_chat {
-            let channel_id = chat.read(cx).channel_id;
+            let channel_id = chat.read(cx).channel().id;
             ActiveCall::global(cx)
                 .update(cx, |call, cx| call.join_channel(channel_id, cx))
                 .detach_and_log_err(cx);

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -1,4 +1,4 @@
-use channel::{ChannelId, ChannelMembership, ChannelStore, MessageParams};
+use channel::{Channel, ChannelMembership, ChannelStore, MessageParams};
 use client::UserId;
 use collections::HashMap;
 use editor::{AnchorRangeExt, Editor};
@@ -30,7 +30,7 @@ pub struct MessageEditor {
     users: HashMap<String, UserId>,
     mentions: Vec<UserId>,
     mentions_task: Option<Task<()>>,
-    channel_id: Option<ChannelId>,
+    channel: Option<Arc<Channel>>,
 }
 
 impl MessageEditor {
@@ -68,33 +68,24 @@ impl MessageEditor {
             editor,
             channel_store,
             users: HashMap::default(),
-            channel_id: None,
+            channel: None,
             mentions: Vec::new(),
             mentions_task: None,
         }
     }
 
-    pub fn set_channel(
-        &mut self,
-        channel_id: u64,
-        channel_name: Option<String>,
-        cx: &mut ViewContext<Self>,
-    ) {
+    pub fn set_channel(&mut self, channel: Arc<Channel>, cx: &mut ViewContext<Self>) {
         self.editor.update(cx, |editor, cx| {
-            if let Some(channel_name) = channel_name {
-                editor.set_placeholder_text(format!("Message #{}", channel_name), cx);
-            } else {
-                editor.set_placeholder_text(format!("Message Channel"), cx);
-            }
+            editor.set_placeholder_text(format!("Message #{}", channel.name), cx);
         });
-        self.channel_id = Some(channel_id);
+        self.channel = Some(channel);
         self.refresh_users(cx);
     }
 
     pub fn refresh_users(&mut self, cx: &mut ViewContext<Self>) {
-        if let Some(channel_id) = self.channel_id {
+        if let Some(channel) = &self.channel {
             let members = self.channel_store.update(cx, |store, cx| {
-                store.get_channel_member_details(channel_id, cx)
+                store.get_channel_member_details(channel.id, cx)
             });
             cx.spawn(|this, mut cx| async move {
                 let members = members.await?;

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -121,8 +121,19 @@ struct StartLinkChannelFor {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct LinkChannel {
+    to: ChannelId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 struct MoveChannel {
     to: ChannelId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct UnlinkChannel {
+    channel_id: ChannelId,
+    parent_id: ChannelId,
 }
 
 type DraggedChannel = (Channel, Option<ChannelId>);
@@ -136,7 +147,8 @@ actions!(
         CollapseSelectedChannel,
         ExpandSelectedChannel,
         StartMoveChannel,
-        MoveSelected,
+        StartLinkChannel,
+        MoveOrLinkToSelected,
         InsertSpace,
     ]
 );
@@ -154,8 +166,11 @@ impl_actions!(
         JoinChannelCall,
         JoinChannelChat,
         CopyChannelLink,
+        LinkChannel,
         StartMoveChannelFor,
+        StartLinkChannelFor,
         MoveChannel,
+        UnlinkChannel,
         ToggleSelectedIx
     ]
 );
@@ -170,7 +185,7 @@ struct ChannelMoveClipboard {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ClipboardIntent {
     Move,
-    // Link,
+    Link,
 }
 
 const COLLABORATION_PANEL_KEY: &'static str = "CollaborationPanel";
@@ -224,6 +239,18 @@ pub fn init(cx: &mut AppContext) {
     );
 
     cx.add_action(
+        |panel: &mut CollabPanel,
+         action: &StartLinkChannelFor,
+         _: &mut ViewContext<CollabPanel>| {
+            panel.channel_clipboard = Some(ChannelMoveClipboard {
+                channel_id: action.channel_id,
+                parent_id: action.parent_id,
+                intent: ClipboardIntent::Link,
+            })
+        },
+    );
+
+    cx.add_action(
         |panel: &mut CollabPanel, _: &StartMoveChannel, _: &mut ViewContext<CollabPanel>| {
             if let Some((_, path)) = panel.selected_channel() {
                 panel.channel_clipboard = Some(ChannelMoveClipboard {
@@ -236,29 +263,55 @@ pub fn init(cx: &mut AppContext) {
     );
 
     cx.add_action(
-        |panel: &mut CollabPanel, _: &MoveSelected, cx: &mut ViewContext<CollabPanel>| {
+        |panel: &mut CollabPanel, _: &StartLinkChannel, _: &mut ViewContext<CollabPanel>| {
+            if let Some((_, path)) = panel.selected_channel() {
+                panel.channel_clipboard = Some(ChannelMoveClipboard {
+                    channel_id: path.channel_id(),
+                    parent_id: path.parent_id(),
+                    intent: ClipboardIntent::Link,
+                })
+            }
+        },
+    );
+
+    cx.add_action(
+        |panel: &mut CollabPanel, _: &MoveOrLinkToSelected, cx: &mut ViewContext<CollabPanel>| {
             let clipboard = panel.channel_clipboard.take();
             if let Some(((selected_channel, _), clipboard)) =
                 panel.selected_channel().zip(clipboard)
             {
                 match clipboard.intent {
-                    ClipboardIntent::Move => panel.channel_store.update(cx, |channel_store, cx| {
-                        match clipboard.parent_id {
-                            Some(parent_id) => channel_store.move_channel(
-                                clipboard.channel_id,
-                                parent_id,
-                                selected_channel.id,
-                                cx,
-                            ),
-                            None => channel_store.link_channel(
-                                clipboard.channel_id,
-                                selected_channel.id,
-                                cx,
-                            ),
-                        }
-                        .detach_and_log_err(cx)
+                    ClipboardIntent::Move if clipboard.parent_id.is_some() => {
+                        let parent_id = clipboard.parent_id.unwrap();
+                        panel.channel_store.update(cx, |channel_store, cx| {
+                            channel_store
+                                .move_channel(
+                                    clipboard.channel_id,
+                                    parent_id,
+                                    selected_channel.id,
+                                    cx,
+                                )
+                                .detach_and_log_err(cx)
+                        })
+                    }
+                    _ => panel.channel_store.update(cx, |channel_store, cx| {
+                        channel_store
+                            .link_channel(clipboard.channel_id, selected_channel.id, cx)
+                            .detach_and_log_err(cx)
                     }),
                 }
+            }
+        },
+    );
+
+    cx.add_action(
+        |panel: &mut CollabPanel, action: &LinkChannel, cx: &mut ViewContext<CollabPanel>| {
+            if let Some(clipboard) = panel.channel_clipboard.take() {
+                panel.channel_store.update(cx, |channel_store, cx| {
+                    channel_store
+                        .link_channel(clipboard.channel_id, action.to, cx)
+                        .detach_and_log_err(cx)
+                })
             }
         },
     );
@@ -267,18 +320,27 @@ pub fn init(cx: &mut AppContext) {
         |panel: &mut CollabPanel, action: &MoveChannel, cx: &mut ViewContext<CollabPanel>| {
             if let Some(clipboard) = panel.channel_clipboard.take() {
                 panel.channel_store.update(cx, |channel_store, cx| {
-                    match clipboard.parent_id {
-                        Some(parent_id) => channel_store.move_channel(
-                            clipboard.channel_id,
-                            parent_id,
-                            action.to,
-                            cx,
-                        ),
-                        None => channel_store.link_channel(clipboard.channel_id, action.to, cx),
+                    if let Some(parent) = clipboard.parent_id {
+                        channel_store
+                            .move_channel(clipboard.channel_id, parent, action.to, cx)
+                            .detach_and_log_err(cx)
+                    } else {
+                        channel_store
+                            .link_channel(clipboard.channel_id, action.to, cx)
+                            .detach_and_log_err(cx)
                     }
-                    .detach_and_log_err(cx)
                 })
             }
+        },
+    );
+
+    cx.add_action(
+        |panel: &mut CollabPanel, action: &UnlinkChannel, cx: &mut ViewContext<CollabPanel>| {
+            panel.channel_store.update(cx, |channel_store, cx| {
+                channel_store
+                    .unlink_channel(action.channel_id, action.parent_id, cx)
+                    .detach_and_log_err(cx)
+            })
         },
     );
 }
@@ -2173,23 +2235,33 @@ impl CollabPanel {
                 this.deploy_channel_context_menu(Some(e.position), &path, ix, cx);
             }
         })
-        .on_up(MouseButton::Left, move |_, this, cx| {
+        .on_up(MouseButton::Left, move |e, this, cx| {
             if let Some((_, dragged_channel)) = cx
                 .global::<DragAndDrop<Workspace>>()
                 .currently_dragged::<DraggedChannel>(cx.window())
             {
-                this.channel_store.update(cx, |channel_store, cx| {
-                    match dragged_channel.1 {
-                        Some(parent_id) => channel_store.move_channel(
-                            dragged_channel.0.id,
-                            parent_id,
-                            channel_id,
-                            cx,
-                        ),
-                        None => channel_store.link_channel(dragged_channel.0.id, channel_id, cx),
-                    }
-                    .detach_and_log_err(cx)
-                })
+                if e.modifiers.alt {
+                    this.channel_store.update(cx, |channel_store, cx| {
+                        channel_store
+                            .link_channel(dragged_channel.0.id, channel_id, cx)
+                            .detach_and_log_err(cx)
+                    })
+                } else {
+                    this.channel_store.update(cx, |channel_store, cx| {
+                        match dragged_channel.1 {
+                            Some(parent_id) => channel_store.move_channel(
+                                dragged_channel.0.id,
+                                parent_id,
+                                channel_id,
+                                cx,
+                            ),
+                            None => {
+                                channel_store.link_channel(dragged_channel.0.id, channel_id, cx)
+                            }
+                        }
+                        .detach_and_log_err(cx)
+                    })
+                }
             }
         })
         .on_move({
@@ -2216,10 +2288,18 @@ impl CollabPanel {
         })
         .as_draggable(
             (channel.clone(), path.parent_id()),
-            move |_, (channel, _), cx: &mut ViewContext<Workspace>| {
+            move |modifiers, (channel, _), cx: &mut ViewContext<Workspace>| {
                 let theme = &theme::current(cx).collab_panel;
 
                 Flex::<Workspace>::row()
+                    .with_children(modifiers.alt.then(|| {
+                        Svg::new("icons/plus.svg")
+                            .with_color(theme.channel_hash.color)
+                            .constrained()
+                            .with_width(theme.channel_hash.width)
+                            .aligned()
+                            .left()
+                    }))
                     .with_child(
                         Svg::new("icons/hash.svg")
                             .with_color(theme.channel_hash.color)
@@ -2641,11 +2721,7 @@ impl CollabPanel {
                 },
             ));
 
-            if self
-                .channel_store
-                .read(cx)
-                .is_channel_admin(path.channel_id())
-            {
+            if self.channel_store.read(cx).is_user_admin(path.channel_id()) {
                 let parent_id = path.parent_id();
 
                 items.extend([
@@ -2662,9 +2738,30 @@ impl CollabPanel {
                             location: path.clone(),
                         },
                     ),
+                    ContextMenuItem::Separator,
+                ]);
+
+                if let Some(parent_id) = parent_id {
+                    items.push(ContextMenuItem::action(
+                        "Unlink from parent",
+                        UnlinkChannel {
+                            channel_id: path.channel_id(),
+                            parent_id,
+                        },
+                    ));
+                }
+
+                items.extend([
                     ContextMenuItem::action(
                         "Move this channel",
                         StartMoveChannelFor {
+                            channel_id: path.channel_id(),
+                            parent_id,
+                        },
+                    ),
+                    ContextMenuItem::action(
+                        "Link this channel",
+                        StartLinkChannelFor {
                             channel_id: path.channel_id(),
                             parent_id,
                         },
@@ -2676,6 +2773,12 @@ impl CollabPanel {
                     items.push(ContextMenuItem::action(
                         format!("Move '#{}' here", channel_name),
                         MoveChannel {
+                            to: path.channel_id(),
+                        },
+                    ));
+                    items.push(ContextMenuItem::action(
+                        format!("Link '#{}' here", channel_name),
+                        LinkChannel {
                             to: path.channel_id(),
                         },
                     ));
@@ -3057,7 +3160,7 @@ impl CollabPanel {
 
     fn rename_channel(&mut self, action: &RenameChannel, cx: &mut ViewContext<Self>) {
         let channel_store = self.channel_store.read(cx);
-        if !channel_store.is_channel_admin(action.location.channel_id()) {
+        if !channel_store.is_user_admin(action.location.channel_id()) {
             return;
         }
         if let Some(channel) = channel_store

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -88,10 +88,8 @@ impl View for CollabTitlebarItem {
             .zip(peer_id)
             .zip(ActiveCall::global(cx).read(cx).room().cloned())
         {
-            if room.read(cx).can_publish() {
-                right_container
-                    .add_children(self.render_in_call_share_unshare_button(&workspace, &theme, cx));
-            }
+            right_container
+                .add_children(self.render_in_call_share_unshare_button(&workspace, &theme, cx));
             right_container.add_child(self.render_leave_call(&theme, cx));
             let muted = room.read(cx).is_muted(cx);
             let speaking = room.read(cx).is_speaking();
@@ -99,14 +97,9 @@ impl View for CollabTitlebarItem {
                 self.render_current_user(&workspace, &theme, &user, peer_id, muted, speaking, cx),
             );
             left_container.add_children(self.render_collaborators(&workspace, &theme, &room, cx));
-            if room.read(cx).can_publish() {
-                right_container.add_child(self.render_toggle_mute(&theme, &room, cx));
-            }
+            right_container.add_child(self.render_toggle_mute(&theme, &room, cx));
             right_container.add_child(self.render_toggle_deafen(&theme, &room, cx));
-            if room.read(cx).can_publish() {
-                right_container
-                    .add_child(self.render_toggle_screen_sharing_button(&theme, &room, cx));
-            }
+            right_container.add_child(self.render_toggle_screen_sharing_button(&theme, &room, cx));
         }
 
         let status = workspace.read(cx).client().status();

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -477,7 +477,7 @@ impl NotificationPanel {
                             return panel.read_with(cx, |panel, cx| {
                                 panel.is_scrolled_to_bottom()
                                     && panel.active_chat().map_or(false, |chat| {
-                                        chat.read(cx).channel_id == *channel_id
+                                        chat.read(cx).channel().id == *channel_id
                                     })
                             });
                         }

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -306,16 +306,6 @@ impl live_kit_server::api::Client for TestApiClient {
             token::VideoGrant::to_join(room),
         )
     }
-
-    fn guest_token(&self, room: &str, identity: &str) -> Result<String> {
-        let server = TestServer::get(&self.url)?;
-        token::create(
-            &server.api_key,
-            &server.secret_key,
-            Some(identity),
-            token::VideoGrant::for_guest(room),
-        )
-    }
 }
 
 pub type Sid = String;

--- a/crates/live_kit_server/src/api.rs
+++ b/crates/live_kit_server/src/api.rs
@@ -12,7 +12,6 @@ pub trait Client: Send + Sync {
     async fn delete_room(&self, name: String) -> Result<()>;
     async fn remove_participant(&self, room: String, identity: String) -> Result<()>;
     fn room_token(&self, room: &str, identity: &str) -> Result<String>;
-    fn guest_token(&self, room: &str, identity: &str) -> Result<String>;
 }
 
 #[derive(Clone)]
@@ -137,15 +136,6 @@ impl Client for LiveKitClient {
             &self.secret,
             Some(identity),
             token::VideoGrant::to_join(room),
-        )
-    }
-
-    fn guest_token(&self, room: &str, identity: &str) -> Result<String> {
-        token::create(
-            &self.key,
-            &self.secret,
-            Some(identity),
-            token::VideoGrant::for_guest(room),
         )
     }
 }

--- a/crates/live_kit_server/src/token.rs
+++ b/crates/live_kit_server/src/token.rs
@@ -57,15 +57,6 @@ impl<'a> VideoGrant<'a> {
             ..Default::default()
         }
     }
-
-    pub fn for_guest(room: &'a str) -> Self {
-        Self {
-            room: Some(Cow::Borrowed(room)),
-            room_join: Some(true),
-            can_subscribe: Some(true),
-            ..Default::default()
-        }
-    }
 }
 
 pub fn create(

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -342,7 +342,6 @@ message RoomUpdated {
 message LiveKitConnectionInfo {
     string server_url = 1;
     string token = 2;
-    bool can_publish = 3;
 }
 
 message ShareProject {
@@ -978,6 +977,7 @@ message UpdateChannels {
     repeated Channel channel_invitations = 5;
     repeated uint64 remove_channel_invitations = 6;
     repeated ChannelParticipants channel_participants = 7;
+    repeated ChannelPermission channel_permissions = 8;
     repeated UnseenChannelMessage unseen_channel_messages = 9;
     repeated UnseenChannelBufferChange unseen_channel_buffer_changes = 10;
 }
@@ -1585,7 +1585,6 @@ message Channel {
     uint64 id = 1;
     string name = 2;
     ChannelVisibility visibility = 3;
-    ChannelRole role = 4;
 }
 
 message Contact {


### PR DESCRIPTION
This reverts commit cc9e92857bc21c6cfe0137d0fdbf5ef582135122, reversing changes made to 0f03f8ff8acb00d411778d1dc23b1cf07c926666.

@maxbrunsfeld @JosephTLyons I have created this PR because when I did some smoke testing this morning it seemed a bit broken. We should not ship this without #3162.

Now I come to write this, I realize that some (all?) of the broken-ness may be because I already ran the migrations for #3162 locally, but I think it would be better to either ship both of these or neither in today's preview.

Bugs found locally:
* Creating new channels doesn't put them in the right parent for invited members
* Deleting channels didn't work
