### PR TITLE
calls: Fix off by one in prompts for leaving a call.

### DIFF
--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -1145,7 +1145,7 @@ impl Workspace {
         let window = cx.window_handle();
 
         cx.spawn(|this, mut cx| async move {
-            let workspace_count = cx.update(|_, cx| {
+            let workspace_count = (*cx).update(|cx| {
                 cx.windows()
                     .iter()
                     .filter(|window| window.downcast::<Workspace>().is_some())


### PR DESCRIPTION
We've noticed how leaving a call with multiple windows open would still prompt with the popup along the lines of "Do you want to leave the current call?". In Zed1, that popup only showed up when you've had just one window open.

The code for prompting did not change at all between zed1 and zed2, but the way we calculate the window count did. Calling AppContext::windows to get all window handles from WindowContext::update essentially excluded the window we were updating (that is the window being closed) from the returned Vec of window handles. I've decided to keep the code as close to original as possible (as the alternative would be to change the \# of workspaces needed for a prompt to pop up). We now query the window handles via a deref to AsyncAppContext, which does not exclude "our" window handle from the returned results.

Release Notes:

- N/A
