### PR TITLE
Use `IconElement` in project panel

### DIFF
--- a/crates/project_panel2/src/project_panel.rs
+++ b/crates/project_panel2/src/project_panel.rs
@@ -8,7 +8,7 @@ use file_associations::FileAssociations;
 
 use anyhow::{anyhow, Result};
 use gpui::{
-    actions, div, px, rems, svg, uniform_list, Action, AppContext, AssetSource, AsyncWindowContext,
+    actions, div, px, uniform_list, Action, AppContext, AssetSource, AsyncWindowContext,
     ClipboardItem, Component, Div, EventEmitter, FocusHandle, FocusableKeyDispatch, Model,
     MouseButton, ParentElement as _, Pixels, Point, PromptLevel, Render, StatefulInteractive,
     StatefulInteractivity, StatelessInteractive, Styled, Task, UniformListScrollHandle, View,
@@ -31,7 +31,7 @@ use std::{
     sync::Arc,
 };
 use theme::ActiveTheme as _;
-use ui::{h_stack, v_stack, Label};
+use ui::{h_stack, v_stack, IconElement, Label};
 use unicase::UniCase;
 use util::{maybe, TryFutureExt};
 use workspace::{
@@ -1353,14 +1353,7 @@ impl ProjectPanel {
 
         h_stack()
             .child(if let Some(icon) = &details.icon {
-                div().child(
-                    // todo!() Marshall: Can we use our `IconElement` component here?
-                    svg()
-                        .size(rems(0.9375))
-                        .flex_none()
-                        .path(icon.to_string())
-                        .text_color(cx.theme().colors().icon),
-                )
+                div().child(IconElement::from_path(icon.to_string()))
             } else {
                 div()
             })

--- a/crates/ui2/src/components/icon.rs
+++ b/crates/ui2/src/components/icon.rs
@@ -129,7 +129,7 @@ impl Icon {
 
 #[derive(Component)]
 pub struct IconElement {
-    icon: Icon,
+    path: SharedString,
     color: TextColor,
     size: IconSize,
 }
@@ -137,7 +137,15 @@ pub struct IconElement {
 impl IconElement {
     pub fn new(icon: Icon) -> Self {
         Self {
-            icon,
+            path: icon.path().into(),
+            color: TextColor::default(),
+            size: IconSize::default(),
+        }
+    }
+
+    pub fn from_path(path: impl Into<SharedString>) -> Self {
+        Self {
+            path: path.into(),
             color: TextColor::default(),
             size: IconSize::default(),
         }
@@ -162,7 +170,7 @@ impl IconElement {
         svg()
             .size(svg_size)
             .flex_none()
-            .path(self.icon.path())
+            .path(self.path)
             .text_color(self.color.color(cx))
     }
 }


### PR DESCRIPTION
This PR updates the project panel to use the `IconElement` to render icons instead of duplicating the styles.

Release Notes:

- N/A
