### PR TITLE
Fix styling of project search tabs

### DIFF
--- a/crates/search2/src/project_search.rs
+++ b/crates/search2/src/project_search.rs
@@ -417,7 +417,12 @@ impl Item for ProjectSearchView {
             .filter(|query| !query.is_empty())
             .unwrap_or_else(|| "Project search".into());
         h_stack()
-            .child(IconElement::new(Icon::MagnifyingGlass))
+            .gap_2()
+            .child(IconElement::new(Icon::MagnifyingGlass).color(if selected {
+                Color::Default
+            } else {
+                Color::Muted
+            }))
             .child(Label::new(tab_name).color(if selected {
                 Color::Default
             } else {


### PR DESCRIPTION
This PR fixes the styling of the project search tabs.

We now have spacing between the icon and the tab label, as well as use the correct color for the icon based on whether the tab is active or not.

Release Notes:

- N/A
