### PR TITLE
Avoid caching zed build script if git state has changed

### DIFF
--- a/crates/zed2/build.rs
+++ b/crates/zed2/build.rs
@@ -3,10 +3,7 @@ use std::process::Command;
 fn main() {
     println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.15.7");
 
-    if let Ok(value) = std::env::var("ZED_PREVIEW_CHANNEL") {
-        println!("cargo:rustc-env=ZED_PREVIEW_CHANNEL={value}");
-    }
-
+    println!("cargo:rerun-if-env-changed=ZED_BUNDLE");
     if std::env::var("ZED_BUNDLE").ok().as_deref() == Some("true") {
         // Find WebRTC.framework in the Frameworks folder when running as part of an application bundle.
         println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../Frameworks");
@@ -25,6 +22,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-ObjC");
 
     // Populate git sha environment variable if git is available
+    println!("cargo:rerun-if-changed=.git/logs/HEAD");
     if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         if output.status.success() {
             let git_sha = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
@as-cii and @SomeoneToIgnore noticed a bug where Zed nightly would continuously report that an update was available. This nightly auto-update logic depends on the `ZED_COMMIT_SHA` constant, which is compiled into the app via an rustc environment variable that is assigned in the `zed2` build script.

I think the bug was caused by the `zed2` build script's output being cached on our CI, when building the nightly app bundle. The result was that the `publish-nightly` action updated the "current SHA" for nightly, but uploaded an artifact whose `ZED_COMMIT_SHA` was cached from an earlier version.

I've added a line to the `build.rs` that triggers a rerun if the `.git/logs/HEAD` file has been changed. I think this should prevent the unwanted caching.