### PR TITLE
theme_importer: Improve syntax token matching

### DIFF
--- a/crates/theme2/src/themes/andromeda.rs
+++ b/crates/theme2/src/themes/andromeda.rs
@@ -66,7 +66,7 @@ pub fn andromeda() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf39c12ff).into()),
+                                    color: Some(rgba(0xffe66dff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -143,7 +143,7 @@ pub fn andromeda() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffe66dff).into()),
+                                    color: Some(rgba(0xee5d43ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -210,7 +210,7 @@ pub fn andromeda() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf39c12ff).into()),
+                                    color: Some(rgba(0xffe66dff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -287,7 +287,7 @@ pub fn andromeda() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffe66dff).into()),
+                                    color: Some(rgba(0xee5d43ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/andromeda.rs
+++ b/crates/theme2/src/themes/andromeda.rs
@@ -78,144 +78,7 @@ pub fn andromeda() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc74dedff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf39c12ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xffe66dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc74dedff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf39c12ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xee5d43ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x96e072ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf92672ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x96e072ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xee5d43ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x00e8c6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Andromeda Bordered".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x1b1d23ff).into()),
-                        border_variant: Some(rgba(0x1b1d23ff).into()),
-                        border_focused: Some(rgba(0x746f77ff).into()),
-                        border_selected: Some(rgba(0x1b1d23ff).into()),
-                        border_transparent: Some(rgba(0x1b1d23ff).into()),
-                        border_disabled: Some(rgba(0x1b1d23ff).into()),
-                        elevated_surface_background: Some(rgba(0x23262eff).into()),
-                        surface_background: Some(rgba(0x23262eff).into()),
-                        background: Some(rgba(0x262a33ff).into()),
-                        element_background: Some(rgba(0x00e8c5cc).into()),
-                        element_hover: Some(rgba(0x23262eff).into()),
-                        element_selected: Some(rgba(0x23262eff).into()),
-                        drop_target_background: Some(rgba(0x3a404eff).into()),
-                        ghost_element_hover: Some(rgba(0x23262eff).into()),
-                        text: Some(rgba(0xd5ced9ff).into()),
-                        tab_inactive_background: Some(rgba(0x23262eff).into()),
-                        tab_active_background: Some(rgba(0x262a33ff).into()),
-                        editor_background: Some(rgba(0x262a33ff).into()),
-                        editor_gutter_background: Some(rgba(0x262a33ff).into()),
-                        editor_line_number: Some(rgba(0x746f77ff).into()),
-                        editor_active_line_number: Some(rgba(0xd5ced9ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xee5d43ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x96e072ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xffe66dff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x7cb7ffff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xff00aaff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x00e8c6ff).into()),
-                        terminal_ansi_red: Some(rgba(0xee5d43ff).into()),
-                        terminal_ansi_green: Some(rgba(0x96e072ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xffe66dff).into()),
-                        terminal_ansi_blue: Some(rgba(0x7cb7ffff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xff00aaff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x00e8c6ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        deleted: Some(rgba(0xfc644dff).into()),
-                        error: Some(rgba(0xfc644dff).into()),
-                        hidden: Some(rgba(0x746f77ff).into()),
-                        hint: Some(rgba(0x969696ff).into()),
-                        ..Default::default()
-                    },
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xffe66dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xa0a1a7cc).into()),
                                     ..Default::default()
@@ -293,6 +156,171 @@ pub fn andromeda() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00e8c6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00e8c6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Andromeda Bordered".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x1b1d23ff).into()),
+                        border_variant: Some(rgba(0x1b1d23ff).into()),
+                        border_focused: Some(rgba(0x746f77ff).into()),
+                        border_selected: Some(rgba(0x1b1d23ff).into()),
+                        border_transparent: Some(rgba(0x1b1d23ff).into()),
+                        border_disabled: Some(rgba(0x1b1d23ff).into()),
+                        elevated_surface_background: Some(rgba(0x23262eff).into()),
+                        surface_background: Some(rgba(0x23262eff).into()),
+                        background: Some(rgba(0x262a33ff).into()),
+                        element_background: Some(rgba(0x00e8c5cc).into()),
+                        element_hover: Some(rgba(0x23262eff).into()),
+                        element_selected: Some(rgba(0x23262eff).into()),
+                        drop_target_background: Some(rgba(0x3a404eff).into()),
+                        ghost_element_hover: Some(rgba(0x23262eff).into()),
+                        text: Some(rgba(0xd5ced9ff).into()),
+                        tab_inactive_background: Some(rgba(0x23262eff).into()),
+                        tab_active_background: Some(rgba(0x262a33ff).into()),
+                        editor_background: Some(rgba(0x262a33ff).into()),
+                        editor_gutter_background: Some(rgba(0x262a33ff).into()),
+                        editor_line_number: Some(rgba(0x746f77ff).into()),
+                        editor_active_line_number: Some(rgba(0xd5ced9ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xee5d43ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x96e072ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xffe66dff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x7cb7ffff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xff00aaff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x00e8c6ff).into()),
+                        terminal_ansi_red: Some(rgba(0xee5d43ff).into()),
+                        terminal_ansi_green: Some(rgba(0x96e072ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xffe66dff).into()),
+                        terminal_ansi_blue: Some(rgba(0x7cb7ffff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xff00aaff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x00e8c6ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        deleted: Some(rgba(0xfc644dff).into()),
+                        error: Some(rgba(0xfc644dff).into()),
+                        hidden: Some(rgba(0x746f77ff).into()),
+                        hint: Some(rgba(0x969696ff).into()),
+                        ..Default::default()
+                    },
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffe66dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa0a1a7cc).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa0a1a7cc).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc74dedff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf39c12ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xffe66dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc74dedff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf39c12ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xee5d43ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x96e072ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf92672ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x96e072ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xee5d43ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x00e8c6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x00e8c6ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -90,6 +90,14 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x787b8099).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x4cbf99ff).into()),
@@ -353,6 +361,14 @@ pub fn ayu() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8cfe680).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x95e6cbff).into()),
@@ -609,6 +625,14 @@ pub fn ayu() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xacb6bf8c).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xacb6bf8c).into()),
                                     font_style: Some(UserFontStyle::Italic),

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -114,7 +114,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf07171ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -122,7 +122,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf2ae49ff).into()),
+                                    color: Some(rgba(0xf07171ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -171,7 +171,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf07171ff).into()),
+                                    color: Some(rgba(0x55b4d4ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -269,7 +269,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf07171ff).into()),
+                                    color: Some(rgba(0xf2ae49ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -377,7 +377,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf28779ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -385,7 +385,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffd173ff).into()),
+                                    color: Some(rgba(0xf28779ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -434,7 +434,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf28779ff).into()),
+                                    color: Some(rgba(0x5ccfe6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -532,7 +532,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf28779ff).into()),
+                                    color: Some(rgba(0xffd173ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -640,7 +640,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf07178ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -648,7 +648,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffb454ff).into()),
+                                    color: Some(rgba(0xf07178ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -697,7 +697,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf07178ff).into()),
+                                    color: Some(rgba(0x39bae6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -795,7 +795,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf07178ff).into()),
+                                    color: Some(rgba(0xffb454ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -122,7 +122,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xf07171ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -137,7 +137,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfa8d3eff).into()),
+                                    color: Some(rgba(0x55b4d4ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -393,7 +393,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xf28779ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -408,7 +408,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffad66ff).into()),
+                                    color: Some(rgba(0x5ccfe6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -664,7 +664,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xf07178ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -679,7 +679,7 @@ pub fn ayu() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff8f40ff).into()),
+                                    color: Some(rgba(0x39bae6ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -84,6 +84,13 @@ pub fn dracula() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "comment.doc".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x6272a4ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "emphasis".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xf1fa8cff).into()),

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -107,6 +107,13 @@ pub fn dracula() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "function".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x50fa7bff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "keyword".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xff79c6ff).into()),

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -100,13 +100,6 @@ pub fn dracula() -> UserThemeFamily {
                             },
                         ),
                         (
-                            "function".into(),
-                            UserHighlightStyle {
-                                color: Some(rgba(0x50fa7bff).into()),
-                                ..Default::default()
-                            },
-                        ),
-                        (
                             "keyword".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xff79c6ff).into()),
