### PR TITLE
Always show channel toggle when collapsed

### DIFF
--- a/crates/ui2/src/components/list/list_item.rs
+++ b/crates/ui2/src/components/list/list_item.rs
@@ -192,7 +192,7 @@ impl RenderOnce for ListItem {
                             .flex()
                             .absolute()
                             .left(rems(-1.))
-                            .visible_on_hover("")
+                            .when(is_open, |this| this.visible_on_hover(""))
                             .child(Disclosure::new(is_open).on_toggle(self.on_toggle))
                     }))
                     .child(


### PR DESCRIPTION
This PR makes the channel toggle disclosure always visible when a channel tree is collapsed, as opposed to just being visible on hover.

This makes it possible to visually identify collapsed channel trees without having to hover over each entry.

Release Notes:

- N/A
