### PR TITLE
Use non-deprecated build flags

### DIFF
--- a/crates/live_kit_client/build.rs
+++ b/crates/live_kit_client/build.rs
@@ -66,7 +66,7 @@ fn build_bridge(swift_target: &SwiftTarget) {
         .arg("--disable-automatic-resolution")
         .args(["--configuration", &env::var("PROFILE").unwrap()])
         .args(["--triple", &swift_target.target.triple])
-        .args(["--build-path".into(), swift_target_folder])
+        .args(["--scratch-path".into(), swift_target_folder])
         .current_dir(&swift_package_root)
         .status()
         .unwrap()

--- a/crates/live_kit_client2/build.rs
+++ b/crates/live_kit_client2/build.rs
@@ -66,7 +66,7 @@ fn build_bridge(swift_target: &SwiftTarget) {
         .arg("--disable-automatic-resolution")
         .args(["--configuration", &env::var("PROFILE").unwrap()])
         .args(["--triple", &swift_target.target.triple])
-        .args(["--build-path".into(), swift_target_folder])
+        .args(["--scratch-path".into(), swift_target_folder])
         .current_dir(&swift_package_root)
         .status()
         .unwrap()


### PR DESCRIPTION
I've got an odd CI run that got cured by restarting, but the failure is somewhat interesting.
https://github.com/zed-industries/zed/actions/runs/6850564599/job/18625131903

The PR fixes a warning from
https://github.com/zed-industries/zed/actions/runs/6850564599/job/18625131903#step:8:456
> warning: '--build-path' option is deprecated; use '--scratch-path' instead

More details in somewhat related PR:
https://github.com/swift-server/vscode-swift/pull/531

--------

Also, there is
https://github.com/zed-industries/zed/actions/runs/6850564599/job/18625131903#step:8:480
> error: an out-of-date resolved file was detected at /Users/administrator/actions-runner-2/_work/zed/zed/crates/live_kit_client/LiveKitBridge/Package.resolved, which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because the following dependencies were added: 'client-sdk-swift' (https://github.com/livekit/client-sdk-swift.git)

which is quite oddly formulated: I would expect that the resolve file is a lock file analogue and should be fine to use outdated.
The PR does not address this, and future CI runs does not seem to have issues with it?


Release Notes:

- N/A