### PR TITLE
Fix `WindowContext::available_actions` missing some actions

### DIFF
--- a/crates/gpui2/src/element.rs
+++ b/crates/gpui2/src/element.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ArenaRef, AvailableSpace, BorrowWindow, Bounds, ElementId, LayoutId, Pixels, Point, Size,
+    ArenaBox, AvailableSpace, BorrowWindow, Bounds, ElementId, LayoutId, Pixels, Point, Size,
     ViewContext, WindowContext, ELEMENT_ARENA,
 };
 use derive_more::{Deref, DerefMut};
@@ -405,7 +405,7 @@ where
     }
 }
 
-pub struct AnyElement(ArenaRef<dyn ElementObject>);
+pub struct AnyElement(ArenaBox<dyn ElementObject>);
 
 impl AnyElement {
     pub fn new<E>(element: E) -> Self

--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -35,6 +35,7 @@ pub(crate) struct DispatchNode {
 
 type KeyListener = ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>;
 
+#[derive(Clone)]
 pub(crate) struct DispatchActionListener {
     pub(crate) action_type: TypeId,
     pub(crate) listener: ArenaRef<dyn Fn(&dyn Any, DispatchPhase, &mut WindowContext)>,
@@ -266,10 +267,6 @@ impl DispatchTree {
 
     pub fn node(&self, node_id: DispatchNodeId) -> &DispatchNode {
         &self.nodes[node_id.0]
-    }
-
-    pub fn node_mut(&mut self, node_id: DispatchNodeId) -> &mut DispatchNode {
-        &mut self.nodes[node_id.0]
     }
 
     fn active_node(&mut self) -> &mut DispatchNode {

--- a/crates/gpui2/src/key_dispatch.rs
+++ b/crates/gpui2/src/key_dispatch.rs
@@ -104,8 +104,6 @@ impl DispatchTree {
                     .keystroke_matchers
                     .remove_entry(self.context_stack.as_slice())
                 {
-                    dbg!("preserve matcher", matcher.has_pending_keystrokes());
-
                     self.keystroke_matchers.insert(context_stack, matcher);
                 }
             }


### PR DESCRIPTION
This pull request also allows turning an `ArenaBox` into an `ArenaRef` when non-mutable access is required, which makes `ArenaRef: Clone`. This fixes a bug that prevented the command palette from reading all the available actions while the `command_palette::Toggle` action was being dispatched.

Release Notes:

- N/A
