### PR TITLE
Extend theme converter to allow multimatching against vscode colors

### DIFF
--- a/assets/themes/src/vscode/gruvbox/gruvbox-dark-hard.json
+++ b/assets/themes/src/vscode/gruvbox/gruvbox-dark-hard.json
@@ -423,7 +423,10 @@
             }
         },
         {
-            "scope": ["string.interpolated.dollar.shell", "string.interpolated.backtick.shell"],
+            "scope": [
+                "string.interpolated.dollar.shell",
+                "string.interpolated.backtick.shell"
+            ],
             "settings": {
                 "foreground": "#8ec07c"
             }
@@ -489,13 +492,19 @@
 
         {
             "name": "coloring of the Java import and package identifiers",
-            "scope": ["storage.modifier.import.java", "storage.modifier.package.java"],
+            "scope": [
+                "storage.modifier.import.java",
+                "storage.modifier.package.java"
+            ],
             "settings": {
                 "foreground": "#bdae93"
             }
         },
         {
-            "scope": ["keyword.other.import.java", "keyword.other.package.java"],
+            "scope": [
+                "keyword.other.import.java",
+                "keyword.other.package.java"
+            ],
             "settings": {
                 "foreground": "#8ec07c"
             }
@@ -628,7 +637,9 @@
         },
         {
             "name": "JSON Level 0",
-            "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+            "scope": [
+                "source.json meta.structure.dictionary.json support.type.property-name.json"
+            ],
             "settings": {
                 "foreground": "#b8bb26"
             }
@@ -761,7 +772,10 @@
             }
         },
         {
-            "scope": ["source.go keyword.interface", "source.go keyword.struct"],
+            "scope": [
+                "source.go keyword.interface",
+                "source.go keyword.struct"
+            ],
             "settings": {
                 "foreground": "#83a598"
             }
@@ -788,7 +802,10 @@
 
         {
             "name": "ReasonML String",
-            "scope": ["source.reason string.double", "source.reason string.regexp"],
+            "scope": [
+                "source.reason string.double",
+                "source.reason string.regexp"
+            ],
             "settings": {
                 "foreground": "#b8bb26"
             }
@@ -809,7 +826,10 @@
         },
         {
             "name": "ReasonML property",
-            "scope": ["source.reason support.property-value", "source.reason entity.name.filename"],
+            "scope": [
+                "source.reason support.property-value",
+                "source.reason entity.name.filename"
+            ],
             "settings": {
                 "foreground": "#fe8019"
             }
@@ -831,7 +851,9 @@
         },
         {
             "name": "Powershell function attribute",
-            "scope": ["source.powershell support.function.attribute.powershell"],
+            "scope": [
+                "source.powershell support.function.attribute.powershell"
+            ],
             "settings": {
                 "foreground": "#bdae93"
             }

--- a/assets/themes/src/vscode/gruvbox/gruvbox-dark-medium.json
+++ b/assets/themes/src/vscode/gruvbox/gruvbox-dark-medium.json
@@ -423,7 +423,10 @@
             }
         },
         {
-            "scope": ["string.interpolated.dollar.shell", "string.interpolated.backtick.shell"],
+            "scope": [
+                "string.interpolated.dollar.shell",
+                "string.interpolated.backtick.shell"
+            ],
             "settings": {
                 "foreground": "#8ec07c"
             }
@@ -489,13 +492,19 @@
 
         {
             "name": "coloring of the Java import and package identifiers",
-            "scope": ["storage.modifier.import.java", "storage.modifier.package.java"],
+            "scope": [
+                "storage.modifier.import.java",
+                "storage.modifier.package.java"
+            ],
             "settings": {
                 "foreground": "#bdae93"
             }
         },
         {
-            "scope": ["keyword.other.import.java", "keyword.other.package.java"],
+            "scope": [
+                "keyword.other.import.java",
+                "keyword.other.package.java"
+            ],
             "settings": {
                 "foreground": "#8ec07c"
             }
@@ -628,7 +637,9 @@
         },
         {
             "name": "JSON Level 0",
-            "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+            "scope": [
+                "source.json meta.structure.dictionary.json support.type.property-name.json"
+            ],
             "settings": {
                 "foreground": "#b8bb26"
             }
@@ -761,7 +772,10 @@
             }
         },
         {
-            "scope": ["source.go keyword.interface", "source.go keyword.struct"],
+            "scope": [
+                "source.go keyword.interface",
+                "source.go keyword.struct"
+            ],
             "settings": {
                 "foreground": "#83a598"
             }
@@ -788,7 +802,10 @@
 
         {
             "name": "ReasonML String",
-            "scope": ["source.reason string.double", "source.reason string.regexp"],
+            "scope": [
+                "source.reason string.double",
+                "source.reason string.regexp"
+            ],
             "settings": {
                 "foreground": "#b8bb26"
             }
@@ -809,7 +826,10 @@
         },
         {
             "name": "ReasonML property",
-            "scope": ["source.reason support.property-value", "source.reason entity.name.filename"],
+            "scope": [
+                "source.reason support.property-value",
+                "source.reason entity.name.filename"
+            ],
             "settings": {
                 "foreground": "#fe8019"
             }
@@ -831,7 +851,9 @@
         },
         {
             "name": "Powershell function attribute",
-            "scope": ["source.powershell support.function.attribute.powershell"],
+            "scope": [
+                "source.powershell support.function.attribute.powershell"
+            ],
             "settings": {
                 "foreground": "#bdae93"
             }

--- a/assets/themes/src/vscode/gruvbox/gruvbox-dark-soft.json
+++ b/assets/themes/src/vscode/gruvbox/gruvbox-dark-soft.json
@@ -423,7 +423,10 @@
             }
         },
         {
-            "scope": ["string.interpolated.dollar.shell", "string.interpolated.backtick.shell"],
+            "scope": [
+                "string.interpolated.dollar.shell",
+                "string.interpolated.backtick.shell"
+            ],
             "settings": {
                 "foreground": "#8ec07c"
             }
@@ -489,13 +492,19 @@
 
         {
             "name": "coloring of the Java import and package identifiers",
-            "scope": ["storage.modifier.import.java", "storage.modifier.package.java"],
+            "scope": [
+                "storage.modifier.import.java",
+                "storage.modifier.package.java"
+            ],
             "settings": {
                 "foreground": "#bdae93"
             }
         },
         {
-            "scope": ["keyword.other.import.java", "keyword.other.package.java"],
+            "scope": [
+                "keyword.other.import.java",
+                "keyword.other.package.java"
+            ],
             "settings": {
                 "foreground": "#8ec07c"
             }
@@ -628,7 +637,9 @@
         },
         {
             "name": "JSON Level 0",
-            "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+            "scope": [
+                "source.json meta.structure.dictionary.json support.type.property-name.json"
+            ],
             "settings": {
                 "foreground": "#b8bb26"
             }
@@ -761,7 +772,10 @@
             }
         },
         {
-            "scope": ["source.go keyword.interface", "source.go keyword.struct"],
+            "scope": [
+                "source.go keyword.interface",
+                "source.go keyword.struct"
+            ],
             "settings": {
                 "foreground": "#83a598"
             }
@@ -788,7 +802,10 @@
 
         {
             "name": "ReasonML String",
-            "scope": ["source.reason string.double", "source.reason string.regexp"],
+            "scope": [
+                "source.reason string.double",
+                "source.reason string.regexp"
+            ],
             "settings": {
                 "foreground": "#b8bb26"
             }
@@ -809,7 +826,10 @@
         },
         {
             "name": "ReasonML property",
-            "scope": ["source.reason support.property-value", "source.reason entity.name.filename"],
+            "scope": [
+                "source.reason support.property-value",
+                "source.reason entity.name.filename"
+            ],
             "settings": {
                 "foreground": "#fe8019"
             }
@@ -831,7 +851,9 @@
         },
         {
             "name": "Powershell function attribute",
-            "scope": ["source.powershell support.function.attribute.powershell"],
+            "scope": [
+                "source.powershell support.function.attribute.powershell"
+            ],
             "settings": {
                 "foreground": "#bdae93"
             }

--- a/assets/themes/src/vscode/gruvbox/gruvbox-light-hard.json
+++ b/assets/themes/src/vscode/gruvbox/gruvbox-light-hard.json
@@ -422,7 +422,10 @@
             }
         },
         {
-            "scope": ["string.interpolated.dollar.shell", "string.interpolated.backtick.shell"],
+            "scope": [
+                "string.interpolated.dollar.shell",
+                "string.interpolated.backtick.shell"
+            ],
             "settings": {
                 "foreground": "#427b58"
             }
@@ -488,13 +491,19 @@
 
         {
             "name": "coloring of the Java import and package identifiers",
-            "scope": ["storage.modifier.import.java", "storage.modifier.package.java"],
+            "scope": [
+                "storage.modifier.import.java",
+                "storage.modifier.package.java"
+            ],
             "settings": {
                 "foreground": "#665c54"
             }
         },
         {
-            "scope": ["keyword.other.import.java", "keyword.other.package.java"],
+            "scope": [
+                "keyword.other.import.java",
+                "keyword.other.package.java"
+            ],
             "settings": {
                 "foreground": "#427b58"
             }
@@ -627,7 +636,9 @@
         },
         {
             "name": "JSON Level 0",
-            "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+            "scope": [
+                "source.json meta.structure.dictionary.json support.type.property-name.json"
+            ],
             "settings": {
                 "foreground": "#79740e"
             }
@@ -760,7 +771,10 @@
             }
         },
         {
-            "scope": ["source.go keyword.interface", "source.go keyword.struct"],
+            "scope": [
+                "source.go keyword.interface",
+                "source.go keyword.struct"
+            ],
             "settings": {
                 "foreground": "#076678"
             }
@@ -787,7 +801,10 @@
 
         {
             "name": "ReasonML String",
-            "scope": ["source.reason string.double", "source.reason string.regexp"],
+            "scope": [
+                "source.reason string.double",
+                "source.reason string.regexp"
+            ],
             "settings": {
                 "foreground": "#79740e"
             }
@@ -808,7 +825,10 @@
         },
         {
             "name": "ReasonML property",
-            "scope": ["source.reason support.property-value", "source.reason entity.name.filename"],
+            "scope": [
+                "source.reason support.property-value",
+                "source.reason entity.name.filename"
+            ],
             "settings": {
                 "foreground": "#af3a03"
             }
@@ -830,7 +850,9 @@
         },
         {
             "name": "Powershell function attribute",
-            "scope": ["source.powershell support.function.attribute.powershell"],
+            "scope": [
+                "source.powershell support.function.attribute.powershell"
+            ],
             "settings": {
                 "foreground": "#665c54"
             }

--- a/assets/themes/src/vscode/gruvbox/gruvbox-light-medium.json
+++ b/assets/themes/src/vscode/gruvbox/gruvbox-light-medium.json
@@ -422,7 +422,10 @@
             }
         },
         {
-            "scope": ["string.interpolated.dollar.shell", "string.interpolated.backtick.shell"],
+            "scope": [
+                "string.interpolated.dollar.shell",
+                "string.interpolated.backtick.shell"
+            ],
             "settings": {
                 "foreground": "#427b58"
             }
@@ -488,13 +491,19 @@
 
         {
             "name": "coloring of the Java import and package identifiers",
-            "scope": ["storage.modifier.import.java", "storage.modifier.package.java"],
+            "scope": [
+                "storage.modifier.import.java",
+                "storage.modifier.package.java"
+            ],
             "settings": {
                 "foreground": "#665c54"
             }
         },
         {
-            "scope": ["keyword.other.import.java", "keyword.other.package.java"],
+            "scope": [
+                "keyword.other.import.java",
+                "keyword.other.package.java"
+            ],
             "settings": {
                 "foreground": "#427b58"
             }
@@ -627,7 +636,9 @@
         },
         {
             "name": "JSON Level 0",
-            "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+            "scope": [
+                "source.json meta.structure.dictionary.json support.type.property-name.json"
+            ],
             "settings": {
                 "foreground": "#79740e"
             }
@@ -760,7 +771,10 @@
             }
         },
         {
-            "scope": ["source.go keyword.interface", "source.go keyword.struct"],
+            "scope": [
+                "source.go keyword.interface",
+                "source.go keyword.struct"
+            ],
             "settings": {
                 "foreground": "#076678"
             }
@@ -787,7 +801,10 @@
 
         {
             "name": "ReasonML String",
-            "scope": ["source.reason string.double", "source.reason string.regexp"],
+            "scope": [
+                "source.reason string.double",
+                "source.reason string.regexp"
+            ],
             "settings": {
                 "foreground": "#79740e"
             }
@@ -808,7 +825,10 @@
         },
         {
             "name": "ReasonML property",
-            "scope": ["source.reason support.property-value", "source.reason entity.name.filename"],
+            "scope": [
+                "source.reason support.property-value",
+                "source.reason entity.name.filename"
+            ],
             "settings": {
                 "foreground": "#af3a03"
             }
@@ -830,7 +850,9 @@
         },
         {
             "name": "Powershell function attribute",
-            "scope": ["source.powershell support.function.attribute.powershell"],
+            "scope": [
+                "source.powershell support.function.attribute.powershell"
+            ],
             "settings": {
                 "foreground": "#665c54"
             }

--- a/assets/themes/src/vscode/gruvbox/gruvbox-light-soft.json
+++ b/assets/themes/src/vscode/gruvbox/gruvbox-light-soft.json
@@ -422,7 +422,10 @@
             }
         },
         {
-            "scope": ["string.interpolated.dollar.shell", "string.interpolated.backtick.shell"],
+            "scope": [
+                "string.interpolated.dollar.shell",
+                "string.interpolated.backtick.shell"
+            ],
             "settings": {
                 "foreground": "#427b58"
             }
@@ -488,13 +491,19 @@
 
         {
             "name": "coloring of the Java import and package identifiers",
-            "scope": ["storage.modifier.import.java", "storage.modifier.package.java"],
+            "scope": [
+                "storage.modifier.import.java",
+                "storage.modifier.package.java"
+            ],
             "settings": {
                 "foreground": "#665c54"
             }
         },
         {
-            "scope": ["keyword.other.import.java", "keyword.other.package.java"],
+            "scope": [
+                "keyword.other.import.java",
+                "keyword.other.package.java"
+            ],
             "settings": {
                 "foreground": "#427b58"
             }
@@ -627,7 +636,9 @@
         },
         {
             "name": "JSON Level 0",
-            "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+            "scope": [
+                "source.json meta.structure.dictionary.json support.type.property-name.json"
+            ],
             "settings": {
                 "foreground": "#79740e"
             }
@@ -760,7 +771,10 @@
             }
         },
         {
-            "scope": ["source.go keyword.interface", "source.go keyword.struct"],
+            "scope": [
+                "source.go keyword.interface",
+                "source.go keyword.struct"
+            ],
             "settings": {
                 "foreground": "#076678"
             }
@@ -787,7 +801,10 @@
 
         {
             "name": "ReasonML String",
-            "scope": ["source.reason string.double", "source.reason string.regexp"],
+            "scope": [
+                "source.reason string.double",
+                "source.reason string.regexp"
+            ],
             "settings": {
                 "foreground": "#79740e"
             }
@@ -808,7 +825,10 @@
         },
         {
             "name": "ReasonML property",
-            "scope": ["source.reason support.property-value", "source.reason entity.name.filename"],
+            "scope": [
+                "source.reason support.property-value",
+                "source.reason entity.name.filename"
+            ],
             "settings": {
                 "foreground": "#af3a03"
             }
@@ -830,7 +850,9 @@
         },
         {
             "name": "Powershell function attribute",
-            "scope": ["source.powershell support.function.attribute.powershell"],
+            "scope": [
+                "source.powershell support.function.attribute.powershell"
+            ],
             "settings": {
                 "foreground": "#665c54"
             }

--- a/assets/themes/src/vscode/rose-pine/family.json
+++ b/assets/themes/src/vscode/rose-pine/family.json
@@ -1,21 +1,21 @@
 {
-    "name": "Rose Pine",
-    "author": "Rosé Pine",
-    "themes": [
-        {
-            "name": "Rose Pine",
-            "file_name": "rose-pine.json",
-            "appearance": "dark"
-        },
-        {
-            "name": "Rose Moon",
-            "file_name": "rose-pine-moon.json",
-            "appearance": "dark"
-        },
-        {
-            "name": "Rose Pine Dawn",
-            "file_name": "rose-pine-dawn.json",
-            "appearance": "light"
-        }
-    ]
+  "name": "Rose Pine",
+  "author": "Rosé Pine",
+  "themes": [
+    {
+      "name": "Rose Pine",
+      "file_name": "rose-pine.json",
+      "appearance": "dark"
+    },
+    {
+      "name": "Rose Pine Moon",
+      "file_name": "rose-pine-moon.json",
+      "appearance": "dark"
+    },
+    {
+      "name": "Rose Pine Dawn",
+      "file_name": "rose-pine-dawn.json",
+      "appearance": "light"
+    }
+  ]
 }

--- a/assets/themes/src/vscode/synthwave-84/synthwave.json
+++ b/assets/themes/src/vscode/synthwave-84/synthwave.json
@@ -1,822 +1,841 @@
 {
-    "name": "SynthWave 84",
-    "type": "dark",
-    "semanticHighlighting": true,
-    "colors": {
-        "focusBorder": "#1f212b",
-        "foreground": "#ffffff",
-        "widget.shadow": "#2a2139",
-        "selection.background": "#ffffff20",
-        "errorForeground": "#fe4450",
-        "textLink.activeForeground": "#ff7edb",
-        "textLink.foreground": "#f97e72",
-        "button.background": "#614D85",
-        "dropdown.background": "#232530",
-        "dropdown.listBackground": "#2a2139",
-        "input.background": "#2a2139",
-        "inputOption.activeBorder": "#ff7edb99",
-        "inputValidation.errorBackground": "#fe445080",
-        "inputValidation.errorBorder": "#fe445000",
-        "scrollbar.shadow": "#2a2139",
-        "scrollbarSlider.activeBackground": "#9d8bca20",
-        "scrollbarSlider.background": "#9d8bca30",
-        "scrollbarSlider.hoverBackground": "#9d8bca50",
-        "badge.foreground": "#ffffff",
-        "badge.background": "#2a2139",
-        "progressBar.background": "#f97e72",
-        "list.activeSelectionBackground": "#ffffff20",
-        "list.activeSelectionForeground": "#ffffff",
-        "list.dropBackground": "#34294f66",
-        "list.focusBackground": "#ffffff20",
-        "list.focusForeground": "#ffffff",
-        "list.highlightForeground": "#f97e72",
-        "list.hoverBackground": "#37294d99",
-        "list.hoverForeground": "#ffffff",
-        "list.inactiveSelectionBackground": "#ffffff20",
-        "list.inactiveSelectionForeground": "#ffffff",
-        "list.inactiveFocusBackground": "#2a213999",
-        "list.errorForeground": "#fe4450E6",
-        "list.warningForeground": "#72f1b8bb",
-        "activityBar.background": "#171520",
-        "activityBar.dropBackground": "#34294f66",
-        "activityBar.foreground": "#ffffffCC",
-        "activityBarBadge.background": "#f97e72",
-        "activityBarBadge.foreground": "#2a2139",
-        "sideBar.background": "#241b2f",
-        "sideBar.foreground": "#ffffff99",
-        "sideBar.dropBackground": "#34294f4c",
-        "sideBarSectionHeader.background": "#241b2f",
-        "sideBarSectionHeader.foreground": "#ffffffca",
-        "menu.background": "#463465",
-        "editorGroup.border": "#495495",
-        "editorGroup.dropBackground": "#4954954a",
-        "editorGroupHeader.tabsBackground": "#241b2f",
-        "tab.border": "#241b2f00",
-        "tab.activeBorder": "#880088",
-        "tab.inactiveBackground": "#262335",
-        "editor.background": "#262335",
-        "editorLineNumber.foreground": "#ffffff73",
-        "editorLineNumber.activeForeground": "#ffffffcc",
-        "editorCursor.background": "#241b2f",
-        "editorCursor.foreground": "#f97e72",
-        "editor.selectionBackground": "#ffffff20",
-        "editor.selectionHighlightBackground": "#ffffff20",
-        "editor.wordHighlightBackground": "#34294f88",
-        "editor.wordHighlightStrongBackground": "#34294f88",
-        "editor.findMatchBackground": "#D18616bb",
-        "editor.findMatchHighlightBackground": "#D1861655",
-        "editor.findRangeHighlightBackground": "#34294f1a",
-        "editor.hoverHighlightBackground": "#463564",
-        "editor.lineHighlightBorder": "#7059AB66",
-        "editor.rangeHighlightBackground": "#49549539",
-        "editorIndentGuide.background": "#444251",
-        "editorIndentGuide.activeBackground": "#A148AB80",
-        "editorRuler.foreground": "#A148AB80",
-        "editorCodeLens.foreground": "#ffffff7c",
-        "editorBracketMatch.background": "#34294f66",
-        "editorBracketMatch.border": "#495495",
-        "editorOverviewRuler.border": "#34294fb3",
-        "editorOverviewRuler.findMatchForeground": "#D1861699",
-        "editorOverviewRuler.modifiedForeground": "#b893ce99",
-        "editorOverviewRuler.addedForeground": "#09f7a099",
-        "editorOverviewRuler.deletedForeground": "#fe445099",
-        "editorOverviewRuler.errorForeground": "#fe4450dd",
-        "editorOverviewRuler.warningForeground": "#72f1b8cc",
-        "editorError.foreground": "#fe4450",
-        "editorWarning.foreground": "#72f1b8cc",
-        "editorGutter.modifiedBackground": "#b893ce8f",
-        "editorGutter.addedBackground": "#206d4bd6",
-        "editorGutter.deletedBackground": "#fa2e46a4",
-        "diffEditor.insertedTextBackground": "#0beb9935",
-        "diffEditor.removedTextBackground": "#fe445035",
-        "editorWidget.background": "#171520DC",
-        "editorWidget.border": "#ffffff22",
-        "editorWidget.resizeBorder": "#ffffff44",
-        "editorSuggestWidget.highlightForeground": "#f97e72",
-        "editorSuggestWidget.selectedBackground": "#ffffff36",
-        "peekView.border": "#495495",
-        "peekViewEditor.background": "#232530",
-        "peekViewEditor.matchHighlightBackground": "#D18616bb",
-        "peekViewResult.background": "#232530",
-        "peekViewResult.matchHighlightBackground": "#D1861655",
-        "peekViewResult.selectionBackground": "#2a213980",
-        "peekViewTitle.background": "#232530",
-        "panelTitle.activeBorder": "#f97e72",
-        "statusBar.background": "#241b2f",
-        "statusBar.foreground": "#ffffff80",
-        "statusBar.debuggingBackground": "#f97e72",
-        "statusBar.debuggingForeground": "#08080f",
-        "statusBar.noFolderBackground": "#241b2f",
-        "statusBarItem.prominentBackground": "#2a2139",
-        "statusBarItem.prominentHoverBackground": "#34294f",
-        "titleBar.activeBackground": "#241b2f",
-        "titleBar.inactiveBackground": "#241b2f",
-        "extensionButton.prominentBackground": "#f97e72",
-        "extensionButton.prominentHoverBackground": "#ff7edb",
-        "pickerGroup.foreground": "#f97e72ea",
-        "terminal.foreground": "#ffffff",
-        "terminal.ansiBlue": "#03edf9",
-        "terminal.ansiBrightBlue": "#03edf9",
-        "terminal.ansiBrightCyan": "#03edf9",
-        "terminal.ansiBrightGreen": "#72f1b8",
-        "terminal.ansiBrightMagenta": "#ff7edb",
-        "terminal.ansiBrightRed": "#fe4450",
-        "terminal.ansiBrightYellow": "#fede5d",
-        "terminal.ansiCyan": "#03edf9",
-        "terminal.ansiGreen": "#72f1b8",
-        "terminal.ansiMagenta": "#ff7edb",
-        "terminal.ansiRed": "#fe4450",
-        "terminal.ansiYellow": "#f3e70f",
-        "terminal.selectionBackground": "#ffffff20",
-        "terminalCursor.background": "#ffffff",
-        "terminalCursor.foreground": "#03edf9",
-        "debugToolBar.background": "#463465",
-        "walkThrough.embeddedEditorBackground": "#232530",
-        "gitDecoration.modifiedResourceForeground": "#b893ceee",
-        "gitDecoration.deletedResourceForeground": "#fe4450",
-        "gitDecoration.addedResourceForeground": "#72f1b8cc",
-        "gitDecoration.untrackedResourceForeground": "#72f1b8",
-        "gitDecoration.ignoredResourceForeground": "#ffffff59",
-        "minimapGutter.addedBackground": "#09f7a099",
-        "minimapGutter.modifiedBackground": "#b893ce",
-        "minimapGutter.deletedBackground": "#fe4450",
-        "breadcrumbPicker.background": "#232530"
+  "name": "SynthWave 84",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "colors": {
+    "focusBorder": "#1f212b",
+    "foreground": "#ffffff",
+    "widget.shadow": "#2a2139",
+    "selection.background": "#ffffff20",
+    "errorForeground": "#fe4450",
+    "textLink.activeForeground": "#ff7edb",
+    "textLink.foreground": "#f97e72",
+    "button.background": "#614D85",
+    "dropdown.background": "#232530",
+    "dropdown.listBackground": "#2a2139",
+    "input.background": "#2a2139",
+    "inputOption.activeBorder": "#ff7edb99",
+    "inputValidation.errorBackground": "#fe445080",
+    "inputValidation.errorBorder": "#fe445000",
+    "scrollbar.shadow": "#2a2139",
+    "scrollbarSlider.activeBackground": "#9d8bca20",
+    "scrollbarSlider.background": "#9d8bca30",
+    "scrollbarSlider.hoverBackground": "#9d8bca50",
+    "badge.foreground": "#ffffff",
+    "badge.background": "#2a2139",
+    "progressBar.background": "#f97e72",
+    "list.activeSelectionBackground": "#ffffff20",
+    "list.activeSelectionForeground": "#ffffff",
+    "list.dropBackground": "#34294f66",
+    "list.focusBackground": "#ffffff20",
+    "list.focusForeground": "#ffffff",
+    "list.highlightForeground": "#f97e72",
+    "list.hoverBackground": "#37294d99",
+    "list.hoverForeground": "#ffffff",
+    "list.inactiveSelectionBackground": "#ffffff20",
+    "list.inactiveSelectionForeground": "#ffffff",
+    "list.inactiveFocusBackground": "#2a213999",
+    "list.errorForeground": "#fe4450E6",
+    "list.warningForeground": "#72f1b8bb",
+    "activityBar.background": "#171520",
+    "activityBar.dropBackground": "#34294f66",
+    "activityBar.foreground": "#ffffffCC",
+    "activityBarBadge.background": "#f97e72",
+    "activityBarBadge.foreground": "#2a2139",
+    "sideBar.background": "#241b2f",
+    "sideBar.foreground": "#ffffff99",
+    "sideBar.dropBackground": "#34294f4c",
+    "sideBarSectionHeader.background": "#241b2f",
+    "sideBarSectionHeader.foreground": "#ffffffca",
+    "menu.background": "#463465",
+    "editorGroup.border": "#495495",
+    "editorGroup.dropBackground": "#4954954a",
+    "editorGroupHeader.tabsBackground": "#241b2f",
+    "tab.border": "#241b2f00",
+    "tab.activeBorder": "#880088",
+    "tab.inactiveBackground": "#262335",
+    "editor.background": "#262335",
+    "editorLineNumber.foreground": "#ffffff73",
+    "editorLineNumber.activeForeground": "#ffffffcc",
+    "editorCursor.background": "#241b2f",
+    "editorCursor.foreground": "#f97e72",
+    "editor.selectionBackground": "#ffffff20",
+    "editor.selectionHighlightBackground": "#ffffff20",
+    "editor.wordHighlightBackground": "#34294f88",
+    "editor.wordHighlightStrongBackground": "#34294f88",
+    "editor.findMatchBackground": "#D18616bb",
+    "editor.findMatchHighlightBackground": "#D1861655",
+    "editor.findRangeHighlightBackground": "#34294f1a",
+    "editor.hoverHighlightBackground": "#463564",
+    "editor.lineHighlightBorder": "#7059AB66",
+    "editor.rangeHighlightBackground": "#49549539",
+    "editorIndentGuide.background": "#444251",
+    "editorIndentGuide.activeBackground": "#A148AB80",
+    "editorRuler.foreground": "#A148AB80",
+    "editorCodeLens.foreground": "#ffffff7c",
+    "editorBracketMatch.background": "#34294f66",
+    "editorBracketMatch.border": "#495495",
+    "editorOverviewRuler.border": "#34294fb3",
+    "editorOverviewRuler.findMatchForeground": "#D1861699",
+    "editorOverviewRuler.modifiedForeground": "#b893ce99",
+    "editorOverviewRuler.addedForeground": "#09f7a099",
+    "editorOverviewRuler.deletedForeground": "#fe445099",
+    "editorOverviewRuler.errorForeground": "#fe4450dd",
+    "editorOverviewRuler.warningForeground": "#72f1b8cc",
+    "editorError.foreground": "#fe4450",
+    "editorWarning.foreground": "#72f1b8cc",
+    "editorGutter.modifiedBackground": "#b893ce8f",
+    "editorGutter.addedBackground": "#206d4bd6",
+    "editorGutter.deletedBackground": "#fa2e46a4",
+    "diffEditor.insertedTextBackground": "#0beb9935",
+    "diffEditor.removedTextBackground": "#fe445035",
+    "editorWidget.background": "#171520DC",
+    "editorWidget.border": "#ffffff22",
+    "editorWidget.resizeBorder": "#ffffff44",
+    "editorSuggestWidget.highlightForeground": "#f97e72",
+    "editorSuggestWidget.selectedBackground": "#ffffff36",
+    "peekView.border": "#495495",
+    "peekViewEditor.background": "#232530",
+    "peekViewEditor.matchHighlightBackground": "#D18616bb",
+    "peekViewResult.background": "#232530",
+    "peekViewResult.matchHighlightBackground": "#D1861655",
+    "peekViewResult.selectionBackground": "#2a213980",
+    "peekViewTitle.background": "#232530",
+    "panelTitle.activeBorder": "#f97e72",
+    "statusBar.background": "#241b2f",
+    "statusBar.foreground": "#ffffff80",
+    "statusBar.debuggingBackground": "#f97e72",
+    "statusBar.debuggingForeground": "#08080f",
+    "statusBar.noFolderBackground": "#241b2f",
+    "statusBarItem.prominentBackground": "#2a2139",
+    "statusBarItem.prominentHoverBackground": "#34294f",
+    "titleBar.activeBackground": "#241b2f",
+    "titleBar.inactiveBackground": "#241b2f",
+    "extensionButton.prominentBackground": "#f97e72",
+    "extensionButton.prominentHoverBackground": "#ff7edb",
+    "pickerGroup.foreground": "#f97e72ea",
+    "terminal.foreground": "#ffffff",
+    "terminal.ansiBlue": "#03edf9",
+    "terminal.ansiBrightBlue": "#03edf9",
+    "terminal.ansiBrightCyan": "#03edf9",
+    "terminal.ansiBrightGreen": "#72f1b8",
+    "terminal.ansiBrightMagenta": "#ff7edb",
+    "terminal.ansiBrightRed": "#fe4450",
+    "terminal.ansiBrightYellow": "#fede5d",
+    "terminal.ansiCyan": "#03edf9",
+    "terminal.ansiGreen": "#72f1b8",
+    "terminal.ansiMagenta": "#ff7edb",
+    "terminal.ansiRed": "#fe4450",
+    "terminal.ansiYellow": "#f3e70f",
+    "terminal.selectionBackground": "#ffffff20",
+    "terminalCursor.background": "#ffffff",
+    "terminalCursor.foreground": "#03edf9",
+    "debugToolBar.background": "#463465",
+    "walkThrough.embeddedEditorBackground": "#232530",
+    "gitDecoration.modifiedResourceForeground": "#b893ceee",
+    "gitDecoration.deletedResourceForeground": "#fe4450",
+    "gitDecoration.addedResourceForeground": "#72f1b8cc",
+    "gitDecoration.untrackedResourceForeground": "#72f1b8",
+    "gitDecoration.ignoredResourceForeground": "#ffffff59",
+    "minimapGutter.addedBackground": "#09f7a099",
+    "minimapGutter.modifiedBackground": "#b893ce",
+    "minimapGutter.deletedBackground": "#fe4450",
+    "breadcrumbPicker.background": "#232530"
+  },
+  "tokenColors": [
+    {
+      "name": "Comment",
+      "scope": [
+        "comment",
+        "string.quoted.docstring.multi.python",
+        "string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+        "string.quoted.docstring.multi.python punctuation.definition.string.end.python"
+      ],
+      "settings": {
+        "foreground": "#848bbd",
+        "fontStyle": "italic"
+      }
     },
-    "tokenColors": [
-        {
-            "name": "Comment",
-            "scope": [
-                "comment",
-                "string.quoted.docstring.multi.python",
-                "string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
-                "string.quoted.docstring.multi.python punctuation.definition.string.end.python"
-            ],
-            "settings": {
-                "foreground": "#848bbd",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "String",
-            "scope": ["string.quoted", "string.template", "punctuation.definition.string"],
-            "settings": {
-                "foreground": "#ff8b39"
-            }
-        },
-        {
-            "name": "Punctuation within templates",
-            "scope": "string.template meta.embedded.line",
-            "settings": {
-                "foreground": "#b6b1b1"
-            }
-        },
-        {
-            "name": "Variable",
-            "scope": ["variable", "entity.name.variable"],
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "Language variable",
-            "scope": "variable.language",
-            "settings": {
-                "foreground": "#fe4450",
-                "fontStyle": "bold"
-            }
-        },
-        {
-            "name": "Parameter",
-            "scope": "variable.parameter",
-            "settings": {
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Storage (declaration or modifier keyword)",
-            "scope": ["storage.type", "storage.modifier"],
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Constant",
-            "scope": "constant",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Regex",
-            "scope": "string.regexp",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Number",
-            "scope": "constant.numeric",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Language constant (boolean, null)",
-            "scope": "constant.language",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Character escape",
-            "scope": "constant.character.escape",
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Entity",
-            "scope": "entity.name",
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "HTML or XML tag",
-            "scope": "entity.name.tag",
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "HTML or XML tag brackets",
-            "scope": ["punctuation.definition.tag"],
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Tag attribute",
-            "scope": "entity.other.attribute-name",
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Tag attribute HTML",
-            "scope": "entity.other.attribute-name.html",
-            "settings": {
-                "foreground": "#fede5d",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Class",
-            "scope": ["entity.name.type", "meta.attribute.class.html"],
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "Inherited class",
-            "scope": "entity.other.inherited-class",
-            "settings": {
-                "foreground": "#D50"
-            }
-        },
-        {
-            "name": "Function",
-            "scope": ["entity.name.function", "variable.function"],
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "JS Export",
-            "scope": ["keyword.control.export.js", "keyword.control.import.js"],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "JS Numerics",
-            "scope": ["constant.numeric.decimal.js"],
-            "settings": {
-                "foreground": "#2EE2FA"
-            }
-        },
-        {
-            "name": "Keyword",
-            "scope": "keyword",
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Control keyword",
-            "scope": "keyword.control",
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Operator",
-            "scope": "keyword.operator",
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Special operator",
-            "scope": [
-                "keyword.operator.new",
-                "keyword.operator.expression",
-                "keyword.operator.logical"
-            ],
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Unit",
-            "scope": "keyword.other.unit",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Support",
-            "scope": "support",
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "Support function",
-            "scope": "support.function",
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Support variable",
-            "scope": "support.variable",
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "Object literal key / property",
-            "scope": ["meta.object-literal.key", "support.type.property-name"],
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "Key-value separator",
-            "scope": "punctuation.separator.key-value",
-            "settings": {
-                "foreground": "#b6b1b1"
-            }
-        },
-        {
-            "name": "Embedded punctuation",
-            "scope": "punctuation.section.embedded",
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Template expression",
-            "scope": [
-                "punctuation.definition.template-expression.begin",
-                "punctuation.definition.template-expression.end"
-            ],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "CSS property",
-            "scope": ["support.type.property-name.css", "support.type.property-name.json"],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "JS Switch control",
-            "scope": "switch-block.expr.js",
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "JS object path",
-            "scope": "variable.other.constant.property.js, variable.other.property.js",
-            "settings": {
-                "foreground": "#2ee2fa"
-            }
-        },
-        {
-            "name": "Color",
-            "scope": "constant.other.color",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Font names",
-            "scope": "support.constant.font-name",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "CSS #id",
-            "scope": "entity.other.attribute-name.id",
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Pseudo CSS",
-            "scope": [
-                "entity.other.attribute-name.pseudo-element",
-                "entity.other.attribute-name.pseudo-class"
-            ],
-            "settings": {
-                "foreground": "#D50"
-            }
-        },
-        {
-            "name": "CSS support functions (rgb)",
-            "scope": "support.function.misc.css",
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "Markup heading",
-            "scope": ["markup.heading", "entity.name.section"],
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "Markup text",
-            "scope": ["text.html", "keyword.operator.assignment"],
-            "settings": {
-                "foreground": "#ffffffee"
-            }
-        },
-        {
-            "name": "Markup quote",
-            "scope": "markup.quote",
-            "settings": {
-                "foreground": "#b6b1b1cc",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Markup list",
-            "scope": "beginning.punctuation.definition.list",
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "Markup link",
-            "scope": "markup.underline.link",
-            "settings": {
-                "foreground": "#D50"
-            }
-        },
-        {
-            "name": "Markup link description",
-            "scope": "string.other.link.description",
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Python function call",
-            "scope": "meta.function-call.generic.python",
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Python variable params",
-            "scope": "variable.parameter.function-call.python",
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "C# storage type",
-            "scope": "storage.type.cs",
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "C# local variable",
-            "scope": "entity.name.variable.local.cs",
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "C# properties and fields",
-            "scope": ["entity.name.variable.field.cs", "entity.name.variable.property.cs"],
-            "settings": {
-                "foreground": "#ff7edb"
-            }
-        },
-        {
-            "name": "C placeholder",
-            "scope": "constant.other.placeholder.c",
-            "settings": {
-                "foreground": "#72f1b8",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "C preprocessors",
-            "scope": ["keyword.control.directive.include.c", "keyword.control.directive.define.c"],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "C storage modifier",
-            "scope": "storage.modifier.c",
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "C++ operators",
-            "scope": "source.cpp keyword.operator",
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "C++ placeholder",
-            "scope": "constant.other.placeholder.cpp",
-            "settings": {
-                "foreground": "#72f1b8",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "C++ include",
-            "scope": [
-                "keyword.control.directive.include.cpp",
-                "keyword.control.directive.define.cpp"
-            ],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "C++ constant modifier",
-            "scope": "storage.modifier.specifier.const.cpp",
-            "settings": {
-                "foreground": "#fe4450"
-            }
-        },
-        {
-            "name": "Elixir Classes",
-            "scope": [
-                "source.elixir support.type.elixir",
-                "source.elixir meta.module.elixir entity.name.class.elixir"
-            ],
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Elixir Functions",
-            "scope": "source.elixir entity.name.function",
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "Elixir Constants",
-            "scope": [
-                "source.elixir constant.other.symbol.elixir",
-                "source.elixir constant.other.keywords.elixir"
-            ],
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Elixir String Punctuation",
-            "scope": "source.elixir punctuation.definition.string",
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "Elixir",
-            "scope": [
-                "source.elixir variable.other.readwrite.module.elixir",
-                "source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir"
-            ],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "Elixir Binary Punctuation",
-            "scope": "source.elixir .punctuation.binary.elixir",
-            "settings": {
-                "foreground": "#ff7edb",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Clojure Globals",
-            "scope": ["entity.global.clojure"],
-            "settings": {
-                "foreground": "#36f9f6",
-                "fontStyle": "bold"
-            }
-        },
-        {
-            "name": "Clojure Storage",
-            "scope": ["storage.control.clojure"],
-            "settings": {
-                "foreground": "#36f9f6",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Clojure Metadata",
-            "scope": ["meta.metadata.simple.clojure", "meta.metadata.map.clojure"],
-            "settings": {
-                "foreground": "#fe4450",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Clojure Macros, Quoted",
-            "scope": ["meta.quoted-expression.clojure"],
-            "settings": {
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Clojure Symbols",
-            "scope": ["meta.symbol.clojure"],
-            "settings": {
-                "foreground": "#ff7edbff"
-            }
-        },
-        {
-            "name": "Go basic",
-            "scope": "source.go",
-            "settings": {
-                "foreground": "#ff7edbff"
-            }
-        },
-        {
-            "name": "Go Function Calls",
-            "scope": "source.go meta.function-call.go",
-            "settings": {
-                "foreground": "#36f9f6"
-            }
-        },
-        {
-            "name": "Go Keywords",
-            "scope": [
-                "source.go keyword.package.go",
-                "source.go keyword.import.go",
-                "source.go keyword.function.go",
-                "source.go keyword.type.go",
-                "source.go keyword.const.go",
-                "source.go keyword.var.go",
-                "source.go keyword.map.go",
-                "source.go keyword.channel.go",
-                "source.go keyword.control.go"
-            ],
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Go interfaces",
-            "scope": [
-                "source.go storage.type",
-                "source.go keyword.struct.go",
-                "source.go keyword.interface.go"
-            ],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "Go Constants e.g. nil, string format (%s, %d, etc.)",
-            "scope": [
-                "source.go constant.language.go",
-                "source.go constant.other.placeholder.go",
-                "source.go variable"
-            ],
-            "settings": {
-                "foreground": "#2EE2FA"
-            }
-        },
-        {
-            "name": "Markdown links and image paths",
-            "scope": ["markup.underline.link.markdown", "markup.inline.raw.string.markdown"],
-            "settings": {
-                "foreground": "#72f1b8",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Markdown links and image paths",
-            "scope": ["string.other.link.title.markdown"],
-            "settings": {
-                "foreground": "#fede5d"
-            }
-        },
-        {
-            "name": "Markdown headings",
-            "scope": ["markup.heading.markdown", "entity.name.section.markdown"],
-            "settings": {
-                "foreground": "#ff7edb",
-                "fontStyle": "bold"
-            }
-        },
-        {
-            "name": "Markdown italic",
-            "scope": ["markup.italic.markdown"],
-            "settings": {
-                "foreground": "#2EE2FA",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Markdown bold",
-            "scope": ["markup.bold.markdown"],
-            "settings": {
-                "foreground": "#2EE2FA",
-                "fontStyle": "bold"
-            }
-        },
-        {
-            "name": "Markdown quotes",
-            "scope": ["punctuation.definition.quote.begin.markdown", "markup.quote.markdown"],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "Basic source colours",
-            "scope": ["source.dart", "source.python", "source.scala"],
-            "settings": {
-                "foreground": "#ff7edbff"
-            }
-        },
-        {
-            "name": "Dart strings",
-            "scope": ["string.interpolated.single.dart"],
-            "settings": {
-                "foreground": "#f97e72"
-            }
-        },
-        {
-            "name": "Dart variable params",
-            "scope": ["variable.parameter.dart"],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        },
-        {
-            "name": "Dart numerics",
-            "scope": ["constant.numeric.dart"],
-            "settings": {
-                "foreground": "#2EE2FA"
-            }
-        },
-        {
-            "name": "Scala variable params",
-            "scope": ["variable.parameter.scala"],
-            "settings": {
-                "foreground": "#2EE2FA"
-            }
-        },
-        {
-            "name": "Scala",
-            "scope": ["meta.template.expression.scala"],
-            "settings": {
-                "foreground": "#72f1b8"
-            }
-        }
-    ]
+    {
+      "name": "String",
+      "scope": [
+        "string.quoted",
+        "string.template",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#ff8b39"
+      }
+    },
+    {
+      "name": "Punctuation within templates",
+      "scope": "string.template meta.embedded.line",
+      "settings": {
+        "foreground": "#b6b1b1"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": ["variable", "entity.name.variable"],
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "Language variable",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#fe4450",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Parameter",
+      "scope": "variable.parameter",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Storage (declaration or modifier keyword)",
+      "scope": ["storage.type", "storage.modifier"],
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Constant",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Regex",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Number",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Language constant (boolean, null)",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Character escape",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Entity",
+      "scope": "entity.name",
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "HTML or XML tag",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "HTML or XML tag brackets",
+      "scope": ["punctuation.definition.tag"],
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Tag attribute",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Tag attribute HTML",
+      "scope": "entity.other.attribute-name.html",
+      "settings": {
+        "foreground": "#fede5d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Class",
+      "scope": ["entity.name.type", "meta.attribute.class.html"],
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "Inherited class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "foreground": "#D50D50"
+      }
+    },
+    {
+      "name": "Function",
+      "scope": ["entity.name.function", "variable.function"],
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "JS Export",
+      "scope": ["keyword.control.export.js", "keyword.control.import.js"],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "JS Numerics",
+      "scope": ["constant.numeric.decimal.js"],
+      "settings": {
+        "foreground": "#2EE2FA"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Control keyword",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Operator",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Special operator",
+      "scope": [
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "keyword.operator.logical"
+      ],
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Unit",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support",
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "Support function",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Support variable",
+      "scope": "support.variable",
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "Object literal key / property",
+      "scope": ["meta.object-literal.key", "support.type.property-name"],
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "Key-value separator",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#b6b1b1"
+      }
+    },
+    {
+      "name": "Embedded punctuation",
+      "scope": "punctuation.section.embedded",
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Template expression",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "CSS property",
+      "scope": [
+        "support.type.property-name.css",
+        "support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "JS Switch control",
+      "scope": "switch-block.expr.js",
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "JS object path",
+      "scope": "variable.other.constant.property.js, variable.other.property.js",
+      "settings": {
+        "foreground": "#2ee2fa"
+      }
+    },
+    {
+      "name": "Color",
+      "scope": "constant.other.color",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Font names",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "CSS #id",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Pseudo CSS",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#D50D50"
+      }
+    },
+    {
+      "name": "CSS support functions (rgb)",
+      "scope": "support.function.misc.css",
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "Markup heading",
+      "scope": ["markup.heading", "entity.name.section"],
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "Markup text",
+      "scope": ["text.html", "keyword.operator.assignment"],
+      "settings": {
+        "foreground": "#ffffffee"
+      }
+    },
+    {
+      "name": "Markup quote",
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#b6b1b1cc",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Markup list",
+      "scope": "beginning.punctuation.definition.list",
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "Markup link",
+      "scope": "markup.underline.link",
+      "settings": {
+        "foreground": "#D50D50"
+      }
+    },
+    {
+      "name": "Markup link description",
+      "scope": "string.other.link.description",
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Python function call",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Python variable params",
+      "scope": "variable.parameter.function-call.python",
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "C# storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "C# local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "C# properties and fields",
+      "scope": [
+        "entity.name.variable.field.cs",
+        "entity.name.variable.property.cs"
+      ],
+      "settings": {
+        "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "C placeholder",
+      "scope": "constant.other.placeholder.c",
+      "settings": {
+        "foreground": "#72f1b8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C preprocessors",
+      "scope": [
+        "keyword.control.directive.include.c",
+        "keyword.control.directive.define.c"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "C storage modifier",
+      "scope": "storage.modifier.c",
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "C++ operators",
+      "scope": "source.cpp keyword.operator",
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "C++ placeholder",
+      "scope": "constant.other.placeholder.cpp",
+      "settings": {
+        "foreground": "#72f1b8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ include",
+      "scope": [
+        "keyword.control.directive.include.cpp",
+        "keyword.control.directive.define.cpp"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "C++ constant modifier",
+      "scope": "storage.modifier.specifier.const.cpp",
+      "settings": {
+        "foreground": "#fe4450"
+      }
+    },
+    {
+      "name": "Elixir Classes",
+      "scope": [
+        "source.elixir support.type.elixir",
+        "source.elixir meta.module.elixir entity.name.class.elixir"
+      ],
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Elixir Functions",
+      "scope": "source.elixir entity.name.function",
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "Elixir Constants",
+      "scope": [
+        "source.elixir constant.other.symbol.elixir",
+        "source.elixir constant.other.keywords.elixir"
+      ],
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Elixir String Punctuation",
+      "scope": "source.elixir punctuation.definition.string",
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "Elixir",
+      "scope": [
+        "source.elixir variable.other.readwrite.module.elixir",
+        "source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "Elixir Binary Punctuation",
+      "scope": "source.elixir .punctuation.binary.elixir",
+      "settings": {
+        "foreground": "#ff7edb",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Clojure Globals",
+      "scope": ["entity.global.clojure"],
+      "settings": {
+        "foreground": "#36f9f6",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Clojure Storage",
+      "scope": ["storage.control.clojure"],
+      "settings": {
+        "foreground": "#36f9f6",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Clojure Metadata",
+      "scope": ["meta.metadata.simple.clojure", "meta.metadata.map.clojure"],
+      "settings": {
+        "foreground": "#fe4450",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Clojure Macros, Quoted",
+      "scope": ["meta.quoted-expression.clojure"],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Clojure Symbols",
+      "scope": ["meta.symbol.clojure"],
+      "settings": {
+        "foreground": "#ff7edbff"
+      }
+    },
+    {
+      "name": "Go basic",
+      "scope": "source.go",
+      "settings": {
+        "foreground": "#ff7edbff"
+      }
+    },
+    {
+      "name": "Go Function Calls",
+      "scope": "source.go meta.function-call.go",
+      "settings": {
+        "foreground": "#36f9f6"
+      }
+    },
+    {
+      "name": "Go Keywords",
+      "scope": [
+        "source.go keyword.package.go",
+        "source.go keyword.import.go",
+        "source.go keyword.function.go",
+        "source.go keyword.type.go",
+        "source.go keyword.const.go",
+        "source.go keyword.var.go",
+        "source.go keyword.map.go",
+        "source.go keyword.channel.go",
+        "source.go keyword.control.go"
+      ],
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Go interfaces",
+      "scope": [
+        "source.go storage.type",
+        "source.go keyword.struct.go",
+        "source.go keyword.interface.go"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "Go Constants e.g. nil, string format (%s, %d, etc.)",
+      "scope": [
+        "source.go constant.language.go",
+        "source.go constant.other.placeholder.go",
+        "source.go variable"
+      ],
+      "settings": {
+        "foreground": "#2EE2FA"
+      }
+    },
+    {
+      "name": "Markdown links and image paths",
+      "scope": [
+        "markup.underline.link.markdown",
+        "markup.inline.raw.string.markdown"
+      ],
+      "settings": {
+        "foreground": "#72f1b8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Markdown links and image paths",
+      "scope": ["string.other.link.title.markdown"],
+      "settings": {
+        "foreground": "#fede5d"
+      }
+    },
+    {
+      "name": "Markdown headings",
+      "scope": ["markup.heading.markdown", "entity.name.section.markdown"],
+      "settings": {
+        "foreground": "#ff7edb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown italic",
+      "scope": ["markup.italic.markdown"],
+      "settings": {
+        "foreground": "#2EE2FA",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Markdown bold",
+      "scope": ["markup.bold.markdown"],
+      "settings": {
+        "foreground": "#2EE2FA",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown quotes",
+      "scope": [
+        "punctuation.definition.quote.begin.markdown",
+        "markup.quote.markdown"
+      ],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "Basic source colours",
+      "scope": ["source.dart", "source.python", "source.scala"],
+      "settings": {
+        "foreground": "#ff7edbff"
+      }
+    },
+    {
+      "name": "Dart strings",
+      "scope": ["string.interpolated.single.dart"],
+      "settings": {
+        "foreground": "#f97e72"
+      }
+    },
+    {
+      "name": "Dart variable params",
+      "scope": ["variable.parameter.dart"],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    },
+    {
+      "name": "Dart numerics",
+      "scope": ["constant.numeric.dart"],
+      "settings": {
+        "foreground": "#2EE2FA"
+      }
+    },
+    {
+      "name": "Scala variable params",
+      "scope": ["variable.parameter.scala"],
+      "settings": {
+        "foreground": "#2EE2FA"
+      }
+    },
+    {
+      "name": "Scala",
+      "scope": ["meta.template.expression.scala"],
+      "settings": {
+        "foreground": "#72f1b8"
+      }
+    }
+  ]
 }

--- a/crates/theme2/src/themes/andromeda.rs
+++ b/crates/theme2/src/themes/andromeda.rs
@@ -77,6 +77,20 @@ pub fn andromeda() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc64dedff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf39c11ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xffe66dff).into()),
@@ -91,7 +105,35 @@ pub fn andromeda() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf39c11ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xee5d42ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x95e072ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf92571ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x95e072ff).into()),
                                     ..Default::default()
@@ -101,6 +143,13 @@ pub fn andromeda() -> UserThemeFamily {
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xffe66dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00e8c6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -171,6 +220,20 @@ pub fn andromeda() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc64dedff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf39c11ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xffe66dff).into()),
@@ -185,7 +248,35 @@ pub fn andromeda() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf39c11ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xee5d42ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x95e072ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf92571ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x95e072ff).into()),
                                     ..Default::default()
@@ -195,6 +286,13 @@ pub fn andromeda() -> UserThemeFamily {
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xffe66dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00e8c6ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -96,6 +96,29 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c6166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7070ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7070ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xf2ad48ff).into()),
@@ -110,6 +133,76 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x86b300ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55b4d3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55b4d3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa37accff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xed9365ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7070ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c6166b3).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55b4d380).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c6166b3).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf2ad48ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x86b300ff).into()),
@@ -117,10 +210,65 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "variable".into(),
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4bbf98ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x86b300ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x86b300ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x55b4d3ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x86b300ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x389ee6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55b4d3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c6166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7070ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -210,6 +358,29 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcccac2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf18678ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf18678ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xffd173ff).into()),
@@ -224,6 +395,76 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd4fe7fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5ccfe6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5ccfe6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdfbfffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf29e74ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf18678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcccac2b3).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5ccfe680).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcccac2b3).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffd173ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xd4fe7fff).into()),
@@ -231,10 +472,65 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "variable".into(),
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x95e6cbff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd4fe7fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd4fe7fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x5ccfe6ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd4fe7fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x73cfffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5ccfe6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcccac2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf18678ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -324,6 +620,29 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbfbdb6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7077ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7077ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xffb353ff).into()),
@@ -338,6 +657,76 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa9d94bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x38b9e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x38b9e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd2a6ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf29668ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7077ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbfbdb6b3).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x38b9e680).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbfbdb6b3).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffb353ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xa9d94bff).into()),
@@ -345,10 +734,65 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "variable".into(),
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x95e6cbff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa9d94bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa9d94bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x38b9e6ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa9d94bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x59c2ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x38b9e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbfbdb6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xef7077ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -85,7 +85,16 @@ pub fn dracula() -> UserThemeFamily {
                         (
                             "emphasis".into(),
                             UserHighlightStyle {
+                                color: Some(rgba(0xf1fa8cff).into()),
                                 font_style: Some(UserFontStyle::Italic),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "emphasis.strong".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xffb76bff).into()),
+                                font_weight: Some(UserFontWeight(700.0)),
                                 ..Default::default()
                             },
                         ),
@@ -104,7 +113,35 @@ pub fn dracula() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "link_text".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x8be9fdff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "link_uri".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x8be9fdff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "string".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xf1fa8cff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "tag".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xff79c6ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "text.literal".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xf1fa8cff).into()),
                                 ..Default::default()
@@ -120,6 +157,14 @@ pub fn dracula() -> UserThemeFamily {
                         ),
                         (
                             "variable".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xbd93f9ff).into()),
