### PR TITLE
zed2: Store constructed terminal tooltip

### DIFF
--- a/crates/terminal_view2/src/terminal_element.rs
+++ b/crates/terminal_view2/src/terminal_element.rs
@@ -469,6 +469,7 @@ impl TerminalElement {
                 .size_full()
                 .id("terminal-element")
                 .tooltip(move |cx| Tooltip::text(hovered_word.word.clone(), cx))
+                .into_any_element()
         });
 
         let TerminalContent {
@@ -570,7 +571,7 @@ impl TerminalElement {
             relative_highlighted_ranges,
             mode: *mode,
             display_offset: *display_offset,
-            hyperlink_tooltip: None, // todo!(tooltips)
+            hyperlink_tooltip,
             gutter,
         }
     }


### PR DESCRIPTION
Allows the terminal to actually render its hyperlink tooltip

Release Notes:

- N/A
