### PR TITLE
Do not add diagnostics for any selection in the diagnostics panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -209,7 +209,7 @@
   "ensure_final_newline_on_save": true,
   // Whether or not to perform a buffer format before saving
   "format_on_save": "on",
-  // How to perform a buffer format. This setting can take two values:
+  // How to perform a buffer format. This setting can take 4 values:
   //
   // 1. Format code using the current language server:
   //     "formatter": "language_server"

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -171,10 +171,9 @@ impl ProjectDiagnosticsEditor {
                         .entry(*language_server_id)
                         .or_default()
                         .insert(path.clone());
-                    let no_multiselections = this.editor.update(cx, |editor, cx| {
-                        editor.selections.all::<usize>(cx).len() <= 1
-                    });
-                    if no_multiselections && !this.is_dirty(cx) {
+                    if this.editor.read(cx).selections.all::<usize>(cx).is_empty()
+                        && !this.is_dirty(cx)
+                    {
                         this.update_excerpts(Some(*language_server_id), cx);
                     }
                 }


### PR DESCRIPTION
Make the panel less jumpy by deferring diagnostics updates until cmd-s is pressed, if any caret is placed inside the diagnostics panel.

Release Notes:

- N/A