### PR TITLE
Rework `List` to use `children`

### DIFF
--- a/crates/terminal_view2/src/terminal_view.rs
+++ b/crates/terminal_view2/src/terminal_view.rs
@@ -300,11 +300,14 @@ impl TerminalView {
         cx: &mut ViewContext<Self>,
     ) {
         self.context_menu = Some(ContextMenu::build(cx, |menu, _| {
-            menu.action(ListEntry::new(Label::new("Clear")), Box::new(Clear))
-                .action(
-                    ListEntry::new(Label::new("Close")),
-                    Box::new(CloseActiveItem { save_intent: None }),
-                )
+            menu.action(
+                ListEntry::new("clear", Label::new("Clear")),
+                Box::new(Clear),
+            )
+            .action(
+                ListEntry::new("close", Label::new("Close")),
+                Box::new(CloseActiveItem { save_intent: None }),
+            )
         }));
         dbg!(&position);
         // todo!()

--- a/crates/ui2/src/static_data.rs
+++ b/crates/ui2/src/static_data.rs
@@ -7,14 +7,13 @@ use gpui::{AppContext, ViewContext};
 use rand::Rng;
 use theme2::ActiveTheme;
 
-use crate::{binding, HighlightedText};
 use crate::{
-    Buffer, BufferRow, BufferRows, Button, EditorPane, FileSystemStatus, GitStatus,
-    HighlightedLine, Icon, KeyBinding, Label, ListEntry, ListEntrySize, Livestream, MicStatus,
-    Notification, PaletteItem, Player, PlayerCallStatus, PlayerWithCallStatus, PublicPlayer,
-    ScreenShareStatus, Symbol, Tab, TextColor, Toggle, VideoStatus,
+    binding, Buffer, BufferRow, BufferRows, Button, EditorPane, FileSystemStatus, GitStatus,
+    HighlightedLine, HighlightedText, Icon, KeyBinding, Label, ListEntry, ListEntrySize,
+    Livestream, MicStatus, Notification, NotificationAction, PaletteItem, Player, PlayerCallStatus,
+    PlayerWithCallStatus, PublicPlayer, ScreenShareStatus, Symbol, Tab, TextColor, Toggle,
+    VideoStatus,
 };
-use crate::{ListItem, NotificationAction};
 
 pub fn static_tabs_example() -> Vec<Tab> {
     vec![
@@ -478,225 +477,238 @@ pub fn static_new_notification_items_2<V: 'static>() -> Vec<Notification<V>> {
     ]
 }
 
-pub fn static_project_panel_project_items<V>() -> Vec<ListItem<V>> {
+pub fn static_project_panel_project_items<V>() -> Vec<ListEntry<V>> {
     vec![
-        ListEntry::new(Label::new("zed"))
+        ListEntry::new("zed", Label::new("zed"))
             .left_icon(Icon::FolderOpen.into())
             .indent_level(0)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new(".cargo"))
+        ListEntry::new(".cargo", Label::new(".cargo"))
             .left_icon(Icon::Folder.into())
             .indent_level(1),
-        ListEntry::new(Label::new(".config"))
+        ListEntry::new(".config", Label::new(".config"))
             .left_icon(Icon::Folder.into())
             .indent_level(1),
-        ListEntry::new(Label::new(".git").color(TextColor::Hidden))
+        ListEntry::new(".git", Label::new(".git").color(TextColor::Hidden))
             .left_icon(Icon::Folder.into())
             .indent_level(1),
-        ListEntry::new(Label::new(".cargo"))
+        ListEntry::new(".cargo", Label::new(".cargo"))
             .left_icon(Icon::Folder.into())
             .indent_level(1),
-        ListEntry::new(Label::new(".idea").color(TextColor::Hidden))
+        ListEntry::new(".idea", Label::new(".idea").color(TextColor::Hidden))
             .left_icon(Icon::Folder.into())
             .indent_level(1),
-        ListEntry::new(Label::new("assets"))
+        ListEntry::new("assets", Label::new("assets"))
             .left_icon(Icon::Folder.into())
             .indent_level(1)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("cargo-target").color(TextColor::Hidden))
-            .left_icon(Icon::Folder.into())
-            .indent_level(1),
-        ListEntry::new(Label::new("crates"))
+        ListEntry::new(
+            "cargo-target",
+            Label::new("cargo-target").color(TextColor::Hidden),
+        )
+        .left_icon(Icon::Folder.into())
+        .indent_level(1),
+        ListEntry::new("crates", Label::new("crates"))
             .left_icon(Icon::FolderOpen.into())
             .indent_level(1)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("activity_indicator"))
+        ListEntry::new("activity_indicator", Label::new("activity_indicator"))
             .left_icon(Icon::Folder.into())
             .indent_level(2),
-        ListEntry::new(Label::new("ai"))
+        ListEntry::new("ai", Label::new("ai"))
             .left_icon(Icon::Folder.into())
             .indent_level(2),
-        ListEntry::new(Label::new("audio"))
+        ListEntry::new("audio", Label::new("audio"))
             .left_icon(Icon::Folder.into())
             .indent_level(2),
-        ListEntry::new(Label::new("auto_update"))
+        ListEntry::new("auto_update", Label::new("auto_update"))
             .left_icon(Icon::Folder.into())
             .indent_level(2),
-        ListEntry::new(Label::new("breadcrumbs"))
+        ListEntry::new("breadcrumbs", Label::new("breadcrumbs"))
             .left_icon(Icon::Folder.into())
             .indent_level(2),
-        ListEntry::new(Label::new("call"))
+        ListEntry::new("call", Label::new("call"))
             .left_icon(Icon::Folder.into())
             .indent_level(2),
-        ListEntry::new(Label::new("sqlez").color(TextColor::Modified))
+        ListEntry::new("sqlez", Label::new("sqlez").color(TextColor::Modified))
             .left_icon(Icon::Folder.into())
             .indent_level(2)
             .toggle(Toggle::Toggled(false)),
-        ListEntry::new(Label::new("gpui2"))
+        ListEntry::new("gpui2", Label::new("gpui2"))
             .left_icon(Icon::FolderOpen.into())
             .indent_level(2)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("src"))
