### PR TITLE
Improve interaction between clicking and dragging

### DIFF
--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -345,6 +345,10 @@ impl Interactivity {
         );
         self.tooltip_builder = Some(Rc::new(build_tooltip));
     }
+
+    pub fn block_mouse(&mut self) {
+        self.block_mouse = true;
+    }
 }
 
 pub trait InteractiveElement: Sized {
@@ -562,6 +566,11 @@ pub trait InteractiveElement: Sized {
 
     fn on_drop<T: 'static>(mut self, listener: impl Fn(&T, &mut WindowContext) + 'static) -> Self {
         self.interactivity().on_drop(listener);
+        self
+    }
+
+    fn block_mouse(mut self) -> Self {
+        self.interactivity().block_mouse();
         self
     }
 }
@@ -888,6 +897,7 @@ pub struct Interactivity {
     pub drag_listener: Option<(Box<dyn Any>, DragListener)>,
     pub hover_listener: Option<Box<dyn Fn(&bool, &mut WindowContext)>>,
     pub tooltip_builder: Option<TooltipBuilder>,
+    pub block_mouse: bool,
 
     #[cfg(debug_assertions)]
     pub location: Option<core::panic::Location<'static>>,
@@ -1076,10 +1086,11 @@ impl Interactivity {
                 });
             }
 
-            if style
-                .background
-                .as_ref()
-                .is_some_and(|fill| fill.color().is_some_and(|color| !color.is_transparent()))
+            if self.block_mouse
+                || style
+                    .background
+                    .as_ref()
+                    .is_some_and(|fill| fill.color().is_some_and(|color| !color.is_transparent()))
             {
                 cx.add_opaque_layer(bounds)
             }
