### PR TITLE
Ensure that new view observers are called by WindowContext::replace_root_view

### DIFF
--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -1926,14 +1926,9 @@ impl VisualContext for WindowContext<'_> {
     where
         V: 'static + Render,
     {
-        let slot = self.app.entities.reserve();
-        let view = View {
-            model: slot.clone(),
-        };
-        let mut cx = ViewContext::new(&mut *self.app, &mut *self.window, &view);
-        let entity = build_view(&mut cx);
-        self.entities.insert(slot, entity);
+        let view = self.build_view(build_view);
         self.window.root_view = Some(view.clone().into());
+        self.notify();
         view
     }
 

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -600,11 +600,6 @@ impl Workspace {
 
         let modal_layer = cx.build_view(|_| ModalLayer::new());
 
-        // todo!()
-        // cx.update_default_global::<DragAndDrop<Workspace>, _, _>(|drag_and_drop, _| {
-        //     drag_and_drop.register_container(weak_handle.clone());
-        // });
-
         let mut active_call = None;
         if cx.has_global::<Model<ActiveCall>>() {
             let call = cx.global::<Model<ActiveCall>>().clone();


### PR DESCRIPTION
This fixes a bug where the window got into a bad, non-interactive state when opening a project from an empty window.