### PR TITLE
WIP: Show correct keybindings in Zed2

### DIFF
--- a/crates/command_palette2/src/command_palette.rs
+++ b/crates/command_palette2/src/command_palette.rs
@@ -311,7 +311,11 @@ impl PickerDelegate for CommandPaletteDelegate {
                         command.name.clone(),
                         r#match.positions.clone(),
                     ))
-                    .children(KeyBinding::for_action(&*command.action, cx)),
+                    .children(KeyBinding::for_action_in(
+                        &*command.action,
+                        &self.previous_focus_handle,
+                        cx,
+                    )),
             ),
         )
     }

--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -167,7 +167,10 @@ impl DispatchTree {
         self.keymap
             .lock()
             .bindings_for_action(action.type_id())
-            .filter(|candidate| candidate.action.partial_eq(action))
+            .filter(|candidate| {
+                candidate.action.partial_eq(action)
+                    && candidate.matches_context(&self.context_stack)
+            })
             .cloned()
             .collect()
     }

--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -176,7 +176,7 @@ impl DispatchTree {
                     return false;
                 }
                 for i in 1..context_stack.len() {
-                    if candidate.matches_context(&context_stack[0..i]) {
+                    if candidate.matches_context(&context_stack[0..=i]) {
                         return true;
                     }
                 }

--- a/crates/ui2/src/components/keybinding.rs
+++ b/crates/ui2/src/components/keybinding.rs
@@ -1,5 +1,5 @@
 use crate::{h_stack, prelude::*, Icon, IconElement, IconSize};
-use gpui::{relative, rems, Action, Div, IntoElement, Keystroke};
+use gpui::{relative, rems, Action, Div, FocusHandle, IntoElement, Keystroke};
 
 #[derive(IntoElement, Clone)]
 pub struct KeyBinding {
@@ -49,9 +49,18 @@ impl RenderOnce for KeyBinding {
 
 impl KeyBinding {
     pub fn for_action(action: &dyn Action, cx: &mut WindowContext) -> Option<Self> {
-        // todo! this last is arbitrary, we want to prefer users key bindings over defaults,
-        // and vim over normal (in vim mode), etc.
         let key_binding = cx.bindings_for_action(action).last().cloned()?;
+        Some(Self::new(key_binding))
+    }
+
+    // like for_action(), but lets you specify the context from which keybindings
+    // are matched.
+    pub fn for_action_in(
+        action: &dyn Action,
+        focus: &FocusHandle,
+        cx: &mut WindowContext,
+    ) -> Option<Self> {
+        let key_binding = cx.bindings_for_action_in(action, focus).last().cloned()?;
         Some(Self::new(key_binding))
     }
 


### PR DESCRIPTION
Currently there's a problem in Zed2 where the Vim keybindings are showing up even when Vim mode is disabled.

This PR attempts to fix that by ensuring that the keybindings for an action are filtered to the correct context.

However, in its current state this is not complete, as while the change does hide the Vim keybindings in some circumstances (e.g., "Jump to Buffer" in the diagnostics pane), it also makes some keybindings disappear entirely (e.g., in the command palette).

Release Notes:

- N/A
