### PR TITLE
Fix multibuffer scroll by reordering z-index of its elements

### DIFF
--- a/crates/editor2/src/element.rs
+++ b/crates/editor2/src/element.rs
@@ -2840,23 +2840,26 @@ impl Element for EditorElement {
                 }
                 self.paint_text(text_bounds, &mut layout, cx);
 
-                cx.with_z_index(0, |cx| {
-                    self.paint_mouse_listeners(bounds, gutter_bounds, text_bounds, &layout, cx);
-                });
-
-                cx.with_z_index(1, |cx| self.paint_scrollbar(bounds, &mut layout, cx));
-
                 if !layout.blocks.is_empty() {
-                    cx.with_z_index(2, |cx| {
+                    cx.with_z_index(0, |cx| {
                         cx.with_element_id(Some("editor_blocks"), |cx| {
                             self.paint_blocks(bounds, &mut layout, cx);
+                            self.paint_mouse_listeners(
+                                bounds,
+                                gutter_bounds,
+                                text_bounds,
+                                &layout,
+                                cx,
+                            );
                         });
                     })
                 }
 
-                cx.with_z_index(3, |cx| {
+                cx.with_z_index(1, |cx| {
                     self.paint_overlays(text_bounds, &mut layout, cx);
                 });
+
+                cx.with_z_index(2, |cx| self.paint_scrollbar(bounds, &mut layout, cx));
             });
         })
     }


### PR DESCRIPTION
1. Blocks (with their headers) and mouse listeners should be drawn together otherwise either starts to loose mouse events.

2. Scrollbar should be above all to match zed1 look and avoid buffer headers popping slightly to the right of the scrollbar.

Release Notes:

- N/A