### PR TITLE
Remove `Default` impl` for `ThemeColors`

### DIFF
--- a/crates/theme2/src/colors.rs
+++ b/crates/theme2/src/colors.rs
@@ -48,7 +48,7 @@ pub struct GitStatusColors {
     pub renamed: Hsla,
 }
 
-#[derive(Refineable, Clone, Debug, Default)]
+#[derive(Refineable, Clone, Debug)]
 #[refineable(debug)]
 pub struct ThemeColors {
     pub border: Hsla,
@@ -94,6 +94,8 @@ pub struct ThemeColors {
 #[derive(Refineable, Clone)]
 pub struct ThemeStyles {
     pub system: SystemColors,
+
+    #[refineable]
     pub colors: ThemeColors,
     pub status: StatusColors,
     pub git: GitStatusColors,


### PR DESCRIPTION
This PR removes the `Default` impl for `ThemeColors`.

Since we need default light and dark variants for `ThemeColors`, we can't use a single `Default` impl.

Release Notes:

- N/A
