### PR TITLE
Fix typo in `ButtonCommon` doc comment

### DIFF
--- a/crates/ui2/src/components/button/button_like.rs
+++ b/crates/ui2/src/components/button/button_like.rs
@@ -11,7 +11,7 @@ pub trait ButtonCommon: Clickable + Disableable {
 
     /// The visual style of the button.
     ///
-    /// Mosty commonly will be [`ButtonStyle::Subtle`], or [`ButtonStyle::Filled`]
+    /// Most commonly will be [`ButtonStyle::Subtle`], or [`ButtonStyle::Filled`]
     /// for an emphasized button.
     fn style(self, style: ButtonStyle) -> Self;
 


### PR DESCRIPTION
This PR fixes a small typo in the doc comments for `ButtonCommon`.

Was waiting to roll this up into another PR, but it never ended up happening.

Release Notes:

- N/A