### PR TITLE
Remove ID hack in `ListItem`

### DIFF
--- a/crates/ui2/src/components/list.rs
+++ b/crates/ui2/src/components/list.rs
@@ -316,21 +316,7 @@ impl RenderOnce for ListItem {
                     .relative()
                     .child(disclosure_control(self.toggle, self.on_toggle))
                     .children(left_content)
-                    .children(self.children)
-                    // HACK: We need to attach the `on_click` handler to the child element in order to have the click
-                    // event actually fire.
-                    // Once this is fixed in GPUI we can remove this and rely on the `on_click` handler set above on the
-                    // outer `div`.
-                    .id("on_click_hack")
-                    .when_some(self.on_click, |this, on_click| {
-                        this.on_click(move |event, cx| {
-                            // HACK: GPUI currently fires `on_click` with any mouse button,
-                            // but we only care about the left button.
-                            if event.down.button == MouseButton::Left {
-                                (on_click)(event, cx)
-                            }
-                        })
-                    }),
+                    .children(self.children),
             )
     }
 }

--- a/crates/ui2/src/components/stories/list_item.rs
+++ b/crates/ui2/src/components/stories/list_item.rs
@@ -24,11 +24,11 @@ impl Render for ListItemStory {
             )
             .child(Story::label("With `on_secondary_mouse_down`"))
             .child(
-                ListItem::new("with_on_secondary_mouse_down").on_secondary_mouse_down(
-                    |_event, _cx| {
+                ListItem::new("with_on_secondary_mouse_down")
+                    .child("Right click me")
+                    .on_secondary_mouse_down(|_event, _cx| {
                         println!("Right mouse down!");
-                    },
-                ),
+                    }),
             )
     }
 }


### PR DESCRIPTION
This PR removes the ID hack in `ListItem`, since the underlying issue was fixed in #3430.

Release Notes:

- N/A
