### PR TITLE
Add more left padding to title bar

### DIFF
--- a/crates/collab_ui2/src/collab_titlebar_item.rs
+++ b/crates/collab_ui2/src/collab_titlebar_item.rs
@@ -74,14 +74,13 @@ impl Render for CollabTitlebarItem {
             // Set a non-scaling min-height here to ensure the titlebar is
             // always at least the height of the traffic lights.
             .min_h(px(32.))
-            .pl_2()
             .map(|this| {
                 if matches!(cx.window_bounds(), WindowBounds::Fullscreen) {
                     this.pl_2()
                 } else {
                     // Use pixels here instead of a rem-based size because the macOS traffic
                     // lights are a static size, and don't scale with the rest of the UI.
-                    this.pl(px(72.))
+                    this.pl(px(80.))
                 }
             })
             .bg(cx.theme().colors().title_bar_background)


### PR DESCRIPTION
This PR adds more left padding to the title bar to achieve the same positioning of the title bar items that we have in Zed1.

Release Notes:

- N/A
