### PR TITLE
Use status colors for contact availability indicators

### DIFF
--- a/crates/ui2/src/components/avatar.rs
+++ b/crates/ui2/src/components/avatar.rs
@@ -47,7 +47,11 @@ impl RenderOnce for Avatar {
                 div()
                     .absolute()
                     .z_index(1)
-                    .bg(if is_free { gpui::green() } else { gpui::red() })
+                    .bg(if is_free {
+                        cx.theme().status().created
+                    } else {
+                        cx.theme().status().deleted
+                    })
                     .size(indicator_size)
                     .rounded(indicator_size)
                     .bottom_0()


### PR DESCRIPTION
This PR updates the availability indicators in the contact list to use the status colors from the theme.

Release Notes:

- N/A
