### PR TITLE
Refine imported themes further

### DIFF
--- a/crates/theme2/src/themes/andromeda.rs
+++ b/crates/theme2/src/themes/andromeda.rs
@@ -63,6 +63,7 @@ pub fn andromeda() -> UserThemeFamily {
                         error: Some(rgba(0xfc644dff).into()),
                         hidden: Some(rgba(0x746f77ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x555555ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -267,6 +268,7 @@ pub fn andromeda() -> UserThemeFamily {
                         error: Some(rgba(0xfc644dff).into()),
                         hidden: Some(rgba(0x746f77ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x555555ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -63,10 +63,13 @@ pub fn ayu() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        created: Some(rgba(0x6cbf43b3).into()),
                         deleted: Some(rgba(0xe65050ff).into()),
                         error: Some(rgba(0xe65050ff).into()),
                         hidden: Some(rgba(0x8a9199ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x8a919980).into()),
+                        modified: Some(rgba(0x478accb3).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -359,10 +362,13 @@ pub fn ayu() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        created: Some(rgba(0x87d96cb3).into()),
                         deleted: Some(rgba(0xff6666ff).into()),
                         error: Some(rgba(0xff6666ff).into()),
                         hidden: Some(rgba(0x707a8cff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x707a8c80).into()),
+                        modified: Some(rgba(0x80bfffb3).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -655,10 +661,13 @@ pub fn ayu() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        created: Some(rgba(0x7fd962b3).into()),
                         deleted: Some(rgba(0xd95757ff).into()),
                         error: Some(rgba(0xd95757ff).into()),
                         hidden: Some(rgba(0x565b66ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x565b6680).into()),
+                        modified: Some(rgba(0x73b8ffb3).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -157,6 +157,13 @@ pub fn dracula() -> UserThemeFamily {
                             },
                         ),
                         (
+                            "number".into(),
+                            UserHighlightStyle {
+                                color: Some(rgba(0xbd93f9ff).into()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
                             "string".into(),
                             UserHighlightStyle {
                                 color: Some(rgba(0xf1fa8cff).into()),

--- a/crates/theme2/src/themes/dracula.rs
+++ b/crates/theme2/src/themes/dracula.rs
@@ -63,10 +63,14 @@ pub fn dracula() -> UserThemeFamily {
                     ..Default::default()
                 },
                 status: StatusColorsRefinement {
+                    conflict: Some(rgba(0xffb86cff).into()),
+                    created: Some(rgba(0x50fa7bff).into()),
                     deleted: Some(rgba(0xff5555ff).into()),
                     error: Some(rgba(0xff5555ff).into()),
                     hidden: Some(rgba(0x6272a4ff).into()),
                     hint: Some(rgba(0x969696ff).into()),
+                    ignored: Some(rgba(0x6272a4ff).into()),
+                    modified: Some(rgba(0x8be9fdff).into()),
                     warning: Some(rgba(0xffb86cff).into()),
                     ..Default::default()
                 },

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -153,6 +153,13 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "operator".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x8ec07cff).into()),
@@ -422,6 +429,13 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xd3869bff).into()),
                                     ..Default::default()
@@ -703,6 +717,13 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "operator".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x8ec07cff).into()),
@@ -972,6 +993,13 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x8f3f71ff).into()),
                                     ..Default::default()
@@ -1253,6 +1281,13 @@ pub fn gruvbox() -> UserThemeFamily {
                                 },
                             ),
                             (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
                                 "operator".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x427b58ff).into()),
@@ -1522,6 +1557,13 @@ pub fn gruvbox() -> UserThemeFamily {
                             ),
                             (
                                 "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x8f3f71ff).into()),
                                     ..Default::default()

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -60,10 +60,14 @@ pub fn gruvbox() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb16286ff).into()),
+                        created: Some(rgba(0x98971aff).into()),
                         deleted: Some(rgba(0xfb4934ff).into()),
                         error: Some(rgba(0xfb4934ff).into()),
                         hidden: Some(rgba(0xa89984ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x7c6f64ff).into()),
+                        modified: Some(rgba(0xd79921ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -331,10 +335,14 @@ pub fn gruvbox() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb16286ff).into()),
+                        created: Some(rgba(0x98971aff).into()),
                         deleted: Some(rgba(0xfb4934ff).into()),
                         error: Some(rgba(0xfb4934ff).into()),
                         hidden: Some(rgba(0xa89984ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x7c6f64ff).into()),
+                        modified: Some(rgba(0xd79921ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -602,10 +610,14 @@ pub fn gruvbox() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb16286ff).into()),
+                        created: Some(rgba(0x98971aff).into()),
                         deleted: Some(rgba(0xfb4934ff).into()),
                         error: Some(rgba(0xfb4934ff).into()),
                         hidden: Some(rgba(0xa89984ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x7c6f64ff).into()),
+                        modified: Some(rgba(0xd79921ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -873,10 +885,14 @@ pub fn gruvbox() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb16286ff).into()),
+                        created: Some(rgba(0x98971aff).into()),
                         deleted: Some(rgba(0x9d0006ff).into()),
                         error: Some(rgba(0x9d0006ff).into()),
                         hidden: Some(rgba(0x7c6f64ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0xa89984ff).into()),
+                        modified: Some(rgba(0xd79921ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -1144,10 +1160,14 @@ pub fn gruvbox() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb16286ff).into()),
+                        created: Some(rgba(0x98971aff).into()),
                         deleted: Some(rgba(0x9d0006ff).into()),
                         error: Some(rgba(0x9d0006ff).into()),
                         hidden: Some(rgba(0x7c6f64ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0xa89984ff).into()),
+                        modified: Some(rgba(0xd79921ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -1415,10 +1435,14 @@ pub fn gruvbox() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb16286ff).into()),
+                        created: Some(rgba(0x98971aff).into()),
                         deleted: Some(rgba(0x9d0006ff).into()),
                         error: Some(rgba(0x9d0006ff).into()),
                         hidden: Some(rgba(0x7c6f64ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0xa89984ff).into()),
+                        modified: Some(rgba(0xd79921ff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {

--- a/crates/theme2/src/themes/night_owl.rs
+++ b/crates/theme2/src/themes/night_owl.rs
@@ -63,10 +63,14 @@ pub fn night_owl() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffeb95cc).into()),
+                        created: Some(rgba(0xc5e478ff).into()),
                         deleted: Some(rgba(0xef5350ff).into()),
                         error: Some(rgba(0xef5350ff).into()),
                         hidden: Some(rgba(0x5f7e97ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x395a75ff).into()),
+                        modified: Some(rgba(0xa2bffcff).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {

--- a/crates/theme2/src/themes/noctis.rs
+++ b/crates/theme2/src/themes/noctis.rs
@@ -64,10 +64,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffc180ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0x9fb6c6ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x5b788bff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa857ff).into()),
                         ..Default::default()
                     },
@@ -330,10 +334,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffc180ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0xbbaab0ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x5b788bff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa857ff).into()),
                         ..Default::default()
                     },
