### PR TITLE
Buffer search channel notes

### DIFF
--- a/crates/search2/src/buffer_search.rs
+++ b/crates/search2/src/buffer_search.rs
@@ -154,10 +154,21 @@ impl Render for BufferSearchBar {
                 Some(ui::Label::new(message))
             });
         let should_show_replace_input = self.replace_enabled && supported_options.replacement;
-        let replace_all = should_show_replace_input
-            .then(|| super::render_replace_button(ReplaceAll, ui::Icon::ReplaceAll, "Replace all"));
+        let replace_all = should_show_replace_input.then(|| {
+            super::render_replace_button(
+                ReplaceAll,
+                ui::Icon::ReplaceAll,
+                "Replace all",
+                cx.listener(|this, _, cx| this.replace_all(&ReplaceAll, cx)),
+            )
+        });
         let replace_next = should_show_replace_input.then(|| {
-            super::render_replace_button(ReplaceNext, ui::Icon::ReplaceNext, "Replace next")
+            super::render_replace_button(
+                ReplaceNext,
+                ui::Icon::ReplaceNext,
+                "Replace next",
+                cx.listener(|this, _, cx| this.replace_next(&ReplaceNext, cx)),
+            )
         });
         let in_replace = self.replacement_editor.focus_handle(cx).is_focused(cx);
 

--- a/crates/search2/src/search.rs
+++ b/crates/search2/src/search.rs
@@ -121,6 +121,7 @@ fn render_replace_button(
     action: impl Action + 'static + Send + Sync,
     icon: Icon,
     tooltip: &'static str,
+    on_click: impl Fn(&gpui::ClickEvent, &mut WindowContext) + 'static,
 ) -> impl IntoElement {
     let id: SharedString = format!("search-replace-{}", action.name()).into();
     IconButton::new(id, icon)
@@ -128,7 +129,5 @@ fn render_replace_button(
             let action = action.boxed_clone();
             move |cx| Tooltip::for_action(tooltip, &*action, cx)
         })
-        .on_click(move |_, cx| {
-            cx.dispatch_action(action.boxed_clone());
-        })
+        .on_click(on_click)
 }

--- a/crates/search2/src/search.rs
+++ b/crates/search2/src/search.rs
@@ -88,14 +88,13 @@ impl SearchOptions {
         options
     }
 
-    pub fn as_button(&self, active: bool) -> impl IntoElement {
+    pub fn as_button(
+        &self,
+        active: bool,
+        action: impl Fn(&gpui::ClickEvent, &mut WindowContext) + 'static,
+    ) -> impl IntoElement {
         IconButton::new(self.label(), self.icon())
-            .on_click({
-                let action = self.to_toggle_action();
-                move |_, cx| {
-                    cx.dispatch_action(action.boxed_clone());
-                }
-            })
+            .on_click(action)
             .style(ButtonStyle::Subtle)
             .when(active, |button| button.style(ButtonStyle::Filled))
             .tooltip({
@@ -106,13 +105,13 @@ impl SearchOptions {
     }
 }
 
-fn toggle_replace_button(active: bool) -> impl IntoElement {
+fn toggle_replace_button(
+    active: bool,
+    action: impl Fn(&gpui::ClickEvent, &mut WindowContext) + 'static,
+) -> impl IntoElement {
     // todo: add toggle_replace button
     IconButton::new("buffer-search-bar-toggle-replace-button", Icon::Replace)
-        .on_click(|_, cx| {
-            cx.dispatch_action(Box::new(ToggleReplace));
-            cx.notify();
-        })
+        .on_click(action)
         .style(ButtonStyle::Subtle)
         .when(active, |button| button.style(ButtonStyle::Filled))
         .tooltip(|cx| Tooltip::for_action("Toggle replace", &ToggleReplace, cx))


### PR DESCRIPTION
We were registering `deploy` only on editors, which did succeed for channel notes; however, channel note does not have an associated workspace (that we pulled from the editor). It made more sense to just register these actions for a workspace, notwithstanding the editor.

This PR also fixes a bunch of cx.dispatch_action calls to call the handler directly instead (e.g. instead of dispatching ReplaceNext we just call buffer_search_bar.replace_next instead) as otherwise these actions are not handled if the buffer search bar does not have the focus.

Release Notes:

- N/A