### PR TITLE
Prevent `ArenaRef` from being cloned

### DIFF
--- a/crates/gpui2/src/arena.rs
+++ b/crates/gpui2/src/arena.rs
@@ -98,15 +98,6 @@ pub struct ArenaRef<T: ?Sized> {
     valid: Rc<Cell<bool>>,
 }
 
-impl<T: ?Sized> Clone for ArenaRef<T> {
-    fn clone(&self) -> Self {
-        Self {
-            ptr: self.ptr,
-            valid: self.valid.clone(),
-        }
-    }
-}
-
 impl<T: ?Sized> ArenaRef<T> {
     #[inline(always)]
     pub fn map<U: ?Sized>(mut self, f: impl FnOnce(&mut T) -> &mut U) -> ArenaRef<U> {

--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -35,7 +35,6 @@ pub(crate) struct DispatchNode {
 
 type KeyListener = ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>;
 
-#[derive(Clone)]
 pub(crate) struct DispatchActionListener {
     pub(crate) action_type: TypeId,
     pub(crate) listener: ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>,
@@ -265,6 +264,10 @@ impl DispatchTree {
 
     pub fn node(&self, node_id: DispatchNodeId) -> &DispatchNode {
         &self.nodes[node_id.0]
+    }
+
+    pub fn node_mut(&mut self, node_id: DispatchNodeId) -> &mut DispatchNode {
+        &mut self.nodes[node_id.0]
     }
 
     fn active_node(&mut self) -> &mut DispatchNode {

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -1572,29 +1572,42 @@ impl<'a> WindowContext<'a> {
         self.propagate_event = true;
 
         for node_id in &dispatch_path {
-            let node = self.window.rendered_frame.dispatch_tree.node(*node_id);
-
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
             if let Some(context) = node.context.clone() {
                 context_stack.push(context);
             }
 
-            for key_listener in node.key_listeners.clone() {
+            let key_listeners = mem::take(&mut node.key_listeners);
+            for key_listener in &key_listeners {
                 key_listener(event, DispatchPhase::Capture, self);
                 if !self.propagate_event {
-                    return;
+                    break;
                 }
+            }
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            node.key_listeners = key_listeners;
+
+            if !self.propagate_event {
+                return;
             }
         }
 
         // Bubble phase
         for node_id in dispatch_path.iter().rev() {
             // Handle low level key events
-            let node = self.window.rendered_frame.dispatch_tree.node(*node_id);
-            for key_listener in node.key_listeners.clone() {
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            let key_listeners = mem::take(&mut node.key_listeners);
+            for key_listener in &key_listeners {
                 key_listener(event, DispatchPhase::Bubble, self);
                 if !self.propagate_event {
-                    return;
+                    break;
                 }
+            }
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            node.key_listeners = key_listeners;
+
+            if !self.propagate_event {
+                return;
             }
 
             // Match keystrokes
@@ -1639,37 +1652,51 @@ impl<'a> WindowContext<'a> {
 
         // Capture phase
         for node_id in &dispatch_path {
-            let node = self.window.rendered_frame.dispatch_tree.node(*node_id);
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            let action_listeners = mem::take(&mut node.action_listeners);
             for DispatchActionListener {
                 action_type,
                 listener,
-            } in node.action_listeners.clone()
+            } in &action_listeners
             {
                 let any_action = action.as_any();
-                if action_type == any_action.type_id() {
+                if *action_type == any_action.type_id() {
                     listener(any_action, DispatchPhase::Capture, self);
                     if !self.propagate_event {
-                        return;
+                        break;
                     }
                 }
+            }
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            node.action_listeners = action_listeners;
+
+            if !self.propagate_event {
+                return;
             }
         }
         // Bubble phase
         for node_id in dispatch_path.iter().rev() {
-            let node = self.window.rendered_frame.dispatch_tree.node(*node_id);
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            let action_listeners = mem::take(&mut node.action_listeners);
             for DispatchActionListener {
                 action_type,
                 listener,
-            } in node.action_listeners.clone()
+            } in &action_listeners
             {
                 let any_action = action.as_any();
-                if action_type == any_action.type_id() {
+                if *action_type == any_action.type_id() {
                     self.propagate_event = false; // Actions stop propagation by default during the bubble phase
                     listener(any_action, DispatchPhase::Bubble, self);
                     if !self.propagate_event {
-                        return;
+                        break;
                     }
                 }
+            }
+
+            let node = self.window.rendered_frame.dispatch_tree.node_mut(*node_id);
+            node.action_listeners = action_listeners;
+            if !self.propagate_event {
+                return;
             }
         }
     }


### PR DESCRIPTION
This could cause multiple mutable references to be acquired for the same arena element, which is unsafe. I didn't see it cause problems in practice, but I realized this could have been a problem and fixed it before it bit us.

Release Notes:

- N/A
