### PR TITLE
Scale down status bar items

### DIFF
--- a/crates/activity_indicator2/src/activity_indicator.rs
+++ b/crates/activity_indicator2/src/activity_indicator.rs
@@ -10,7 +10,7 @@ use language::{LanguageRegistry, LanguageServerBinaryStatus};
 use project::{LanguageServerProgress, Project};
 use smallvec::SmallVec;
 use std::{cmp::Reverse, fmt::Write, sync::Arc};
-use ui::{h_stack, Label};
+use ui::prelude::*;
 use util::ResultExt;
 use workspace::{item::ItemHandle, StatusItemView, Workspace};
 
@@ -324,7 +324,7 @@ impl Render for ActivityIndicator {
 
         result
             .children(content.icon.map(|icon| svg().path(icon)))
-            .child(Label::new(SharedString::from(content.message)))
+            .child(Label::new(SharedString::from(content.message)).size(LabelSize::Small))
     }
 }
 

--- a/crates/copilot_button2/src/copilot_button.rs
+++ b/crates/copilot_button2/src/copilot_button.rs
@@ -18,7 +18,8 @@ use workspace::{
     create_and_open_local_file,
     item::ItemHandle,
     ui::{
-        popover_menu, ButtonCommon, Clickable, ContextMenu, Icon, IconButton, PopoverMenu, Tooltip,
+        popover_menu, ButtonCommon, Clickable, ContextMenu, Icon, IconButton, IconSize,
+        PopoverMenu, Tooltip,
     },
     StatusItemView, Toast, Workspace,
 };
