### PR TITLE
Status color tinting

### DIFF
--- a/crates/collab_ui2/src/collab_titlebar_item.rs
+++ b/crates/collab_ui2/src/collab_titlebar_item.rs
@@ -10,7 +10,7 @@ use gpui::{
 use project::{Project, RepositoryEntry};
 use recent_projects::RecentProjects;
 use std::sync::Arc;
-use theme::{ActiveTheme, PlayerColors};
+use theme::{ActiveTheme, PlayerColors, StatusColor};
 use ui::{
     h_stack, popover_menu, prelude::*, Avatar, Button, ButtonLike, ButtonStyle, ContextMenu, Icon,
     IconButton, IconElement, KeyBinding, Tooltip,
@@ -169,6 +169,7 @@ impl Render for CollabTitlebarItem {
                         let is_shared = self.project.read(cx).is_shared();
                         let is_muted = room.is_muted(cx);
                         let is_deafened = room.is_deafened().unwrap_or(false);
+                        let is_sharing_screen = room.is_screen_sharing();
 
                         this.child(
                             Button::new(
@@ -227,6 +228,8 @@ impl Render for CollabTitlebarItem {
                         .child(
                             IconButton::new("screen-share", ui::Icon::Screen)
                                 .style(ButtonStyle::Subtle)
+                                .selected(is_sharing_screen)
+                                .selected_style(Some(ButtonStyle::Tinted(StatusColor::Info)))
                                 .on_click(move |_, cx| {
                                     crate::toggle_screen_sharing(&Default::default(), cx)
                                 }),

--- a/crates/theme2/src/styles/status.rs
+++ b/crates/theme2/src/styles/status.rs
@@ -3,7 +3,7 @@ use refineable::Refineable;
 
 use crate::{blue, color_alpha, grass, neutral, red, yellow, ActiveTheme};
 
-#[derive(Clone, Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub enum StatusColor {
     Conflict,
     Created,
@@ -21,43 +21,44 @@ pub enum StatusColor {
     Warning,
 }
 
-impl StatusColor {
-    pub fn fg(self, cx: &mut WindowContext) -> Hsla {
-        match self {
-            Self::Conflict => cx.theme().status().conflict,
-            Self::Created => cx.theme().status().created,
-            Self::Deleted => cx.theme().status().deleted,
-            Self::Error => cx.theme().status().error,
-            Self::Hidden => cx.theme().status().hidden,
-            Self::Hint => cx.theme().status().hint,
-            Self::Ignored => cx.theme().status().ignored,
-            Self::Info => cx.theme().status().info,
-            Self::Modified => cx.theme().status().modified,
-            Self::Predictive => cx.theme().status().predictive,
-            Self::Renamed => cx.theme().status().renamed,
-            Self::Success => cx.theme().status().success,
-            Self::Unreachable => cx.theme().status().unreachable,
-            Self::Warning => cx.theme().status().warning,
-        }
-    }
+macro_rules! status_color_functions {
+    ($($fn_name:ident, $alpha:expr);+ $(;)?) => {
+        $(
+            pub fn $fn_name(self, cx: &mut WindowContext) -> Hsla {
+                match self {
+                    Self::Conflict => color_alpha(cx.theme().status().conflict, $alpha),
+                    Self::Created => color_alpha(cx.theme().status().created, $alpha),
+                    Self::Deleted => color_alpha(cx.theme().status().deleted, $alpha),
+                    Self::Error => color_alpha(cx.theme().status().error, $alpha),
+                    Self::Hidden => color_alpha(cx.theme().status().hidden, $alpha),
+                    Self::Hint => color_alpha(cx.theme().status().hint, $alpha),
+                    Self::Ignored => color_alpha(cx.theme().status().ignored, $alpha),
+                    Self::Info => color_alpha(cx.theme().status().info, $alpha),
+                    Self::Modified => color_alpha(cx.theme().status().modified, $alpha),
+                    Self::Predictive => color_alpha(cx.theme().status().predictive, $alpha),
+                    Self::Renamed => color_alpha(cx.theme().status().renamed, $alpha),
+                    Self::Success => color_alpha(cx.theme().status().success, $alpha),
+                    Self::Unreachable => color_alpha(cx.theme().status().unreachable, $alpha),
+                    Self::Warning => color_alpha(cx.theme().status().warning, $alpha),
+                }
+            }
+        )+
+    };
+}
 
-    pub fn bg(self, cx: &mut WindowContext) -> Hsla {
-        match self {
-            Self::Conflict => color_alpha(cx.theme().status().conflict, 0.12),
-            Self::Created => color_alpha(cx.theme().status().created, 0.12),
-            Self::Deleted => color_alpha(cx.theme().status().deleted, 0.12),
-            Self::Error => color_alpha(cx.theme().status().error, 0.12),
-            Self::Hidden => color_alpha(cx.theme().status().hidden, 0.12),
-            Self::Hint => color_alpha(cx.theme().status().hint, 0.12),
-            Self::Ignored => color_alpha(cx.theme().status().ignored, 0.12),
-            Self::Info => color_alpha(cx.theme().status().info, 0.12),
-            Self::Modified => color_alpha(cx.theme().status().modified, 0.12),
-            Self::Predictive => color_alpha(cx.theme().status().predictive, 0.12),
-            Self::Renamed => color_alpha(cx.theme().status().renamed, 0.12),
-            Self::Success => color_alpha(cx.theme().status().success, 0.12),
-            Self::Unreachable => color_alpha(cx.theme().status().unreachable, 0.12),
-            Self::Warning => color_alpha(cx.theme().status().warning, 0.12),
-        }
+impl StatusColor {
+    status_color_functions! {
+        fg, 1.0;
+        fg_hover, 0.9;
+        fb_disabled, 0.5;
+        bg, 0.12;
+        bg_hover, 0.16;
+        bg_active, 0.24;
+        bg_disabled, 0.08;
+        border, 0.15;
+        border_hover, 0.2;
+        border_active, 0.3;
+        border_disabled, 0.1;
     }
 }
 

--- a/crates/theme2/src/styles/status.rs
+++ b/crates/theme2/src/styles/status.rs
@@ -1,7 +1,65 @@
-use gpui::Hsla;
+use gpui::{Hsla, WindowContext};
 use refineable::Refineable;
 
-use crate::{blue, grass, neutral, red, yellow};
+use crate::{blue, color_alpha, grass, neutral, red, yellow, ActiveTheme};
+
+#[derive(Clone, Debug)]
+pub enum StatusColor {
+    Conflict,
+    Created,
+    Deleted,
+    Error,
+    Hidden,
+    Hint,
+    Ignored,
+    Info,
+    Modified,
+    Predictive,
+    Renamed,
+    Success,
+    Unreachable,
+    Warning,
+}
+
+impl StatusColor {
+    pub fn fg(self, cx: &mut WindowContext) -> Hsla {
+        match self {
+            Self::Conflict => cx.theme().status().conflict,
+            Self::Created => cx.theme().status().created,
+            Self::Deleted => cx.theme().status().deleted,
+            Self::Error => cx.theme().status().error,
+            Self::Hidden => cx.theme().status().hidden,
+            Self::Hint => cx.theme().status().hint,
+            Self::Ignored => cx.theme().status().ignored,
+            Self::Info => cx.theme().status().info,
+            Self::Modified => cx.theme().status().modified,
+            Self::Predictive => cx.theme().status().predictive,
+            Self::Renamed => cx.theme().status().renamed,
+            Self::Success => cx.theme().status().success,
+            Self::Unreachable => cx.theme().status().unreachable,
+            Self::Warning => cx.theme().status().warning,
+        }
+    }
+
+    pub fn bg(self, cx: &mut WindowContext) -> Hsla {
+        match self {
+            Self::Conflict => color_alpha(cx.theme().status().conflict, 0.12),
+            Self::Created => color_alpha(cx.theme().status().created, 0.12),
+            Self::Deleted => color_alpha(cx.theme().status().deleted, 0.12),
+            Self::Error => color_alpha(cx.theme().status().error, 0.12),
+            Self::Hidden => color_alpha(cx.theme().status().hidden, 0.12),
+            Self::Hint => color_alpha(cx.theme().status().hint, 0.12),
+            Self::Ignored => color_alpha(cx.theme().status().ignored, 0.12),
+            Self::Info => color_alpha(cx.theme().status().info, 0.12),
+            Self::Modified => color_alpha(cx.theme().status().modified, 0.12),
+            Self::Predictive => color_alpha(cx.theme().status().predictive, 0.12),
+            Self::Renamed => color_alpha(cx.theme().status().renamed, 0.12),
+            Self::Success => color_alpha(cx.theme().status().success, 0.12),
+            Self::Unreachable => color_alpha(cx.theme().status().unreachable, 0.12),
+            Self::Warning => color_alpha(cx.theme().status().warning, 0.12),
+        }
+    }
+}
 
 #[derive(Refineable, Clone, Debug)]
 #[refineable(Debug, serde::Deserialize)]

--- a/crates/ui2/src/components/button/button.rs
+++ b/crates/ui2/src/components/button/button.rs
@@ -18,6 +18,7 @@ pub struct Button {
     icon_size: Option<IconSize>,
     icon_color: Option<Color>,
     selected_icon: Option<Icon>,
+    selected_style: Option<ButtonStyle>,
 }
 
 impl Button {
@@ -32,6 +33,7 @@ impl Button {
             icon_size: None,
             icon_color: None,
             selected_icon: None,
+            selected_style: None,
         }
     }
 
@@ -124,6 +126,11 @@ impl ButtonCommon for Button {
 
     fn tooltip(mut self, tooltip: impl Fn(&mut WindowContext) -> AnyView + 'static) -> Self {
         self.base = self.base.tooltip(tooltip);
+        self
+    }
+
+    fn selected_style(mut self, style: impl Into<Option<ButtonStyle>>) -> Self {
+        self.selected_style = style.into();
         self
     }
 }

--- a/crates/ui2/src/components/button/icon_button.rs
+++ b/crates/ui2/src/components/button/icon_button.rs
@@ -12,6 +12,7 @@ pub struct IconButton {
     icon_size: IconSize,
     icon_color: Color,
     selected_icon: Option<Icon>,
+    selected_style: Option<ButtonStyle>,
 }
 
 impl IconButton {
@@ -22,6 +23,7 @@ impl IconButton {
             icon_size: IconSize::default(),
             icon_color: Color::Default,
             selected_icon: None,
+            selected_style: None,
         }
     }
 
@@ -94,6 +96,11 @@ impl ButtonCommon for IconButton {
 
     fn tooltip(mut self, tooltip: impl Fn(&mut WindowContext) -> AnyView + 'static) -> Self {
         self.base = self.base.tooltip(tooltip);
+        self
+    }
+
+    fn selected_style(mut self, style: impl Into<Option<ButtonStyle>>) -> Self {
+        self.selected_style = style.into();
         self
     }
 }


### PR DESCRIPTION
[[PR Description]]

This allows us to create states from status colors and use them for things like tinted buttons, tinted surfaces (like hover diagnostic error backgrounds, etc)

TODO:

- [ ] Resolve correct tinted color in ButtonStyle::Tinted test
- [ ] Make a story/update button story with tinting examples

Release Notes:

- N/A
