### PR TITLE
Render `Picker` matches using `ListItem`s

### DIFF
--- a/crates/command_palette2/src/command_palette.rs
+++ b/crates/command_palette2/src/command_palette.rs
@@ -294,32 +294,34 @@ impl PickerDelegate for CommandPaletteDelegate {
         ix: usize,
         selected: bool,
         cx: &mut ViewContext<Picker<Self>>,
-    ) -> Self::ListItem {
+    ) -> Option<Self::ListItem> {
         let colors = cx.theme().colors();
         let Some(r#match) = self.matches.get(ix) else {
-            return div();
+            return None;
         };
         let Some(command) = self.commands.get(r#match.candidate_id) else {
-            return div();
+            return None;
         };
 
-        div()
-            .px_1()
-            .text_color(colors.text)
-            .text_ui()
-            .bg(colors.ghost_element_background)
-            .rounded_md()
-            .when(selected, |this| this.bg(colors.ghost_element_selected))
-            .hover(|this| this.bg(colors.ghost_element_hover))
-            .child(
-                h_stack()
-                    .justify_between()
-                    .child(HighlightedLabel::new(
-                        command.name.clone(),
-                        r#match.positions.clone(),
-                    ))
-                    .children(KeyBinding::for_action(&*command.action, cx)),
-            )
+        Some(
+            div()
+                .px_1()
+                .text_color(colors.text)
+                .text_ui()
+                .bg(colors.ghost_element_background)
+                .rounded_md()
+                .when(selected, |this| this.bg(colors.ghost_element_selected))
+                .hover(|this| this.bg(colors.ghost_element_hover))
+                .child(
+                    h_stack()
+                        .justify_between()
+                        .child(HighlightedLabel::new(
+                            command.name.clone(),
+                            r#match.positions.clone(),
+                        ))
+                        .children(KeyBinding::for_action(&*command.action, cx)),
+                ),
+        )
     }
 }
 

--- a/crates/command_palette2/src/command_palette.rs
+++ b/crates/command_palette2/src/command_palette.rs
@@ -1,17 +1,15 @@
 use collections::{CommandPaletteFilter, HashMap};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, div, prelude::*, Action, AppContext, DismissEvent, Div, EventEmitter, FocusHandle,
-    FocusableView, Keystroke, ParentElement, Render, Styled, View, ViewContext, VisualContext,
-    WeakView,
+    actions, Action, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView,
+    Keystroke, ParentElement, Render, Styled, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
 use std::{
     cmp::{self, Reverse},
     sync::Arc,
 };
