### PR TITLE
Increase inline assistant editor's line height

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -3066,7 +3066,7 @@ impl InlineAssistant {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.).into(),
+            line_height: relative(1.3).into(),
             background_color: None,
             underline: None,
             white_space: WhiteSpace::Normal,


### PR DESCRIPTION
This PR increases the line height for the inline assistant editor.

This fixes an issue where descenders were being clipped.

Release Notes:

- N/A
