### PR TITLE
Style pane drop targets

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1817,9 +1817,6 @@ impl Render for Pane {
     type Element = Focusable<Div>;
 
     fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
-        let mut drag_target_color = cx.theme().colors().text;
-        drag_target_color.a = 0.5;
-
         v_stack()
             .key_context("Pane")
             .track_focus(&self.focus_handle)
@@ -1922,7 +1919,10 @@ impl Render for Pane {
                         div()
                             .invisible()
                             .absolute()
-                            .bg(drag_target_color)
+                            .bg(theme::color_alpha(
+                                cx.theme().colors().drop_target_background,
+                                0.75,
+                            ))
                             .group_drag_over::<DraggedTab>("", |style| style.visible())
                             .group_drag_over::<ProjectEntryId>("", |style| style.visible())
                             .on_drop(cx.listener(move |this, dragged_tab, cx| {


### PR DESCRIPTION
This PR styles the pane drop targets using the `drop_target_background` color from the theme.

We do have to adjust the alpha channel of the color so that it doesn't obscure the contents of the buffer.

Release Notes:

- N/A