+                                font_style: Some(UserFontStyle::Italic),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "variable.special".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xbd93f9ff).into()),
                                 font_style: Some(UserFontStyle::Italic),

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -88,6 +88,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfe7f18ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfabd2eff).into()),
@@ -98,6 +106,41 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfb4833ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679d6aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -123,9 +166,37 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8bb25ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -207,6 +278,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfe7f18ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfabd2eff).into()),
@@ -217,6 +296,41 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfb4833ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679d6aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -242,9 +356,37 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8bb25ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -326,6 +468,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfe7f18ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfabd2eff).into()),
@@ -336,6 +486,41 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfb4833ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679d6aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -361,9 +546,37 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8bb25ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfabd2eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -445,6 +658,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaf3a02ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb57613ff).into()),
@@ -455,6 +676,41 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x9d0006ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3e71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3e71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679d6aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -480,9 +736,37 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x79740eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x066578ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -564,6 +848,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaf3a02ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb57613ff).into()),
@@ -574,6 +866,41 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x9d0006ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3e71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3e71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679d6aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -599,9 +926,37 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x79740eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x066578ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -683,6 +1038,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaf3a02ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb57613ff).into()),
@@ -693,6 +1056,41 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x9d0006ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3e71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3e71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679d6aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -718,9 +1116,37 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x79740eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb57613ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x066578ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/night_owl.rs
+++ b/crates/theme2/src/themes/night_owl.rs
@@ -113,6 +113,35 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf78b6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fdbcaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fcac3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xecc48dff).into()),
@@ -120,7 +149,42 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x82aaffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcaece6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xecc48dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc5e478ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc5e478ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x7fdbcaff).into()),
                                     ..Default::default()
