### PR TITLE
Don't load the Vim keymap temporarily

### DIFF
--- a/crates/settings2/src/settings_file.rs
+++ b/crates/settings2/src/settings_file.rs
@@ -124,6 +124,17 @@ pub fn update_settings_file<T: Settings>(
 
 pub fn load_default_keymap(cx: &mut AppContext) {
     for path in ["keymaps/default.json", "keymaps/vim.json"] {
+        // TODO: Remove this conditional when we're ready to add Vim support.
+        // Right now we're avoiding loading the Vim keymap to silence the warnings
+        // about invalid action bindings.
+        if path.contains("vim") {
+            let _: Option<()> = Err(format!(
+                "TODO: Skipping {path} until we're ready to add Vim support"
+            ))
+            .log_err();
+            continue;
+        }
+
         KeymapFile::load_asset(path, cx).unwrap();
     }
 


### PR DESCRIPTION
This PR removes the loading of the Vim keymap temporarily.

This cuts down on the noise from all of the Vim-related action warnings.

We can resume loading the Vim keymap once we're ready to add Vim support.

Release Notes:

- N/A