@@ -159,8 +152,7 @@ pub fn dracula() -> UserThemeFamily {
                         (
                             "variable".into(),
                             UserHighlightStyle {
-                                color: Some(rgba(0xbd93f9ff).into()),
-                                font_style: Some(UserFontStyle::Italic),
+                                color: Some(rgba(0xf8f8f2ff).into()),
                                 ..Default::default()
                             },
                         ),

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -148,7 +148,7 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -339,7 +339,7 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -530,7 +530,7 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -721,7 +721,7 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7c6f64ff).into()),
+                                    color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -912,7 +912,7 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7c6f64ff).into()),
+                                    color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1103,7 +1103,7 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7c6f64ff).into()),
+                                    color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -90,13 +90,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfe8019ff).into()),
@@ -291,13 +284,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x928374ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -502,13 +488,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xfe8019ff).into()),
@@ -703,13 +682,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x928374ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -914,13 +886,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xaf3a03ff).into()),
@@ -1115,13 +1080,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x928374ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -82,6 +82,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x928374ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "emphasis".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
@@ -196,6 +204,13 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
@@ -273,6 +288,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x928374ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "emphasis".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
@@ -387,6 +410,13 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
@@ -464,6 +494,14 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x928374ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "emphasis".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
@@ -583,6 +621,13 @@ pub fn gruvbox() -> UserThemeFamily {
                                     ..Default::default()
                                 },
                             ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
                         ],
                     }),
                 },