@@ -230,6 +294,35 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa0881ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0b969bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0b969bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x994bc3ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x4876d6ff).into()),
@@ -237,7 +330,42 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4876d6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x994bc3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4876d6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4876d6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4876d6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0b969bff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/noctis.rs
+++ b/crates/theme2/src/themes/noctis.rs
@@ -97,6 +97,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -111,6 +118,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5888a5ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbecfdaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -118,7 +181,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbecfdaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()
@@ -211,6 +316,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -225,6 +337,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8b737bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcbbec2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -232,7 +400,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcbbec2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()
@@ -325,6 +535,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0094a8ff).into()),
@@ -339,6 +556,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5841ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ca6a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x004d57ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x00b368ff).into()),
@@ -346,7 +619,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x004d57ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff5792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00b368ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfa8900ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
@@ -439,6 +754,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0094a8ff).into()),
@@ -453,6 +775,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5841ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9995b7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0c006bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x00b368ff).into()),
@@ -460,7 +838,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0c006bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff5792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00b368ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfa8900ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
@@ -553,6 +973,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0094a8ff).into()),
@@ -567,6 +994,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5841ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0094a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ca6a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x004d57ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x00b368ff).into()),
@@ -574,7 +1057,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x004d57ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff5792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00b368ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfa8900ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
@@ -667,6 +1192,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x3e848dff).into()),
@@ -681,6 +1213,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x72b7c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3e848dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3e848dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7067b1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3e848dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5d7787ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc5cdd3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x72c09fff).into()),
@@ -688,7 +1276,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc5cdd3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc88da2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x72c09fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x72b7c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x72b7c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3b692ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc37455ff).into()),
                                     ..Default::default()
