### PR TITLE
Don't show empty documentation labels in completions menu

### DIFF
--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -1250,6 +1250,7 @@ impl CompletionsMenu {
                         let documentation_label =
                             if let Some(Documentation::SingleLine(text)) = documentation {
                                 Some(SharedString::from(text.clone()))
+                                    .filter(|text| !text.trim().is_empty())
                             } else {
                                 None
                             };


### PR DESCRIPTION
This PR fixes an issue where we would sometimes have extra blank lines in the completions menu.

This was due to some items including documentation labels that were empty strings.

Release Notes:

- N/A