@@ -648,6 +693,14 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x928374ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x928374ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
@@ -769,6 +822,13 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x076678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()
@@ -846,190 +906,7 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xaf3a03ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9d0006ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8f3f71ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8f3f71ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x689d6aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x076678ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x79740eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9d0006ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x79740eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x076678ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Gruvbox Light Soft".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0xebdbb2ff).into()),
-                        border_variant: Some(rgba(0xebdbb2ff).into()),
-                        border_focused: Some(rgba(0xebdbb2ff).into()),
-                        border_selected: Some(rgba(0xebdbb2ff).into()),
-                        border_transparent: Some(rgba(0xebdbb2ff).into()),
-                        border_disabled: Some(rgba(0xebdbb2ff).into()),
-                        background: Some(rgba(0xf2e5bcff).into()),
-                        element_background: Some(rgba(0x45858880).into()),
-                        element_hover: Some(rgba(0xebdbb280).into()),
-                        element_selected: Some(rgba(0xebdbb280).into()),
-                        drop_target_background: Some(rgba(0xebdbb2ff).into()),
-                        ghost_element_hover: Some(rgba(0xebdbb280).into()),
-                        text: Some(rgba(0x3c3836ff).into()),
-                        tab_inactive_background: Some(rgba(0xf2e5bcff).into()),
-                        tab_active_background: Some(rgba(0xd5c4a1ff).into()),
-                        editor_background: Some(rgba(0xf2e5bcff).into()),
-                        editor_gutter_background: Some(rgba(0xf2e5bcff).into()),
-                        editor_line_number: Some(rgba(0xbdae93ff).into()),
-                        editor_active_line_number: Some(rgba(0x3c3836ff).into()),
-                        terminal_background: Some(rgba(0xf2e5bcff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x928374ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x9d0006ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x79740eff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xb57614ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x076678ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x8f3f71ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x427b58ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x3c3836ff).into()),
-                        terminal_ansi_black: Some(rgba(0xebdbb2ff).into()),
-                        terminal_ansi_red: Some(rgba(0xcc241dff).into()),
-                        terminal_ansi_green: Some(rgba(0x98971aff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xd79921ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x458588ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xb16286ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x689d6aff).into()),
-                        terminal_ansi_white: Some(rgba(0x7c6f64ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        deleted: Some(rgba(0x9d0006ff).into()),
-                        error: Some(rgba(0x9d0006ff).into()),
-                        hidden: Some(rgba(0x7c6f64ff).into()),
-                        hint: Some(rgba(0x969696ff).into()),
-                        ..Default::default()
-                    },
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x928374ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
@@ -1151,6 +1028,219 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x076678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x076678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Gruvbox Light Soft".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0xebdbb2ff).into()),
+                        border_variant: Some(rgba(0xebdbb2ff).into()),
+                        border_focused: Some(rgba(0xebdbb2ff).into()),
+                        border_selected: Some(rgba(0xebdbb2ff).into()),
+                        border_transparent: Some(rgba(0xebdbb2ff).into()),
+                        border_disabled: Some(rgba(0xebdbb2ff).into()),
+                        background: Some(rgba(0xf2e5bcff).into()),
+                        element_background: Some(rgba(0x45858880).into()),
+                        element_hover: Some(rgba(0xebdbb280).into()),
+                        element_selected: Some(rgba(0xebdbb280).into()),
+                        drop_target_background: Some(rgba(0xebdbb2ff).into()),
+                        ghost_element_hover: Some(rgba(0xebdbb280).into()),
+                        text: Some(rgba(0x3c3836ff).into()),
+                        tab_inactive_background: Some(rgba(0xf2e5bcff).into()),
+                        tab_active_background: Some(rgba(0xd5c4a1ff).into()),
+                        editor_background: Some(rgba(0xf2e5bcff).into()),
+                        editor_gutter_background: Some(rgba(0xf2e5bcff).into()),
+                        editor_line_number: Some(rgba(0xbdae93ff).into()),
+                        editor_active_line_number: Some(rgba(0x3c3836ff).into()),
+                        terminal_background: Some(rgba(0xf2e5bcff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x928374ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x9d0006ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x79740eff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xb57614ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x076678ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x8f3f71ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x427b58ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x3c3836ff).into()),
+                        terminal_ansi_black: Some(rgba(0xebdbb2ff).into()),
+                        terminal_ansi_red: Some(rgba(0xcc241dff).into()),
+                        terminal_ansi_green: Some(rgba(0x98971aff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xd79921ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x458588ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xb16286ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x689d6aff).into()),
+                        terminal_ansi_white: Some(rgba(0x7c6f64ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        deleted: Some(rgba(0x9d0006ff).into()),
+                        error: Some(rgba(0x9d0006ff).into()),
+                        hidden: Some(rgba(0x7c6f64ff).into()),
+                        hint: Some(rgba(0x969696ff).into()),
+                        ..Default::default()
+                    },
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57614ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x928374ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x928374ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaf3a03ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57614ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d0006ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57614ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x689d6aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x076678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x79740eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d0006ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427b58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x79740eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57614ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb57614ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x076678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/night_owl.rs
+++ b/crates/theme2/src/themes/night_owl.rs
@@ -113,6 +113,14 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc792eaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "number".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xf78c6cff).into()),
@@ -120,9 +128,23 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fdbcaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "property".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x80cbc4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7fdbcaff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -164,7 +186,7 @@ pub fn night_owl() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7fdbcaff).into()),
+                                    color: Some(rgba(0xd7dbe0ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -279,6 +301,14 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x994cc3ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "number".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xaa0982ff).into()),
@@ -286,9 +316,23 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x0c969bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "property".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0c969bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x994cc3ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -330,7 +374,7 @@ pub fn night_owl() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0c969bff).into()),
+                                    color: Some(rgba(0x403f53ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/night_owl.rs
+++ b/crates/theme2/src/themes/night_owl.rs
@@ -91,6 +91,14 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x637777ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x82aaffff).into()),
@@ -242,6 +250,14 @@ pub fn night_owl() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x989fb1ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x989fb1ff).into()),
                                     font_style: Some(UserFontStyle::Italic),

