### PR TITLE
Fix the selected state for the panel icons in the status bar

### DIFF
--- a/crates/ui2/src/components/stories/icon_button.rs
+++ b/crates/ui2/src/components/stories/icon_button.rs
@@ -14,6 +14,12 @@ impl Render for IconButtonStory {
             .child(Story::title_for::<IconButton>())
             .child(Story::label("Default"))
             .child(div().w_8().child(IconButton::new("icon_a", Icon::Hash)))
+            .child(Story::label("Selected"))
+            .child(
+                div()
+                    .w_8()
+                    .child(IconButton::new("icon_a", Icon::Hash).selected(true)),
+            )
             .child(Story::label("With `on_click`"))
             .child(
                 div()

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -701,11 +701,6 @@ impl Render for PanelButtons {
                     (action, name.into())
                 };
 
-                let button = IconButton::new(name, icon)
-                    .selected(is_active_button)
-                    .action(action.boxed_clone())
-                    .tooltip(move |cx| Tooltip::for_action(tooltip.clone(), &*action, cx));
-
                 Some(
                     menu_handle(name)
                         .menu(move |cx| {
@@ -731,7 +726,14 @@ impl Render for PanelButtons {
                         })
                         .anchor(menu_anchor)
                         .attach(menu_attach)
-                        .child(|is_open| button.selected(is_open)),
+                        .child(move |_is_open| {
+                            IconButton::new(name, icon)
+                                .selected(is_active_button)
+                                .action(action.boxed_clone())
+                                .tooltip(move |cx| {
+                                    Tooltip::for_action(tooltip.clone(), &*action, cx)
+                                })
+                        }),
                 )
             });
 


### PR DESCRIPTION
This PR fixes a bug where the selected state for the panel icons in the status bar was not correctly reflecting whether the panel was open.

It was erroneously using the `is_open` state for the context menu.

Release Notes:

- N/A