### PR TITLE
Defer drawing the window until the CoreAnimation `displayLayer:` method is called

### DIFF
--- a/crates/gpui2/src/app.rs
+++ b/crates/gpui2/src/app.rs
@@ -595,6 +595,14 @@ impl AppContext {
                 break;
             }
         }
+
+        for (_, window) in &self.windows {
+            if let Some(window) = window.as_ref() {
+                if window.dirty {
+                    window.platform_window.invalidate();
+                }
+            }
+        }
     }
 
     /// Repeatedly called during `flush_effects` to release any entities whose
@@ -713,7 +721,7 @@ impl AppContext {
     fn apply_refresh_effect(&mut self) {
         for window in self.windows.values_mut() {
             if let Some(window) = window.as_mut() {
-                window.platform_window.invalidate();
+                window.dirty = true;
             }
         }
     }

--- a/crates/gpui2/src/app.rs
+++ b/crates/gpui2/src/app.rs
@@ -596,12 +596,25 @@ impl AppContext {
             }
         }
 
-        for (_, window) in &self.windows {
+        for window in self.windows.values() {
             if let Some(window) = window.as_ref() {
                 if window.dirty {
                     window.platform_window.invalidate();
                 }
             }
+        }
+
+        #[cfg(any(test, feature = "test-support"))]
+        for window in self
+            .windows
+            .values()
+            .filter_map(|window| {
+                let window = window.as_ref()?;
+                window.dirty.then_some(window.handle)
+            })
+            .collect::<Vec<_>>()
+        {
+            self.update_window(window, |_, cx| cx.draw()).ok();
         }
     }
 

--- a/crates/gpui2/src/app.rs
+++ b/crates/gpui2/src/app.rs
@@ -9,7 +9,6 @@ use derive_more::{Deref, DerefMut};
 pub use entity_map::*;
 pub use model_context::*;
 use refineable::Refineable;
-use smallvec::SmallVec;
 use smol::future::FutureExt;
 #[cfg(any(test, feature = "test-support"))]
 pub use test_context::*;
@@ -596,23 +595,6 @@ impl AppContext {
                 break;
             }
         }
