### PR TITLE
Allow deriving `Serialize` and `Deserialize` on generated refinement

### DIFF
--- a/crates/theme2/src/colors.rs
+++ b/crates/theme2/src/colors.rs
@@ -49,7 +49,7 @@ pub struct GitStatusColors {
 }
 
 #[derive(Refineable, Clone, Debug)]
-#[refineable(debug)]
+#[refineable(debug, deserialize)]
 pub struct ThemeColors {
     pub border: Hsla,
     pub border_variant: Hsla,
@@ -105,6 +105,8 @@ pub struct ThemeStyles {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -145,5 +147,17 @@ mod tests {
 
         assert_eq!(colors.text, magenta);
         assert_eq!(colors.background, green);
+    }
+
+    #[test]
+    fn deserialize_theme_colors_refinement_from_json() {
+        let colors: ThemeColorsRefinement = serde_json::from_value(json!({
+            "background": "#ff00ff",
+            "text": "#ff0000"
+        }))
+        .unwrap();
+
+        assert_eq!(colors.background, Some(gpui::rgb(0xff00ff)));
+        assert_eq!(colors.text, Some(gpui::rgb(0xff0000)));
     }
 }


### PR DESCRIPTION
This PR adds support for deriving `Serialize` and `Deserialize` on the refinement type generated by `#[derive(Refineable)]`.

Release Notes:

- N/A
