### PR TITLE
Fix click events by notifying when we assign pending_mouse_down

### DIFF
--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -597,7 +597,7 @@ impl<V: 'static> ParentComponent<V> for Div<V> {
 }
 
 impl<V: 'static> Element<V> for Div<V> {
-    type ElementState = NodeState;
+    type ElementState = DivState;
 
     fn element_id(&self) -> Option<ElementId> {
         self.interactivity.element_id.clone()
@@ -617,7 +617,7 @@ impl<V: 'static> Element<V> for Div<V> {
             child.initialize(view_state, cx);
         }
 
-        NodeState {
+        DivState {
             interactive_state,
             child_layout_ids: SmallVec::new(),
         }
@@ -706,7 +706,7 @@ impl<V: 'static> Component<V> for Div<V> {
     }
 }
 
-pub struct NodeState {
+pub struct DivState {
     child_layout_ids: SmallVec<[LayoutId; 4]>,
     interactive_state: InteractiveElementState,
 }
@@ -911,11 +911,13 @@ where
                         }
                     }
                     *pending_mouse_down.lock() = None;
+                    cx.notify();
                 });
             } else {
-                cx.on_mouse_event(move |_state, event: &MouseDownEvent, phase, _cx| {
+                cx.on_mouse_event(move |_view_state, event: &MouseDownEvent, phase, cx| {
                     if phase == DispatchPhase::Bubble && bounds.contains_point(&event.position) {
                         *pending_mouse_down.lock() = Some(event.clone());
+                        cx.notify();
                     }
                 });
             }


### PR DESCRIPTION
We need to notify when we set the pending mouse down so we attach the mouse up event listener before the mouse button is released.

Release Notes:

- N/A