### PR TITLE
CI: use global config toml

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -22,13 +22,9 @@ runs:
       run: script/clear-target-dir-if-larger-than 70
 
     - name: Run check
-      env:
-        RUSTFLAGS: -D warnings
       shell: bash -euxo pipefail {0}
       run: cargo check --tests --workspace
 
     - name: Run tests
-      env:
-        RUSTFLAGS: -D warnings
       shell: bash -euxo pipefail {0}
       run: cargo nextest run --workspace --no-fail-fast

--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Limit target directory size
       shell: bash -euxo pipefail {0}
-      run: script/clear-target-dir-if-larger-than 70
+      run: script/clear-target-dir-if-larger-than 100
 
     - name: Run check
       shell: bash -euxo pipefail {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - test
     steps:
       - name: Set up default .cargo/config.toml
-	run: echo "[build]\nrustflags = [\"-D\", \"warnings\"]" > $HOME/.cargo/config.toml
+        run: echo "[build]\nrustflags = [\"-D\", \"warnings\"]" > $HOME/.cargo/config.toml
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - test
     steps:
       - name: Set up default .cargo/config.toml
-        run: echo "[build]\nrustflags = [\"-D\", \"warnings\"]" > $HOME/.cargo/config.toml
+        run: printf "[build]\nrustflags = [\"-D\", \"warnings\"]" > $HOME/.cargo/config.toml
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - self-hosted
       - test
     steps:
+      - name: Set up default .cargo/config.toml
+	run: echo "[build]\nrustflags = [\"-D\", \"warnings\"]" > $HOME/.cargo/config.toml
+
       - name: Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           submodules: "recursive"
 
       - name: Limit target directory size
-        run: script/clear-target-dir-if-larger-than 70
+        run: script/clear-target-dir-if-larger-than 100
 
       - name: Determine version and release channel
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -79,7 +79,7 @@ jobs:
           submodules: "recursive"
 
       - name: Limit target directory size
-        run: script/clear-target-dir-if-larger-than 70
+        run: script/clear-target-dir-if-larger-than 100
 
       - name: Set release channel to nightly
         run: |


### PR DESCRIPTION
It looks like we should keep RUSTFLAGS consistent in CI if possible; some commands augmented RUSTFLAGS with "-D warnings" which overrode `.cargo/config.toml`, causing unnecessary rebuilds even for non-bundling runs. Tl;dr: for the last few days our average CI time spiked significantly.
There are several solutions:
- We can place `-D warnings` in our `.cargo/config.toml`. That's not a good solution, because then you wouldn't ever be able to build Zed with warnings locally. A true PITA!
- We can place another config.toml somewhere in the search path (https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) and rely on the merging of properties. That way we can avoid having `-D warnings` on developer machines while being able to override CI behaviour at will.

This PR implements the latter approach by creating the new config file manually. Ideally we should have it a a separate file in repository that's moved into $HOME/.cargo on each CI run. Maybe we should even place it somewhere more local to the checked out Zed version, as placing it in a global spot is kinda bad too - what if we start building multiple cargo projects on our CI machines?

Release Notes:

- N/A
