### PR TITLE
Remove nightly from zed1 and use proper namespaces for nightly in zed2 manifest

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -171,14 +171,6 @@ osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
 osx_url_schemes = ["zed-dev"]
 
-[package.metadata.bundle-nightly]
-icon = ["resources/app-icon-nightly@2x.png", "resources/app-icon-nightly.png"]
-identifier = "dev.zed.Zed-Nightly"
-name = "Zed Nightly"
-osx_minimum_system_version = "10.15.7"
-osx_info_plist_exts = ["resources/info/*"]
-osx_url_schemes = ["zed-nightly"]
-
 [package.metadata.bundle-preview]
 icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]
 identifier = "dev.zed.Zed-Preview"

--- a/crates/zed2/Cargo.toml
+++ b/crates/zed2/Cargo.toml
@@ -169,11 +169,11 @@ osx_url_schemes = ["zed-dev"]
 
 [package.metadata.bundle-nightly]
 icon = ["resources/app-icon-nightly@2x.png", "resources/app-icon-nightly.png"]
-identifier = "dev.zed.Zed-Dev"
+identifier = "dev.zed.Zed-Nightly"
 name = "Zed Nightly"
 osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
-osx_url_schemes = ["zed-dev"]
+osx_url_schemes = ["zed-nightly"]
 
 [package.metadata.bundle-preview]
 icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]


### PR DESCRIPTION
Currently, I get 404 when trying to open links for nightly, like https://zed.dev/nightly/channel/Rooms-329
The PR ensures nightly has a separate protocol handler in zed2, removes nightly mentions from zed1.

See also zed.dev change: https://github.com/zed-industries/zed.dev/pull/429

Release Notes:

- N/A