### PR TITLE
Make clicking the breadcrumb toggle the symbol outline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "gpui2",
  "itertools 0.10.5",
  "language2",
+ "outline2",
  "project2",
  "search2",
  "settings2",

--- a/crates/breadcrumbs2/Cargo.toml
+++ b/crates/breadcrumbs2/Cargo.toml
@@ -19,7 +19,7 @@ search = { package = "search2", path = "../search2" }
 settings = { package = "settings2", path = "../settings2" }
 theme = { package = "theme2", path = "../theme2" }
 workspace = { package = "workspace2", path = "../workspace2" }
-# outline = { path = "../outline" }
+outline = { package = "outline2", path = "../outline2" }
 itertools = "0.10"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR wires up clicks on the breadcrumb to toggle the symbol outline.

Note that the behavior of the symbol outline is a little wonky at the moment, due to the issues with pane focus.

Release Notes:

- N/A
