### PR TITLE
Dismiss theme_selector on esc

### DIFF
--- a/crates/theme_selector2/src/theme_selector.rs
+++ b/crates/theme_selector2/src/theme_selector.rs
@@ -187,6 +187,10 @@ impl PickerDelegate for ThemeSelectorDelegate {
             Self::set_theme(self.original_theme.clone(), cx);
             self.selection_completed = true;
         }
+
+        self.view
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
     }
 
     fn selected_index(&self) -> usize {


### PR DESCRIPTION
I noticed that the theme selector wasn't dismissed on "escape".

If this is the correct way, I'll try to implement the same in the base keymap picker.

Release Notes:

- N/A
