### PR TITLE
Fix typo in "Noctis Hibernus" theme name

### DIFF
--- a/assets/themes/src/vscode/noctis/family.json
+++ b/assets/themes/src/vscode/noctis/family.json
@@ -13,7 +13,7 @@
       "appearance": "dark"
     },
     {
-      "name": "Noctus Hibernus",
+      "name": "Noctis Hibernus",
       "file_name": "hibernus.json",
       "appearance": "light"
     },

--- a/crates/theme2/src/themes/noctis.rs
+++ b/crates/theme2/src/themes/noctis.rs
@@ -577,7 +577,7 @@ pub fn noctis() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Noctus Hibernus".into(),
+                name: "Noctis Hibernus".into(),
                 appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {


### PR DESCRIPTION
This PR fixes a typo in the name of the "Noctis Hibernus" theme.

Release Notes:

- N/A
