### PR TITLE
theme_importer: Support importing themes containing comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,6 +4434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_comments"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+
+[[package]]
 name = "jwt"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9156,6 +9162,7 @@ dependencies = [
  "convert_case 0.6.0",
  "gpui2",
  "indexmap 1.9.3",
+ "json_comments",
  "log",
  "rust-embed",
  "serde",

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 convert_case = "0.6.0"
 gpui = { package = "gpui2", path = "../gpui2" }
 indexmap = "1.6.2"
+json_comments = "0.2.2"
 log.workspace = true
 rust-embed.workspace = true
 serde.workspace = true

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context, Result};
 use convert_case::{Case, Casing};
 use gpui::serde_json;
+use json_comments::StripComments;
 use log::LevelFilter;
 use serde::Deserialize;
 use simplelog::SimpleLogger;
@@ -111,7 +112,8 @@ fn main() -> Result<()> {
                 }
             };
 
-            let vscode_theme: VsCodeTheme = serde_json::from_reader(theme_file)
+            let theme_without_comments = StripComments::new(theme_file);
+            let vscode_theme: VsCodeTheme = serde_json::from_reader(theme_without_comments)
                 .context(format!("failed to parse theme {theme_file_path:?}"))?;
 
             let converter = VsCodeThemeConverter::new(vscode_theme, theme_metadata);


### PR DESCRIPTION
This PR updates the `theme_importer` with support for parsing theme files containing comments.

Up until now we've been manually removing comments from the VS Code theme files.

Release Notes:

- N/A