@@ -781,6 +1411,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -795,6 +1432,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b858bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb1c9ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -802,7 +1495,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb1c9ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()
@@ -895,6 +1630,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -909,6 +1651,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b858bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb1c9ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -916,7 +1714,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb1c9ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()
@@ -1009,6 +1849,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -1023,6 +1870,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b858bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb1c9ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -1030,7 +1933,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb1c9ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()
@@ -1123,6 +2068,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -1137,6 +2089,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x716b93ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc5c2d6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -1144,7 +2152,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc5c2d6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()
@@ -1237,6 +2287,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x15a2b6ff).into()),
@@ -1251,6 +2308,62 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x705febff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x15a2b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7e6499ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xccbfd9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x49e9a6ff).into()),
@@ -1258,7 +2371,49 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xccbfd9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf759aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49e9a6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x49d5e9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe4b781ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe66432ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/nord.rs
+++ b/crates/theme2/src/themes/nord.rs
@@ -96,9 +96,9 @@ pub fn nord() -> UserThemeFamily {
                             },
                         ),
                         (
-                            "emphasis".into(),
+                            "emphasis.strong".into(),
                             UserHighlightStyle {
-                                font_style: Some(UserFontStyle::Italic),
+                                font_weight: Some(UserFontWeight(700.0)),
                                 ..Default::default()
                             },
                         ),
