### PR TITLE
Deploy the buffer search in a second row in the toolbar

### DIFF
--- a/crates/search2/src/buffer_search.rs
+++ b/crates/search2/src/buffer_search.rs
@@ -23,7 +23,7 @@ use util::ResultExt;
 use workspace::{
     item::ItemHandle,
     searchable::{Direction, SearchEvent, SearchableItemHandle, WeakSearchableItemHandle},
-    ToolbarItemLocation, ToolbarItemView, Workspace,
+    ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
 };
 
 #[derive(PartialEq, Clone, Deserialize)]
@@ -456,6 +456,9 @@ impl BufferSearchBar {
             cx.focus(&handle);
         }
         cx.emit(Event::UpdateLocation);
+        cx.emit(ToolbarItemEvent::ChangeLocation(
+            ToolbarItemLocation::Hidden,
+        ));
         cx.notify();
     }
 
@@ -488,6 +491,9 @@ impl BufferSearchBar {
         self.dismissed = false;
         cx.notify();
         cx.emit(Event::UpdateLocation);
+        cx.emit(ToolbarItemEvent::ChangeLocation(
+            ToolbarItemLocation::Secondary,
+        ));
         true
     }
 

--- a/crates/workspace2/src/toolbar.rs
+++ b/crates/workspace2/src/toolbar.rs
@@ -74,12 +74,24 @@ impl Toolbar {
             }
         })
     }
+
+    fn secondary_items(&self) -> impl Iterator<Item = &dyn ToolbarItemViewHandle> {
+        self.items.iter().filter_map(|(item, location)| {
+            if *location == ToolbarItemLocation::Secondary {
+                Some(item.as_ref())
+            } else {
+                None
+            }
+        })
+    }
 }
 
 impl Render for Toolbar {
     type Element = Div;
 
     fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+        let secondary_item = self.secondary_items().next().map(|item| item.to_any());
+
         v_stack()
             .border_b()
             .border_color(cx.theme().colors().border_variant)
@@ -87,8 +99,10 @@ impl Render for Toolbar {
             .child(
                 h_stack()
                     .justify_between()
-                    .children(self.items.iter().map(|(child, _)| child.to_any())),
+                    .child(h_stack().children(self.left_items().map(|item| item.to_any())))
+                    .child(h_stack().children(self.right_items().map(|item| item.to_any()))),
             )
+            .children(secondary_item)
     }
 }
 


### PR DESCRIPTION
This PR updates the buffer search to deploy to a second row in the toolbar, instead of trying to deploy into the initial row.

This is the same way it works in Zed1.

Release Notes:

- N/A
