### PR TITLE
More heuristics for diagnostics updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "client",
  "collections",
  "editor",
+ "futures 0.3.28",
  "gpui",
  "language",
  "log",

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -22,6 +22,7 @@ workspace = { path = "../workspace" }
 
 log.workspace = true
 anyhow.workspace = true
+futures.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -165,6 +165,12 @@ impl ProjectDiagnosticsEditor {
                     log::debug!("Adding path {path:?} to update for server {language_server_id}");
                     this.paths_to_update
                         .insert((path.clone(), *language_server_id));
+                    let no_multiselections = this.editor.update(cx, |editor, cx| {
+                        editor.selections.all::<usize>(cx).len() <= 1
+                    });
+                    if no_multiselections && !this.is_dirty(cx) {
+                        this.update_excerpts(Some(*language_server_id), cx);
+                    }
                 }
                 _ => {}
             });


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/3225
That PR enabled every `project::Event::DiskBasedDiagnosticsFinished` to update the diagnostics, which turned out to be bad, Zed does query for more diagnostics after every excerpt update, and that seems to be due to `Event::Edited` emitted by the multibuffers created in the diagnostics panel.

* now, instead of eagerly updating the diagnostics every time, only do that if the panel has 0 or 1 caret placed and no changes were made in the panel yet.
Otherwise, use previous approach and register the updated paths to defer their update later.

* on every `update_excerpts` in the diagnostics panel, query the entire diagnostics summary (and store it for the future comparisons), compare old and new summaries and re-query diagnostics for every path that's not in both summaries.
Also, query every path that was registered during the `DiskBasedDiagnosticsFinished` updates that were not eagerly updated before.

This way we're supposed to get all new diagnostics (for new paths added) and re-check all old paths that might have stale diagnostics now.

* do diagnostics rechecks concurrently for every path now, speeding the overall process

Release Notes:

- Fixed diagnostics triggering too eagerly during multicaret edits and certain stale diagnostics not being removed in time