@@ -117,9 +117,30 @@ pub fn nord() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "number".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xb48eacff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "operator".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x81a1c1ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "punctuation".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xeceff4ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "punctuation.delimiter".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x81a1c1ff).into()),
                                 ..Default::default()
                             },
                         ),
@@ -131,7 +152,42 @@ pub fn nord() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "string.escape".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xebcb8bff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "tag".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x81a1c1ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "text.literal".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xa3be8cff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "type".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x8fbcbbff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "variable".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x81a1c1ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "variable.special".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0x81a1c1ff).into()),
                                 ..Default::default()

--- a/crates/theme2/src/themes/palenight.rs
+++ b/crates/theme2/src/themes/palenight.rs
@@ -96,6 +96,22 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x82aaffff).into()),
@@ -110,6 +126,48 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff869aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff869aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf78b6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x89ddffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fcac3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc3e88dff).into()),
@@ -117,7 +175,42 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x82aaffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff5571ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc3e88dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xff5571ff).into()),
                                     ..Default::default()
@@ -209,6 +302,22 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x82aaffff).into()),
@@ -223,6 +332,48 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff869aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff869aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf78b6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x89ddffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fcac3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc3e88dff).into()),
@@ -230,7 +381,42 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x82aaffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff5571ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc3e88dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xff5571ff).into()),
                                     ..Default::default()
