### PR TITLE
Do not run the same workflow concurrently on non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
         branches:
             - "**"
 
+concurrency:
+    # Allow only one workflow per any non-`main` branch.
+    group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+    cancel-in-progress: true
+
 env:
     CARGO_TERM_COLOR: always
     CARGO_INCREMENTAL: 0


### PR DESCRIPTION
<img width="1376" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/681cca85-e1b9-4a99-8363-60c931ba1393">

For any push (or force-push) into a branch, a separate CI workflow is run.
This is rather worker-consuming, esp. given the fact that GitHub will wait for the last job to update PR's status.
So cancel every old job for the same branch if it's not `main`.
CI run on `main` might catch a regression brought in by specific PR merged, so run CI on every commit due to that.


Release Notes:

- N/A