### PR TITLE
Fix focus issues with gpui2 docks

### DIFF
--- a/crates/gpui2/src/app.rs
+++ b/crates/gpui2/src/app.rs
@@ -569,60 +569,60 @@ impl AppContext {
     /// such as notifying observers, emitting events, etc. Effects can themselves
     /// cause effects, so we continue looping until all effects are processed.
     fn flush_effects(&mut self) {
-        while !self.pending_effects.is_empty() {
-            loop {
-                self.release_dropped_entities();
-                self.release_dropped_focus_handles();
-                if let Some(effect) = self.pending_effects.pop_front() {
-                    match effect {
-                        Effect::Notify { emitter } => {
-                            self.apply_notify_effect(emitter);
-                        }
-                        Effect::Emit {
-                            emitter,
-                            event_type,
-                            event,
-                        } => self.apply_emit_effect(emitter, event_type, event),
-                        Effect::FocusChanged {
-                            window_handle,
-                            focused,
-                        } => {
-                            self.apply_focus_changed_effect(window_handle, focused);
-                        }
-                        Effect::Refresh => {
-                            self.apply_refresh_effect();
-                        }
-                        Effect::NotifyGlobalObservers { global_type } => {
-                            self.apply_notify_global_observers_effect(global_type);
-                        }
-                        Effect::Defer { callback } => {
-                            self.apply_defer_effect(callback);
+        loop {
+            self.release_dropped_entities();
+            self.release_dropped_focus_handles();
+            if let Some(effect) = self.pending_effects.pop_front() {
+                match effect {
+                    Effect::Notify { emitter } => {
+                        self.apply_notify_effect(emitter);
+                    }
+                    Effect::Emit {
+                        emitter,
+                        event_type,
+                        event,
+                    } => self.apply_emit_effect(emitter, event_type, event),
+                    Effect::FocusChanged {
+                        window_handle,
+                        focused,
+                    } => {
+                        self.apply_focus_changed_effect(window_handle, focused);
+                    }
+                    Effect::Refresh => {
+                        self.apply_refresh_effect();
+                    }
+                    Effect::NotifyGlobalObservers { global_type } => {
+                        self.apply_notify_global_observers_effect(global_type);
+                    }
+                    Effect::Defer { callback } => {
+                        self.apply_defer_effect(callback);
+                    }
+                }
+            } else {
+                for window in self.windows.values() {
+                    if let Some(window) = window.as_ref() {
+                        if window.dirty {
+                            window.platform_window.invalidate();
                         }
                     }
-                } else {
+                }
+
+                #[cfg(any(test, feature = "test-support"))]
+                for window in self
+                    .windows
+                    .values()
+                    .filter_map(|window| {
+                        let window = window.as_ref()?;
+                        window.dirty.then_some(window.handle)
+                    })
+                    .collect::<Vec<_>>()
+                {
+                    self.update_window(window, |_, cx| cx.draw()).unwrap();
+                }
+
+                if self.pending_effects.is_empty() {
                     break;
                 }
-            }
-
-            for window in self.windows.values() {
-                if let Some(window) = window.as_ref() {
-                    if window.dirty {
-                        window.platform_window.invalidate();
-                    }
-                }
-            }
-
-            #[cfg(any(test, feature = "test-support"))]
-            for window in self
-                .windows
-                .values()
-                .filter_map(|window| {
-                    let window = window.as_ref()?;
-                    window.dirty.then_some(window.handle)
-                })
-                .collect::<Vec<_>>()
-            {
-                self.update_window(window, |_, cx| cx.draw()).unwrap();
             }
         }
     }

--- a/crates/gpui2/src/app.rs
+++ b/crates/gpui2/src/app.rs
@@ -646,8 +646,6 @@ impl AppContext {
     }
 
     /// Repeatedly called during `flush_effects` to handle a focused handle being dropped.
-    /// For now, we simply blur the window if this happens, but we may want to support invoking
-    /// a window blur handler to restore focus to some logical element.
     fn release_dropped_focus_handles(&mut self) {
         for window_handle in self.windows() {
             window_handle

--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -441,7 +441,6 @@ pub trait StatefulInteractiveElement: InteractiveElement {
     }
 }
 
-// TODO kb do we leave those on an element?
 pub trait FocusableElement: InteractiveElement {
     fn focus(mut self, f: impl FnOnce(StyleRefinement) -> StyleRefinement) -> Self
     where
@@ -456,34 +455,6 @@ pub trait FocusableElement: InteractiveElement {
         Self: Sized,
     {
         self.interactivity().in_focus_style = f(StyleRefinement::default());
-        self
-    }
-
-    fn on_focus(mut self, listener: impl Fn(&FocusEvent, &mut WindowContext) + 'static) -> Self
-    where
-        Self: Sized,
-    {
-        self.interactivity()
-            .focus_listeners
-            .push(Box::new(move |focus_handle, event, cx| {
-                if event.focused.as_ref() == Some(focus_handle) {
-                    listener(event, cx)
-                }
-            }));
-        self
-    }
-
-    fn on_blur(mut self, listener: impl Fn(&FocusEvent, &mut WindowContext) + 'static) -> Self
-    where
-        Self: Sized,
-    {
-        self.interactivity()
-            .focus_listeners
-            .push(Box::new(move |focus_handle, event, cx| {
-                if event.blurred.as_ref() == Some(focus_handle) {
-                    listener(event, cx)
-                }
-            }));
         self
     }
 }

--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -441,6 +441,7 @@ pub trait StatefulInteractiveElement: InteractiveElement {
     }
 }
 
+// TODO kb do we leave those on an element?
 pub trait FocusableElement: InteractiveElement {
     fn focus(mut self, f: impl FnOnce(StyleRefinement) -> StyleRefinement) -> Self
     where
@@ -480,51 +481,6 @@ pub trait FocusableElement: InteractiveElement {
             .focus_listeners
             .push(Box::new(move |focus_handle, event, cx| {
                 if event.blurred.as_ref() == Some(focus_handle) {
-                    listener(event, cx)
-                }
-            }));
-        self
-    }
-
-    fn on_focus_in(mut self, listener: impl Fn(&FocusEvent, &mut WindowContext) + 'static) -> Self
-    where
-        Self: Sized,
-    {
-        self.interactivity()
-            .focus_listeners
-            .push(Box::new(move |focus_handle, event, cx| {
-                let descendant_blurred = event
-                    .blurred
-                    .as_ref()
-                    .map_or(false, |blurred| focus_handle.contains(blurred, cx));
-                let descendant_focused = event
-                    .focused
-                    .as_ref()
-                    .map_or(false, |focused| focus_handle.contains(focused, cx));
-
-                if !descendant_blurred && descendant_focused {
-                    listener(event, cx)
-                }
-            }));
-        self
-    }
-
-    fn on_focus_out(mut self, listener: impl Fn(&FocusEvent, &mut WindowContext) + 'static) -> Self
-    where
-        Self: Sized,
-    {
-        self.interactivity()
-            .focus_listeners
-            .push(Box::new(move |focus_handle, event, cx| {
-                let descendant_blurred = event
-                    .blurred
-                    .as_ref()
-                    .map_or(false, |blurred| focus_handle.contains(blurred, cx));
-                let descendant_focused = event
-                    .focused
-                    .as_ref()
-                    .map_or(false, |focused| focus_handle.contains(focused, cx));
-                if descendant_blurred && !descendant_focused {
                     listener(event, cx)
                 }
             }));

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -168,6 +168,7 @@ impl FocusHandle {
         self.id.within_focused(cx)
     }
 
+    // TODO kb now never used?
     /// Obtains whether this handle contains the given handle in the most recently rendered frame.
     pub(crate) fn contains(&self, other: &Self, cx: &WindowContext) -> bool {
         self.id.contains(other.id, cx)

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -168,9 +168,8 @@ impl FocusHandle {
         self.id.within_focused(cx)
     }
 
-    // TODO kb now never used?
     /// Obtains whether this handle contains the given handle in the most recently rendered frame.
-    pub(crate) fn contains(&self, other: &Self, cx: &WindowContext) -> bool {
+    pub fn contains(&self, other: &Self, cx: &WindowContext) -> bool {
         self.id.contains(other.id, cx)
     }
 }

--- a/crates/storybook2/src/stories/focus.rs
+++ b/crates/storybook2/src/stories/focus.rs
@@ -1,14 +1,16 @@
 use gpui::{
-    actions, div, prelude::*, Div, FocusHandle, Focusable, KeyBinding, Render, Stateful, View,
-    WindowContext,
+    actions, div, prelude::*, Div, FocusHandle, Focusable, KeyBinding, Render, Stateful,
+    Subscription, View, WindowContext,
 };
 use ui::prelude::*;
 
 actions!(focus, [ActionA, ActionB, ActionC]);
 
 pub struct FocusStory {
+    parent_focus: FocusHandle,
     child_1_focus: FocusHandle,
     child_2_focus: FocusHandle,
+    _focus_subscriptions: Vec<Subscription>,
 }
 
 impl FocusStory {
@@ -19,9 +21,37 @@ impl FocusStory {
             KeyBinding::new("cmd-c", ActionC, None),
         ]);
 
-        cx.build_view(move |cx| Self {
-            child_1_focus: cx.focus_handle(),
-            child_2_focus: cx.focus_handle(),
+        cx.build_view(move |cx| {
+            let parent_focus = cx.focus_handle();
+            let child_1_focus = cx.focus_handle();
+            let child_2_focus = cx.focus_handle();
+            let _focus_subscriptions = vec![
+                cx.on_focus(&parent_focus, |_, _| {
+                    println!("Parent focused");
+                }),
+                cx.on_blur(&parent_focus, |_, _| {
+                    println!("Parent blurred");
+                }),
+                cx.on_focus(&child_1_focus, |_, _| {
+                    println!("Child 1 focused");
+                }),
+                cx.on_blur(&child_1_focus, |_, _| {
+                    println!("Child 1 blurred");
+                }),
+                cx.on_focus(&child_2_focus, |_, _| {
+                    println!("Child 2 focused");
+                }),
+                cx.on_blur(&child_2_focus, |_, _| {
+                    println!("Child 2 blurred");
+                }),
+            ];
+
+            Self {
+                parent_focus,
+                child_1_focus,
+                child_2_focus,
+                _focus_subscriptions,
+            }
         })
     }
 }
@@ -39,7 +69,7 @@ impl Render for FocusStory {
 
         div()
             .id("parent")
-            .focusable()
+            .track_focus(&self.parent_focus)
             .key_context("parent")
             .on_action(cx.listener(|_, _action: &ActionA, _cx| {
                 println!("Action A dispatched on parent");
@@ -47,11 +77,6 @@ impl Render for FocusStory {
             .on_action(cx.listener(|_, _action: &ActionB, _cx| {
                 println!("Action B dispatched on parent");
             }))
-            .on_focus(cx.listener(|_, _, _| println!("Parent focused")))
-            .on_blur(cx.listener(|_, _, _| println!("Parent blurred")))
-            // TODO kb todo!() remove?
-            // .on_focus_in(cx.listener(|_, _, _| println!("Parent focus_in")))
-            // .on_focus_out(cx.listener(|_, _, _| println!("Parent focus_out")))
             .on_key_down(cx.listener(|_, event, _| println!("Key down on parent {:?}", event)))
             .on_key_up(cx.listener(|_, event, _| println!("Key up on parent {:?}", event)))
             .size_full()
@@ -69,11 +94,6 @@ impl Render for FocusStory {
                     .bg(color_4)
                     .focus(|style| style.bg(color_5))
                     .in_focus(|style| style.bg(color_6))
-                    .on_focus(cx.listener(|_, _, _| println!("Child 1 focused")))
-                    .on_blur(cx.listener(|_, _, _| println!("Child 1 blurred")))
-                    // TODO kb todo!() remove?
-                    // .on_focus_in(cx.listener(|_, _, _| println!("Child 1 focus_in")))
-                    // .on_focus_out(cx.listener(|_, _, _| println!("Child 1 focus_out")))
                     .on_key_down(
                         cx.listener(|_, event, _| println!("Key down on child 1 {:?}", event)),
                     )
@@ -90,11 +110,6 @@ impl Render for FocusStory {
                     .w_full()
                     .h_6()
                     .bg(color_4)
-                    .on_focus(cx.listener(|_, _, _| println!("Child 2 focused")))
-                    .on_blur(cx.listener(|_, _, _| println!("Child 2 blurred")))
-                    // TODO kb todo!() remove?
-                    // .on_focus_in(cx.listener(|_, _, _| println!("Child 2 focus_in")))
-                    // .on_focus_out(cx.listener(|_, _, _| println!("Child 2 focus_out")))
                     .on_key_down(
                         cx.listener(|_, event, _| println!("Key down on child 2 {:?}", event)),
                     )

--- a/crates/storybook2/src/stories/focus.rs
+++ b/crates/storybook2/src/stories/focus.rs
@@ -49,8 +49,9 @@ impl Render for FocusStory {
             }))
             .on_focus(cx.listener(|_, _, _| println!("Parent focused")))
             .on_blur(cx.listener(|_, _, _| println!("Parent blurred")))
-            .on_focus_in(cx.listener(|_, _, _| println!("Parent focus_in")))
-            .on_focus_out(cx.listener(|_, _, _| println!("Parent focus_out")))
+            // TODO kb todo!() remove?
+            // .on_focus_in(cx.listener(|_, _, _| println!("Parent focus_in")))
+            // .on_focus_out(cx.listener(|_, _, _| println!("Parent focus_out")))
             .on_key_down(cx.listener(|_, event, _| println!("Key down on parent {:?}", event)))
             .on_key_up(cx.listener(|_, event, _| println!("Key up on parent {:?}", event)))
             .size_full()
@@ -70,8 +71,9 @@ impl Render for FocusStory {
                     .in_focus(|style| style.bg(color_6))
                     .on_focus(cx.listener(|_, _, _| println!("Child 1 focused")))
                     .on_blur(cx.listener(|_, _, _| println!("Child 1 blurred")))
-                    .on_focus_in(cx.listener(|_, _, _| println!("Child 1 focus_in")))
-                    .on_focus_out(cx.listener(|_, _, _| println!("Child 1 focus_out")))
+                    // TODO kb todo!() remove?
+                    // .on_focus_in(cx.listener(|_, _, _| println!("Child 1 focus_in")))
+                    // .on_focus_out(cx.listener(|_, _, _| println!("Child 1 focus_out")))
                     .on_key_down(
                         cx.listener(|_, event, _| println!("Key down on child 1 {:?}", event)),
                     )
@@ -90,8 +92,9 @@ impl Render for FocusStory {
                     .bg(color_4)
                     .on_focus(cx.listener(|_, _, _| println!("Child 2 focused")))
                     .on_blur(cx.listener(|_, _, _| println!("Child 2 blurred")))
-                    .on_focus_in(cx.listener(|_, _, _| println!("Child 2 focus_in")))
-                    .on_focus_out(cx.listener(|_, _, _| println!("Child 2 focus_out")))
+                    // TODO kb todo!() remove?
+                    // .on_focus_in(cx.listener(|_, _, _| println!("Child 2 focus_in")))
+                    // .on_focus_out(cx.listener(|_, _, _| println!("Child 2 focus_out")))
                     .on_key_down(
                         cx.listener(|_, event, _| println!("Key down on child 2 {:?}", event)),
                     )

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -346,6 +346,7 @@ impl Dock {
                         })
                         .ok();
                 }
+                // todo!() we do not use this event in the production code (even in zed1), remove it
                 PanelEvent::Activate => {
                     if let Some(ix) = this
                         .panel_entries

--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -10,7 +10,7 @@ use gpui::{
     actions, impl_actions, overlay, prelude::*, rems, Action, AnchorCorner, AnyWeakView,
     AppContext, AsyncWindowContext, DismissEvent, Div, EntityId, EventEmitter, FocusHandle,
     Focusable, FocusableView, Model, MouseButton, NavigationDirection, Pixels, Point, PromptLevel,
-    Render, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
+    Render, Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use parking_lot::Mutex;
 use project::{Project, ProjectEntryId, ProjectPath};
@@ -174,6 +174,7 @@ pub struct Pane {
     //     can_drop: Rc<dyn Fn(&DragAndDrop<Workspace>, &WindowContext) -> bool>,
     can_split: bool,
     //     render_tab_bar_buttons: Rc<dyn Fn(&mut Pane, &mut ViewContext<Pane>) -> AnyElement<Pane>>,
+    subscriptions: Vec<Subscription>,
 }
 
 pub struct ItemNavHistory {
@@ -312,10 +313,17 @@ impl Pane {
         // context_menu.update(cx, |menu, _| {
         //     menu.set_position_mode(OverlayPositionMode::Local)
         // });
+        //
+        let focus_handle = cx.focus_handle();
+
+        let subscriptions = vec![
+            cx.on_focus_in(&focus_handle, move |this, cx| this.focus_in(cx)),
+            cx.on_focus_out(&focus_handle, move |this, cx| this.focus_out(cx)),
+        ];
 
         let handle = cx.view().downgrade();
         Self {
-            focus_handle: cx.focus_handle(),
+            focus_handle,
             items: Vec::new(),
             activation_history: Vec::new(),
             was_focused: false,
@@ -402,6 +410,7 @@ impl Pane {
             //         })
             //         .into_any()
             // }),
+            subscriptions,
         }
     }
 
@@ -2062,18 +2071,6 @@ impl Render for Pane {
             .track_focus(&self.focus_handle)
             .size_full()
             .overflow_hidden()
-            .on_focus_in({
-                let this = this.clone();
-                move |event, cx| {
-                    this.update(cx, |this, cx| this.focus_in(cx)).ok();
-                }
-            })
-            .on_focus_out({
-                let this = this.clone();
-                move |event, cx| {
-                    this.update(cx, |this, cx| this.focus_out(cx)).ok();
-                }
-            })
             .on_action(cx.listener(|pane, _: &SplitLeft, cx| pane.split(SplitDirection::Left, cx)))
             .on_action(cx.listener(|pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx)))
             .on_action(

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -532,6 +532,11 @@ impl Workspace {
             cx.notify()
         })
         .detach();
+        cx.on_window_focus_lost(|this, cx| {
+            let focus_handle = this.focus_handle(cx);
+            cx.focus(&focus_handle);
+        })
+        .detach();
 
         let weak_handle = cx.view().downgrade();
         let pane_history_timestamp = Arc::new(AtomicUsize::new(0));

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -532,7 +532,7 @@ impl Workspace {
             cx.notify()
         })
         .detach();
-        cx.on_window_focus_lost(|this, cx| {
+        cx.on_blur_window(|this, cx| {
             let focus_handle = this.focus_handle(cx);
             cx.focus(&focus_handle);
         })

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -1633,6 +1633,7 @@ impl Workspace {
                             panel.focus_handle(cx).focus(cx);
                             reveal_dock = true;
                         } else {
+                            // todo!()
                             // if panel.is_zoomed(cx) {
                             //     dock.set_open(false, cx);
                             // }


### PR DESCRIPTION
* Fixed dock toggling not focusing the terminal element
* Fixed loosing focus on dock close (e.g. cmd-d on the last terminal in the dock)
* Removed element stateless focus API since it would not work when the element is not rendered, update all API usages to the stateful one via `gpui::Subscription`

Release Notes:

- N/A