### PR TITLE
Fix workspace sizing

### DIFF
--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3704,10 +3704,13 @@ impl Render for Workspace {
                     .child(self.modal_layer.clone())
                     .child(
                         h_stack()
+                            .h_full()
                             // Left Dock
                             .child(
-                                v_stack()
+                                div()
+                                    .flex()
                                     .flex_none()
+                                    .overflow_hidden()
                                     .debug_bg_red()
                                     .child(self.left_dock.clone()),
                             )
@@ -3731,8 +3734,10 @@ impl Render for Workspace {
                             )
                             // Right Dock
                             .child(
-                                v_stack()
+                                div()
+                                    .flex()
                                     .flex_none()
+                                    .overflow_hidden()
                                     .debug_bg_magenta()
                                     .child(self.right_dock.clone()),
                             ),

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3666,7 +3666,9 @@ impl Render for Workspace {
                     .child(canvas(|bounds, cx| cx.set_global(WorkspaceBounds(bounds))))
                     .child(self.modal_layer.clone())
                     .child(
-                        h_stack()
+                        div()
+                            .flex()
+                            .flex_row()
                             .h_full()
                             // Left Dock
                             .child(
@@ -3674,7 +3676,6 @@ impl Render for Workspace {
                                     .flex()
                                     .flex_none()
                                     .overflow_hidden()
-                                    .debug_bg_red()
                                     .child(self.left_dock.clone()),
                             )
                             // Panes
@@ -3683,7 +3684,6 @@ impl Render for Workspace {
                                     .flex_grow()
                                     .overflow_hidden()
                                     .h_full()
-                                    .debug_bg_cyan()
                                     .child(self.center.render(
                                         &self.project,
                                         &self.follower_states,
@@ -3701,7 +3701,6 @@ impl Render for Workspace {
                                     .flex()
                                     .flex_none()
                                     .overflow_hidden()
-                                    .debug_bg_magenta()
                                     .child(self.right_dock.clone()),
                             ),
                     )

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3711,24 +3711,26 @@ impl Render for Workspace {
                                     .w_32()
                                     .h_full()
                                     .debug_bg_red()
-                                    .child("Left"),
+                                    .child(self.left_dock.clone()),
                             )
-                            .child(
-                                v_stack()
-                                    .flex_1()
-                                    .w_32()
-                                    .h_full()
-                                    .debug_bg_cyan()
-                                    .child("Center")
-                                    .child(debug_tab_bar()),
-                            )
+                            .child(v_stack().flex_1().w_32().h_full().debug_bg_cyan().child(
+                                self.center.render(
+                                    &self.project,
+                                    &self.follower_states,
+                                    self.active_call(),
+                                    &self.active_pane,
+                                    self.zoomed.as_ref(),
+                                    &self.app_state,
+                                    cx,
+                                ),
+                            ))
                             .child(
                                 v_stack()
                                     .flex_none()
                                     .w_32()
                                     .h_full()
                                     .debug_bg_magenta()
-                                    .child("Right"),
+                                    .child(self.right_dock.clone()),
                             ),
                     )
                     // .child(
@@ -3738,7 +3740,7 @@ impl Render for Workspace {
                     //             div()
                     //                 .flex()
                     //                 .flex_none()
-                    //                 .overflow_hidden()
+                    //                 // .overflow_hidden()
                     //                 .child(self.left_dock.clone()),
                     //         )
                     //         // Panes
@@ -3764,7 +3766,7 @@ impl Render for Workspace {
                     //             div()
                     //                 .flex()
                     //                 .flex_none()
-                    //                 .overflow_hidden()
+                    //                 // .overflow_hidden()
                     //                 .child(self.right_dock.clone()),
                     //         ),
                     // )

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3620,92 +3620,102 @@ impl Render for Workspace {
             .border()
             .border_color(cx.theme().colors().border)
             .children(self.titlebar_item.clone())
-            .child(
-                div()
-                    .id("workspace")
-                    .relative()
-                    .flex_1()
-                    .w_full()
-                    .flex()
-                    .overflow_hidden()
-                    .border_t()
-                    .border_b()
-                    .border_color(cx.theme().colors().border)
-                    .on_mouse_up(gpui::MouseButton::Left, |_, cx| {
-                        cx.update_global(|drag: &mut DockDragState, cx| {
-                            drag.0 = None;
-                        })
-                    })
-                    .on_mouse_move(cx.listener(|workspace, e: &MouseMoveEvent, cx| {
-                        if let Some(types) = &cx.global::<DockDragState>().0 {
-                            let workspace_bounds = cx.global::<WorkspaceBounds>().0;
-                            match types {
-                                DockPosition::Left => {
-                                    let size = e.position.x;
-                                    workspace.left_dock.update(cx, |left_dock, cx| {
-                                        left_dock.resize_active_panel(Some(size.0), cx);
-                                    });
-                                }
-                                DockPosition::Right => {
-                                    let size = workspace_bounds.size.width - e.position.x;
-                                    workspace.right_dock.update(cx, |right_dock, cx| {
-                                        right_dock.resize_active_panel(Some(size.0), cx);
-                                    });
-                                }
-                                DockPosition::Bottom => {
-                                    let size = workspace_bounds.size.height - e.position.y;
-                                    workspace.bottom_dock.update(cx, |bottom_dock, cx| {
-                                        bottom_dock.resize_active_panel(Some(size.0), cx);
-                                    });
-                                }
-                            }
-                        }
-                    }))
-                    .child(canvas(|bounds, cx| cx.set_global(WorkspaceBounds(bounds))))
-                    .child(self.modal_layer.clone())
-                    .child(
-                        div()
-                            .flex()
-                            .flex_row()
-                            .flex_1()
-                            .h_full()
-                            // Left Dock
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_none()
-                                    .overflow_hidden()
-                                    .child(self.left_dock.clone()),
-                            )
-                            // Panes
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .flex_1()
-                                    .child(self.center.render(
-                                        &self.project,
-                                        &self.follower_states,
-                                        self.active_call(),
-                                        &self.active_pane,
-                                        self.zoomed.as_ref(),
-                                        &self.app_state,
-                                        cx,
-                                    ))
-                                    .child(self.bottom_dock.clone()),
-                            )
-                            // Right Dock
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_none()
-                                    .overflow_hidden()
-                                    .child(self.right_dock.clone()),
-                            ),
-                    )
-                    .children(self.render_notifications(cx)),
-            )
-            .child(self.status_bar.clone())
+            .child(self.center.render(
+                &self.project,
+                &self.follower_states,
+                self.active_call(),
+                &self.active_pane,
+                self.zoomed.as_ref(),
+                &self.app_state,
+                cx,
+            ))
+
+            // .child(
+            //     div()
+            //         .id("workspace")
+            //         .relative()
+            //         .flex_1()
+            //         .w_full()
+            //         .flex()
+            //         .overflow_hidden()
+            //         .border_t()
+            //         .border_b()
+            //         .border_color(cx.theme().colors().border)
+            //         .on_mouse_up(gpui::MouseButton::Left, |_, cx| {
+            //             cx.update_global(|drag: &mut DockDragState, cx| {
+            //                 drag.0 = None;
+            //             })
+            //         })
+            //         .on_mouse_move(cx.listener(|workspace, e: &MouseMoveEvent, cx| {
+            //             if let Some(types) = &cx.global::<DockDragState>().0 {
+            //                 let workspace_bounds = cx.global::<WorkspaceBounds>().0;
+            //                 match types {
+            //                     DockPosition::Left => {
+            //                         let size = e.position.x;
+            //                         workspace.left_dock.update(cx, |left_dock, cx| {
+            //                             left_dock.resize_active_panel(Some(size.0), cx);
+            //                         });
+            //                     }
+            //                     DockPosition::Right => {
+            //                         let size = workspace_bounds.size.width - e.position.x;
+            //                         workspace.right_dock.update(cx, |right_dock, cx| {
+            //                             right_dock.resize_active_panel(Some(size.0), cx);
+            //                         });
+            //                     }
+            //                     DockPosition::Bottom => {
+            //                         let size = workspace_bounds.size.height - e.position.y;
+            //                         workspace.bottom_dock.update(cx, |bottom_dock, cx| {
+            //                             bottom_dock.resize_active_panel(Some(size.0), cx);
+            //                         });
+            //                     }
+            //                 }
+            //             }
+            //         }))
+            //         .child(canvas(|bounds, cx| cx.set_global(WorkspaceBounds(bounds))))
+            //         .child(self.modal_layer.clone())
+            //         .child(
+            //             div()
+            //                 .flex()
+            //                 .flex_row()
+            //                 .flex_1()
+            //                 .h_full()
+            //                 // Left Dock
+            //                 .child(
+            //                     div()
+            //                         .flex()
+            //                         .flex_none()
+            //                         .overflow_hidden()
+            //                         .child(self.left_dock.clone()),
+            //                 )
+            //                 // Panes
+            //                 .child(
+            //                     div()
+            //                         .flex()
+            //                         .flex_col()
+            //                         .flex_1()
+            //                         .child(self.center.render(
+            //                             &self.project,
+            //                             &self.follower_states,
+            //                             self.active_call(),
+            //                             &self.active_pane,
+            //                             self.zoomed.as_ref(),
+            //                             &self.app_state,
+            //                             cx,
+            //                         ))
+            //                         .child(self.bottom_dock.clone()),
+            //                 )
+            //                 // Right Dock
+            //                 .child(
+            //                     div()
+            //                         .flex()
+            //                         .flex_none()
+            //                         .overflow_hidden()
+            //                         .child(self.right_dock.clone()),
+            //                 ),
+            //         )
+            //         .children(self.render_notifications(cx)),
+            // )
+            // .child(self.status_bar.clone())
     }
 }
 

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3708,8 +3708,8 @@ impl Render for Workspace {
                             .child(
                                 v_stack()
                                     .flex_none()
-                                    .w_32()
-                                    .h_full()
+                                    // .w_32()
+                                    // .h_full()
                                     .debug_bg_red()
                                     .child(self.left_dock.clone()),
                             )
@@ -3732,8 +3732,8 @@ impl Render for Workspace {
                             .child(
                                 v_stack()
                                     .flex_none()
-                                    .w_32()
-                                    .h_full()
+                                    // .w_32()
+                                    // .h_full()
                                     .debug_bg_magenta()
                                     .child(self.right_dock.clone()),
                             ),

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3704,46 +3704,70 @@ impl Render for Workspace {
                     .child(self.modal_layer.clone())
                     .child(debug_tab_bar())
                     .child(
-                        div()
-                            .flex()
-                            .flex_row()
-                            // .flex_1()
-                            .h_full()
-                            // Left Dock
+                        h_stack()
                             .child(
-                                div()
-                                    .flex()
+                                v_stack()
                                     .flex_none()
-                                    .overflow_hidden()
-                                    .child(self.left_dock.clone()),
+                                    .w_32()
+                                    .h_full()
+                                    .debug_bg_red()
+                                    .child("Left"),
                             )
-                            // Panes
                             .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
+                                v_stack()
                                     .flex_1()
-                                    .child(debug_tab_bar())
-                                    .child(self.center.render(
-                                        &self.project,
-                                        &self.follower_states,
-                                        self.active_call(),
-                                        &self.active_pane,
-                                        self.zoomed.as_ref(),
-                                        &self.app_state,
-                                        cx,
-                                    ))
-                                    .child(self.bottom_dock.clone()),
+                                    .w_32()
+                                    .h_full()
+                                    .debug_bg_cyan()
+                                    .child("Center")
+                                    .child(debug_tab_bar()),
                             )
-                            // Right Dock
                             .child(
-                                div()
-                                    .flex()
+                                v_stack()
                                     .flex_none()
-                                    .overflow_hidden()
-                                    .child(self.right_dock.clone()),
+                                    .w_32()
+                                    .h_full()
+                                    .debug_bg_magenta()
+                                    .child("Right"),
                             ),
                     )
+                    // .child(
+                    //     h_stack()
+                    //         // Left Dock
+                    //         .child(
+                    //             div()
+                    //                 .flex()
+                    //                 .flex_none()
+                    //                 .overflow_hidden()
+                    //                 .child(self.left_dock.clone()),
+                    //         )
+                    //         // Panes
+                    //         .child(
+                    //             div()
+                    //                 .flex()
+                    //                 .flex_col()
+                    //                 .flex_1()
+                    //                 .child(debug_tab_bar())
+                    //                 .child(self.center.render(
+                    //                     &self.project,
+                    //                     &self.follower_states,
+                    //                     self.active_call(),
+                    //                     &self.active_pane,
+                    //                     self.zoomed.as_ref(),
+                    //                     &self.app_state,
+                    //                     cx,
+                    //                 ))
+                    //                 .child(self.bottom_dock.clone()),
+                    //         )
+                    //         // Right Dock
+                    //         .child(
+                    //             div()
+                    //                 .flex()
+                    //                 .flex_none()
+                    //                 .overflow_hidden()
+                    //                 .child(self.right_dock.clone()),
+                    //         ),
+                    // )
                     .children(self.render_notifications(cx)),
             )
             .child(self.status_bar.clone())

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3620,102 +3620,100 @@ impl Render for Workspace {
             .border()
             .border_color(cx.theme().colors().border)
             .children(self.titlebar_item.clone())
-            .child(self.center.render(
-                &self.project,
-                &self.follower_states,
-                self.active_call(),
-                &self.active_pane,
-                self.zoomed.as_ref(),
-                &self.app_state,
-                cx,
-            ))
-
-            // .child(
-            //     div()
-            //         .id("workspace")
-            //         .relative()
-            //         .flex_1()
-            //         .w_full()
-            //         .flex()
-            //         .overflow_hidden()
-            //         .border_t()
-            //         .border_b()
-            //         .border_color(cx.theme().colors().border)
-            //         .on_mouse_up(gpui::MouseButton::Left, |_, cx| {
-            //             cx.update_global(|drag: &mut DockDragState, cx| {
-            //                 drag.0 = None;
-            //             })
-            //         })
-            //         .on_mouse_move(cx.listener(|workspace, e: &MouseMoveEvent, cx| {
-            //             if let Some(types) = &cx.global::<DockDragState>().0 {
-            //                 let workspace_bounds = cx.global::<WorkspaceBounds>().0;
-            //                 match types {
-            //                     DockPosition::Left => {
-            //                         let size = e.position.x;
-            //                         workspace.left_dock.update(cx, |left_dock, cx| {
-            //                             left_dock.resize_active_panel(Some(size.0), cx);
-            //                         });
-            //                     }
-            //                     DockPosition::Right => {
-            //                         let size = workspace_bounds.size.width - e.position.x;
-            //                         workspace.right_dock.update(cx, |right_dock, cx| {
-            //                             right_dock.resize_active_panel(Some(size.0), cx);
-            //                         });
-            //                     }
-            //                     DockPosition::Bottom => {
-            //                         let size = workspace_bounds.size.height - e.position.y;
-            //                         workspace.bottom_dock.update(cx, |bottom_dock, cx| {
-            //                             bottom_dock.resize_active_panel(Some(size.0), cx);
-            //                         });
-            //                     }
-            //                 }
-            //             }
-            //         }))
-            //         .child(canvas(|bounds, cx| cx.set_global(WorkspaceBounds(bounds))))
-            //         .child(self.modal_layer.clone())
-            //         .child(
-            //             div()
-            //                 .flex()
-            //                 .flex_row()
-            //                 .flex_1()
-            //                 .h_full()
-            //                 // Left Dock
-            //                 .child(
-            //                     div()
-            //                         .flex()
-            //                         .flex_none()
-            //                         .overflow_hidden()
-            //                         .child(self.left_dock.clone()),
-            //                 )
-            //                 // Panes
-            //                 .child(
-            //                     div()
-            //                         .flex()
-            //                         .flex_col()
-            //                         .flex_1()
-            //                         .child(self.center.render(
-            //                             &self.project,
-            //                             &self.follower_states,
-            //                             self.active_call(),
-            //                             &self.active_pane,
-            //                             self.zoomed.as_ref(),
-            //                             &self.app_state,
-            //                             cx,
-            //                         ))
-            //                         .child(self.bottom_dock.clone()),
-            //                 )
-            //                 // Right Dock
-            //                 .child(
-            //                     div()
-            //                         .flex()
-            //                         .flex_none()
-            //                         .overflow_hidden()
-            //                         .child(self.right_dock.clone()),
-            //                 ),
-            //         )
-            //         .children(self.render_notifications(cx)),
-            // )
-            // .child(self.status_bar.clone())
+            .child(
+                div()
+                    .id("workspace")
+                    .relative()
+                    .flex_1()
+                    .w_full()
+                    .flex()
+                    .overflow_hidden()
+                    .border_t()
+                    .border_b()
+                    .border_color(cx.theme().colors().border)
+                    .on_mouse_up(gpui::MouseButton::Left, |_, cx| {
+                        cx.update_global(|drag: &mut DockDragState, cx| {
+                            drag.0 = None;
+                        })
+                    })
+                    .on_mouse_move(cx.listener(|workspace, e: &MouseMoveEvent, cx| {
+                        if let Some(types) = &cx.global::<DockDragState>().0 {
+                            let workspace_bounds = cx.global::<WorkspaceBounds>().0;
+                            match types {
+                                DockPosition::Left => {
+                                    let size = e.position.x;
+                                    workspace.left_dock.update(cx, |left_dock, cx| {
+                                        left_dock.resize_active_panel(Some(size.0), cx);
+                                    });
+                                }
+                                DockPosition::Right => {
+                                    let size = workspace_bounds.size.width - e.position.x;
+                                    workspace.right_dock.update(cx, |right_dock, cx| {
+                                        right_dock.resize_active_panel(Some(size.0), cx);
+                                    });
+                                }
+                                DockPosition::Bottom => {
+                                    let size = workspace_bounds.size.height - e.position.y;
+                                    workspace.bottom_dock.update(cx, |bottom_dock, cx| {
+                                        bottom_dock.resize_active_panel(Some(size.0), cx);
+                                    });
+                                }
+                            }
+                        }
+                    }))
+                    .child(canvas(|bounds, cx| cx.set_global(WorkspaceBounds(bounds))))
+                    .child(self.modal_layer.clone())
+                    .child(self.center.render(
+                        &self.project,
+                        &self.follower_states,
+                        self.active_call(),
+                        &self.active_pane,
+                        self.zoomed.as_ref(),
+                        &self.app_state,
+                        cx,
+                    )), //         .child(
+                        //             div()
+                        //                 .flex()
+                        //                 .flex_row()
+                        //                 .flex_1()
+                        //                 .h_full()
+                        //                 // Left Dock
+                        //                 .child(
+                        //                     div()
+                        //                         .flex()
+                        //                         .flex_none()
+                        //                         .overflow_hidden()
+                        //                         .child(self.left_dock.clone()),
+                        //                 )
+                        //                 // Panes
+                        //                 .child(
+                        //                     div()
+                        //                         .flex()
+                        //                         .flex_col()
+                        //                         .flex_1()
+                        //                         .child(self.center.render(
+                        //                             &self.project,
+                        //                             &self.follower_states,
+                        //                             self.active_call(),
+                        //                             &self.active_pane,
+                        //                             self.zoomed.as_ref(),
+                        //                             &self.app_state,
+                        //                             cx,
+                        //                         ))
+                        //                         .child(self.bottom_dock.clone()),
+                        //                 )
+                        //                 // Right Dock
+                        //                 .child(
+                        //                     div()
+                        //                         .flex()
+                        //                         .flex_none()
+                        //                         .overflow_hidden()
+                        //                         .child(self.right_dock.clone()),
+                        //                 ),
+                        //         )
+                        //         .children(self.render_notifications(cx)),
+            )
+            .child(self.status_bar.clone())
     }
 }
 

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3702,17 +3702,16 @@ impl Render for Workspace {
                     }))
                     .child(canvas(|bounds, cx| cx.set_global(WorkspaceBounds(bounds))))
                     .child(self.modal_layer.clone())
-                    .child(debug_tab_bar())
                     .child(
                         h_stack()
+                            // Left Dock
                             .child(
                                 v_stack()
                                     .flex_none()
-                                    // .w_32()
-                                    // .h_full()
                                     .debug_bg_red()
                                     .child(self.left_dock.clone()),
                             )
+                            // Panes
                             .child(
                                 v_stack()
                                     .flex_grow()
@@ -3727,54 +3726,17 @@ impl Render for Workspace {
                                         self.zoomed.as_ref(),
                                         &self.app_state,
                                         cx,
-                                    )),
+                                    ))
+                                    .child(self.bottom_dock.clone()),
                             )
