### PR TITLE
Make the Zed2 window movable

### DIFF
--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -622,7 +622,7 @@ impl StatusItemView for PanelButtons {
         _active_pane_item: Option<&dyn crate::ItemHandle>,
         _cx: &mut ViewContext<Self>,
     ) {
-        todo!()
+        // todo!(This is empty in the old `workspace::dock`)
     }
 }
 

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -1043,9 +1043,9 @@ impl Workspace {
     //         dock.update(cx, |dock, cx| dock.add_panel(panel, cx));
     //     }
 
-    //     pub fn status_bar(&self) -> &View<StatusBar> {
-    //         &self.status_bar
-    //     }
+    pub fn status_bar(&self) -> &View<StatusBar> {
+        &self.status_bar
+    }
 
     pub fn app_state(&self) -> &Arc<AppState> {
         &self.app_state

--- a/crates/zed2/src/zed2.rs
+++ b/crates/zed2/src/zed2.rs
@@ -242,7 +242,7 @@ pub fn build_window_options(
         focus: false,
         show: false,
         kind: WindowKind::Normal,
-        is_movable: false,
+        is_movable: true,
         display_id: display.map(|display| display.id()),
     }
 }
@@ -317,16 +317,16 @@ pub fn initialize_workspace(
             //         feedback::deploy_feedback_button::DeployFeedbackButton::new(workspace)
             //     });
             //     let cursor_position = cx.add_view(|_| editor::items::CursorPosition::new());
-            //     workspace.status_bar().update(cx, |status_bar, cx| {
-            //         status_bar.add_left_item(diagnostic_summary, cx);
-            //         status_bar.add_left_item(activity_indicator, cx);
+            workspace.status_bar().update(cx, |status_bar, cx| {
+                // status_bar.add_left_item(diagnostic_summary, cx);
+                // status_bar.add_left_item(activity_indicator, cx);
 
-            //         status_bar.add_right_item(feedback_button, cx);
-            //         status_bar.add_right_item(copilot, cx);
-            //         status_bar.add_right_item(active_buffer_language, cx);
-            //         status_bar.add_right_item(vim_mode_indicator, cx);
-            //         status_bar.add_right_item(cursor_position, cx);
-            //     });
+                // status_bar.add_right_item(feedback_button, cx);
+                // status_bar.add_right_item(copilot, cx);
+                // status_bar.add_right_item(active_buffer_language, cx);
+                // status_bar.add_right_item(vim_mode_indicator, cx);
+                // status_bar.add_right_item(cursor_position, cx);
+            });
 
             //     auto_update::notify_of_any_new_update(cx.weak_handle(), cx);
 


### PR DESCRIPTION
This PR makes the Zed2 window movable and fixes a crash related to a `todo!()` that wasn't necessary.

Release Notes:

- N/A
