### PR TITLE
Introduce an `Arena` to allocate and deallocate frame-related structs more cheaply

### DIFF
--- a/crates/gpui2/src/arena.rs
+++ b/crates/gpui2/src/arena.rs
@@ -1,40 +1,49 @@
 use std::{
     alloc,
+    cell::Cell,
+    ops::{Deref, DerefMut},
     ptr::{self, NonNull},
+    rc::Rc,
 };
-
-pub struct Arena {
-    start: NonNull<u8>,
-    offset: usize,
-    elements: Vec<ArenaElement>,
-}
-
-impl Default for Arena {
-    fn default() -> Self {
-        unsafe {
-            let layout = alloc::Layout::from_size_align(16 * 1024 * 1024, 1).unwrap();
-            let ptr = alloc::alloc(layout);
-            Self {
-                start: NonNull::new_unchecked(ptr),
-                offset: 0,
-                elements: Vec::new(),
-            }
-        }
-    }
-}
 
 struct ArenaElement {
     value: NonNull<u8>,
     drop: unsafe fn(NonNull<u8>),
 }
 
+impl Drop for ArenaElement {
+    fn drop(&mut self) {
+        unsafe {
+            (self.drop)(self.value);
+        }
+    }
+}
+
+pub struct Arena {
+    start: NonNull<u8>,
+    offset: usize,
+    elements: Vec<ArenaElement>,
+    valid: Rc<Cell<bool>>,
+}
+
 impl Arena {
-    pub fn clear(&mut self) {
-        for element in self.elements.drain(..) {
-            unsafe {
-                (element.drop)(element.value);
+    pub fn new(size_in_bytes: usize) -> Self {
+        unsafe {
+            let layout = alloc::Layout::from_size_align(size_in_bytes, 1).unwrap();
+            let ptr = alloc::alloc(layout);
+            Self {
+                start: NonNull::new_unchecked(ptr),
+                offset: 0,
+                elements: Vec::new(),
+                valid: Rc::new(Cell::new(true)),
             }
         }
+    }
+
+    pub fn clear(&mut self) {
+        self.valid.set(false);
+        self.valid = Rc::new(Cell::new(true));
+        self.elements.clear();
         self.offset = 0;
     }
 
@@ -46,42 +55,71 @@ impl Arena {
 
         unsafe {
             let layout = alloc::Layout::for_value(&value).pad_to_align();
-            let value_ptr = self.start.as_ptr().add(self.offset).cast::<T>();
-            ptr::write(value_ptr, value);
+            let ptr = NonNull::new_unchecked(self.start.as_ptr().add(self.offset).cast::<T>());
+            ptr::write(ptr.as_ptr(), value);
 
-            let value = NonNull::new_unchecked(value_ptr);
             self.elements.push(ArenaElement {
-                value: value.cast(),
+                value: ptr.cast(),
                 drop: drop::<T>,
             });
             self.offset += layout.size();
-            ArenaRef(value)
+            ArenaRef {
+                ptr,
+                valid: self.valid.clone(),
+            }
         }
     }
 }
 
-pub struct ArenaRef<T: ?Sized>(NonNull<T>);
+impl Drop for Arena {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
 
-impl<T: ?Sized> Copy for ArenaRef<T> {}
+pub struct ArenaRef<T: ?Sized> {
+    ptr: NonNull<T>,
+    valid: Rc<Cell<bool>>,
+}
 
 impl<T: ?Sized> Clone for ArenaRef<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        Self {
+            ptr: self.ptr,
+            valid: self.valid.clone(),
+        }
     }
 }
 
 impl<T: ?Sized> ArenaRef<T> {
-    pub unsafe fn map<U: ?Sized>(mut self, f: impl FnOnce(&mut T) -> &mut U) -> ArenaRef<U> {
-        let u = f(self.get_mut());
-        ArenaRef(NonNull::new_unchecked(u))
+    pub fn map<U: ?Sized>(mut self, f: impl FnOnce(&mut T) -> &mut U) -> ArenaRef<U> {
+        ArenaRef {
+            ptr: unsafe { NonNull::new_unchecked(f(&mut *self)) },
+            valid: self.valid,
+        }
     }
 
-    pub unsafe fn get(&self) -> &T {
-        self.0.as_ref()
+    fn validate(&self) {
+        assert!(
+            self.valid.get(),
+            "attempted to dereference an ArenaRef after its Arena was cleared"
+        );
     }
+}
 
-    pub unsafe fn get_mut(&mut self) -> &mut T {
-        self.0.as_mut()
+impl<T: ?Sized> Deref for ArenaRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.validate();
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for ArenaRef<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.validate();
+        unsafe { self.ptr.as_mut() }
     }
 }
 
@@ -93,25 +131,25 @@ mod tests {
 
     #[test]
     fn test_arena() {
-        let mut arena = Arena::default();
-        let mut a = arena.alloc(1u64);
-        let mut b = arena.alloc(2u32);
-        let mut c = arena.alloc(3u16);
-        let mut d = arena.alloc(4u8);
-        assert_eq!(unsafe { *a.get_mut() }, 1);
-        assert_eq!(unsafe { *b.get_mut() }, 2);
-        assert_eq!(unsafe { *c.get_mut() }, 3);
-        assert_eq!(unsafe { *d.get_mut() }, 4);
+        let mut arena = Arena::new(1024);
+        let a = arena.alloc(1u64);
+        let b = arena.alloc(2u32);
+        let c = arena.alloc(3u16);
+        let d = arena.alloc(4u8);
+        assert_eq!(*a, 1);
+        assert_eq!(*b, 2);
+        assert_eq!(*c, 3);
+        assert_eq!(*d, 4);
 
         arena.clear();
-        let mut a = arena.alloc(5u64);
-        let mut b = arena.alloc(6u32);
-        let mut c = arena.alloc(7u16);
-        let mut d = arena.alloc(8u8);
-        assert_eq!(unsafe { *a.get_mut() }, 5);
-        assert_eq!(unsafe { *b.get_mut() }, 6);
-        assert_eq!(unsafe { *c.get_mut() }, 7);
-        assert_eq!(unsafe { *d.get_mut() }, 8);
+        let a = arena.alloc(5u64);
+        let b = arena.alloc(6u32);
+        let c = arena.alloc(7u16);
+        let d = arena.alloc(8u8);
+        assert_eq!(*a, 5);
+        assert_eq!(*b, 6);
+        assert_eq!(*c, 7);
+        assert_eq!(*d, 8);
 
         // Ensure drop gets called.
         let dropped = Rc::new(Cell::new(false));

--- a/crates/gpui2/src/arena.rs
+++ b/crates/gpui2/src/arena.rs
@@ -76,6 +76,10 @@ impl<T: ?Sized> ArenaRef<T> {
         ArenaRef(NonNull::new_unchecked(u))
     }
 
+    pub unsafe fn get(&self) -> &T {
+        self.0.as_ref()
+    }
+
     pub unsafe fn get_mut(&mut self) -> &mut T {
         self.0.as_mut()
     }

--- a/crates/gpui2/src/arena.rs
+++ b/crates/gpui2/src/arena.rs
@@ -1,0 +1,124 @@
+use std::{
+    alloc,
+    ptr::{self, NonNull},
+};
+
+pub struct Arena {
+    start: NonNull<u8>,
+    offset: usize,
+    elements: Vec<ArenaElement>,
+}
+
+impl Default for Arena {
+    fn default() -> Self {
+        unsafe {
+            let layout = alloc::Layout::from_size_align(16 * 1024 * 1024, 1).unwrap();
+            let ptr = alloc::alloc(layout);
+            Self {
+                start: NonNull::new_unchecked(ptr),
+                offset: 0,
+                elements: Vec::new(),
+            }
+        }
+    }
+}
+
+struct ArenaElement {
+    value: NonNull<u8>,
+    drop: unsafe fn(NonNull<u8>),
+}
+
+impl Arena {
+    pub fn clear(&mut self) {
+        for element in self.elements.drain(..) {
+            unsafe {
+                (element.drop)(element.value);
+            }
+        }
+        self.offset = 0;
+    }
+
+    #[inline(always)]
+    pub fn alloc<T>(&mut self, value: T) -> ArenaRef<T> {
+        unsafe fn drop<T>(ptr: NonNull<u8>) {
+            std::ptr::drop_in_place(ptr.cast::<T>().as_ptr());
+        }
+
+        unsafe {
+            let layout = alloc::Layout::for_value(&value).pad_to_align();
+            let value_ptr = self.start.as_ptr().add(self.offset).cast::<T>();
+            ptr::write(value_ptr, value);
+
+            let value = NonNull::new_unchecked(value_ptr);
+            self.elements.push(ArenaElement {
+                value: value.cast(),
+                drop: drop::<T>,
+            });
+            self.offset += layout.size();
+            ArenaRef(value)
+        }
+    }
+}
+
+pub struct ArenaRef<T: ?Sized>(NonNull<T>);
+
+impl<T: ?Sized> Copy for ArenaRef<T> {}
+
+impl<T: ?Sized> Clone for ArenaRef<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<T: ?Sized> ArenaRef<T> {
+    pub unsafe fn map<U: ?Sized>(mut self, f: impl FnOnce(&mut T) -> &mut U) -> ArenaRef<U> {
+        let u = f(self.get_mut());
+        ArenaRef(NonNull::new_unchecked(u))
+    }
+
+    pub unsafe fn get_mut(&mut self) -> &mut T {
+        self.0.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use super::*;
+
+    #[test]
+    fn test_arena() {
+        let mut arena = Arena::default();
+        let mut a = arena.alloc(1u64);
+        let mut b = arena.alloc(2u32);
+        let mut c = arena.alloc(3u16);
+        let mut d = arena.alloc(4u8);
+        assert_eq!(unsafe { *a.get_mut() }, 1);
+        assert_eq!(unsafe { *b.get_mut() }, 2);
+        assert_eq!(unsafe { *c.get_mut() }, 3);
+        assert_eq!(unsafe { *d.get_mut() }, 4);
+
+        arena.clear();
+        let mut a = arena.alloc(5u64);
+        let mut b = arena.alloc(6u32);
+        let mut c = arena.alloc(7u16);
+        let mut d = arena.alloc(8u8);
+        assert_eq!(unsafe { *a.get_mut() }, 5);
+        assert_eq!(unsafe { *b.get_mut() }, 6);
+        assert_eq!(unsafe { *c.get_mut() }, 7);
+        assert_eq!(unsafe { *d.get_mut() }, 8);
+
+        // Ensure drop gets called.
+        let dropped = Rc::new(Cell::new(false));
+        struct DropGuard(Rc<Cell<bool>>);
+        impl Drop for DropGuard {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+        arena.alloc(DropGuard(dropped.clone()));
+        arena.clear();
+        assert!(dropped.get());
+    }
+}

--- a/crates/gpui2/src/element.rs
+++ b/crates/gpui2/src/element.rs
@@ -415,16 +415,16 @@ impl AnyElement {
     {
         let element =
             FRAME_ARENA.with_borrow_mut(|arena| arena.alloc(Some(DrawableElement::new(element))));
-        let element = unsafe { element.map(|element| element as &mut dyn ElementObject) };
+        let element = element.map(|element| element as &mut dyn ElementObject);
         AnyElement(element)
     }
 
     pub fn layout(&mut self, cx: &mut WindowContext) -> LayoutId {
-        unsafe { self.0.get_mut() }.layout(cx)
+        self.0.layout(cx)
     }
 
     pub fn paint(&mut self, cx: &mut WindowContext) {
-        unsafe { self.0.get_mut() }.paint(cx)
+        self.0.paint(cx)
     }
 
     /// Initializes this element and performs layout within the given available space to determine its size.
@@ -433,7 +433,7 @@ impl AnyElement {
         available_space: Size<AvailableSpace>,
         cx: &mut WindowContext,
     ) -> Size<Pixels> {
-        unsafe { self.0.get_mut() }.measure(available_space, cx)
+        self.0.measure(available_space, cx)
     }
 
     /// Initializes this element and performs layout in the available space, then paints it at the given origin.
@@ -443,11 +443,11 @@ impl AnyElement {
         available_space: Size<AvailableSpace>,
         cx: &mut WindowContext,
     ) {
-        unsafe { self.0.get_mut() }.draw(origin, available_space, cx)
+        self.0.draw(origin, available_space, cx)
     }
 
     pub fn inner_id(&self) -> Option<ElementId> {
-        unsafe { self.0.get() }.element_id()
+        self.0.element_id()
     }
 }
 

--- a/crates/gpui2/src/element.rs
+++ b/crates/gpui2/src/element.rs
@@ -1,6 +1,6 @@
 use crate::{
-    arena::ArenaRef, AvailableSpace, BorrowWindow, Bounds, ElementId, LayoutId, Pixels, Point,
-    Size, ViewContext, WindowContext, FRAME_ARENA,
+    frame_alloc, ArenaRef, AvailableSpace, BorrowWindow, Bounds, ElementId, LayoutId, Pixels,
+    Point, Size, ViewContext, WindowContext,
 };
 use derive_more::{Deref, DerefMut};
 pub(crate) use smallvec::SmallVec;
@@ -413,9 +413,8 @@ impl AnyElement {
         E: 'static + Element,
         E::State: Any,
     {
-        let element =
-            FRAME_ARENA.with_borrow_mut(|arena| arena.alloc(Some(DrawableElement::new(element))));
-        let element = element.map(|element| element as &mut dyn ElementObject);
+        let element = frame_alloc(|| Some(DrawableElement::new(element)))
+            .map(|element| element as &mut dyn ElementObject);
         AnyElement(element)
     }
 

--- a/crates/gpui2/src/gpui2.rs
+++ b/crates/gpui2/src/gpui2.rs
@@ -2,6 +2,7 @@
 mod action;
 mod app;
 
+mod arena;
 mod assets;
 mod color;
 mod element;

--- a/crates/gpui2/src/gpui2.rs
+++ b/crates/gpui2/src/gpui2.rs
@@ -39,6 +39,7 @@ mod private {
 pub use action::*;
 pub use anyhow::Result;
 pub use app::*;
+pub(crate) use arena::*;
 pub use assets::*;
 pub use color::*;
 pub use ctor::ctor;

--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Action, ActionRegistry, DispatchPhase, FocusId, KeyBinding, KeyContext, KeyMatch, Keymap,
-    Keystroke, KeystrokeMatcher, WindowContext,
+    arena::ArenaRef, Action, ActionRegistry, DispatchPhase, FocusId, KeyBinding, KeyContext,
+    KeyMatch, Keymap, Keystroke, KeystrokeMatcher, WindowContext,
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -33,12 +33,12 @@ pub(crate) struct DispatchNode {
     parent: Option<DispatchNodeId>,
 }
 
-type KeyListener = Rc<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>;
+type KeyListener = ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>;
 
 #[derive(Clone)]
 pub(crate) struct DispatchActionListener {
     pub(crate) action_type: TypeId,
-    pub(crate) listener: Rc<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>,
+    pub(crate) listener: ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>,
 }
 
 impl DispatchTree {
@@ -117,7 +117,7 @@ impl DispatchTree {
     pub fn on_action(
         &mut self,
         action_type: TypeId,
-        listener: Rc<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>,
+        listener: ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>,
     ) {
         self.active_node()
             .action_listeners


### PR DESCRIPTION
Picture worth a thousand words:

![before-after](https://github.com/zed-industries/zed/assets/482957/0aa92baf-f1cd-485e-a234-6d8f8b63a79a)

Note how having an arena makes a substantial amount of frames between 0.5ms and 1ms faster (15-20% faster frames).

Release Notes:

- N/A
