### PR TITLE
Add vertical padding to the picker empty state

### DIFF
--- a/crates/picker2/src/picker2.rs
+++ b/crates/picker2/src/picker2.rs
@@ -292,11 +292,13 @@ impl<D: PickerDelegate> Render for Picker<D> {
             })
             .when(self.delegate.match_count() == 0, |el| {
                 el.child(
-                    ListItem::new("empty_state")
-                        .inset(true)
-                        .spacing(ListItemSpacing::Sparse)
-                        .disabled(true)
-                        .child(Label::new("No matches").color(Color::Muted)),
+                    v_stack().flex_grow().py_2().child(
+                        ListItem::new("empty_state")
+                            .inset(true)
+                            .spacing(ListItemSpacing::Sparse)
+                            .disabled(true)
+                            .child(Label::new("No matches").color(Color::Muted)),
+                    ),
                 )
             })
     }


### PR DESCRIPTION
This PR adds vertical padding to the picker's empty state.

This matches the styles added in #3769.

Release Notes:

- N/A