### PR TITLE
Allow a button to take a color

### DIFF
--- a/crates/ui2/src/components/icon.rs
+++ b/crates/ui2/src/components/icon.rs
@@ -1,7 +1,7 @@
 use gpui::{rems, svg, Hsla};
 use strum::EnumIter;
 
-use crate::prelude::*;
+use crate::{prelude::*, LabelColor};
 
 #[derive(Default, PartialEq, Copy, Clone)]
 pub enum IconSize {
@@ -14,15 +14,20 @@ pub enum IconSize {
 pub enum IconColor {
     #[default]
     Default,
-    Muted,
-    Disabled,
-    Placeholder,
     Accent,
+    Created,
+    Deleted,
+    Disabled,
     Error,
-    Warning,
-    Success,
+    Hidden,
     Info,
+    Modified,
+    Muted,
+    Placeholder,
+    Player(u32),
     Selected,
+    Success,
+    Warning,
 }
 
 impl IconColor {
@@ -38,6 +43,33 @@ impl IconColor {
             IconColor::Success => cx.theme().status().success,
             IconColor::Info => cx.theme().status().info,
             IconColor::Selected => cx.theme().colors().icon_accent,
+            IconColor::Player(i) => cx.theme().styles.player.0[i.clone() as usize].cursor,
+            IconColor::Created => cx.theme().status().created,
+            IconColor::Modified => cx.theme().status().modified,
+            IconColor::Deleted => cx.theme().status().deleted,
+            IconColor::Hidden => cx.theme().status().hidden,
+        }
+    }
+}
+
+impl From<LabelColor> for IconColor {
+    fn from(label: LabelColor) -> Self {
+        match label {
+            LabelColor::Default => IconColor::Default,
+            LabelColor::Muted => IconColor::Muted,
+            LabelColor::Disabled => IconColor::Disabled,
+            LabelColor::Placeholder => IconColor::Placeholder,
+            LabelColor::Accent => IconColor::Accent,
+            LabelColor::Error => IconColor::Error,
+            LabelColor::Warning => IconColor::Warning,
+            LabelColor::Success => IconColor::Success,
+            LabelColor::Info => IconColor::Info,
+            LabelColor::Selected => IconColor::Selected,
+            LabelColor::Player(i) => IconColor::Player(i),
+            LabelColor::Created => IconColor::Created,
+            LabelColor::Modified => IconColor::Modified,
+            LabelColor::Deleted => IconColor::Deleted,
+            LabelColor::Hidden => IconColor::Hidden,
         }
     }
 }

--- a/crates/ui2/src/components/icon_button.rs
+++ b/crates/ui2/src/components/icon_button.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::{rems, MouseButton};
+use gpui::MouseButton;
 
 use crate::{h_stack, prelude::*};
 use crate::{ClickHandler, Icon, IconColor, IconElement};
@@ -88,9 +88,7 @@ impl<V: 'static> IconButton<V> {
             .id(self.id.clone())
             .justify_center()
             .rounded_md()
-            // todo!("Where do these numbers come from?")
-            .py(rems(0.21875))
-            .px(rems(0.375))
+            .p_1()
             .bg(bg_color)
             .hover(|style| style.bg(bg_hover_color))
             .active(|style| style.bg(bg_active_color))

--- a/crates/ui2/src/components/label.rs
+++ b/crates/ui2/src/components/label.rs
@@ -8,28 +8,40 @@ use crate::styled_ext::StyledExt;
 pub enum LabelColor {
     #[default]
     Default,
-    Muted,
+    Accent,
     Created,
-    Modified,
     Deleted,
     Disabled,
+    Error,
     Hidden,
+    Info,
+    Modified,
+    Muted,
     Placeholder,
-    Accent,
+    Player(u32),
+    Selected,
+    Success,
+    Warning,
 }
 
 impl LabelColor {
     pub fn hsla(&self, cx: &WindowContext) -> Hsla {
         match self {
-            Self::Default => cx.theme().colors().text,
-            Self::Muted => cx.theme().colors().text_muted,
-            Self::Created => cx.theme().status().created,
-            Self::Modified => cx.theme().status().modified,
-            Self::Deleted => cx.theme().status().deleted,
-            Self::Disabled => cx.theme().colors().text_disabled,
-            Self::Hidden => cx.theme().status().hidden,
-            Self::Placeholder => cx.theme().colors().text_placeholder,
-            Self::Accent => cx.theme().colors().text_accent,
+            LabelColor::Default => cx.theme().colors().text,
+            LabelColor::Muted => cx.theme().colors().text_muted,
+            LabelColor::Created => cx.theme().status().created,
+            LabelColor::Modified => cx.theme().status().modified,
+            LabelColor::Deleted => cx.theme().status().deleted,
+            LabelColor::Disabled => cx.theme().colors().text_disabled,
+            LabelColor::Hidden => cx.theme().status().hidden,
+            LabelColor::Info => cx.theme().status().info,
+            LabelColor::Placeholder => cx.theme().colors().text_placeholder,
+            LabelColor::Accent => cx.theme().colors().text_accent,
+            LabelColor::Player(i) => cx.theme().styles.player.0[i.clone() as usize].cursor,
+            LabelColor::Error => cx.theme().status().error,
+            LabelColor::Selected => cx.theme().colors().text_accent,
+            LabelColor::Success => cx.theme().status().success,
+            LabelColor::Warning => cx.theme().status().warning,
         }
     }
 }

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -69,7 +69,7 @@ use std::{
 };
 use theme2::ActiveTheme;
 pub use toolbar::{ToolbarItemLocation, ToolbarItemView};
-use ui::{h_stack, Label};
+use ui::{h_stack, Button, ButtonVariant, Label, LabelColor};
 use util::ResultExt;
 use uuid::Uuid;
 use workspace_settings::{AutosaveSetting, WorkspaceSettings};
@@ -2641,19 +2641,35 @@ impl Workspace {
         h_stack()
             .id("titlebar")
             .justify_between()
-            .w_full()
-            .h(rems(1.75))
-            .bg(cx.theme().colors().title_bar_background)
             .when(
                 !matches!(cx.window_bounds(), WindowBounds::Fullscreen),
                 |s| s.pl_20(),
             )
+            .w_full()
+            .h(rems(1.75))
+            .bg(cx.theme().colors().title_bar_background)
             .on_click(|_, event, cx| {
                 if event.up.click_count == 2 {
                     cx.zoom_window();
                 }
             })
-            .child(h_stack().child(Label::new("Left side titlebar item"))) // self.titlebar_item
+            .child(
+                h_stack()
+                    // TODO - Add player menu
+                    .child(
+                        Button::new("player")
+                            .variant(ButtonVariant::Ghost)
+                            .color(Some(LabelColor::Player(0))),
+                    )
+                    // TODO - Add project menu
+                    .child(Button::new("project_name").variant(ButtonVariant::Ghost))
+                    // TODO - Add git menu
+                    .child(
+                        Button::new("branch_name")
+                            .variant(ButtonVariant::Ghost)
+                            .color(Some(LabelColor::Muted)),
+                    ),
+            ) // self.titlebar_item
             .child(h_stack().child(Label::new("Right side titlebar item")))
     }
 


### PR DESCRIPTION
[[PR Description]]
- Allows a button to take a color and resolve it into `IconColor` and `LabelColor`
- Extend `IconColor` and `LabelColor` to allow them to take a `Player(i)`
- `impl From<LabelColor> for IconColor`

Release Notes:

- N/A