@@ -69,6 +70,7 @@ impl Render for CopilotButton {
         if let Status::Error(e) = status {
             return div().child(
                 IconButton::new("copilot-error", icon)
+                    .icon_size(IconSize::Small)
                     .on_click(cx.listener(move |this, _, cx| {
                         if let Some(workspace) = cx.window_handle().downcast::<Workspace>() {
                             workspace.update(cx, |workspace, cx| {

--- a/crates/diagnostics2/src/items.rs
+++ b/crates/diagnostics2/src/items.rs
@@ -25,29 +25,54 @@ impl Render for DiagnosticIndicator {
 
     fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
         let diagnostic_indicator = match (self.summary.error_count, self.summary.warning_count) {
-            (0, 0) => h_stack().child(IconElement::new(Icon::Check).color(Color::Success)),
+            (0, 0) => h_stack().child(
+                IconElement::new(Icon::Check)
+                    .size(IconSize::Small)
+                    .color(Color::Success),
+            ),
             (0, warning_count) => h_stack()
                 .gap_1()
-                .child(IconElement::new(Icon::ExclamationTriangle).color(Color::Warning))
-                .child(Label::new(warning_count.to_string())),
+                .child(
+                    IconElement::new(Icon::ExclamationTriangle)
+                        .size(IconSize::Small)
+                        .color(Color::Warning),
+                )
+                .child(Label::new(warning_count.to_string()).size(LabelSize::Small)),
             (error_count, 0) => h_stack()
                 .gap_1()
-                .child(IconElement::new(Icon::XCircle).color(Color::Error))
-                .child(Label::new(error_count.to_string())),
+                .child(
+                    IconElement::new(Icon::XCircle)
+                        .size(IconSize::Small)
+                        .color(Color::Error),
+                )
+                .child(Label::new(error_count.to_string()).size(LabelSize::Small)),
             (error_count, warning_count) => h_stack()
                 .gap_1()
-                .child(IconElement::new(Icon::XCircle).color(Color::Error))
-                .child(Label::new(error_count.to_string()))
-                .child(IconElement::new(Icon::ExclamationTriangle).color(Color::Warning))
-                .child(Label::new(warning_count.to_string())),
+                .child(
+                    IconElement::new(Icon::XCircle)
+                        .size(IconSize::Small)
+                        .color(Color::Error),
+                )
+                .child(Label::new(error_count.to_string()).size(LabelSize::Small))
+                .child(
+                    IconElement::new(Icon::ExclamationTriangle)
+                        .size(IconSize::Small)
+                        .color(Color::Warning),
+                )
+                .child(Label::new(warning_count.to_string()).size(LabelSize::Small)),
         };
 
         let status = if !self.in_progress_checks.is_empty() {
-            Some(Label::new("Checking…").into_any_element())
+            Some(
+                Label::new("Checking…")
+                    .size(LabelSize::Small)
+                    .into_any_element(),
+            )
         } else if let Some(diagnostic) = &self.current_diagnostic {
             let message = diagnostic.message.split('\n').next().unwrap().to_string();
             Some(
                 Button::new("diagnostic_message", message)
+                    .label_size(LabelSize::Small)
                     .tooltip(|cx| {
                         Tooltip::for_action("Next Diagnostic", &editor::GoToDiagnostic, cx)
                     })

--- a/crates/editor2/src/items.rs
+++ b/crates/editor2/src/items.rs
@@ -1200,7 +1200,7 @@ impl Render for CursorPosition {
                 write!(text, " ({} selected)", self.selected_count).unwrap();
             }
 
-            el.child(Label::new(text))
+            el.child(Label::new(text).size(LabelSize::Small))
         })
     }
 }

--- a/crates/feedback2/src/deploy_feedback_button.rs
+++ b/crates/feedback2/src/deploy_feedback_button.rs
@@ -31,6 +31,7 @@ impl Render for DeployFeedbackButton {
             .is_some();
         IconButton::new("give-feedback", Icon::Envelope)
             .style(ui::ButtonStyle::Subtle)
+            .icon_size(IconSize::Small)
             .selected(is_open)
             .tooltip(|cx| Tooltip::text("Share Feedback", cx))
             .on_click(|_, cx| {

--- a/crates/language_selector2/src/active_buffer_language.rs
+++ b/crates/language_selector2/src/active_buffer_language.rs
@@ -3,7 +3,7 @@ use gpui::{
     div, Div, IntoElement, ParentElement, Render, Subscription, View, ViewContext, WeakView,
 };
 use std::sync::Arc;
-use ui::{Button, ButtonCommon, Clickable, Tooltip};
+use ui::{Button, ButtonCommon, Clickable, LabelSize, Tooltip};
 use workspace::{item::ItemHandle, StatusItemView, Workspace};
 
 use crate::LanguageSelector;
@@ -50,6 +50,7 @@ impl Render for ActiveBufferLanguage {
 
             el.child(
                 Button::new("change-language", active_language_text)
+                    .label_size(LabelSize::Small)
                     .on_click(cx.listener(|this, _, cx| {
                         if let Some(workspace) = this.workspace.upgrade() {
                             workspace.update(cx, |workspace, cx| {

--- a/crates/vim2/src/mode_indicator.rs
+++ b/crates/vim2/src/mode_indicator.rs
@@ -1,6 +1,6 @@
-use gpui::{div, AnyElement, Element, IntoElement, Render, Subscription, ViewContext};
+use gpui::{div, AnyElement, Element, Render, Subscription, ViewContext};
 use settings::SettingsStore;
-use workspace::{item::ItemHandle, ui::Label, StatusItemView};
+use workspace::{item::ItemHandle, ui::prelude::*, StatusItemView};
 
 use crate::{state::Mode, Vim};
 
@@ -61,7 +61,7 @@ impl Render for ModeIndicator {
             Mode::VisualLine => "-- VISUAL LINE --",
             Mode::VisualBlock => "-- VISUAL BLOCK --",
         };
-        Label::new(text).into_any_element()
+        Label::new(text).size(LabelSize::Small).into_any_element()
     }
 }
 

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -637,6 +637,7 @@ impl Render for PanelButtons {
                         .attach(menu_attach)
                         .trigger(
                             IconButton::new(name, icon)
+                                .icon_size(IconSize::Small)
                                 .selected(is_active_button)
                                 .on_click({
                                     let action = action.boxed_clone();


### PR DESCRIPTION
This PR scales down the sizes of items in the status bar.

This brings us more in line with Zed1.

Release Notes:

- N/A
