### PR TITLE
Style hover popover

### DIFF
--- a/crates/editor2/src/hover_popover.rs
+++ b/crates/editor2/src/hover_popover.rs
@@ -15,7 +15,7 @@ use lsp::DiagnosticSeverity;
 use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart, Project};
 use settings::Settings;
 use std::{ops::Range, sync::Arc, time::Duration};
-use ui::Tooltip;
+use ui::{StyledExt, Tooltip};
 use util::TryFutureExt;
 use workspace::Workspace;
 
@@ -476,8 +476,10 @@ impl InfoPopover {
     ) -> AnyElement {
         div()
             .id("info_popover")
+            .elevation_2(cx)
+            .text_ui()
+            .p_2()
             .overflow_y_scroll()
-            .bg(gpui::red())
             .max_w(max_size.width)
             .max_h(max_size.height)
             // Prevent a mouse move on the popover from being propagated to the editor,


### PR DESCRIPTION
[[PR Description]]

This PR styles the hover popover, and sets it on the [second elevation level](https://zed-docs.vercel.app/doc/ui2/trait.StyledExt.html#method.elevation_2).

![CleanShot 2023-11-29 at 14 55 55@2x](https://github.com/zed-industries/zed/assets/1714999/01589b2a-d6e2-4baa-ba5d-050f06cf2c58)


Release Notes:

- N/A
