### PR TITLE
Apply padding at the toolbar level

### DIFF
--- a/crates/search2/src/buffer_search.rs
+++ b/crates/search2/src/buffer_search.rs
@@ -240,7 +240,6 @@ impl Render for BufferSearchBar {
                 this.on_action(cx.listener(Self::toggle_whole_word))
             })
             .w_full()
-            .p_1()
             .child(
                 h_stack()
                     .flex_1()

--- a/crates/search2/src/project_search.rs
+++ b/crates/search2/src/project_search.rs
@@ -1716,8 +1716,6 @@ impl Render for ProjectSearchBar {
         v_stack()
             .key_context(key_context)
             .flex_grow()
-            .p_1()
-            .m_2()
             .gap_2()
             .on_action(cx.listener(|this, _: &ToggleFilters, cx| {
                 this.toggle_filters(cx);

--- a/crates/workspace2/src/toolbar.rs
+++ b/crates/workspace2/src/toolbar.rs
@@ -103,6 +103,8 @@ impl Render for Toolbar {
         let secondary_item = self.secondary_items().next().map(|item| item.to_any());
 
         v_stack()
+            .p_1()
+            .gap_2()
             .border_b()
             .border_color(cx.theme().colors().border_variant)
             .bg(cx.theme().colors().toolbar_background)
@@ -112,7 +114,6 @@ impl Render for Toolbar {
                     .when(self.left_items().count() > 0, |this| {
                         this.child(
                             h_stack()
-                                .p_1()
                                 .flex_1()
                                 .justify_start()
                                 .children(self.left_items().map(|item| item.to_any())),


### PR DESCRIPTION
This PR adjusts the padding in the toolbar to be applied within the toolbar itself.

Previously the different elements within the toolbar were applying their own padding, which led to inconsistencies.

Release Notes:

- N/A