+                            // Right Dock
                             .child(
                                 v_stack()
                                     .flex_none()
-                                    // .w_32()
-                                    // .h_full()
                                     .debug_bg_magenta()
                                     .child(self.right_dock.clone()),
                             ),
                     )
-                    // .child(
-                    //     h_stack()
-                    //         // Left Dock
-                    //         .child(
-                    //             div()
-                    //                 .flex()
-                    //                 .flex_none()
-                    //                 // .overflow_hidden()
-                    //                 .child(self.left_dock.clone()),
-                    //         )
-                    //         // Panes
-                    //         .child(
-                    //             div()
-                    //                 .flex()
-                    //                 .flex_col()
-                    //                 .flex_1()
-                    //                 .child(debug_tab_bar())
-                    //                 .child(self.center.render(
-                    //                     &self.project,
-                    //                     &self.follower_states,
-                    //                     self.active_call(),
-                    //                     &self.active_pane,
-                    //                     self.zoomed.as_ref(),
-                    //                     &self.app_state,
-                    //                     cx,
-                    //                 ))
-                    //                 .child(self.bottom_dock.clone()),
-                    //         )
-                    //         // Right Dock
-                    //         .child(
-                    //             div()
-                    //                 .flex()
-                    //                 .flex_none()
-                    //                 // .overflow_hidden()
-                    //                 .child(self.right_dock.clone()),
-                    //         ),
-                    // )
                     .children(self.render_notifications(cx)),
             )
             .child(self.status_bar.clone())

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3589,43 +3589,6 @@ struct DockDragState(Option<DockPosition>);
 #[derive(Default)]
 struct DockClickReset(Option<Task<()>>);
 
