### PR TITLE
Make `toggle` method accept `impl Into<Option<bool>>`

### DIFF
--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -2505,7 +2505,7 @@ impl CollabPanel {
             .when_some(button, |el, button| el.right_button(button))
             .selected(is_selected)
             .when(can_collapse, |el| {
-                el.toggle(Some(is_collapsed)).on_toggle(
+                el.toggle(is_collapsed).on_toggle(
                     cx.listener(move |this, _, cx| this.toggle_section_expanded(section, cx)),
                 )
             });

--- a/crates/ui2/src/components/disclosure.rs
+++ b/crates/ui2/src/components/disclosure.rs
@@ -34,10 +34,9 @@ impl RenderOnce for Disclosure {
     fn render(self, _cx: &mut WindowContext) -> Self::Rendered {
         IconButton::new(
             "toggle",
-            if self.is_open {
-                Icon::ChevronDown
-            } else {
-                Icon::ChevronRight
+            match self.is_open {
+                true => Icon::ChevronDown,
+                false => Icon::ChevronRight,
             },
         )
         .color(Color::Muted)

--- a/crates/ui2/src/components/list.rs
+++ b/crates/ui2/src/components/list.rs
@@ -44,8 +44,8 @@ impl List {
         self
     }
 
-    pub fn toggle(mut self, toggle: Option<bool>) -> Self {
-        self.toggle = toggle;
+    pub fn toggle(mut self, toggle: impl Into<Option<bool>>) -> Self {
+        self.toggle = toggle.into();
         self
     }
 }

--- a/crates/ui2/src/components/list/list_header.rs
+++ b/crates/ui2/src/components/list/list_header.rs
@@ -36,8 +36,8 @@ impl ListHeader {
         }
     }
 
-    pub fn toggle(mut self, toggle: Option<bool>) -> Self {
-        self.toggle = toggle;
+    pub fn toggle(mut self, toggle: impl Into<Option<bool>>) -> Self {
+        self.toggle = toggle.into();
         self
     }
 

--- a/crates/ui2/src/components/list/list_item.rs
+++ b/crates/ui2/src/components/list/list_item.rs
@@ -70,8 +70,8 @@ impl ListItem {
         self
     }
 
-    pub fn toggle(mut self, toggle: Option<bool>) -> Self {
-        self.toggle = toggle;
+    pub fn toggle(mut self, toggle: impl Into<Option<bool>>) -> Self {
+        self.toggle = toggle.into();
         self
     }
 


### PR DESCRIPTION
This PR makes the `toggle` method on the various list components accept an `impl Into<Option<bool>>` instead of just an `Option<bool>`.

This allows a caller with just a `bool` avoid having to wrap the `Option` themselves.

Release Notes:

- N/A
