### PR TITLE
Fix typo in "Quote Selection" tooltip

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -990,7 +990,7 @@ impl AssistantPanel {
                 }
             }))
             .icon_size(IconSize::Small)
-            .tooltip(|cx| Tooltip::for_action("Quote Seleciton", &QuoteSelection, cx))
+            .tooltip(|cx| Tooltip::for_action("Quote Selection", &QuoteSelection, cx))
     }
 
     fn render_plus_button(cx: &mut ViewContext<Self>) -> impl IntoElement {


### PR DESCRIPTION
This PR fixes a typo in the "Quote Selection" tooltip.

Release Notes:

- N/A