+        ListEntry::new("src", Label::new("src"))
             .left_icon(Icon::FolderOpen.into())
             .indent_level(3)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("derive_element.rs"))
+        ListEntry::new("derive_element.rs", Label::new("derive_element.rs"))
             .left_icon(Icon::FileRust.into())
             .indent_level(4),
-        ListEntry::new(Label::new("storybook").color(TextColor::Modified))
-            .left_icon(Icon::FolderOpen.into())
-            .indent_level(1)
-            .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("docs").color(TextColor::Default))
+        ListEntry::new(
+            "storybook",
+            Label::new("storybook").color(TextColor::Modified),
+        )
+        .left_icon(Icon::FolderOpen.into())
+        .indent_level(1)
+        .toggle(Toggle::Toggled(true)),
+        ListEntry::new("docs", Label::new("docs").color(TextColor::Default))
             .left_icon(Icon::Folder.into())
             .indent_level(2)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("src").color(TextColor::Modified))
+        ListEntry::new("src", Label::new("src").color(TextColor::Modified))
             .left_icon(Icon::FolderOpen.into())
             .indent_level(3)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("ui").color(TextColor::Modified))
+        ListEntry::new("ui", Label::new("ui").color(TextColor::Modified))
             .left_icon(Icon::FolderOpen.into())
             .indent_level(4)
             .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("component").color(TextColor::Created))