--- a/crates/theme2/src/themes/night_owl.rs
+++ b/crates/theme2/src/themes/night_owl.rs
@@ -100,16 +100,7 @@ pub fn night_owl() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x82aaffff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -121,24 +112,9 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7fdbcaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x80cbc4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -180,7 +156,7 @@ pub fn night_owl() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc5e478ff).into()),
+                                    color: Some(rgba(0x7fdbcaff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -282,16 +258,7 @@ pub fn night_owl() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x994cc3ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x994cc3ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x4876d6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -303,24 +270,9 @@ pub fn night_owl() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x0c969bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0c969bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x994cc3ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -362,7 +314,7 @@ pub fn night_owl() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x4876d6ff).into()),
+                                    color: Some(rgba(0x0c969bff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/noctis.rs
+++ b/crates/theme2/src/themes/noctis.rs
@@ -79,14 +79,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5988a6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5988a6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -94,20 +94,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xbecfdaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -121,7 +107,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -154,30 +140,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xbecfdaff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xbecfdaff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -219,21 +198,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -306,14 +285,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x8b747cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x8b747cff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -321,20 +300,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xcbbec2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -348,7 +313,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -381,30 +346,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xcbbec2ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xcbbec2ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -446,21 +404,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -533,14 +491,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x8ca6a6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x8ca6a6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -548,20 +506,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x004d57ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -575,7 +519,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -608,30 +552,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x0095a8ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0x004d57ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0x004d57ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -673,21 +610,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    color: Some(rgba(0xb3694dff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xfa8900ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -760,14 +697,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x9995b7ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x9995b7ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -775,20 +712,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0c006bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -802,7 +725,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -835,30 +758,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x0095a8ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0x0c006bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0x0c006bff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -900,21 +816,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    color: Some(rgba(0xb3694dff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xfa8900ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -987,14 +903,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x8ca6a6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x8ca6a6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1002,20 +918,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x004d57ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1029,7 +931,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1062,30 +964,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x0095a8ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0x004d57ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0x004d57ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1127,21 +1022,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x00bdd6ff).into()),
+                                    color: Some(rgba(0xb3694dff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xfa8900ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1214,14 +1109,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5e7887ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5e7887ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1229,20 +1124,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc5cdd3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1256,7 +1137,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xc37455ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1289,30 +1170,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x3f848dff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xc5cdd3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xc5cdd3ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1354,21 +1228,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x72b7c0ff).into()),
+                                    color: Some(rgba(0xbe856fff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xd3b692ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xc37455ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1441,14 +1315,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5b858bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5b858bff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1456,20 +1330,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb2cacdff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1483,7 +1343,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1516,30 +1376,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xb2cacdff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xb2cacdff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1581,21 +1434,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1668,14 +1521,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5b858bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5b858bff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1683,20 +1536,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb2cacdff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1710,7 +1549,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1743,30 +1582,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xb2cacdff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xb2cacdff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1808,21 +1640,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1895,14 +1727,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5b858bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x5b858bff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1910,20 +1742,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb2cacdff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1937,7 +1755,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1970,30 +1788,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xb2cacdff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xb2cacdff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2035,21 +1846,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2122,14 +1933,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x716c93ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x716c93ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2137,20 +1948,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc5c2d6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -2164,7 +1961,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2197,30 +1994,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xc5c2d6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xc5c2d6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2262,21 +2052,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2349,14 +2139,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x7f659aff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x7f659aff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2364,20 +2154,6 @@ pub fn noctis() -> UserThemeFamily {
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xccbfd9ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -2391,7 +2167,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2424,30 +2200,23 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x16a3b6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xccbfd9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    font_weight: Some(UserFontWeight(700.0)),
+                                    color: Some(rgba(0xccbfd9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2489,21 +2258,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x49d6e9ff).into()),
+                                    color: Some(rgba(0xd67e5cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe4b781ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/noctis.rs
+++ b/crates/theme2/src/themes/noctis.rs
@@ -79,7 +79,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5988a6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -114,7 +114,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -128,14 +128,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -156,21 +156,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5988a6ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xbecfdaff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -191,7 +191,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -219,14 +219,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -299,7 +299,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b747cff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -334,7 +334,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -348,14 +348,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -376,21 +376,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b747cff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xcbbec2ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -411,7 +411,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -439,14 +439,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -519,7 +519,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ca6a6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -554,7 +554,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5792ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -568,14 +568,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    color: Some(rgba(0x00bdd6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    color: Some(rgba(0x00bdd6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -596,21 +596,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ca6a6ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x004d57ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -631,7 +631,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5792ff).into()),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -659,14 +659,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfa8900ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe64100ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -739,7 +739,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x9995b7ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -774,7 +774,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5792ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -788,14 +788,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    color: Some(rgba(0x00bdd6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    color: Some(rgba(0x00bdd6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -816,21 +816,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x9995b7ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0c006bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -851,7 +851,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5792ff).into()),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -879,14 +879,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfa8900ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe64100ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -959,7 +959,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ca6a6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -994,7 +994,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5792ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1008,14 +1008,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    color: Some(rgba(0x00bdd6ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    color: Some(rgba(0x00bdd6ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1036,21 +1036,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0095a8ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ca6a6ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x004d57ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1071,7 +1071,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5792ff).into()),
+                                    color: Some(rgba(0xe64100ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1099,14 +1099,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfa8900ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe64100ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1179,7 +1179,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5e7887ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1214,7 +1214,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc88da2ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1228,14 +1228,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x3f848dff).into()),
+                                    color: Some(rgba(0x72b7c0ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x3f848dff).into()),
+                                    color: Some(rgba(0x72b7c0ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1256,21 +1256,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x3f848dff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5e7887ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc5cdd3ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1291,7 +1291,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc88da2ff).into()),
+                                    color: Some(rgba(0xc37455ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1319,14 +1319,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd3b692ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc37455ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1399,7 +1399,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b858bff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1434,7 +1434,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1448,14 +1448,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1476,21 +1476,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b858bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb2cacdff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1511,7 +1511,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1539,14 +1539,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1619,7 +1619,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b858bff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1654,7 +1654,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1668,14 +1668,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1696,21 +1696,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b858bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb2cacdff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1731,7 +1731,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1759,14 +1759,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1839,7 +1839,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b858bff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -1874,7 +1874,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1888,14 +1888,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1916,21 +1916,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b858bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb2cacdff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -1951,7 +1951,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1979,14 +1979,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -2059,7 +2059,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x716c93ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -2094,7 +2094,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -2108,14 +2108,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2136,21 +2136,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x716c93ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc5c2d6ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -2171,7 +2171,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2199,14 +2199,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -2279,7 +2279,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7f659aff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -2314,7 +2314,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -2328,14 +2328,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    color: Some(rgba(0x49d6e9ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2356,21 +2356,21 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x16a3b6ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7f659aff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xccbfd9ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
                             ),
@@ -2391,7 +2391,7 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xdf769bff).into()),
+                                    color: Some(rgba(0xe66533ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2419,14 +2419,14 @@ pub fn noctis() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe4b781ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe66533ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/noctis.rs
+++ b/crates/theme2/src/themes/noctis.rs
@@ -84,6 +84,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xbecfdaff).into()),
@@ -298,6 +305,13 @@ pub fn noctis() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
@@ -524,6 +538,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x004d57ff).into()),
@@ -738,6 +759,13 @@ pub fn noctis() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
@@ -964,6 +992,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x004d57ff).into()),
@@ -1178,6 +1213,13 @@ pub fn noctis() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
@@ -1404,6 +1446,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb2cacdff).into()),
@@ -1618,6 +1667,13 @@ pub fn noctis() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
@@ -1844,6 +1900,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xb2cacdff).into()),
@@ -2064,6 +2127,13 @@ pub fn noctis() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc5c2d6ff).into()),
@@ -2278,6 +2348,13 @@ pub fn noctis() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()

--- a/crates/theme2/src/themes/nord.rs
+++ b/crates/theme2/src/themes/nord.rs
@@ -104,13 +104,6 @@ pub fn nord() -> UserThemeFamily {
                             },
                         ),
                         (
-                            "emphasis.strong".into(),
-                            UserHighlightStyle {
-                                font_weight: Some(UserFontWeight(700.0)),
-                                ..Default::default()
-                            },
-                        ),
-                        (
                             "function".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0x88c0d0ff).into()),
@@ -190,7 +183,7 @@ pub fn nord() -> UserThemeFamily {
                         (
                             "variable".into(),
                             UserHighlightStyle {
-                                color: Some(rgba(0x81a1c1ff).into()),
+                                color: Some(rgba(0xd8dee9ff).into()),
                                 ..Default::default()
                             },
                         ),

--- a/crates/theme2/src/themes/nord.rs
+++ b/crates/theme2/src/themes/nord.rs
@@ -134,7 +134,7 @@ pub fn nord() -> UserThemeFamily {
                         (
                             "punctuation".into(),
                             UserHighlightStyle {
-                                color: Some(rgba(0xeceff4ff).into()),
+                                color: Some(rgba(0x81a1c1ff).into()),
                                 ..Default::default()
                             },
                         ),

--- a/crates/theme2/src/themes/nord.rs
+++ b/crates/theme2/src/themes/nord.rs
@@ -90,6 +90,13 @@ pub fn nord() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "comment.doc".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x616e88ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "constant".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xebcb8bff).into()),

--- a/crates/theme2/src/themes/palenight.rs
+++ b/crates/theme2/src/themes/palenight.rs
@@ -162,13 +162,6 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc3e88dff).into()),
@@ -206,7 +199,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffcb6bff).into()),
+                                    color: Some(rgba(0xff5572ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -277,21 +270,20 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffcb6bff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "boolean".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x82aaffff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x697098ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -329,7 +321,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -369,16 +361,9 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "string".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc3e88dff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -399,7 +384,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "text.literal".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc3e88dff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -413,14 +398,14 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffcb6bff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xff5572ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
                             ),
@@ -576,13 +561,6 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc792eaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc3e88dff).into()),
@@ -620,7 +598,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xffcb6bff).into()),
+                                    color: Some(rgba(0xff5572ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/palenight.rs
+++ b/crates/theme2/src/themes/palenight.rs
@@ -90,6 +90,14 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x697098ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x82aaffff).into()),
@@ -289,6 +297,13 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x82aaffff).into()),
@@ -482,6 +497,14 @@ pub fn palenight() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x697098ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x697098ff).into()),
                                     font_style: Some(UserFontStyle::Italic),

