### PR TITLE
Do not use prettier for formatting node_modules/** files

### DIFF
--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -64,6 +64,12 @@ impl Prettier {
             .components()
             .take_while(|component| component.as_os_str().to_string_lossy() != "node_modules")
             .collect::<PathBuf>();
+        if path_to_check != locate_from {
+            log::debug!(
+                "Skipping prettier location for path {path_to_check:?} that is inside node_modules"
+            );
+            return Ok(ControlFlow::Break(()));
+        }
         let path_to_check_metadata = fs
             .metadata(&path_to_check)
             .await

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -173,8 +173,7 @@ pub struct Project {
 struct DefaultPrettier {
     instance: Option<Shared<Task<Result<Arc<Prettier>, Arc<anyhow::Error>>>>>,
     installation_process: Option<Shared<Task<Result<(), Arc<anyhow::Error>>>>>,
-    // TODO kb uncomment
-    // #[cfg(not(any(test, feature = "test-support")))]
+    #[cfg(not(any(test, feature = "test-support")))]
     installed_plugins: HashSet<&'static str>,
 }
 
@@ -8540,18 +8539,17 @@ impl Project {
         }
     }
 
-    // TODO kb uncomment
-    // #[cfg(any(test, feature = "test-support"))]
-    // fn install_default_formatters(
-    //     &mut self,
-    //     _worktree: Option<WorktreeId>,
-    //     _new_language: &Language,
-    //     _language_settings: &LanguageSettings,
-    //     _cx: &mut ModelContext<Self>,
-    // ) {
-    // }
+    #[cfg(any(test, feature = "test-support"))]
+    fn install_default_formatters(
+        &mut self,
+        _worktree: Option<WorktreeId>,
+        _new_language: &Language,
+        _language_settings: &LanguageSettings,
+        _cx: &mut ModelContext<Self>,
+    ) {
+    }
 
-    // #[cfg(not(any(test, feature = "test-support")))]
+    #[cfg(not(any(test, feature = "test-support")))]
     fn install_default_formatters(
         &mut self,
         worktree: Option<WorktreeId>,
@@ -8714,8 +8712,7 @@ fn start_default_prettier(
                         .get_or_insert_with(|| DefaultPrettier {
                             instance: None,
                             installation_process: None,
-                            // TODO kb uncomment
-                            // #[cfg(not(any(test, feature = "test-support")))]
+                            #[cfg(not(any(test, feature = "test-support")))]
                             installed_plugins: HashSet::default(),
                         })
                         .instance = Some(new_default_prettier.clone());
@@ -8797,8 +8794,7 @@ fn register_new_prettier(
     }
 }
 
-// TODO kb uncomment
-// #[cfg(not(any(test, feature = "test-support")))]
+#[cfg(not(any(test, feature = "test-support")))]
 async fn install_default_prettier(
     plugins_to_install: HashSet<&'static str>,
     node: Arc<dyn NodeRuntime>,

--- a/crates/project2/src/project2.rs
+++ b/crates/project2/src/project2.rs
@@ -69,7 +69,7 @@ use std::{
     hash::Hash,
     mem,
     num::NonZeroU32,
-    ops::Range,
+    ops::{ControlFlow, Range},
     path::{self, Component, Path, PathBuf},
     process::Stdio,
     str,
@@ -8488,7 +8488,10 @@ impl Project {
                             })
                             .await
                         {
-                            Ok(None) => {
+                            Ok(ControlFlow::Break(())) => {
+                                return None;
+                            }
+                            Ok(ControlFlow::Continue(None)) => {
                                 match project.update(&mut cx, |project, _| {
                                     project
                                         .prettiers_per_worktree
@@ -8520,7 +8523,7 @@ impl Project {
                                         .shared())),
                                 }
                             }
-                            Ok(Some(prettier_dir)) => {
+                            Ok(ControlFlow::Continue(Some(prettier_dir))) => {
                                 match project.update(&mut cx, |project, _| {
                                     project
                                         .prettiers_per_worktree
@@ -8662,7 +8665,7 @@ impl Project {
                     .await
                 })
             }
-            None => Task::ready(Ok(None)),
+            None => Task::ready(Ok(ControlFlow::Break(()))),
         };
         let mut plugins_to_install = prettier_plugins;
         let previous_installation_process =
@@ -8692,8 +8695,9 @@ impl Project {
                     .context("locate prettier installation")
                     .map_err(Arc::new)?
                 {
-                    Some(_non_default_prettier) => return Ok(()),
-                    None => {
+                    ControlFlow::Break(()) => return Ok(()),
+                    ControlFlow::Continue(Some(_non_default_prettier)) => return Ok(()),
+                    ControlFlow::Continue(None) => {
                         let mut needs_install = match previous_installation_process {
                             Some(previous_installation_process) => {
                                 previous_installation_process.await.is_err()


### PR DESCRIPTION
Fixes

> the most annoying thing i'm running into right now is that when i'm patching something inside node_modules, Zed tries to pretty-format it according to my prettier config. this messes up the patch because it has formatting changes now. i need the pretty formatting on save to be off inside node_modules, that never makes sense

feedback from #influencers 

Do note though, that language servers will still format any file inside node_modules, but at least it's not prettier now.
VSCode seem to format the node_modules/** files via language servers too, so that seems ok for now, and the rest could be fixed during 

> "project diagnostics" (eslint) seem to be running inside node_modules, e.g. i'm seeing 3182 "errors" in my project. that doesn't make sense and probably wastes resources in addition to being annoying

feedback later.

Release Notes:

- Fixed prettier formatting files inside node_modules