### PR TITLE
Fix cursor styles not displaying properly

### DIFF
--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -866,6 +866,7 @@ impl Interactivity {
         }
 
         if self.hover_style.is_some()
+            || self.base_style.mouse_cursor.is_some()
             || cx.active_drag.is_some() && !self.drag_over_styles.is_empty()
         {
             let bounds = bounds.intersect(&cx.content_mask().bounds);

--- a/crates/storybook2/src/stories/cursor.rs
+++ b/crates/storybook2/src/stories/cursor.rs
@@ -102,7 +102,6 @@ impl Render for CursorStory {
                         .w_64()
                         .h_8()
                         .bg(gpui::red())
-                        .hover(|style| style.bg(gpui::blue()))
                         .active(|style| style.bg(gpui::green()))
                         .text_sm()
                         .child(Story::label(name)),


### PR DESCRIPTION
This PR fixes an issue where an element with a cursor style set would not update the cursor when hovering over it.

Previously the cursor style would only appear by interacting with the element in some way, for instance, by clicking on the element or by having a `.hover` with some other style being applied.

Release Notes:

- N/A
