### PR TITLE
Document geometry module and replace `zero` method with `default`

### DIFF
--- a/crates/editor2/src/editor_tests.rs
+++ b/crates/editor2/src/editor_tests.rs
@@ -345,7 +345,12 @@ fn test_selection_with_mouse(cx: &mut TestAppContext) {
     );
 
     editor.update(cx, |view, cx| {
-        view.update_selection(DisplayPoint::new(3, 3), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(3, 3),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
     });
 
     assert_eq!(
@@ -356,7 +361,12 @@ fn test_selection_with_mouse(cx: &mut TestAppContext) {
     );
 
     editor.update(cx, |view, cx| {
-        view.update_selection(DisplayPoint::new(1, 1), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(1, 1),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
     });
 
     assert_eq!(
@@ -368,7 +378,12 @@ fn test_selection_with_mouse(cx: &mut TestAppContext) {
 
     editor.update(cx, |view, cx| {
         view.end_selection(cx);
-        view.update_selection(DisplayPoint::new(3, 3), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(3, 3),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
     });
 
     assert_eq!(
@@ -380,7 +395,12 @@ fn test_selection_with_mouse(cx: &mut TestAppContext) {
 
     editor.update(cx, |view, cx| {
         view.begin_selection(DisplayPoint::new(3, 3), true, 1, cx);
-        view.update_selection(DisplayPoint::new(0, 0), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(0, 0),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
     });
 
     assert_eq!(
@@ -423,7 +443,12 @@ fn test_canceling_pending_selection(cx: &mut TestAppContext) {
     });
 
     view.update(cx, |view, cx| {
-        view.update_selection(DisplayPoint::new(3, 3), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(3, 3),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
         assert_eq!(
             view.selections.display_ranges(cx),
             [DisplayPoint::new(2, 2)..DisplayPoint::new(3, 3)]
@@ -432,7 +457,12 @@ fn test_canceling_pending_selection(cx: &mut TestAppContext) {
 
     view.update(cx, |view, cx| {
         view.cancel(&Cancel, cx);
-        view.update_selection(DisplayPoint::new(1, 1), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(1, 1),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
         assert_eq!(
             view.selections.display_ranges(cx),
             [DisplayPoint::new(2, 2)..DisplayPoint::new(3, 3)]
@@ -643,11 +673,21 @@ fn test_cancel(cx: &mut TestAppContext) {
 
     view.update(cx, |view, cx| {
         view.begin_selection(DisplayPoint::new(3, 4), false, 1, cx);
-        view.update_selection(DisplayPoint::new(1, 1), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(1, 1),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
         view.end_selection(cx);
 
         view.begin_selection(DisplayPoint::new(0, 1), true, 1, cx);
-        view.update_selection(DisplayPoint::new(0, 3), 0, gpui::Point::<f32>::zero(), cx);
+        view.update_selection(
+            DisplayPoint::new(0, 3),
+            0,
+            gpui::Point::<f32>::default(),
+            cx,
+        );
         view.end_selection(cx);
         assert_eq!(
             view.selections.display_ranges(cx),

--- a/crates/editor2/src/element.rs
+++ b/crates/editor2/src/element.rs
@@ -485,7 +485,7 @@ impl EditorElement {
         let modifiers = event.modifiers;
         if editor.has_pending_selection() && event.pressed_button == Some(MouseButton::Left) {
             let point_for_position = position_map.point_for_position(text_bounds, event.position);
-            let mut scroll_delta = gpui::Point::<f32>::zero();
+            let mut scroll_delta = gpui::Point::<f32>::default();
             let vertical_margin = position_map.line_height.min(text_bounds.size.height / 3.0);
             let top = text_bounds.origin.y + vertical_margin;
             let bottom = text_bounds.lower_left().y - vertical_margin;
@@ -511,7 +511,7 @@ impl EditorElement {
                     position: point_for_position.previous_valid,
                     goal_column: point_for_position.exact_unclipped.column(),
                     scroll_position: (position_map.snapshot.scroll_position() + scroll_delta)
-                        .clamp(&gpui::Point::zero(), &position_map.scroll_max),
+                        .clamp(&gpui::Point::default(), &position_map.scroll_max),
                 },
                 cx,
             );

--- a/crates/gpui2/src/elements/overlay.rs
+++ b/crates/gpui2/src/elements/overlay.rs
@@ -102,7 +102,7 @@ impl Element for Overlay {
 
         let mut desired = self.anchor_corner.get_bounds(origin, size);
         let limits = Bounds {
-            origin: Point::zero(),
+            origin: Point::default(),
             size: cx.viewport_size(),
         };
 

--- a/crates/gpui2/src/platform/test/display.rs
+++ b/crates/gpui2/src/platform/test/display.rs
@@ -15,7 +15,7 @@ impl TestDisplay {
             id: DisplayId(1),
             uuid: uuid::Uuid::new_v4(),
             bounds: Bounds::from_corners(
-                Point::zero(),
+                Point::default(),
                 Point::new(GlobalPixels(1920.), GlobalPixels(1080.)),
             ),
         }

--- a/crates/gpui2/src/platform/test/window.rs
+++ b/crates/gpui2/src/platform/test/window.rs
@@ -78,7 +78,7 @@ impl PlatformWindow for TestWindow {
     }
 
     fn mouse_position(&self) -> Point<Pixels> {
-        Point::zero()
+        Point::default()
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
@@ -223,7 +223,7 @@ impl PlatformAtlas for TestAtlas {
                 },
                 tile_id: TileId(tile_id),
                 bounds: crate::Bounds {
-                    origin: Point::zero(),
+                    origin: Point::default(),
                     size,
                 },
             },

--- a/crates/gpui2/src/style.rs
+++ b/crates/gpui2/src/style.rs
@@ -385,7 +385,7 @@ impl Default for Style {
             min_size: Size::auto(),
             max_size: Size::auto(),
             aspect_ratio: None,
-            gap: Size::zero(),
+            gap: Size::default(),
             // Aligment
             align_items: None,
             align_self: None,

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -1167,7 +1167,7 @@ impl<'a> WindowContext<'a> {
                 }
 
                 let available_space = cx.window.viewport_size.map(Into::into);
-                root_view.draw(Point::zero(), available_space, cx);
+                root_view.draw(Point::default(), available_space, cx);
             })
         });
 


### PR DESCRIPTION
Nothing earth-shattering here, but all our geometry types are now fully documented.

Release Notes:

- N/A