### PR TITLE
Only apply scroll correction in `uniform_list` when already scrolled

### DIFF
--- a/crates/gpui2/src/elements/uniform_list.rs
+++ b/crates/gpui2/src/elements/uniform_list.rs
@@ -206,7 +206,9 @@ impl Element for UniformList {
                             let content_height =
                                 item_height * self.item_count + padding.top + padding.bottom;
                             let min_scroll_offset = padded_bounds.size.height - content_height;
-                            if scroll_offset.y < min_scroll_offset {
+                            let is_scrolled = scroll_offset.y != px(0.);
+
+                            if is_scrolled && scroll_offset.y < min_scroll_offset {
                                 shared_scroll_offset.borrow_mut().y = min_scroll_offset;
                                 scroll_offset.y = min_scroll_offset;
                             }


### PR DESCRIPTION
This PR fixes an issue where the scroll correction added to the uniform list in a35fdf45fc9de57b7696c4deacbc62c49b26a516 was being applied even if the list wasn't scrolled at all.

This manifested in the project panel starting with an incorrect scroll offset that would disappear once scrolled.

It seems like we should only need to apply this scroll correction when the list is already scrolled.

Release Notes:

- N/A
