### PR TITLE
Disable instance handshake in dev builds

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -350,7 +350,6 @@ impl Telemetry {
             milliseconds_since_first_event: self.milliseconds_since_first_event(),
         };
 
-        dbg!(telemetry_settings);
         self.report_clickhouse_event(event, telemetry_settings, true)
     }
 

--- a/crates/zed/src/only_instance.rs
+++ b/crates/zed/src/only_instance.rs
@@ -39,7 +39,7 @@ pub enum IsOnlyInstance {
 }
 
 pub fn ensure_only_instance() -> IsOnlyInstance {
-    if *db::ZED_STATELESS {
+    if *db::ZED_STATELESS || *util::channel::RELEASE_CHANNEL == ReleaseChannel::Dev {
         return IsOnlyInstance::Yes;
     }
 

--- a/crates/zed2/src/only_instance.rs
+++ b/crates/zed2/src/only_instance.rs
@@ -39,7 +39,7 @@ pub enum IsOnlyInstance {
 }
 
 pub fn ensure_only_instance() -> IsOnlyInstance {
-    if *db::ZED_STATELESS {
+    if *db::ZED_STATELESS || *util::channel::RELEASE_CHANNEL == ReleaseChannel::Dev {
         return IsOnlyInstance::Yes;
     }
 


### PR DESCRIPTION
It feels like every week or two someone hits this and is confused about why the app isn't launch, been meaning to disable this in dev builds for a while. This does mean that it'll be possible to hit the local DB lock panic in a dev build if you run it multiple times but that is so rare that it seems preferable

Release Notes:

- N/A
