### PR TITLE
Add some text to clarify no api key state

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1220,6 +1220,31 @@ impl View for AssistantPanel {
             Flex::column()
                 .with_child(
                     Text::new(
+                        "To use the assistant panel or inline assistant, you need to add your OpenAI api key.",
+                        style.api_key_prompt.text.clone(),
+                    ),
+                )
+                .with_child(
+                    Text::new(
+                        " - Having a subscription for another service like GitHub Copilot won't work.",
+                        style.api_key_prompt.text.clone(),
+                    ),
+                )
+                .with_child(
+                    Text::new(
+                        " - You can create a api key at: platform.openai.com/api-keys",
+                        style.api_key_prompt.text.clone(),
+                    ),
+                )
+                .with_child(
+                    Text::new(
+                        " ",
+                        style.api_key_prompt.text.clone(),
+                    )
+                    .aligned(),
+                )
+                .with_child(
+                    Text::new(
                         "Paste your OpenAI API key and press Enter to use the assistant",
                         style.api_key_prompt.text.clone(),
                     )
@@ -1230,6 +1255,20 @@ impl View for AssistantPanel {
                         .contained()
                         .with_style(style.api_key_editor.container)
                         .aligned(),
+                )
+                .with_child(
+                    Text::new(
+                        " ",
+                        style.api_key_prompt.text.clone(),
+                    )
+                    .aligned(),
+                )
+                .with_child(
+                    Text::new(
+                        "Click on the Z button in the status bar to close this panel.",
+                        style.api_key_prompt.text.clone(),
+                    )
+                    .aligned(),
                 )
                 .contained()
                 .with_style(style.api_key_prompt.container)


### PR DESCRIPTION
This PR is a quick-and-dirty approach to clarify what is happening when a user doesn't have an API key so the assistant opens with the key editor.

- Adds some text explaining how to close the panel
- Explains that other subscriptions don't cover the assistant, it needs an api key.
- Helps people understand where to go to get an API key.

This is a Zed 1 change only, a bandaid. Zed 2 will have a better solution: [Working issue](https://github.com/zed-industries/zed/issues/3461)

Release Notes:

- N/A
