### PR TITLE
Avoid notifying editor when wrap width changes

### DIFF
--- a/crates/editor2/src/display_map/wrap_map.rs
+++ b/crates/editor2/src/display_map/wrap_map.rs
@@ -184,7 +184,6 @@ impl WrapMap {
                 Ok((snapshot, edits)) => {
                     self.snapshot = snapshot;
                     self.edits_since_sync = self.edits_since_sync.compose(&edits);
-                    cx.notify();
                 }
                 Err(wrap_task) => {
                     self.background_task = Some(cx.spawn(|this, mut cx| async move {

--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -8300,7 +8300,9 @@ impl Editor {
         self.style.as_ref()
     }
 
-    pub fn set_wrap_width(&self, width: Option<Pixels>, cx: &mut AppContext) -> bool {
+    // Called by the element. This method is not designed to be called outside of the editor
+    // element's layout code because it does not notify when rewrapping is computed synchronously.
+    pub(crate) fn set_wrap_width(&self, width: Option<Pixels>, cx: &mut AppContext) -> bool {
         self.display_map
             .update(cx, |map, cx| map.set_wrap_width(width, cx))
     }


### PR DESCRIPTION
Wrap width is already assigned from within draw. It can be called multiple times as taffy iteratively computes the layout.

This fixes a hang we were seeing in nightly when opening the chat panel.
