### PR TITLE
zed2: Restore buffer search deploy & focus behavior

### DIFF
--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -9739,12 +9739,8 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, is_valid: bool) -> Rend
         };
         highlighted_lines.push(line);
     }
-    let message = diagnostic.message;
     Arc::new(move |cx: &mut BlockContext| {
-        let message = message.clone();
         let copy_id: SharedString = format!("copy-{}", cx.block_id.clone()).to_string().into();
-        let write_to_clipboard = cx.write_to_clipboard(ClipboardItem::new(message.clone()));
-
         // TODO: Nate: We should tint the background of the block with the severity color
         // We need to extend the theme before we can do this
         v_stack()
@@ -9754,7 +9750,6 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, is_valid: bool) -> Rend
             .bg(gpui::red())
             .children(highlighted_lines.iter().map(|(line, highlights)| {
                 let group_id = cx.block_id.to_string();
-
                 h_stack()
                     .group(group_id.clone())
                     .gap_2()
@@ -9769,7 +9764,12 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, is_valid: bool) -> Rend
                                 .size(ButtonSize::Compact)
                                 .style(ButtonStyle::Transparent)
                                 .visible_on_hover(group_id)
-                                .on_click(cx.listener(move |_, _, cx| write_to_clipboard))
+                                .on_click(cx.listener({
+                                    let message = diagnostic.message.clone();
+                                    move |_, _, cx| {
+                                        cx.write_to_clipboard(ClipboardItem::new(message.clone()))
+                                    }
+                                }))
                                 .tooltip(|cx| Tooltip::text("Copy diagnostic message", cx)),
                         ),
                     )

--- a/crates/editor2/src/element.rs
+++ b/crates/editor2/src/element.rs
@@ -2284,8 +2284,8 @@ impl EditorElement {
                                 .cursor_pointer()
                                 .hover(|style| style.bg(cx.theme().colors().element_hover))
                                 .on_click(cx.listener(|_editor, _event, _cx| {
-                                    // TODO: Implement collapsing path headers
-                                    todo!("Clicking path header")
+                                    // todo!() Implement collapsing path headers
+                                    // todo!("Clicking path header")
                                 }))
                                 .child(
                                     h_stack()

--- a/crates/gpui2/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui2/src/platform/mac/metal_renderer.rs
@@ -187,8 +187,6 @@ impl MetalRenderer {
     }
 
     pub fn draw(&mut self, scene: &Scene) {
-        let start = std::time::Instant::now();
-
         let layer = self.layer.clone();
         let viewport_size = layer.drawable_size();
         let viewport_size: Size<DevicePixels> = size(
@@ -305,9 +303,6 @@ impl MetalRenderer {
 
         command_buffer.commit();
         self.sprite_atlas.clear_textures(AtlasTextureKind::Path);
-
-        let duration_since_start = start.elapsed();
-        println!("renderer draw: {:?}", duration_since_start);
 
         command_buffer.wait_until_completed();
         drawable.present();

--- a/crates/gpui2/src/view.rs
+++ b/crates/gpui2/src/view.rs
@@ -209,20 +209,9 @@ impl AnyView {
         cx: &mut WindowContext,
     ) {
         cx.with_absolute_element_offset(origin, |cx| {
-            let start_time = std::time::Instant::now();
             let (layout_id, mut rendered_element) = (self.layout)(self, cx);
-            let duration = start_time.elapsed();
-            println!("request layout: {:?}", duration);
-
-            let start_time = std::time::Instant::now();
             cx.compute_layout(layout_id, available_space);
-            let duration = start_time.elapsed();
-            println!("compute layout: {:?}", duration);
-
-            let start_time = std::time::Instant::now();
             (self.paint)(self, &mut rendered_element, cx);
-            let duration = start_time.elapsed();
-            println!("paint: {:?}", duration);
         })
     }
 }

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -1255,7 +1255,6 @@ impl<'a> WindowContext<'a> {
 
     /// Draw pixels to the display for this window based on the contents of its scene.
     pub(crate) fn draw(&mut self) -> Scene {
-        let t0 = std::time::Instant::now();
         self.window.dirty = false;
         self.window.drawing = true;
 
@@ -1347,7 +1346,6 @@ impl<'a> WindowContext<'a> {
         }
 
         self.window.drawing = false;
-        eprintln!("window draw: {:?}", t0.elapsed());
 
         scene
     }

--- a/crates/search2/src/buffer_search.rs
+++ b/crates/search2/src/buffer_search.rs
@@ -338,7 +338,9 @@ impl BufferSearchBar {
             pane.update(cx, |this, cx| {
                 this.toolbar().update(cx, |this, cx| {
                     if let Some(search_bar) = this.item_of_type::<BufferSearchBar>() {
-                        search_bar.update(cx, |this, cx| this.toggle(deploy, cx));
+                        search_bar.update(cx, |this, cx| {
+                            this.deploy(deploy, cx);
+                        });
                         return;
                     }
                     let view = cx.build_view(|cx| BufferSearchBar::new(cx));
@@ -1483,9 +1485,9 @@ mod tests {
                     search_bar.select_all_matches(&SelectAllMatches, cx);
                 });
                 assert!(
-                editor.update(cx, |this, cx| !this.is_focused(cx.window_context())),
-                "Should not switch focus to editor if SelectAllMatches does not find any matches"
-            );
+                    editor.update(cx, |this, cx| !this.is_focused(cx.window_context())),
+                    "Should not switch focus to editor if SelectAllMatches does not find any matches"
+                );
                 search_bar.update(cx, |search_bar, cx| {
                     let all_selections =
                         editor.update(cx, |editor, cx| editor.selections.display_ranges(cx));
@@ -1651,6 +1653,7 @@ mod tests {
             assert_eq!(search_bar.search_options, SearchOptions::NONE);
         });
     }
+
     #[gpui::test]
     async fn test_replace_simple(cx: &mut TestAppContext) {
         let (editor, search_bar, cx) = init_test(cx);


### PR DESCRIPTION
In zed1, cmd-f either opened the search buffer, or focused into it if it was open already. Search query got updated, if any selection was made on the moment of cmd-f call.

The PR restores that behavior and also

* fixes a bug when opened diagnostics error always got pasted
* comments out the panic on multibuffer separator click 
* removes extra stdout & stderr debug logging

Release Notes:

- N/A