### PR TITLE
Disable bundling for `main` commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         runs-on:
             - self-hosted
             - bundle
-        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
         needs: tests
         env:
             MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,144 +1,144 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - "v[0-9]+.[0-9]+.x"
-    tags:
-      - "v*"
-  pull_request:
-    branches:
-      - "**"
+    push:
+        branches:
+            - main
+            - "v[0-9]+.[0-9]+.x"
+        tags:
+            - "v*"
+    pull_request:
+        branches:
+            - "**"
 
 env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  RUST_BACKTRACE: 1
+    CARGO_TERM_COLOR: always
+    CARGO_INCREMENTAL: 0
+    RUST_BACKTRACE: 1
 
 jobs:
-  rustfmt:
-    name: Check formatting
-    runs-on:
-      - self-hosted
-      - test
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          submodules: "recursive"
+    rustfmt:
+        name: Check formatting
+        runs-on:
+            - self-hosted
+            - test
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Set up default .cargo/config.toml
-        run: cp ./.cargo/ci-config.toml ~/.cargo/config.toml
+            - name: Set up default .cargo/config.toml
+              run: cp ./.cargo/ci-config.toml ~/.cargo/config.toml
 
-      - name: Run rustfmt
-        uses: ./.github/actions/check_formatting
+            - name: Run rustfmt
+              uses: ./.github/actions/check_formatting
 
-  tests:
-    name: Run tests
-    runs-on:
-      - self-hosted
-      - test
-    needs: rustfmt
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          submodules: "recursive"
+    tests:
+        name: Run tests
+        runs-on:
+            - self-hosted
+            - test
+        needs: rustfmt
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Run tests
-        uses: ./.github/actions/run_tests
+            - name: Run tests
+              uses: ./.github/actions/run_tests
 
-      - name: Build collab
-        run: cargo build -p collab
+            - name: Build collab
+              run: cargo build -p collab
 
-      - name: Build other binaries
-        run: cargo build --workspace --bins --all-features
+            - name: Build other binaries
+              run: cargo build --workspace --bins --all-features
 
-  bundle:
-    name: Bundle app
-    runs-on:
-      - self-hosted
-      - bundle
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
-    needs: tests
-    env:
-      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-      APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
-      APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-    steps:
-      - name: Install Rust
-        run: |
-          rustup set profile minimal
-          rustup update stable
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
-          rustup target add wasm32-wasi
-
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          submodules: "recursive"
-
-      - name: Limit target directory size
-        run: script/clear-target-dir-if-larger-than 100
-
-      - name: Determine version and release channel
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          set -eu
-
-          version=$(script/get-crate-version zed)
-          channel=$(cat crates/zed/RELEASE_CHANNEL)
-          echo "Publishing version: ${version} on release channel ${channel}"
-          echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
-
-          expected_tag_name=""
-          case ${channel} in
-            stable)
-              expected_tag_name="v${version}";;
-            preview)
-              expected_tag_name="v${version}-pre";;
-            nightly)
-              expected_tag_name="v${version}-nightly";;
-            *)
-              echo "can't publish a release on channel ${channel}"
-              exit 1;;
-          esac
-          if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
-            echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
-            exit 1
-          fi
-
-      - name: Generate license file
-        run: script/generate-licenses
-
-      - name: Create app bundle
-        run: script/bundle
-
-      - name: Upload app bundle to workflow run if main branch or specific label
-        uses: actions/upload-artifact@v3
-        if: ${{ github.ref == 'refs/heads/main' }} || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
-        with:
-          name: Zed_${{ github.event.pull_request.head.sha || github.sha }}.dmg
-          path: target/release/Zed.dmg
-
-      - uses: softprops/action-gh-release@v1
-        name: Upload app bundle to release
-        if: ${{ env.RELEASE_CHANNEL == 'preview' || env.RELEASE_CHANNEL == 'stable' }}
-        with:
-          draft: true
-          prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
-          files: target/release/Zed.dmg
-          body: ""
+    bundle:
+        name: Bundle app
+        runs-on:
+            - self-hosted
+            - bundle
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
+        needs: tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+            MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+            APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
+            APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+        steps:
+            - name: Install Rust
+              run: |
+                  rustup set profile minimal
+                  rustup update stable
+                  rustup target add aarch64-apple-darwin
+                  rustup target add x86_64-apple-darwin
+                  rustup target add wasm32-wasi
+
+            - name: Install Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
+
+            - name: Checkout repo
+              uses: actions/checkout@v3
+              with:
+                  clean: false
+                  submodules: "recursive"
+
+            - name: Limit target directory size
+              run: script/clear-target-dir-if-larger-than 100
+
+            - name: Determine version and release channel
+              if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+              run: |
+                  set -eu
+
+                  version=$(script/get-crate-version zed)
+                  channel=$(cat crates/zed/RELEASE_CHANNEL)
+                  echo "Publishing version: ${version} on release channel ${channel}"
+                  echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
+
+                  expected_tag_name=""
+                  case ${channel} in
+                    stable)
+                      expected_tag_name="v${version}";;
+                    preview)
+                      expected_tag_name="v${version}-pre";;
+                    nightly)
+                      expected_tag_name="v${version}-nightly";;
+                    *)
+                      echo "can't publish a release on channel ${channel}"
+                      exit 1;;
+                  esac
+                  if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
+                    echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
+                    exit 1
+                  fi
+
+            - name: Generate license file
+              run: script/generate-licenses
+
+            - name: Create app bundle
+              run: script/bundle
+
+            - name: Upload app bundle to workflow run if main branch or specific label
+              uses: actions/upload-artifact@v3
+              if: ${{ github.ref == 'refs/heads/main' }} || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
+              with:
+                  name: Zed_${{ github.event.pull_request.head.sha || github.sha }}.dmg
+                  path: target/release/Zed.dmg
+
+            - uses: softprops/action-gh-release@v1
+              name: Upload app bundle to release
+              if: ${{ env.RELEASE_CHANNEL == 'preview' || env.RELEASE_CHANNEL == 'stable' }}
+              with:
+                  draft: true
+                  prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
+                  files: target/release/Zed.dmg
+                  body: ""
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -1,98 +1,98 @@
 name: Release Nightly
 
 on:
