### PR TITLE
Use specified color for non-highlighted text in `HighlightedLabel`

### DIFF
--- a/crates/ui2/src/components/label.rs
+++ b/crates/ui2/src/components/label.rs
@@ -129,6 +129,9 @@ impl RenderOnce for HighlightedLabel {
             ));
         }
 
+        let mut text_style = cx.text_style().clone();
+        text_style.color = self.color.color(cx);
+
         div()
             .flex()
             .when(self.strikethrough, |this| {
@@ -146,7 +149,7 @@ impl RenderOnce for HighlightedLabel {
                 LabelSize::Default => this.text_ui(),
                 LabelSize::Small => this.text_ui_sm(),
             })
-            .child(StyledText::new(self.label).with_highlights(&cx.text_style(), highlights))
+            .child(StyledText::new(self.label).with_highlights(&text_style, highlights))
     }
 }
 

--- a/crates/ui2/src/components/stories/label.rs
+++ b/crates/ui2/src/components/stories/label.rs
@@ -23,5 +23,9 @@ impl Render for LabelStory {
                 "Héllo, world!",
                 vec![0, 1, 3, 8, 9, 13],
             ))
+            .child(Story::label("Highlighted with `color`"))
+            .child(
+                HighlightedLabel::new("Hello, world!", vec![0, 1, 2, 7, 8, 12]).color(Color::Error),
+            )
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the specified color for a `HighlightedLabel` was not respected as the default color for non-highlighted text.

Release Notes:

- N/A