### PR TITLE
Adjust `ColorScale` representation

### DIFF
--- a/crates/theme2/src/default_colors.rs
+++ b/crates/theme2/src/default_colors.rs
@@ -272,19 +272,21 @@ impl ThemeColors {
     }
 }
 
-struct DefaultColorScaleSet {
+type StaticColorScale = [&'static str; 12];
+
+struct StaticColorScaleSet {
     scale: &'static str,
-    light: [&'static str; 12],
-    light_alpha: [&'static str; 12],
-    dark: [&'static str; 12],
-    dark_alpha: [&'static str; 12],
+    light: StaticColorScale,
+    light_alpha: StaticColorScale,
+    dark: StaticColorScale,
+    dark_alpha: StaticColorScale,
 }
 
-impl TryFrom<DefaultColorScaleSet> for ColorScaleSet {
+impl TryFrom<StaticColorScaleSet> for ColorScaleSet {
     type Error = ParseIntError;
 
-    fn try_from(value: DefaultColorScaleSet) -> Result<Self, Self::Error> {
-        fn to_color_scale(scale: [&'static str; 12]) -> Result<ColorScale, ParseIntError> {
+    fn try_from(value: StaticColorScaleSet) -> Result<Self, Self::Error> {
+        fn to_color_scale(scale: StaticColorScale) -> Result<ColorScale, ParseIntError> {
             scale
                 .into_iter()
                 .map(|color| Rgba::try_from(color).map(Hsla::from))
@@ -341,7 +343,7 @@ pub fn default_color_scales() -> ColorScales {
 }
 
 fn gray() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Gray",
         light: [
             "#fcfcfcff",
@@ -405,7 +407,7 @@ fn gray() -> ColorScaleSet {
 }
 
 fn mauve() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Mauve",
         light: [
             "#fdfcfdff",
@@ -469,7 +471,7 @@ fn mauve() -> ColorScaleSet {
 }
 
 fn slate() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Slate",
         light: [
             "#fcfcfdff",
@@ -533,7 +535,7 @@ fn slate() -> ColorScaleSet {
 }
 
 fn sage() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Sage",
         light: [
             "#fbfdfcff",
@@ -597,7 +599,7 @@ fn sage() -> ColorScaleSet {
 }
 
 fn olive() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Olive",
         light: [
             "#fcfdfcff",
@@ -661,7 +663,7 @@ fn olive() -> ColorScaleSet {
 }
 
 fn sand() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Sand",
         light: [
             "#fdfdfcff",
@@ -725,7 +727,7 @@ fn sand() -> ColorScaleSet {
 }
 
 fn gold() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Gold",
         light: [
             "#fdfdfcff",
@@ -789,7 +791,7 @@ fn gold() -> ColorScaleSet {
 }
 
 fn bronze() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Bronze",
         light: [
             "#fdfcfcff",
@@ -853,7 +855,7 @@ fn bronze() -> ColorScaleSet {
 }
 
 fn brown() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Brown",
         light: [
             "#fefdfcff",
@@ -917,7 +919,7 @@ fn brown() -> ColorScaleSet {
 }
 
 fn yellow() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Yellow",
         light: [
             "#fdfdf9ff",
@@ -981,7 +983,7 @@ fn yellow() -> ColorScaleSet {
 }
 
 fn amber() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Amber",
         light: [
             "#fefdfbff",
@@ -1045,7 +1047,7 @@ fn amber() -> ColorScaleSet {
 }
 
 fn orange() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Orange",
         light: [
             "#fefcfbff",
@@ -1109,7 +1111,7 @@ fn orange() -> ColorScaleSet {
 }
 
 fn tomato() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Tomato",
         light: [
             "#fffcfcff",
@@ -1173,7 +1175,7 @@ fn tomato() -> ColorScaleSet {
 }
 
 fn red() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Red",
         light: [
             "#fffcfcff",
@@ -1237,7 +1239,7 @@ fn red() -> ColorScaleSet {
 }
 
 fn ruby() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Ruby",
         light: [
             "#fffcfdff",
@@ -1301,7 +1303,7 @@ fn ruby() -> ColorScaleSet {
 }
 
 fn crimson() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Crimson",
         light: [
             "#fffcfdff",
@@ -1365,7 +1367,7 @@ fn crimson() -> ColorScaleSet {
 }
 
 fn pink() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Pink",
         light: [
             "#fffcfeff",
@@ -1429,7 +1431,7 @@ fn pink() -> ColorScaleSet {
 }
 
 fn plum() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Plum",
         light: [
             "#fefcffff",
@@ -1493,7 +1495,7 @@ fn plum() -> ColorScaleSet {
 }
 
 fn purple() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Purple",
         light: [
             "#fefcfeff",
@@ -1557,7 +1559,7 @@ fn purple() -> ColorScaleSet {
 }
 
 fn violet() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Violet",
         light: [
             "#fdfcfeff",
@@ -1621,7 +1623,7 @@ fn violet() -> ColorScaleSet {
 }
 
 fn iris() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Iris",
         light: [
             "#fdfdffff",
@@ -1685,7 +1687,7 @@ fn iris() -> ColorScaleSet {
 }
 
 fn indigo() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Indigo",
         light: [
             "#fdfdfeff",
@@ -1749,7 +1751,7 @@ fn indigo() -> ColorScaleSet {
 }
 
 fn blue() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Blue",
         light: [
             "#fbfdffff",
@@ -1813,7 +1815,7 @@ fn blue() -> ColorScaleSet {
 }
 
 fn cyan() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Cyan",
         light: [
             "#fafdfeff",
@@ -1877,7 +1879,7 @@ fn cyan() -> ColorScaleSet {
 }
 
 fn teal() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Teal",
         light: [
             "#fafefdff",
@@ -1941,7 +1943,7 @@ fn teal() -> ColorScaleSet {
 }
 
 fn jade() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Jade",
         light: [
             "#fbfefdff",
@@ -2005,7 +2007,7 @@ fn jade() -> ColorScaleSet {
 }
 
 fn green() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Green",
         light: [
             "#fbfefcff",
@@ -2069,7 +2071,7 @@ fn green() -> ColorScaleSet {
 }
 
 fn grass() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Grass",
         light: [
             "#fbfefbff",
@@ -2133,7 +2135,7 @@ fn grass() -> ColorScaleSet {
 }
 
 fn lime() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Lime",
         light: [
             "#fcfdfaff",
@@ -2197,7 +2199,7 @@ fn lime() -> ColorScaleSet {
 }
 
 fn mint() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Mint",
         light: [
             "#f9fefdff",
@@ -2261,7 +2263,7 @@ fn mint() -> ColorScaleSet {
 }
 
 fn sky() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Sky",
         light: [
             "#f9feffff",
@@ -2325,7 +2327,7 @@ fn sky() -> ColorScaleSet {
 }
 
 fn black() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "Black",
         light: [
             "#0000000d",
@@ -2389,7 +2391,7 @@ fn black() -> ColorScaleSet {
 }
 
 fn white() -> ColorScaleSet {
-    DefaultColorScaleSet {
+    StaticColorScaleSet {
         scale: "White",
         light: [
             "#ffffff0d",

--- a/crates/theme2/src/default_colors.rs
+++ b/crates/theme2/src/default_colors.rs
@@ -1,9 +1,12 @@
-use gpui2::{hsla, Rgba};
+use std::num::ParseIntError;
+
+use gpui2::{hsla, Hsla, Rgba};
 
 use crate::{
     colors::{GitStatusColors, PlayerColor, PlayerColors, StatusColors, SystemColors, ThemeColors},
     scale::{ColorScaleSet, ColorScales},
     syntax::SyntaxTheme,
+    ColorScale,
 };
 
 impl Default for SystemColors {
@@ -277,23 +280,25 @@ struct DefaultColorScaleSet {
     dark_alpha: [&'static str; 12],
 }
 
-impl From<DefaultColorScaleSet> for ColorScaleSet {
-    fn from(default: DefaultColorScaleSet) -> Self {
-        Self::new(
-            default.scale,
-            default
-                .light
-                .map(|color| Rgba::try_from(color).unwrap().into()),
-            default
-                .light_alpha
-                .map(|color| Rgba::try_from(color).unwrap().into()),
-            default
-                .dark
-                .map(|color| Rgba::try_from(color).unwrap().into()),
-            default
-                .dark_alpha
-                .map(|color| Rgba::try_from(color).unwrap().into()),
-        )
+impl TryFrom<DefaultColorScaleSet> for ColorScaleSet {
+    type Error = ParseIntError;
+
+    fn try_from(value: DefaultColorScaleSet) -> Result<Self, Self::Error> {
+        fn to_color_scale(scale: [&'static str; 12]) -> Result<ColorScale, ParseIntError> {
+            scale
+                .into_iter()
+                .map(|color| Rgba::try_from(color).map(Hsla::from))
+                .collect::<Result<Vec<_>, _>>()
+                .map(ColorScale::from_iter)
+        }
+
+        Ok(Self::new(
+            value.scale,
+            to_color_scale(value.light)?,
+            to_color_scale(value.light_alpha)?,
+            to_color_scale(value.dark)?,
+            to_color_scale(value.dark_alpha)?,
+        ))
     }
 }
 
@@ -395,7 +400,8 @@ fn gray() -> ColorScaleSet {
             "#ffffffed",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn mauve() -> ColorScaleSet {
@@ -458,7 +464,8 @@ fn mauve() -> ColorScaleSet {
             "#fdfdffef",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn slate() -> ColorScaleSet {
@@ -521,7 +528,8 @@ fn slate() -> ColorScaleSet {
             "#fcfdffef",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn sage() -> ColorScaleSet {
@@ -584,7 +592,8 @@ fn sage() -> ColorScaleSet {
             "#fdfffeed",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn olive() -> ColorScaleSet {
@@ -647,7 +656,8 @@ fn olive() -> ColorScaleSet {
             "#fdfffded",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn sand() -> ColorScaleSet {
@@ -710,7 +720,8 @@ fn sand() -> ColorScaleSet {
             "#fffffded",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn gold() -> ColorScaleSet {
@@ -773,7 +784,8 @@ fn gold() -> ColorScaleSet {
             "#fef7ede7",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn bronze() -> ColorScaleSet {
@@ -836,7 +848,8 @@ fn bronze() -> ColorScaleSet {
             "#fff1e9ec",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn brown() -> ColorScaleSet {
@@ -899,7 +912,8 @@ fn brown() -> ColorScaleSet {
             "#feecd4f2",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn yellow() -> ColorScaleSet {
@@ -962,7 +976,8 @@ fn yellow() -> ColorScaleSet {
             "#fef6baf6",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn amber() -> ColorScaleSet {
@@ -1025,7 +1040,8 @@ fn amber() -> ColorScaleSet {
             "#ffe7b3ff",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn orange() -> ColorScaleSet {
@@ -1088,7 +1104,8 @@ fn orange() -> ColorScaleSet {
             "#ffe0c2ff",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn tomato() -> ColorScaleSet {
@@ -1151,7 +1168,8 @@ fn tomato() -> ColorScaleSet {
             "#ffd6cefb",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn red() -> ColorScaleSet {
@@ -1214,7 +1232,8 @@ fn red() -> ColorScaleSet {
             "#ffd1d9ff",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn ruby() -> ColorScaleSet {
@@ -1277,7 +1296,8 @@ fn ruby() -> ColorScaleSet {
             "#ffd3e2fe",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn crimson() -> ColorScaleSet {
@@ -1340,7 +1360,8 @@ fn crimson() -> ColorScaleSet {
             "#ffd5eafd",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn pink() -> ColorScaleSet {
@@ -1403,7 +1424,8 @@ fn pink() -> ColorScaleSet {
             "#ffd3ecfd",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn plum() -> ColorScaleSet {
@@ -1466,7 +1488,8 @@ fn plum() -> ColorScaleSet {
             "#feddfef4",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn purple() -> ColorScaleSet {
@@ -1529,7 +1552,8 @@ fn purple() -> ColorScaleSet {
             "#f1ddfffa",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn violet() -> ColorScaleSet {
@@ -1592,7 +1616,8 @@ fn violet() -> ColorScaleSet {
             "#e3defffe",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn iris() -> ColorScaleSet {
@@ -1655,7 +1680,8 @@ fn iris() -> ColorScaleSet {
             "#e1e0fffe",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn indigo() -> ColorScaleSet {
@@ -1718,7 +1744,8 @@ fn indigo() -> ColorScaleSet {
             "#d6e1ffff",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn blue() -> ColorScaleSet {
@@ -1781,7 +1808,8 @@ fn blue() -> ColorScaleSet {
             "#c2e6ffff",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn cyan() -> ColorScaleSet {
@@ -1844,7 +1872,8 @@ fn cyan() -> ColorScaleSet {
             "#bbf3fef7",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn teal() -> ColorScaleSet {
@@ -1907,7 +1936,8 @@ fn teal() -> ColorScaleSet {
             "#b8ffebef",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn jade() -> ColorScaleSet {
@@ -1970,7 +2000,8 @@ fn jade() -> ColorScaleSet {
             "#b8ffe1ef",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn green() -> ColorScaleSet {
@@ -2033,7 +2064,8 @@ fn green() -> ColorScaleSet {
             "#bbffd7f0",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn grass() -> ColorScaleSet {
@@ -2096,7 +2128,8 @@ fn grass() -> ColorScaleSet {
             "#ceffceef",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn lime() -> ColorScaleSet {
@@ -2159,7 +2192,8 @@ fn lime() -> ColorScaleSet {
             "#e9febff7",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn mint() -> ColorScaleSet {
@@ -2222,7 +2256,8 @@ fn mint() -> ColorScaleSet {
             "#cbfee9f5",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn sky() -> ColorScaleSet {
@@ -2285,7 +2320,8 @@ fn sky() -> ColorScaleSet {
             "#c2f3ffff",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn black() -> ColorScaleSet {
@@ -2348,7 +2384,8 @@ fn black() -> ColorScaleSet {
             "#000000f2",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }
 
 fn white() -> ColorScaleSet {
@@ -2411,5 +2448,6 @@ fn white() -> ColorScaleSet {
             "#fffffff2",
         ],
     }
-    .into()
+    .try_into()
+    .unwrap()
 }

--- a/crates/theme2/src/scale.rs
+++ b/crates/theme2/src/scale.rs
@@ -2,7 +2,24 @@ use gpui2::{AppContext, Hsla, SharedString};
 
 use crate::{ActiveTheme, Appearance};
 
-pub type ColorScale = [Hsla; 12];
+/// A one-based step in a [`ColorScale`].
+pub type ColorScaleStep = usize;
+
+pub struct ColorScale(Vec<Hsla>);
+
+impl FromIterator<Hsla> for ColorScale {
+    fn from_iter<T: IntoIterator<Item = Hsla>>(iter: T) -> Self {
+        Self(Vec::from_iter(iter))
+    }
+}
+
+impl std::ops::Index<ColorScaleStep> for ColorScale {
+    type Output = Hsla;
+
+    fn index(&self, index: ColorScaleStep) -> &Self::Output {
+        &self.0[index - 1]
+    }
+}
 
 pub struct ColorScales {
     pub gray: ColorScaleSet,
@@ -84,9 +101,6 @@ impl IntoIterator for ColorScales {
         .into_iter()
     }
 }
-
-/// A one-based step in a [`ColorScale`].
-pub type ColorScaleStep = usize;
 
 pub struct ColorScaleSet {
     name: SharedString,


### PR DESCRIPTION
This PR adjusts the representations of `ColorScale`s to allow us to remove an unsafe `From` impl when converting from the statically-defined representation of the scale.

Release Notes:

- N/A
