### PR TITLE
Add Uiua language and Nu LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10179,6 +10179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-uiua"
+version = "0.3.3"
+source = "git+https://github.com/shnarazk/tree-sitter-uiua?rev=9260f11be5900beda4ee6d1a24ab8ddfaf5a19b2#9260f11be5900beda4ee6d1a24ab8ddfaf5a19b2"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-vue"
 version = "0.0.1"
 source = "git+https://github.com/zed-industries/tree-sitter-vue?rev=9b6cb221ccb8d0b956fcb17e9a1efac2feefeb58#9b6cb221ccb8d0b956fcb17e9a1efac2feefeb58"
@@ -11616,6 +11625,7 @@ dependencies = [
  "tree-sitter-svelte",
  "tree-sitter-toml",
  "tree-sitter-typescript",
+ "tree-sitter-uiua",
  "tree-sitter-vue",
  "tree-sitter-yaml",
  "unindent",
@@ -11738,6 +11748,7 @@ dependencies = [
  "tree-sitter-svelte",
  "tree-sitter-toml",
  "tree-sitter-typescript",
+ "tree-sitter-uiua",
  "tree-sitter-vue",
  "tree-sitter-yaml",
  "unindent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ tree-sitter-lua = "0.0.14"
 tree-sitter-nix = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "66e3e9ce9180ae08fc57372061006ef83f0abde7" }
 tree-sitter-nu = { git = "https://github.com/nushell/tree-sitter-nu", rev = "786689b0562b9799ce53e824cb45a1a2a04dc673"}
 tree-sitter-vue = {git = "https://github.com/zed-industries/tree-sitter-vue", rev = "9b6cb221ccb8d0b956fcb17e9a1efac2feefeb58"}
+tree-sitter-uiua = {git = "https://github.com/shnarazk/tree-sitter-uiua", rev = "9260f11be5900beda4ee6d1a24ab8ddfaf5a19b2"}
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "3b0159d25559b603af566ade3c83d930bf466db1" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -140,6 +140,7 @@ tree-sitter-lua.workspace = true
 tree-sitter-nix.workspace = true
 tree-sitter-nu.workspace = true
 tree-sitter-vue.workspace = true
+tree-sitter-uiua.workspace = true
 
 url = "2.2"
 urlencoding = "2.1.2"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -17,6 +17,7 @@ mod json;
 #[cfg(feature = "plugin_runtime")]
 mod language_plugin;
 mod lua;
+mod nu;
 mod php;
 mod python;
 mod ruby;
@@ -24,6 +25,7 @@ mod rust;
 mod svelte;
 mod tailwind;
 mod typescript;
+mod uiua;
 mod vue;
 mod yaml;
 
@@ -210,11 +212,20 @@ pub fn init(
     language("elm", tree_sitter_elm::language(), vec![]);
     language("glsl", tree_sitter_glsl::language(), vec![]);
     language("nix", tree_sitter_nix::language(), vec![]);
-    language("nu", tree_sitter_nu::language(), vec![]);
+    language(
+        "nu",
+        tree_sitter_nu::language(),
+        vec![Arc::new(nu::NuLanguageServer {})],
+    );
     language(
         "vue",
         tree_sitter_vue::language(),
         vec![Arc::new(vue::VueLspAdapter::new(node_runtime))],
+    );
+    language(
+        "uiua",
+        tree_sitter_uiua::language(),
+        vec![Arc::new(uiua::UiuaLanguageServer {})],
     );
 }
 

--- a/crates/zed/src/languages/nu.rs
+++ b/crates/zed/src/languages/nu.rs
@@ -1,0 +1,81 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use language::{CodeLabel, Language, LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use std::{any::Any, path::PathBuf, sync::Arc};
+
+pub struct NuLanguageServer;
+
+#[async_trait]
+impl LspAdapter for NuLanguageServer {
+    async fn name(&self) -> LanguageServerName {
+        LanguageServerName("nu".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "nu"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!(
+            "nu v0.87.0 or greater must be installed and available in your $PATH"
+        ))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "nu".into(),
+            arguments: vec!["--lsp".into()],
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        None
+    }
+
+    async fn label_for_completion(
+        &self,
+        completion: &lsp::CompletionItem,
+        language: &Arc<Language>,
+    ) -> Option<CodeLabel> {
+        return Some(CodeLabel {
+            runs: language
+                .highlight_text(&completion.label.clone().into(), 0..completion.label.len()),
+            text: completion.label.clone(),
+            filter_range: 0..completion.label.len(),
+        });
+    }
+
+    async fn label_for_symbol(
+        &self,
+        name: &str,
+        _: lsp::SymbolKind,
+        language: &Arc<Language>,
+    ) -> Option<CodeLabel> {
+        Some(CodeLabel {
+            runs: language.highlight_text(&name.into(), 0..name.len()),
+            text: name.to_string(),
+            filter_range: 0..name.len(),
+        })
+    }
+}

--- a/crates/zed/src/languages/uiua.rs
+++ b/crates/zed/src/languages/uiua.rs
@@ -1,0 +1,55 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use std::{any::Any, path::PathBuf};
+
+pub struct UiuaLanguageServer;
+
+#[async_trait]
+impl LspAdapter for UiuaLanguageServer {
+    async fn name(&self) -> LanguageServerName {
+        LanguageServerName("uiua".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "uiua"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!(
+            "uiua must be installed and available in your $PATH"
+        ))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "uiua".into(),
+            arguments: vec!["lsp".into()],
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        None
+    }
+}

--- a/crates/zed/src/languages/uiua/config.toml
+++ b/crates/zed/src/languages/uiua/config.toml
@@ -1,0 +1,10 @@
+name = "Uiua"
+path_suffixes = ["ua"]
+line_comment = "# "
+autoclose_before = ")]}\""
+brackets = [
+    { start = "{", end = "}", close = true, newline = false },
+    { start = "[", end = "]", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = false },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]

--- a/crates/zed/src/languages/uiua/highlights.scm
+++ b/crates/zed/src/languages/uiua/highlights.scm
@@ -1,0 +1,50 @@
+[
+  (openParen)
+  (closeParen)
+  (openCurly)
+  (closeCurly)
+  (openBracket)
+  (closeBracket)
+] @punctuation.bracket
+
+[
+  (branchSeparator)
+  (underscore)
+] @constructor
+; ] @punctuation.delimiter
+
+[ (character) ] @constant.character
+[ (comment) ] @comment
+[ (constant) ] @constant.numeric
+[ (identifier) ] @variable
+[ (leftArrow) ] @keyword
+[ (function) ] @function
+[ (modifier1) ] @operator
+[ (modifier2) ] @operator
+[ (number) ] @constant.numeric
+[ (placeHolder) ] @special
+[ (otherConstant) ] @string.special
+[ (signature) ] @type
+[ (system) ] @function.builtin
+[ (tripleMinus) ] @module
+
+; planet
+[
+  "id"
+  "identity"
+  "∘"
+  "dip"
+  "⊙"
+  "gap"
+  "⋅"
+] @tag
+
+[
+  (string)
+  (multiLineString)
+] @string
+
+; [
+;   (deprecated)
+;   (identifierDeprecated)
+; ] @warning

--- a/crates/zed/src/languages/uiua/indents.scm
+++ b/crates/zed/src/languages/uiua/indents.scm
@@ -1,0 +1,3 @@
+[
+  (array)
+] @indent

--- a/crates/zed2/Cargo.toml
+++ b/crates/zed2/Cargo.toml
@@ -136,6 +136,7 @@ tree-sitter-lua.workspace = true
 tree-sitter-nix.workspace = true
 tree-sitter-nu.workspace = true
 tree-sitter-vue.workspace = true
+tree-sitter-uiua.workspace = true
 
 url = "2.2"
 urlencoding = "2.1.2"

--- a/crates/zed2/src/languages.rs
+++ b/crates/zed2/src/languages.rs
@@ -18,6 +18,7 @@ mod json;
 #[cfg(feature = "plugin_runtime")]
 mod language_plugin;
 mod lua;
+mod nu;
 mod php;
 mod python;
 mod ruby;
@@ -25,6 +26,7 @@ mod rust;
 mod svelte;
 mod tailwind;
 mod typescript;
+mod uiua;
 mod vue;
 mod yaml;
 
@@ -211,11 +213,20 @@ pub fn init(
     language("elm", tree_sitter_elm::language(), vec![]);
     language("glsl", tree_sitter_glsl::language(), vec![]);
     language("nix", tree_sitter_nix::language(), vec![]);
-    language("nu", tree_sitter_nu::language(), vec![]);
+    language(
+        "nu",
+        tree_sitter_nu::language(),
+        vec![Arc::new(nu::NuLanguageServer {})],
+    );
     language(
         "vue",
         tree_sitter_vue::language(),
         vec![Arc::new(vue::VueLspAdapter::new(node_runtime))],
+    );
+    language(
+        "uiua",
+        tree_sitter_uiua::language(),
+        vec![Arc::new(uiua::UiuaLanguageServer {})],
     );
 }
 

--- a/crates/zed2/src/languages/nu.rs
+++ b/crates/zed2/src/languages/nu.rs
@@ -1,0 +1,55 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use std::{any::Any, path::PathBuf};
+
+pub struct NuLanguageServer;
+
+#[async_trait]
+impl LspAdapter for NuLanguageServer {
+    async fn name(&self) -> LanguageServerName {
+        LanguageServerName("nu".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "nu"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!(
+            "nu v0.87.0 or greater must be installed and available in your $PATH"
+        ))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "nu".into(),
+            arguments: vec!["--lsp".into()],
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        None
+    }
+}

--- a/crates/zed2/src/languages/uiua.rs
+++ b/crates/zed2/src/languages/uiua.rs
@@ -1,0 +1,55 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use std::{any::Any, path::PathBuf};
+
+pub struct UiuaLanguageServer;
+
+#[async_trait]
+impl LspAdapter for UiuaLanguageServer {
+    async fn name(&self) -> LanguageServerName {
+        LanguageServerName("uiua".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "uiua"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!(
+            "uiua must be installed and available in your $PATH"
+        ))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "uiua".into(),
+            arguments: vec!["lsp".into()],
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        None
+    }
+}

--- a/crates/zed2/src/languages/uiua/config.toml
+++ b/crates/zed2/src/languages/uiua/config.toml
@@ -1,0 +1,10 @@
+name = "Uiua"
+path_suffixes = ["ua"]
+line_comment = "# "
+autoclose_before = ")]}\""
+brackets = [
+    { start = "{", end = "}", close = true, newline = false},
+    { start = "[", end = "]", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = false },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]

--- a/crates/zed2/src/languages/uiua/highlights.scm
+++ b/crates/zed2/src/languages/uiua/highlights.scm
@@ -1,0 +1,50 @@
+[
+  (openParen)
+  (closeParen)
+  (openCurly)
+  (closeCurly)
+  (openBracket)
+  (closeBracket)
+] @punctuation.bracket
+
+[
+  (branchSeparator)
+  (underscore)
+] @constructor
+; ] @punctuation.delimiter
+
+[ (character) ] @constant.character
+[ (comment) ] @comment
+[ (constant) ] @constant.numeric
+[ (identifier) ] @variable
+[ (leftArrow) ] @keyword
+[ (function) ] @function
+[ (modifier1) ] @operator
+[ (modifier2) ] @operator
+[ (number) ] @constant.numeric
+[ (placeHolder) ] @special
+[ (otherConstant) ] @string.special
+[ (signature) ] @type
+[ (system) ] @function.builtin
+[ (tripleMinus) ] @module
+
+; planet
+[
+  "id"
+  "identity"
+  "∘"
+  "dip"
+  "⊙"
+  "gap"
+  "⋅"
+] @tag
+
+[
+  (string)
+  (multiLineString)
+] @string
+
+; [
+;   (deprecated)
+;   (identifierDeprecated)
+; ] @warning

--- a/crates/zed2/src/languages/uiua/indents.scm
+++ b/crates/zed2/src/languages/uiua/indents.scm
@@ -1,0 +1,3 @@
+[
+  (array)
+] @indent


### PR DESCRIPTION
Adds support for Uiua to my favorite editor in advance of AOC and integrates the new nushell lsp. Change made to both zed1 and zed2.

Release Notes:

- Added support for the integrated Nushell LSP
- Added support for the Uiua language