### PR TITLE
chore: Remove 'db' dependency from recent_projects2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7481,7 +7481,6 @@ dependencies = [
 name = "recent_projects2"
 version = "0.1.0"
 dependencies = [
- "db",
  "editor2",
  "futures 0.3.28",
  "fuzzy2",

--- a/crates/recent_projects2/Cargo.toml
+++ b/crates/recent_projects2/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/recent_projects.rs"
 doctest = false
 
 [dependencies]
-db = { path = "../db" }
 editor = { package = "editor2", path = "../editor2" }
 fuzzy = { package = "fuzzy2", path = "../fuzzy2" }
 gpui = { package = "gpui2", path = "../gpui2" }


### PR DESCRIPTION
It was pulling in gpui1 into zed2 build.

Release Notes:

- N/A
