### PR TITLE
Fix panic in completions menu

### DIFF
--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -1350,15 +1350,15 @@ impl CompletionsMenu {
                 completion.sort_key(),
             )
         });
-        drop(completions);
 
         for mat in &mut matches {
-            let completions = self.completions.read();
-            let filter_start = completions[mat.candidate_id].label.filter_range.start;
+            let completion = &completions[mat.candidate_id];
+            mat.string = completion.label.text.clone();
             for position in &mut mat.positions {
-                *position += filter_start;
+                *position += completion.label.filter_range.start;
             }
         }
+        drop(completions);
 
         self.matches = matches.into();
         self.selected_item = 0;


### PR DESCRIPTION
We were shifting all the positions while keeping the original string, which caused problems later when combining highlighted ranges with matched indices.

Release Notes:

- N/A
