### PR TITLE
Prevent panels from getting so small they can't be resized

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -84,8 +84,8 @@ pub fn init(cx: &mut AppContext) {
 
 pub struct AssistantPanel {
     workspace: WeakView<Workspace>,
-    width: Option<f32>,
-    height: Option<f32>,
+    width: Option<Pixels>,
+    height: Option<Pixels>,
     active_editor_index: Option<usize>,
     prev_active_editor_index: Option<usize>,
     editors: Vec<View<ConversationEditor>>,
@@ -1242,7 +1242,7 @@ impl Panel for AssistantPanel {
         });
     }
 
-    fn size(&self, cx: &WindowContext) -> f32 {
+    fn size(&self, cx: &WindowContext) -> Pixels {
         let settings = AssistantSettings::get_global(cx);
         match self.position(cx) {
             DockPosition::Left | DockPosition::Right => {
@@ -1252,7 +1252,7 @@ impl Panel for AssistantPanel {
         }
     }
 
-    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
+    fn set_size(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
         match self.position(cx) {
             DockPosition::Left | DockPosition::Right => self.width = size,
             DockPosition::Bottom => self.height = size,

--- a/crates/assistant2/src/assistant_settings.rs
+++ b/crates/assistant2/src/assistant_settings.rs
@@ -1,4 +1,5 @@
 use anyhow;
+use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
@@ -51,8 +52,8 @@ pub enum AssistantDockPosition {
 pub struct AssistantSettings {
     pub button: bool,
     pub dock: AssistantDockPosition,
-    pub default_width: f32,
-    pub default_height: f32,
+    pub default_width: Pixels,
+    pub default_height: Pixels,
     pub default_open_ai_model: OpenAIModel,
 }
 

--- a/crates/collab_ui2/src/chat_panel.rs
+++ b/crates/collab_ui2/src/chat_panel.rs
@@ -51,7 +51,7 @@ pub struct ChatPanel {
     input_editor: View<MessageEditor>,
     local_timezone: UtcOffset,
     fs: Arc<dyn Fs>,
-    width: Option<f32>,
+    width: Option<Pixels>,
     active: bool,
     pending_serialization: Task<Option<()>>,
     subscriptions: Vec<gpui::Subscription>,
@@ -62,7 +62,7 @@ pub struct ChatPanel {
 
 #[derive(Serialize, Deserialize)]
 struct SerializedChatPanel {
-    width: Option<f32>,
+    width: Option<Pixels>,
 }
 
 #[derive(Debug)]
@@ -584,12 +584,12 @@ impl Panel for ChatPanel {
         });
     }
 
-    fn size(&self, cx: &gpui::WindowContext) -> f32 {
+    fn size(&self, cx: &gpui::WindowContext) -> Pixels {
         self.width
             .unwrap_or_else(|| ChatPanelSettings::get_global(cx).default_width)
     }
 
-    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
+    fn set_size(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
         self.width = size;
         self.serialize(cx);
         cx.notify();

--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -2314,15 +2314,13 @@ impl Panel for CollabPanel {
         );
     }
 
-    fn size(&self, cx: &gpui::WindowContext) -> f32 {
-        self.width.map_or_else(
-            || CollaborationPanelSettings::get_global(cx).default_width,
-            |width| width.0,
-        )
+    fn size(&self, cx: &gpui::WindowContext) -> Pixels {
+        self.width
+            .unwrap_or_else(|| CollaborationPanelSettings::get_global(cx).default_width)
     }
 
-    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
-        self.width = size.map(|s| px(s));
+    fn set_size(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
+        self.width = size;
         self.serialize(cx);
         cx.notify();
     }

--- a/crates/collab_ui2/src/notification_panel.rs
+++ b/crates/collab_ui2/src/notification_panel.rs
@@ -37,7 +37,7 @@ pub struct NotificationPanel {
     channel_store: Model<ChannelStore>,
     notification_store: Model<NotificationStore>,
     fs: Arc<dyn Fs>,
-    width: Option<f32>,
+    width: Option<Pixels>,
     active: bool,
     notification_list: ListState,
     pending_serialization: Task<Option<()>>,
@@ -51,7 +51,7 @@ pub struct NotificationPanel {
 
 #[derive(Serialize, Deserialize)]
 struct SerializedNotificationPanel {
-    width: Option<f32>,
+    width: Option<Pixels>,
 }
 
 #[derive(Debug)]
@@ -639,12 +639,12 @@ impl Panel for NotificationPanel {
         );
     }
 
-    fn size(&self, cx: &gpui::WindowContext) -> f32 {
+    fn size(&self, cx: &gpui::WindowContext) -> Pixels {
         self.width
             .unwrap_or_else(|| NotificationPanelSettings::get_global(cx).default_width)
     }
 
-    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
+    fn set_size(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
         self.width = size;
         self.serialize(cx);
         cx.notify();

--- a/crates/collab_ui2/src/panel_settings.rs
+++ b/crates/collab_ui2/src/panel_settings.rs
@@ -1,4 +1,5 @@
 use anyhow;
+use gpui::Pixels;
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
 use settings::Settings;
@@ -8,21 +9,21 @@ use workspace::dock::DockPosition;
 pub struct CollaborationPanelSettings {
     pub button: bool,
     pub dock: DockPosition,
-    pub default_width: f32,
+    pub default_width: Pixels,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct ChatPanelSettings {
     pub button: bool,
     pub dock: DockPosition,
-    pub default_width: f32,
+    pub default_width: Pixels,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct NotificationPanelSettings {
     pub button: bool,
     pub dock: DockPosition,
-    pub default_width: f32,
+    pub default_width: Pixels,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]

--- a/crates/project_panel2/src/project_panel_settings.rs
+++ b/crates/project_panel2/src/project_panel_settings.rs
@@ -1,4 +1,5 @@
 use anyhow;
+use gpui::Pixels;
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
 use settings::Settings;
@@ -12,7 +13,7 @@ pub enum ProjectPanelDockPosition {
 
 #[derive(Deserialize, Debug)]
 pub struct ProjectPanelSettings {
-    pub default_width: f32,
+    pub default_width: Pixels,
     pub dock: ProjectPanelDockPosition,
     pub file_icons: bool,
     pub folder_icons: bool,

--- a/crates/terminal2/src/terminal_settings.rs
+++ b/crates/terminal2/src/terminal_settings.rs
@@ -25,8 +25,8 @@ pub struct TerminalSettings {
     pub option_as_meta: bool,
     pub copy_on_select: bool,
     pub dock: TerminalDockPosition,
-    pub default_width: f32,
-    pub default_height: f32,
+    pub default_width: Pixels,
+    pub default_height: Pixels,
     pub detect_venv: VenvSettings,
 }
 

--- a/crates/terminal_view2/src/terminal_panel.rs
+++ b/crates/terminal_view2/src/terminal_panel.rs
@@ -4,7 +4,7 @@ use crate::TerminalView;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
     actions, div, serde_json, AppContext, AsyncWindowContext, Div, Entity, EventEmitter,
-    ExternalPaths, FocusHandle, FocusableView, IntoElement, ParentElement, Render, Styled,
+    ExternalPaths, FocusHandle, FocusableView, IntoElement, ParentElement, Pixels, Render, Styled,
     Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use project::Fs;
@@ -44,8 +44,8 @@ pub struct TerminalPanel {
     pane: View<Pane>,
     fs: Arc<dyn Fs>,
     workspace: WeakView<Workspace>,
-    width: Option<f32>,
-    height: Option<f32>,
+    width: Option<Pixels>,
+    height: Option<Pixels>,
     pending_serialization: Task<Option<()>>,
     _subscriptions: Vec<Subscription>,
 }
@@ -364,7 +364,7 @@ impl Panel for TerminalPanel {
         });
     }
 
-    fn size(&self, cx: &WindowContext) -> f32 {
+    fn size(&self, cx: &WindowContext) -> Pixels {
         let settings = TerminalSettings::get_global(cx);
         match self.position(cx) {
             DockPosition::Left | DockPosition::Right => {
@@ -374,7 +374,7 @@ impl Panel for TerminalPanel {
         }
     }
 
-    fn set_size(&mut self, size: Option<f32>, cx: &mut ViewContext<Self>) {
+    fn set_size(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
         match self.position(cx) {
             DockPosition::Left | DockPosition::Right => self.width = size,
             DockPosition::Bottom => self.height = size,
@@ -428,6 +428,6 @@ impl Panel for TerminalPanel {
 struct SerializedTerminalPanel {
     items: Vec<u64>,
     active_item_id: Option<u64>,
-    width: Option<f32>,
-    height: Option<f32>,
+    width: Option<Pixels>,
+    height: Option<Pixels>,
 }

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -467,6 +467,7 @@ impl Dock {
 
     pub fn resize_active_panel(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
         if let Some(entry) = self.panel_entries.get_mut(self.active_panel_index) {
+            let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE));
             entry.panel.set_size(size, cx);
             cx.notify();
         }

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3549,19 +3549,19 @@ impl Render for Workspace {
                                 DockPosition::Left => {
                                     let size = workspace.bounds.left() + e.event.position.x;
                                     workspace.left_dock.update(cx, |left_dock, cx| {
-                                        left_dock.resize_active_panel(Some(size.0), cx);
+                                        left_dock.resize_active_panel(Some(size), cx);
                                     });
                                 }
                                 DockPosition::Right => {
                                     let size = workspace.bounds.right() - e.event.position.x;
                                     workspace.right_dock.update(cx, |right_dock, cx| {
-                                        right_dock.resize_active_panel(Some(size.0), cx);
+                                        right_dock.resize_active_panel(Some(size), cx);
                                     });
                                 }
                                 DockPosition::Bottom => {
                                     let size = workspace.bounds.bottom() - e.event.position.y;
                                     workspace.bottom_dock.update(cx, |bottom_dock, cx| {
-                                        bottom_dock.resize_active_panel(Some(size.0), cx);
+                                        bottom_dock.resize_active_panel(Some(size), cx);
                                     });
                                 }
                             }


### PR DESCRIPTION
This also switches to using `Pixels` instead of `f32` to store the panel size everywhere.

Release Notes:

- N/A
