### PR TITLE
ui2: Do not enable 'stories' feature by default.

### DIFF
--- a/crates/ui2/Cargo.toml
+++ b/crates/ui2/Cargo.toml
@@ -18,5 +18,5 @@ theme2 = { path = "../theme2" }
 rand = "0.8"
 
 [features]
-default = ["stories"]
+default = []
 stories = ["dep:itertools"]

--- a/crates/ui2/src/components/button.rs
+++ b/crates/ui2/src/components/button.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::{div, DefiniteLength, Hsla, MouseButton, StatefulInteractiveComponent, WindowContext};
+use gpui::{DefiniteLength, Hsla, MouseButton, StatefulInteractiveComponent, WindowContext};
 
 use crate::prelude::*;
 use crate::{h_stack, Icon, IconButton, IconElement, Label, LineHeightStyle, TextColor};

--- a/crates/ui2/src/components/keybinding.rs
+++ b/crates/ui2/src/components/keybinding.rs
@@ -80,17 +80,11 @@ pub use stories::*;
 #[cfg(feature = "stories")]
 mod stories {
     use super::*;
-    use crate::Story;
-    use gpui::{actions, Div, Render};
+    pub use crate::KeyBinding;
+    use crate::{binding, Story};
+    use gpui::{Div, Render};
     use itertools::Itertools;
-
     pub struct KeybindingStory;
-
-    actions!(NoAction);
-
-    pub fn binding(key: &str) -> gpui::KeyBinding {
-        gpui::KeyBinding::new(key, NoAction {}, None)
-    }
 
     impl Render for KeybindingStory {
         type Element = Div<Self>;

--- a/crates/ui2/src/components/keybinding.rs
+++ b/crates/ui2/src/components/keybinding.rs
@@ -1,4 +1,4 @@
-use gpui::Action;
+use gpui::{actions, Action};
 use strum::EnumIter;
 
 use crate::prelude::*;
@@ -72,6 +72,12 @@ pub enum ModifierKey {
     Alt,
     Command,
     Shift,
+}
+
+actions!(NoAction);
+
+pub fn binding(key: &str) -> gpui::KeyBinding {
+    gpui::KeyBinding::new(key, NoAction {}, None)
 }
 
 #[cfg(feature = "stories")]

--- a/crates/ui2/src/lib.rs
+++ b/crates/ui2/src/lib.rs
@@ -24,6 +24,7 @@ mod to_extract;
 pub mod utils;
 
 pub use components::*;
+use gpui::actions;
 pub use prelude::*;
 pub use static_data::*;
 pub use styled_ext::*;
@@ -42,3 +43,8 @@ pub use crate::settings::*;
 mod story;
 #[cfg(feature = "stories")]
 pub use story::*;
+actions!(NoAction);
+
+pub fn binding(key: &str) -> gpui::KeyBinding {
+    gpui::KeyBinding::new(key, NoAction {}, None)
+}


### PR DESCRIPTION
This cuts down LLVM IR size from 3 million lines to 700k in debug build. This then leads to ~3s compile time in debug build (without incremental on ui itself), as opposed to 10.5s on main.

Release Notes:

- N/A
