### PR TITLE
Add more harness around nightly builds

### DIFF
--- a/crates/zed2/build.rs
+++ b/crates/zed2/build.rs
@@ -27,10 +27,20 @@ fn main() {
     // Populate git sha environment variable if git is available
     if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         if output.status.success() {
-            println!(
-                "cargo:rustc-env=ZED_COMMIT_SHA={}",
-                String::from_utf8_lossy(&output.stdout).trim()
-            );
+            let git_sha = String::from_utf8_lossy(&output.stdout);
+            let git_sha = git_sha.trim();
+
+            println!("cargo:rustc-env=ZED_COMMIT_SHA={git_sha}");
+
+            if let Ok(build_profile) = std::env::var("PROFILE") {
+                if build_profile == "release" {
+                    // This is currently the best way to make `cargo build ...`'s build script
+                    // to print something to stdout without extra verbosity.
+                    println!(
+                        "cargo:warning=Info: using '{git_sha}' hash for ZED_COMMIT_SHA env var"
+                    );
+                }
+            }
         }
     }
 }

--- a/script/upload-nightly
+++ b/script/upload-nightly
@@ -20,7 +20,7 @@ function uploadToSpaces
   string="PUT\n\n${content_type}\n${date}\n${acl}\n${storage_type}\n/${SPACE}/${space_path}/${file_name}"
   signature=$(echo -en "${string}" | openssl sha1 -hmac "${DIGITALOCEAN_SPACES_SECRET_KEY}" -binary | base64)
 
-  curl -vv -s -X PUT -T "$file_to_upload" \
+  curl --fail -vv -s -X PUT -T "$file_to_upload" \
     -H "Host: ${SPACE}.${REGION}.digitaloceanspaces.com" \
     -H "Date: $date" \
     -H "Content-Type: $content_type" \


### PR DESCRIPTION
Part of https://zed-industries.slack.com/archives/C05SJGT0M33/p1702039430077589
The nightly job managed to pass successfully (build & upload nightly), logged a proper commit sha that got into latest_sha on the nightly bucket — but Zed version in about was wrong.

* Log Zed build sha in release builds to ensure CI uses the right one
* make curl to return non-zero code for non-200 nightly file uploads

Release Notes:

- N/A