### PR TITLE
Add scripts for running Zed2 collab environment

### DIFF
--- a/Procfile.zed2
+++ b/Procfile.zed2
@@ -1,0 +1,4 @@
+web: cd ../zed.dev && PORT=3000 npm run dev
+collab: cd crates/collab2 && RUST_LOG=${RUST_LOG:-warn,collab=info} cargo run serve
+livekit: livekit-server --dev
+postgrest: postgrest crates/collab2/admin_api.conf

--- a/script/zed-local
+++ b/script/zed-local
@@ -4,6 +4,7 @@ const {spawn, execFileSync} = require('child_process')
 
 const RESOLUTION_REGEX = /(\d+) x (\d+)/
 const DIGIT_FLAG_REGEX = /^--?(\d+)$/
+const ZED_2_MODE = "--zed2"
 
 const args = process.argv.slice(2)
 
@@ -14,6 +15,7 @@ if (digitMatch) {
   instanceCount = parseInt(digitMatch[1])
   args.shift()
 }
+const isZed2 = args.some(arg => arg === ZED_2_MODE);
 if (instanceCount > 4) {
   throw new Error('Cannot spawn more than 4 instances')
 }
@@ -70,11 +72,12 @@ const positions = [
   `${instanceWidth},${instanceHeight}`
 ]
 
-execFileSync('cargo', ['build'], {stdio: 'inherit'})
-
+const buildArgs = isZed2 ? ["build", "-p", "zed2"] : ["build"]
+const zedBinary = isZed2 ? "target/debug/Zed2" : "target/debug/Zed"
+execFileSync('cargo', buildArgs, { stdio: 'inherit' })
 setTimeout(() => {
   for (let i = 0; i < instanceCount; i++) {
-    spawn('target/debug/Zed', i == 0 ? args : [], {
+    spawn(zedBinary, i == 0 ? args : [], {
       stdio: 'inherit',
       env: {
         ZED_IMPERSONATE: users[i],


### PR DESCRIPTION
./script/zed-local now looks for "--zed2" flag in its args and runs Zed2 binaries instead of zed1. 'foreman start' can be launched with '-f Procfile.zed2" argument to launch zed2 collab server.

Release Notes:

- N/A
