### PR TITLE
Add ability to warn on missing theme values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9813,6 +9813,7 @@ name = "theme_importer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 4.4.4",
  "convert_case 0.6.0",
  "gpui2",
  "indexmap 1.9.3",

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+clap = { version = "4.4", features = ["derive"] }
 convert_case = "0.6.0"
 gpui = { package = "gpui2", path = "../gpui2" }
 indexmap = { version = "1.6.2", features = ["serde"] }

--- a/crates/theme_importer/src/theme_printer.rs
+++ b/crates/theme_importer/src/theme_printer.rs
@@ -282,6 +282,8 @@ impl<'a> Debug for ThemeColorsRefinementPrinter<'a> {
                 HslaPrinter(color).fmt(f)?;
                 f.write_str(")")?;
                 f.write_str(",")?;
+            } else {
+                log::warn!(target: "theme_printer", "No value for '{}' in theme", color_name);
             }
         }
 


### PR DESCRIPTION
This PR adds the ability to warn in the `theme_importer` when a theme is missing values.

Providing the `--warn-on-missing` flag to the `theme_importer` will print a warning for missing theme value when printing the theme.

```sh
cargo run -p theme_importer -- --warn-on-missing
```

Release Notes:

- N/A
