### PR TITLE
Fix text wrapping when a child of a v_stack()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,7 +3759,7 @@ dependencies = [
  "smol",
  "sqlez",
  "sum_tree",
- "taffy",
+ "taffy 0.3.11 (git+https://github.com/DioxusLabs/taffy?rev=4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e)",
  "thiserror",
  "time",
  "tiny-skia",
@@ -3824,7 +3824,7 @@ dependencies = [
  "smol",
  "sqlez",
  "sum_tree",
- "taffy",
+ "taffy 0.3.11 (git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b)",
  "thiserror",
  "time",
  "tiny-skia",
@@ -3858,6 +3858,12 @@ name = "grid"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eec1c01eb1de97451ee0d60de7d81cf1e72aabefb021616027f3d1c3ec1c723c"
+
+[[package]]
+name = "grid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
 
 [[package]]
 name = "h2"
@@ -9056,10 +9062,21 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.3.11"
+source = "git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b#1876f72bee5e376023eaa518aa7b8a34c769bd1b"
+dependencies = [
+ "arrayvec 0.7.4",
+ "grid 0.11.0",
+ "num-traits",
+ "slotmap",
+]
+
+[[package]]
+name = "taffy"
+version = "0.3.11"
 source = "git+https://github.com/DioxusLabs/taffy?rev=4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e#4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e"
 dependencies = [
  "arrayvec 0.7.4",
- "grid",
+ "grid 0.10.0",
  "num-traits",
  "slotmap",
 ]

--- a/crates/gpui2/Cargo.toml
+++ b/crates/gpui2/Cargo.toml
@@ -47,7 +47,7 @@ serde_derive.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e" }
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
 thiserror.workspace = true
 time.workspace = true
 tiny-skia = "0.5"

--- a/crates/gpui2/src/elements/text.rs
+++ b/crates/gpui2/src/elements/text.rs
@@ -64,13 +64,18 @@ impl<V: 'static> Element<V> for Text {
 
         let layout_id = cx.request_measured_layout(Default::default(), rem_size, {
             let element_state = element_state.clone();
-            move |known_dimensions, _| {
+            move |known_dimensions, available_space| {
+                let wrap_width = known_dimensions.width.or(match available_space.width {
+                    crate::AvailableSpace::Definite(x) => Some(x),
+                    _ => None,
+                });
+
                 let Some(lines) = text_system
                     .shape_text(
                         &text,
                         font_size,
                         &runs[..],
-                        known_dimensions.width, // Wrap if we know the width.
+                        wrap_width, // Wrap if we know the width.
                     )
                     .log_err()
                 else {

--- a/crates/gpui2/src/elements/text.rs
+++ b/crates/gpui2/src/elements/text.rs
@@ -1,5 +1,5 @@
 use crate::{
-    px, AnyElement, BorrowWindow, Bounds, Component, Element, ElementId, LayoutId, Pixels,
+    AnyElement, BorrowWindow, Bounds, Component, Element, ElementId, LayoutId, Pixels,
     SharedString, Size, TextRun, ViewContext, WrappedLine,
 };
 use parking_lot::{Mutex, MutexGuard};

--- a/crates/gpui2/src/taffy.rs
+++ b/crates/gpui2/src/taffy.rs
@@ -159,7 +159,7 @@ impl TaffyLayoutEngine {
             .compute_layout_with_measure(
                 id.into(),
                 available_space.into(),
-                |known_dimensions, available_space, node_id, context| {
+                |known_dimensions, available_space, _node_id, context| {
                     let Some(measure) = context else {
                         return taffy::geometry::Size::default();
                     };

--- a/crates/storybook2/src/stories/text.rs
+++ b/crates/storybook2/src/stories/text.rs
@@ -1,4 +1,6 @@
-use gpui::{div, white, Div, ParentComponent, Render, Styled, View, VisualContext, WindowContext};
+use gpui::{
+    blue, div, red, white, Div, ParentComponent, Render, Styled, View, VisualContext, WindowContext,
+};
 use ui::v_stack;
 
 pub struct TextStory;
@@ -13,10 +15,46 @@ impl Render for TextStory {
     type Element = Div<Self>;
 
     fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
-        v_stack().w_96().bg(white()).child(concat!(
-            "The quick brown fox jumps over the lazy dog. ",
-            "Meanwhile, the lazy dog decided it was time for a change. ",
-            "He started daily workout routines, ate healthier and became the fastest dog in town.",
-        ))
+        v_stack()
+            .bg(blue())
+            .child(
+                div()
+                    .flex()
+                    .child(div().max_w_96().bg(white()).child(concat!(
+        "max-width: 96. The quick brown fox jumps over the lazy dog. ",
+        "Meanwhile, the lazy dog decided it was time for a change. ",
+        "He started daily workout routines, ate healthier and became the fastest dog in town.",
+    ))),
+            )
+            .child(div().h_5())
+            .child(div().flex().flex_col().w_96().bg(white()).child(concat!(
+        "flex-col. width: 96; The quick brown fox jumps over the lazy dog. ",
+        "Meanwhile, the lazy dog decided it was time for a change. ",
+        "He started daily workout routines, ate healthier and became the fastest dog in town.",
+    )))
+            .child(div().h_5())
+            .child(
+                div()
+                    .flex()
+                    .child(div().min_w_96().bg(white()).child(concat!(
+    "min-width: 96. The quick brown fox jumps over the lazy dog. ",
+    "Meanwhile, the lazy dog decided it was time for a change. ",
+    "He started daily workout routines, ate healthier and became the fastest dog in town.",
+))))
+            .child(div().h_5())
+            .child(div().flex().w_96().bg(white()).child(div().overflow_hidden().child(concat!(
+        "flex-row. width 96. overflow-hidden. The quick brown fox jumps over the lazy dog. ",
+        "Meanwhile, the lazy dog decided it was time for a change. ",
+        "He started daily workout routines, ate healthier and became the fastest dog in town.",
+    ))))
+            // NOTE: When rendering text in a horizonal flex container,
+            // Taffy will not pass width constraints down from the parent.
+            // To fix this, render text in a praent with overflow: hidden, which
+                    .child(div().h_5())
+                    .child(div().flex().w_96().bg(red()).child(concat!(
+                "flex-row. width 96. The quick brown fox jumps over the lazy dog. ",
+                "Meanwhile, the lazy dog decided it was time for a change. ",
+                "He started daily workout routines, ate healthier and became the fastest dog in town.",
+            )))
     }
 }

--- a/crates/storybook2/src/stories/text.rs
+++ b/crates/storybook2/src/stories/text.rs
@@ -1,4 +1,5 @@
 use gpui::{div, white, Div, ParentComponent, Render, Styled, View, VisualContext, WindowContext};
+use ui::v_stack;
 
 pub struct TextStory;
 
@@ -12,7 +13,7 @@ impl Render for TextStory {
     type Element = Div<Self>;
 
     fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
-        div().size_full().bg(white()).child(concat!(
+        v_stack().w_96().bg(white()).child(concat!(
             "The quick brown fox jumps over the lazy dog. ",
             "Meanwhile, the lazy dog decided it was time for a change. ",
             "He started daily workout routines, ate healthier and became the fastest dog in town.",

--- a/crates/storybook3/src/storybook3.rs
+++ b/crates/storybook3/src/storybook3.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
-use gpui::AssetSource;
 use gpui::{
     div, px, size, AnyView, Bounds, Div, Render, ViewContext, VisualContext, WindowBounds,
     WindowOptions,
 };
+use gpui::{white, AssetSource};
 use settings::{default_settings, Settings, SettingsStore};
 use std::borrow::Cow;
 use std::sync::Arc;
 use theme::ThemeSettings;
-use ui::{prelude::*, ContextMenuStory};
+use ui::{h_stack, prelude::*, ContextMenuStory};
 
 struct Assets;
 
@@ -65,9 +65,22 @@ impl Render for TestView {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
         div()
             .flex()
+            .bg(gpui::blue())
             .flex_col()
             .size_full()
             .font("Helvetica")
-            .child(self.story.clone())
+            .child(div().h_5())
+            .child(
+                div()
+                    .flex()
+                    .w_96()
+                    .bg(white())
+                    .relative()
+                    .child(div().child(concat!(
+            "The quick brown fox jumps over the lazy dog. ",
+            "Meanwhile, the lazy dog decided it was time for a change. ",
+            "He started daily workout routines, ate healthier and became the fastest dog in town.",
+        ))),
+            )
     }
 }

--- a/crates/storybook3/src/storybook3.rs
+++ b/crates/storybook3/src/storybook3.rs
@@ -8,7 +8,7 @@ use settings::{default_settings, Settings, SettingsStore};
 use std::borrow::Cow;
 use std::sync::Arc;
 use theme::ThemeSettings;
-use ui::{h_stack, prelude::*, ContextMenuStory};
+use ui::{prelude::*, ContextMenuStory};
 
 struct Assets;
 
@@ -56,6 +56,7 @@ fn main() {
 }
 
 struct TestView {
+    #[allow(unused)]
     story: AnyView,
 }
 


### PR DESCRIPTION
Previously text that was rendered in a flex-column would reserve the correct
amount of space during layout, and then paint itself incorrectly.

Release Notes:

- N/A