-use theme::ActiveTheme;
-use ui::{h_stack, v_stack, HighlightedLabel, KeyBinding, StyledExt};
+use ui::{h_stack, v_stack, HighlightedLabel, KeyBinding, ListItem};
 use util::{
     channel::{parse_zed_link, ReleaseChannel, RELEASE_CHANNEL},
     ResultExt,
@@ -141,7 +139,7 @@ impl CommandPaletteDelegate {
 }
 
 impl PickerDelegate for CommandPaletteDelegate {
-    type ListItem = Div;
+    type ListItem = ListItem;
 
     fn placeholder_text(&self) -> Arc<str> {
         "Execute a command...".into()
@@ -295,7 +293,6 @@ impl PickerDelegate for CommandPaletteDelegate {
         selected: bool,
         cx: &mut ViewContext<Picker<Self>>,
     ) -> Option<Self::ListItem> {
-        let colors = cx.theme().colors();
         let Some(r#match) = self.matches.get(ix) else {
             return None;
         };
@@ -304,23 +301,15 @@ impl PickerDelegate for CommandPaletteDelegate {
         };
 
         Some(
-            div()
-                .px_1()
-                .text_color(colors.text)
-                .text_ui()
-                .bg(colors.ghost_element_background)
-                .rounded_md()
-                .when(selected, |this| this.bg(colors.ghost_element_selected))
-                .hover(|this| this.bg(colors.ghost_element_hover))
-                .child(
-                    h_stack()
-                        .justify_between()
-                        .child(HighlightedLabel::new(
-                            command.name.clone(),
-                            r#match.positions.clone(),
-                        ))
-                        .children(KeyBinding::for_action(&*command.action, cx)),
-                ),
+            ListItem::new(ix).selected(selected).child(
+                h_stack()
+                    .justify_between()
+                    .child(HighlightedLabel::new(
+                        command.name.clone(),
+                        r#match.positions.clone(),
+                    ))
+                    .children(KeyBinding::for_action(&*command.action, cx)),
+            ),
         )
     }
 }

--- a/crates/file_finder2/src/file_finder.rs
+++ b/crates/file_finder2/src/file_finder.rs
@@ -711,7 +711,7 @@ impl PickerDelegate for FileFinderDelegate {
         ix: usize,
         selected: bool,
         cx: &mut ViewContext<Picker<Self>>,
-    ) -> Self::ListItem {
+    ) -> Option<Self::ListItem> {
         let path_match = self
             .matches
             .get(ix)
@@ -722,19 +722,21 @@ impl PickerDelegate for FileFinderDelegate {
         let (file_name, file_name_positions, full_path, full_path_positions) =
             self.labels_for_match(path_match, cx, ix);
 
-        div()
-            .px_1()
-            .text_color(colors.text)
-            .text_ui()
-            .bg(colors.ghost_element_background)
-            .rounded_md()
-            .when(selected, |this| this.bg(colors.ghost_element_selected))
-            .hover(|this| this.bg(colors.ghost_element_hover))
-            .child(
-                v_stack()
-                    .child(HighlightedLabel::new(file_name, file_name_positions))
-                    .child(HighlightedLabel::new(full_path, full_path_positions)),
-            )
+        Some(
+            div()
+                .px_1()
+                .text_color(colors.text)
+                .text_ui()
+                .bg(colors.ghost_element_background)
+                .rounded_md()
+                .when(selected, |this| this.bg(colors.ghost_element_selected))
+                .hover(|this| this.bg(colors.ghost_element_hover))
+                .child(
+                    v_stack()
+                        .child(HighlightedLabel::new(file_name, file_name_positions))
+                        .child(HighlightedLabel::new(full_path, full_path_positions)),
+                ),
+        )
     }
 }
 

--- a/crates/file_finder2/src/file_finder.rs
+++ b/crates/file_finder2/src/file_finder.rs
@@ -2,9 +2,8 @@ use collections::HashMap;
 use editor::{scroll::autoscroll::Autoscroll, Bias, Editor};
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
-    actions, div, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView,
-    InteractiveElement, IntoElement, Model, ParentElement, Render, Styled, Task, View, ViewContext,
-    VisualContext, WeakView,
+    actions, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView, Model,
+    ParentElement, Render, Styled, Task, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
 use project::{PathMatchCandidateSet, Project, ProjectPath, WorktreeId};
@@ -16,8 +15,7 @@ use std::{
     },
 };
 use text::Point;
-use theme::ActiveTheme;
-use ui::{v_stack, HighlightedLabel, StyledExt};
+use ui::{v_stack, HighlightedLabel, ListItem};
 use util::{paths::PathLikeWithPosition, post_inc, ResultExt};
 use workspace::Workspace;
 
@@ -530,7 +528,7 @@ impl FileFinderDelegate {
 }
 
 impl PickerDelegate for FileFinderDelegate {
-    type ListItem = Div;
+    type ListItem = ListItem;
 
     fn placeholder_text(&self) -> Arc<str> {
         "Search project files...".into()
@@ -716,26 +714,16 @@ impl PickerDelegate for FileFinderDelegate {
             .matches
             .get(ix)
             .expect("Invalid matches state: no element for index {ix}");
-        let theme = cx.theme();
-        let colors = theme.colors();
 
         let (file_name, file_name_positions, full_path, full_path_positions) =
             self.labels_for_match(path_match, cx, ix);
 
         Some(
-            div()
-                .px_1()
-                .text_color(colors.text)
-                .text_ui()
-                .bg(colors.ghost_element_background)
-                .rounded_md()
-                .when(selected, |this| this.bg(colors.ghost_element_selected))
-                .hover(|this| this.bg(colors.ghost_element_hover))
-                .child(
-                    v_stack()
-                        .child(HighlightedLabel::new(file_name, file_name_positions))
-                        .child(HighlightedLabel::new(full_path, full_path_positions)),
-                ),
+            ListItem::new(ix).selected(selected).child(
+                v_stack()
+                    .child(HighlightedLabel::new(file_name, file_name_positions))
+                    .child(HighlightedLabel::new(full_path, full_path_positions)),
+            ),
         )
     }
 }

--- a/crates/picker2/src/picker2.rs
+++ b/crates/picker2/src/picker2.rs
@@ -32,7 +32,7 @@ pub trait PickerDelegate: Sized + 'static {
         ix: usize,
         selected: bool,
         cx: &mut ViewContext<Picker<Self>>,
-    ) -> Self::ListItem;
+    ) -> Option<Self::ListItem>;
 }
 
 impl<D: PickerDelegate> FocusableView for Picker<D> {
@@ -230,7 +230,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
                                                             )
                                                         }),
                                                     )
