### PR TITLE
chore: Use "limited" debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,11 +208,12 @@ core-graphics = { git = "https://github.com/servo/core-foundation-rs", rev = "07
 
 [profile.dev]
 split-debuginfo = "unpacked"
+debug = "limited"
 
 [profile.dev.package.taffy]
 opt-level = 3
 
 [profile.release]
-debug = true
+debug = "limited"
 lto = "thin"
 codegen-units = 1


### PR DESCRIPTION
This one does not contain variable-level debug info; since we mostly rely on backtraces though, this should be fine. It also improves compile times a bunch for both incremental and clean scenarios.

Release Notes:

- N/A