### PR TITLE
Pass proper theme colors for inlays and suggestions

### DIFF
--- a/crates/editor2/src/display_map.rs
+++ b/crates/editor2/src/display_map.rs
@@ -24,7 +24,7 @@ use lsp::DiagnosticSeverity;
 use std::{any::TypeId, borrow::Cow, fmt::Debug, num::NonZeroU32, ops::Range, sync::Arc};
 use sum_tree::{Bias, TreeMap};
 use tab_map::TabMap;
-use theme::{SyntaxTheme, Theme};
+use theme::{StatusColors, SyntaxTheme, Theme};
 use wrap_map::WrapMap;
 
 pub use block_map::{
@@ -513,8 +513,8 @@ impl DisplaySnapshot {
         self.chunks(
             display_rows,
             language_aware,
-            Some(editor_style.syntax.inlay_style),
-            Some(editor_style.syntax.suggestion_style),
+            Some(editor_style.hints_style),
+            Some(editor_style.suggestions_style),
         )
         .map(|chunk| {
             let mut highlight_style = chunk

--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -499,6 +499,8 @@ pub struct EditorStyle {
     pub scrollbar_width: Pixels,
     pub syntax: Arc<SyntaxTheme>,
     pub diagnostic_style: DiagnosticStyle,
+    pub hints_style: HighlightStyle,
+    pub suggestions_style: HighlightStyle,
 }
 
 type CompletionId = usize;
@@ -7640,6 +7642,18 @@ impl Editor {
                                                     .editor_style
                                                     .diagnostic_style
                                                     .clone(),
+                                                // todo!("what about the rest of the highlight style parts for inlays and suggestions?")
+                                                hints_style: HighlightStyle {
+                                                    color: Some(cx.theme().status().hint),
+                                                    font_weight: Some(FontWeight::BOLD),
+                                                    fade_out: Some(0.6),
+                                                    ..HighlightStyle::default()
+                                                },
+                                                suggestions_style: HighlightStyle {
+                                                    color: Some(cx.theme().status().predictive),
+                                                    fade_out: Some(0.6),
+                                                    ..HighlightStyle::default()
+                                                },
                                             },
                                         ))
                                         .into_any_element()
@@ -9302,6 +9316,19 @@ impl Render for Editor {
                 scrollbar_width: px(12.),
                 syntax: cx.theme().syntax().clone(),
                 diagnostic_style: cx.theme().diagnostic_style(),
+                // TODO kb find `HighlightStyle` usages
+                // todo!("what about the rest of the highlight style parts?")
+                hints_style: HighlightStyle {
+                    color: Some(cx.theme().status().hint),
+                    font_weight: Some(FontWeight::BOLD),
+                    fade_out: Some(0.6),
+                    ..HighlightStyle::default()
+                },
+                suggestions_style: HighlightStyle {
+                    color: Some(cx.theme().status().predictive),
+                    fade_out: Some(0.6),
+                    ..HighlightStyle::default()
+                },
             },
         )
     }

--- a/crates/language2/src/highlight_map.rs
+++ b/crates/language2/src/highlight_map.rs
@@ -95,8 +95,6 @@ mod tests {
             .iter()
             .map(|(name, color)| (name.to_string(), (*color).into()))
             .collect(),
-            inlay_style: HighlightStyle::default(),
-            suggestion_style: HighlightStyle::default(),
         };
 
         let capture_names = &[

--- a/crates/theme2/src/one_themes.rs
+++ b/crates/theme2/src/one_themes.rs
@@ -191,8 +191,6 @@ pub(crate) fn one_dark() -> Theme {
                     ("variable.special".into(), red.into()),
                     ("variant".into(), HighlightStyle::default()),
                 ],
-                inlay_style: HighlightStyle::default(),
-                suggestion_style: HighlightStyle::default(),
             }),
         },
     }

--- a/crates/theme2/src/styles/syntax.rs
+++ b/crates/theme2/src/styles/syntax.rs
@@ -8,12 +8,6 @@ use crate::{
 #[derive(Clone, Default)]
 pub struct SyntaxTheme {
     pub highlights: Vec<(String, HighlightStyle)>,
-    // todo!("Remove this in favor of StatusColor.hint")
-    // If this should be overridable we should move it to ThemeColors
-    pub inlay_style: HighlightStyle,
-    // todo!("Remove this in favor of StatusColor.prediction")
-    // If this should be overridable we should move it to ThemeColors
-    pub suggestion_style: HighlightStyle,
 }
 
 impl SyntaxTheme {
@@ -72,8 +66,6 @@ impl SyntaxTheme {
                 ("variable.special".into(), red().light().step_9().into()),
                 ("variant".into(), red().light().step_9().into()),
             ],
-            inlay_style: tomato().light().step_1().into(), // todo!("nate: use a proper style")
-            suggestion_style: orange().light().step_1().into(), // todo!("nate: use proper style")
         }
     }
 
@@ -132,8 +124,6 @@ impl SyntaxTheme {
                 ("variable.special".into(), red().dark().step_11().into()),
                 ("variant".into(), red().dark().step_11().into()),
             ],
-            inlay_style: neutral().dark().step_11().into(), // todo!("nate: use a proper style")
-            suggestion_style: orange().dark().step_11().into(), // todo!("nate: use a proper style")
         }
     }
 
@@ -152,8 +142,6 @@ impl SyntaxTheme {
                     )
                 })
                 .collect(),
-            inlay_style: HighlightStyle::default(),
-            suggestion_style: HighlightStyle::default(),
         }
     }
 


### PR DESCRIPTION
<img width="1728" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/f6f1e24f-71fe-4a2e-9bcf-9e98861c0da4">

![image](https://github.com/zed-industries/zed/assets/2690773/8434d8a1-ee7e-49c1-9e88-362363225d96)

Now inlays are visible in all zed2 themes, but 
* always have a blue color which is the same as some theme colors
* not other hint-related style changes like font width, background, etc. seem to exist in the theme, ergo not propagated.

In general though, people want those style changes applied to their hints, so we might want to do something about it later.
I've left a `// todo!("what about the rest of the highlight style parts for inlays and suggestions?")` in the corresponding places for that.

Release Notes:

- N/A