### PR TITLE
Rename `ThemeVariant` to `Theme`

### DIFF
--- a/crates/editor2/src/display_map.rs
+++ b/crates/editor2/src/display_map.rs
@@ -21,7 +21,7 @@ use lsp::DiagnosticSeverity;
 use std::{any::TypeId, borrow::Cow, fmt::Debug, num::NonZeroU32, ops::Range, sync::Arc};
 use sum_tree::{Bias, TreeMap};
 use tab_map::TabMap;
-use theme::ThemeVariant;
+use theme::Theme;
 use wrap_map::WrapMap;
 
 pub use block_map::{
@@ -505,7 +505,7 @@ impl DisplaySnapshot {
         &'a self,
         display_rows: Range<u32>,
         language_aware: bool,
-        theme: &'a ThemeVariant,
+        theme: &'a Theme,
     ) -> impl Iterator<Item = HighlightedChunk<'a>> {
         self.chunks(
             display_rows,

--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -81,7 +81,7 @@ use std::{
 pub use sum_tree::Bias;
 use sum_tree::TreeMap;
 use text::Rope;
-use theme::{ActiveTheme, PlayerColor, ThemeColors, ThemeSettings, ThemeVariant};
+use theme::{ActiveTheme, PlayerColor, Theme, ThemeColors, ThemeSettings};
 use util::{post_inc, RangeExt, ResultExt, TryFutureExt};
 use workspace::{ItemNavHistory, SplitDirection, ViewId, Workspace};
 
@@ -9962,7 +9962,7 @@ pub fn highlight_diagnostic_message(
     (message_without_backticks, highlights)
 }
 
-pub fn diagnostic_style(severity: DiagnosticSeverity, valid: bool, theme: &ThemeVariant) -> Hsla {
+pub fn diagnostic_style(severity: DiagnosticSeverity, valid: bool, theme: &Theme) -> Hsla {
     match (severity, valid) {
         (DiagnosticSeverity::ERROR, true) => theme.status().error,
         (DiagnosticSeverity::ERROR, false) => theme.status().error,

--- a/crates/editor2/src/items.rs
+++ b/crates/editor2/src/items.rs
@@ -27,7 +27,7 @@ use std::{
     sync::Arc,
 };
 use text::Selection;
-use theme::{ActiveTheme, ThemeVariant};
+use theme::{ActiveTheme, Theme};
 use util::{paths::PathExt, ResultExt, TryFutureExt};
 use workspace::item::{BreadcrumbText, FollowableItemHandle};
 use workspace::{
@@ -777,7 +777,7 @@ impl Item for Editor {
         ToolbarItemLocation::PrimaryLeft { flex: None }
     }
 
-    fn breadcrumbs(&self, variant: &ThemeVariant, cx: &AppContext) -> Option<Vec<BreadcrumbText>> {
+    fn breadcrumbs(&self, variant: &Theme, cx: &AppContext) -> Option<Vec<BreadcrumbText>> {
         todo!();
         // let cursor = self.selections.newest_anchor().head();
         // let multibuffer = &self.buffer().read(cx);

--- a/crates/language2/src/language2.rs
+++ b/crates/language2/src/language2.rs
@@ -43,7 +43,7 @@ use std::{
     },
 };
 use syntax_map::SyntaxSnapshot;
-use theme::{SyntaxTheme, ThemeVariant};
+use theme::{SyntaxTheme, Theme};
 use tree_sitter::{self, Query};
 use unicase::UniCase;
 use util::{http::HttpClient, paths::PathExt};
@@ -643,7 +643,7 @@ struct LanguageRegistryState {
     next_available_language_id: AvailableLanguageId,
     loading_languages: HashMap<AvailableLanguageId, Vec<oneshot::Sender<Result<Arc<Language>>>>>,
     subscription: (watch::Sender<()>, watch::Receiver<()>),
-    theme: Option<Arc<ThemeVariant>>,
+    theme: Option<Arc<Theme>>,
     version: usize,
     reload_count: usize,
 }
@@ -744,7 +744,7 @@ impl LanguageRegistry {
         self.state.read().reload_count
     }
 
-    pub fn set_theme(&self, theme: Arc<ThemeVariant>) {
+    pub fn set_theme(&self, theme: Arc<Theme>) {
         let mut state = self.state.write();
         state.theme = Some(theme.clone());
         for language in &state.languages {

--- a/crates/theme2/src/default_theme.rs
+++ b/crates/theme2/src/default_theme.rs
@@ -1,10 +1,10 @@
 use crate::{
     colors::{GitStatusColors, PlayerColors, StatusColors, SystemColors, ThemeColors, ThemeStyles},
-    default_color_scales, Appearance, SyntaxTheme, ThemeFamily, ThemeVariant,
+    default_color_scales, Appearance, SyntaxTheme, Theme, ThemeFamily,
 };
 
-fn zed_pro_daylight() -> ThemeVariant {
-    ThemeVariant {
+fn zed_pro_daylight() -> Theme {
+    Theme {
         id: "zed_pro_daylight".to_string(),
         name: "Zed Pro Daylight".into(),
         appearance: Appearance::Light,
@@ -19,8 +19,8 @@ fn zed_pro_daylight() -> ThemeVariant {
     }
 }
 
-pub(crate) fn zed_pro_moonlight() -> ThemeVariant {
-    ThemeVariant {
+pub(crate) fn zed_pro_moonlight() -> Theme {
+    Theme {
         id: "zed_pro_moonlight".to_string(),
         name: "Zed Pro Moonlight".into(),
         appearance: Appearance::Dark,
@@ -51,7 +51,7 @@ impl Default for ThemeFamily {
     }
 }
 
-impl Default for ThemeVariant {
+impl Default for Theme {
     fn default() -> Self {
         zed_pro_daylight()
     }

--- a/crates/theme2/src/registry.rs
+++ b/crates/theme2/src/registry.rs
@@ -1,10 +1,10 @@
-use crate::{zed_pro_family, ThemeFamily, ThemeVariant};
+use crate::{zed_pro_family, Theme, ThemeFamily};
 use anyhow::{anyhow, Result};
 use gpui::SharedString;
 use std::{collections::HashMap, sync::Arc};
 
 pub struct ThemeRegistry {
-    themes: HashMap<SharedString, Arc<ThemeVariant>>,
+    themes: HashMap<SharedString, Arc<Theme>>,
 }
 
 impl ThemeRegistry {
@@ -14,7 +14,7 @@ impl ThemeRegistry {
         }
     }
 
-    fn insert_themes(&mut self, themes: impl IntoIterator<Item = ThemeVariant>) {
+    fn insert_themes(&mut self, themes: impl IntoIterator<Item = Theme>) {
         for theme in themes.into_iter() {
             self.themes.insert(theme.name.clone(), Arc::new(theme));
         }
@@ -28,7 +28,7 @@ impl ThemeRegistry {
         self.themes.values().map(|theme| theme.name.clone())
     }
 
-    pub fn get(&self, name: &str) -> Result<Arc<ThemeVariant>> {
+    pub fn get(&self, name: &str) -> Result<Arc<Theme>> {
         self.themes
             .get(name)
             .ok_or_else(|| anyhow!("theme not found: {}", name))

--- a/crates/theme2/src/settings.rs
+++ b/crates/theme2/src/settings.rs
@@ -1,4 +1,4 @@
-use crate::{ThemeRegistry, ThemeVariant};
+use crate::{Theme, ThemeRegistry};
 use anyhow::Result;
 use gpui::{px, AppContext, Font, FontFeatures, FontStyle, FontWeight, Pixels};
 use schemars::{
@@ -21,7 +21,7 @@ pub struct ThemeSettings {
     pub buffer_font: Font,
     pub buffer_font_size: Pixels,
     pub buffer_line_height: BufferLineHeight,
-    pub active_theme: Arc<ThemeVariant>,
+    pub active_theme: Arc<Theme>,
 }
 
 #[derive(Default)]

--- a/crates/theme2/src/theme2.rs
+++ b/crates/theme2/src/theme2.rs
@@ -33,11 +33,11 @@ pub fn init(cx: &mut AppContext) {
 }
 
 pub trait ActiveTheme {
-    fn theme(&self) -> &Arc<ThemeVariant>;
+    fn theme(&self) -> &Arc<Theme>;
 }
 
 impl ActiveTheme for AppContext {
-    fn theme(&self) -> &Arc<ThemeVariant> {
+    fn theme(&self) -> &Arc<Theme> {
         &ThemeSettings::get_global(self).active_theme
     }
 }
@@ -46,20 +46,20 @@ pub struct ThemeFamily {
     pub id: String,
     pub name: SharedString,
     pub author: SharedString,
-    pub themes: Vec<ThemeVariant>,
+    pub themes: Vec<Theme>,
     pub scales: ColorScales,
 }
 
 impl ThemeFamily {}
 
-pub struct ThemeVariant {
+pub struct Theme {
     pub id: String,
     pub name: SharedString,
     pub appearance: Appearance,
     pub styles: ThemeStyles,
 }
 
-impl ThemeVariant {
+impl Theme {
     /// Returns the [`ThemeColors`] for the theme.
     #[inline(always)]
     pub fn players(&self) -> &PlayerColors {

--- a/crates/theme2/src/themes/andromeda.rs
+++ b/crates/theme2/src/themes/andromeda.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn andromeda() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn andromeda() -> ThemeFamily {
         name: "Andromeda".into(),
         author: "Eliver Lara (EliverLara)".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "3bfb3b6e-365a-4cd2-9a80-2d2c81434729".into(),
                 name: "Andromeda".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn andromeda() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "7bc92ac8-152c-46d5-b346-df68e4db2e7c".into(),
                 name: "Andromeda Bordered".into(),
                 appearance: Appearance::Dark,

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn ayu() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn ayu() -> ThemeFamily {
         name: "Ayu".into(),
         author: "dempfi (Ike Ku)".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "733aeb9b-98fd-4492-984e-d71540daf72e".into(),
                 name: "Ayu Light".into(),
                 appearance: Appearance::Light,
@@ -178,7 +178,7 @@ pub fn ayu() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "50f68427-2e1d-4bf1-981a-d08c6b38e846".into(),
                 name: "Ayu Mirage".into(),
                 appearance: Appearance::Dark,
@@ -345,7 +345,7 @@ pub fn ayu() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "22d8dede-57da-46e1-946a-16876679b4d2".into(),
                 name: "Ayu Dark".into(),
                 appearance: Appearance::Dark,

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn dracula() -> ThemeFamily {
@@ -10,7 +10,7 @@ pub fn dracula() -> ThemeFamily {
         id: "0abb0e55-f034-45d9-a84d-e880dfd65711".into(),
         name: "Dracula".into(),
         author: "Zeno Rocha".into(),
-        themes: vec![ThemeVariant {
+        themes: vec![Theme {
             id: "d20497ef-85be-4ea2-9070-a182d03aac73".into(),
             name: "Dracula".into(),
             appearance: Appearance::Dark,

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn gruvbox() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn gruvbox() -> ThemeFamily {
         name: "Gruvbox".into(),
         author: "morhetz".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "0db938b2-2267-453b-af84-f82c5f3400e7".into(),
                 name: "Gruvbox Dark Hard".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn gruvbox() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "8e1a1896-ed0f-40be-b127-6c389eacc9f1".into(),
                 name: "Gruvbox Dark Medium".into(),
                 appearance: Appearance::Dark,
@@ -345,7 +345,7 @@ pub fn gruvbox() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "94410e6f-f4c4-4669-bb4d-5a20b4e4b1f3".into(),
                 name: "Gruvbox Dark Soft".into(),
                 appearance: Appearance::Dark,
@@ -512,7 +512,7 @@ pub fn gruvbox() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "e4a58582-478a-4934-ad73-135e23a0d66e".into(),
                 name: "Gruvbox Light Hard".into(),
                 appearance: Appearance::Light,
@@ -679,7 +679,7 @@ pub fn gruvbox() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "0e875280-93fa-4c76-8874-f858c7d985c1".into(),
                 name: "Gruvbox Light Medium".into(),
                 appearance: Appearance::Light,
@@ -846,7 +846,7 @@ pub fn gruvbox() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "914dbe6f-bc0f-4e6f-8d8c-5f4cabc1ca2d".into(),
                 name: "Gruvbox Light Soft".into(),
                 appearance: Appearance::Light,

--- a/crates/theme2/src/themes/night_owl.rs
+++ b/crates/theme2/src/themes/night_owl.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn night_owl() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn night_owl() -> ThemeFamily {
         name: "Night Owl".into(),
         author: "Sarah Drasner (sdras)".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "e5de91ed-fc95-46fb-a60b-ebd0602d04c7".into(),
                 name: "Night Owl".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn night_owl() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "998fc053-40c1-4a32-a31f-a17c9c07949a".into(),
                 name: "Night Owl Light".into(),
                 appearance: Appearance::Light,

--- a/crates/theme2/src/themes/nord.rs
+++ b/crates/theme2/src/themes/nord.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn nord() -> ThemeFamily {
@@ -10,7 +10,7 @@ pub fn nord() -> ThemeFamily {
         id: "3295b94b-731f-41a8-8d5e-ad02638f8e0d".into(),
         name: "Nord".into(),
         author: "Sven Greb (svengreb)".into(),
-        themes: vec![ThemeVariant {
+        themes: vec![Theme {
             id: "dfdfd9f6-bc57-46dd-b919-42b18df35bdd".into(),
             name: "Nord".into(),
             appearance: Appearance::Dark,

--- a/crates/theme2/src/themes/notctis.rs
+++ b/crates/theme2/src/themes/notctis.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn notctis() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn notctis() -> ThemeFamily {
         name: "Notctis".into(),
         author: "Liviu Schera (liviuschera)".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "2dc5fee8-30ff-4a50-bfae-c13bd19c9f89".into(),
                 name: "Noctis Azureus".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "ba4f5a34-987a-4e2c-939c-7f1b02d0e432".into(),
                 name: "Noctis Bordo".into(),
                 appearance: Appearance::Dark,
@@ -345,7 +345,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "a2e4f327-82e8-41c1-a66f-bc7f27419c2e".into(),
                 name: "Noctus Hibernus".into(),
                 appearance: Appearance::Light,
@@ -512,7 +512,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "2fde44fb-e5b2-4cc2-962f-f1c77a4eb12a".into(),
                 name: "Noctis Lilac".into(),
                 appearance: Appearance::Dark,
@@ -679,7 +679,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "2b89f218-c238-4905-9578-674d6995d2e0".into(),
                 name: "Noctis Lux".into(),
                 appearance: Appearance::Light,
@@ -846,7 +846,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "f88e2cd7-2415-4118-a638-5cfd3132ecf8".into(),
                 name: "Noctis Minimus".into(),
                 appearance: Appearance::Dark,
@@ -1013,7 +1013,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "c4d43fc2-6166-47b7-8c5c-dd24afd4b735".into(),
                 name: "Noctis".into(),
                 appearance: Appearance::Dark,
@@ -1180,7 +1180,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "7253a515-c612-403c-89de-5b62dc5cbac7".into(),
                 name: "Noctis Obscuro".into(),
                 appearance: Appearance::Dark,
@@ -1347,7 +1347,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "b0f2d7b8-ac5f-466f-9bbf-e7cac242149c".into(),
                 name: "Noctis Sereno".into(),
                 appearance: Appearance::Dark,
@@ -1514,7 +1514,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "331ce3fd-8faf-4a46-ad89-2c678abc4cd3".into(),
                 name: "Noctis Uva".into(),
                 appearance: Appearance::Dark,
@@ -1681,7 +1681,7 @@ pub fn notctis() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "209964f1-6a61-4e40-a605-be245555c493".into(),
                 name: "Noctis Viola".into(),
                 appearance: Appearance::Dark,

--- a/crates/theme2/src/themes/palenight.rs
+++ b/crates/theme2/src/themes/palenight.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn palenight() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn palenight() -> ThemeFamily {
         name: "Palenight".into(),
         author: "Olaolu Olawuyi (whizkydee)".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "39fdf216-2c76-4b3d-b368-7c31f479d524".into(),
                 name: "Palenight".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn palenight() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "5ff8120f-37e9-4ad3-8bd0-c3e449ff1aa1".into(),
                 name: "Palenight Operator".into(),
                 appearance: Appearance::Dark,
@@ -345,7 +345,7 @@ pub fn palenight() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "cff26efb-72f8-4496-b33b-991080a47f1c".into(),
                 name: "Palenight (Mild Contrast)".into(),
                 appearance: Appearance::Dark,

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn rose_pine() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn rose_pine() -> ThemeFamily {
         name: "Rose Pine".into(),
         author: "Rosé Pine".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "80a8f5dd-2ab5-4ee7-9b25-a60c8513234e".into(),
                 name: "Rose Pine".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn rose_pine() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "fe9e3c9e-954e-4f8e-849e-451ba5f6ceca".into(),
                 name: "Rose Moon".into(),
                 appearance: Appearance::Dark,
@@ -345,7 +345,7 @@ pub fn rose_pine() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "00cc7f69-9658-443e-b643-1c8dbffa047d".into(),
                 name: "Rose Pine Dawn".into(),
                 appearance: Appearance::Light,

--- a/crates/theme2/src/themes/solarized.rs
+++ b/crates/theme2/src/themes/solarized.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn solarized() -> ThemeFamily {
@@ -11,7 +11,7 @@ pub fn solarized() -> ThemeFamily {
         name: "Solarized".into(),
         author: "Ethan Schoonover (altercation)".into(),
         themes: vec![
-            ThemeVariant {
+            Theme {
                 id: "265f93c5-c8e7-4962-b083-8550f4b5c2ff".into(),
                 name: "Solarized Dark".into(),
                 appearance: Appearance::Dark,
@@ -178,7 +178,7 @@ pub fn solarized() -> ThemeFamily {
                     },
                 },
             },
-            ThemeVariant {
+            Theme {
                 id: "40e2070d-5846-4182-9dc9-bf56badf019f".into(),
                 name: "Solarized Light".into(),
                 appearance: Appearance::Light,

--- a/crates/theme2/src/themes/synthwave_84.rs
+++ b/crates/theme2/src/themes/synthwave_84.rs
@@ -2,7 +2,7 @@ use gpui::rgba;
 
 use crate::{
     default_color_scales, Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 pub fn synthwave_84() -> ThemeFamily {
@@ -10,7 +10,7 @@ pub fn synthwave_84() -> ThemeFamily {
         id: "161a14a0-533c-4df1-b909-2bac37ac807d".into(),
         name: "Synthwave 84".into(),
         author: "Robb Owen (robb0wen)".into(),
-        themes: vec![ThemeVariant {
+        themes: vec![Theme {
             id: "7a7102b7-8778-4c24-ba79-7407857b4f8c".into(),
             name: "Synthwave 84".into(),
             appearance: Appearance::Dark,

--- a/crates/theme_importer/src/theme_printer.rs
+++ b/crates/theme_importer/src/theme_printer.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Debug};
 use gpui::{Hsla, Rgba};
 use theme::{
     Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors, SyntaxTheme,
-    SystemColors, ThemeColors, ThemeFamily, ThemeStyles, ThemeVariant,
+    SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles,
 };
 
 struct RawSyntaxPrinter<'a>(&'a str);
@@ -68,7 +68,7 @@ impl Debug for ThemeFamilyPrinter {
     }
 }
 
-pub struct ThemeVariantPrinter<'a>(&'a ThemeVariant);
+pub struct ThemeVariantPrinter<'a>(&'a Theme);
 
 impl<'a> Debug for ThemeVariantPrinter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/theme_importer/src/vscode.rs
+++ b/crates/theme_importer/src/vscode.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use gpui::{Hsla, Refineable, Rgba};
 use serde::Deserialize;
 use theme::{
-    Appearance, GitStatusColors, PlayerColors, StatusColors, SyntaxTheme, SystemColors,
-    ThemeColors, ThemeColorsRefinement, ThemeStyles, ThemeVariant,
+    Appearance, GitStatusColors, PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme,
+    ThemeColors, ThemeColorsRefinement, ThemeStyles,
 };
 
 use crate::util::Traverse;
@@ -433,7 +433,7 @@ impl VsCodeThemeConverter {
         }
     }
 
-    pub fn convert(self) -> Result<ThemeVariant> {
+    pub fn convert(self) -> Result<Theme> {
         let appearance = self.theme_metadata.appearance.into();
 
         let mut theme_colors = match appearance {
@@ -569,7 +569,7 @@ impl VsCodeThemeConverter {
 
         theme_colors.refine(&theme_colors_refinements);
 
-        Ok(ThemeVariant {
+        Ok(Theme {
             id: uuid::Uuid::new_v4().to_string(),
             name: self.theme_metadata.name.into(),
             appearance,

--- a/crates/workspace2/src/item.rs
+++ b/crates/workspace2/src/item.rs
@@ -32,7 +32,7 @@ use std::{
     },
     time::Duration,
 };
-use theme2::ThemeVariant;
+use theme2::Theme;
 
 #[derive(Deserialize)]
 pub struct ItemSettings {
@@ -184,7 +184,7 @@ pub trait Item: Render + EventEmitter {
         ToolbarItemLocation::Hidden
     }
 
-    fn breadcrumbs(&self, _theme: &ThemeVariant, _cx: &AppContext) -> Option<Vec<BreadcrumbText>> {
+    fn breadcrumbs(&self, _theme: &Theme, _cx: &AppContext) -> Option<Vec<BreadcrumbText>> {
         None
     }
 
@@ -270,7 +270,7 @@ pub trait ItemHandle: 'static + Send {
     ) -> gpui::Subscription;
     fn to_searchable_item_handle(&self, cx: &AppContext) -> Option<Box<dyn SearchableItemHandle>>;
     fn breadcrumb_location(&self, cx: &AppContext) -> ToolbarItemLocation;
-    fn breadcrumbs(&self, theme: &ThemeVariant, cx: &AppContext) -> Option<Vec<BreadcrumbText>>;
+    fn breadcrumbs(&self, theme: &Theme, cx: &AppContext) -> Option<Vec<BreadcrumbText>>;
     fn serialized_item_kind(&self) -> Option<&'static str>;
     fn show_toolbar(&self, cx: &AppContext) -> bool;
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>>;
@@ -603,7 +603,7 @@ impl<T: Item> ItemHandle for View<T> {
         self.read(cx).breadcrumb_location()
     }
 
-    fn breadcrumbs(&self, theme: &ThemeVariant, cx: &AppContext) -> Option<Vec<BreadcrumbText>> {
+    fn breadcrumbs(&self, theme: &Theme, cx: &AppContext) -> Option<Vec<BreadcrumbText>> {
         self.read(cx).breadcrumbs(theme, cx)
     }
 


### PR DESCRIPTION
This PR renames the `ThemeVariant` type to `Theme`.

This better reflects its purpose, as well as matches the same name as we had before, which should make porting crates slightly easier.

Release Notes:

- N/A