### PR TITLE
Fix names for Rosé Pine themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_ascii"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9836,6 +9842,7 @@ dependencies = [
 name = "theme_importer"
 version = "0.1.0"
 dependencies = [
+ "any_ascii",
  "anyhow",
  "clap 4.4.4",
  "convert_case 0.6.0",

--- a/assets/themes/src/vscode/rose-pine/family.json
+++ b/assets/themes/src/vscode/rose-pine/family.json
@@ -1,19 +1,19 @@
 {
-  "name": "Rose Pine",
+  "name": "Rosé Pine",
   "author": "Rosé Pine",
   "themes": [
     {
-      "name": "Rose Pine",
+      "name": "Rosé Pine",
       "file_name": "rose-pine.json",
       "appearance": "dark"
     },
     {
-      "name": "Rose Pine Moon",
+      "name": "Rosé Pine Moon",
       "file_name": "rose-pine-moon.json",
       "appearance": "dark"
     },
     {
-      "name": "Rose Pine Dawn",
+      "name": "Rosé Pine Dawn",
       "file_name": "rose-pine-dawn.json",
       "appearance": "light"
     }

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -11,11 +11,11 @@ use crate::{
 
 pub fn rose_pine() -> UserThemeFamily {
     UserThemeFamily {
-        name: "Rose Pine".into(),
+        name: "Rosé Pine".into(),
         author: "Rosé Pine".into(),
         themes: vec![
             UserTheme {
-                name: "Rose Pine".into(),
+                name: "Rosé Pine".into(),
                 appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {
@@ -278,7 +278,7 @@ pub fn rose_pine() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Rose Pine Moon".into(),
+                name: "Rosé Pine Moon".into(),
                 appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {
@@ -541,7 +541,7 @@ pub fn rose_pine() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Rose Pine Dawn".into(),
+                name: "Rosé Pine Dawn".into(),
                 appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+any_ascii = "0.3.2"
 anyhow.workspace = true
 clap = { version = "4.4", features = ["derive"] }
 convert_case = "0.6.0"

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
 
+use any_ascii::any_ascii;
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use convert_case::{Case, Casing};
@@ -187,7 +188,7 @@ fn main() -> Result<()> {
     let mut theme_modules = Vec::new();
 
     for theme_family in theme_families {
-        let theme_family_slug = theme_family.name.to_string().to_case(Case::Snake);
+        let theme_family_slug = any_ascii(&theme_family.name).to_case(Case::Snake);
 
         let mut output_file =
             File::create(themes_output_path.join(format!("{theme_family_slug}.rs")))?;

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -56,7 +56,7 @@ impl VsCodeThemeConverter {
         let syntax_theme = self.convert_syntax_theme()?;
 
         Ok(UserTheme {
-            name: self.theme_metadata.name.into(),
+            name: self.theme_metadata.name,
             appearance,
             styles: UserThemeStylesRefinement {
                 colors: theme_colors_refinements,


### PR DESCRIPTION
This PR fixes the names of the Rosé Pine themes.

We want to keep the Unicode "é" in the theme name, both because this is the actual name of the theme, and also to maintain parity with Zed1.

Release Notes:

- N/A