### PR TITLE
Make npm to use local cache more aggressively

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -208,6 +208,7 @@ impl NodeRuntime for RealNodeRuntime {
                     "5000",
                     "--fetch-timeout",
                     "5000",
+                    "--prefer-offline",
                 ],
             )
             .await?;
@@ -237,6 +238,7 @@ impl NodeRuntime for RealNodeRuntime {
             "5000",
             "--fetch-timeout",
             "5000",
+            "--prefer-offline",
         ]);
 
         self.run_npm_subcommand(Some(directory), "install", &arguments)


### PR DESCRIPTION
npm by default considers its cache as stale relatively quickly, which makes it to fetch extra package info from remote registry per package. With the current `--fetch-timeout 5000` argument, this takes TIMEOUT x NUM_PACKAGES when Zed is offline.

According to npm documentation, `--prefer-offline` flag makes npm to use local cache more agressively and taking package metadata and tarballs from it instead of querying the remote registry. On cache miss, offline mode fails and online mode repopulates the cache with missing, actualized package data.

Release Notes:

- Improved Zed's npm usage speed, when offline