### PR TITLE
Use distinct version for zed2, append git hash to its nightly version

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -81,11 +81,12 @@ jobs:
             - name: Limit target directory size
               run: script/clear-target-dir-if-larger-than 100
 
-            - name: Set release channel to nightly
+            - name: Set release channel to nightly, add nightly prefix to the final version
               run: |
                   set -eu
                   version=$(git rev-parse --short HEAD)
                   echo "Publishing version: ${version} on release channel nightly"
+                  sed -i '' "s/version = \"\(.*\)\"/version = \"\1-nightly\"/" crates/zed2/Cargo.toml
                   echo "nightly" > crates/zed/RELEASE_CHANNEL
 
             - name: Generate license file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11889,7 +11889,7 @@ dependencies = [
 
 [[package]]
 name = "zed2"
-version = "0.109.0"
+version = "2.0.0"
 dependencies = [
  "activity_indicator2",
  "ai2",

--- a/crates/editor2/src/display_map.rs
+++ b/crates/editor2/src/display_map.rs
@@ -513,7 +513,7 @@ impl DisplaySnapshot {
         self.chunks(
             display_rows,
             language_aware,
-            Some(editor_style.hints_style),
+            Some(editor_style.inlays_style),
             Some(editor_style.suggestions_style),
         )
         .map(|chunk| {

--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -499,7 +499,7 @@ pub struct EditorStyle {
     pub scrollbar_width: Pixels,
     pub syntax: Arc<SyntaxTheme>,
     pub diagnostic_style: DiagnosticStyle,
-    pub hints_style: HighlightStyle,
+    pub inlays_style: HighlightStyle,
     pub suggestions_style: HighlightStyle,
 }
 
@@ -7643,7 +7643,7 @@ impl Editor {
                                                     .diagnostic_style
                                                     .clone(),
                                                 // todo!("what about the rest of the highlight style parts for inlays and suggestions?")
-                                                hints_style: HighlightStyle {
+                                                inlays_style: HighlightStyle {
                                                     color: Some(cx.theme().status().hint),
                                                     font_weight: Some(FontWeight::BOLD),
                                                     fade_out: Some(0.6),
@@ -9318,7 +9318,7 @@ impl Render for Editor {
                 diagnostic_style: cx.theme().diagnostic_style(),
                 // TODO kb find `HighlightStyle` usages
                 // todo!("what about the rest of the highlight style parts?")
-                hints_style: HighlightStyle {
+                inlays_style: HighlightStyle {
                     color: Some(cx.theme().status().hint),
                     font_weight: Some(FontWeight::BOLD),
                     fade_out: Some(0.6),

--- a/crates/zed2/Cargo.toml
+++ b/crates/zed2/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition = "2021"
 name = "zed2"
-version = "0.109.0"
+version = "2.0.0"
 publish = false
 
 [lib]


### PR DESCRIPTION
Current panic reports are now harder to tell apart by the following criteria:
* nightly or preview or stable
* zed2 or zed1
 
![image](https://github.com/zed-industries/zed/assets/2690773/d12c8272-9f78-403c-ba49-e5f05982c0f5)

Current PR adds uses a different version for zed2 (2.0.0, selected relatively arbitrary as zed2 is nothing officially released now) and adds a `-nightly` suffix to the version number of the nightly bundle.

Release Notes:

- N/A