### PR TITLE
Replace `GitStatusColors` with `StatusColors`

### DIFF
--- a/crates/storybook2/src/stories/focus.rs
+++ b/crates/storybook2/src/stories/focus.rs
@@ -25,12 +25,12 @@ impl Render for FocusStory {
 
     fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
         let theme = cx.theme();
-        let color_1 = theme.styles.git.created;
-        let color_2 = theme.styles.git.modified;
-        let color_3 = theme.styles.git.deleted;
-        let color_4 = theme.styles.git.conflict;
-        let color_5 = theme.styles.git.ignored;
-        let color_6 = theme.styles.git.renamed;
+        let color_1 = theme.status().created;
+        let color_2 = theme.status().modified;
+        let color_3 = theme.status().deleted;
+        let color_4 = theme.status().conflict;
+        let color_5 = theme.status().ignored;
+        let color_6 = theme.status().renamed;
         let child_1 = cx.focus_handle();
         let child_2 = cx.focus_handle();
 

--- a/crates/storybook2/src/stories/scroll.rs
+++ b/crates/storybook2/src/stories/scroll.rs
@@ -17,8 +17,8 @@ impl Render for ScrollStory {
 
     fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
         let theme = cx.theme();
-        let color_1 = theme.styles.git.created;
-        let color_2 = theme.styles.git.modified;
+        let color_1 = theme.status().created;
+        let color_2 = theme.status().modified;
 
         div()
             .id("parent")

--- a/crates/theme2/src/colors.rs
+++ b/crates/theme2/src/colors.rs
@@ -30,17 +30,6 @@ pub struct StatusColors {
 }
 
 #[derive(Refineable, Clone, Debug)]
-#[refineable(debug)]
-pub struct GitStatusColors {
-    pub conflict: Hsla,
-    pub created: Hsla,
-    pub deleted: Hsla,
-    pub ignored: Hsla,
-    pub modified: Hsla,
-    pub renamed: Hsla,
-}
-
-#[derive(Refineable, Clone, Debug)]
 #[refineable(debug, deserialize)]
 pub struct ThemeColors {
     pub border: Hsla,
@@ -260,7 +249,6 @@ pub struct ThemeStyles {
     #[refineable]
     pub colors: ThemeColors,
     pub status: StatusColors,
-    pub git: GitStatusColors,
     pub player: PlayerColors,
     pub syntax: Arc<SyntaxTheme>,
 }

--- a/crates/theme2/src/default_colors.rs
+++ b/crates/theme2/src/default_colors.rs
@@ -2,12 +2,10 @@ use std::num::ParseIntError;
 
 use gpui::{hsla, Hsla, Rgba};
 
-use crate::{
-    colors::{GitStatusColors, StatusColors, SystemColors, ThemeColors},
-    scale::{ColorScaleSet, ColorScales},
-    syntax::SyntaxTheme,
-    ColorScale, PlayerColor, PlayerColors,
-};
+use crate::colors::{StatusColors, SystemColors, ThemeColors};
+use crate::scale::{ColorScaleSet, ColorScales};
+use crate::syntax::SyntaxTheme;
+use crate::{ColorScale, PlayerColor, PlayerColors};
 
 impl Default for PlayerColors {
     fn default() -> Self {
@@ -132,19 +130,6 @@ impl Default for StatusColors {
             renamed: blue().dark().step_9(),
             success: grass().dark().step_9(),
             warning: yellow().dark().step_9(),
-        }
-    }
-}
-
-impl Default for GitStatusColors {
-    fn default() -> Self {
-        Self {
-            conflict: orange().dark().step_9(),
-            created: grass().dark().step_9(),
-            deleted: red().dark().step_9(),
-            ignored: neutral().dark().step_9(),
-            modified: yellow().dark().step_9(),
-            renamed: blue().dark().step_9(),
         }
     }
 }

--- a/crates/theme2/src/default_theme.rs
+++ b/crates/theme2/src/default_theme.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    colors::{GitStatusColors, StatusColors, SystemColors, ThemeColors, ThemeStyles},
+    colors::{StatusColors, SystemColors, ThemeColors, ThemeStyles},
     default_color_scales, Appearance, PlayerColors, SyntaxTheme, Theme, ThemeFamily,
 };
 
@@ -14,7 +14,6 @@ fn zed_pro_daylight() -> Theme {
             system: SystemColors::default(),
             colors: ThemeColors::default_light(),
             status: StatusColors::default(),
-            git: GitStatusColors::default(),
             player: PlayerColors::default_light(),
             syntax: Arc::new(SyntaxTheme::default_light()),
         },
@@ -30,7 +29,6 @@ pub(crate) fn zed_pro_moonlight() -> Theme {
             system: SystemColors::default(),
             colors: ThemeColors::default_dark(),
             status: StatusColors::default(),
-            git: GitStatusColors::default(),
             player: PlayerColors::default(),
             syntax: Arc::new(SyntaxTheme::default_dark()),
         },

--- a/crates/theme2/src/registry.rs
+++ b/crates/theme2/src/registry.rs
@@ -6,8 +6,8 @@ use gpui::SharedString;
 use refineable::Refineable;
 
 use crate::{
-    zed_pro_family, Appearance, GitStatusColors, PlayerColors, StatusColors, SyntaxTheme,
-    SystemColors, Theme, ThemeColors, ThemeFamily, ThemeStyles, UserTheme, UserThemeFamily,
+    zed_pro_family, Appearance, PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme,
+    ThemeColors, ThemeFamily, ThemeStyles, UserTheme, UserThemeFamily,
 };
 
 pub struct ThemeRegistry {
@@ -50,7 +50,6 @@ impl ThemeRegistry {
                     system: SystemColors::default(),
                     colors: theme_colors,
                     status: StatusColors::default(),
-                    git: GitStatusColors::default(),
                     player: PlayerColors::default(),
                     syntax: match user_theme.appearance {
                         Appearance::Light => Arc::new(SyntaxTheme::default_light()),

--- a/crates/theme2/src/theme2.rs
+++ b/crates/theme2/src/theme2.rs
@@ -65,6 +65,12 @@ pub struct Theme {
 }
 
 impl Theme {
+    /// Returns the [`SystemColors`] for the theme.
+    #[inline(always)]
+    pub fn system(&self) -> &SystemColors {
+        &self.styles.system
+    }
+
     /// Returns the [`ThemeColors`] for the theme.
     #[inline(always)]
     pub fn players(&self) -> &PlayerColors {
@@ -89,19 +95,13 @@ impl Theme {
         &self.styles.status
     }
 
-    /// Returns the [`GitStatusColors`] for the theme.
-    #[inline(always)]
-    pub fn git(&self) -> &GitStatusColors {
-        &self.styles.git
-    }
-
     /// Returns the color for the syntax node with the given name.
     #[inline(always)]
     pub fn syntax_color(&self, name: &str) -> Hsla {
         self.syntax().color(name)
     }
 
-    /// Returns the [`StatusColors`] for the theme.
+    /// Returns the [`DiagnosticStyle`] for the theme.
     #[inline(always)]
     pub fn diagnostic_style(&self) -> DiagnosticStyle {
         DiagnosticStyle {

--- a/crates/theme_importer/src/theme_printer.rs
+++ b/crates/theme_importer/src/theme_printer.rs
@@ -2,8 +2,8 @@ use std::fmt::{self, Debug};
 
 use gpui::{Hsla, Rgba};
 use theme::{
-    Appearance, GitStatusColors, PlayerColor, PlayerColors, StatusColors, SyntaxTheme,
-    SystemColors, ThemeColorsRefinement, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColors, SyntaxTheme, SystemColors,
+    ThemeColorsRefinement, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
 };
 
 struct RawSyntaxPrinter<'a>(&'a str);
@@ -266,21 +266,6 @@ impl<'a> Debug for StatusColorsPrinter<'a> {
             .field("renamed", &HslaPrinter(self.0.renamed))
             .field("success", &HslaPrinter(self.0.success))
             .field("warning", &HslaPrinter(self.0.warning))
-            .finish()
-    }
-}
-
-pub struct GitStatusColorsPrinter<'a>(&'a GitStatusColors);
-
-impl<'a> Debug for GitStatusColorsPrinter<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("GitStatusColors")
-            .field("conflict", &HslaPrinter(self.0.conflict))
-            .field("created", &HslaPrinter(self.0.created))
-            .field("deleted", &HslaPrinter(self.0.deleted))
-            .field("ignored", &HslaPrinter(self.0.ignored))
-            .field("modified", &HslaPrinter(self.0.modified))
-            .field("renamed", &HslaPrinter(self.0.renamed))
             .finish()
     }
 }

--- a/crates/ui2/src/prelude.rs
+++ b/crates/ui2/src/prelude.rs
@@ -46,12 +46,12 @@ pub enum GitStatus {
 impl GitStatus {
     pub fn hsla(&self, cx: &WindowContext) -> Hsla {
         match self {
-            Self::None => cx.theme().styles.system.transparent,
-            Self::Created => cx.theme().styles.git.created,
-            Self::Modified => cx.theme().styles.git.modified,
-            Self::Deleted => cx.theme().styles.git.deleted,
-            Self::Conflict => cx.theme().styles.git.conflict,
-            Self::Renamed => cx.theme().styles.git.renamed,
+            Self::None => cx.theme().system().transparent,
+            Self::Created => cx.theme().status().created,
+            Self::Modified => cx.theme().status().modified,
+            Self::Deleted => cx.theme().status().deleted,
+            Self::Conflict => cx.theme().status().conflict,
+            Self::Renamed => cx.theme().status().renamed,
         }
     }
 }


### PR DESCRIPTION
This PR removes `GitStatusColors` in favor of just using `StatusColors` instead.

Release Notes:

- N/A
