### PR TITLE
Add vertical padding to the picker entry list

### DIFF
--- a/crates/picker2/src/picker2.rs
+++ b/crates/picker2/src/picker2.rs
@@ -252,6 +252,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
                 el.child(
                     v_stack()
                         .flex_grow()
+                        .py_2()
                         .child(
                             uniform_list(
                                 cx.view().clone(),


### PR DESCRIPTION
This PR adds vertical padding to the list of picker entries.

This prevents us from ending up with entries squished against the edges of the picker.

Release Notes:

- N/A
