### PR TITLE
lsp/next-ls: Fix wrong nls binary being fetched.

### DIFF
--- a/crates/zed/src/languages/elixir.rs
+++ b/crates/zed/src/languages/elixir.rs
@@ -321,8 +321,8 @@ impl LspAdapter for NextLspAdapter {
             latest_github_release("elixir-tools/next-ls", false, delegate.http_client()).await?;
         let version = release.name.clone();
         let platform = match consts::ARCH {
-            "x86_64" => "darwin_arm64",
-            "aarch64" => "darwin_amd64",
+            "x86_64" => "darwin_amd64",
+            "aarch64" => "darwin_arm64",
             other => bail!("Running on unsupported platform: {other}"),
         };
         let asset_name = format!("next_ls_{}", platform);


### PR DESCRIPTION
CPU types had to be swapped around.

Fixed zed-industries/zed#6351

Release Notes:
- Fixed Elixir next-ls LSP installation failing due to fetching a binary for the wrong architecture (zed-industries/zed#6351).