### PR TITLE
Implement `Selectable` for buttons

### DIFF
--- a/crates/ui2/src/components/button/button.rs
+++ b/crates/ui2/src/components/button/button.rs
@@ -8,7 +8,6 @@ pub struct Button {
     base: ButtonLike,
     label: SharedString,
     label_color: Option<Color>,
-    selected: bool,
 }
 
 impl Button {
@@ -17,17 +16,25 @@ impl Button {
             base: ButtonLike::new(id),
             label: label.into(),
             label_color: None,
-            selected: false,
         }
-    }
-
-    pub fn selected(mut self, selected: bool) -> Self {
-        self.selected = selected;
-        self
     }
 
     pub fn color(mut self, label_color: impl Into<Option<Color>>) -> Self {
         self.label_color = label_color.into();
+        self
+    }
+}
+
+impl Selectable for Button {
+    fn selected(mut self, selected: bool) -> Self {
+        self.base = self.base.selected(selected);
+        self
+    }
+}
+
+impl Disableable for Button {
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.base = self.base.disabled(disabled);
         self
     }
 }
@@ -38,13 +45,6 @@ impl Clickable for Button {
         handler: impl Fn(&gpui::ClickEvent, &mut WindowContext) + 'static,
     ) -> Self {
         self.base = self.base.on_click(handler);
-        self
-    }
-}
-
-impl Disableable for Button {
-    fn disabled(mut self, disabled: bool) -> Self {
-        self.base = self.base.disabled(disabled);
         self
     }
 }
@@ -76,7 +76,7 @@ impl RenderOnce for Button {
     fn render(self, _cx: &mut WindowContext) -> Self::Rendered {
         let label_color = if self.base.disabled {
             Color::Disabled
-        } else if self.selected {
+        } else if self.base.selected {
             Color::Selected
         } else {
             Color::Default

--- a/crates/ui2/src/components/button/button_like.rs
+++ b/crates/ui2/src/components/button/button_like.rs
@@ -172,6 +172,7 @@ pub struct ButtonLike {
     id: ElementId,
     pub(super) style: ButtonStyle2,
     pub(super) disabled: bool,
+    pub(super) selected: bool,
     size: ButtonSize2,
     tooltip: Option<Box<dyn Fn(&mut WindowContext) -> AnyView>>,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
@@ -184,6 +185,7 @@ impl ButtonLike {
             id: id.into(),
             style: ButtonStyle2::default(),
             disabled: false,
+            selected: false,
             size: ButtonSize2::Default,
             tooltip: None,
             children: SmallVec::new(),
@@ -199,25 +201,19 @@ impl Disableable for ButtonLike {
     }
 }
 
+impl Selectable for ButtonLike {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+}
+
 impl Clickable for ButtonLike {
     fn on_click(mut self, handler: impl Fn(&ClickEvent, &mut WindowContext) + 'static) -> Self {
         self.on_click = Some(Box::new(handler));
         self
     }
 }
-
-// impl Selectable for ButtonLike {
-//     fn selected(&mut self, selected: bool) -> &mut Self {
-//         todo!()
-//     }
-
-//     fn selected_tooltip(
-//         &mut self,
-//         tooltip: Box<dyn Fn(&mut WindowContext) -> AnyView + 'static>,
-//     ) -> &mut Self {
-//         todo!()
-//     }
-// }
 
 impl ButtonCommon for ButtonLike {
     fn id(&self) -> &ElementId {

--- a/crates/ui2/src/components/button/icon_button.rs
+++ b/crates/ui2/src/components/button/icon_button.rs
@@ -9,7 +9,6 @@ pub struct IconButton {
     icon: Icon,
     icon_size: IconSize,
     icon_color: Color,
-    selected: bool,
 }
 
 impl IconButton {
@@ -19,13 +18,7 @@ impl IconButton {
             icon,
             icon_size: IconSize::default(),
             icon_color: Color::Default,
-            selected: false,
         }
-    }
-
-    pub fn selected(mut self, selected: bool) -> Self {
-        self.selected = selected;
-        self
     }
 
     pub fn icon_size(mut self, icon_size: IconSize) -> Self {
@@ -43,19 +36,26 @@ impl IconButton {
     }
 }
 
+impl Disableable for IconButton {
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.base = self.base.disabled(disabled);
+        self
+    }
+}
+
+impl Selectable for IconButton {
+    fn selected(mut self, selected: bool) -> Self {
+        self.base = self.base.selected(selected);
+        self
+    }
+}
+
 impl Clickable for IconButton {
     fn on_click(
         mut self,
         handler: impl Fn(&gpui::ClickEvent, &mut WindowContext) + 'static,
     ) -> Self {
         self.base = self.base.on_click(handler);
-        self
-    }
-}
-
-impl Disableable for IconButton {
-    fn disabled(mut self, disabled: bool) -> Self {
-        self.base = self.base.disabled(disabled);
         self
     }
 }
@@ -87,7 +87,7 @@ impl RenderOnce for IconButton {
     fn render(self, _cx: &mut WindowContext) -> Self::Rendered {
         let icon_color = if self.base.disabled {
             Color::Disabled
-        } else if self.selected {
+        } else if self.base.selected {
             Color::Selected
         } else {
             self.icon_color

--- a/crates/ui2/src/components/stories/icon_button.rs
+++ b/crates/ui2/src/components/stories/icon_button.rs
@@ -20,6 +20,12 @@ impl Render for IconButtonStory {
                     .w_8()
                     .child(IconButton::new("icon_a", Icon::Hash).selected(true)),
             )
+            .child(Story::label("Disabled"))
+            .child(
+                div()
+                    .w_8()
+                    .child(IconButton::new("icon_a", Icon::Hash).disabled(true)),
+            )
             .child(Story::label("With `on_click`"))
             .child(
                 div()

--- a/crates/ui2/src/selectable.rs
+++ b/crates/ui2/src/selectable.rs
@@ -1,15 +1,7 @@
-use gpui::{AnyView, WindowContext};
-
 /// A trait for elements that can be selected.
 pub trait Selectable {
     /// Sets whether the element is selected.
     fn selected(self, selected: bool) -> Self;
-
-    /// Sets the tooltip that should be shown when the element is selected.
-    fn selected_tooltip(
-        self,
-        tooltip: Box<dyn Fn(&mut WindowContext) -> AnyView + 'static>,
-    ) -> Self;
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]


### PR DESCRIPTION
This PR implements the `Selectable` trait for `ButtonLike`, `Button`, and `IconButton`.

Release Notes:

- N/A
