### PR TITLE
Fix panic when deploying emoji picker (character palette)

### DIFF
--- a/crates/gpui2/src/platform/mac/window.rs
+++ b/crates/gpui2/src/platform/mac/window.rs
@@ -886,11 +886,16 @@ impl PlatformWindow for MacWindow {
     }
 
     fn show_character_palette(&self) {
-        unsafe {
-            let app = NSApplication::sharedApplication(nil);
-            let window = self.0.lock().native_window;
-            let _: () = msg_send![app, orderFrontCharacterPalette: window];
-        }
+        let this = self.0.lock();
+        let window = this.native_window;
+        this.executor
+            .spawn(async move {
+                unsafe {
+                    let app = NSApplication::sharedApplication(nil);
+                    let _: () = msg_send![app, orderFrontCharacterPalette: window];
+                }
+            })
+            .detach();
     }
 
     fn minimize(&self) {


### PR DESCRIPTION
The panic was caused by Cocoa synchronously invoking the `selected_text_range` method on the registered input handler while we already had a borrow of the app.

This pull request fixes this issue by showing the character palette on the next tick of the loop (we've had this problem in other spots too and used the same technique).

Release Notes:

- N/A
