### PR TITLE
Fix panic when opening settings in zed2

### DIFF
--- a/crates/theme2/src/settings.rs
+++ b/crates/theme2/src/settings.rs
@@ -184,7 +184,7 @@ impl settings::Settings for ThemeSettings {
     ) -> schemars::schema::RootSchema {
         let mut root_schema = generator.root_schema_for::<ThemeSettingsContent>();
         let theme_names = cx
-            .global::<Arc<ThemeRegistry>>()
+            .global::<ThemeRegistry>()
             .list_names(params.staff_mode)
             .map(|theme_name| Value::String(theme_name.to_string()))
             .collect();


### PR DESCRIPTION
This PR fixes a panic that occurs when opening the settings in zed2.

We store the `ThemeRegistry` as a global without wrapping it in an `Arc`, so we need to retrieve it the same way.

Release Notes:

- N/A
