### PR TITLE
Wire up the middle mouse button to close tabs

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1494,12 +1494,13 @@ impl Pane {
                 cx.listener(move |pane: &mut Self, _, cx| pane.activate_item(ix, true, true, cx)),
             )
             // TODO: This should be a click listener with the middle mouse button instead of a mouse down listener.
-            .on_mouse_down(MouseButton::Middle, {
+            .on_mouse_down(
+                MouseButton::Middle,
                 cx.listener(move |pane, _event, cx| {
                     pane.close_item_by_id(item_id, SaveIntent::Close, cx)
                         .detach_and_log_err(cx);
-                })
-            })
+                }),
+            )
             .on_drag(
                 DraggedTab {
                     pane: cx.view().clone(),

--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1493,6 +1493,13 @@ impl Pane {
             .on_click(
                 cx.listener(move |pane: &mut Self, _, cx| pane.activate_item(ix, true, true, cx)),
             )
+            // TODO: This should be a click listener with the middle mouse button instead of a mouse down listener.
+            .on_mouse_down(MouseButton::Middle, {
+                cx.listener(move |pane, _event, cx| {
+                    pane.close_item_by_id(item_id, SaveIntent::Close, cx)
+                        .detach_and_log_err(cx);
+                })
+            })
             .on_drag(
                 DraggedTab {
                     pane: cx.view().clone(),


### PR DESCRIPTION
This PR wires up the middle mouse button to close tabs.

Right now we're doing this using `on_mouse_down`, but we need a way in GPUI2 to have an `on_click` for a mouse button other than the left one.

Release Notes:

- N/A
