### PR TITLE
Parameterize `theme2::init` to allow loading just the base theme

### DIFF
--- a/crates/collab2/src/tests/test_server.rs
+++ b/crates/collab2/src/tests/test_server.rs
@@ -224,7 +224,7 @@ impl TestServer {
         });
 
         cx.update(|cx| {
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             Project::init(&client, cx);
             client::init(&client, cx);
             language::init(cx);

--- a/crates/command_palette2/src/command_palette.rs
+++ b/crates/command_palette2/src/command_palette.rs
@@ -456,7 +456,7 @@ mod tests {
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
         cx.update(|cx| {
             let app_state = AppState::test(cx);
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             language::init(cx);
             editor::init(cx);
             workspace::init(app_state.clone(), cx);

--- a/crates/editor2/src/display_map/inlay_map.rs
+++ b/crates/editor2/src/display_map/inlay_map.rs
@@ -1891,6 +1891,6 @@ mod tests {
     fn init_test(cx: &mut AppContext) {
         let store = SettingsStore::test(cx);
         cx.set_global(store);
-        theme::init(cx);
+        theme::init(theme::LoadThemes::JustBase, cx);
     }
 }

--- a/crates/editor2/src/editor_tests.rs
+++ b/crates/editor2/src/editor_tests.rs
@@ -8277,7 +8277,7 @@ pub(crate) fn init_test(cx: &mut TestAppContext, f: fn(&mut AllLanguageSettingsC
     cx.update(|cx| {
         let store = SettingsStore::test(cx);
         cx.set_global(store);
-        theme::init(cx);
+        theme::init(theme::LoadThemes::JustBase, cx);
         client::init_settings(cx);
         language::init(cx);
         Project::init_settings(cx);

--- a/crates/editor2/src/inlay_hint_cache.rs
+++ b/crates/editor2/src/inlay_hint_cache.rs
@@ -3179,7 +3179,7 @@ all hints should be invalidated and requeried for all of its visible excerpts"
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             client::init_settings(cx);
             language::init(cx);
             Project::init_settings(cx);

--- a/crates/file_finder2/src/file_finder.rs
+++ b/crates/file_finder2/src/file_finder.rs
@@ -1763,7 +1763,7 @@ mod tests {
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
         cx.update(|cx| {
             let state = AppState::test(cx);
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             language::init(cx);
             super::init(cx);
             editor::init(cx);

--- a/crates/project_panel2/src/project_panel.rs
+++ b/crates/project_panel2/src/project_panel.rs
@@ -2785,7 +2785,7 @@ mod tests {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
             init_settings(cx);
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             language::init(cx);
             editor::init_settings(cx);
             crate::init((), cx);
@@ -2798,7 +2798,7 @@ mod tests {
     fn init_test_with_editor(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let app_state = AppState::test(cx);
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             init_settings(cx);
             language::init(cx);
             editor::init(cx);

--- a/crates/storybook2/src/storybook2.rs
+++ b/crates/storybook2/src/storybook2.rs
@@ -60,7 +60,7 @@ fn main() {
             .unwrap();
         cx.set_global(store);
 
-        theme2::init(cx);
+        theme2::init(theme2::LoadThemes::All, cx);
 
         let selector =
             story_selector.unwrap_or(StorySelector::Component(ComponentStory::Workspace));

--- a/crates/terminal_view2/src/terminal_view.rs
+++ b/crates/terminal_view2/src/terminal_view.rs
@@ -1126,7 +1126,7 @@ mod tests {
     pub async fn init_test(cx: &mut TestAppContext) -> (Model<Project>, View<Workspace>) {
         let params = cx.update(AppState::test);
         cx.update(|cx| {
-            theme::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
             Project::init_settings(cx);
             language::init(cx);
         });

--- a/crates/theme2/src/registry.rs
+++ b/crates/theme2/src/registry.rs
@@ -100,6 +100,11 @@ impl ThemeRegistry {
             .ok_or_else(|| anyhow!("theme not found: {}", name))
             .cloned()
     }
+
+    pub fn load_user_themes(&mut self) {
+        #[cfg(not(feature = "importing-themes"))]
+        self.insert_user_theme_familes(crate::all_user_themes());
+    }
 }
 
 impl Default for ThemeRegistry {
@@ -109,9 +114,6 @@ impl Default for ThemeRegistry {
         };
 
         this.insert_theme_families([one_family()]);
-
-        #[cfg(not(feature = "importing-themes"))]
-        this.insert_user_theme_familes(crate::all_user_themes());
 
         this
     }

--- a/crates/theme2/src/settings.rs
+++ b/crates/theme2/src/settings.rs
@@ -117,7 +117,7 @@ impl settings::Settings for ThemeSettings {
         user_values: &[&Self::FileContent],
         cx: &mut AppContext,
     ) -> Result<Self> {
-        let themes = cx.default_global::<Arc<ThemeRegistry>>();
+        let themes = cx.default_global::<ThemeRegistry>();
 
         let mut this = Self {
             ui_font_size: defaults.ui_font_size.unwrap_or(16.).into(),

--- a/crates/theme2/src/theme2.rs
+++ b/crates/theme2/src/theme2.rs
@@ -31,8 +31,25 @@ pub enum Appearance {
     Dark,
 }
 
-pub fn init(cx: &mut AppContext) {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LoadThemes {
+    /// Only load the base theme.
+    ///
+    /// No user themes will be loaded.
+    JustBase,
+
+    /// Load all of the built-in themes.
+    All,
+}
+
+pub fn init(themes_to_load: LoadThemes, cx: &mut AppContext) {
     cx.set_global(ThemeRegistry::default());
+
+    match themes_to_load {
+        LoadThemes::JustBase => (),
+        LoadThemes::All => cx.global_mut::<ThemeRegistry>().load_user_themes(),
+    }
+
     ThemeSettings::register(cx);
 }
 

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -355,7 +355,7 @@ impl AppState {
         let user_store = cx.build_model(|cx| UserStore::new(client.clone(), http_client, cx));
         let workspace_store = cx.build_model(|cx| WorkspaceStore::new(client.clone(), cx));
 
-        theme2::init(cx);
+        theme2::init(theme2::LoadThemes::JustBase, cx);
         client2::init(&client, cx);
         crate::init_settings(cx);
 

--- a/crates/zed2/src/main.rs
+++ b/crates/zed2/src/main.rs
@@ -40,7 +40,7 @@ use std::{
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
-use theme::{ActiveTheme, ThemeRegistry};
+use theme::ActiveTheme;
 use util::{
     async_maybe,
     channel::{parse_zed_link, ReleaseChannel, RELEASE_CHANNEL},

--- a/crates/zed2/src/main.rs
+++ b/crates/zed2/src/main.rs
@@ -40,7 +40,7 @@ use std::{
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
-use theme::ActiveTheme;
+use theme::{ActiveTheme, ThemeRegistry};
 use util::{
     async_maybe,
     channel::{parse_zed_link, ReleaseChannel, RELEASE_CHANNEL},
@@ -140,7 +140,7 @@ fn main() {
 
         cx.set_global(client.clone());
 
-        theme::init(cx);
+        theme::init(theme::LoadThemes::All, cx);
         project::Project::init(&client, cx);
         client::init(&client, cx);
         command_palette::init(cx);


### PR DESCRIPTION
This PR adds a parameter to the `theme2::init` method to indicate what the theme-loading behavior should be.

This allows us to indicate when we want to load all of the additional built-in user themes (like in the Zed binary and in the storybook), and when we don't want to load the user themes (like in tests).

We're using an enum over just a `bool` here for clarity at the call site.

Release Notes:

- N/A
