### PR TITLE
Use small labels for title bar buttons

### DIFF
--- a/crates/collab_ui2/src/collab_titlebar_item.rs
+++ b/crates/collab_ui2/src/collab_titlebar_item.rs
@@ -334,6 +334,7 @@ impl CollabTitlebarItem {
             .trigger(
                 Button::new("project_name_trigger", name)
                     .style(ButtonStyle::Subtle)
+                    .label_size(LabelSize::Small)
                     .tooltip(move |cx| Tooltip::text("Recent Projects", cx))
                     .on_click(cx.listener(|this, _, cx| {
                         this.toggle_project_menu(&ToggleProjectMenu, cx);
@@ -368,6 +369,7 @@ impl CollabTitlebarItem {
                     Button::new("project_branch_trigger", branch_name)
                         .color(Color::Muted)
                         .style(ButtonStyle::Subtle)
+                        .label_size(LabelSize::Small)
                         .tooltip(move |cx| {
                             Tooltip::with_meta(
                                 "Recent Branches",

--- a/crates/ui2/src/components/button/button.rs
+++ b/crates/ui2/src/components/button/button.rs
@@ -12,6 +12,7 @@ pub struct Button {
     base: ButtonLike,
     label: SharedString,
     label_color: Option<Color>,
+    label_size: Option<LabelSize>,
     selected_label: Option<SharedString>,
     icon: Option<Icon>,
     icon_position: Option<IconPosition>,
@@ -26,6 +27,7 @@ impl Button {
             base: ButtonLike::new(id),
             label: label.into(),
             label_color: None,
+            label_size: None,
             selected_label: None,
             icon: None,
             icon_position: None,
@@ -37,6 +39,11 @@ impl Button {
 
     pub fn color(mut self, label_color: impl Into<Option<Color>>) -> Self {
         self.label_color = label_color.into();
+        self
+    }
+
+    pub fn label_size(mut self, label_size: impl Into<Option<LabelSize>>) -> Self {
+        self.label_size = label_size.into();
         self
     }
 
@@ -164,6 +171,7 @@ impl RenderOnce for Button {
                 .child(
                     Label::new(label)
                         .color(label_color)
+                        .size(self.label_size.unwrap_or_default())
                         .line_height_style(LineHeightStyle::UILabel),
                 )
                 .when(!self.icon_position.is_some(), |this| {


### PR DESCRIPTION
This PR adjusts the sizing of the labels in the buttons in the title bar to use the small label size.

This should bring them more in line with how things looked in Zed1.

Release Notes:

- N/A
