### PR TITLE
Remove more `Send` bounds and simplify view rendering

### DIFF
--- a/crates/feature_flags2/src/feature_flags2.rs
+++ b/crates/feature_flags2/src/feature_flags2.rs
@@ -28,7 +28,7 @@ pub trait FeatureFlagViewExt<V: 'static> {
         F: Fn(bool, &mut V, &mut ViewContext<V>) + Send + Sync + 'static;
 }
 
-impl<V> FeatureFlagViewExt<V> for ViewContext<'_, '_, V>
+impl<V> FeatureFlagViewExt<V> for ViewContext<'_, V>
 where
     V: 'static + Send + Sync,
 {

--- a/crates/gpui2/src/action.rs
+++ b/crates/gpui2/src/action.rs
@@ -4,7 +4,7 @@ use collections::{HashMap, HashSet};
 use serde::Deserialize;
 use std::any::{type_name, Any};
 
-pub trait Action: Any + Send {
+pub trait Action: 'static {
     fn qualified_name() -> SharedString
     where
         Self: Sized;
@@ -19,7 +19,7 @@ pub trait Action: Any + Send {
 
 impl<A> Action for A
 where
-    A: for<'a> Deserialize<'a> + PartialEq + Any + Send + Clone + Default,
+    A: for<'a> Deserialize<'a> + PartialEq + Clone + Default + 'static,
 {
     fn qualified_name() -> SharedString {
         type_name::<A>().into()

--- a/crates/gpui2/src/app/async_context.rs
+++ b/crates/gpui2/src/app/async_context.rs
@@ -184,13 +184,12 @@ impl AsyncWindowContext {
         self.window.update(self, |_, cx| cx.update_global(update))
     }
 
-    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncWindowContext) -> Fut + 'static) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncWindowContext) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,
         R: 'static,
     {
-        let this = self.clone();
-        self.foreground_executor.spawn(async move { f(this).await })
+        self.foreground_executor.spawn(f(self.clone()))
     }
 }
 

--- a/crates/gpui2/src/app/async_context.rs
+++ b/crates/gpui2/src/app/async_context.rs
@@ -1,8 +1,8 @@
 use crate::{
-    AnyWindowHandle, AppContext, BackgroundExecutor, Context, ForegroundExecutor, Model,
-    ModelContext, Result, Task, WindowContext,
+    AnyView, AnyWindowHandle, AppContext, BackgroundExecutor, Context, ForegroundExecutor, Model,
+    ModelContext, Render, Result, Task, View, ViewContext, VisualContext, WindowContext,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use derive_more::{Deref, DerefMut};
 use std::{cell::RefCell, future::Future, rc::Weak};
 
@@ -14,12 +14,11 @@ pub struct AsyncAppContext {
 }
 
 impl Context for AsyncAppContext {
-    type ModelContext<'a, T> = ModelContext<'a, T>;
     type Result<T> = Result<T>;
 
     fn build_model<T: 'static>(
         &mut self,
-        build_model: impl FnOnce(&mut Self::ModelContext<'_, T>) -> T,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
     ) -> Self::Result<Model<T>>
     where
         T: 'static,
@@ -35,7 +34,7 @@ impl Context for AsyncAppContext {
     fn update_model<T: 'static, R>(
         &mut self,
         handle: &Model<T>,
-        update: impl FnOnce(&mut T, &mut Self::ModelContext<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut ModelContext<'_, T>) -> R,
     ) -> Self::Result<R> {
         let app = self
             .app
@@ -43,6 +42,15 @@ impl Context for AsyncAppContext {
             .ok_or_else(|| anyhow!("app was released"))?;
         let mut app = app.borrow_mut();
         Ok(app.update_model(handle, update))
+    }
+
+    fn update_window<T, F>(&mut self, window: AnyWindowHandle, f: F) -> Result<T>
+    where
+        F: FnOnce(AnyView, &mut WindowContext<'_>) -> T,
+    {
+        let app = self.app.upgrade().context("app was released")?;
+        let mut lock = app.borrow_mut();
+        lock.update_window(window, f)
     }
 }
 
@@ -74,30 +82,17 @@ impl AsyncAppContext {
         Ok(f(&mut *lock))
     }
 
-    pub fn read_window<R>(
-        &self,
-        handle: AnyWindowHandle,
-        update: impl FnOnce(&WindowContext) -> R,
-    ) -> Result<R> {
-        let app = self
-            .app
-            .upgrade()
-            .ok_or_else(|| anyhow!("app was released"))?;
-        let app_context = app.borrow();
-        app_context.read_window(handle.id, update)
-    }
-
     pub fn update_window<R>(
         &self,
         handle: AnyWindowHandle,
-        update: impl FnOnce(&mut WindowContext) -> R,
+        update: impl FnOnce(AnyView, &mut WindowContext) -> R,
     ) -> Result<R> {
         let app = self
             .app
             .upgrade()
             .ok_or_else(|| anyhow!("app was released"))?;
         let mut app_context = app.borrow_mut();
-        app_context.update_window(handle.id, update)
+        app_context.update_window(handle, update)
     }
 
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncAppContext) -> Fut) -> Task<R>
@@ -161,22 +156,22 @@ impl AsyncWindowContext {
         Self { app, window }
     }
 
-    pub fn update<R>(&self, update: impl FnOnce(&mut WindowContext) -> R) -> Result<R> {
+    pub fn update<R>(
+        &mut self,
+        update: impl FnOnce(AnyView, &mut WindowContext) -> R,
+    ) -> Result<R> {
         self.app.update_window(self.window, update)
     }
 
-    pub fn on_next_frame(&mut self, f: impl FnOnce(&mut WindowContext) + Send + 'static) {
-        self.app
-            .update_window(self.window, |cx| cx.on_next_frame(f))
-            .ok();
+    pub fn on_next_frame(&mut self, f: impl FnOnce(&mut WindowContext) + 'static) {
+        self.window.update(self, |_, cx| cx.on_next_frame(f)).ok();
     }
 
     pub fn read_global<G: 'static, R>(
-        &self,
+        &mut self,
         read: impl FnOnce(&G, &WindowContext) -> R,
     ) -> Result<R> {
-        self.app
-            .read_window(self.window, |cx| read(cx.global(), cx))
+        self.window.update(self, |_, cx| read(cx.global(), cx))
     }
 
     pub fn update_global<G, R>(
@@ -186,32 +181,79 @@ impl AsyncWindowContext {
     where
         G: 'static,
     {
-        self.app
-            .update_window(self.window, |cx| cx.update_global(update))
+        self.window.update(self, |_, cx| cx.update_global(update))
+    }
+
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncWindowContext) -> Fut + 'static) -> Task<R>
+    where
+        Fut: Future<Output = R> + 'static,
+        R: 'static,
+    {
+        let this = self.clone();
+        self.foreground_executor.spawn(async move { f(this).await })
     }
 }
 
 impl Context for AsyncWindowContext {
-    type ModelContext<'a, T> = ModelContext<'a, T>;
     type Result<T> = Result<T>;
 
     fn build_model<T>(
         &mut self,
-        build_model: impl FnOnce(&mut Self::ModelContext<'_, T>) -> T,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
     ) -> Result<Model<T>>
     where
         T: 'static,
     {
-        self.app
-            .update_window(self.window, |cx| cx.build_model(build_model))
+        self.window
+            .update(self, |_, cx| cx.build_model(build_model))
     }
 
     fn update_model<T: 'static, R>(
         &mut self,
         handle: &Model<T>,
-        update: impl FnOnce(&mut T, &mut Self::ModelContext<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut ModelContext<'_, T>) -> R,
     ) -> Result<R> {
-        self.app
-            .update_window(self.window, |cx| cx.update_model(handle, update))
+        self.window
+            .update(self, |_, cx| cx.update_model(handle, update))
+    }
+
+    fn update_window<T, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<T>
+    where
+        F: FnOnce(AnyView, &mut WindowContext<'_>) -> T,
+    {
+        self.app.update_window(window, update)
+    }
+}
+
+impl VisualContext for AsyncWindowContext {
+    fn build_view<V>(
+        &mut self,
+        build_view_state: impl FnOnce(&mut ViewContext<'_, V>) -> V,
+    ) -> Self::Result<View<V>>
+    where
+        V: 'static,
+    {
+        self.window
+            .update(self, |_, cx| cx.build_view(build_view_state))
+    }
+
+    fn update_view<V: 'static, R>(
+        &mut self,
+        view: &View<V>,
+        update: impl FnOnce(&mut V, &mut ViewContext<'_, V>) -> R,
+    ) -> Self::Result<R> {
+        self.window
+            .update(self, |_, cx| cx.update_view(view, update))
+    }
+
+    fn replace_root_view<V>(
+        &mut self,
+        build_view: impl FnOnce(&mut ViewContext<'_, V>) -> V,
+    ) -> Self::Result<View<V>>
+    where
+        V: Render,
+    {
+        self.window
+            .update(self, |_, cx| cx.replace_root_view(build_view))
     }
 }

--- a/crates/gpui2/src/app/entity_map.rs
+++ b/crates/gpui2/src/app/entity_map.rs
@@ -1,4 +1,4 @@
-use crate::{private::Sealed, AnyBox, AppContext, Context, Entity};
+use crate::{private::Sealed, AnyBox, AppContext, Context, Entity, ModelContext};
 use anyhow::{anyhow, Result};
 use derive_more::{Deref, DerefMut};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
@@ -169,6 +169,10 @@ impl AnyModel {
         self.entity_id
     }
 
+    pub fn entity_type(&self) -> TypeId {
+        self.entity_type
+    }
+
     pub fn downgrade(&self) -> AnyWeakModel {
         AnyWeakModel {
             entity_id: self.entity_id,
@@ -329,7 +333,7 @@ impl<T: 'static> Model<T> {
     pub fn update<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut T, &mut C::ModelContext<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut ModelContext<'_, T>) -> R,
     ) -> C::Result<R>
     where
         C: Context,
@@ -475,7 +479,7 @@ impl<T: 'static> WeakModel<T> {
     pub fn update<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut T, &mut C::ModelContext<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut ModelContext<'_, T>) -> R,
     ) -> Result<R>
     where
         C: Context,

--- a/crates/gpui2/src/assets.rs
+++ b/crates/gpui2/src/assets.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 
-pub trait AssetSource: 'static + Send + Sync {
+pub trait AssetSource: 'static {
     fn load(&self, path: &str) -> Result<Cow<[u8]>>;
     fn list(&self, path: &str) -> Result<Vec<SharedString>>;
 }

--- a/crates/gpui2/src/assets.rs
+++ b/crates/gpui2/src/assets.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 
-pub trait AssetSource: 'static {
+pub trait AssetSource: 'static + Send + Sync {
     fn load(&self, path: &str) -> Result<Cow<[u8]>>;
     fn list(&self, path: &str) -> Result<Vec<SharedString>>;
 }

--- a/crates/gpui2/src/element.rs
+++ b/crates/gpui2/src/element.rs
@@ -219,7 +219,7 @@ impl<V, E, F> Element<V> for Option<F>
 where
     V: 'static,
     E: 'static + Component<V>,
-    F: FnOnce(&mut V, &mut ViewContext<'_, '_, V>) -> E + 'static,
+    F: FnOnce(&mut V, &mut ViewContext<'_, V>) -> E + 'static,
 {
     type ElementState = AnyElement<V>;
 
@@ -263,7 +263,7 @@ impl<V, E, F> Component<V> for Option<F>
 where
     V: 'static,
     E: 'static + Component<V>,
-    F: FnOnce(&mut V, &mut ViewContext<'_, '_, V>) -> E + 'static,
+    F: FnOnce(&mut V, &mut ViewContext<'_, V>) -> E + 'static,
 {
     fn render(self) -> AnyElement<V> {
         AnyElement::new(self)
@@ -274,7 +274,7 @@ impl<V, E, F> Component<V> for F
 where
     V: 'static,
     E: 'static + Component<V>,
-    F: FnOnce(&mut V, &mut ViewContext<'_, '_, V>) -> E + 'static,
+    F: FnOnce(&mut V, &mut ViewContext<'_, V>) -> E + 'static,
 {
     fn render(self) -> AnyElement<V> {
         AnyElement::new(Some(self))

--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -305,7 +305,6 @@ where
 
 impl<V, I, F> Component<V> for Div<V, I, F>
 where
-    // V: Any + Send + Sync,
     I: ElementInteraction<V>,
     F: ElementFocus<V>,
 {

--- a/crates/gpui2/src/elements/text.rs
+++ b/crates/gpui2/src/elements/text.rs
@@ -44,9 +44,6 @@ pub struct Text<V> {
     state_type: PhantomData<V>,
 }
 
-unsafe impl<V> Send for Text<V> {}
-unsafe impl<V> Sync for Text<V> {}
-
 impl<V: 'static> Component<V> for Text<V> {
     fn render(self) -> AnyElement<V> {
         AnyElement::new(self)

--- a/crates/gpui2/src/focusable.rs
+++ b/crates/gpui2/src/focusable.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 pub type FocusListeners<V> = SmallVec<[FocusListener<V>; 2]>;
 
 pub type FocusListener<V> =
-    Box<dyn Fn(&mut V, &FocusHandle, &FocusEvent, &mut ViewContext<V>) + Send + 'static>;
+    Box<dyn Fn(&mut V, &FocusHandle, &FocusEvent, &mut ViewContext<V>) + 'static>;
 
 pub trait Focusable<V: 'static>: Element<V> {
     fn focus_listeners(&mut self) -> &mut FocusListeners<V>;
@@ -42,7 +42,7 @@ pub trait Focusable<V: 'static>: Element<V> {
 
     fn on_focus(
         mut self,
-        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + Send + 'static,
+        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + 'static,
     ) -> Self
     where
         Self: Sized,
@@ -58,7 +58,7 @@ pub trait Focusable<V: 'static>: Element<V> {
 
     fn on_blur(
         mut self,
-        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + Send + 'static,
+        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + 'static,
     ) -> Self
     where
         Self: Sized,
@@ -74,7 +74,7 @@ pub trait Focusable<V: 'static>: Element<V> {
 
     fn on_focus_in(
         mut self,
-        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + Send + 'static,
+        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + 'static,
     ) -> Self
     where
         Self: Sized,
@@ -99,7 +99,7 @@ pub trait Focusable<V: 'static>: Element<V> {
 
     fn on_focus_out(
         mut self,
-        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + Send + 'static,
+        listener: impl Fn(&mut V, &FocusEvent, &mut ViewContext<V>) + 'static,
     ) -> Self
     where
         Self: Sized,
@@ -122,7 +122,7 @@ pub trait Focusable<V: 'static>: Element<V> {
     }
 }
 
-pub trait ElementFocus<V: 'static>: 'static + Send {
+pub trait ElementFocus<V: 'static>: 'static {
     fn as_focusable(&self) -> Option<&FocusEnabled<V>>;
     fn as_focusable_mut(&mut self) -> Option<&mut FocusEnabled<V>>;
 

--- a/crates/gpui2/src/geometry.rs
+++ b/crates/gpui2/src/geometry.rs
@@ -931,6 +931,18 @@ impl From<f64> for GlobalPixels {
     }
 }
 
+impl sqlez::bindable::StaticColumnCount for GlobalPixels {}
+
+impl sqlez::bindable::Bind for GlobalPixels {
+    fn bind(
+        &self,
+        statement: &sqlez::statement::Statement,
+        start_index: i32,
+    ) -> anyhow::Result<i32> {
+        self.0.bind(statement, start_index)
+    }
+}
+
 #[derive(Clone, Copy, Default, Add, Sub, Mul, Div, Neg)]
 pub struct Rems(f32);
 

--- a/crates/gpui2/src/platform.rs
+++ b/crates/gpui2/src/platform.rs
@@ -5,9 +5,10 @@ mod mac;
 mod test;
 
 use crate::{
-    AnyWindowHandle, BackgroundExecutor, Bounds, DevicePixels, Font, FontId, FontMetrics, FontRun,
-    ForegroundExecutor, GlobalPixels, GlyphId, InputEvent, LineLayout, Pixels, Point,
-    RenderGlyphParams, RenderImageParams, RenderSvgParams, Result, Scene, SharedString, Size,
+    point, size, AnyWindowHandle, BackgroundExecutor, Bounds, DevicePixels, Font, FontId,
+    FontMetrics, FontRun, ForegroundExecutor, GlobalPixels, GlyphId, InputEvent, LineLayout,
+    Pixels, Point, RenderGlyphParams, RenderImageParams, RenderSvgParams, Result, Scene,
+    SharedString, Size,
 };
 use anyhow::{anyhow, bail};
 use async_task::Runnable;
@@ -422,12 +423,15 @@ impl Column for WindowBounds {
             "Fullscreen" => WindowBounds::Fullscreen,
             "Maximized" => WindowBounds::Maximized,
             "Fixed" => {
-                // let ((x, y, width, height), _) = Column::column(statement, next_index)?;
-                // WindowBounds::Fixed(RectF::new(
-                //     Vector2F::new(x, y),
-                //     Vector2F::new(width, height),
-                // ))
-                todo!()
+                let ((x, y, width, height), _) = Column::column(statement, next_index)?;
+                let x: f64 = x;
+                let y: f64 = y;
+                let width: f64 = width;
+                let height: f64 = height;
+                WindowBounds::Fixed(Bounds {
+                    origin: point(x.into(), y.into()),
+                    size: size(width.into(), height.into()),
+                })
             }
             _ => bail!("Window State did not have a valid string"),
         };

--- a/crates/gpui2_macros/src/derive_component.rs
+++ b/crates/gpui2_macros/src/derive_component.rs
@@ -30,7 +30,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let expanded = quote! {
         impl #impl_generics gpui2::Component<#view_type> for #name #ty_generics #where_clause {
             fn render(self) -> gpui2::AnyElement<#view_type> {
-                (move |view_state: &mut #view_type, cx: &mut gpui2::ViewContext<'_, '_, #view_type>| self.render(view_state, cx))
+                (move |view_state: &mut #view_type, cx: &mut gpui2::ViewContext<'_, #view_type>| self.render(view_state, cx))
                     .render()
             }
         }


### PR DESCRIPTION
This pull request removes more `Send` bounds from GPUI2 after #3206 and simplifies some internals. Specifically:

- The `Reference` enum was removed, as we always capture mutable references anyway.
- A few GATs from `Context` and `VisualContext` were removed, as they're unnecessary now that `MainThread` isn't a thing.
- View rendering was greatly simplified (we were able to remove `EraseViewState` and `ViewObject`)

Release Notes:

- N/A