### PR TITLE
Align `Picker` editor with entries

### DIFF
--- a/crates/picker2/src/picker2.rs
+++ b/crates/picker2/src/picker2.rs
@@ -226,7 +226,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
             .overflow_hidden()
             .flex_none()
             .h_9()
-            .px_3()
+            .px_4()
             .child(self.editor.clone());
 
         div()


### PR DESCRIPTION
This PR re-aligns the `Picker` editor with the entries after the changes in #3764.

Release Notes:

- N/A
