### PR TITLE
Port `language_tools` crate to gpui2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12198,6 +12198,7 @@ dependencies = [
  "journal2",
  "language2",
  "language_selector2",
+ "language_tools2",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5008,6 +5008,7 @@ dependencies = [
  "settings2",
  "theme2",
  "tree-sitter",
+ "ui2",
  "unindent",
  "util",
  "workspace2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,6 +4991,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "language_tools2"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "client2",
+ "collections",
+ "editor2",
+ "env_logger 0.9.3",
+ "futures 0.3.28",
+ "gpui2",
+ "language2",
+ "lsp2",
+ "project2",
+ "serde",
+ "settings2",
+ "theme2",
+ "tree-sitter",
+ "unindent",
+ "util",
+ "workspace2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "crates/language_selector",
     "crates/language_selector2",
     "crates/language_tools",
+    "crates/language_tools2",
     "crates/live_kit_client",
     "crates/live_kit_server",
     "crates/lsp",

--- a/crates/collab_ui2/src/collab_titlebar_item.rs
+++ b/crates/collab_ui2/src/collab_titlebar_item.rs
@@ -68,7 +68,6 @@ impl Render for CollabTitlebarItem {
 
         h_stack()
             .id("titlebar")
-            .z_index(160) // todo!("z-index")
             .justify_between()
             .w_full()
             .h(rems(1.75))

--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -1652,14 +1652,11 @@ impl Editor {
         Self::new(EditorMode::SingleLine, buffer, None, cx)
     }
 
-    //     pub fn multi_line(
-    //         field_editor_style: Option<Arc<GetFieldEditorTheme>>,
-    //         cx: &mut ViewContext<Self>,
-    //     ) -> Self {
-    //         let buffer = cx.build_model(|cx| Buffer::new(0, cx.model_id() as u64, String::new()));
-    //         let buffer = cx.build_model(|cx| MultiBuffer::singleton(buffer, cx));
-    //         Self::new(EditorMode::Full, buffer, None, field_editor_style, cx)
-    //     }
+    pub fn multi_line(cx: &mut ViewContext<Self>) -> Self {
+        let buffer = cx.build_model(|cx| Buffer::new(0, cx.entity_id().as_u64(), String::new()));
+        let buffer = cx.build_model(|cx| MultiBuffer::singleton(buffer, cx));
+        Self::new(EditorMode::Full, buffer, None, cx)
+    }
 
     pub fn auto_height(max_lines: usize, cx: &mut ViewContext<Self>) -> Self {
         let buffer = cx.build_model(|cx| Buffer::new(0, cx.entity_id().as_u64(), String::new()));

--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -1427,16 +1427,7 @@ impl Interactivity {
                 let line_height = cx.line_height();
                 let scroll_max = (content_size - bounds.size).max(&Size::default());
                 let interactive_bounds = interactive_bounds.clone();
-            let id = self.element_id.clone();
                 cx.on_mouse_event(move |event: &ScrollWheelEvent, phase, cx| {
-                if id == Some(ElementId::Name("SyntaxTreeView".into())) {
-                    dbg!(
-                        &overflow,
-                        event.position,
-                        &interactive_bounds,
-                        interactive_bounds.visibly_contains(&event.position, cx)
-                    );
-                }
                     if phase == DispatchPhase::Bubble
                         && interactive_bounds.visibly_contains(&event.position, cx)
                     {
@@ -1450,15 +1441,9 @@ impl Interactivity {
                         }
 
                         if overflow.y == Overflow::Scroll {
-                            if id == Some(ElementId::Name("SyntaxTreeView".into())) {
-                            println!("prev scroll offset: {old_scroll_offset:?}, scroll_max: {scroll_max:?}, delta:{delta:?}");
+                            scroll_offset.y =
+                                (scroll_offset.y + delta.y).clamp(-scroll_max.height, px(0.));
                         }
-                        scroll_offset.y =
-                            (scroll_offset.y + delta.y).clamp(-scroll_max.height, px(0.));
-                        if id == Some(ElementId::Name("SyntaxTreeView".into())) {
-                            println!("new scroll offset: {scroll_offset:?}, scroll_max: {scroll_max:?}, delta:{delta:?}");
-                        }
-                    }
 
                         if *scroll_offset != old_scroll_offset {
                             cx.notify();
@@ -1501,16 +1486,16 @@ impl Interactivity {
                     }
 
                     cx.with_z_index(style.z_index.unwrap_or(0), |cx| {
-                    if style.background.as_ref().is_some_and(|fill| {
-                        fill.color().is_some_and(|color| !color.is_transparent())
-                    }) {
-                        cx.add_opaque_layer(bounds)
-                    }
+                        if style.background.as_ref().is_some_and(|fill| {
+                            fill.color().is_some_and(|color| !color.is_transparent())
+                        }) {
+                            cx.add_opaque_layer(bounds)
+                        }
 
-                    f(style, scroll_offset.unwrap_or_default(), cx)
-                })
-            },
-        );
+                        f(style, scroll_offset.unwrap_or_default(), cx)
+                    })
+                },
+            );
 
             if let Some(group) = self.group.as_ref() {
                 GroupBounds::pop(group, cx);

--- a/crates/gpui2/src/elements/uniform_list.rs
+++ b/crates/gpui2/src/elements/uniform_list.rs
@@ -91,6 +91,14 @@ impl UniformListScrollHandle {
             }
         }
     }
+
+    pub fn scroll_top(&self) -> Pixels {
+        if let Some(state) = &*self.0.borrow() {
+            -state.scroll_offset.borrow().y
+        } else {
+            Pixels::ZERO
+        }
+    }
 }
 
 impl Styled for UniformList {

--- a/crates/gpui2/src/elements/uniform_list.rs
+++ b/crates/gpui2/src/elements/uniform_list.rs
@@ -127,6 +127,7 @@ impl Element for UniformList {
             .map(|s| s.item_size)
             .unwrap_or_else(|| self.measure_item(None, cx));
 
+        let element_id = self.interactivity.element_id.clone();
         let (layout_id, interactive) =
             self.interactivity
                 .layout(state.map(|s| s.interactive), cx, |style, cx| {
@@ -143,6 +144,10 @@ impl Element for UniformList {
                                             item_size.width
                                         }
                                     });
+
+                            if element_id == Some(ElementId::Name("SyntaxTreeView".into())) {
+                                dbg!(known_dimensions, available_space.height);
+                            }
                             let height = match available_space.height {
                                 AvailableSpace::Definite(height) => desired_height.min(height),
                                 AvailableSpace::MinContent | AvailableSpace::MaxContent => {

--- a/crates/gpui2/src/elements/uniform_list.rs
+++ b/crates/gpui2/src/elements/uniform_list.rs
@@ -127,7 +127,6 @@ impl Element for UniformList {
             .map(|s| s.item_size)
             .unwrap_or_else(|| self.measure_item(None, cx));
 
-        let element_id = self.interactivity.element_id.clone();
         let (layout_id, interactive) =
             self.interactivity
                 .layout(state.map(|s| s.interactive), cx, |style, cx| {
@@ -145,9 +144,6 @@ impl Element for UniformList {
                                         }
                                     });
 
-                            if element_id == Some(ElementId::Name("SyntaxTreeView".into())) {
-                                dbg!(known_dimensions, available_space.height);
-                            }
                             let height = match available_space.height {
                                 AvailableSpace::Definite(height) => desired_height.min(height),
                                 AvailableSpace::MinContent | AvailableSpace::MaxContent => {

--- a/crates/language_tools2/Cargo.toml
+++ b/crates/language_tools2/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "language_tools2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/language_tools.rs"
+doctest = false
+
+[dependencies]
+collections = { path = "../collections" }
+editor = { package = "editor2", path = "../editor2" }
+settings = { package = "settings2", path = "../settings2" }
+theme = { package = "theme2", path = "../theme2" }
+language = { package = "language2", path = "../language2" }
+project = { package = "project2", path = "../project2" }
+workspace = { package = "workspace2", path = "../workspace2" }
+gpui = { package = "gpui2", path = "../gpui2" }
+util = { path = "../util" }
+lsp = { package = "lsp2", path = "../lsp2" }
+futures.workspace = true
+serde.workspace = true
+anyhow.workspace = true
+tree-sitter.workspace = true
+
+[dev-dependencies]
+client = { package = "client2", path = "../client2", features = ["test-support"] }
+editor = { package = "editor2", path = "../editor2", features = ["test-support"] }
+gpui = { package = "gpui2", path = "../gpui2", features = ["test-support"] }
+util = { path = "../util", features = ["test-support"] }
+env_logger.workspace = true
+unindent.workspace = true

--- a/crates/language_tools2/Cargo.toml
+++ b/crates/language_tools2/Cargo.toml
@@ -17,6 +17,7 @@ language = { package = "language2", path = "../language2" }
 project = { package = "project2", path = "../project2" }
 workspace = { package = "workspace2", path = "../workspace2" }
 gpui = { package = "gpui2", path = "../gpui2" }
+ui = { package = "ui2", path = "../ui2" }
 util = { path = "../util" }
 lsp = { package = "lsp2", path = "../lsp2" }
 futures.workspace = true

--- a/crates/language_tools2/src/language_tools.rs
+++ b/crates/language_tools2/src/language_tools.rs
@@ -1,0 +1,15 @@
+mod lsp_log;
+mod syntax_tree_view;
+
+#[cfg(test)]
+mod lsp_log_tests;
+
+use gpui::AppContext;
+
+pub use lsp_log::{LogStore, LspLogToolbarItemView, LspLogView};
+pub use syntax_tree_view::{SyntaxTreeToolbarItemView, SyntaxTreeView};
+
+pub fn init(cx: &mut AppContext) {
+    lsp_log::init(cx);
+    syntax_tree_view::init(cx);
+}

--- a/crates/language_tools2/src/lsp_log.rs
+++ b/crates/language_tools2/src/lsp_log.rs
@@ -741,11 +741,13 @@ impl Render for LspLogToolbarItemView {
         let _server_selected = current_server.is_some();
 
         let lsp_menu = h_stack()
+            .size_full()
             .child(Self::render_language_server_menu_header(current_server, cx))
             .children(if self.menu_open {
                 Some(
                     overlay().child(
                         v_stack()
+                            .size_full()
                             // todo!()
                             // .scrollable::<LspLogScroll>(0, None, cx)
                             .children(menu_rows.into_iter().map(|row| {
@@ -769,11 +771,11 @@ impl Render for LspLogToolbarItemView {
                        // .with_hoverable(true)
                        // .with_fit_mode(OverlayFitMode::SwitchAnchor)
                        // .with_anchor_corner(AnchorCorner::TopLeft)
-                       // .with_z_index(999),
                 )
             } else {
                 None
-            });
+            })
+            .z_index(99);
 
         let log_cleanup_button = div()
             .child(Label::new("Clear"))
@@ -794,6 +796,7 @@ impl Render for LspLogToolbarItemView {
             .cursor(CursorStyle::PointingHand);
 
         h_stack()
+            .size_full()
             .child(lsp_menu)
             .child(log_cleanup_button)
             .border_1()
@@ -897,6 +900,7 @@ impl LspLogToolbarItemView {
         cx: &mut ViewContext<Self>,
     ) -> Div {
         v_stack()
+            .size_full()
             .child(Label::new(format!("{} ({})", name.0, worktree_root_name)))
             .child(
                 div()
@@ -911,6 +915,7 @@ impl LspLogToolbarItemView {
             )
             .child(
                 h_stack()
+                    .size_full()
                     .child(Label::new(RPC_MESSAGES))
                     .child(
                         Checkbox::new(
@@ -940,6 +945,7 @@ impl LspLogToolbarItemView {
             )
             .border_1()
             .border_color(red())
+            .bg(red())
     }
 }
 

--- a/crates/language_tools2/src/lsp_log.rs
+++ b/crates/language_tools2/src/lsp_log.rs
@@ -3,9 +3,8 @@ use editor::{Editor, EditorElement, EditorEvent, MoveToEnd};
 use futures::{channel::mpsc, StreamExt};
 use gpui::{
     actions, div, AnchorCorner, AnyElement, AppContext, Context, Div, EventEmitter, FocusHandle,
-    FocusableView, InteractiveElement, IntoElement, Model, ModelContext, MouseButton,
-    ParentElement, Render, Styled, Subscription, View, ViewContext, VisualContext, WeakModel,
-    WindowContext,
+    FocusableView, IntoElement, Model, ModelContext, ParentElement, Render, Styled, Subscription,
+    View, ViewContext, VisualContext, WeakModel, WindowContext,
 };
 use language::{LanguageServerId, LanguageServerName};
 use lsp::IoKind;
@@ -776,47 +775,48 @@ impl Render for LspLogToolbarItemView {
                             );
                         }
 
-                        menu = menu.custom_entry({
-                            let log_view = log_view.clone();
-                            let log_toolbar_view = log_toolbar_view.clone();
-                            move |cx| {
-                                h_stack()
-                                    .w_full()
-                                    .justify_between()
-                                    .child(Label::new(RPC_MESSAGES))
-                                    .child(
-                                        Checkbox::new(
-                                            ix,
-                                            if row.rpc_trace_enabled {
-                                                Selection::Selected
-                                            } else {
-                                                Selection::Unselected
-                                            },
-                                        )
-                                        .on_click(
-                                            cx.listener_for(
-                                                &log_toolbar_view,
-                                                move |view, selection, cx| {
-                                                    let enabled =
-                                                        matches!(selection, Selection::Selected);
-                                                    view.toggle_logging_for_server(
-                                                        row.server_id,
-                                                        enabled,
-                                                        cx,
-                                                    );
-                                                },
+                        menu = menu.custom_entry(
+                            {
+                                let log_toolbar_view = log_toolbar_view.clone();
+                                move |cx| {
+                                    h_stack()
+                                        .w_full()
+                                        .justify_between()
+                                        .child(Label::new(RPC_MESSAGES))
+                                        .child(
+                                            div().z_index(120).child(
+                                                Checkbox::new(
+                                                    ix,
+                                                    if row.rpc_trace_enabled {
+                                                        Selection::Selected
+                                                    } else {
+                                                        Selection::Unselected
+                                                    },
+                                                )
+                                                .on_click(cx.listener_for(
+                                                    &log_toolbar_view,
+                                                    move |view, selection, cx| {
+                                                        let enabled = matches!(
+                                                            selection,
+                                                            Selection::Selected
+                                                        );
+                                                        view.toggle_logging_for_server(
+                                                            row.server_id,
+                                                            enabled,
+                                                            cx,
+                                                        );
+                                                        cx.stop_propagation();
+                                                    },
+                                                )),
                                             ),
-                                        ),
-                                    )
-                                    .on_mouse_down(
-                                        MouseButton::Left,
-                                        cx.listener_for(&log_view, move |view, _, cx| {
-                                            view.show_rpc_trace_for_server(row.server_id, cx);
-                                        }),
-                                    )
-                                    .into_any_element()
-                            }
-                        });
+                                        )
+                                        .into_any_element()
+                                }
+                            },
+                            cx.handler_for(&log_view, move |view, cx| {
+                                view.show_rpc_trace_for_server(row.server_id, cx);
+                            }),
+                        );
                         if server_selected && row.rpc_trace_selected {
                             debug_assert_eq!(
                                 Some(ix * 3 + 2),

--- a/crates/language_tools2/src/lsp_log.rs
+++ b/crates/language_tools2/src/lsp_log.rs
@@ -1,0 +1,1023 @@
+use collections::{HashMap, VecDeque};
+use editor::{Editor, MoveToEnd};
+use futures::{channel::mpsc, StreamExt};
+use gpui::{
+    actions,
+    elements::{
+        AnchorCorner, ChildView, Empty, Flex, Label, MouseEventHandler, Overlay, OverlayFitMode,
+        ParentElement, Stack,
+    },
+    platform::{CursorStyle, MouseButton},
+    AnyElement, AppContext, Element, Entity, Model, ModelContext, Subscription, View, View,
+    ViewContext, WeakModel,
+};
+use language::{LanguageServerId, LanguageServerName};
+use lsp::IoKind;
+use project::{search::SearchQuery, Project};
+use std::{borrow::Cow, sync::Arc};
+use theme::{ui, Theme};
+use workspace::{
+    item::{Item, ItemHandle},
+    searchable::{SearchableItem, SearchableItemHandle},
+    ToolbarItemLocation, ToolbarItemView, Workspace, WorkspaceCreated,
+};
+
+const SEND_LINE: &str = "// Send:";
+const RECEIVE_LINE: &str = "// Receive:";
+const MAX_STORED_LOG_ENTRIES: usize = 2000;
+
+pub struct LogStore {
+    projects: HashMap<WeakModel<Project>, ProjectState>,
+    io_tx: mpsc::UnboundedSender<(WeakModel<Project>, LanguageServerId, IoKind, String)>,
+}
+
+struct ProjectState {
+    servers: HashMap<LanguageServerId, LanguageServerState>,
+    _subscriptions: [gpui::Subscription; 2],
+}
+
+struct LanguageServerState {
+    log_messages: VecDeque<String>,
+    rpc_state: Option<LanguageServerRpcState>,
+    _io_logs_subscription: Option<lsp::Subscription>,
+    _lsp_logs_subscription: Option<lsp::Subscription>,
+}
+
+struct LanguageServerRpcState {
+    rpc_messages: VecDeque<String>,
+    last_message_kind: Option<MessageKind>,
+}
+
+pub struct LspLogView {
+    pub(crate) editor: View<Editor>,
+    editor_subscription: Subscription,
+    log_store: Model<LogStore>,
+    current_server_id: Option<LanguageServerId>,
+    is_showing_rpc_trace: bool,
+    project: Model<Project>,
+    _log_store_subscriptions: Vec<Subscription>,
+}
+
+pub struct LspLogToolbarItemView {
+    log_view: Option<View<LspLogView>>,
+    _log_view_subscription: Option<Subscription>,
+    menu_open: bool,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum MessageKind {
+    Send,
+    Receive,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct LogMenuItem {
+    pub server_id: LanguageServerId,
+    pub server_name: LanguageServerName,
+    pub worktree_root_name: String,
+    pub rpc_trace_enabled: bool,
+    pub rpc_trace_selected: bool,
+    pub logs_selected: bool,
+}
+
+actions!(debug, [OpenLanguageServerLogs]);
+
+pub fn init(cx: &mut AppContext) {
+    let log_store = cx.add_model(|cx| LogStore::new(cx));
+
+    cx.subscribe_global::<WorkspaceCreated, _>({
+        let log_store = log_store.clone();
+        move |event, cx| {
+            let workspace = &event.0;
+            if let Some(workspace) = workspace.upgrade(cx) {
+                let project = workspace.read(cx).project().clone();
+                if project.read(cx).is_local() {
+                    log_store.update(cx, |store, cx| {
+                        store.add_project(&project, cx);
+                    });
+                }
+            }
+        }
+    })
+    .detach();
+
+    cx.add_action(
+        move |workspace: &mut Workspace, _: &OpenLanguageServerLogs, cx: _| {
+            let project = workspace.project().read(cx);
+            if project.is_local() {
+                workspace.add_item(
+                    Box::new(cx.add_view(|cx| {
+                        LspLogView::new(workspace.project().clone(), log_store.clone(), cx)
+                    })),
+                    cx,
+                );
+            }
+        },
+    );
+}
+
+impl LogStore {
+    pub fn new(cx: &mut ModelContext<Self>) -> Self {
+        let (io_tx, mut io_rx) = mpsc::unbounded();
+        let this = Self {
+            projects: HashMap::default(),
+            io_tx,
+        };
+        cx.spawn_weak(|this, mut cx| async move {
+            while let Some((project, server_id, io_kind, message)) = io_rx.next().await {
+                if let Some(this) = this.upgrade(&cx) {
+                    this.update(&mut cx, |this, cx| {
+                        this.on_io(project, server_id, io_kind, &message, cx);
+                    });
+                }
+            }
+            anyhow::Ok(())
+        })
+        .detach();
+        this
+    }
+
+    pub fn add_project(&mut self, project: &Model<Project>, cx: &mut ModelContext<Self>) {
+        let weak_project = project.downgrade();
+        self.projects.insert(
+            weak_project,
+            ProjectState {
+                servers: HashMap::default(),
+                _subscriptions: [
+                    cx.observe_release(&project, move |this, _, _| {
+                        this.projects.remove(&weak_project);
+                    }),
+                    cx.subscribe(project, |this, project, event, cx| match event {
+                        project::Event::LanguageServerAdded(id) => {
+                            this.add_language_server(&project, *id, cx);
+                        }
+                        project::Event::LanguageServerRemoved(id) => {
+                            this.remove_language_server(&project, *id, cx);
+                        }
+                        project::Event::LanguageServerLog(id, message) => {
+                            this.add_language_server_log(&project, *id, message, cx);
+                        }
+                        _ => {}
+                    }),
+                ],
+            },
+        );
+    }
+
+    fn add_language_server(
+        &mut self,
+        project: &Model<Project>,
+        id: LanguageServerId,
+        cx: &mut ModelContext<Self>,
+    ) -> Option<&mut LanguageServerState> {
+        let project_state = self.projects.get_mut(&project.downgrade())?;
+        let server_state = project_state.servers.entry(id).or_insert_with(|| {
+            cx.notify();
+            LanguageServerState {
+                rpc_state: None,
+                log_messages: VecDeque::with_capacity(MAX_STORED_LOG_ENTRIES),
+                _io_logs_subscription: None,
+                _lsp_logs_subscription: None,
+            }
+        });
+
+        let server = project.read(cx).language_server_for_id(id);
+        if let Some(server) = server.as_deref() {
+            if server.has_notification_handler::<lsp::notification::LogMessage>() {
+                // Another event wants to re-add the server that was already added and subscribed to, avoid doing it again.
+                return Some(server_state);
+            }
+        }
+
+        let weak_project = project.downgrade();
+        let io_tx = self.io_tx.clone();
+        server_state._io_logs_subscription = server.as_ref().map(|server| {
+            server.on_io(move |io_kind, message| {
+                io_tx
+                    .unbounded_send((weak_project, id, io_kind, message.to_string()))
+                    .ok();
+            })
+        });
+        let this = cx.weak_handle();
+        let weak_project = project.downgrade();
+        server_state._lsp_logs_subscription = server.map(|server| {
+            let server_id = server.server_id();
+            server.on_notification::<lsp::notification::LogMessage, _>({
+                move |params, mut cx| {
+                    if let Some((project, this)) =
+                        weak_project.upgrade(&mut cx).zip(this.upgrade(&mut cx))
+                    {
+                        this.update(&mut cx, |this, cx| {
+                            this.add_language_server_log(&project, server_id, &params.message, cx);
+                        });
+                    }
+                }
+            })
+        });
+        Some(server_state)
+    }
+
+    fn add_language_server_log(
+        &mut self,
+        project: &Model<Project>,
+        id: LanguageServerId,
+        message: &str,
+        cx: &mut ModelContext<Self>,
+    ) -> Option<()> {
+        let language_server_state = match self
+            .projects
+            .get_mut(&project.downgrade())?
+            .servers
+            .get_mut(&id)
+        {
+            Some(existing_state) => existing_state,
+            None => self.add_language_server(&project, id, cx)?,
+        };
+
+        let log_lines = &mut language_server_state.log_messages;
+        while log_lines.len() >= MAX_STORED_LOG_ENTRIES {
+            log_lines.pop_front();
+        }
+        let message = message.trim();
+        log_lines.push_back(message.to_string());
+        cx.emit(Event::NewServerLogEntry {
+            id,
+            entry: message.to_string(),
+            is_rpc: false,
+        });
+        cx.notify();
+        Some(())
+    }
+
+    fn remove_language_server(
+        &mut self,
+        project: &Model<Project>,
+        id: LanguageServerId,
+        cx: &mut ModelContext<Self>,
+    ) -> Option<()> {
+        let project_state = self.projects.get_mut(&project.downgrade())?;
+        project_state.servers.remove(&id);
+        cx.notify();
+        Some(())
+    }
+
+    fn server_logs(
+        &self,
+        project: &Model<Project>,
+        server_id: LanguageServerId,
+    ) -> Option<&VecDeque<String>> {
+        let weak_project = project.downgrade();
+        let project_state = self.projects.get(&weak_project)?;
+        let server_state = project_state.servers.get(&server_id)?;
+        Some(&server_state.log_messages)
+    }
+
+    fn enable_rpc_trace_for_language_server(
+        &mut self,
+        project: &Model<Project>,
+        server_id: LanguageServerId,
+    ) -> Option<&mut LanguageServerRpcState> {
+        let weak_project = project.downgrade();
+        let project_state = self.projects.get_mut(&weak_project)?;
+        let server_state = project_state.servers.get_mut(&server_id)?;
+        let rpc_state = server_state
+            .rpc_state
+            .get_or_insert_with(|| LanguageServerRpcState {
+                rpc_messages: VecDeque::with_capacity(MAX_STORED_LOG_ENTRIES),
+                last_message_kind: None,
+            });
+        Some(rpc_state)
+    }
+
+    pub fn disable_rpc_trace_for_language_server(
+        &mut self,
+        project: &Model<Project>,
+        server_id: LanguageServerId,
+        _: &mut ModelContext<Self>,
+    ) -> Option<()> {
+        let project = project.downgrade();
+        let project_state = self.projects.get_mut(&project)?;
+        let server_state = project_state.servers.get_mut(&server_id)?;
+        server_state.rpc_state.take();
+        Some(())
+    }
+
+    fn on_io(
+        &mut self,
+        project: WeakModel<Project>,
+        language_server_id: LanguageServerId,
+        io_kind: IoKind,
+        message: &str,
+        cx: &mut ModelContext<Self>,
+    ) -> Option<()> {
+        let is_received = match io_kind {
+            IoKind::StdOut => true,
+            IoKind::StdIn => false,
+            IoKind::StdErr => {
+                let project = project.upgrade(cx)?;
+                let message = format!("stderr: {}", message.trim());
+                self.add_language_server_log(&project, language_server_id, &message, cx);
+                return Some(());
+            }
+        };
+
+        let state = self
+            .projects
+            .get_mut(&project)?
+            .servers
+            .get_mut(&language_server_id)?
+            .rpc_state
+            .as_mut()?;
+        let kind = if is_received {
+            MessageKind::Receive
+        } else {
+            MessageKind::Send
+        };
+
+        let rpc_log_lines = &mut state.rpc_messages;
+        if state.last_message_kind != Some(kind) {
+            let line_before_message = match kind {
+                MessageKind::Send => SEND_LINE,
+                MessageKind::Receive => RECEIVE_LINE,
+            };
+            rpc_log_lines.push_back(line_before_message.to_string());
+            cx.emit(Event::NewServerLogEntry {
+                id: language_server_id,
+                entry: line_before_message.to_string(),
+                is_rpc: true,
+            });
+        }
+
+        while rpc_log_lines.len() >= MAX_STORED_LOG_ENTRIES {
+            rpc_log_lines.pop_front();
+        }
+        let message = message.trim();
+        rpc_log_lines.push_back(message.to_string());
+        cx.emit(Event::NewServerLogEntry {
+            id: language_server_id,
+            entry: message.to_string(),
+            is_rpc: true,
+        });
+        cx.notify();
+        Some(())
+    }
+}
+
+impl LspLogView {
+    pub fn new(
+        project: Model<Project>,
+        log_store: Model<LogStore>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
+        let server_id = log_store
+            .read(cx)
+            .projects
+            .get(&project.downgrade())
+            .and_then(|project| project.servers.keys().copied().next());
+        let model_changes_subscription = cx.observe(&log_store, |this, store, cx| {
+            (|| -> Option<()> {
+                let project_state = store.read(cx).projects.get(&this.project.downgrade())?;
+                if let Some(current_lsp) = this.current_server_id {
+                    if !project_state.servers.contains_key(&current_lsp) {
+                        if let Some(server) = project_state.servers.iter().next() {
+                            if this.is_showing_rpc_trace {
+                                this.show_rpc_trace_for_server(*server.0, cx)
+                            } else {
+                                this.show_logs_for_server(*server.0, cx)
+                            }
+                        } else {
+                            this.current_server_id = None;
+                            this.editor.update(cx, |editor, cx| {
+                                editor.set_read_only(false);
+                                editor.clear(cx);
+                                editor.set_read_only(true);
+                            });
+                            cx.notify();
+                        }
+                    }
+                } else {
+                    if let Some(server) = project_state.servers.iter().next() {
+                        if this.is_showing_rpc_trace {
+                            this.show_rpc_trace_for_server(*server.0, cx)
+                        } else {
+                            this.show_logs_for_server(*server.0, cx)
+                        }
+                    }
+                }
+
+                Some(())
+            })();
+
+            cx.notify();
+        });
+        let events_subscriptions = cx.subscribe(&log_store, |log_view, _, e, cx| match e {
+            Event::NewServerLogEntry { id, entry, is_rpc } => {
+                if log_view.current_server_id == Some(*id) {
+                    if (*is_rpc && log_view.is_showing_rpc_trace)
+                        || (!*is_rpc && !log_view.is_showing_rpc_trace)
+                    {
+                        log_view.editor.update(cx, |editor, cx| {
+                            editor.set_read_only(false);
+                            editor.handle_input(entry.trim(), cx);
+                            editor.handle_input("\n", cx);
+                            editor.set_read_only(true);
+                        });
+                    }
+                }
+            }
+        });
+        let (editor, editor_subscription) = Self::editor_for_logs(String::new(), cx);
+        let mut this = Self {
+            editor,
+            editor_subscription,
+            project,
+            log_store,
+            current_server_id: None,
+            is_showing_rpc_trace: false,
+            _log_store_subscriptions: vec![model_changes_subscription, events_subscriptions],
+        };
+        if let Some(server_id) = server_id {
+            this.show_logs_for_server(server_id, cx);
+        }
+        this
+    }
+
+    fn editor_for_logs(
+        log_contents: String,
+        cx: &mut ViewContext<Self>,
+    ) -> (View<Editor>, Subscription) {
+        let editor = cx.add_view(|cx| {
+            let mut editor = Editor::multi_line(None, cx);
+            editor.set_text(log_contents, cx);
+            editor.move_to_end(&MoveToEnd, cx);
+            editor.set_read_only(true);
+            editor
+        });
+        let editor_subscription = cx.subscribe(&editor, |_, _, event, cx| cx.emit(event.clone()));
+        (editor, editor_subscription)
+    }
+
+    pub(crate) fn menu_items<'a>(&'a self, cx: &'a AppContext) -> Option<Vec<LogMenuItem>> {
+        let log_store = self.log_store.read(cx);
+        let state = log_store.projects.get(&self.project.downgrade())?;
+        let mut rows = self
+            .project
+            .read(cx)
+            .language_servers()
+            .filter_map(|(server_id, language_server_name, worktree_id)| {
+                let worktree = self.project.read(cx).worktree_for_id(worktree_id, cx)?;
+                let state = state.servers.get(&server_id)?;
+                Some(LogMenuItem {
+                    server_id,
+                    server_name: language_server_name,
+                    worktree_root_name: worktree.read(cx).root_name().to_string(),
+                    rpc_trace_enabled: state.rpc_state.is_some(),
+                    rpc_trace_selected: self.is_showing_rpc_trace
+                        && self.current_server_id == Some(server_id),
+                    logs_selected: !self.is_showing_rpc_trace
+                        && self.current_server_id == Some(server_id),
+                })
+            })
+            .chain(
+                self.project
+                    .read(cx)
+                    .supplementary_language_servers()
+                    .filter_map(|(&server_id, (name, _))| {
+                        let state = state.servers.get(&server_id)?;
+                        Some(LogMenuItem {
+                            server_id,
+                            server_name: name.clone(),
+                            worktree_root_name: "supplementary".to_string(),
+                            rpc_trace_enabled: state.rpc_state.is_some(),
+                            rpc_trace_selected: self.is_showing_rpc_trace
+                                && self.current_server_id == Some(server_id),
+                            logs_selected: !self.is_showing_rpc_trace
+                                && self.current_server_id == Some(server_id),
+                        })
+                    }),
+            )
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|row| row.server_id);
+        rows.dedup_by_key(|row| row.server_id);
+        Some(rows)
+    }
+
+    fn show_logs_for_server(&mut self, server_id: LanguageServerId, cx: &mut ViewContext<Self>) {
+        let log_contents = self
+            .log_store
+            .read(cx)
+            .server_logs(&self.project, server_id)
+            .map(log_contents);
+        if let Some(log_contents) = log_contents {
+            self.current_server_id = Some(server_id);
+            self.is_showing_rpc_trace = false;
+            let (editor, editor_subscription) = Self::editor_for_logs(log_contents, cx);
+            self.editor = editor;
+            self.editor_subscription = editor_subscription;
+            cx.notify();
+        }
+    }
+
+    fn show_rpc_trace_for_server(
+        &mut self,
+        server_id: LanguageServerId,
+        cx: &mut ViewContext<Self>,
+    ) {
+        let rpc_log = self.log_store.update(cx, |log_store, _| {
+            log_store
+                .enable_rpc_trace_for_language_server(&self.project, server_id)
+                .map(|state| log_contents(&state.rpc_messages))
+        });
+        if let Some(rpc_log) = rpc_log {
+            self.current_server_id = Some(server_id);
+            self.is_showing_rpc_trace = true;
+            let (editor, editor_subscription) = Self::editor_for_logs(rpc_log, cx);
+            let language = self.project.read(cx).languages().language_for_name("JSON");
+            editor
+                .read(cx)
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .expect("log buffer should be a singleton")
+                .update(cx, |_, cx| {
+                    cx.spawn_weak({
+                        let buffer = cx.handle();
+                        |_, mut cx| async move {
+                            let language = language.await.ok();
+                            buffer.update(&mut cx, |buffer, cx| {
+                                buffer.set_language(language, cx);
+                            });
+                        }
+                    })
+                    .detach();
+                });
+
+            self.editor = editor;
+            self.editor_subscription = editor_subscription;
+            cx.notify();
+        }
+    }
+
+    fn toggle_rpc_trace_for_server(
+        &mut self,
+        server_id: LanguageServerId,
+        enabled: bool,
+        cx: &mut ViewContext<Self>,
+    ) {
+        self.log_store.update(cx, |log_store, cx| {
+            if enabled {
+                log_store.enable_rpc_trace_for_language_server(&self.project, server_id);
+            } else {
+                log_store.disable_rpc_trace_for_language_server(&self.project, server_id, cx);
+            }
+        });
+        if !enabled && Some(server_id) == self.current_server_id {
+            self.show_logs_for_server(server_id, cx);
+            cx.notify();
+        }
+    }
+}
+
+fn log_contents(lines: &VecDeque<String>) -> String {
+    let (a, b) = lines.as_slices();
+    let log_contents = a.join("\n");
+    if b.is_empty() {
+        log_contents
+    } else {
+        log_contents + "\n" + &b.join("\n")
+    }
+}
+
+impl View for LspLogView {
+    fn ui_name() -> &'static str {
+        "LspLogView"
+    }
+
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
+        ChildView::new(&self.editor, cx).into_any()
+    }
+
+    fn focus_in(&mut self, _: gpui::AnyView, cx: &mut ViewContext<Self>) {
+        if cx.is_self_focused() {
+            cx.focus(&self.editor);
+        }
+    }
+}
+
+impl Item for LspLogView {
+    fn tab_content<V: 'static>(
+        &self,
+        _: Option<usize>,
+        style: &theme::Tab,
+        _: &AppContext,
+    ) -> AnyElement<V> {
+        Label::new("LSP Logs", style.label.clone()).into_any()
+    }
+
+    fn as_searchable(&self, handle: &View<Self>) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(handle.clone()))
+    }
+}
+
+impl SearchableItem for LspLogView {
+    type Match = <Editor as SearchableItem>::Match;
+
+    fn to_search_event(
+        &mut self,
+        event: &Self::Event,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<workspace::searchable::SearchEvent> {
+        self.editor
+            .update(cx, |editor, cx| editor.to_search_event(event, cx))
+    }
+
+    fn clear_matches(&mut self, cx: &mut ViewContext<Self>) {
+        self.editor.update(cx, |e, cx| e.clear_matches(cx))
+    }
+
+    fn update_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>) {
+        self.editor
+            .update(cx, |e, cx| e.update_matches(matches, cx))
+    }
+
+    fn query_suggestion(&mut self, cx: &mut ViewContext<Self>) -> String {
+        self.editor.update(cx, |e, cx| e.query_suggestion(cx))
+    }
+
+    fn activate_match(
+        &mut self,
+        index: usize,
+        matches: Vec<Self::Match>,
+        cx: &mut ViewContext<Self>,
+    ) {
+        self.editor
+            .update(cx, |e, cx| e.activate_match(index, matches, cx))
+    }
+
+    fn select_matches(&mut self, matches: Vec<Self::Match>, cx: &mut ViewContext<Self>) {
+        self.editor
+            .update(cx, |e, cx| e.select_matches(matches, cx))
+    }
+
+    fn find_matches(
+        &mut self,
+        query: Arc<project::search::SearchQuery>,
+        cx: &mut ViewContext<Self>,
+    ) -> gpui::Task<Vec<Self::Match>> {
+        self.editor.update(cx, |e, cx| e.find_matches(query, cx))
+    }
+
+    fn replace(&mut self, _: &Self::Match, _: &SearchQuery, _: &mut ViewContext<Self>) {
+        // Since LSP Log is read-only, it doesn't make sense to support replace operation.
+    }
+    fn supported_options() -> workspace::searchable::SearchOptions {
+        workspace::searchable::SearchOptions {
+            case: true,
+            word: true,
+            regex: true,
+            // LSP log is read-only.
+            replacement: false,
+        }
+    }
+    fn active_match_index(
+        &mut self,
+        matches: Vec<Self::Match>,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<usize> {
+        self.editor
+            .update(cx, |e, cx| e.active_match_index(matches, cx))
+    }
+}
+
+impl ToolbarItemView for LspLogToolbarItemView {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        cx: &mut ViewContext<Self>,
+    ) -> workspace::ToolbarItemLocation {
+        self.menu_open = false;
+        if let Some(item) = active_pane_item {
+            if let Some(log_view) = item.downcast::<LspLogView>() {
+                self.log_view = Some(log_view.clone());
+                self._log_view_subscription = Some(cx.observe(&log_view, |_, _, cx| {
+                    cx.notify();
+                }));
+                return ToolbarItemLocation::PrimaryLeft {
+                    flex: Some((1., false)),
+                };
+            }
+        }
+        self.log_view = None;
+        self._log_view_subscription = None;
+        ToolbarItemLocation::Hidden
+    }
+}
+
+impl View for LspLogToolbarItemView {
+    fn ui_name() -> &'static str {
+        "LspLogView"
+    }
+
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> AnyElement<Self> {
+        let theme = theme::current(cx).clone();
+        let Some(log_view) = self.log_view.as_ref() else {
+            return Empty::new().into_any();
+        };
+        let (menu_rows, current_server_id) = log_view.update(cx, |log_view, cx| {
+            let menu_rows = log_view.menu_items(cx).unwrap_or_default();
+            let current_server_id = log_view.current_server_id;
+            (menu_rows, current_server_id)
+        });
+
+        let current_server = current_server_id.and_then(|current_server_id| {
+            if let Ok(ix) = menu_rows.binary_search_by_key(&current_server_id, |e| e.server_id) {
+                Some(menu_rows[ix].clone())
+            } else {
+                None
+            }
+        });
+        let server_selected = current_server.is_some();
+
+        enum LspLogScroll {}
+        enum Menu {}
+        let lsp_menu = Stack::new()
+            .with_child(Self::render_language_server_menu_header(
+                current_server,
+                &theme,
+                cx,
+            ))
+            .with_children(if self.menu_open {
+                Some(
+                    Overlay::new(
+                        MouseEventHandler::new::<Menu, _>(0, cx, move |_, cx| {
+                            Flex::column()
+                                .scrollable::<LspLogScroll>(0, None, cx)
+                                .with_children(menu_rows.into_iter().map(|row| {
+                                    Self::render_language_server_menu_item(
+                                        row.server_id,
+                                        row.server_name,
+                                        &row.worktree_root_name,
+                                        row.rpc_trace_enabled,
+                                        row.logs_selected,
+                                        row.rpc_trace_selected,
+                                        &theme,
+                                        cx,
+                                    )
+                                }))
+                                .contained()
+                                .with_style(theme.toolbar_dropdown_menu.container)
+                                .constrained()
+                                .with_width(400.)
+                                .with_height(400.)
+                        })
+                        .on_down_out(MouseButton::Left, |_, this, cx| {
+                            this.menu_open = false;
+                            cx.notify()
+                        }),
+                    )
+                    .with_hoverable(true)
+                    .with_fit_mode(OverlayFitMode::SwitchAnchor)
+                    .with_anchor_corner(AnchorCorner::TopLeft)
+                    .with_z_index(999)
+                    .aligned()
+                    .bottom()
+                    .left(),
+                )
+            } else {
+                None
+            })
+            .aligned()
+            .left()
+            .clipped();
+
+        enum LspCleanupButton {}
+        let log_cleanup_button =
+            MouseEventHandler::new::<LspCleanupButton, _>(1, cx, |state, cx| {
+                let theme = theme::current(cx).clone();
+                let style = theme
+                    .workspace
+                    .toolbar
+                    .toggleable_text_tool
+                    .in_state(server_selected)
+                    .style_for(state);
+                Label::new("Clear", style.text.clone())
+                    .aligned()
+                    .contained()
+                    .with_style(style.container)
+                    .constrained()
+                    .with_height(theme.toolbar_dropdown_menu.row_height / 6.0 * 5.0)
+            })
+            .on_click(MouseButton::Left, move |_, this, cx| {
+                if let Some(log_view) = this.log_view.as_ref() {
+                    log_view.update(cx, |log_view, cx| {
+                        log_view.editor.update(cx, |editor, cx| {
+                            editor.set_read_only(false);
+                            editor.clear(cx);
+                            editor.set_read_only(true);
+                        });
+                    })
+                }
+            })
+            .with_cursor_style(CursorStyle::PointingHand)
+            .aligned()
+            .right();
+
+        Flex::row()
+            .with_child(lsp_menu)
+            .with_child(log_cleanup_button)
+            .contained()
+            .aligned()
+            .left()
+            .into_any_named("lsp log controls")
+    }
+}
+
+const RPC_MESSAGES: &str = "RPC Messages";
+const SERVER_LOGS: &str = "Server Logs";
+
+impl LspLogToolbarItemView {
+    pub fn new() -> Self {
+        Self {
+            menu_open: false,
+            log_view: None,
+            _log_view_subscription: None,
+        }
+    }
+
+    fn toggle_menu(&mut self, cx: &mut ViewContext<Self>) {
+        self.menu_open = !self.menu_open;
+        cx.notify();
+    }
+
+    fn toggle_logging_for_server(
+        &mut self,
+        id: LanguageServerId,
+        enabled: bool,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(log_view) = &self.log_view {
+            log_view.update(cx, |log_view, cx| {
+                log_view.toggle_rpc_trace_for_server(id, enabled, cx);
+                if !enabled && Some(id) == log_view.current_server_id {
+                    log_view.show_logs_for_server(id, cx);
+                    cx.notify();
+                }
+            });
+        }
+        cx.notify();
+    }
+
+    fn show_logs_for_server(&mut self, id: LanguageServerId, cx: &mut ViewContext<Self>) {
+        if let Some(log_view) = &self.log_view {
+            log_view.update(cx, |view, cx| view.show_logs_for_server(id, cx));
+            self.menu_open = false;
+            cx.notify();
+        }
+    }
+
+    fn show_rpc_trace_for_server(&mut self, id: LanguageServerId, cx: &mut ViewContext<Self>) {
+        if let Some(log_view) = &self.log_view {
+            log_view.update(cx, |view, cx| view.show_rpc_trace_for_server(id, cx));
+            self.menu_open = false;
+            cx.notify();
+        }
+    }
+
+    fn render_language_server_menu_header(
+        current_server: Option<LogMenuItem>,
+        theme: &Arc<Theme>,
+        cx: &mut ViewContext<Self>,
+    ) -> impl Element<Self> {
+        enum ToggleMenu {}
+        MouseEventHandler::new::<ToggleMenu, _>(0, cx, move |state, _| {
+            let label: Cow<str> = current_server
+                .and_then(|row| {
+                    Some(
+                        format!(
+                            "{} ({}) - {}",
+                            row.server_name.0,
+                            row.worktree_root_name,
+                            if row.rpc_trace_selected {
+                                RPC_MESSAGES
+                            } else {
+                                SERVER_LOGS
+                            },
+                        )
+                        .into(),
+                    )
+                })
+                .unwrap_or_else(|| "No server selected".into());
+            let style = theme.toolbar_dropdown_menu.header.style_for(state);
+            Label::new(label, style.text.clone())
+                .contained()
+                .with_style(style.container)
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_click(MouseButton::Left, move |_, view, cx| {
+            view.toggle_menu(cx);
+        })
+    }
+
+    fn render_language_server_menu_item(
+        id: LanguageServerId,
+        name: LanguageServerName,
+        worktree_root_name: &str,
+        rpc_trace_enabled: bool,
+        logs_selected: bool,
+        rpc_trace_selected: bool,
+        theme: &Arc<Theme>,
+        cx: &mut ViewContext<Self>,
+    ) -> impl Element<Self> {
+        enum ActivateLog {}
+        enum ActivateRpcTrace {}
+        enum LanguageServerCheckbox {}
+
+        Flex::column()
+            .with_child({
+                let style = &theme.toolbar_dropdown_menu.section_header;
+                Label::new(
+                    format!("{} ({})", name.0, worktree_root_name),
+                    style.text.clone(),
+                )
+                .contained()
+                .with_style(style.container)
+                .constrained()
+                .with_height(theme.toolbar_dropdown_menu.row_height)
+            })
+            .with_child(
+                MouseEventHandler::new::<ActivateLog, _>(id.0, cx, move |state, _| {
+                    let style = theme
+                        .toolbar_dropdown_menu
+                        .item
+                        .in_state(logs_selected)
+                        .style_for(state);
+                    Label::new(SERVER_LOGS, style.text.clone())
+                        .contained()
+                        .with_style(style.container)
+                        .constrained()
+                        .with_height(theme.toolbar_dropdown_menu.row_height)
+                })
+                .with_cursor_style(CursorStyle::PointingHand)
+                .on_click(MouseButton::Left, move |_, view, cx| {
+                    view.show_logs_for_server(id, cx);
+                }),
+            )
+            .with_child(
+                MouseEventHandler::new::<ActivateRpcTrace, _>(id.0, cx, move |state, cx| {
+                    let style = theme
+                        .toolbar_dropdown_menu
+                        .item
+                        .in_state(rpc_trace_selected)
+                        .style_for(state);
+                    Flex::row()
+                        .with_child(
+                            Label::new(RPC_MESSAGES, style.text.clone())
+                                .constrained()
+                                .with_height(theme.toolbar_dropdown_menu.row_height),
+                        )
+                        .with_child(
+                            ui::checkbox_with_label::<LanguageServerCheckbox, _, Self, _>(
+                                Empty::new(),
+                                &theme.welcome.checkbox,
+                                rpc_trace_enabled,
+                                id.0,
+                                cx,
+                                move |this, enabled, cx| {
+                                    this.toggle_logging_for_server(id, enabled, cx);
+                                },
+                            )
+                            .flex_float(),
+                        )
+                        .align_children_center()
+                        .contained()
+                        .with_style(style.container)
+                        .constrained()
+                        .with_height(theme.toolbar_dropdown_menu.row_height)
+                })
+                .with_cursor_style(CursorStyle::PointingHand)
+                .on_click(MouseButton::Left, move |_, view, cx| {
+                    view.show_rpc_trace_for_server(id, cx);
+                }),
+            )
+    }
+}
+
+pub enum Event {
+    NewServerLogEntry {
+        id: LanguageServerId,
+        entry: String,
+        is_rpc: bool,
+    },
+}
+
+impl Entity for LogStore {
+    type Event = Event;
+}
+
+impl Entity for LspLogView {
+    type Event = editor::Event;
+}
+
+impl Entity for LspLogToolbarItemView {
+    type Event = ();
+}

--- a/crates/language_tools2/src/lsp_log_tests.rs
+++ b/crates/language_tools2/src/lsp_log_tests.rs
@@ -1,0 +1,109 @@
+// todo!("TODO kb")
+// use std::sync::Arc;
+
+// use crate::lsp_log::LogMenuItem;
+
+// use super::*;
+// use futures::StreamExt;
+// use gpui::{serde_json::json, TestAppContext};
+// use language::{tree_sitter_rust, FakeLspAdapter, Language, LanguageConfig, LanguageServerName};
+// use project::{FakeFs, Project};
+// use settings::SettingsStore;
+
+// #[gpui::test]
+// async fn test_lsp_logs(cx: &mut TestAppContext) {
+//     if std::env::var("RUST_LOG").is_ok() {
+//         env_logger::init();
+//     }
+
+//     init_test(cx);
+
+//     let mut rust_language = Language::new(
+//         LanguageConfig {
+//             name: "Rust".into(),
+//             path_suffixes: vec!["rs".to_string()],
+//             ..Default::default()
+//         },
+//         Some(tree_sitter_rust::language()),
+//     );
+//     let mut fake_rust_servers = rust_language
+//         .set_fake_lsp_adapter(Arc::new(FakeLspAdapter {
+//             name: "the-rust-language-server",
+//             ..Default::default()
+//         }))
+//         .await;
+
+//     let fs = FakeFs::new(cx.background());
+//     fs.insert_tree(
+//         "/the-root",
+//         json!({
+//             "test.rs": "",
+//             "package.json": "",
+//         }),
+//     )
+//     .await;
+//     let project = Project::test(fs.clone(), ["/the-root".as_ref()], cx).await;
+//     project.update(cx, |project, _| {
+//         project.languages().add(Arc::new(rust_language));
+//     });
+
+//     let log_store = cx.add_model(|cx| LogStore::new(cx));
+//     log_store.update(cx, |store, cx| store.add_project(&project, cx));
+
+//     let _rust_buffer = project
+//         .update(cx, |project, cx| {
+//             project.open_local_buffer("/the-root/test.rs", cx)
+//         })
+//         .await
+//         .unwrap();
+
+//     let mut language_server = fake_rust_servers.next().await.unwrap();
+//     language_server
+//         .receive_notification::<lsp::notification::DidOpenTextDocument>()
+//         .await;
+
+//     let log_view = cx
+//         .add_window(|cx| LspLogView::new(project.clone(), log_store.clone(), cx))
+//         .root(cx);
+
+//     language_server.notify::<lsp::notification::LogMessage>(lsp::LogMessageParams {
+//         message: "hello from the server".into(),
+//         typ: lsp::MessageType::INFO,
+//     });
+//     cx.foreground().run_until_parked();
+
+//     log_view.read_with(cx, |view, cx| {
+//         assert_eq!(
+//             view.menu_items(cx).unwrap(),
+//             &[LogMenuItem {
+//                 server_id: language_server.server.server_id(),
+//                 server_name: LanguageServerName("the-rust-language-server".into()),
+//                 worktree_root_name: project
+//                     .read(cx)
+//                     .worktrees(cx)
+//                     .next()
+//                     .unwrap()
+//                     .read(cx)
+//                     .root_name()
+//                     .to_string(),
+//                 rpc_trace_enabled: false,
+//                 rpc_trace_selected: false,
+//                 logs_selected: true,
+//             }]
+//         );
+//         assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");
+//     });
+// }
+
+// fn init_test(cx: &mut gpui::TestAppContext) {
+//     cx.foreground().forbid_parking();
+
+//     cx.update(|cx| {
+//         cx.set_global(SettingsStore::test(cx));
+//         theme::init((), cx);
+//         language::init(cx);
+//         client::init_settings(cx);
+//         Project::init_settings(cx);
+//         editor::init_settings(cx);
+//     });
+// }

--- a/crates/language_tools2/src/lsp_log_tests.rs
+++ b/crates/language_tools2/src/lsp_log_tests.rs
@@ -1,109 +1,107 @@
-// todo!("TODO kb")
-// use std::sync::Arc;
+use std::sync::Arc;
 
-// use crate::lsp_log::LogMenuItem;
+use crate::lsp_log::LogMenuItem;
 
-// use super::*;
-// use futures::StreamExt;
-// use gpui::{serde_json::json, TestAppContext};
-// use language::{tree_sitter_rust, FakeLspAdapter, Language, LanguageConfig, LanguageServerName};
-// use project::{FakeFs, Project};
-// use settings::SettingsStore;
+use super::*;
+use futures::StreamExt;
+use gpui::{serde_json::json, Context, TestAppContext, VisualTestContext};
+use language::{tree_sitter_rust, FakeLspAdapter, Language, LanguageConfig, LanguageServerName};
+use project::{FakeFs, Project};
+use settings::SettingsStore;
 
-// #[gpui::test]
-// async fn test_lsp_logs(cx: &mut TestAppContext) {
-//     if std::env::var("RUST_LOG").is_ok() {
-//         env_logger::init();
-//     }
+#[gpui::test]
+async fn test_lsp_logs(cx: &mut TestAppContext) {
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    }
 
-//     init_test(cx);
+    init_test(cx);
 
-//     let mut rust_language = Language::new(
-//         LanguageConfig {
-//             name: "Rust".into(),
-//             path_suffixes: vec!["rs".to_string()],
-//             ..Default::default()
-//         },
-//         Some(tree_sitter_rust::language()),
-//     );
-//     let mut fake_rust_servers = rust_language
-//         .set_fake_lsp_adapter(Arc::new(FakeLspAdapter {
-//             name: "the-rust-language-server",
-//             ..Default::default()
-//         }))
-//         .await;
+    let mut rust_language = Language::new(
+        LanguageConfig {
+            name: "Rust".into(),
+            path_suffixes: vec!["rs".to_string()],
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::language()),
+    );
+    let mut fake_rust_servers = rust_language
+        .set_fake_lsp_adapter(Arc::new(FakeLspAdapter {
+            name: "the-rust-language-server",
+            ..Default::default()
+        }))
+        .await;
 
-//     let fs = FakeFs::new(cx.background());
-//     fs.insert_tree(
-//         "/the-root",
-//         json!({
-//             "test.rs": "",
-//             "package.json": "",
-//         }),
-//     )
-//     .await;
-//     let project = Project::test(fs.clone(), ["/the-root".as_ref()], cx).await;
-//     project.update(cx, |project, _| {
-//         project.languages().add(Arc::new(rust_language));
-//     });
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/the-root",
+        json!({
+            "test.rs": "",
+            "package.json": "",
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), ["/the-root".as_ref()], cx).await;
+    project.update(cx, |project, _| {
+        project.languages().add(Arc::new(rust_language));
+    });
 
-//     let log_store = cx.add_model(|cx| LogStore::new(cx));
-//     log_store.update(cx, |store, cx| store.add_project(&project, cx));
+    let log_store = cx.build_model(|cx| LogStore::new(cx));
+    log_store.update(cx, |store, cx| store.add_project(&project, cx));
 
-//     let _rust_buffer = project
-//         .update(cx, |project, cx| {
-//             project.open_local_buffer("/the-root/test.rs", cx)
-//         })
-//         .await
-//         .unwrap();
+    let _rust_buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer("/the-root/test.rs", cx)
+        })
+        .await
+        .unwrap();
 
-//     let mut language_server = fake_rust_servers.next().await.unwrap();
-//     language_server
-//         .receive_notification::<lsp::notification::DidOpenTextDocument>()
-//         .await;
+    let mut language_server = fake_rust_servers.next().await.unwrap();
+    language_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
 
-//     let log_view = cx
-//         .add_window(|cx| LspLogView::new(project.clone(), log_store.clone(), cx))
-//         .root(cx);
+    let window = cx.add_window(|cx| LspLogView::new(project.clone(), log_store.clone(), cx));
+    let log_view = window.root(cx).unwrap();
+    let mut cx = VisualTestContext::from_window(*window, cx);
 
-//     language_server.notify::<lsp::notification::LogMessage>(lsp::LogMessageParams {
-//         message: "hello from the server".into(),
-//         typ: lsp::MessageType::INFO,
-//     });
-//     cx.foreground().run_until_parked();
+    language_server.notify::<lsp::notification::LogMessage>(lsp::LogMessageParams {
+        message: "hello from the server".into(),
+        typ: lsp::MessageType::INFO,
+    });
+    cx.executor().run_until_parked();
 
-//     log_view.read_with(cx, |view, cx| {
-//         assert_eq!(
-//             view.menu_items(cx).unwrap(),
-//             &[LogMenuItem {
-//                 server_id: language_server.server.server_id(),
-//                 server_name: LanguageServerName("the-rust-language-server".into()),
-//                 worktree_root_name: project
-//                     .read(cx)
-//                     .worktrees(cx)
-//                     .next()
-//                     .unwrap()
-//                     .read(cx)
-//                     .root_name()
-//                     .to_string(),
-//                 rpc_trace_enabled: false,
-//                 rpc_trace_selected: false,
-//                 logs_selected: true,
-//             }]
-//         );
-//         assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");
-//     });
-// }
+    log_view.update(&mut cx, |view, cx| {
+        assert_eq!(
+            view.menu_items(cx).unwrap(),
+            &[LogMenuItem {
+                server_id: language_server.server.server_id(),
+                server_name: LanguageServerName("the-rust-language-server".into()),
+                worktree_root_name: project
+                    .read(cx)
+                    .worktrees()
+                    .next()
+                    .unwrap()
+                    .read(cx)
+                    .root_name()
+                    .to_string(),
+                rpc_trace_enabled: false,
+                rpc_trace_selected: false,
+                logs_selected: true,
+            }]
+        );
+        assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");
+    });
+}
 
-// fn init_test(cx: &mut gpui::TestAppContext) {
-//     cx.foreground().forbid_parking();
-
-//     cx.update(|cx| {
-//         cx.set_global(SettingsStore::test(cx));
-//         theme::init((), cx);
-//         language::init(cx);
-//         client::init_settings(cx);
-//         Project::init_settings(cx);
-//         editor::init_settings(cx);
-//     });
-// }
+fn init_test(cx: &mut gpui::TestAppContext) {
+    cx.update(|cx| {
+        let settings_store = SettingsStore::test(cx);
+        cx.set_global(settings_store);
+        theme::init(theme::LoadThemes::JustBase, cx);
+        language::init(cx);
+        client::init_settings(cx);
+        Project::init_settings(cx);
+        editor::init_settings(cx);
+    });
+}

--- a/crates/language_tools2/src/syntax_tree_view.rs
+++ b/crates/language_tools2/src/syntax_tree_view.rs
@@ -480,6 +480,7 @@ impl SyntaxTreeToolbarItemView {
             buffer_state.active_layer = Some(layer.to_owned());
             view.selected_descendant_ix = None;
             cx.notify();
+            view.focus_handle.focus(cx);
             Some(())
         })
     }

--- a/crates/language_tools2/src/syntax_tree_view.rs
+++ b/crates/language_tools2/src/syntax_tree_view.rs
@@ -319,7 +319,7 @@ impl SyntaxTreeView {
             anonymous_node_style.color = color;
         }
 
-        let mut row = h_stack();
+        let mut row = h_stack().size_full();
         if let Some(field_name) = cursor.field_name() {
             let mut field_style = style.clone();
             if let Some(color) = property_color {
@@ -378,6 +378,8 @@ impl Render for SyntaxTreeView {
             self.hover_state_changed(cx);
         }
 
+        let mut rendered = div();
+
         if let Some(layer) = self
             .editor
             .as_ref()
@@ -390,7 +392,7 @@ impl Render for SyntaxTreeView {
             // todo!()
             // let list_hovered = state.hovered();
             let list_hovered = false;
-            uniform_list(
+            let list = uniform_list(
                 cx.view().clone(),
                 "SyntaxTreeView",
                 layer.node().descendant_count(),
@@ -444,9 +446,11 @@ impl Render for SyntaxTreeView {
                 }),
             )
             .text_bg(editor_colors.background);
+
+            rendered = rendered.child(list);
         }
 
-        div()
+        rendered
     }
 }
 
@@ -505,10 +509,12 @@ impl SyntaxTreeToolbarItemView {
 
         Some(
             v_stack()
+                .size_full()
                 .child(Self::render_header(&active_layer, cx))
                 .children(self.menu_open.then(|| {
                     overlay().child(
                         v_stack()
+                            .size_full()
                             .children(active_buffer.syntax_layers().enumerate().map(
                                 |(ix, layer)| Self::render_menu_item(&active_layer, layer, ix, cx),
                             ))
@@ -519,7 +525,8 @@ impl SyntaxTreeToolbarItemView {
                                 }
                             })),
                     )
-                })),
+                }))
+                .z_index(99),
         )
     }
 
@@ -545,6 +552,7 @@ impl SyntaxTreeToolbarItemView {
 
     fn render_header(active_layer: &OwnedSyntaxLayerInfo, cx: &mut ViewContext<Self>) -> Div {
         h_stack()
+            .size_full()
             .child(Label::new(active_layer.language.name()))
             .child(Label::new(format_node_range(active_layer.node())))
             .on_mouse_down(
@@ -567,6 +575,7 @@ impl SyntaxTreeToolbarItemView {
         // todo!() styling
         let _is_selected = layer.node() == active_layer.node();
         h_stack()
+            .size_full()
             .child(Label::new(layer.language.name().to_string()))
             .child(Label::new(format_node_range(layer.node())))
             .cursor(CursorStyle::PointingHand)
@@ -578,6 +587,7 @@ impl SyntaxTreeToolbarItemView {
             )
             .border_1()
             .border_color(red())
+            .bg(red())
     }
 }
 

--- a/crates/language_tools2/src/syntax_tree_view.rs
+++ b/crates/language_tools2/src/syntax_tree_view.rs
@@ -1,0 +1,677 @@
+use editor::{scroll::autoscroll::Autoscroll, Anchor, Editor, ExcerptId};
+use gpui::{
+    actions,
+    elements::{
+        AnchorCorner, Empty, Flex, Label, MouseEventHandler, Overlay, OverlayFitMode,
+        ParentElement, ScrollTarget, Stack, UniformList, UniformListState,
+    },
+    fonts::TextStyle,
+    AppContext, CursorStyle, Element, Entity, Model, MouseButton, View, View, ViewContext,
+    WeakView,
+};
+use language::{Buffer, OwnedSyntaxLayerInfo, SyntaxLayerInfo};
+use std::{mem, ops::Range, sync::Arc};
+use theme::{Theme, ThemeSettings};
+use tree_sitter::{Node, TreeCursor};
+use workspace::{
+    item::{Item, ItemHandle},
+    ToolbarItemLocation, ToolbarItemView, Workspace,
+};
+
+actions!(debug, [OpenSyntaxTreeView]);
+
+pub fn init(cx: &mut AppContext) {
+    cx.add_action(
+        move |workspace: &mut Workspace, _: &OpenSyntaxTreeView, cx: _| {
+            let active_item = workspace.active_item(cx);
+            let workspace_handle = workspace.weak_handle();
+            let syntax_tree_view =
+                cx.build_view(|cx| SyntaxTreeView::new(workspace_handle, active_item, cx));
+            workspace.add_item(Box::new(syntax_tree_view), cx);
+        },
+    );
+}
+
+pub struct SyntaxTreeView {
+    workspace_handle: WeakView<Workspace>,
+    editor: Option<EditorState>,
+    mouse_y: Option<f32>,
+    line_height: Option<f32>,
+    list_state: UniformListState,
+    selected_descendant_ix: Option<usize>,
+    hovered_descendant_ix: Option<usize>,
+}
+
+pub struct SyntaxTreeToolbarItemView {
+    tree_view: Option<View<SyntaxTreeView>>,
+    subscription: Option<gpui::Subscription>,
+    menu_open: bool,
+}
+
+struct EditorState {
+    editor: ViewHandle<Editor>,
+    active_buffer: Option<BufferState>,
+    _subscription: gpui::Subscription,
+}
+
+#[derive(Clone)]
+struct BufferState {
+    buffer: Model<Buffer>,
+    excerpt_id: ExcerptId,
+    active_layer: Option<OwnedSyntaxLayerInfo>,
+}
+
+impl SyntaxTreeView {
+    pub fn new(
+        workspace_handle: WeakView<Workspace>,
+        active_item: Option<Box<dyn ItemHandle>>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
+        let mut this = Self {
+            workspace_handle: workspace_handle.clone(),
+            list_state: UniformListState::default(),
+            editor: None,
+            mouse_y: None,
+            line_height: None,
+            hovered_descendant_ix: None,
+            selected_descendant_ix: None,
+        };
+
+        this.workspace_updated(active_item, cx);
+        cx.observe(
+            &workspace_handle.upgrade(cx).unwrap(),
+            |this, workspace, cx| {
+                this.workspace_updated(workspace.read(cx).active_item(cx), cx);
+            },
+        )
+        .detach();
+
+        this
+    }
+
+    fn workspace_updated(
+        &mut self,
+        active_item: Option<Box<dyn ItemHandle>>,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(item) = active_item {
+            if item.id() != cx.view_id() {
+                if let Some(editor) = item.act_as::<Editor>(cx) {
+                    self.set_editor(editor, cx);
+                }
+            }
+        }
+    }
+
+    fn set_editor(&mut self, editor: ViewHandle<Editor>, cx: &mut ViewContext<Self>) {
+        if let Some(state) = &self.editor {
+            if state.editor == editor {
+                return;
+            }
+            editor.update(cx, |editor, cx| {
+                editor.clear_background_highlights::<Self>(cx)
+            });
+        }
+
+        let subscription = cx.subscribe(&editor, |this, _, event, cx| {
+            let did_reparse = match event {
+                editor::Event::Reparsed => true,
+                editor::Event::SelectionsChanged { .. } => false,
+                _ => return,
+            };
+            this.editor_updated(did_reparse, cx);
+        });
+
+        self.editor = Some(EditorState {
+            editor,
+            _subscription: subscription,
+            active_buffer: None,
+        });
+        self.editor_updated(true, cx);
+    }
+
+    fn editor_updated(&mut self, did_reparse: bool, cx: &mut ViewContext<Self>) -> Option<()> {
+        // Find which excerpt the cursor is in, and the position within that excerpted buffer.
+        let editor_state = self.editor.as_mut()?;
+        let editor = &editor_state.editor.read(cx);
+        let selection_range = editor.selections.last::<usize>(cx).range();
+        let multibuffer = editor.buffer().read(cx);
+        let (buffer, range, excerpt_id) = multibuffer
+            .range_to_buffer_ranges(selection_range, cx)
+            .pop()?;
+
+        // If the cursor has moved into a different excerpt, retrieve a new syntax layer
+        // from that buffer.
+        let buffer_state = editor_state
+            .active_buffer
+            .get_or_insert_with(|| BufferState {
+                buffer: buffer.clone(),
+                excerpt_id,
+                active_layer: None,
+            });
+        let mut prev_layer = None;
+        if did_reparse {
+            prev_layer = buffer_state.active_layer.take();
+        }
+        if buffer_state.buffer != buffer || buffer_state.excerpt_id != buffer_state.excerpt_id {
+            buffer_state.buffer = buffer.clone();
+            buffer_state.excerpt_id = excerpt_id;
+            buffer_state.active_layer = None;
+        }
+
+        let layer = match &mut buffer_state.active_layer {
+            Some(layer) => layer,
+            None => {
+                let snapshot = buffer.read(cx).snapshot();
+                let layer = if let Some(prev_layer) = prev_layer {
+                    let prev_range = prev_layer.node().byte_range();
+                    snapshot
+                        .syntax_layers()
+                        .filter(|layer| layer.language == &prev_layer.language)
+                        .min_by_key(|layer| {
+                            let range = layer.node().byte_range();
+                            ((range.start as i64) - (prev_range.start as i64)).abs()
+                                + ((range.end as i64) - (prev_range.end as i64)).abs()
+                        })?
+                } else {
+                    snapshot.syntax_layers().next()?
+                };
+                buffer_state.active_layer.insert(layer.to_owned())
+            }
+        };
+
+        // Within the active layer, find the syntax node under the cursor,
+        // and scroll to it.
+        let mut cursor = layer.node().walk();
+        while cursor.goto_first_child_for_byte(range.start).is_some() {
+            if !range.is_empty() && cursor.node().end_byte() == range.start {
+                cursor.goto_next_sibling();
+            }
+        }
+
+        // Ascend to the smallest ancestor that contains the range.
+        loop {
+            let node_range = cursor.node().byte_range();
+            if node_range.start <= range.start && node_range.end >= range.end {
+                break;
+            }
+            if !cursor.goto_parent() {
+                break;
+            }
+        }
+
+        let descendant_ix = cursor.descendant_index();
+        self.selected_descendant_ix = Some(descendant_ix);
+        self.list_state.scroll_to(ScrollTarget::Show(descendant_ix));
+
+        cx.notify();
+        Some(())
+    }
+
+    fn handle_click(&mut self, y: f32, cx: &mut ViewContext<SyntaxTreeView>) -> Option<()> {
+        let line_height = self.line_height?;
+        let ix = ((self.list_state.scroll_top() + y) / line_height) as usize;
+
+        self.update_editor_with_range_for_descendant_ix(ix, cx, |editor, mut range, cx| {
+            // Put the cursor at the beginning of the node.
+            mem::swap(&mut range.start, &mut range.end);
+
+            editor.change_selections(Some(Autoscroll::newest()), cx, |selections| {
+                selections.select_ranges(vec![range]);
+            });
+        });
+        Some(())
+    }
+
+    fn hover_state_changed(&mut self, cx: &mut ViewContext<SyntaxTreeView>) {
+        if let Some((y, line_height)) = self.mouse_y.zip(self.line_height) {
+            let ix = ((self.list_state.scroll_top() + y) / line_height) as usize;
+            if self.hovered_descendant_ix != Some(ix) {
+                self.hovered_descendant_ix = Some(ix);
+                self.update_editor_with_range_for_descendant_ix(ix, cx, |editor, range, cx| {
+                    editor.clear_background_highlights::<Self>(cx);
+                    editor.highlight_background::<Self>(
+                        vec![range],
+                        |theme| theme.editor.document_highlight_write_background,
+                        cx,
+                    );
+                });
+                cx.notify();
+            }
+        }
+    }
+
+    fn update_editor_with_range_for_descendant_ix(
+        &self,
+        descendant_ix: usize,
+        cx: &mut ViewContext<Self>,
+        mut f: impl FnMut(&mut Editor, Range<Anchor>, &mut ViewContext<Editor>),
+    ) -> Option<()> {
+        let editor_state = self.editor.as_ref()?;
+        let buffer_state = editor_state.active_buffer.as_ref()?;
+        let layer = buffer_state.active_layer.as_ref()?;
+
+        // Find the node.
+        let mut cursor = layer.node().walk();
+        cursor.goto_descendant(descendant_ix);
+        let node = cursor.node();
+        let range = node.byte_range();
+
+        // Build a text anchor range.
+        let buffer = buffer_state.buffer.read(cx);
+        let range = buffer.anchor_before(range.start)..buffer.anchor_after(range.end);
+
+        // Build a multibuffer anchor range.
+        let multibuffer = editor_state.editor.read(cx).buffer();
+        let multibuffer = multibuffer.read(cx).snapshot(cx);
+        let excerpt_id = buffer_state.excerpt_id;
+        let range = multibuffer.anchor_in_excerpt(excerpt_id, range.start)
+            ..multibuffer.anchor_in_excerpt(excerpt_id, range.end);
+
+        // Update the editor with the anchor range.
+        editor_state.editor.update(cx, |editor, cx| {
+            f(editor, range, cx);
+        });
+        Some(())
+    }
+
+    fn render_node(
+        cursor: &TreeCursor,
+        depth: u32,
+        selected: bool,
+        hovered: bool,
+        list_hovered: bool,
+        style: &TextStyle,
+        editor_theme: &theme::Editor,
+        cx: &AppContext,
+    ) -> gpui::AnyElement<SyntaxTreeView> {
+        let node = cursor.node();
+        let mut range_style = style.clone();
+        let em_width = style.em_width(cx.font_cache());
+        let gutter_padding = (em_width * editor_theme.gutter_padding_factor).round();
+
+        range_style.color = editor_theme.line_number;
+
+        let mut anonymous_node_style = style.clone();
+        let string_color = editor_theme
+            .syntax
+            .highlights
+            .iter()
+            .find_map(|(name, style)| (name == "string").then(|| style.color)?);
+        let property_color = editor_theme
+            .syntax
+            .highlights
+            .iter()
+            .find_map(|(name, style)| (name == "property").then(|| style.color)?);
+        if let Some(color) = string_color {
+            anonymous_node_style.color = color;
+        }
+
+        let mut row = Flex::row();
+        if let Some(field_name) = cursor.field_name() {
+            let mut field_style = style.clone();
+            if let Some(color) = property_color {
+                field_style.color = color;
+            }
+
+            row.add_children([
+                Label::new(field_name, field_style),
+                Label::new(": ", style.clone()),
+            ]);
+        }
+
+        return row
+            .with_child(
+                if node.is_named() {
+                    Label::new(node.kind(), style.clone())
+                } else {
+                    Label::new(format!("\"{}\"", node.kind()), anonymous_node_style)
+                }
+                .contained()
+                .with_margin_right(em_width),
+            )
+            .with_child(Label::new(format_node_range(node), range_style))
+            .contained()
+            .with_background_color(if selected {
+                editor_theme.selection.selection
+            } else if hovered && list_hovered {
+                editor_theme.active_line_background
+            } else {
+                Default::default()
+            })
+            .with_padding_left(gutter_padding + depth as f32 * 18.0)
+            .into_any();
+    }
+}
+
+impl Entity for SyntaxTreeView {
+    type Event = ();
+}
+
+impl View for SyntaxTreeView {
+    fn ui_name() -> &'static str {
+        "SyntaxTreeView"
+    }
+
+    fn render(&mut self, cx: &mut gpui::ViewContext<'_, '_, Self>) -> gpui::AnyElement<Self> {
+        let settings = settings::get::<ThemeSettings>(cx);
+        let font_family_id = settings.buffer_font_family;
+        let font_family_name = cx.font_cache().family_name(font_family_id).unwrap();
+        let font_properties = Default::default();
+        let font_id = cx
+            .font_cache()
+            .select_font(font_family_id, &font_properties)
+            .unwrap();
+        let font_size = settings.buffer_font_size(cx);
+
+        let editor_theme = settings.theme.editor.clone();
+        let style = TextStyle {
+            color: editor_theme.text_color,
+            font_family_name,
+            font_family_id,
+            font_id,
+            font_size,
+            font_properties: Default::default(),
+            underline: Default::default(),
+            soft_wrap: false,
+        };
+
+        let line_height = cx.font_cache().line_height(font_size);
+        if Some(line_height) != self.line_height {
+            self.line_height = Some(line_height);
+            self.hover_state_changed(cx);
+        }
+
+        if let Some(layer) = self
+            .editor
+            .as_ref()
+            .and_then(|editor| editor.active_buffer.as_ref())
+            .and_then(|buffer| buffer.active_layer.as_ref())
+        {
+            let layer = layer.clone();
+            let theme = editor_theme.clone();
+            return MouseEventHandler::new::<Self, _>(0, cx, move |state, cx| {
+                let list_hovered = state.hovered();
+                UniformList::new(
+                    self.list_state.clone(),
+                    layer.node().descendant_count(),
+                    cx,
+                    move |this, range, items, cx| {
+                        let mut cursor = layer.node().walk();
+                        let mut descendant_ix = range.start as usize;
+                        cursor.goto_descendant(descendant_ix);
+                        let mut depth = cursor.depth();
+                        let mut visited_children = false;
+                        while descendant_ix < range.end {
+                            if visited_children {
+                                if cursor.goto_next_sibling() {
+                                    visited_children = false;
+                                } else if cursor.goto_parent() {
+                                    depth -= 1;
+                                } else {
+                                    break;
+                                }
+                            } else {
+                                items.push(Self::render_node(
+                                    &cursor,
+                                    depth,
+                                    Some(descendant_ix) == this.selected_descendant_ix,
+                                    Some(descendant_ix) == this.hovered_descendant_ix,
+                                    list_hovered,
+                                    &style,
+                                    &theme,
+                                    cx,
+                                ));
+                                descendant_ix += 1;
+                                if cursor.goto_first_child() {
+                                    depth += 1;
+                                } else {
+                                    visited_children = true;
+                                }
+                            }
+                        }
+                    },
+                )
+            })
+            .on_move(move |event, this, cx| {
+                let y = event.position.y() - event.region.origin_y();
+                this.mouse_y = Some(y);
+                this.hover_state_changed(cx);
+            })
+            .on_click(MouseButton::Left, move |event, this, cx| {
+                let y = event.position.y() - event.region.origin_y();
+                this.handle_click(y, cx);
+            })
+            .contained()
+            .with_background_color(editor_theme.background)
+            .into_any();
+        }
+
+        Empty::new().into_any()
+    }
+}
+
+impl Item for SyntaxTreeView {
+    fn tab_content<V: 'static>(
+        &self,
+        _: Option<usize>,
+        style: &theme::Tab,
+        _: &AppContext,
+    ) -> gpui::AnyElement<V> {
+        Label::new("Syntax Tree", style.label.clone()).into_any()
+    }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: workspace::WorkspaceId,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let mut clone = Self::new(self.workspace_handle.clone(), None, cx);
+        if let Some(editor) = &self.editor {
+            clone.set_editor(editor.editor.clone(), cx)
+        }
+        Some(clone)
+    }
+}
+
+impl SyntaxTreeToolbarItemView {
+    pub fn new() -> Self {
+        Self {
+            menu_open: false,
+            tree_view: None,
+            subscription: None,
+        }
+    }
+
+    fn render_menu(
+        &mut self,
+        cx: &mut ViewContext<'_, '_, Self>,
+    ) -> Option<gpui::AnyElement<Self>> {
+        let theme = theme::current(cx).clone();
+        let tree_view = self.tree_view.as_ref()?;
+        let tree_view = tree_view.read(cx);
+
+        let editor_state = tree_view.editor.as_ref()?;
+        let buffer_state = editor_state.active_buffer.as_ref()?;
+        let active_layer = buffer_state.active_layer.clone()?;
+        let active_buffer = buffer_state.buffer.read(cx).snapshot();
+
+        enum Menu {}
+
+        Some(
+            Stack::new()
+                .with_child(Self::render_header(&theme, &active_layer, cx))
+                .with_children(self.menu_open.then(|| {
+                    Overlay::new(
+                        MouseEventHandler::new::<Menu, _>(0, cx, move |_, cx| {
+                            Flex::column()
+                                .with_children(active_buffer.syntax_layers().enumerate().map(
+                                    |(ix, layer)| {
+                                        Self::render_menu_item(&theme, &active_layer, layer, ix, cx)
+                                    },
+                                ))
+                                .contained()
+                                .with_style(theme.toolbar_dropdown_menu.container)
+                                .constrained()
+                                .with_width(400.)
+                                .with_height(400.)
+                        })
+                        .on_down_out(MouseButton::Left, |_, this, cx| {
+                            this.menu_open = false;
+                            cx.notify()
+                        }),
+                    )
+                    .with_hoverable(true)
+                    .with_fit_mode(OverlayFitMode::SwitchAnchor)
+                    .with_anchor_corner(AnchorCorner::TopLeft)
+                    .with_z_index(999)
+                    .aligned()
+                    .bottom()
+                    .left()
+                }))
+                .aligned()
+                .left()
+                .clipped()
+                .into_any(),
+        )
+    }
+
+    fn toggle_menu(&mut self, cx: &mut ViewContext<Self>) {
+        self.menu_open = !self.menu_open;
+        cx.notify();
+    }
+
+    fn select_layer(&mut self, layer_ix: usize, cx: &mut ViewContext<Self>) -> Option<()> {
+        let tree_view = self.tree_view.as_ref()?;
+        tree_view.update(cx, |view, cx| {
+            let editor_state = view.editor.as_mut()?;
+            let buffer_state = editor_state.active_buffer.as_mut()?;
+            let snapshot = buffer_state.buffer.read(cx).snapshot();
+            let layer = snapshot.syntax_layers().nth(layer_ix)?;
+            buffer_state.active_layer = Some(layer.to_owned());
+            view.selected_descendant_ix = None;
+            self.menu_open = false;
+            cx.notify();
+            Some(())
+        })
+    }
+
+    fn render_header(
+        theme: &Arc<Theme>,
+        active_layer: &OwnedSyntaxLayerInfo,
+        cx: &mut ViewContext<Self>,
+    ) -> impl Element<Self> {
+        enum ToggleMenu {}
+        MouseEventHandler::new::<ToggleMenu, _>(0, cx, move |state, _| {
+            let style = theme.toolbar_dropdown_menu.header.style_for(state);
+            Flex::row()
+                .with_child(
+                    Label::new(active_layer.language.name().to_string(), style.text.clone())
+                        .contained()
+                        .with_margin_right(style.secondary_text_spacing),
+                )
+                .with_child(Label::new(
+                    format_node_range(active_layer.node()),
+                    style
+                        .secondary_text
+                        .clone()
+                        .unwrap_or_else(|| style.text.clone()),
+                ))
+                .contained()
+                .with_style(style.container)
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_click(MouseButton::Left, move |_, view, cx| {
+            view.toggle_menu(cx);
+        })
+    }
+
+    fn render_menu_item(
+        theme: &Arc<Theme>,
+        active_layer: &OwnedSyntaxLayerInfo,
+        layer: SyntaxLayerInfo,
+        layer_ix: usize,
+        cx: &mut ViewContext<Self>,
+    ) -> impl Element<Self> {
+        enum ActivateLayer {}
+        MouseEventHandler::new::<ActivateLayer, _>(layer_ix, cx, move |state, _| {
+            let is_selected = layer.node() == active_layer.node();
+            let style = theme
+                .toolbar_dropdown_menu
+                .item
+                .in_state(is_selected)
+                .style_for(state);
+            Flex::row()
+                .with_child(
+                    Label::new(layer.language.name().to_string(), style.text.clone())
+                        .contained()
+                        .with_margin_right(style.secondary_text_spacing),
+                )
+                .with_child(Label::new(
+                    format_node_range(layer.node()),
+                    style
+                        .secondary_text
+                        .clone()
+                        .unwrap_or_else(|| style.text.clone()),
+                ))
+                .contained()
+                .with_style(style.container)
+        })
+        .with_cursor_style(CursorStyle::PointingHand)
+        .on_click(MouseButton::Left, move |_, view, cx| {
+            view.select_layer(layer_ix, cx);
+        })
+    }
+}
+
+fn format_node_range(node: Node) -> String {
+    let start = node.start_position();
+    let end = node.end_position();
+    format!(
+        "[{}:{} - {}:{}]",
+        start.row + 1,
+        start.column + 1,
+        end.row + 1,
+        end.column + 1,
+    )
+}
+
+impl Entity for SyntaxTreeToolbarItemView {
+    type Event = ();
+}
+
+impl View for SyntaxTreeToolbarItemView {
+    fn ui_name() -> &'static str {
+        "SyntaxTreeToolbarItemView"
+    }
+
+    fn render(&mut self, cx: &mut ViewContext<'_, '_, Self>) -> gpui::AnyElement<Self> {
+        self.render_menu(cx)
+            .unwrap_or_else(|| Empty::new().into_any())
+    }
+}
+
+impl ToolbarItemView for SyntaxTreeToolbarItemView {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        cx: &mut ViewContext<Self>,
+    ) -> workspace::ToolbarItemLocation {
+        self.menu_open = false;
+        if let Some(item) = active_pane_item {
+            if let Some(view) = item.downcast::<SyntaxTreeView>() {
+                self.tree_view = Some(view.clone());
+                self.subscription = Some(cx.observe(&view, |_, _, cx| cx.notify()));
+                return ToolbarItemLocation::PrimaryLeft {
+                    flex: Some((1., false)),
+                };
+            }
+        }
+        self.tree_view = None;
+        self.subscription = None;
+        ToolbarItemLocation::Hidden
+    }
+}

--- a/crates/ui2/src/components/context_menu.rs
+++ b/crates/ui2/src/components/context_menu.rs
@@ -9,7 +9,7 @@ use gpui::{
 use menu::{SelectFirst, SelectLast, SelectNext, SelectPrev};
 use std::{rc::Rc, time::Duration};
 
-pub enum ContextMenuItem {
+enum ContextMenuItem {
     Separator,
     Header(SharedString),
     Entry {

--- a/crates/ui2/src/components/context_menu.rs
+++ b/crates/ui2/src/components/context_menu.rs
@@ -3,8 +3,8 @@ use crate::{
     ListSeparator, ListSubHeader,
 };
 use gpui::{
-    px, Action, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView,
-    IntoElement, Render, Subscription, View, VisualContext,
+    px, Action, AnyElement, AppContext, DismissEvent, Div, EventEmitter, FocusHandle,
+    FocusableView, IntoElement, Render, Subscription, View, VisualContext,
 };
 use menu::{SelectFirst, SelectLast, SelectNext, SelectPrev};
 use std::{rc::Rc, time::Duration};
@@ -17,6 +17,9 @@ enum ContextMenuItem {
         icon: Option<Icon>,
         handler: Rc<dyn Fn(&mut WindowContext)>,
         action: Option<Box<dyn Action>>,
+    },
+    CustomEntry {
+        entry_render: Box<dyn Fn(&mut WindowContext) -> AnyElement>,
     },
 }
 
@@ -79,6 +82,16 @@ impl ContextMenu {
             handler: Rc::new(handler),
             icon: None,
             action: None,
+        });
+        self
+    }
+
+    pub fn custom_entry(
+        mut self,
+        entry_render: impl Fn(&mut WindowContext) -> AnyElement + 'static,
+    ) -> Self {
+        self.items.push(ContextMenuItem::CustomEntry {
+            entry_render: Box::new(entry_render),
         });
         self
     }
@@ -230,9 +243,9 @@ impl Render for ContextMenu {
                     el
                 })
                 .flex_none()
-                .child(
-                    List::new().children(self.items.iter().enumerate().map(
-                        |(ix, item)| match item {
+                .child(List::new().children(self.items.iter_mut().enumerate().map(
+                    |(ix, item)| {
+                        match item {
                             ContextMenuItem::Separator => ListSeparator.into_any_element(),
                             ContextMenuItem::Header(header) => {
                                 ListSubHeader::new(header.clone()).into_any_element()
@@ -255,7 +268,7 @@ impl Render for ContextMenu {
                                     Label::new(label.clone()).into_any_element()
                                 };
 
-                                ListItem::new(label.clone())
+                                ListItem::new(ix)
                                     .inset(true)
                                     .selected(Some(ix) == self.selected_index)
                                     .on_click(move |_, cx| handler(cx))
@@ -271,9 +284,14 @@ impl Render for ContextMenu {
                                     )
                                     .into_any_element()
                             }
-                        },
-                    )),
-                ),
+                            ContextMenuItem::CustomEntry { entry_render } => ListItem::new(ix)
+                                .inset(true)
+                                .selected(Some(ix) == self.selected_index)
+                                .child(entry_render(cx))
+                                .into_any_element(),
+                        }
+                    },
+                ))),
         )
     }
 }

