### PR TITLE
Rename button-related enums

### DIFF
--- a/crates/collab_ui2/src/collab_titlebar_item.rs
+++ b/crates/collab_ui2/src/collab_titlebar_item.rs
@@ -37,7 +37,7 @@ use gpui::{
 };
 use project::Project;
 use theme::ActiveTheme;
-use ui::{h_stack, prelude::*, Avatar, Button, ButtonStyle2, IconButton, KeyBinding, Tooltip};
+use ui::{h_stack, prelude::*, Avatar, Button, ButtonStyle, IconButton, KeyBinding, Tooltip};
 use util::ResultExt;
 use workspace::{notifications::NotifyResultExt, Workspace};
 
@@ -154,7 +154,7 @@ impl Render for CollabTitlebarItem {
                             .id("project_owner_indicator")
                             .child(
                                 Button::new("player", "player")
-                                    .style(ButtonStyle2::Subtle)
+                                    .style(ButtonStyle::Subtle)
                                     .color(Some(Color::Player(0))),
                             )
                             .tooltip(move |cx| Tooltip::text("Toggle following", cx)),
@@ -167,7 +167,7 @@ impl Render for CollabTitlebarItem {
                             .id("titlebar_project_menu_button")
                             .child(
                                 Button::new("project_name", "project_name")
-                                    .style(ButtonStyle2::Subtle),
+                                    .style(ButtonStyle::Subtle),
                             )
                             .tooltip(move |cx| Tooltip::text("Recent Projects", cx)),
                     )
@@ -179,7 +179,7 @@ impl Render for CollabTitlebarItem {
                             .id("titlebar_git_menu_button")
                             .child(
                                 Button::new("branch_name", "branch_name")
-                                    .style(ButtonStyle2::Subtle)
+                                    .style(ButtonStyle::Subtle)
                                     .color(Some(Color::Muted)),
                             )
                             .tooltip(move |cx| {

--- a/crates/search2/src/search.rs
+++ b/crates/search2/src/search.rs
@@ -4,7 +4,7 @@ use gpui::{actions, Action, AppContext, IntoElement};
 pub use mode::SearchMode;
 use project::search::SearchQuery;
 use ui::prelude::*;
-use ui::{ButtonStyle2, Icon, IconButton};
+use ui::{ButtonStyle, Icon, IconButton};
 //pub use project_search::{ProjectSearchBar, ProjectSearchView};
 // use theme::components::{
 //     action_button::Button, svg::Svg, ComponentExt, IconButtonStyle, ToggleIconButtonStyle,
@@ -91,8 +91,8 @@ impl SearchOptions {
                     cx.dispatch_action(action.boxed_clone());
                 }
             })
-            .style(ButtonStyle2::Subtle)
-            .when(active, |button| button.style(ButtonStyle2::Filled))
+            .style(ButtonStyle::Subtle)
+            .when(active, |button| button.style(ButtonStyle::Filled))
     }
 }
 
@@ -103,8 +103,8 @@ fn toggle_replace_button(active: bool) -> impl IntoElement {
             cx.dispatch_action(Box::new(ToggleReplace));
             cx.notify();
         })