@@ -1642,6 +1653,7 @@ impl Default for Interactivity {
             drag_listener: None,
             hover_listener: None,
             tooltip_builder: None,
+            block_mouse: false,
 
             #[cfg(debug_assertions)]
             location: None,

--- a/crates/gpui2/src/elements/div.rs
+++ b/crates/gpui2/src/elements/div.rs
@@ -1311,6 +1311,7 @@ impl Interactivity {
                         return;
                     }
                     let is_hovered = interactive_bounds.visibly_contains(&event.position, cx)
+                        && !cx.has_active_drag()
                         && has_mouse_down.borrow().is_none();
                     let mut was_hovered = was_hovered.borrow_mut();
 
@@ -1538,22 +1539,25 @@ impl Interactivity {
 
             if let Some(bounds) = bounds {
                 let mouse_position = cx.mouse_position();
-                if let Some(group_hover) = self.group_hover_style.as_ref() {
-                    if let Some(group_bounds) = GroupBounds::get(&group_hover.group, cx) {
-                        if group_bounds.contains(&mouse_position)
-                            && cx.was_top_layer(&mouse_position, cx.stacking_order())
-                        {
-                            style.refine(&group_hover.style);
+                if !cx.has_active_drag() {
+                    if let Some(group_hover) = self.group_hover_style.as_ref() {
+                        if let Some(group_bounds) = GroupBounds::get(&group_hover.group, cx) {
+                            if group_bounds.contains(&mouse_position)
+                                && cx.was_top_layer(&mouse_position, cx.stacking_order())
+                            {
+                                style.refine(&group_hover.style);
+                            }
                         }
                     }
-                }
-                if let Some(hover_style) = self.hover_style.as_ref() {
-                    if bounds
-                        .intersect(&cx.content_mask().bounds)
-                        .contains(&mouse_position)
-                        && cx.was_top_layer(&mouse_position, cx.stacking_order())
-                    {
-                        style.refine(hover_style);
+
+                    if let Some(hover_style) = self.hover_style.as_ref() {
+                        if bounds
+                            .intersect(&cx.content_mask().bounds)
+                            .contains(&mouse_position)
+                            && cx.was_top_layer(&mouse_position, cx.stacking_order())
+                        {
+                            style.refine(hover_style);
+                        }
                     }
                 }
 

--- a/crates/gpui2/src/elements/uniform_list.rs
+++ b/crates/gpui2/src/elements/uniform_list.rs
@@ -200,54 +200,52 @@ impl Element for UniformList {
                     bounds.lower_right() - point(border.right + padding.right, border.bottom),
                 );
 
-                style.paint(bounds, cx, |cx| {
-                    if self.item_count > 0 {
-                        let content_height =
-                            item_height * self.item_count + padding.top + padding.bottom;
-                        let min_scroll_offset = padded_bounds.size.height - content_height;
-                        let is_scrolled = scroll_offset.y != px(0.);
+                if self.item_count > 0 {
+                    let content_height =
+                        item_height * self.item_count + padding.top + padding.bottom;
+                    let min_scroll_offset = padded_bounds.size.height - content_height;
+                    let is_scrolled = scroll_offset.y != px(0.);
 
-                        if is_scrolled && scroll_offset.y < min_scroll_offset {
-                            shared_scroll_offset.borrow_mut().y = min_scroll_offset;
-                            scroll_offset.y = min_scroll_offset;
-                        }
+                    if is_scrolled && scroll_offset.y < min_scroll_offset {
+                        shared_scroll_offset.borrow_mut().y = min_scroll_offset;
+                        scroll_offset.y = min_scroll_offset;
+                    }
 
-                        if let Some(scroll_handle) = self.scroll_handle.clone() {
-                            scroll_handle.0.borrow_mut().replace(ScrollHandleState {
-                                item_height,
-                                list_height: padded_bounds.size.height,
-                                scroll_offset: shared_scroll_offset,
-                            });
-                        }
-
-                        let first_visible_element_ix =
-                            (-(scroll_offset.y + padding.top) / item_height).floor() as usize;
-                        let last_visible_element_ix =
-                            ((-scroll_offset.y + padded_bounds.size.height) / item_height).ceil()
-                                as usize;
-                        let visible_range = first_visible_element_ix
-                            ..cmp::min(last_visible_element_ix, self.item_count);
-
-                        let mut items = (self.render_items)(visible_range.clone(), cx);
-                        cx.with_z_index(1, |cx| {
-                            let content_mask = ContentMask { bounds };
-                            cx.with_content_mask(Some(content_mask), |cx| {
-                                for (item, ix) in items.iter_mut().zip(visible_range) {
-                                    let item_origin = padded_bounds.origin
-                                        + point(
-                                            px(0.),
-                                            item_height * ix + scroll_offset.y + padding.top,
-                                        );
-                                    let available_space = size(
-                                        AvailableSpace::Definite(padded_bounds.size.width),
-                                        AvailableSpace::Definite(item_height),
-                                    );
-                                    item.draw(item_origin, available_space, cx);
-                                }
-                            });
+                    if let Some(scroll_handle) = self.scroll_handle.clone() {
+                        scroll_handle.0.borrow_mut().replace(ScrollHandleState {
+                            item_height,
+                            list_height: padded_bounds.size.height,
+                            scroll_offset: shared_scroll_offset,
                         });
                     }
-                });
+
+                    let first_visible_element_ix =
+                        (-(scroll_offset.y + padding.top) / item_height).floor() as usize;
+                    let last_visible_element_ix = ((-scroll_offset.y + padded_bounds.size.height)
+                        / item_height)
+                        .ceil() as usize;
+                    let visible_range = first_visible_element_ix
+                        ..cmp::min(last_visible_element_ix, self.item_count);
+
+                    let mut items = (self.render_items)(visible_range.clone(), cx);
+                    cx.with_z_index(1, |cx| {
+                        let content_mask = ContentMask { bounds };
+                        cx.with_content_mask(Some(content_mask), |cx| {
+                            for (item, ix) in items.iter_mut().zip(visible_range) {
+                                let item_origin = padded_bounds.origin
+                                    + point(
+                                        px(0.),
+                                        item_height * ix + scroll_offset.y + padding.top,
+                                    );
+                                let available_space = size(
+                                    AvailableSpace::Definite(padded_bounds.size.width),
+                                    AvailableSpace::Definite(item_height),
+                                );
+                                item.draw(item_origin, available_space, cx);
+                            }
+                        });
+                    });
+                }
             },
         )
     }

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -537,6 +537,7 @@ impl Render for Dock {
             div()
                 .flex()
                 .border_color(cx.theme().colors().border)
+                .overflow_hidden()
                 .map(|this| match self.position().axis() {
                     Axis::Horizontal => this.w(px(size)).h_full().flex_row(),
                     Axis::Vertical => this.h(px(size)).w_full().flex_col(),

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -499,7 +499,8 @@ impl Render for Dock {
                         cx.stop_propagation();
                     }
                 }))
-                .z_index(1);
+                .z_index(1)
+                .block_mouse();
 
             const HANDLE_SIZE: Pixels = Pixels(6.);
 


### PR DESCRIPTION
Once a drag starts, we won't fire click listeners or style any elements as active.

- Don't fire click listeners or show active state once a drag is in progress
- Don't show hover style when a drag is in progress
- Draw borders above content
- If borders are opaque, apply them to the content mask. This prevents hovers from firing on content underneath the border, which was creating issues where the drag handle was inside the border, so we'd flicker the hover when the mouse moved out of the drag handle and into the 1px border on the left dock.
- Add a `block_mouse` helper which causes transparent elements to paint an "opaque" layer to prevent mouse events from falling through. We use this for the drag handle as well to disable hover, click, etc on items in the panel.

Release Notes:

- N/A