### PR TITLE
Upgrade async-compression dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
 dependencies = [
  "flate2",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = { version = "1.0.57" }
 async-trait = { version = "0.1" }
+async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 # TODO: Switch back to the published version of `ctor` once:
 #       1. A new version of `ctor` is published with this change: https://github.com/mmastrac/rust-ctor/pull/295
 #       2. We've confirmed it's fine to update to the latest version of `ctor` (we're currently on v0.1.20).

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -28,7 +28,7 @@ theme = { path = "../theme" }
 lsp = { path = "../lsp" }
 node_runtime = { path = "../node_runtime"}
 util = { path = "../util" }
-async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
+async-compression.workspace = true
 async-tar = "0.4.2"
 anyhow.workspace = true
 log.workspace = true

--- a/crates/copilot2/Cargo.toml
+++ b/crates/copilot2/Cargo.toml
@@ -29,7 +29,7 @@ lsp = { package = "lsp2", path = "../lsp2" }
 node_runtime = { path = "../node_runtime"}
 util = { path = "../util" }
 ui = { package = "ui2", path = "../ui2" }
-async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
+async-compression.workspace = true
 async-tar = "0.4.2"
 anyhow.workspace = true
 log.workspace = true

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [dependencies]
 util = { path = "../util" }
-async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
+async-compression.workspace = true
 async-tar = "0.4.2"
 futures.workspace = true
 async-trait.workspace = true

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -78,7 +78,7 @@ workspace = { path = "../workspace" }
 welcome = { path = "../welcome" }
 zed-actions = {path = "../zed-actions"}
 anyhow.workspace = true
-async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
+async-compression.workspace = true
 async-tar = "0.4.2"
 async-recursion = "0.3"
 async-trait.workspace = true

--- a/crates/zed2/Cargo.toml
+++ b/crates/zed2/Cargo.toml
@@ -74,7 +74,7 @@ workspace = { package = "workspace2", path = "../workspace2" }
 welcome = { package = "welcome2", path = "../welcome2" }
 zed_actions = {package = "zed_actions2", path = "../zed_actions2"}
 anyhow.workspace = true
-async-compression = { version = "0.3", features = ["gzip", "futures-bufread"] }
+async-compression.workspace = true
 async-tar = "0.4.2"
 async-recursion = "0.3"
 async-trait.workspace = true


### PR DESCRIPTION
Fixes a build failure on CI:

https://github.com/zed-industries/zed/actions/runs/7120057787/job/19387718091

```
2023-12-06 21:26:40.468791 +00:00:00 [ERROR] `cargo metadata` exited with an error:     Updating crates.io index
error: failed to select a version for `async-compression`.
    ... required by package `zed2 v2.0.0-nightly (/Users/administrator/actions-runner-2/_work/zed/zed/crates/zed2)`
versions that meet the requirements `^0.3` (locked to 0.3.15) are: 0.3.15

the package `zed2` depends on `async-compression`, with features: `futures-bufread-nightly` but `async-compression` does not have these features.
```