### PR TITLE
Suppress unused vars warning generated by gpui macro

### DIFF
--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -170,6 +170,8 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                     #max_retries,
                     #detect_nondeterminism,
                     &mut |cx, foreground_platform, deterministic, seed| {
+                        // some of the macro contents do not use all variables, silence the warnings
+                        let _ = (&cx, &foreground_platform, &deterministic, &seed);
                         #cx_vars
                         cx.foreground().run(#inner_fn_name(#inner_fn_args));
                         #cx_teardowns
@@ -247,6 +249,8 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                     #max_retries,
                     #detect_nondeterminism,
                     &mut |cx, foreground_platform, deterministic, seed| {
+                        // some of the macro contents do not use all variables, silence the warnings
+                        let _ = (&cx, &foreground_platform, &deterministic, &seed);
                         #cx_vars
                         #inner_fn_name(#inner_fn_args);
                         #cx_teardowns


### PR DESCRIPTION
![image](https://github.com/zed-industries/zed/assets/2690773/bc86915b-2f11-46d1-ad5e-b58beb3e4290)


Release Notes:

- N/A