### PR TITLE
Prevent panes from overflowing the window

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -2106,6 +2106,7 @@ impl Render for Pane {
             .key_context("Pane")
             .track_focus(&self.focus_handle)
             .size_full()
+            .flex_none()
             .overflow_hidden()
             .on_action(cx.listener(|pane, _: &SplitLeft, cx| pane.split(SplitDirection::Left, cx)))
             .on_action(cx.listener(|pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx)))


### PR DESCRIPTION
This PR fixes an issues where it was possible for panes to overflow the window (for instance, by having a large number of tabs in the tab bar).

Release Notes:

- N/A
