### PR TITLE
Fix color for selections in scrollbar

### DIFF
--- a/crates/editor2/src/element.rs
+++ b/crates/editor2/src/element.rs
@@ -1302,7 +1302,7 @@ impl EditorElement {
                     cx.paint_quad(
                         bounds,
                         Corners::default(),
-                        cx.theme().colors().scrollbar_thumb_background,
+                        cx.theme().status().info,
                         Edges {
                             top: Pixels::ZERO,
                             right: px(1.),


### PR DESCRIPTION
This PR fixes an issue where we weren't using the right color for displaying selections within the scrollbar.

Release Notes:

- N/A
