### PR TITLE
Fix layout for terminal tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9531,6 +9531,7 @@ dependencies = [
  "terminal2",
  "theme2",
  "thiserror",
+ "ui2",
  "util",
  "workspace2",
 ]

--- a/crates/terminal_view2/Cargo.toml
+++ b/crates/terminal_view2/Cargo.toml
@@ -21,6 +21,7 @@ workspace = { package = "workspace2", path = "../workspace2" }
 db = { package = "db2", path = "../db2" }
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
 terminal = { package = "terminal2", path = "../terminal2" }
+ui = { package = "ui2", path = "../ui2" }
 smallvec.workspace = true
 smol.workspace = true
 mio-extras = "2.0.6"

--- a/crates/terminal_view2/src/terminal_view.rs
+++ b/crates/terminal_view2/src/terminal_view.rs
@@ -25,13 +25,13 @@ use terminal::{
     terminal_settings::{TerminalBlink, TerminalSettings, WorkingDirectory},
     Event, MaybeNavigationTarget, Terminal,
 };
+use ui::{h_stack, prelude::*, ContextMenu, Icon, IconElement, Label};
 use util::{paths::PathLikeWithPosition, ResultExt};
 use workspace::{
     item::{BreadcrumbText, Item, ItemEvent},
     notifications::NotifyResultExt,
     register_deserializable_item,
     searchable::{SearchEvent, SearchOptions, SearchableItem},
-    ui::{ContextMenu, Icon, IconElement, Label},
     CloseActiveItem, NewCenterTerminal, Pane, ToolbarItemLocation, Workspace, WorkspaceId,
 };
 
@@ -745,7 +745,8 @@ impl Item for TerminalView {
     fn tab_content(&self, _detail: Option<usize>, cx: &WindowContext) -> AnyElement {
         let title = self.terminal().read(cx).title();
 
-        div()
+        h_stack()
+            .gap_2()
             .child(IconElement::new(Icon::Terminal))
             .child(Label::new(title))
             .into_any()

--- a/crates/terminal_view2/src/terminal_view.rs
+++ b/crates/terminal_view2/src/terminal_view.rs
@@ -9,10 +9,9 @@ pub mod terminal_panel;
 // use crate::terminal_element::TerminalElement;
 use editor::{scroll::autoscroll::Autoscroll, Editor};
 use gpui::{
-    actions, div, Action, AnyElement, AppContext, Div, Element, EventEmitter, FocusEvent,
-    FocusHandle, Focusable, FocusableElement, FocusableView, InputHandler, InteractiveElement,
-    KeyDownEvent, Keystroke, Model, MouseButton, MouseDownEvent, ParentElement, Pixels, Render,
-    SharedString, Styled, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
+    actions, div, Action, AnyElement, AppContext, Div, EventEmitter, FocusEvent, FocusHandle,
+    Focusable, FocusableElement, FocusableView, InputHandler, KeyDownEvent, Keystroke, Model,
+    MouseButton, MouseDownEvent, Pixels, Render, Task, View, VisualContext, WeakView,
 };
 use language::Bias;
 use persistence::TERMINAL_DB;


### PR DESCRIPTION
This PR fixes the layout for terminal tabs.

We need to use an `h_stack` here to get the icon and the label to position themselves next to each other instead of one on top of the other.

Release Notes:

- N/A
