### PR TITLE
Remove padding from `ButtonSize::None`

### DIFF
--- a/crates/ui2/src/components/button/button_like.rs
+++ b/crates/ui2/src/components/button/button_like.rs
@@ -342,7 +342,10 @@ impl RenderOnce for ButtonLike {
             .when_some(self.width, |this, width| this.w(width))
             .rounded_md()
             .gap_1()
-            .px_1()
+            .map(|this| match self.size {
+                ButtonSize::Default | ButtonSize::Compact => this.px_1(),
+                ButtonSize::None => this,
+            })
             .bg(self.style.enabled(cx).background)
             .when(!self.disabled, |this| {
                 this.cursor_pointer()

--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1481,7 +1481,6 @@ impl Pane {
                 })
                 .start_slot::<Indicator>(indicator)
                 .end_slot(
-                    // TODO: Fix button size
                     IconButton::new("close tab", Icon::Close)
                         .icon_color(Color::Muted)
                         .size(ButtonSize::None)


### PR DESCRIPTION
This PR removes the padding from buttons when using `ButtonSize::None`.

This fixes the size of the tab close buttons.

Release Notes:

- N/A