@@ -322,6 +508,22 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x82aaffff).into()),
@@ -336,6 +538,48 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff869aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff869aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf78b6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x89ddffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fcac3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc3e88dff).into()),
@@ -343,7 +587,42 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x82aaffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xff5571ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc3e88dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffcb6bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xff5571ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -91,9 +91,31 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xeb6f92ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x30738fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -112,6 +134,27 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9ccfd8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf5c177ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x9ccfd8ff).into()),
@@ -120,6 +163,14 @@ pub fn rose_pine() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe0def4ff).into()),
                                     ..Default::default()
@@ -206,9 +257,31 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xeb6f92ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x3d8fb0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xea9a97ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xea9a97ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -227,6 +300,27 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9ccfd8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf5c177ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xea9a97ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x9ccfd8ff).into()),
@@ -235,6 +329,14 @@ pub fn rose_pine() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xea9a97ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe0def4ff).into()),
                                     ..Default::default()
@@ -321,9 +423,31 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb3627aff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "keyword".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x276983ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd7827dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd7827dff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -342,6 +466,27 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55949fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xea9d34ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd7827dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "type".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x55949fff).into()),
@@ -350,6 +495,14 @@ pub fn rose_pine() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd7827dff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x575279ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -181,7 +181,7 @@ pub fn rose_pine() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Rose Moon".into(),
+                name: "Rose Pine Moon".into(),
                 appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {

--- a/crates/theme2/src/themes/solarized.rs
+++ b/crates/theme2/src/themes/solarized.rs
@@ -93,6 +93,27 @@ pub fn solarized() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x93a1a1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd33582ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd33582ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x258ad2ff).into()),
@@ -107,6 +128,13 @@ pub fn solarized() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd33582ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "property".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x839496ff).into()),
@@ -114,7 +142,35 @@ pub fn solarized() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x657b83ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x29a198ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4b15ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x258ad2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x29a198ff).into()),
                                     ..Default::default()