-            .left_icon(Icon::FolderOpen.into())
-            .indent_level(5)
-            .toggle(Toggle::Toggled(true)),
-        ListEntry::new(Label::new("facepile.rs").color(TextColor::Default))
+        ListEntry::new(
+            "component",
+            Label::new("component").color(TextColor::Created),
+        )
+        .left_icon(Icon::FolderOpen.into())
+        .indent_level(5)
+        .toggle(Toggle::Toggled(true)),
+        ListEntry::new(
+            "facepile.rs",
+            Label::new("facepile.rs").color(TextColor::Default),
+        )
+        .left_icon(Icon::FileRust.into())
+        .indent_level(6),
+        ListEntry::new(
+            "follow_group.rs",
+            Label::new("follow_group.rs").color(TextColor::Default),
+        )
+        .left_icon(Icon::FileRust.into())
+        .indent_level(6),
+        ListEntry::new(
+            "list_item.rs",
+            Label::new("list_item.rs").color(TextColor::Created),
+        )
+        .left_icon(Icon::FileRust.into())
+        .indent_level(6),
+        ListEntry::new("tab.rs", Label::new("tab.rs").color(TextColor::Default))
             .left_icon(Icon::FileRust.into())
             .indent_level(6),
-        ListEntry::new(Label::new("follow_group.rs").color(TextColor::Default))
-            .left_icon(Icon::FileRust.into())
-            .indent_level(6),
-        ListEntry::new(Label::new("list_item.rs").color(TextColor::Created))
-            .left_icon(Icon::FileRust.into())
-            .indent_level(6),
-        ListEntry::new(Label::new("tab.rs").color(TextColor::Default))
-            .left_icon(Icon::FileRust.into())
-            .indent_level(6),
-        ListEntry::new(Label::new("target").color(TextColor::Hidden))
+        ListEntry::new("target", Label::new("target").color(TextColor::Hidden))
             .left_icon(Icon::Folder.into())
             .indent_level(1),
-        ListEntry::new(Label::new(".dockerignore"))
+        ListEntry::new(".dockerignore", Label::new(".dockerignore"))
             .left_icon(Icon::FileGeneric.into())
             .indent_level(1),
-        ListEntry::new(Label::new(".DS_Store").color(TextColor::Hidden))
-            .left_icon(Icon::FileGeneric.into())
-            .indent_level(1),
-        ListEntry::new(Label::new("Cargo.lock"))
+        ListEntry::new(
+            ".DS_Store",
+            Label::new(".DS_Store").color(TextColor::Hidden),
+        )
+        .left_icon(Icon::FileGeneric.into())
+        .indent_level(1),
+        ListEntry::new("Cargo.lock", Label::new("Cargo.lock"))
             .left_icon(Icon::FileLock.into())
             .indent_level(1),
-        ListEntry::new(Label::new("Cargo.toml"))
+        ListEntry::new("Cargo.toml", Label::new("Cargo.toml"))
             .left_icon(Icon::FileToml.into())
             .indent_level(1),
-        ListEntry::new(Label::new("Dockerfile"))
+        ListEntry::new("Dockerfile", Label::new("Dockerfile"))
             .left_icon(Icon::FileGeneric.into())
             .indent_level(1),
-        ListEntry::new(Label::new("Procfile"))
+        ListEntry::new("Procfile", Label::new("Procfile"))
             .left_icon(Icon::FileGeneric.into())
             .indent_level(1),
-        ListEntry::new(Label::new("README.md"))
+        ListEntry::new("README.md", Label::new("README.md"))
             .left_icon(Icon::FileDoc.into())
             .indent_level(1),
     ]
-    .into_iter()
-    .map(From::from)
-    .collect()
 }
 