@@ -596,10 +604,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xe9a149ff).into()),
+                        created: Some(rgba(0x00c6e0ff).into()),
                         deleted: Some(rgba(0xff4000ff).into()),
                         error: Some(rgba(0xff4000ff).into()),
                         hidden: Some(rgba(0x71838eff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0xa8a28faa).into()),
+                        modified: Some(rgba(0x14b832ff).into()),
                         warning: Some(rgba(0xe07a52ff).into()),
                         ..Default::default()
                     },
@@ -862,10 +874,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xe9a149ff).into()),
+                        created: Some(rgba(0x00c6e0ff).into()),
                         deleted: Some(rgba(0xff4000ff).into()),
                         error: Some(rgba(0xff4000ff).into()),
                         hidden: Some(rgba(0x75718eff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0xa8a28faa).into()),
+                        modified: Some(rgba(0x14b832ff).into()),
                         warning: Some(rgba(0xe07a52ff).into()),
                         ..Default::default()
                     },
@@ -1128,10 +1144,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xe9a149ff).into()),
+                        created: Some(rgba(0x00c6e0ff).into()),
                         deleted: Some(rgba(0xff4000ff).into()),
                         error: Some(rgba(0xff4000ff).into()),
                         hidden: Some(rgba(0x888477ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0xa8a28faa).into()),
+                        modified: Some(rgba(0x14b832ff).into()),
                         warning: Some(rgba(0xe07a52ff).into()),
                         ..Default::default()
                     },
@@ -1394,10 +1414,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xdfc09fff).into()),
+                        created: Some(rgba(0x6fb0b8ff).into()),
                         deleted: Some(rgba(0xb96346ff).into()),
                         error: Some(rgba(0xb96346ff).into()),
                         hidden: Some(rgba(0x96a8b6ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x5b788bff).into()),
+                        modified: Some(rgba(0x72c09fff).into()),
                         warning: Some(rgba(0xffa857ff).into()),
                         ..Default::default()
                     },
@@ -1660,10 +1684,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xe4b781ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0x87a7abff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x5b858bff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa487ff).into()),
                         ..Default::default()
                     },
@@ -1926,10 +1954,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xe4b781ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0x87a7abff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x647e82ff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa487ff).into()),
                         ..Default::default()
                     },
@@ -2192,10 +2224,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xe4b781ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0x87a7abff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x647e82ff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa487ff).into()),
                         ..Default::default()
                     },
@@ -2458,10 +2494,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffc180ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0xa9a5c0ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x5b788bff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa857ff).into()),
                         ..Default::default()
                     },
@@ -2724,10 +2764,14 @@ pub fn noctis() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffc180ff).into()),
+                        created: Some(rgba(0x40d4e7ff).into()),
                         deleted: Some(rgba(0xe34e1cff).into()),
                         error: Some(rgba(0xe34e1cff).into()),
                         hidden: Some(rgba(0xb3a5c0ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x5b788bff).into()),
+                        modified: Some(rgba(0x49e9a6ff).into()),
                         warning: Some(rgba(0xffa857ff).into()),
                         ..Default::default()
                     },

--- a/crates/theme2/src/themes/nord.rs
+++ b/crates/theme2/src/themes/nord.rs
@@ -63,10 +63,14 @@ pub fn nord() -> UserThemeFamily {
                     ..Default::default()
                 },
                 status: StatusColorsRefinement {
+                    conflict: Some(rgba(0x5e81acff).into()),
+                    created: Some(rgba(0xa3be8cff).into()),
                     deleted: Some(rgba(0xbf616aff).into()),
                     error: Some(rgba(0xbf616aff).into()),
                     hidden: Some(rgba(0xd8dee966).into()),
                     hint: Some(rgba(0xd8dee9ff).into()),
+                    ignored: Some(rgba(0xd8dee966).into()),
+                    modified: Some(rgba(0xebcb8bff).into()),
                     warning: Some(rgba(0xebcb8bff).into()),
                     ..Default::default()
                 },

--- a/crates/theme2/src/themes/palenight.rs
+++ b/crates/theme2/src/themes/palenight.rs
@@ -63,10 +63,14 @@ pub fn palenight() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffeb95cc).into()),
+                        created: Some(rgba(0xa9c77dff).into()),
                         deleted: Some(rgba(0xef5350ff).into()),
                         error: Some(rgba(0xef5350ff).into()),
                         hidden: Some(rgba(0x929ac9ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x69709890).into()),
+                        modified: Some(rgba(0xe2c08de6).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -338,10 +342,14 @@ pub fn palenight() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffeb95cc).into()),
+                        created: Some(rgba(0xa9c77dff).into()),
                         deleted: Some(rgba(0xef5350ff).into()),
                         error: Some(rgba(0xef5350ff).into()),
                         hidden: Some(rgba(0x929ac9ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x69709890).into()),
+                        modified: Some(rgba(0xe2c08de6).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {
@@ -613,10 +621,14 @@ pub fn palenight() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xffeb95cc).into()),
+                        created: Some(rgba(0xa9c77dff).into()),
                         deleted: Some(rgba(0xef5350ff).into()),
                         error: Some(rgba(0xef5350ff).into()),
                         hidden: Some(rgba(0x929ac9ff).into()),
                         hint: Some(rgba(0x969696ff).into()),
