### PR TITLE
Always show tooltips on buttons

### DIFF
--- a/crates/ui2/src/components/button/button_like.rs
+++ b/crates/ui2/src/components/button/button_like.rs
@@ -359,11 +359,7 @@ impl RenderOnce for ButtonLike {
                 },
             )
             .when_some(self.tooltip, |this, tooltip| {
-                if !self.selected {
-                    this.tooltip(move |cx| tooltip(cx))
-                } else {
-                    this
-                }
+                this.tooltip(move |cx| tooltip(cx))
             })
             .children(self.children)
     }

--- a/crates/ui2/src/components/stories/icon_button.rs
+++ b/crates/ui2/src/components/stories/icon_button.rs
@@ -51,5 +51,13 @@ impl Render for IconButtonStory {
                         .tooltip(|cx| Tooltip::text("Open messages", cx)),
                 ),
             )
+            .child(Story::label("Selected with `tooltip`"))
+            .child(
+                div().w_8().child(
+                    IconButton::new("selected_with_tooltip", Icon::InlayHint)
+                        .selected(true)
+                        .tooltip(|cx| Tooltip::text("Toggle inlay hints", cx)),
+                ),
+            )
     }
 }


### PR DESCRIPTION
This PR fixes an issue where tooltips weren't being shown on selected buttons.

We now always show tooltips on buttons that have one.

Release Notes:

- N/A