### PR TITLE
Fix tab bar drop target sizing

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1664,6 +1664,10 @@ impl Pane {
             )
             .child(
                 div()
+                    .min_w_6()
+                    // HACK: This empty child is currently necessary to force the drop traget to appear
+                    // despite us setting a min width above.
+                    .child("")
                     .h_full()
                     .flex_grow()
                     .drag_over::<DraggedTab>(|bar| {


### PR DESCRIPTION
This PR fixes an issue where the tab bar drop target was not receiving any size.

The styling isn't 100% correct yet, as the updated background color has a gap around it.

Release Notes:

- N/A