-pub fn static_project_panel_single_items<V>() -> Vec<ListItem<V>> {
+pub fn static_project_panel_single_items<V>() -> Vec<ListEntry<V>> {
     vec![
-        ListEntry::new(Label::new("todo.md"))
+        ListEntry::new("todo.md", Label::new("todo.md"))
             .left_icon(Icon::FileDoc.into())
             .indent_level(0),
-        ListEntry::new(Label::new("README.md"))
+        ListEntry::new("README.md", Label::new("README.md"))
             .left_icon(Icon::FileDoc.into())
             .indent_level(0),
-        ListEntry::new(Label::new("config.json"))
+        ListEntry::new("config.json", Label::new("config.json"))
             .left_icon(Icon::FileGeneric.into())
             .indent_level(0),
     ]
-    .into_iter()
-    .map(From::from)
-    .collect()
 }
 
-pub fn static_collab_panel_current_call<V>() -> Vec<ListItem<V>> {
+pub fn static_collab_panel_current_call<V>() -> Vec<ListEntry<V>> {
     vec![
-        ListEntry::new(Label::new("as-cii")).left_avatar("http://github.com/as-cii.png?s=50"),
-        ListEntry::new(Label::new("nathansobo"))
+        ListEntry::new("as-cii", Label::new("as-cii"))
+            .left_avatar("http://github.com/as-cii.png?s=50"),
+        ListEntry::new("nathansobo", Label::new("nathansobo"))
             .left_avatar("http://github.com/nathansobo.png?s=50"),
-        ListEntry::new(Label::new("maxbrunsfeld"))
+        ListEntry::new("maxbrunsfeld", Label::new("maxbrunsfeld"))
             .left_avatar("http://github.com/maxbrunsfeld.png?s=50"),
     ]
-    .into_iter()
-    .map(From::from)
-    .collect()
 }
 
-pub fn static_collab_panel_channels<V>() -> Vec<ListItem<V>> {
+pub fn static_collab_panel_channels<V>() -> Vec<ListEntry<V>> {
     vec![
-        ListEntry::new(Label::new("zed"))
+        ListEntry::new("zed", Label::new("zed"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(0),
-        ListEntry::new(Label::new("community"))
+        ListEntry::new("community", Label::new("community"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(1),
-        ListEntry::new(Label::new("dashboards"))
+        ListEntry::new("dashboards", Label::new("dashboards"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("feedback"))
+        ListEntry::new("feedback", Label::new("feedback"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("teams-in-channels-alpha"))
-            .left_icon(Icon::Hash.into())
-            .size(ListEntrySize::Medium)
-            .indent_level(2),
-        ListEntry::new(Label::new("current-projects"))
+        ListEntry::new(
+            "teams-in-channels-alpha",
+            Label::new("teams-in-channels-alpha"),
+        )
+        .left_icon(Icon::Hash.into())
+        .size(ListEntrySize::Medium)
+        .indent_level(2),
+        ListEntry::new("current-projects", Label::new("current-projects"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(1),
-        ListEntry::new(Label::new("codegen"))
+        ListEntry::new("codegen", Label::new("codegen"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("gpui2"))
+        ListEntry::new("gpui2", Label::new("gpui2"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("livestreaming"))
+        ListEntry::new("livestreaming", Label::new("livestreaming"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("open-source"))
+        ListEntry::new("open-source", Label::new("open-source"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("replace"))
+        ListEntry::new("replace", Label::new("replace"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("semantic-index"))
+        ListEntry::new("semantic-index", Label::new("semantic-index"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("vim"))
+        ListEntry::new("vim", Label::new("vim"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
-        ListEntry::new(Label::new("web-tech"))
+        ListEntry::new("web-tech", Label::new("web-tech"))
             .left_icon(Icon::Hash.into())
             .size(ListEntrySize::Medium)
             .indent_level(2),
     ]
-    .into_iter()
-    .map(From::from)
-    .collect()
 }
 
 pub fn example_editor_actions() -> Vec<PaletteItem> {

--- a/crates/ui2/src/to_extract/collab_panel.rs
+++ b/crates/ui2/src/to_extract/collab_panel.rs
@@ -28,41 +28,45 @@ impl<V: 'static> Component<V> for CollabPanel {
                             .border_color(cx.theme().colors().border)
                             .border_b()
                             .child(
-                                List::new(static_collab_panel_current_call())
+                                List::new()
                                     .header(
                                         ListHeader::new("CRDB")
                                             .left_icon(Icon::Hash.into())
                                             .toggle(Toggle::Toggled(true)),
                                     )
-                                    .toggle(Toggle::Toggled(true)),
+                                    .toggle(Toggle::Toggled(true))
+                                    .children(static_collab_panel_current_call()),
                             ),
                     )
                     .child(
                         v_stack().id("channels").py_1().child(
-                            List::new(static_collab_panel_channels())
+                            List::new()
                                 .header(ListHeader::new("CHANNELS").toggle(Toggle::Toggled(true)))
                                 .empty_message("No channels yet. Add a channel to get started.")
-                                .toggle(Toggle::Toggled(true)),
+                                .toggle(Toggle::Toggled(true))
+                                .children(static_collab_panel_channels()),
                         ),
                     )
                     .child(
                         v_stack().id("contacts-online").py_1().child(
-                            List::new(static_collab_panel_current_call())
+                            List::new()
                                 .header(
                                     ListHeader::new("CONTACTS – ONLINE")
                                         .toggle(Toggle::Toggled(true)),
                                 )
-                                .toggle(Toggle::Toggled(true)),
+                                .toggle(Toggle::Toggled(true))
+                                .children(static_collab_panel_current_call()),
                         ),
                     )
                     .child(
                         v_stack().id("contacts-offline").py_1().child(
-                            List::new(static_collab_panel_current_call())
+                            List::new()
                                 .header(
                                     ListHeader::new("CONTACTS – OFFLINE")
                                         .toggle(Toggle::Toggled(false)),
                                 )
-                                .toggle(Toggle::Toggled(false)),
+                                .toggle(Toggle::Toggled(false))
+                                .children(static_collab_panel_current_call()),
                         ),
                     ),
             )

--- a/crates/ui2/src/to_extract/project_panel.rs
+++ b/crates/ui2/src/to_extract/project_panel.rs
@@ -29,14 +29,16 @@ impl<V: 'static> Component<V> for ProjectPanel {
                     .flex_col()
                     .overflow_y_scroll()
                     .child(
-                        List::new(static_project_panel_single_items())
+                        List::new()
                             .header(ListHeader::new("FILES"))
-                            .empty_message("No files in directory"),
+                            .empty_message("No files in directory")
+                            .children(static_project_panel_single_items()),
                     )
                     .child(
-                        List::new(static_project_panel_project_items())
+                        List::new()
                             .header(ListHeader::new("PROJECT"))
-                            .empty_message("No folders in directory"),
+                            .empty_message("No folders in directory")
+                            .children(static_project_panel_project_items()),
                     ),
             )
             .child(
@@ -67,14 +69,16 @@ impl ProjectPanel {
                     .flex_col()
                     .overflow_y_scroll()
                     .child(
-                        List::new(static_project_panel_single_items())
+                        List::new()
                             .header(ListHeader::new("FILES"))
-                            .empty_message("No files in directory"),
+                            .empty_message("No files in directory")
+                            .children(static_project_panel_single_items()),
                     )
                     .child(
-                        List::new(static_project_panel_project_items())
+                        List::new()
                             .header(ListHeader::new("PROJECT"))
-                            .empty_message("No folders in directory"),
+                            .empty_message("No folders in directory")
+                            .children(static_project_panel_project_items()),
                     ),
             )
             .child(

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -719,10 +719,10 @@ impl Render<Self> for PanelButtons {
                                     {
                                         let panel = panel.clone();
                                         menu = menu.entry(
-                                            ListEntry::new(Label::new(format!(
-                                                "Dock {}",
-                                                position.to_label()
-                                            ))),
+                                            ListEntry::new(
+                                                SharedString::from(format!("dock-{position:?}")),
+                                                Label::new(format!("Dock {}", position.to_label())),
+                                            ),
                                             move |_, cx| {
                                                 panel.set_position(position, cx);
                                             },


### PR DESCRIPTION
This PR reworks the `List` component to use `children` instead of accepting a `Vec<ListItem>` in its constructor.

This is a step towards making the `List` component more open.

Release Notes:

- N/A
