### PR TITLE
Extend RGBA hex color parsing to support 3-value and 4-value variants

### DIFF
--- a/crates/gpui2/src/color.rs
+++ b/crates/gpui2/src/color.rs
@@ -127,19 +127,22 @@ impl TryFrom<&'_ str> for Rgba {
 
         let (r, g, b, a) = match hex.len() {
             RGB | RGBA => {
-                // There's likely a better way to handle 3 and 4-value hex codes without
-                // needing to use `.repeat` and incur additional allocations.
-                // What we probably want to do is parse the single hex digit and then perform
-                // bit-shifting to "duplicate" the digit.
-                let r = u8::from_str_radix(&hex[0..1].repeat(2), 16)?;
-                let g = u8::from_str_radix(&hex[1..2].repeat(2), 16)?;
-                let b = u8::from_str_radix(&hex[2..3].repeat(2), 16)?;
+                let r = u8::from_str_radix(&hex[0..1], 16)?;
+                let g = u8::from_str_radix(&hex[1..2], 16)?;
+                let b = u8::from_str_radix(&hex[2..3], 16)?;
                 let a = if hex.len() == RGBA {
-                    u8::from_str_radix(&hex[3..4].repeat(2), 16)?
+                    u8::from_str_radix(&hex[3..4], 16)?
                 } else {
-                    0xff
+                    0xf
                 };
-                (r, g, b, a)
+
+                /// Duplicates a given hex digit.
+                /// E.g., `0xf` -> `0xff`.
+                const fn duplicate(value: u8) -> u8 {
+                    value << 4 | value
+                }
+
+                (duplicate(r), duplicate(g), duplicate(b), duplicate(a))
             }
             RRGGBB | RRGGBBAA => {
                 let r = u8::from_str_radix(&hex[0..2], 16)?;

--- a/crates/theme2/src/default_colors.rs
+++ b/crates/theme2/src/default_colors.rs
@@ -1,5 +1,3 @@
-use std::num::ParseIntError;
-
 use gpui::{hsla, Hsla, Rgba};
 
 use crate::colors::{StatusColors, SystemColors, ThemeColors};
@@ -413,10 +411,10 @@ struct StaticColorScaleSet {
 }
 
 impl TryFrom<StaticColorScaleSet> for ColorScaleSet {
-    type Error = ParseIntError;
+    type Error = anyhow::Error;
 
     fn try_from(value: StaticColorScaleSet) -> Result<Self, Self::Error> {
-        fn to_color_scale(scale: StaticColorScale) -> Result<ColorScale, ParseIntError> {
+        fn to_color_scale(scale: StaticColorScale) -> Result<ColorScale, anyhow::Error> {
             scale
                 .into_iter()
                 .map(|color| Rgba::try_from(color).map(Hsla::from))


### PR DESCRIPTION
This PR extends our support for parsing hex color codes to `Rgba` to additionally support 3-value (`#rgb`) and 4-value (`#rgba`) formats.

See [here](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color) for more details on these hex color variants.

Release Notes:

- N/A
