### PR TITLE
Increase telemetry queue size

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -125,7 +125,7 @@ const MAX_QUEUE_LEN: usize = 50;
 const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(1);
 
 #[cfg(not(debug_assertions))]
-const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(30);
+const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(120);
 
 impl Telemetry {
     pub fn new(client: Arc<dyn HttpClient>, cx: &AppContext) -> Arc<Self> {

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -119,7 +119,7 @@ pub enum ClickhouseEvent {
 const MAX_QUEUE_LEN: usize = 1;
 
 #[cfg(not(debug_assertions))]
-const MAX_QUEUE_LEN: usize = 10;
+const MAX_QUEUE_LEN: usize = 50;
 
 #[cfg(debug_assertions)]
 const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(1);

--- a/crates/client2/src/telemetry.rs
+++ b/crates/client2/src/telemetry.rs
@@ -124,7 +124,7 @@ const MAX_QUEUE_LEN: usize = 50;
 const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(1);
 
 #[cfg(not(debug_assertions))]
-const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(30);
+const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(120);
 
 impl Telemetry {
     pub fn new(client: Arc<dyn HttpClient>, cx: &mut AppContext) -> Arc<Self> {

--- a/crates/client2/src/telemetry.rs
+++ b/crates/client2/src/telemetry.rs
@@ -118,7 +118,7 @@ pub enum ClickhouseEvent {
 const MAX_QUEUE_LEN: usize = 1;
 
 #[cfg(not(debug_assertions))]
-const MAX_QUEUE_LEN: usize = 10;
+const MAX_QUEUE_LEN: usize = 50;
 
 #[cfg(debug_assertions)]
 const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(1);


### PR DESCRIPTION
It seems like we've fixed the clickhouse errors by switching to `async_insert`, but we're still seeing a hiccup here and there on vercel's socket. I slowed down the collection of cpu and memory events earlier, and this PR will slow down how frequently we send events in general, by increasing the queue size and the debounce time.

Release Notes:

- N/A