### PR TITLE
Fix nightly auto-update failure due to version parsing error

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -81,12 +81,11 @@ jobs:
             - name: Limit target directory size
               run: script/clear-target-dir-if-larger-than 100
 
-            - name: Set release channel to nightly, add nightly prefix to the final version
+            - name: Set release channel to nightly
               run: |
                   set -eu
                   version=$(git rev-parse --short HEAD)
                   echo "Publishing version: ${version} on release channel nightly"
-                  sed -i '' "s/version = \"\(.*\)\"/version = \"\1-nightly\"/" crates/zed2/Cargo.toml
                   echo "nightly" > crates/zed/RELEASE_CHANNEL
 
             - name: Generate license file

--- a/crates/auto_update2/src/auto_update.rs
+++ b/crates/auto_update2/src/auto_update.rs
@@ -85,15 +85,7 @@ pub fn init(http_client: Arc<dyn HttpClient>, server_url: String, cx: &mut AppCo
     AutoUpdateSetting::register(cx);
 
     cx.observe_new_views(|workspace: &mut Workspace, _cx| {
-        workspace
-            .register_action(|_, action: &Check, cx| check(action, cx))
-            .register_action(|_, _action: &CheckThatAutoUpdaterWorks, cx| {
-                let prompt = cx.prompt(gpui::PromptLevel::Info, "It does!", &["Ok"]);
-                cx.spawn(|_, _cx| async move {
-                    prompt.await.ok();
-                })
-                .detach();
-            });
+        workspace.register_action(|_, action: &Check, cx| check(action, cx));
 
         // @nate - code to trigger update notification on launch
         // workspace.show_notification(0, _cx, |cx| {
@@ -130,9 +122,15 @@ pub fn init(http_client: Arc<dyn HttpClient>, server_url: String, cx: &mut AppCo
     }
 }
 
-pub fn check(_: &Check, cx: &mut AppContext) {
+pub fn check(_: &Check, cx: &mut ViewContext<Workspace>) {
     if let Some(updater) = AutoUpdater::get(cx) {
         updater.update(cx, |updater, cx| updater.poll(cx));
+    } else {
+        drop(cx.prompt(
+            gpui::PromptLevel::Info,
+            "Auto-updates disabled for non-bundled app.",
+            &["Ok"],
+        ));
     }
 }
 


### PR DESCRIPTION
After https://github.com/zed-industries/zed/pull/3507, parsing the app's semver version from the application plist stopped working, which caused auto-updates to stop.

I don't think we need to put `-nightly` in the version number: it's already in the release channel name, which is reported alongside the version in most cases. For example, the 'About' dialog was saying `Zed Nightly 2.0.0-nightly`.

I think even without nightly, it would be a good idea to include the *release channel* name in the datadog alerts that show up in slack. @JosephTLyons could you look into how to do that?

/cc @SomeoneToIgnore 