### PR TITLE
Disambiguate GPUI2 macOS class names

### DIFF
--- a/crates/gpui2/src/platform/mac/platform.rs
+++ b/crates/gpui2/src/platform/mac/platform.rs
@@ -66,7 +66,7 @@ static mut APP_DELEGATE_CLASS: *const Class = ptr::null();
 #[ctor]
 unsafe fn build_classes() {
     APP_CLASS = {
-        let mut decl = ClassDecl::new("GPUIApplication", class!(NSApplication)).unwrap();
+        let mut decl = ClassDecl::new("GPUI2Application", class!(NSApplication)).unwrap();
         decl.add_ivar::<*mut c_void>(MAC_PLATFORM_IVAR);
         decl.add_method(
             sel!(sendEvent:),
@@ -76,7 +76,7 @@ unsafe fn build_classes() {
     };
 
     APP_DELEGATE_CLASS = {
-        let mut decl = ClassDecl::new("GPUIApplicationDelegate", class!(NSResponder)).unwrap();
+        let mut decl = ClassDecl::new("GPUI2ApplicationDelegate", class!(NSResponder)).unwrap();
         decl.add_ivar::<*mut c_void>(MAC_PLATFORM_IVAR);
         decl.add_method(
             sel!(applicationDidFinishLaunching:),

--- a/crates/gpui2/src/platform/mac/window.rs
+++ b/crates/gpui2/src/platform/mac/window.rs
@@ -85,10 +85,10 @@ const NSDragOperationCopy: NSDragOperation = 1;
 unsafe fn build_classes() {
     ::util::gpui2_loaded();
 
-    WINDOW_CLASS = build_window_class("GPUIWindow", class!(NSWindow));
-    PANEL_CLASS = build_window_class("GPUIPanel", class!(NSPanel));
+    WINDOW_CLASS = build_window_class("GPUI2Window", class!(NSWindow));
+    PANEL_CLASS = build_window_class("GPUI2Panel", class!(NSPanel));
     VIEW_CLASS = {
-        let mut decl = ClassDecl::new("GPUIView", class!(NSView)).unwrap();
+        let mut decl = ClassDecl::new("GPUI2View", class!(NSView)).unwrap();
         decl.add_ivar::<*mut c_void>(WINDOW_STATE_IVAR);
 
         decl.add_method(sel!(dealloc), dealloc_view as extern "C" fn(&Object, Sel));


### PR DESCRIPTION
This PR disambiguates the macOS class names used in GPUI2 from the ones used in GPUI1.

Right now if you happen to end up with a copy of both `gpui` and `gpui2` in the dependency tree you get an unhelpful `unwrap` error when we try to build the class names.

By giving them different names we are able to get to our more helpful error that informs you that both GPUI1 and GPUI2 are in the module tree.

We can change these names back once we do the big "un-2-ing".

Release Notes:

- N/A