@@ -129,6 +185,13 @@ pub fn solarized() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x258ad2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x258ad2ff).into()),
                                     ..Default::default()
@@ -214,6 +277,27 @@ pub fn solarized() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x657b83ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd33582ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd33582ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x258ad2ff).into()),
@@ -228,7 +312,42 @@ pub fn solarized() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd33582ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x93a1a1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x29a198ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4b15ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x258ad2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x29a198ff).into()),
                                     ..Default::default()
@@ -243,6 +362,13 @@ pub fn solarized() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x258ad2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x258ad2ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/synthwave_84.rs
+++ b/crates/theme2/src/themes/synthwave_84.rs
@@ -89,6 +89,69 @@ pub fn synthwave_84() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "label".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xfe444fff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "link_text".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xd50c50ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "link_uri".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xd50c50ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "number".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xf97d71ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "operator".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xfede5cff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "property".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xff7ddaff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "punctuation".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x35f9f5ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "tag".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x71f1b7ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "title".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xfe444fff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "type".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xfe444fff).into()),
@@ -97,6 +160,13 @@ pub fn synthwave_84() -> UserThemeFamily {
                         ),
                         (
                             "variable".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xff7ddaff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "variable.special".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xfe444fff).into()),
                                 font_weight: Some(UserFontWeight(700.0)),

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -11,7 +11,7 @@ use crate::util::Traverse;
 use crate::vscode::VsCodeTheme;
 use crate::ThemeMetadata;
 