--- a/crates/theme2/src/themes/palenight.rs
+++ b/crates/theme2/src/themes/palenight.rs
@@ -170,6 +170,13 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x89ddffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc3e88dff).into()),
@@ -278,20 +285,21 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xffcb6bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "boolean".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x82aaffff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
+                                    color: Some(rgba(0x697098ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -299,6 +307,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
+                                    color: Some(rgba(0x697098ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -336,7 +345,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xc792eaff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -376,9 +385,16 @@ pub fn palenight() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x89ddffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "string".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xc3e88dff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -399,7 +415,7 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "text.literal".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xc3e88dff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -413,14 +429,14 @@ pub fn palenight() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xff5572ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xff5572ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -580,6 +596,13 @@ pub fn palenight() -> UserThemeFamily {
                                 "property".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x80cbc4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x89ddffff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -94,8 +94,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xeb6f92ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe0def4ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -123,7 +122,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x908caaff).into()),
+                                    color: Some(rgba(0x6e6a86ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -165,8 +164,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xebbcbaff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe0def4ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -261,8 +259,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xeb6f92ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe0def4ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -290,7 +287,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x908caaff).into()),
+                                    color: Some(rgba(0x6e6a86ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -332,8 +329,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xea9a97ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0xe0def4ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -428,8 +424,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb4637aff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x575279ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -457,7 +452,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x797593ff).into()),
+                                    color: Some(rgba(0x9893a5ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -499,8 +494,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd7827eff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
+                                    color: Some(rgba(0x575279ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -92,6 +92,14 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6a86ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe0def4ff).into()),
@@ -257,6 +265,14 @@ pub fn rose_pine() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6a86ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "function".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xe0def4ff).into()),
@@ -415,6 +431,14 @@ pub fn rose_pine() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9893a5ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x9893a5ff).into()),
                                     font_style: Some(UserFontStyle::Italic),

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -172,7 +172,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
+                                    color: Some(rgba(0xc4a7e7ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -345,7 +345,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
+                                    color: Some(rgba(0xc4a7e7ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -518,7 +518,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x575279ff).into()),
+                                    color: Some(rgba(0x907aa9ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/solarized.rs
+++ b/crates/theme2/src/themes/solarized.rs
@@ -132,7 +132,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x859900ff).into()),
+                                    color: Some(rgba(0x268bd2ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -195,7 +195,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x268bd2ff).into()),
+                                    color: Some(rgba(0x839496ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -325,7 +325,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x859900ff).into()),
+                                    color: Some(rgba(0x268bd2ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/solarized.rs
+++ b/crates/theme2/src/themes/solarized.rs
@@ -87,6 +87,14 @@ pub fn solarized() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x657b83ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "constant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xcb4b16ff).into()),
@@ -265,6 +273,14 @@ pub fn solarized() -> UserThemeFamily {
                             ),
                             (
                                 "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x93a1a1ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x93a1a1ff).into()),
                                     font_style: Some(UserFontStyle::Italic),

--- a/crates/theme2/src/themes/solarized.rs
+++ b/crates/theme2/src/themes/solarized.rs
@@ -117,7 +117,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x268bd2ff).into()),
+                                    color: Some(rgba(0x839496ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -180,7 +180,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xcb4b16ff).into()),
+                                    color: Some(rgba(0x859900ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -302,7 +302,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x268bd2ff).into()),
+                                    color: Some(rgba(0x657b83ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -358,7 +358,7 @@ pub fn solarized() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x268bd2ff).into()),
+                                    color: Some(rgba(0x859900ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme2/src/themes/synthwave_84.rs
+++ b/crates/theme2/src/themes/synthwave_84.rs
@@ -162,7 +162,8 @@ pub fn synthwave_84() -> UserThemeFamily {
                         (
                             "variable".into(),
                             UserHighlightStyle {
-                                color: Some(rgba(0xff7edbff).into()),
+                                color: Some(rgba(0xfe4450ff).into()),
+                                font_weight: Some(UserFontWeight(700.0)),
                                 ..Default::default()
                             },
                         ),

--- a/crates/theme2/src/themes/synthwave_84.rs
+++ b/crates/theme2/src/themes/synthwave_84.rs
@@ -76,6 +76,14 @@ pub fn synthwave_84() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "comment.doc".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0x848bbdff).into()),
+                                font_style: Some(UserFontStyle::Italic),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "function".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0x36f9f6ff).into()),

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -57,11 +57,13 @@ fn main() -> Result<()> {
     const OUT_PATH: &str = "crates/theme2/src/themes";
 
     let log_config = simplelog::ConfigBuilder::new()
+        .set_level_color(log::Level::Trace, simplelog::Color::Cyan)
         .set_level_color(log::Level::Info, simplelog::Color::Blue)
         .set_level_color(log::Level::Warn, simplelog::Color::Yellow)
+        .set_level_color(log::Level::Error, simplelog::Color::Red)
         .build();
 
-    TermLogger::init(LevelFilter::Info, log_config, TerminalMode::Mixed)
+    TermLogger::init(LevelFilter::Trace, log_config, TerminalMode::Mixed)
         .expect("could not initialize logger");
 
     log::info!("Loading themes source...");

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -278,12 +278,12 @@ impl VsCodeThemeConverter {
             let Some(token_color) =
                 syntax_token.find_best_token_color_match(&self.theme.token_colors)
             else {
-                eprintln!("No matching token color found for '{syntax_token}'");
+                log::warn!("No matching token color found for '{syntax_token}'");
 
                 continue;
             };
 
-            println!(
+            log::info!(
                 "Matched '{syntax_token}' to '{}'",
                 token_color
                     .name

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -275,19 +275,21 @@ impl VsCodeThemeConverter {
         let mut highlight_styles = IndexMap::new();
 
         for syntax_token in ZedSyntaxToken::iter() {
-            let multimatch_scopes = syntax_token.to_vscode();
+            let Some(token_color) =
+                syntax_token.find_best_token_color_match(&self.theme.token_colors)
+            else {
+                eprintln!("No matching token color found for {syntax_token}");
 
-            let token_color = self.theme.token_colors.iter().find(|token_color| {
-                token_color
-                    .scope
-                    .as_ref()
-                    .map(|scope| scope.multimatch(&multimatch_scopes))
-                    .unwrap_or(false)
-            });
-
-            let Some(token_color) = token_color else {
                 continue;
             };
+
+            println!(
+                "Matched {syntax_token} to {}",
+                token_color
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| String::from("no name"))
+            );
 
             let highlight_style = UserHighlightStyle {
                 color: token_color

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -278,17 +278,21 @@ impl VsCodeThemeConverter {
             let Some(token_color) =
                 syntax_token.find_best_token_color_match(&self.theme.token_colors)
             else {
-                eprintln!("No matching token color found for {syntax_token}");
+                eprintln!("No matching token color found for '{syntax_token}'");
 
                 continue;
             };
 
             println!(
-                "Matched {syntax_token} to {}",
+                "Matched '{syntax_token}' to '{}'",
                 token_color
                     .name
                     .clone()
-                    .unwrap_or_else(|| String::from("no name"))
+                    .or_else(|| token_color
+                        .scope
+                        .as_ref()
+                        .map(|scope| format!("{:?}", scope)))
+                    .unwrap_or_else(|| "no identifier".to_string())
             );
 
             let highlight_style = UserHighlightStyle {

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -275,11 +275,16 @@ impl VsCodeThemeConverter {
         let mut highlight_styles = IndexMap::new();
 
         for syntax_token in ZedSyntaxToken::iter() {
-            let Some(token_color) =
-                syntax_token.find_best_token_color_match(&self.theme.token_colors)
-            else {
-                log::warn!("No matching token color found for '{syntax_token}'");
+            let best_match = syntax_token
+                .find_best_token_color_match(&self.theme.token_colors)
+                .or_else(|| {
+                    syntax_token.fallbacks().iter().find_map(|fallback| {
+                        fallback.find_best_token_color_match(&self.theme.token_colors)
+                    })
+                });
 
+            let Some(token_color) = best_match else {
+                log::warn!("No matching token color found for '{syntax_token}'");
                 continue;
             };
 

--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -9,17 +9,6 @@ pub enum VsCodeTokenScope {
     Many(Vec<String>),
 }
 
-impl VsCodeTokenScope {
-    pub fn multimatch(&self, matches: &[&'static str]) -> bool {
-        match self {
-            VsCodeTokenScope::One(scope) => matches.iter().any(|&s| s == scope),
-            VsCodeTokenScope::Many(scopes) => {
-                matches.iter().any(|s| scopes.contains(&s.to_string()))
-            }
-        }
-    }
-}
-
 #[derive(Debug, Deserialize)]
 pub struct VsCodeTokenColor {
     pub name: Option<String>,
@@ -292,34 +281,5 @@ impl ZedSyntaxToken {
             ],
             ZedSyntaxToken::Variant => vec!["variant"],
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_scope_multimatch_with_no_matches() {
-        assert_eq!(
-            VsCodeTokenScope::Many(vec![
-                "entity.name.function".to_string(),
-                "variable.function".to_string()
-            ])
-            .multimatch(&["entity.name"]),
-            false
-        );
-    }
-
-    #[test]
-    fn test_scope_multimatch_with_one_match() {
-        assert_eq!(
-            VsCodeTokenScope::Many(vec![
-                "entity.name.function".to_string(),
-                "variable.function".to_string()
-            ])
-            .multimatch(&["entity.name.function"]),
-            true
-        );
     }
 }

--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -136,6 +136,10 @@ impl ZedSyntaxToken {
         let mut ranked_matches = IndexMap::new();
 
         for (ix, token_color) in token_colors.iter().enumerate() {
+            if token_color.settings.foreground.is_none() {
+                continue;
+            }
+
             let Some(rank) = self.rank_match(token_color) else {
                 continue;
             };
@@ -152,17 +156,18 @@ impl ZedSyntaxToken {
     }
 
     fn rank_match(&self, token_color: &VsCodeTokenColor) -> Option<u32> {
-        let scopes_to_match = self.to_vscode();
-
         let candidate_scopes = match token_color.scope.as_ref()? {
             VsCodeTokenScope::One(scope) => vec![scope],
             VsCodeTokenScope::Many(scopes) => scopes.iter().collect(),
-        };
+        }
+        .iter()
+        .map(|scope| scope.as_str())
+        .collect::<Vec<_>>();
 
         let mut matches = 0;
 
-        for candidate_scope in candidate_scopes {
-            if scopes_to_match.contains(&candidate_scope.as_str()) {
+        for scope in self.to_vscode() {
+            if candidate_scopes.contains(&scope) {
                 matches += 1;
             }
         }
@@ -202,7 +207,14 @@ impl ZedSyntaxToken {
                 "support.function",
             ],
             ZedSyntaxToken::Hint => vec![],
-            ZedSyntaxToken::Keyword => vec!["keyword"],
+            ZedSyntaxToken::Keyword => vec![
+                "keyword",
+                "keyword.control",
+                "keyword.control.fun",
+                "keyword.other.fn.rust",
+                "punctuation.accessor",
+                "entity.name.tag",
+            ],
             ZedSyntaxToken::Label => vec![
                 "label",
                 "entity.name",
@@ -256,11 +268,20 @@ impl ZedSyntaxToken {
             ZedSyntaxToken::Tag => vec!["tag", "entity.name.tag", "meta.tag.sgml"],
             ZedSyntaxToken::TextLiteral => vec!["text.literal", "string"],
             ZedSyntaxToken::Title => vec!["title", "entity.name"],
-            ZedSyntaxToken::Type => vec!["entity.name.type", "support.type", "support.class"],
+            ZedSyntaxToken::Type => vec![
+                "entity.name.type",
+                "entity.name.type.primitive",
+                "entity.name.type.numeric",
+                "keyword.type",
+                "support.type",
+                "support.type.primitive",
+                "support.class",
+            ],
             ZedSyntaxToken::Variable => vec![
                 "variable",
                 "variable.language",
                 "variable.member",
+                "variable.parameter",
                 "variable.parameter.function-call",
             ],
             ZedSyntaxToken::VariableSpecial => vec![

--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -170,6 +170,14 @@ impl ZedSyntaxToken {
         Some(matches)
     }
 
+    pub fn fallbacks(&self) -> &[Self] {
+        match self {
+            ZedSyntaxToken::CommentDoc => &[ZedSyntaxToken::Comment],
+            ZedSyntaxToken::VariableSpecial => &[ZedSyntaxToken::Variable],
+            _ => &[],
+        }
+    }
+
     pub fn to_vscode(&self) -> Vec<&'static str> {
         match self {
             ZedSyntaxToken::Attribute => vec!["entity.other.attribute-name"],
@@ -193,6 +201,7 @@ impl ZedSyntaxToken {
                 "variable.function",
                 "support.function",
             ],
+            ZedSyntaxToken::Hint => vec![],
             ZedSyntaxToken::Keyword => vec!["keyword"],
             ZedSyntaxToken::Label => vec![
                 "label",
@@ -204,7 +213,9 @@ impl ZedSyntaxToken {
             ZedSyntaxToken::LinkUri => vec!["markup.underline.link", "string.other.link"],
             ZedSyntaxToken::Number => vec!["constant.numeric", "number"],
             ZedSyntaxToken::Operator => vec!["operator", "keyword.operator"],
+            ZedSyntaxToken::Predictive => vec![],
             ZedSyntaxToken::Preproc => vec!["preproc"],
+            ZedSyntaxToken::Primary => vec![],
             ZedSyntaxToken::Property => vec![
                 "variable.member",
                 "support.type.property-name",
@@ -259,7 +270,6 @@ impl ZedSyntaxToken {
                 "variable.language",
             ],
             ZedSyntaxToken::Variant => vec!["variant"],
-            _ => vec![],
         }
     }
 }


### PR DESCRIPTION
This PR improves the approach we use to match syntax tokens between Zed and VS Code in the `theme_importer`.

We now use the list of scopes assigned to each Zed syntax token to rank the possible candidates in the VS Code and then pick the candidate with the highest rank.

So far this has proved to provide better colors across the board, but we'll continue to refine the matching over time.

Release Notes:

- N/A