-fn debug_tab_bar() -> impl IntoElement {
-    let tab_count = 20;
-    let selected_tab_index = 3;
-
-    let tabs = (0..tab_count)
-        .map(|index| {
-            Tab::new(index)
-                .selected(index == selected_tab_index)
-                .position(if index == 0 {
-                    TabPosition::First
-                } else if index == tab_count - 1 {
-                    TabPosition::Last
-                } else {
-                    TabPosition::Middle(index.cmp(&selected_tab_index))
-                })
-                .child(Label::new(format!("Tab {}", index + 1)).color(
-                    if index == selected_tab_index {
-                        Color::Default
-                    } else {
-                        Color::Muted
-                    },
-                ))
-        })
-        .collect::<Vec<_>>();
-
-    TabBar::new("tab_bar_1")
-        .start_child(
-            IconButton::new("navigate_backward", Icon::ArrowLeft).icon_size(IconSize::Small),
-        )
-        .start_child(
-            IconButton::new("navigate_forward", Icon::ArrowRight).icon_size(IconSize::Small),
-        )
-        .end_child(IconButton::new("new", Icon::Plus).icon_size(IconSize::Small))
-        .end_child(IconButton::new("split_pane", Icon::Split).icon_size(IconSize::Small))
-        .children(tabs)
-}
-
 impl Render for Workspace {
     type Element = Div;
 

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3713,17 +3713,22 @@ impl Render for Workspace {
                                     .debug_bg_red()
                                     .child(self.left_dock.clone()),
                             )
-                            .child(v_stack().flex_1().w_32().h_full().debug_bg_cyan().child(
-                                self.center.render(
-                                    &self.project,
-                                    &self.follower_states,
-                                    self.active_call(),
-                                    &self.active_pane,
-                                    self.zoomed.as_ref(),
-                                    &self.app_state,
-                                    cx,
-                                ),
-                            ))
+                            .child(
+                                v_stack()
+                                    .flex_grow()
+                                    .overflow_hidden()
+                                    .h_full()
+                                    .debug_bg_cyan()
+                                    .child(self.center.render(
+                                        &self.project,
+                                        &self.follower_states,
+                                        self.active_call(),
+                                        &self.active_pane,
+                                        self.zoomed.as_ref(),
+                                        &self.app_state,
+                                        cx,
+                                    )),
+                            )
                             .child(
                                 v_stack()
                                     .flex_none()

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -68,7 +68,6 @@ use std::{
 use theme::{ActiveTheme, ThemeSettings};
 pub use toolbar::{Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
 pub use ui;
-use ui::prelude::*;
 use util::ResultExt;
 use uuid::Uuid;
 pub use workspace_settings::{AutosaveSetting, WorkspaceSettings};

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -68,7 +68,7 @@ use std::{
 use theme::{ActiveTheme, ThemeSettings};
 pub use toolbar::{Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
 pub use ui;
-use ui::{prelude::*, Tab, TabBar, TabPosition};
+use ui::prelude::*;
 use util::ResultExt;
 use uuid::Uuid;
 pub use workspace_settings::{AutosaveSetting, WorkspaceSettings};

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3685,7 +3685,6 @@ impl Render for Workspace {
                                     .flex_col()
                                     .flex_1()
                                     .overflow_hidden()
-                                    .h_full()
                                     .child(self.center.render(
                                         &self.project,
                                         &self.follower_states,

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3680,8 +3680,10 @@ impl Render for Workspace {
                             )
                             // Panes
                             .child(
-                                v_stack()
-                                    .flex_grow()
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
                                     .overflow_hidden()
                                     .h_full()
                                     .child(self.center.render(


### PR DESCRIPTION
This PR fixes the sizing of the workspace, specifically with regards to the center pane.

This fixes the issue where the tab bar would get clipped when its width exceeded the size of the screen.

<img width="1298" alt="Screenshot 2023-12-12 at 8 36 15 PM" src="https://github.com/zed-industries/zed/assets/1486634/592d7c6d-6901-4bd4-b5e7-e30bcad67e21">

Release Notes:

- N/A
