### PR TITLE
Fix bug preventing spaces from being used in file names in the project panel

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -530,10 +530,15 @@
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
-      "space": "project_panel::Open",
       "backspace": "project_panel::Delete",
       "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
+    }
+  },
+  {
+    "context": "ProjectPanel && not_editing",
+    "bindings": {
+      "space": "project_panel::Open"
     }
   },
   {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1627,9 +1627,21 @@ impl View for ProjectPanel {
         }
     }
 
-    fn update_keymap_context(&self, keymap: &mut KeymapContext, _: &AppContext) {
+    fn update_keymap_context(&self, keymap: &mut KeymapContext, cx: &AppContext) {
         Self::reset_to_default_keymap_context(keymap);
         keymap.add_identifier("menu");
+
+        if let Some(window) = cx.active_window() {
+            window.read_with(cx, |cx| {
+                let identifier = if self.filename_editor.is_focused(cx) {
+                    "editing"
+                } else {
+                    "not_editing"
+                };
+
+                keymap.add_identifier(identifier);
+            });
+        }
     }
 
     fn focus_in(&mut self, _: gpui::AnyViewHandle, cx: &mut ViewContext<Self>) {

--- a/crates/project_panel2/src/project_panel.rs
+++ b/crates/project_panel2/src/project_panel.rs
@@ -3011,3 +3011,21 @@ mod tests {
             .unwrap();
     }
 }
+
+// TODO - implement this in the new keymap system
+// fn update_keymap_context(&self, keymap: &mut KeymapContext, cx: &AppContext) {
+//     Self::reset_to_default_keymap_context(keymap);
+//     keymap.add_identifier("menu");
+
+//     if let Some(window) = cx.active_window() {
+//         window.read_with(cx, |cx| {
+//             let identifier = if self.filename_editor.is_focused(cx) {
+//                 "editing"
+//             } else {
+//                 "not_editing"
+//             };
+
+//             keymap.add_identifier(identifier);
+//         });
+//     }
+// }


### PR DESCRIPTION
This bug was my fault, something I changed months ago to be more consistent with VS Code - really strange that it took months for someone to find out spaces couldn't be used in the project panel.

~I didn't apply this fix to zed2 because I dont think the facilities are in place to do so (@maxbrunsfeld, @mikayla-maki, is there a system in place for this that I missed?). I did leave a TODO.~

Fix is now in zed 2.

Release Notes:

- Fixed a bug where spaces could not be inserted when editing file names in the project panel ([#2308](https://github.com/zed-industries/zed/issues/6377)).
