### PR TITLE
Add support for theme family-specific syntax mapping overrides

### DIFF
--- a/assets/themes/src/vscode/rose-pine/family.json
+++ b/assets/themes/src/vscode/rose-pine/family.json
@@ -17,5 +17,8 @@
       "file_name": "rose-pine-dawn.json",
       "appearance": "light"
     }
-  ]
+  ],
+  "syntax": {
+    "function": ["entity.name"]
+  }
 }

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -106,7 +106,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
+                                    color: Some(rgba(0xebbcbaff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -283,7 +283,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
+                                    color: Some(rgba(0xea9a97ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -460,7 +460,7 @@ pub fn rose_pine() -> UserThemeFamily {
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x575279ff).into()),
+                                    color: Some(rgba(0xd7827eff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow.workspace = true
 convert_case = "0.6.0"
 gpui = { package = "gpui2", path = "../gpui2" }
-indexmap = "1.6.2"
+indexmap = { version = "1.6.2", features = ["serde"] }
 json_comments = "0.2.2"
 log.workspace = true
 palette = { version = "0.7.3", default-features = false, features = ["std"] }

--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use strum::EnumIter;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]
 pub enum VsCodeTokenScope {
     One(String),


### PR DESCRIPTION
This PR adds support for adding a specific set of mappings from Zed syntax tokens to VS Code scopes for a particular theme family.

We can use this as a fallback when we aren't otherwise able to rely on the mappings in the theme importer, as sometimes it isn't possible to make a specific enough matcher that works across all of the themes.

Release Notes:

- N/A