-                                                    .child(picker.delegate.render_match(
+                                                    .children(picker.delegate.render_match(
                                                         ix,
                                                         ix == selected_index,
                                                         cx,

--- a/crates/storybook2/src/stories/picker.rs
+++ b/crates/storybook2/src/stories/picker.rs
@@ -5,6 +5,7 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use std::sync::Arc;
 use theme2::ActiveTheme;
+use ui::{Label, ListItem};
 
 pub struct PickerStory {
     picker: View<Picker<Delegate>>,
@@ -36,7 +37,7 @@ impl Delegate {
 }
 
 impl PickerDelegate for Delegate {
-    type ListItem = Div;
+    type ListItem = ListItem;
 
     fn match_count(&self) -> usize {
         self.candidates.len()
@@ -52,7 +53,6 @@ impl PickerDelegate for Delegate {
         selected: bool,
         cx: &mut gpui::ViewContext<Picker<Self>>,
     ) -> Option<Self::ListItem> {
-        let colors = cx.theme().colors();
         let Some(candidate_ix) = self.matches.get(ix) else {
             return None;
         };
@@ -60,17 +60,9 @@ impl PickerDelegate for Delegate {
         let candidate = SharedString::from(self.candidates[*candidate_ix].string.clone());
 
         Some(
-            div()
-                .text_color(colors.text)
-                .when(selected, |s| {
-                    s.border_l_10().border_color(colors.terminal_ansi_yellow)
-                })
-                .hover(|style| {
-                    style
-                        .bg(colors.element_active)
-                        .text_color(colors.text_accent)
-                })
-                .child(candidate),
+            ListItem::new(ix)
+                .selected(selected)
+                .child(Label::new(candidate)),
         )
     }
 

--- a/crates/storybook2/src/stories/picker.rs
+++ b/crates/storybook2/src/stories/picker.rs
@@ -51,25 +51,27 @@ impl PickerDelegate for Delegate {
         ix: usize,
         selected: bool,
         cx: &mut gpui::ViewContext<Picker<Self>>,
-    ) -> Self::ListItem {
+    ) -> Option<Self::ListItem> {
         let colors = cx.theme().colors();
         let Some(candidate_ix) = self.matches.get(ix) else {
-            return div();
+            return None;
         };
         // TASK: Make StringMatchCandidate::string a SharedString
         let candidate = SharedString::from(self.candidates[*candidate_ix].string.clone());
 
-        div()
-            .text_color(colors.text)
-            .when(selected, |s| {
-                s.border_l_10().border_color(colors.terminal_ansi_yellow)
-            })
-            .hover(|style| {
-                style
-                    .bg(colors.element_active)
-                    .text_color(colors.text_accent)
-            })
-            .child(candidate)
+        Some(
+            div()
+                .text_color(colors.text)
+                .when(selected, |s| {
+                    s.border_l_10().border_color(colors.terminal_ansi_yellow)
+                })
+                .hover(|style| {
+                    style
+                        .bg(colors.element_active)
+                        .text_color(colors.text_accent)
+                })
+                .child(candidate),
+        )
     }
 
     fn selected_index(&self) -> usize {


### PR DESCRIPTION
This PR updates the `PickerDelegate` implementations to render their matches using the `ListItem` component so that they can have a consistent style.

At some point it might make sense to move the `ListItem` rendering up into the `Picker` implementation itself, and just have the delegate responsible for giving us the inner content of the `ListItem`.

Release Notes:

- N/A
