### PR TITLE
Add inset variant to `ListItem`

### DIFF
--- a/crates/command_palette2/src/command_palette.rs
+++ b/crates/command_palette2/src/command_palette.rs
@@ -301,7 +301,7 @@ impl PickerDelegate for CommandPaletteDelegate {
         };
 
         Some(
-            ListItem::new(ix).selected(selected).child(
+            ListItem::new(ix).inset(true).selected(selected).child(
                 h_stack()
                     .justify_between()
                     .child(HighlightedLabel::new(

--- a/crates/file_finder2/src/file_finder.rs
+++ b/crates/file_finder2/src/file_finder.rs
@@ -719,7 +719,7 @@ impl PickerDelegate for FileFinderDelegate {
             self.labels_for_match(path_match, cx, ix);
 
         Some(
-            ListItem::new(ix).selected(selected).child(
+            ListItem::new(ix).inset(true).selected(selected).child(
                 v_stack()
                     .child(HighlightedLabel::new(file_name, file_name_positions))
                     .child(HighlightedLabel::new(full_path, full_path_positions)),

--- a/crates/storybook2/src/stories/picker.rs
+++ b/crates/storybook2/src/stories/picker.rs
@@ -61,6 +61,7 @@ impl PickerDelegate for Delegate {
 
         Some(
             ListItem::new(ix)
+                .inset(true)
                 .selected(selected)
                 .child(Label::new(candidate)),
         )

--- a/crates/ui2/src/components/list.rs
+++ b/crates/ui2/src/components/list.rs
@@ -297,6 +297,15 @@ impl RenderOnce for ListItem {
             .when(self.selected, |this| {
                 this.bg(cx.theme().colors().ghost_element_selected)
             })
+            .when_some(self.on_click.clone(), |this, on_click| {
+                this.on_click(move |event, cx| {
+                    // HACK: GPUI currently fires `on_click` with any mouse button,
+                    // but we only care about the left button.
+                    if event.down.button == MouseButton::Left {
+                        (on_click)(event, cx)
+                    }
+                })
+            })
             .when_some(self.on_secondary_mouse_down, |this, on_mouse_down| {
                 this.on_mouse_down(MouseButton::Right, move |event, cx| {
                     (on_mouse_down)(event, cx)


### PR DESCRIPTION
This PR adds an inset variant to the `ListItem` component.

We're now using this inset variant for the `ListItem`s we render in pickers.

Release Notes:

- N/A