-
-        let dirty_window_ids = self
-            .windows
-            .iter()
-            .filter_map(|(_, window)| {
-                let window = window.as_ref()?;
-                if window.dirty {
-                    Some(window.handle.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<SmallVec<[_; 8]>>();
-
-        for dirty_window_handle in dirty_window_ids {
-            dirty_window_handle.update(self, |_, cx| cx.draw()).unwrap();
-        }
     }
 
     /// Repeatedly called during `flush_effects` to release any entities whose
@@ -731,7 +713,7 @@ impl AppContext {
     fn apply_refresh_effect(&mut self) {
         for window in self.windows.values_mut() {
             if let Some(window) = window.as_mut() {
-                window.dirty = true;
+                window.platform_window.invalidate();
             }
         }
     }

--- a/crates/gpui2/src/app.rs
+++ b/crates/gpui2/src/app.rs
@@ -614,7 +614,7 @@ impl AppContext {
             })
             .collect::<Vec<_>>()
         {
-            self.update_window(window, |_, cx| cx.draw()).ok();
+            self.update_window(window, |_, cx| cx.draw()).unwrap();
         }
     }
 

--- a/crates/gpui2/src/platform.rs
+++ b/crates/gpui2/src/platform.rs
@@ -46,6 +46,8 @@ pub(crate) fn current_platform() -> Rc<dyn Platform> {
     Rc::new(MacPlatform::new())
 }
 
+pub type DrawWindow = Box<dyn FnMut() -> Result<Scene>>;
+
 pub(crate) trait Platform: 'static {
     fn background_executor(&self) -> BackgroundExecutor;
     fn foreground_executor(&self) -> ForegroundExecutor;
@@ -66,6 +68,7 @@ pub(crate) trait Platform: 'static {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
+        draw: DrawWindow,
     ) -> Box<dyn PlatformWindow>;
 
     fn set_display_link_output_callback(
@@ -163,7 +166,7 @@ pub trait PlatformWindow {
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn is_topmost_for_position(&self, position: Point<Pixels>) -> bool;
-    fn draw(&self, scene: Scene);
+    fn invalidate(&self);
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
 

--- a/crates/gpui2/src/platform/mac/platform.rs
+++ b/crates/gpui2/src/platform/mac/platform.rs
@@ -3,7 +3,8 @@ use crate::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId,
     ForegroundExecutor, InputEvent, Keymap, MacDispatcher, MacDisplay, MacDisplayLinker,
     MacTextSystem, MacWindow, Menu, MenuItem, PathPromptOptions, Platform, PlatformDisplay,
-    PlatformTextSystem, PlatformWindow, Result, SemanticVersion, VideoTimestamp, WindowOptions,
+    PlatformTextSystem, PlatformWindow, Result, Scene, SemanticVersion, VideoTimestamp,
+    WindowOptions,
 };
 use anyhow::anyhow;
 use block::ConcreteBlock;
@@ -490,8 +491,14 @@ impl Platform for MacPlatform {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
+        draw: Box<dyn FnMut() -> Result<Scene>>,
     ) -> Box<dyn PlatformWindow> {
-        Box::new(MacWindow::open(handle, options, self.foreground_executor()))
+        Box::new(MacWindow::open(
+            handle,
+            options,
+            draw,
+            self.foreground_executor(),
+        ))
     }
 
     fn set_display_link_output_callback(

--- a/crates/gpui2/src/platform/test/platform.rs
+++ b/crates/gpui2/src/platform/test/platform.rs
@@ -136,11 +136,12 @@ impl Platform for TestPlatform {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
-        _draw: Box<dyn FnMut() -> Result<Scene>>,
+        draw: Box<dyn FnMut() -> Result<Scene>>,
     ) -> Box<dyn crate::PlatformWindow> {
         *self.active_window.lock() = Some(handle);
         Box::new(TestWindow::new(
             options,
+            draw,
             self.weak.clone(),
             self.active_display.clone(),
         ))

--- a/crates/gpui2/src/platform/test/platform.rs
+++ b/crates/gpui2/src/platform/test/platform.rs
@@ -136,12 +136,11 @@ impl Platform for TestPlatform {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
-        draw: Box<dyn FnMut() -> Result<Scene>>,
+        _draw: Box<dyn FnMut() -> Result<Scene>>,
     ) -> Box<dyn crate::PlatformWindow> {
         *self.active_window.lock() = Some(handle);
         Box::new(TestWindow::new(
             options,
-            draw,
             self.weak.clone(),
             self.active_display.clone(),
         ))

--- a/crates/gpui2/src/platform/test/platform.rs
+++ b/crates/gpui2/src/platform/test/platform.rs
@@ -1,6 +1,7 @@
 use crate::{
     AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId, ForegroundExecutor,
-    Keymap, Platform, PlatformDisplay, PlatformTextSystem, TestDisplay, TestWindow, WindowOptions,
+    Keymap, Platform, PlatformDisplay, PlatformTextSystem, Scene, TestDisplay, TestWindow,
+    WindowOptions,
 };
 use anyhow::{anyhow, Result};
 use collections::VecDeque;
@@ -135,6 +136,7 @@ impl Platform for TestPlatform {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
+        _draw: Box<dyn FnMut() -> Result<Scene>>,
     ) -> Box<dyn crate::PlatformWindow> {
         *self.active_window.lock() = Some(handle);
         Box::new(TestWindow::new(

--- a/crates/gpui2/src/platform/test/window.rs
+++ b/crates/gpui2/src/platform/test/window.rs
@@ -166,9 +166,7 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
-    fn draw(&self, scene: crate::Scene) {
-        self.current_scene.lock().replace(scene);
-    }
+    fn invalidate(&self) {}
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {
         self.sprite_atlas.clone()

--- a/crates/gpui2/src/platform/test/window.rs
+++ b/crates/gpui2/src/platform/test/window.rs
@@ -1,7 +1,7 @@
 use crate::{
-    px, AtlasKey, AtlasTextureId, AtlasTile, Pixels, PlatformAtlas, PlatformDisplay,
-    PlatformInputHandler, PlatformWindow, Point, Scene, Size, TestPlatform, TileId,
-    WindowAppearance, WindowBounds, WindowOptions,
+    px, AtlasKey, AtlasTextureId, AtlasTile, DrawWindow, Pixels, PlatformAtlas, PlatformDisplay,
+    PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
+    WindowBounds, WindowOptions,
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -20,7 +20,7 @@ pub(crate) struct TestWindowHandlers {
 
 pub struct TestWindow {
     pub(crate) bounds: WindowBounds,
-    current_scene: Mutex<Option<Scene>>,
+    draw: Mutex<DrawWindow>,
     display: Rc<dyn PlatformDisplay>,
     pub(crate) window_title: Option<String>,
     pub(crate) input_handler: Option<Arc<Mutex<Box<dyn PlatformInputHandler>>>>,
@@ -32,12 +32,13 @@ pub struct TestWindow {
 impl TestWindow {
     pub fn new(
         options: WindowOptions,
+        draw: DrawWindow,
         platform: Weak<TestPlatform>,
         display: Rc<dyn PlatformDisplay>,
     ) -> Self {
         Self {
             bounds: options.bounds,
-            current_scene: Default::default(),
+            draw: Mutex::new(draw),
             display,
             platform,
             input_handler: None,
@@ -166,7 +167,9 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
-    fn invalidate(&self) {}
+    fn invalidate(&self) {
+        (self.draw.lock())().unwrap();
+    }
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {
         self.sprite_atlas.clone()

--- a/crates/gpui2/src/platform/test/window.rs
+++ b/crates/gpui2/src/platform/test/window.rs
@@ -1,5 +1,5 @@
 use crate::{
-    px, AtlasKey, AtlasTextureId, AtlasTile, DrawWindow, Pixels, PlatformAtlas, PlatformDisplay,
+    px, AtlasKey, AtlasTextureId, AtlasTile, Pixels, PlatformAtlas, PlatformDisplay,
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
     WindowBounds, WindowOptions,
 };
@@ -20,7 +20,6 @@ pub(crate) struct TestWindowHandlers {
 
 pub struct TestWindow {
     pub(crate) bounds: WindowBounds,
-    draw: Mutex<DrawWindow>,
     display: Rc<dyn PlatformDisplay>,
     pub(crate) window_title: Option<String>,
     pub(crate) input_handler: Option<Arc<Mutex<Box<dyn PlatformInputHandler>>>>,
@@ -32,13 +31,11 @@ pub struct TestWindow {
 impl TestWindow {
     pub fn new(
         options: WindowOptions,
-        draw: DrawWindow,
         platform: Weak<TestPlatform>,
         display: Rc<dyn PlatformDisplay>,
     ) -> Self {
         Self {
             bounds: options.bounds,
-            draw: Mutex::new(draw),
             display,
             platform,
             input_handler: None,

--- a/crates/gpui2/src/platform/test/window.rs
+++ b/crates/gpui2/src/platform/test/window.rs
@@ -168,7 +168,7 @@ impl PlatformWindow for TestWindow {
     }
 
     fn invalidate(&self) {
-        (self.draw.lock())().unwrap();
+        // (self.draw.lock())().unwrap();
     }
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -7,9 +7,9 @@ use crate::{
     ModelContext, Modifiers, MonochromeSprite, MouseButton, MouseMoveEvent, MouseUpEvent, Path,
     Pixels, PlatformAtlas, PlatformDisplay, PlatformInputHandler, PlatformWindow, Point,
     PolychromeSprite, PromptLevel, Quad, Render, RenderGlyphParams, RenderImageParams,
-    RenderSvgParams, ScaledPixels, SceneBuilder, Shadow, SharedString, Size, Style, SubscriberSet,
-    Subscription, Surface, TaffyLayoutEngine, Task, Underline, UnderlineStyle, View, VisualContext,
-    WeakView, WindowBounds, WindowOptions, SUBPIXEL_VARIANTS,
+    RenderSvgParams, ScaledPixels, Scene, SceneBuilder, Shadow, SharedString, Size, Style,
+    SubscriberSet, Subscription, Surface, TaffyLayoutEngine, Task, Underline, UnderlineStyle, View,
+    VisualContext, WeakView, WindowBounds, WindowOptions, SUBPIXEL_VARIANTS,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::HashMap;
@@ -224,7 +224,6 @@ pub struct Window {
     bounds_observers: SubscriberSet<(), AnyObserver>,
     active: bool,
     activation_observers: SubscriberSet<(), AnyObserver>,
-    pub(crate) dirty: bool,
     pub(crate) last_blur: Option<Option<FocusId>>,
     pub(crate) focus: Option<FocusId>,
 }
@@ -278,7 +277,14 @@ impl Window {
         options: WindowOptions,
         cx: &mut AppContext,
     ) -> Self {
-        let platform_window = cx.platform.open_window(handle, options);
+        let platform_window = cx.platform.open_window(
+            handle,
+            options,
+            Box::new({
+                let mut cx = cx.to_async();
+                move || handle.update(&mut cx, |_, cx| cx.draw())
+            }),
+        );
         let display_id = platform_window.display().id();
         let sprite_atlas = platform_window.sprite_atlas();
         let mouse_position = platform_window.mouse_position();
@@ -350,7 +356,6 @@ impl Window {
             bounds_observers: SubscriberSet::new(),
             active: false,
             activation_observers: SubscriberSet::new(),
-            dirty: true,
             last_blur: None,
             focus: None,
         }
@@ -401,7 +406,7 @@ impl<'a> WindowContext<'a> {
 
     /// Mark the window as dirty, scheduling it to be redrawn on the next frame.
     pub fn notify(&mut self) {
-        self.window.dirty = true;
+        self.window.platform_window.invalidate();
     }
 
     /// Close this window.
@@ -673,7 +678,7 @@ impl<'a> WindowContext<'a> {
         self.window.viewport_size = self.window.platform_window.content_size();
         self.window.bounds = self.window.platform_window.bounds();
         self.window.display_id = self.window.platform_window.display().id();
-        self.window.dirty = true;
+        self.notify();
 
         self.window
             .bounds_observers
@@ -1174,7 +1179,7 @@ impl<'a> WindowContext<'a> {
     }
 
     /// Draw pixels to the display for this window based on the contents of its scene.
-    pub(crate) fn draw(&mut self) {
+    fn draw(&mut self) -> Scene {
         self.text_system().start_frame();
         self.window.platform_window.clear_input_handler();
         self.window.layout_engine.as_mut().unwrap().clear();
@@ -1226,7 +1231,6 @@ impl<'a> WindowContext<'a> {
         mem::swap(&mut window.rendered_frame, &mut window.next_frame);
 
         let scene = self.window.rendered_frame.scene_builder.build();
-        self.window.platform_window.draw(scene);
         let cursor_style = self
             .window
             .requested_cursor_style
@@ -1234,7 +1238,7 @@ impl<'a> WindowContext<'a> {
             .unwrap_or(CursorStyle::Arrow);
         self.platform.set_cursor_style(cursor_style);
 
-        self.window.dirty = false;
+        scene
     }
 
     /// Dispatch a mouse or keyboard event on the window.

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -1181,7 +1181,7 @@ impl<'a> WindowContext<'a> {
     }
 
     /// Draw pixels to the display for this window based on the contents of its scene.
-    fn draw(&mut self) -> Scene {
+    pub(crate) fn draw(&mut self) -> Scene {
         self.text_system().start_frame();
         self.window.platform_window.clear_input_handler();
         self.window.layout_engine.as_mut().unwrap().clear();

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -223,6 +223,7 @@ pub struct Window {
     bounds: WindowBounds,
     bounds_observers: SubscriberSet<(), AnyObserver>,
     active: bool,
+    pub(crate) dirty: bool,
     activation_observers: SubscriberSet<(), AnyObserver>,
     pub(crate) last_blur: Option<Option<FocusId>>,
     pub(crate) focus: Option<FocusId>,
@@ -355,6 +356,7 @@ impl Window {
             bounds,
             bounds_observers: SubscriberSet::new(),
             active: false,
+            dirty: false,
             activation_observers: SubscriberSet::new(),
             last_blur: None,
             focus: None,
@@ -406,7 +408,7 @@ impl<'a> WindowContext<'a> {
 
     /// Mark the window as dirty, scheduling it to be redrawn on the next frame.
     pub fn notify(&mut self) {
-        self.window.platform_window.invalidate();
+        self.window.dirty = true;
     }
 
     /// Close this window.
@@ -1237,6 +1239,7 @@ impl<'a> WindowContext<'a> {
             .take()
             .unwrap_or(CursorStyle::Arrow);
         self.platform.set_cursor_style(cursor_style);
+        self.window.dirty = false;
 
         scene
     }


### PR DESCRIPTION
GPUI (both 1 and 2) currently performs rendering, layout, and painting at the end of every effect cycle. This leads to poor performance when the app receives events more frequently than the display refreshes. Such rapid events can come from a terminal, an LSP, or a mouse with a high polling rate.

This PR changes GPUI so that we don't render until the OS notifies us that the content will be presented, via the `displayLayer:` callback.

Because render, layout, and paint have side effects that are sometimes relied on in tests, we currently keep the old behavior (drawing after every effects cycle) in tests.

This is similar to what @ForLoveOfCats explored in https://github.com/zed-industries/zed/pull/3542, but slightly simpler, in that we're not using the display link. As a follow-up, we could use the display link to start rendering earlier, to possibly reduce latency further.