### PR TITLE
chore: Bump cc to 1.0.84

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,11 +1275,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -4393,15 +4392,6 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "journal"


### PR DESCRIPTION
This resolves a minor issue where build scripts could've acquired more job server tokens from Cargo than allowed by `-j` parameter. I've filled a PR at https://github.com/rust-lang/cc-rs/pull/878 and we've iterated on the design over there since.

TL;DR: some build scripts may complete a tad bit quicker, potentially shaving off a few seconds off of debug/release builds. Full description of the issue is available in https://github.com/rust-lang/cc-rs/issues/858

Release Notes:

- N/A
