### PR TITLE
Add config files for running Postgres inside Docker Compose

### DIFF
--- a/docker-compose.sql
+++ b/docker-compose.sql
@@ -1,0 +1,1 @@
+create database zed;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: zed_postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker-compose.sql:/docker-entrypoint-initdb.d/init.sql
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
This PR adds config files for running the Postgres instance for local Zed development in a Docker Compose instance.

For those of us who don't like to have a Postgres install always present on the host system 😄 

Usage:

```
docker compose up -d
```

Release Notes:

- N/A
