### PR TITLE
chore: Set limited debug info on CI only

### DIFF
--- a/.cargo/ci-config.toml
+++ b/.cargo/ci-config.toml
@@ -10,3 +10,6 @@
 # in one spot, that's going to trigger a rebuild of all of the artifacts. Using ci-config.toml we can define these overrides for CI in one spot and not worry about it.
 [build]
 rustflags = ["-D", "warnings"]
+
+[profile.dev]
+debug = "limited"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,6 @@ core-graphics = { git = "https://github.com/servo/core-foundation-rs", rev = "07
 
 [profile.dev]
 split-debuginfo = "unpacked"
-debug = "limited"
 
 [profile.dev.package.taffy]
 opt-level = 3


### PR DESCRIPTION
We're not sure if this causes issues with symbolification yet, but just in case it does, CI should pass by the time we confirm it.

Release Notes:

- N/A
