### PR TITLE
theme_importer: Fall back to inactive tab background if no active tab background set

### DIFF
--- a/crates/theme2/src/themes/synthwave_84.rs
+++ b/crates/theme2/src/themes/synthwave_84.rs
@@ -33,6 +33,7 @@ pub fn synthwave_84() -> UserThemeFamily {
                     toolbar_background: Some(rgba(0x262335ff).into()),
                     tab_bar_background: Some(rgba(0x241b2fff).into()),
                     tab_inactive_background: Some(rgba(0x262335ff).into()),
+                    tab_active_background: Some(rgba(0x262335ff).into()),
                     scrollbar_thumb_background: Some(rgba(0x9d8bca30).into()),
                     scrollbar_thumb_hover_background: Some(rgba(0x9d8bca50).into()),
                     scrollbar_thumb_border: Some(rgba(0x9d8bca30).into()),

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -127,6 +127,11 @@ impl VsCodeThemeConverter {
             .as_ref()
             .traverse(|color| try_parse_color(&color))?;
 
+        let vscode_tab_inactive_background = vscode_colors
+            .tab_inactive_background
+            .as_ref()
+            .traverse(|color| try_parse_color(&color))?;
+
         let vscode_editor_background = vscode_colors
             .editor_background
             .as_ref()
@@ -213,11 +218,9 @@ impl VsCodeThemeConverter {
             tab_active_background: vscode_colors
                 .tab_active_background
                 .as_ref()
-                .traverse(|color| try_parse_color(&color))?,
-            tab_inactive_background: vscode_colors
-                .tab_inactive_background
-                .as_ref()
-                .traverse(|color| try_parse_color(&color))?,
+                .traverse(|color| try_parse_color(&color))?
+                .or(vscode_tab_inactive_background),
+            tab_inactive_background: vscode_tab_inactive_background,
             toolbar_background: vscode_colors
                 .breadcrumb_background
                 .as_ref()


### PR DESCRIPTION
This PR makes it so the `theme_importer` falls back to the inactive tab background color if the theme doesn't not an active tab background color.

This fixes the active tab color in the Synthwave 84 theme.

Release Notes:

- N/A
