### PR TITLE
Rework collab panel rendering to use `gpui::list`

### DIFF
--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -584,10 +584,7 @@ impl CollabPanel {
     }
 
     fn scroll_to_item(&mut self, ix: usize) {
-        self.list_state.scroll_to(ListOffset {
-            item_ix: ix,
-            offset_in_item: px(0.),
-        })
+        self.list_state.scroll_to_reveal_item(ix)
     }
 
     fn update_entries(&mut self, select_same_item: bool, cx: &mut ViewContext<Self>) {

--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -2225,14 +2225,14 @@ impl CollabPanel {
                     .selected(is_selected),
             )
             .when(section == Section::Channels, |el| {
-                el.drag_over::<DraggedChannelView>(|style| {
+                el.drag_over::<Channel>(|style| {
                     style.bg(cx.theme().colors().ghost_element_hover)
                 })
                 .on_drop(cx.listener(
-                    move |this, view: &View<DraggedChannelView>, cx| {
+                    move |this, dragged_channel: &Channel, cx| {
                         this.channel_store
                             .update(cx, |channel_store, cx| {
-                                channel_store.move_channel(view.read(cx).channel.id, None, cx)
+                                channel_store.move_channel(dragged_channel.id, None, cx)
                             })
                             .detach_and_log_err(cx)
                     },
@@ -2451,15 +2451,15 @@ impl CollabPanel {
                     width,
                 })
             })
-            .drag_over::<DraggedChannelView>(|style| {
+            .drag_over::<Channel>(|style| {
                 style.bg(cx.theme().colors().ghost_element_hover)
             })
             .on_drop(
-                cx.listener(move |this, view: &View<DraggedChannelView>, cx| {
+                cx.listener(move |this, dragged_channel: &Channel, cx| {
                     this.channel_store
                         .update(cx, |channel_store, cx| {
                             channel_store.move_channel(
-                                view.read(cx).channel.id,
+                                dragged_channel.id,
                                 Some(channel_id),
                                 cx,
                             )

--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -2225,18 +2225,14 @@ impl CollabPanel {
                     .selected(is_selected),
             )
             .when(section == Section::Channels, |el| {
-                el.drag_over::<Channel>(|style| {
-                    style.bg(cx.theme().colors().ghost_element_hover)
-                })
-                .on_drop(cx.listener(
-                    move |this, dragged_channel: &Channel, cx| {
+                el.drag_over::<Channel>(|style| style.bg(cx.theme().colors().ghost_element_hover))
+                    .on_drop(cx.listener(move |this, dragged_channel: &Channel, cx| {
                         this.channel_store
                             .update(cx, |channel_store, cx| {
                                 channel_store.move_channel(dragged_channel.id, None, cx)
                             })
                             .detach_and_log_err(cx)
-                    },
-                ))
+                    }))
             });
 
         if section == Section::Offline {
@@ -2451,22 +2447,14 @@ impl CollabPanel {
                     width,
                 })
             })
-            .drag_over::<Channel>(|style| {
-                style.bg(cx.theme().colors().ghost_element_hover)
-            })
-            .on_drop(
-                cx.listener(move |this, dragged_channel: &Channel, cx| {
-                    this.channel_store
-                        .update(cx, |channel_store, cx| {
-                            channel_store.move_channel(
-                                dragged_channel.id,
-                                Some(channel_id),
-                                cx,
-                            )
-                        })
-                        .detach_and_log_err(cx)
-                }),
-            )
+            .drag_over::<Channel>(|style| style.bg(cx.theme().colors().ghost_element_hover))
+            .on_drop(cx.listener(move |this, dragged_channel: &Channel, cx| {
+                this.channel_store
+                    .update(cx, |channel_store, cx| {
+                        channel_store.move_channel(dragged_channel.id, Some(channel_id), cx)
+                    })
+                    .detach_and_log_err(cx)
+            }))
             .child(
                 ListItem::new(channel_id as usize)
                     // Offset the indent depth by one to give us room to show the disclosure.


### PR DESCRIPTION
This PR reworks the rendering of the collab panel to use `gpui::list`, so that we don't render any items that are not visible on the screen.

In the process we also fixed some bugs in the channel list:

- Fixed the context menu for channels not deploying when activated via keyboard
- Fixed drag and drop for channels
- Made it so when navigating the collab panel via keyboard the list only scrolls enough to reveal the next item when navigating to an item that is currently off-screen

Release Notes:

- N/A