-  schedule:
-    # Fire every night at 1:00am
-    - cron: "0 1 * * *"
-  push:
-    tags:
-      - "nightly"
+    schedule:
+        # Fire every night at 1:00am
+        - cron: "0 1 * * *"
+    push:
+        tags:
+            - "nightly"
 
 env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  RUST_BACKTRACE: 1
+    CARGO_TERM_COLOR: always
+    CARGO_INCREMENTAL: 0
+    RUST_BACKTRACE: 1
 
 jobs:
-  rustfmt:
-    name: Check formatting
-    runs-on:
-      - self-hosted
-      - test
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          submodules: "recursive"
+    rustfmt:
+        name: Check formatting
+        runs-on:
+            - self-hosted
+            - test
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Run rustfmt
-        uses: ./.github/actions/check_formatting
+            - name: Run rustfmt
+              uses: ./.github/actions/check_formatting
 
-  tests:
-    name: Run tests
-    runs-on:
-      - self-hosted
-      - test
-    needs: rustfmt
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          submodules: "recursive"
+    tests:
+        name: Run tests
+        runs-on:
+            - self-hosted
+            - test
+        needs: rustfmt
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Run tests
-        uses: ./.github/actions/run_tests
+            - name: Run tests
+              uses: ./.github/actions/run_tests
 
-  bundle:
-    name: Bundle app
-    runs-on:
-      - self-hosted
-      - bundle
-    needs: tests
-    env:
-      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-      APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
-      APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-      DIGITALOCEAN_SPACES_ACCESS_KEY: ${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}
-      DIGITALOCEAN_SPACES_SECRET_KEY: ${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}
-    steps:
-      - name: Install Rust
-        run: |
-          rustup set profile minimal
-          rustup update stable
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
-          rustup target add wasm32-wasi
+    bundle:
+        name: Bundle app
+        runs-on:
+            - self-hosted
+            - bundle
+        needs: tests
+        env:
+            MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+            MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+            APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
+            APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+            DIGITALOCEAN_SPACES_ACCESS_KEY: ${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}
+            DIGITALOCEAN_SPACES_SECRET_KEY: ${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}
+        steps:
+            - name: Install Rust
+              run: |
+                  rustup set profile minimal
+                  rustup update stable
+                  rustup target add aarch64-apple-darwin
+                  rustup target add x86_64-apple-darwin
+                  rustup target add wasm32-wasi
 
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
+            - name: Install Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
 
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          submodules: "recursive"
+            - name: Checkout repo
+              uses: actions/checkout@v3
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Limit target directory size
-        run: script/clear-target-dir-if-larger-than 100
+            - name: Limit target directory size
+              run: script/clear-target-dir-if-larger-than 100
 
-      - name: Set release channel to nightly
-        run: |
-          set -eu
-          version=$(git rev-parse --short HEAD)
-          echo "Publishing version: ${version} on release channel nightly"
-          echo "nightly" > crates/zed/RELEASE_CHANNEL
+            - name: Set release channel to nightly
+              run: |
+                  set -eu
+                  version=$(git rev-parse --short HEAD)
+                  echo "Publishing version: ${version} on release channel nightly"
+                  echo "nightly" > crates/zed/RELEASE_CHANNEL
 
-      - name: Generate license file
-        run: script/generate-licenses
+            - name: Generate license file
+              run: script/generate-licenses
 
-      - name: Create app bundle
-        run: script/bundle -2
+            - name: Create app bundle
+              run: script/bundle -2
 
-      - name: Upload Zed Nightly
-        run: script/upload-nightly
+            - name: Upload Zed Nightly
+              run: script/upload-nightly


### PR DESCRIPTION
(in the first commit, this PR autoformats both yaml files with Zed's default prettier, to be able to edit those in prettier from now on)

Bundling is a relatively long procedure, and now we have nightly builds for zed2 (with their own lifecycle, CI file and tag for triggering it from non-main branch).

Hence, bundling zed1 and/or zed2 by default looks wasteful and unnecessary, disable them by default.
There's still a `run-build-dmg` label that enables bundling for any PR needed, and a `startsWith(github.ref, 'refs/tags/v')` check in the CI run to keep the releases working.

Release Notes:

- N/A