+                        ignored: Some(rgba(0x69709890).into()),
+                        modified: Some(rgba(0xe2c08de6).into()),
                         ..Default::default()
                     },
                     syntax: Some(UserSyntaxTheme {

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -63,10 +63,14 @@ pub fn rose_pine() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xeb6f92ff).into()),
+                        created: Some(rgba(0xf6c177ff).into()),
                         deleted: Some(rgba(0xeb6f92ff).into()),
                         error: Some(rgba(0xeb6f92ff).into()),
                         hidden: Some(rgba(0x908caaff).into()),
                         hint: Some(rgba(0x908caaff).into()),
+                        ignored: Some(rgba(0x6e6a86ff).into()),
+                        modified: Some(rgba(0xebbcbaff).into()),
                         warning: Some(rgba(0xf6c177ff).into()),
                         ..Default::default()
                     },
@@ -310,10 +314,14 @@ pub fn rose_pine() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xeb6f92ff).into()),
+                        created: Some(rgba(0xf6c177ff).into()),
                         deleted: Some(rgba(0xeb6f92ff).into()),
                         error: Some(rgba(0xeb6f92ff).into()),
                         hidden: Some(rgba(0x908caaff).into()),
                         hint: Some(rgba(0x908caaff).into()),
+                        ignored: Some(rgba(0x6e6a86ff).into()),
+                        modified: Some(rgba(0xea9a97ff).into()),
                         warning: Some(rgba(0xf6c177ff).into()),
                         ..Default::default()
                     },
@@ -557,10 +565,14 @@ pub fn rose_pine() -> UserThemeFamily {
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb4637aff).into()),
+                        created: Some(rgba(0xea9d34ff).into()),
                         deleted: Some(rgba(0xb4637aff).into()),
                         error: Some(rgba(0xb4637aff).into()),
                         hidden: Some(rgba(0x797593ff).into()),
                         hint: Some(rgba(0x797593ff).into()),
+                        ignored: Some(rgba(0x9893a5ff).into()),
+                        modified: Some(rgba(0xd7827eff).into()),
                         warning: Some(rgba(0xea9d34ff).into()),
                         ..Default::default()
                     },

