### PR TITLE
Add support for copying diagnostic messages to the clipboard

### DIFF
--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -9692,8 +9692,7 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, is_valid: bool) -> Rend
     Arc::new(move |cx: &mut BlockContext| {
         let message = message.clone();
         let copy_id: SharedString = format!("copy-{}", cx.block_id.clone()).to_string().into();
-        // TODO: `cx.write_to_clipboard` is not implemented in tests.
-        // let write_to_clipboard = cx.write_to_clipboard(ClipboardItem::new(message.clone()));
+        let write_to_clipboard = cx.write_to_clipboard(ClipboardItem::new(message.clone()));
 
         // TODO: Nate: We should tint the background of the block with the severity color
         // We need to extend the theme before we can do this
@@ -9723,8 +9722,7 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, is_valid: bool) -> Rend
                                     .icon_color(Color::Muted)
                                     .size(ButtonSize::Compact)
                                     .style(ButtonStyle::Transparent)
-                                    // TODO: `cx.write_to_clipboard` is not implemented in tests.
-                                    // .on_click(cx.listener(move |_, _, cx| write_to_clipboard))
+                                    .on_click(cx.listener(move |_, _, cx| write_to_clipboard))
                                     .tooltip(|cx| Tooltip::text("Copy diagnostic message", cx)),
                             ),
                     )

--- a/crates/gpui2/src/platform/test/platform.rs
+++ b/crates/gpui2/src/platform/test/platform.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AnyWindowHandle, BackgroundExecutor, CursorStyle, DisplayId, ForegroundExecutor, Platform,
-    PlatformDisplay, PlatformTextSystem, TestDisplay, TestWindow, WindowOptions,
+    AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId, ForegroundExecutor,
+    Platform, PlatformDisplay, PlatformTextSystem, TestDisplay, TestWindow, WindowOptions,
 };
 use anyhow::{anyhow, Result};
 use collections::VecDeque;
@@ -20,6 +20,7 @@ pub struct TestPlatform {
     active_window: Arc<Mutex<Option<AnyWindowHandle>>>,
     active_display: Rc<dyn PlatformDisplay>,
     active_cursor: Mutex<CursorStyle>,
+    current_clipboard_item: Mutex<Option<ClipboardItem>>,
     pub(crate) prompts: RefCell<TestPrompts>,
     weak: Weak<Self>,
 }
@@ -39,6 +40,7 @@ impl TestPlatform {
             active_cursor: Default::default(),
             active_display: Rc::new(TestDisplay::new()),
             active_window: Default::default(),
+            current_clipboard_item: Mutex::new(None),
             weak: weak.clone(),
         })
     }
@@ -236,12 +238,12 @@ impl Platform for TestPlatform {
         true
     }
 
-    fn write_to_clipboard(&self, _item: crate::ClipboardItem) {
-        unimplemented!()
+    fn write_to_clipboard(&self, item: ClipboardItem) {
+        *self.current_clipboard_item.lock() = Some(item);
     }
 
-    fn read_from_clipboard(&self) -> Option<crate::ClipboardItem> {
-        unimplemented!()
+    fn read_from_clipboard(&self) -> Option<ClipboardItem> {
+        self.current_clipboard_item.lock().clone()
     }
 
     fn write_credentials(&self, _url: &str, _username: &str, _password: &[u8]) -> Result<()> {


### PR DESCRIPTION
This PR adds support for copying diagnostics messages to the clipboard.

This was already working, but we were missing implementations clipboard-related methods in the `TestPlatform` that were causing the tests to fail when the copying functionality was added.

Release Notes:

- N/A