-use super::{VsCodeTokenScope, ZedSyntaxToken};
+use super::ZedSyntaxToken;
 
 pub(crate) fn try_parse_color(color: &str) -> Result<Hsla> {
     Ok(Rgba::try_from(color)?.into())

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -268,19 +268,15 @@ impl VsCodeThemeConverter {
         let mut highlight_styles = IndexMap::new();
 
         for syntax_token in ZedSyntaxToken::iter() {
-            let vscode_scope = syntax_token.to_vscode();
+            let multimatch_scopes = syntax_token.to_vscode();
 
-            let token_color = self
-                .theme
-                .token_colors
-                .iter()
-                .find(|token_color| match token_color.scope {
-                    Some(VsCodeTokenScope::One(ref scope)) => scope == vscode_scope,
-                    Some(VsCodeTokenScope::Many(ref scopes)) => {
-                        scopes.contains(&vscode_scope.to_string())
-                    }
-                    None => false,
-                });
+            let token_color = self.theme.token_colors.iter().find(|token_color| {
+                token_color
+                    .scope
+                    .as_ref()
+                    .map(|scope| scope.multimatch(&multimatch_scopes))
+                    .unwrap_or(false)
+            });
 
             let Some(token_color) = token_color else {
                 continue;

--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -8,6 +8,17 @@ pub enum VsCodeTokenScope {
     Many(Vec<String>),
 }
 
+impl VsCodeTokenScope {
+    pub fn multimatch(&self, matches: &[&'static str]) -> bool {
+        match self {
+            VsCodeTokenScope::One(scope) => matches.iter().any(|&s| s == scope),
+            VsCodeTokenScope::Many(scopes) => {
+                matches.iter().any(|s| scopes.contains(&s.to_string()))
+            }
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct VsCodeTokenColor {
     pub scope: Option<VsCodeTokenScope>,
@@ -118,49 +129,90 @@ impl std::fmt::Display for ZedSyntaxToken {
 }
 
 impl ZedSyntaxToken {
-    pub fn to_vscode(&self) -> &'static str {
+    pub fn to_vscode(&self) -> Vec<&'static str> {
         use ZedSyntaxToken::*;
 
         match self {
-            SyntaxAttribute => "entity.other.attribute-name",
-            SyntaxBoolean => "constant.language",
-            SyntaxComment => "comment",
-            SyntaxCommentDoc => "comment.block.documentation",
-            SyntaxConstant => "constant.character",
-            SyntaxConstructor => "entity.name.function.definition.special.constructor",
-            SyntaxEmbedded => "embedded",
-            SyntaxEmphasis => "emphasis",
-            SyntaxEmphasisStrong => "emphasis.strong",
-            SyntaxEnum => "support.type.enum",
-            SyntaxFunction => "entity.name.function",
-            SyntaxHint => "hint",
-            SyntaxKeyword => "keyword",
-            SyntaxLabel => "label",
-            SyntaxLinkText => "link_text",
-            SyntaxLinkUri => "link_uri",
-            SyntaxNumber => "number",
-            SyntaxOperator => "operator",
-            SyntaxPredictive => "predictive",
-            SyntaxPreproc => "preproc",
-            SyntaxPrimary => "primary",
-            SyntaxProperty => "variable.object.property", //"variable.other.field"
-            SyntaxPunctuation => "punctuation",
-            SyntaxPunctuationBracket => "punctuation.bracket",
-            SyntaxPunctuationDelimiter => "punctuation.delimiter",
-            SyntaxPunctuationListMarker => "punctuation.list_marker",
-            SyntaxPunctuationSpecial => "punctuation.special",
-            SyntaxString => "string",
-            SyntaxStringEscape => "string.escape",
-            SyntaxStringRegex => "string.regex",
-            SyntaxStringSpecial => "string.special",
-            SyntaxStringSpecialSymbol => "string.special.symbol",
-            SyntaxTag => "tag",
-            SyntaxTextLiteral => "text.literal",
-            SyntaxTitle => "title",
-            SyntaxType => "entity.name.type",
-            SyntaxVariable => "variable.language",
-            SyntaxVariableSpecial => "variable.special",
-            SyntaxVariant => "variant",
+            SyntaxAttribute => vec!["entity.other.attribute-name"],
+            SyntaxBoolean => vec!["constant.language"],
+            SyntaxComment => vec!["comment"],
+            SyntaxCommentDoc => vec!["comment.block.documentation"],
+            SyntaxConstant => vec!["constant.character"],
+            SyntaxConstructor => vec!["entity.name.function.definition.special.constructor"],
+            SyntaxEmbedded => vec!["meta.embedded"],
+            SyntaxEmphasis => vec!["markup.italic"],
+            SyntaxEmphasisStrong => vec![
+                "markup.bold",
+                "markup.italic markup.bold",
+                "markup.bold markup.italic",
+            ],
+            SyntaxEnum => vec!["support.type.enum"],
+            SyntaxFunction => vec![
+                "entity.name.function",
+                "variable.function",
+                "support.function",
+            ],
+            SyntaxKeyword => vec!["keyword"],
+            SyntaxLabel => vec![
+                "label",
+                "entity.name",
+                "entity.name.import",
+                "entity.name.package",
+            ],
+            SyntaxLinkText => vec!["markup.underline.link", "string.other.link"],
+            SyntaxLinkUri => vec!["markup.underline.link", "string.other.link"],
+            SyntaxNumber => vec!["constant.numeric", "number"],
+            SyntaxOperator => vec!["operator", "keyword.operator"],
+            SyntaxPreproc => vec!["preproc"],
+            SyntaxProperty => vec![
+                "variable.member",
+                "support.type.property-name",
+                "variable.object.property",
+                "variable.other.field",
+            ],
+            SyntaxPunctuation => vec![
+                "punctuation",
+                "punctuation.section",
+                "punctuation.accessor",
+                "punctuation.separator",
+                "punctuation.terminator",
+                "punctuation.definition.tag",
+            ],
+            SyntaxPunctuationBracket => vec![
+                "punctuation.bracket",
+                "punctuation.definition.tag.begin",
+                "punctuation.definition.tag.end",
+            ],
+            SyntaxPunctuationDelimiter => vec![
+                "punctuation.delimiter",
+                "punctuation.separator",
+                "punctuation.terminator",
+            ],
+            SyntaxPunctuationListMarker => vec!["markup.list punctuation.definition.list.begin"],
+            SyntaxPunctuationSpecial => vec!["punctuation.special"],
+            SyntaxString => vec!["string"],
+            SyntaxStringEscape => vec!["string.escape", "constant.character", "constant.other"],
+            SyntaxStringRegex => vec!["string.regex"],
+            SyntaxStringSpecial => vec!["string.special", "constant.other.symbol"],
+            SyntaxStringSpecialSymbol => vec!["string.special.symbol", "constant.other.symbol"],
+            SyntaxTag => vec!["tag", "entity.name.tag", "meta.tag.sgml"],
+            SyntaxTextLiteral => vec!["text.literal", "string"],
+            SyntaxTitle => vec!["title", "entity.name"],
+            SyntaxType => vec!["entity.name.type", "support.type", "support.class"],
+            SyntaxVariable => vec![
+                "variable",
+                "variable.language",
+                "variable.member",
+                "variable.parameter.function-call",
+            ],
+            SyntaxVariableSpecial => vec![
+                "variable.special",
+                "variable.member",
+                "variable.annotation",
+                "variable.language",
+            ],
+            SyntaxVariant => vec!["variant"],
+            _ => vec![],
         }
     }
 }


### PR DESCRIPTION
[[PR Description]]

Adds the ability to specify a vec of VScode syntax scopes to match against for a given syntax style.

Example:

```rust
pub fn to_vscode(&self) -> Vec<&'static str> {
        use ZedSyntaxToken::*;

        match self {
            SyntaxAttribute => vec!["entity.other.attribute-name"],
            SyntaxBoolean => vec!["constant.language"],
            SyntaxComment => vec!["comment"],
            SyntaxCommentDoc => vec!["comment.block.documentation"],
            SyntaxConstant => vec!["constant.character"],
            SyntaxConstructor => vec!["entity.name.function.definition.special.constructor"],
            SyntaxEmbedded => vec!["meta.embedded"],
            SyntaxEmphasis => vec!["markup.italic"],
            SyntaxEmphasisStrong => vec![
                "markup.bold",
                "markup.italic markup.bold",
                "markup.bold markup.italic",
            ],
            SyntaxEnum => vec!["support.type.enum"],
            SyntaxFunction => vec![
                "entity.name.function",
                "variable.function",
                "support.function",
            ],
            SyntaxKeyword => vec!["keyword"],
            SyntaxLabel => vec![
                "label",
                "entity.name",
                "entity.name.import",
                "entity.name.package",
            ],
            // .. more styles
}}
```

Useful `settings.json` for testing themes:

```json5
{
  // --- Dark Themes ---
  "theme": "Ayu Dark"
  // "theme": "Ayu Mirage"
  // "theme": "Dracula"
  // "theme": "Gruvbox Dark Hard"
  // "theme": "Gruvbox Dark Medium"
  // "theme": "Gruvbox Dark Soft"
  // "theme": "Night Owl"
  // "theme": "Noctis Obscuro"
  // "theme": "Noctis"
  // "theme": "Nord"
  // "theme": "Palenight (Mild Contrast)"
  // "theme": "Palenight Operator"
  // "theme": "Palenight"
  // "theme": "Rose Pine Moon"
  // "theme": "Rose Pine"
  // "theme": "Solarized Dark"
  // "theme": "Synthwave 84"
  // --- Light Themes ---
  // "theme": "Ayu Light"
  // "theme": "Gruvbox Light Hard"
  // "theme": "Gruvbox Light Medium"
  // "theme": "Gruvbox Light Soft"
  // "theme": "Noctis Lux"
  // "theme": "Rose Pine Dawn"
  // "theme": "Solarized Light"
}
```

Release Notes:

- N/A
