### PR TITLE
Pane rendering fixes

### DIFF
--- a/crates/workspace2/src/pane_group.rs
+++ b/crates/workspace2/src/pane_group.rs
@@ -172,6 +172,10 @@ impl Member {
     ) -> impl IntoElement {
         match self {
             Member::Pane(pane) => {
+                if zoomed == Some(&pane.downgrade().into()) {
+                    return div().into_any();
+                }
+
                 let leader = follower_states.get(pane).and_then(|state| {
                     let room = active_call?.read(cx).room()?.read(cx);
                     room.remote_participant_for_peer_id(state.leader_id)


### PR DESCRIPTION
* Fix a bug where a pane's leader info was not rendered if the pane was part of a split
* Fix a crash when zooming a pane, due to duplicate render of that view.