### PR TITLE
Properly toggle diagnostics

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -227,6 +227,7 @@ impl ProjectDiagnosticsEditor {
 
     fn toggle_warnings(&mut self, _: &ToggleWarnings, cx: &mut ViewContext<Self>) {
         self.include_warnings = !self.include_warnings;
+        self.paths_to_update = self.current_diagnostics.clone();
         self.update_excerpts(None, cx);
         cx.notify();
     }


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/3236 that fixes a bug introduced in that PR: diagnostics warning toggle stopped working.

Release Notes:

- N/A