### PR TITLE
Fix toolbar width

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1897,9 +1897,7 @@ impl Render for Pane {
                     .on_drag_move::<ProjectEntryId>(cx.listener(Self::handle_drag_move))
                     .map(|div| {
                         if let Some(item) = self.active_item() {
-                            v_stack()
-                                .child(self.toolbar.clone())
-                                .child(item.to_any())
+                            v_stack().child(self.toolbar.clone()).child(item.to_any())
                         } else {
                             div.flex()
                                 .flex_row()

--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1897,7 +1897,7 @@ impl Render for Pane {
                     .on_drag_move::<ProjectEntryId>(cx.listener(Self::handle_drag_move))
                     .map(|div| {
                         if let Some(item) = self.active_item() {
-                            div.flex_col()
+                            v_stack()
                                 .child(self.toolbar.clone())
                                 .child(item.to_any())
                         } else {

--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1897,17 +1897,14 @@ impl Render for Pane {
                     .on_drag_move::<ProjectEntryId>(cx.listener(Self::handle_drag_move))
                     .map(|div| {
                         if let Some(item) = self.active_item() {
-                            v_stack().child(self.toolbar.clone()).child(item.to_any())
+                            div.v_flex()
+                                .child(self.toolbar.clone())
+                                .child(item.to_any())
                         } else {
-                            div.flex()
-                                .flex_row()
-                                .items_center()
-                                .size_full()
-                                .justify_center()
-                                .child(
-                                    Label::new("Open a file or project to get started.")
-                                        .color(Color::Muted),
-                                )
+                            div.h_flex().size_full().justify_center().child(
+                                Label::new("Open a file or project to get started.")
+                                    .color(Color::Muted),
+                            )
                         }
                     })
                     .child(


### PR DESCRIPTION
This PR fixes an issue with the toolbar width introduced in #3666.

The lack of a flex container was making the toolbar contents not take up the full width, and thus not positions items correctly along its main axis.

Release Notes:

- N/A
