### PR TITLE
Clear pending keystrokes when an action is dispatched

### DIFF
--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -103,6 +103,8 @@ impl DispatchTree {
                     .keystroke_matchers
                     .remove_entry(self.context_stack.as_slice())
                 {
+                    dbg!("preserve matcher", matcher.has_pending_keystrokes());
+
                     self.keystroke_matchers.insert(context_stack, matcher);
                 }
             }

--- a/crates/gpui2/src/keymap/matcher.rs
+++ b/crates/gpui2/src/keymap/matcher.rs
@@ -19,11 +19,6 @@ impl KeystrokeMatcher {
         }
     }
 
-    // todo!("replace with a function that calls an FnMut for every binding matching the action")
-    // pub fn bindings_for_action(&self, action_id: TypeId) -> impl Iterator<Item = &Binding> {
-    //     self.keymap.lock().bindings_for_action(action_id)
-    // }
-
     pub fn clear_pending(&mut self) {
         self.pending_keystrokes.clear();
     }

--- a/crates/gpui2/src/window.rs
+++ b/crates/gpui2/src/window.rs
@@ -572,6 +572,17 @@ impl<'a> WindowContext<'a> {
             });
     }
 
+    pub(crate) fn clear_pending_keystrokes(&mut self) {
+        self.window
+            .rendered_frame
+            .dispatch_tree
+            .clear_pending_keystrokes();
+        self.window
+            .next_frame
+            .dispatch_tree
+            .clear_pending_keystrokes();
+    }
+
     /// Schedules the given function to be run at the end of the current effect cycle, allowing entities
     /// that are currently on the stack to be returned to the app.
     pub fn defer(&mut self, f: impl FnOnce(&mut WindowContext) + 'static) {
@@ -1624,6 +1635,10 @@ impl<'a> WindowContext<'a> {
 
                 context_stack.pop();
             }
+        }
+
+        if !actions.is_empty() {
+            self.clear_pending_keystrokes();
         }
 
         for action in actions {


### PR DESCRIPTION
This prevents the `cmd-k` keystroke, which clears the terminal, from staying around as a pending keystroke on the parent workspace.

Release Notes:

- N/A