-        .style(ButtonStyle2::Subtle)
-        .when(active, |button| button.style(ButtonStyle2::Filled))
+        .style(ButtonStyle::Subtle)
+        .when(active, |button| button.style(ButtonStyle::Filled))
 }
 
 fn render_replace_button(

--- a/crates/ui2/src/components/button/button.rs
+++ b/crates/ui2/src/components/button/button.rs
@@ -1,7 +1,7 @@
 use gpui::AnyView;
 
 use crate::prelude::*;
-use crate::{ButtonCommon, ButtonLike, ButtonSize2, ButtonStyle2, Label, LineHeightStyle};
+use crate::{ButtonCommon, ButtonLike, ButtonSize, ButtonStyle, Label, LineHeightStyle};
 
 #[derive(IntoElement)]
 pub struct Button {
@@ -54,12 +54,12 @@ impl ButtonCommon for Button {
         self.base.id()
     }
 
-    fn style(mut self, style: ButtonStyle2) -> Self {
+    fn style(mut self, style: ButtonStyle) -> Self {
         self.base = self.base.style(style);
         self
     }
 
-    fn size(mut self, size: ButtonSize2) -> Self {
+    fn size(mut self, size: ButtonSize) -> Self {
         self.base = self.base.size(size);
         self
     }

--- a/crates/ui2/src/components/button/button_like.rs
+++ b/crates/ui2/src/components/button/button_like.rs
@@ -1,4 +1,4 @@
-use gpui::{rems, AnyElement, AnyView, ClickEvent, Div, Hsla, Rems, Stateful};
+use gpui::{rems, transparent_black, AnyElement, AnyView, ClickEvent, Div, Hsla, Rems, Stateful};
 use smallvec::SmallVec;
 
 use crate::h_stack;
@@ -6,13 +6,13 @@ use crate::prelude::*;
 
 pub trait ButtonCommon: Clickable + Disableable {
     fn id(&self) -> &ElementId;
-    fn style(self, style: ButtonStyle2) -> Self;
-    fn size(self, size: ButtonSize2) -> Self;
+    fn style(self, style: ButtonStyle) -> Self;
+    fn size(self, size: ButtonSize) -> Self;
     fn tooltip(self, tooltip: impl Fn(&mut WindowContext) -> AnyView + 'static) -> Self;
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
-pub enum ButtonStyle2 {
+pub enum ButtonStyle {
     #[default]
     Filled,
     // Tinted,
@@ -21,54 +21,57 @@ pub enum ButtonStyle2 {
 }
 
 #[derive(Debug, Clone)]
-pub struct ButtonStyle {
+pub(crate) struct ButtonLikeStyles {
     pub background: Hsla,
+    #[allow(unused)]
     pub border_color: Hsla,
+    #[allow(unused)]
     pub label_color: Hsla,
+    #[allow(unused)]
     pub icon_color: Hsla,
 }
 
-impl ButtonStyle2 {
-    pub fn enabled(self, cx: &mut WindowContext) -> ButtonStyle {
+impl ButtonStyle {
+    pub(crate) fn enabled(self, cx: &mut WindowContext) -> ButtonLikeStyles {
         match self {
-            ButtonStyle2::Filled => ButtonStyle {
+            ButtonStyle::Filled => ButtonLikeStyles {
                 background: cx.theme().colors().element_background,
-                border_color: gpui::transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Subtle => ButtonStyle {
+            ButtonStyle::Subtle => ButtonLikeStyles {
                 background: cx.theme().colors().ghost_element_background,
-                border_color: gpui::transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Transparent => ButtonStyle {
-                background: gpui::transparent_black(),
-                border_color: gpui::transparent_black(),
+            ButtonStyle::Transparent => ButtonLikeStyles {
+                background: transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
         }
     }
 
-    pub fn hovered(self, cx: &mut WindowContext) -> ButtonStyle {
+    pub(crate) fn hovered(self, cx: &mut WindowContext) -> ButtonLikeStyles {
         match self {
-            ButtonStyle2::Filled => ButtonStyle {
+            ButtonStyle::Filled => ButtonLikeStyles {
                 background: cx.theme().colors().element_hover,
-                border_color: gpui::transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Subtle => ButtonStyle {
+            ButtonStyle::Subtle => ButtonLikeStyles {
                 background: cx.theme().colors().ghost_element_hover,
-                border_color: gpui::transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Transparent => ButtonStyle {
-                background: gpui::transparent_black(),
-                border_color: gpui::transparent_black(),
+            ButtonStyle::Transparent => ButtonLikeStyles {
+                background: transparent_black(),
+                border_color: transparent_black(),
                 // TODO: These are not great
                 label_color: Color::Muted.color(cx),
                 // TODO: These are not great
@@ -77,23 +80,23 @@ impl ButtonStyle2 {
         }
     }
 
-    pub fn active(self, cx: &mut WindowContext) -> ButtonStyle {
+    pub(crate) fn active(self, cx: &mut WindowContext) -> ButtonLikeStyles {
         match self {
-            ButtonStyle2::Filled => ButtonStyle {
+            ButtonStyle::Filled => ButtonLikeStyles {
                 background: cx.theme().colors().element_active,
-                border_color: gpui::transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Subtle => ButtonStyle {
+            ButtonStyle::Subtle => ButtonLikeStyles {
                 background: cx.theme().colors().ghost_element_active,
-                border_color: gpui::transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Transparent => ButtonStyle {
-                background: gpui::transparent_black(),
-                border_color: gpui::transparent_black(),
+            ButtonStyle::Transparent => ButtonLikeStyles {
+                background: transparent_black(),
+                border_color: transparent_black(),
                 // TODO: These are not great
                 label_color: Color::Muted.color(cx),
                 // TODO: These are not great
@@ -102,22 +105,23 @@ impl ButtonStyle2 {
         }
     }
 
-    pub fn focused(self, cx: &mut WindowContext) -> ButtonStyle {
+    #[allow(unused)]
+    pub(crate) fn focused(self, cx: &mut WindowContext) -> ButtonLikeStyles {
         match self {
-            ButtonStyle2::Filled => ButtonStyle {
+            ButtonStyle::Filled => ButtonLikeStyles {
                 background: cx.theme().colors().element_background,
                 border_color: cx.theme().colors().border_focused,
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Subtle => ButtonStyle {
+            ButtonStyle::Subtle => ButtonLikeStyles {
                 background: cx.theme().colors().ghost_element_background,
                 border_color: cx.theme().colors().border_focused,
                 label_color: Color::Default.color(cx),
                 icon_color: Color::Default.color(cx),
             },
-            ButtonStyle2::Transparent => ButtonStyle {
-                background: gpui::transparent_black(),
+            ButtonStyle::Transparent => ButtonLikeStyles {
+                background: transparent_black(),
                 border_color: cx.theme().colors().border_focused,
                 label_color: Color::Accent.color(cx),
                 icon_color: Color::Accent.color(cx),
@@ -125,23 +129,23 @@ impl ButtonStyle2 {
         }
     }
 
-    pub fn disabled(self, cx: &mut WindowContext) -> ButtonStyle {
+    pub(crate) fn disabled(self, cx: &mut WindowContext) -> ButtonLikeStyles {
         match self {
-            ButtonStyle2::Filled => ButtonStyle {
+            ButtonStyle::Filled => ButtonLikeStyles {
                 background: cx.theme().colors().element_disabled,
                 border_color: cx.theme().colors().border_disabled,
                 label_color: Color::Disabled.color(cx),
                 icon_color: Color::Disabled.color(cx),
             },
-            ButtonStyle2::Subtle => ButtonStyle {
+            ButtonStyle::Subtle => ButtonLikeStyles {
                 background: cx.theme().colors().ghost_element_disabled,
                 border_color: cx.theme().colors().border_disabled,
                 label_color: Color::Disabled.color(cx),
                 icon_color: Color::Disabled.color(cx),
             },
-            ButtonStyle2::Transparent => ButtonStyle {
-                background: gpui::transparent_black(),
-                border_color: gpui::transparent_black(),
+            ButtonStyle::Transparent => ButtonLikeStyles {
+                background: transparent_black(),
+                border_color: transparent_black(),
                 label_color: Color::Disabled.color(cx),
                 icon_color: Color::Disabled.color(cx),
             },
@@ -150,19 +154,19 @@ impl ButtonStyle2 {
 }
 
 #[derive(Default, PartialEq, Clone, Copy)]
-pub enum ButtonSize2 {
+pub enum ButtonSize {
     #[default]
     Default,
     Compact,
     None,
 }
 
-impl ButtonSize2 {
+impl ButtonSize {
     fn height(self) -> Rems {
         match self {
-            ButtonSize2::Default => rems(22. / 16.),
-            ButtonSize2::Compact => rems(18. / 16.),
-            ButtonSize2::None => rems(16. / 16.),
+            ButtonSize::Default => rems(22. / 16.),
+            ButtonSize::Compact => rems(18. / 16.),
+            ButtonSize::None => rems(16. / 16.),
         }
     }
 }
@@ -170,10 +174,10 @@ impl ButtonSize2 {
 #[derive(IntoElement)]
 pub struct ButtonLike {
     id: ElementId,
-    pub(super) style: ButtonStyle2,
+    pub(super) style: ButtonStyle,
     pub(super) disabled: bool,
     pub(super) selected: bool,
-    size: ButtonSize2,
+    size: ButtonSize,
     tooltip: Option<Box<dyn Fn(&mut WindowContext) -> AnyView>>,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
     children: SmallVec<[AnyElement; 2]>,
@@ -183,10 +187,10 @@ impl ButtonLike {
     pub fn new(id: impl Into<ElementId>) -> Self {
         Self {
             id: id.into(),
-            style: ButtonStyle2::default(),
+            style: ButtonStyle::default(),
             disabled: false,
             selected: false,
-            size: ButtonSize2::Default,
+            size: ButtonSize::Default,
             tooltip: None,
             children: SmallVec::new(),
             on_click: None,
@@ -220,12 +224,12 @@ impl ButtonCommon for ButtonLike {
         &self.id
     }
 
-    fn style(mut self, style: ButtonStyle2) -> Self {
+    fn style(mut self, style: ButtonStyle) -> Self {
         self.style = style;
         self
     }
 
-    fn size(mut self, size: ButtonSize2) -> Self {
+    fn size(mut self, size: ButtonSize) -> Self {
         self.size = size;
         self
     }

--- a/crates/ui2/src/components/button/icon_button.rs
+++ b/crates/ui2/src/components/button/icon_button.rs
@@ -1,7 +1,7 @@
 use gpui::{Action, AnyView};
 
 use crate::prelude::*;
-use crate::{ButtonCommon, ButtonLike, ButtonSize2, ButtonStyle2, Icon, IconElement, IconSize};
+use crate::{ButtonCommon, ButtonLike, ButtonSize, ButtonStyle, Icon, IconElement, IconSize};
 
 #[derive(IntoElement)]
 pub struct IconButton {
@@ -65,12 +65,12 @@ impl ButtonCommon for IconButton {
         self.base.id()
     }
 
-    fn style(mut self, style: ButtonStyle2) -> Self {
+    fn style(mut self, style: ButtonStyle) -> Self {
         self.base = self.base.style(style);
         self
     }
 
-    fn size(mut self, size: ButtonSize2) -> Self {
+    fn size(mut self, size: ButtonSize) -> Self {
         self.base = self.base.size(size);
         self
     }

--- a/crates/ui2/src/components/stories/button.rs
+++ b/crates/ui2/src/components/stories/button.rs
@@ -2,7 +2,7 @@ use gpui::{Div, Render};
 use story::Story;
 
 use crate::prelude::*;
-use crate::{Button, ButtonStyle2};
+use crate::{Button, ButtonStyle};
 
 pub struct ButtonStory;
 
@@ -15,8 +15,8 @@ impl Render for ButtonStory {
             .child(Story::label("Default"))
             .child(Button::new("default_filled", "Click me"))
             .child(Story::label("Default (Subtle)"))
-            .child(Button::new("default_subtle", "Click me").style(ButtonStyle2::Subtle))
+            .child(Button::new("default_subtle", "Click me").style(ButtonStyle::Subtle))
             .child(Story::label("Default (Transparent)"))
-            .child(Button::new("default_transparent", "Click me").style(ButtonStyle2::Transparent))
+            .child(Button::new("default_transparent", "Click me").style(ButtonStyle::Transparent))
     }
 }


### PR DESCRIPTION
This PR renames the `ButtonStyle2` and `ButtonSize2` enums to `ButtonStyle` and `ButtonSize`, respectively.

Release Notes:

- N/A