--- a/crates/theme2/src/themes/synthwave_84.rs
+++ b/crates/theme2/src/themes/synthwave_84.rs
@@ -47,9 +47,12 @@ pub fn synthwave_84() -> UserThemeFamily {
                     ..Default::default()
                 },
                 status: StatusColorsRefinement {
+                    created: Some(rgba(0x72f1b8ff).into()),
                     deleted: Some(rgba(0xfe4450ff).into()),
                     error: Some(rgba(0xfe4450ff).into()),
                     hint: Some(rgba(0x969696ff).into()),
+                    ignored: Some(rgba(0xffffff59).into()),
+                    modified: Some(rgba(0xb893ceee).into()),
                     warning: Some(rgba(0x72f1b8bb).into()),
                     ..Default::default()
                 },

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -75,8 +75,14 @@ impl VsCodeThemeConverter {
         };
 
         Ok(StatusColorsRefinement {
-            // conflict: None,
-            // created: None,
+            conflict: vscode_colors
+                .git_decoration_conflicting_resource_foreground
+                .as_ref()
+                .traverse(|color| try_parse_color(&color))?,
+            created: vscode_colors
+                .git_decoration_untracked_resource_foreground
+                .as_ref()
+                .traverse(|color| try_parse_color(&color))?,
             deleted: vscode_colors
                 .error_foreground
                 .as_ref()
@@ -94,9 +100,15 @@ impl VsCodeThemeConverter {
                 .as_ref()
                 .traverse(|color| try_parse_color(&color))?
                 .or(vscode_base_status_colors.hint),
-            // ignored: None,
+            ignored: vscode_colors
+                .git_decoration_ignored_resource_foreground
+                .as_ref()
+                .traverse(|color| try_parse_color(&color))?,
             // info: None,
-            // modified: None,
+            modified: vscode_colors
+                .git_decoration_modified_resource_foreground
+                .as_ref()
+                .traverse(|color| try_parse_color(&color))?,
             // renamed: None,
             // success: None,
             warning: vscode_colors

--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -167,6 +167,7 @@ impl ZedSyntaxToken {
     pub fn fallbacks(&self) -> &[Self] {
         match self {
             ZedSyntaxToken::CommentDoc => &[ZedSyntaxToken::Comment],
+            ZedSyntaxToken::Number => &[ZedSyntaxToken::Constant],
             ZedSyntaxToken::VariableSpecial => &[ZedSyntaxToken::Variable],
             ZedSyntaxToken::PunctuationBracket
             | ZedSyntaxToken::PunctuationDelimiter

--- a/crates/theme_importer/src/vscode/theme.rs
+++ b/crates/theme_importer/src/vscode/theme.rs
@@ -161,6 +161,7 @@ pub struct VsCodeColors {
     )]
     pub focus_border: Option<String>,
 
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub foreground: Option<String>,
 
     #[serde(

--- a/crates/theme_importer/src/vscode/theme.rs
+++ b/crates/theme_importer/src/vscode/theme.rs
@@ -1,6 +1,14 @@
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::vscode::VsCodeTokenColor;
+
+fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.filter(|value| !value.is_empty()))
+}
 
 #[derive(Deserialize, Debug)]
 pub struct VsCodeTheme {
@@ -20,405 +28,1405 @@ pub struct VsCodeTheme {
 
 #[derive(Debug, Deserialize)]
 pub struct VsCodeColors {
-    #[serde(rename = "terminal.background")]
+    #[serde(
+        default,
+        rename = "terminal.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_background: Option<String>,
-    #[serde(rename = "terminal.foreground")]
+
+    #[serde(
+        default,
+        rename = "terminal.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_foreground: Option<String>,
-    #[serde(rename = "terminal.ansiBrightBlack")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightBlack",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_black: Option<String>,
-    #[serde(rename = "terminal.ansiBrightRed")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightRed",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_red: Option<String>,
-    #[serde(rename = "terminal.ansiBrightGreen")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightGreen",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_green: Option<String>,
-    #[serde(rename = "terminal.ansiBrightYellow")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightYellow",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_yellow: Option<String>,
-    #[serde(rename = "terminal.ansiBrightBlue")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightBlue",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_blue: Option<String>,
-    #[serde(rename = "terminal.ansiBrightMagenta")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightMagenta",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_magenta: Option<String>,
-    #[serde(rename = "terminal.ansiBrightCyan")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightCyan",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_cyan: Option<String>,
-    #[serde(rename = "terminal.ansiBrightWhite")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBrightWhite",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_bright_white: Option<String>,
-    #[serde(rename = "terminal.ansiBlack")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBlack",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_black: Option<String>,
-    #[serde(rename = "terminal.ansiRed")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiRed",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_red: Option<String>,
-    #[serde(rename = "terminal.ansiGreen")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiGreen",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_green: Option<String>,
-    #[serde(rename = "terminal.ansiYellow")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiYellow",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_yellow: Option<String>,
-    #[serde(rename = "terminal.ansiBlue")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiBlue",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_blue: Option<String>,
-    #[serde(rename = "terminal.ansiMagenta")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiMagenta",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_magenta: Option<String>,
-    #[serde(rename = "terminal.ansiCyan")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiCyan",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_cyan: Option<String>,
-    #[serde(rename = "terminal.ansiWhite")]
+
+    #[serde(
+        default,
+        rename = "terminal.ansiWhite",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub terminal_ansi_white: Option<String>,
-    #[serde(rename = "focusBorder")]
+
+    #[serde(
+        default,
+        rename = "focusBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub focus_border: Option<String>,
+
     pub foreground: Option<String>,
-    #[serde(rename = "selection.background")]
+
+    #[serde(
+        default,
+        rename = "selection.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub selection_background: Option<String>,
-    #[serde(rename = "errorForeground")]
+
+    #[serde(
+        default,
+        rename = "errorForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub error_foreground: Option<String>,
-    #[serde(rename = "button.background")]
+
+    #[serde(
+        default,
+        rename = "button.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub button_background: Option<String>,
-    #[serde(rename = "button.foreground")]
+
+    #[serde(
+        default,
+        rename = "button.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub button_foreground: Option<String>,
-    #[serde(rename = "button.secondaryBackground")]
+
+    #[serde(
+        default,
+        rename = "button.secondaryBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub button_secondary_background: Option<String>,
-    #[serde(rename = "button.secondaryForeground")]
+
+    #[serde(
+        default,
+        rename = "button.secondaryForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub button_secondary_foreground: Option<String>,
-    #[serde(rename = "button.secondaryHoverBackground")]
+
+    #[serde(
+        default,
+        rename = "button.secondaryHoverBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub button_secondary_hover_background: Option<String>,
-    #[serde(rename = "dropdown.background")]
+
+    #[serde(
+        default,
+        rename = "dropdown.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub dropdown_background: Option<String>,
-    #[serde(rename = "dropdown.border")]
+
+    #[serde(
+        default,
+        rename = "dropdown.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub dropdown_border: Option<String>,
-    #[serde(rename = "dropdown.foreground")]
+
+    #[serde(
+        default,
+        rename = "dropdown.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub dropdown_foreground: Option<String>,
-    #[serde(rename = "input.background")]
+
+    #[serde(
+        default,
+        rename = "input.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_background: Option<String>,
-    #[serde(rename = "input.foreground")]
+
+    #[serde(
+        default,
+        rename = "input.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_foreground: Option<String>,
-    #[serde(rename = "input.border")]
+
+    #[serde(
+        default,
+        rename = "input.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_border: Option<String>,
-    #[serde(rename = "input.placeholderForeground")]
+
+    #[serde(
+        default,
+        rename = "input.placeholderForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_placeholder_foreground: Option<String>,
-    #[serde(rename = "inputOption.activeBorder")]
+
+    #[serde(
+        default,
+        rename = "inputOption.activeBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_option_active_border: Option<String>,
-    #[serde(rename = "inputValidation.infoBorder")]
+
+    #[serde(
+        default,
+        rename = "inputValidation.infoBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_validation_info_border: Option<String>,
-    #[serde(rename = "inputValidation.warningBorder")]
+
+    #[serde(
+        default,
+        rename = "inputValidation.warningBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_validation_warning_border: Option<String>,
-    #[serde(rename = "inputValidation.errorBorder")]
+
+    #[serde(
+        default,
+        rename = "inputValidation.errorBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub input_validation_error_border: Option<String>,
-    #[serde(rename = "badge.foreground")]
+
+    #[serde(
+        default,
+        rename = "badge.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub badge_foreground: Option<String>,
-    #[serde(rename = "badge.background")]
+
+    #[serde(
+        default,
+        rename = "badge.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub badge_background: Option<String>,
-    #[serde(rename = "progressBar.background")]
+
+    #[serde(
+        default,
+        rename = "progressBar.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub progress_bar_background: Option<String>,
-    #[serde(rename = "list.activeSelectionBackground")]
+
+    #[serde(
+        default,
+        rename = "list.activeSelectionBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_active_selection_background: Option<String>,
-    #[serde(rename = "list.activeSelectionForeground")]
+
+    #[serde(
+        default,
+        rename = "list.activeSelectionForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_active_selection_foreground: Option<String>,
-    #[serde(rename = "list.dropBackground")]
+
+    #[serde(
+        default,
+        rename = "list.dropBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_drop_background: Option<String>,
-    #[serde(rename = "list.focusBackground")]
+
+    #[serde(
+        default,
+        rename = "list.focusBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_focus_background: Option<String>,
-    #[serde(rename = "list.highlightForeground")]
+
+    #[serde(
+        default,
+        rename = "list.highlightForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_highlight_foreground: Option<String>,
-    #[serde(rename = "list.hoverBackground")]
+
+    #[serde(
+        default,
+        rename = "list.hoverBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_hover_background: Option<String>,
-    #[serde(rename = "list.inactiveSelectionBackground")]
+
+    #[serde(
+        default,
+        rename = "list.inactiveSelectionBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_inactive_selection_background: Option<String>,
-    #[serde(rename = "list.warningForeground")]
+
+    #[serde(
+        default,
+        rename = "list.warningForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_warning_foreground: Option<String>,
-    #[serde(rename = "list.errorForeground")]
+
+    #[serde(
+        default,
+        rename = "list.errorForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_error_foreground: Option<String>,
-    #[serde(rename = "activityBar.background")]
+
+    #[serde(
+        default,
+        rename = "activityBar.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_background: Option<String>,
-    #[serde(rename = "activityBar.inactiveForeground")]
+
+    #[serde(
+        default,
+        rename = "activityBar.inactiveForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_inactive_foreground: Option<String>,
-    #[serde(rename = "activityBar.foreground")]
+
+    #[serde(
+        default,
+        rename = "activityBar.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_foreground: Option<String>,
-    #[serde(rename = "activityBar.activeBorder")]
+
+    #[serde(
+        default,
+        rename = "activityBar.activeBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_active_border: Option<String>,
-    #[serde(rename = "activityBar.activeBackground")]
+
+    #[serde(
+        default,
+        rename = "activityBar.activeBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_active_background: Option<String>,
-    #[serde(rename = "activityBarBadge.background")]
+
+    #[serde(
+        default,
+        rename = "activityBarBadge.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_badge_background: Option<String>,
-    #[serde(rename = "activityBarBadge.foreground")]
+
+    #[serde(
+        default,
+        rename = "activityBarBadge.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub activity_bar_badge_foreground: Option<String>,
-    #[serde(rename = "sideBar.background")]
+
+    #[serde(
+        default,
+        rename = "sideBar.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub side_bar_background: Option<String>,
-    #[serde(rename = "sideBarTitle.foreground")]
+
+    #[serde(
+        default,
+        rename = "sideBarTitle.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub side_bar_title_foreground: Option<String>,
-    #[serde(rename = "sideBarSectionHeader.background")]
+
+    #[serde(
+        default,
+        rename = "sideBarSectionHeader.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub side_bar_section_header_background: Option<String>,
-    #[serde(rename = "sideBarSectionHeader.border")]
+
+    #[serde(
+        default,
+        rename = "sideBarSectionHeader.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub side_bar_section_header_border: Option<String>,
-    #[serde(rename = "editorGroup.border")]
+
+    #[serde(
+        default,
+        rename = "editorGroup.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_group_border: Option<String>,
-    #[serde(rename = "editorGroup.dropBackground")]
+
+    #[serde(
+        default,
+        rename = "editorGroup.dropBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_group_drop_background: Option<String>,
-    #[serde(rename = "editorGroupHeader.tabsBackground")]
+
+    #[serde(
+        default,
+        rename = "editorGroupHeader.tabsBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_group_header_tabs_background: Option<String>,
-    #[serde(rename = "tab.activeBackground")]
+
+    #[serde(
+        default,
+        rename = "tab.activeBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub tab_active_background: Option<String>,
-    #[serde(rename = "tab.activeForeground")]
+
+    #[serde(
+        default,
+        rename = "tab.activeForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub tab_active_foreground: Option<String>,
-    #[serde(rename = "tab.border")]
+
+    #[serde(
+        default,
+        rename = "tab.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub tab_border: Option<String>,
-    #[serde(rename = "tab.activeBorderTop")]
+
+    #[serde(
+        default,
+        rename = "tab.activeBorderTop",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub tab_active_border_top: Option<String>,
-    #[serde(rename = "tab.inactiveBackground")]
+
+    #[serde(
+        default,
+        rename = "tab.inactiveBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub tab_inactive_background: Option<String>,
-    #[serde(rename = "tab.inactiveForeground")]
+
+    #[serde(
+        default,
+        rename = "tab.inactiveForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub tab_inactive_foreground: Option<String>,
-    #[serde(rename = "editor.foreground")]
+
+    #[serde(
+        default,
+        rename = "editor.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_foreground: Option<String>,
-    #[serde(rename = "editor.background")]
+
+    #[serde(
+        default,
+        rename = "editor.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_background: Option<String>,
-    #[serde(rename = "editorInlayHint.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorInlayHint.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_inlay_hint_foreground: Option<String>,
-    #[serde(rename = "editorInlayHint.background")]
+
+    #[serde(
+        default,
+        rename = "editorInlayHint.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_inlay_hint_background: Option<String>,
-    #[serde(rename = "editorInlayHint.parameterForeground")]
+
+    #[serde(
+        default,
+        rename = "editorInlayHint.parameterForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_inlay_hint_parameter_foreground: Option<String>,
-    #[serde(rename = "editorInlayHint.parameterBackground")]
+
+    #[serde(
+        default,
+        rename = "editorInlayHint.parameterBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_inlay_hint_parameter_background: Option<String>,
-    #[serde(rename = "editorInlayHint.typForeground")]
+
+    #[serde(
+        default,
+        rename = "editorInlayHint.typForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_inlay_hint_typ_foreground: Option<String>,
-    #[serde(rename = "editorInlayHint.typBackground")]
+
+    #[serde(
+        default,
+        rename = "editorInlayHint.typBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_inlay_hint_typ_background: Option<String>,
-    #[serde(rename = "editorLineNumber.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorLineNumber.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_line_number_foreground: Option<String>,
-    #[serde(rename = "editor.selectionBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.selectionBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_selection_background: Option<String>,
-    #[serde(rename = "editor.selectionHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.selectionHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_selection_highlight_background: Option<String>,
-    #[serde(rename = "editor.foldBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.foldBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_fold_background: Option<String>,
-    #[serde(rename = "editor.wordHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.wordHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_word_highlight_background: Option<String>,
-    #[serde(rename = "editor.wordHighlightStrongBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.wordHighlightStrongBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_word_highlight_strong_background: Option<String>,
-    #[serde(rename = "editor.findMatchBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.findMatchBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_find_match_background: Option<String>,
-    #[serde(rename = "editor.findMatchHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.findMatchHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_find_match_highlight_background: Option<String>,
-    #[serde(rename = "editor.findRangeHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.findRangeHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_find_range_highlight_background: Option<String>,
-    #[serde(rename = "editor.hoverHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.hoverHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_hover_highlight_background: Option<String>,
-    #[serde(rename = "editor.lineHighlightBorder")]
+
+    #[serde(
+        default,
+        rename = "editor.lineHighlightBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_line_highlight_border: Option<String>,
-    #[serde(rename = "editorLink.activeForeground")]
+
+    #[serde(
+        default,
+        rename = "editorLink.activeForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_link_active_foreground: Option<String>,
-    #[serde(rename = "editor.rangeHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.rangeHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_range_highlight_background: Option<String>,
-    #[serde(rename = "editor.snippetTabstopHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.snippetTabstopHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_snippet_tabstop_highlight_background: Option<String>,
-    #[serde(rename = "editor.snippetTabstopHighlightBorder")]
+
+    #[serde(
+        default,
+        rename = "editor.snippetTabstopHighlightBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_snippet_tabstop_highlight_border: Option<String>,
-    #[serde(rename = "editor.snippetFinalTabstopHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "editor.snippetFinalTabstopHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_snippet_final_tabstop_highlight_background: Option<String>,
-    #[serde(rename = "editor.snippetFinalTabstopHighlightBorder")]
+
+    #[serde(
+        default,
+        rename = "editor.snippetFinalTabstopHighlightBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_snippet_final_tabstop_highlight_border: Option<String>,
-    #[serde(rename = "editorWhitespace.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorWhitespace.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_whitespace_foreground: Option<String>,
-    #[serde(rename = "editorIndentGuide.background")]
+
+    #[serde(
+        default,
+        rename = "editorIndentGuide.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_indent_guide_background: Option<String>,
-    #[serde(rename = "editorIndentGuide.activeBackground")]
+
+    #[serde(
+        default,
+        rename = "editorIndentGuide.activeBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_indent_guide_active_background: Option<String>,
-    #[serde(rename = "editorRuler.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorRuler.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_ruler_foreground: Option<String>,
-    #[serde(rename = "editorCodeLens.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorCodeLens.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_code_lens_foreground: Option<String>,
-    #[serde(rename = "editorBracketHighlight.foreground1")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.foreground1",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_foreground1: Option<String>,
-    #[serde(rename = "editorBracketHighlight.foreground2")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.foreground2",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_foreground2: Option<String>,
-    #[serde(rename = "editorBracketHighlight.foreground3")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.foreground3",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_foreground3: Option<String>,
-    #[serde(rename = "editorBracketHighlight.foreground4")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.foreground4",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_foreground4: Option<String>,
-    #[serde(rename = "editorBracketHighlight.foreground5")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.foreground5",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_foreground5: Option<String>,
-    #[serde(rename = "editorBracketHighlight.foreground6")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.foreground6",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_foreground6: Option<String>,
-    #[serde(rename = "editorBracketHighlight.unexpectedBracket.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorBracketHighlight.unexpectedBracket.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_bracket_highlight_unexpected_bracket_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.border")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_border: Option<String>,
-    #[serde(rename = "editorOverviewRuler.selectionHighlightForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.selectionHighlightForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_selection_highlight_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.wordHighlightForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.wordHighlightForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_word_highlight_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.wordHighlightStrongForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.wordHighlightStrongForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_word_highlight_strong_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.modifiedForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.modifiedForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_modified_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.addedForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.addedForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_added_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.deletedForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.deletedForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_deleted_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.errorForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.errorForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_error_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.warningForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.warningForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_warning_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.infoForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.infoForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_info_foreground: Option<String>,
-    #[serde(rename = "editorError.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorError.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_error_foreground: Option<String>,
-    #[serde(rename = "editorWarning.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorWarning.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_warning_foreground: Option<String>,
-    #[serde(rename = "editorGutter.modifiedBackground")]
+
+    #[serde(
+        default,
+        rename = "editorGutter.modifiedBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_gutter_modified_background: Option<String>,
-    #[serde(rename = "editorGutter.addedBackground")]
+
+    #[serde(
+        default,
+        rename = "editorGutter.addedBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_gutter_added_background: Option<String>,
-    #[serde(rename = "editorGutter.deletedBackground")]
+
+    #[serde(
+        default,
+        rename = "editorGutter.deletedBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_gutter_deleted_background: Option<String>,
-    #[serde(rename = "gitDecoration.modifiedResourceForeground")]
+
+    #[serde(
+        default,
+        rename = "gitDecoration.modifiedResourceForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub git_decoration_modified_resource_foreground: Option<String>,
-    #[serde(rename = "gitDecoration.deletedResourceForeground")]
+
+    #[serde(
+        default,
+        rename = "gitDecoration.deletedResourceForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub git_decoration_deleted_resource_foreground: Option<String>,
-    #[serde(rename = "gitDecoration.untrackedResourceForeground")]
+
+    #[serde(
+        default,
+        rename = "gitDecoration.untrackedResourceForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub git_decoration_untracked_resource_foreground: Option<String>,
-    #[serde(rename = "gitDecoration.ignoredResourceForeground")]
+
+    #[serde(
+        default,
+        rename = "gitDecoration.ignoredResourceForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub git_decoration_ignored_resource_foreground: Option<String>,
-    #[serde(rename = "gitDecoration.conflictingResourceForeground")]
+
+    #[serde(
+        default,
+        rename = "gitDecoration.conflictingResourceForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub git_decoration_conflicting_resource_foreground: Option<String>,
-    #[serde(rename = "diffEditor.insertedTextBackground")]
+
+    #[serde(
+        default,
+        rename = "diffEditor.insertedTextBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub diff_editor_inserted_text_background: Option<String>,
-    #[serde(rename = "diffEditor.removedTextBackground")]
+
+    #[serde(
+        default,
+        rename = "diffEditor.removedTextBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub diff_editor_removed_text_background: Option<String>,
-    #[serde(rename = "inlineChat.regionHighlight")]
+
+    #[serde(
+        default,
+        rename = "inlineChat.regionHighlight",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub inline_chat_region_highlight: Option<String>,
-    #[serde(rename = "editorWidget.background")]
+
+    #[serde(
+        default,
+        rename = "editorWidget.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_widget_background: Option<String>,
-    #[serde(rename = "editorSuggestWidget.background")]
+
+    #[serde(
+        default,
+        rename = "editorSuggestWidget.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_suggest_widget_background: Option<String>,
-    #[serde(rename = "editorSuggestWidget.foreground")]
+
+    #[serde(
+        default,
+        rename = "editorSuggestWidget.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_suggest_widget_foreground: Option<String>,
-    #[serde(rename = "editorSuggestWidget.selectedBackground")]
+
+    #[serde(
+        default,
+        rename = "editorSuggestWidget.selectedBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_suggest_widget_selected_background: Option<String>,
-    #[serde(rename = "editorHoverWidget.background")]
+
+    #[serde(
+        default,
+        rename = "editorHoverWidget.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_hover_widget_background: Option<String>,
-    #[serde(rename = "editorHoverWidget.border")]
+
+    #[serde(
+        default,
+        rename = "editorHoverWidget.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_hover_widget_border: Option<String>,
-    #[serde(rename = "editorMarkerNavigation.background")]
+
+    #[serde(
+        default,
+        rename = "editorMarkerNavigation.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_marker_navigation_background: Option<String>,
-    #[serde(rename = "peekView.border")]
+
+    #[serde(
+        default,
+        rename = "peekView.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_border: Option<String>,
-    #[serde(rename = "peekViewEditor.background")]
+
+    #[serde(
+        default,
+        rename = "peekViewEditor.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_editor_background: Option<String>,
-    #[serde(rename = "peekViewEditor.matchHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "peekViewEditor.matchHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_editor_match_highlight_background: Option<String>,
-    #[serde(rename = "peekViewResult.background")]
+
+    #[serde(
+        default,
+        rename = "peekViewResult.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_result_background: Option<String>,
-    #[serde(rename = "peekViewResult.fileForeground")]
+
+    #[serde(
+        default,
+        rename = "peekViewResult.fileForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_result_file_foreground: Option<String>,
-    #[serde(rename = "peekViewResult.lineForeground")]
+
+    #[serde(
+        default,
+        rename = "peekViewResult.lineForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_result_line_foreground: Option<String>,
-    #[serde(rename = "peekViewResult.matchHighlightBackground")]
+
+    #[serde(
+        default,
+        rename = "peekViewResult.matchHighlightBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_result_match_highlight_background: Option<String>,
-    #[serde(rename = "peekViewResult.selectionBackground")]
+
+    #[serde(
+        default,
+        rename = "peekViewResult.selectionBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_result_selection_background: Option<String>,
-    #[serde(rename = "peekViewResult.selectionForeground")]
+
+    #[serde(
+        default,
+        rename = "peekViewResult.selectionForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_result_selection_foreground: Option<String>,
-    #[serde(rename = "peekViewTitle.background")]
+
+    #[serde(
+        default,
+        rename = "peekViewTitle.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_title_background: Option<String>,
-    #[serde(rename = "peekViewTitleDescription.foreground")]
+
+    #[serde(
+        default,
+        rename = "peekViewTitleDescription.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_title_description_foreground: Option<String>,
-    #[serde(rename = "peekViewTitleLabel.foreground")]
+
+    #[serde(
+        default,
+        rename = "peekViewTitleLabel.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub peek_view_title_label_foreground: Option<String>,
-    #[serde(rename = "merge.currentHeaderBackground")]
+
+    #[serde(
+        default,
+        rename = "merge.currentHeaderBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub merge_current_header_background: Option<String>,
-    #[serde(rename = "merge.incomingHeaderBackground")]
+
+    #[serde(
+        default,
+        rename = "merge.incomingHeaderBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub merge_incoming_header_background: Option<String>,
-    #[serde(rename = "editorOverviewRuler.currentContentForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.currentContentForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_current_content_foreground: Option<String>,
-    #[serde(rename = "editorOverviewRuler.incomingContentForeground")]
+
+    #[serde(
+        default,
+        rename = "editorOverviewRuler.incomingContentForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub editor_overview_ruler_incoming_content_foreground: Option<String>,
-    #[serde(rename = "panel.background")]
+
+    #[serde(
+        default,
+        rename = "panel.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub panel_background: Option<String>,
-    #[serde(rename = "panel.border")]
+
+    #[serde(
+        default,
+        rename = "panel.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub panel_border: Option<String>,
-    #[serde(rename = "panelTitle.activeBorder")]
+
+    #[serde(
+        default,
+        rename = "panelTitle.activeBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub panel_title_active_border: Option<String>,
-    #[serde(rename = "panelTitle.activeForeground")]
+
+    #[serde(
+        default,
+        rename = "panelTitle.activeForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub panel_title_active_foreground: Option<String>,
-    #[serde(rename = "panelTitle.inactiveForeground")]
+
+    #[serde(
+        default,
+        rename = "panelTitle.inactiveForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub panel_title_inactive_foreground: Option<String>,
-    #[serde(rename = "statusBar.background")]
+
+    #[serde(
+        default,
+        rename = "statusBar.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_background: Option<String>,
-    #[serde(rename = "statusBar.foreground")]
+
+    #[serde(
+        default,
+        rename = "statusBar.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_foreground: Option<String>,
-    #[serde(rename = "statusBar.debuggingBackground")]
+
+    #[serde(
+        default,
+        rename = "statusBar.debuggingBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_debugging_background: Option<String>,
-    #[serde(rename = "statusBar.debuggingForeground")]
+
+    #[serde(
+        default,
+        rename = "statusBar.debuggingForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_debugging_foreground: Option<String>,
-    #[serde(rename = "statusBar.noFolderBackground")]
+
+    #[serde(
+        default,
+        rename = "statusBar.noFolderBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_no_folder_background: Option<String>,
-    #[serde(rename = "statusBar.noFolderForeground")]
+
+    #[serde(
+        default,
+        rename = "statusBar.noFolderForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_no_folder_foreground: Option<String>,
-    #[serde(rename = "statusBarItem.prominentBackground")]
+
+    #[serde(
+        default,
+        rename = "statusBarItem.prominentBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_item_prominent_background: Option<String>,
-    #[serde(rename = "statusBarItem.prominentHoverBackground")]
+
+    #[serde(
+        default,
+        rename = "statusBarItem.prominentHoverBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_item_prominent_hover_background: Option<String>,
-    #[serde(rename = "statusBarItem.remoteForeground")]
+
+    #[serde(
+        default,
+        rename = "statusBarItem.remoteForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_item_remote_foreground: Option<String>,
-    #[serde(rename = "statusBarItem.remoteBackground")]
+
+    #[serde(
+        default,
+        rename = "statusBarItem.remoteBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub status_bar_item_remote_background: Option<String>,
-    #[serde(rename = "titleBar.activeBackground")]
+
+    #[serde(
+        default,
+        rename = "titleBar.activeBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub title_bar_active_background: Option<String>,
-    #[serde(rename = "titleBar.activeForeground")]
+
+    #[serde(
+        default,
+        rename = "titleBar.activeForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub title_bar_active_foreground: Option<String>,
-    #[serde(rename = "titleBar.inactiveBackground")]
+
+    #[serde(
+        default,
+        rename = "titleBar.inactiveBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub title_bar_inactive_background: Option<String>,
-    #[serde(rename = "titleBar.inactiveForeground")]
+
+    #[serde(
+        default,
+        rename = "titleBar.inactiveForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub title_bar_inactive_foreground: Option<String>,
-    #[serde(rename = "extensionButton.prominentForeground")]
+
+    #[serde(
+        default,
+        rename = "extensionButton.prominentForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub extension_button_prominent_foreground: Option<String>,
-    #[serde(rename = "extensionButton.prominentBackground")]
+
+    #[serde(
+        default,
+        rename = "extensionButton.prominentBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub extension_button_prominent_background: Option<String>,
-    #[serde(rename = "extensionButton.prominentHoverBackground")]
+
+    #[serde(
+        default,
+        rename = "extensionButton.prominentHoverBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub extension_button_prominent_hover_background: Option<String>,
-    #[serde(rename = "pickerGroup.border")]
+
+    #[serde(
+        default,
+        rename = "pickerGroup.border",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub picker_group_border: Option<String>,
-    #[serde(rename = "pickerGroup.foreground")]
+
+    #[serde(
+        default,
+        rename = "pickerGroup.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub picker_group_foreground: Option<String>,
-    #[serde(rename = "debugToolBar.background")]
+
+    #[serde(
+        default,
+        rename = "debugToolBar.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub debug_tool_bar_background: Option<String>,
-    #[serde(rename = "walkThrough.embeddedEditorBackground")]
+
+    #[serde(
+        default,
+        rename = "walkThrough.embeddedEditorBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub walk_through_embedded_editor_background: Option<String>,
-    #[serde(rename = "settings.headerForeground")]
+
+    #[serde(
+        default,
+        rename = "settings.headerForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_header_foreground: Option<String>,
-    #[serde(rename = "settings.modifiedItemIndicator")]
+
+    #[serde(
+        default,
+        rename = "settings.modifiedItemIndicator",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_modified_item_indicator: Option<String>,
-    #[serde(rename = "settings.dropdownBackground")]
+
+    #[serde(
+        default,
+        rename = "settings.dropdownBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_dropdown_background: Option<String>,
-    #[serde(rename = "settings.dropdownForeground")]
+
+    #[serde(
+        default,
+        rename = "settings.dropdownForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_dropdown_foreground: Option<String>,
-    #[serde(rename = "settings.dropdownBorder")]
+
+    #[serde(
+        default,
+        rename = "settings.dropdownBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_dropdown_border: Option<String>,
-    #[serde(rename = "settings.checkboxBackground")]
+
+    #[serde(
+        default,
+        rename = "settings.checkboxBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_checkbox_background: Option<String>,
-    #[serde(rename = "settings.checkboxForeground")]
+
+    #[serde(
+        default,
+        rename = "settings.checkboxForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_checkbox_foreground: Option<String>,
-    #[serde(rename = "settings.checkboxBorder")]
+
+    #[serde(
+        default,
+        rename = "settings.checkboxBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_checkbox_border: Option<String>,
-    #[serde(rename = "settings.textInputBackground")]
+
+    #[serde(
+        default,
+        rename = "settings.textInputBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_text_input_background: Option<String>,
-    #[serde(rename = "settings.textInputForeground")]
+
+    #[serde(
+        default,
+        rename = "settings.textInputForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_text_input_foreground: Option<String>,
-    #[serde(rename = "settings.textInputBorder")]
+
+    #[serde(
+        default,
+        rename = "settings.textInputBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_text_input_border: Option<String>,
-    #[serde(rename = "settings.numberInputBackground")]
+
+    #[serde(
+        default,
+        rename = "settings.numberInputBackground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_number_input_background: Option<String>,
-    #[serde(rename = "settings.numberInputForeground")]
+
+    #[serde(
+        default,
+        rename = "settings.numberInputForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_number_input_foreground: Option<String>,
-    #[serde(rename = "settings.numberInputBorder")]
+
+    #[serde(
+        default,
+        rename = "settings.numberInputBorder",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub settings_number_input_border: Option<String>,
-    #[serde(rename = "breadcrumb.foreground")]
+
+    #[serde(
+        default,
+        rename = "breadcrumb.foreground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub breadcrumb_foreground: Option<String>,
-    #[serde(rename = "breadcrumb.background")]
+
+    #[serde(
+        default,
+        rename = "breadcrumb.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub breadcrumb_background: Option<String>,
-    #[serde(rename = "breadcrumb.focusForeground")]
+
+    #[serde(
+        default,
+        rename = "breadcrumb.focusForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub breadcrumb_focus_foreground: Option<String>,
-    #[serde(rename = "breadcrumb.activeSelectionForeground")]
+
+    #[serde(
+        default,
+        rename = "breadcrumb.activeSelectionForeground",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub breadcrumb_active_selection_foreground: Option<String>,
-    #[serde(rename = "breadcrumbPicker.background")]
+
+    #[serde(
+        default,
+        rename = "breadcrumbPicker.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub breadcrumb_picker_background: Option<String>,
-    #[serde(rename = "listFilterWidget.background")]
+
+    #[serde(
+        default,
+        rename = "listFilterWidget.background",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_filter_widget_background: Option<String>,
-    #[serde(rename = "listFilterWidget.outline")]
+
+    #[serde(
+        default,
+        rename = "listFilterWidget.outline",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_filter_widget_outline: Option<String>,
-    #[serde(rename = "listFilterWidget.noMatchesOutline")]
+
+    #[serde(
+        default,
+        rename = "listFilterWidget.noMatchesOutline",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub list_filter_widget_no_matches_outline: Option<String>,
 }


### PR DESCRIPTION
This PR refines the imported themes further:

- Empty strings for color values in the VS Code theme are now ignored
- Pull Git status colors from VS Code themes
- Add `constant` colors as a fallback for `number` tokens

Release Notes:

- N/A