--- a/crates/ui2/src/components/tab_bar.rs
+++ b/crates/ui2/src/components/tab_bar.rs
@@ -96,7 +96,6 @@ impl RenderOnce for TabBar {
 
         div()
             .id(self.id)
-            .z_index(120) // todo!("z-index")
             .group("tab_bar")
             .flex()
             .flex_none()

--- a/crates/workspace2/src/toolbar.rs
+++ b/crates/workspace2/src/toolbar.rs
@@ -105,7 +105,6 @@ impl Render for Toolbar {
         v_stack()
             .p_1()
             .gap_2()
-            .z_index(80) // todo!("z-index")
             .border_b()
             .border_color(cx.theme().colors().border_variant)
             .bg(cx.theme().colors().toolbar_background)

--- a/crates/zed2/Cargo.toml
+++ b/crates/zed2/Cargo.toml
@@ -47,7 +47,7 @@ language = { package = "language2", path = "../language2" }
 language_selector = { package = "language_selector2", path = "../language_selector2" }
 lsp = { package = "lsp2", path = "../lsp2" }
 menu = { package = "menu2", path = "../menu2" }
-# language_tools = { path = "../language_tools" }
+language_tools = { package = "language_tools2", path = "../language_tools2" }
 node_runtime = { path = "../node_runtime" }
 notifications = { package = "notifications2", path = "../notifications2" }
 assistant = { package = "assistant2", path = "../assistant2" }

--- a/crates/zed2/src/main.rs
+++ b/crates/zed2/src/main.rs
@@ -217,8 +217,7 @@ fn main() {
         // journal2::init(app_state.clone(), cx);
         language_selector::init(cx);
         theme_selector::init(cx);
-        // activity_indicator::init(cx);
-        // language_tools::init(cx);
+        language_tools::init(cx);
         call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
         notifications::init(app_state.client.clone(), app_state.user_store.clone(), cx);
         collab_ui::init(&app_state, cx);

--- a/crates/zed2/src/zed2.rs
+++ b/crates/zed2/src/zed2.rs
@@ -429,12 +429,11 @@ fn initialize_pane(workspace: &mut Workspace, pane: &View<Pane>, cx: &mut ViewCo
             toolbar.add_item(diagnostic_editor_controls, cx);
             let project_search_bar = cx.build_view(|_| ProjectSearchBar::new());
             toolbar.add_item(project_search_bar, cx);
-            //     let lsp_log_item =
-            //         cx.add_view(|_| language_tools::LspLogToolbarItemView::new());
-            //     toolbar.add_item(lsp_log_item, cx);
-            //     let syntax_tree_item = cx
-            //         .add_view(|_| language_tools::SyntaxTreeToolbarItemView::new());
-            //     toolbar.add_item(syntax_tree_item, cx);
+            let lsp_log_item = cx.build_view(|_| language_tools::LspLogToolbarItemView::new());
+            toolbar.add_item(lsp_log_item, cx);
+            let syntax_tree_item =
+                cx.build_view(|_| language_tools::SyntaxTreeToolbarItemView::new());
+            toolbar.add_item(syntax_tree_item, cx);
         })
     });
 }


### PR DESCRIPTION
Add back a way to show syntax trees and LSP logs in Zed.
There's a number of `todo!()` related to styling.

Release Notes:

- N/A