### PR TITLE
Fix warning in release mode

### DIFF
--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -544,17 +544,20 @@ pub type ActionListener = Box<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext
 
 #[track_caller]
 pub fn div() -> Div {
-    let mut div = Div {
-        interactivity: Interactivity::default(),
-        children: SmallVec::default(),
+    #[cfg(debug_assertions)]
+    let interactivity = {
+        let mut interactivity = Interactivity::default();
+        interactivity.location = Some(*core::panic::Location::caller());
+        interactivity
     };
 
-    #[cfg(debug_assertions)]
-    {
-        div.interactivity.location = Some(*core::panic::Location::caller());
-    }
+    #[cfg(not(debug_assertions))]
+    let interactivity = Interactivity::default();
 
-    div
+    Div {
+        interactivity,
+        children: SmallVec::default(),
+    }
 }
 
 pub struct Div {


### PR DESCRIPTION
This PR fixes a warning that was present in release mode, which was preventing the nightly builds from running:

```
error: variable does not need to be mutable
   --> crates/gpui2/src/elements/div.rs:547:9
    |
547 |     let mut div = Div {
    |         ----^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `-D unused-mut` implied by `-D warnings`
```

Release Notes:

- N/A
