### PR TITLE
Assign player colors from the theme

### DIFF
--- a/crates/theme2/src/registry.rs
+++ b/crates/theme2/src/registry.rs
@@ -49,8 +49,19 @@ impl ThemeRegistry {
             };
             theme_colors.refine(&user_theme.styles.colors);
 
-            let mut status_colors = StatusColors::dark();
+            let mut status_colors = match user_theme.appearance {
+                Appearance::Light => StatusColors::light(),
+                Appearance::Dark => StatusColors::dark(),
+            };
             status_colors.refine(&user_theme.styles.status);
+
+            let mut player_colors = match user_theme.appearance {
+                Appearance::Light => PlayerColors::light(),
+                Appearance::Dark => PlayerColors::dark(),
+            };
+            if let Some(player_colors_from_theme) = user_theme.styles.player {
+                player_colors = player_colors_from_theme;
+            }
 
             let mut syntax_colors = match user_theme.appearance {
                 Appearance::Light => SyntaxTheme::light(),
@@ -82,10 +93,7 @@ impl ThemeRegistry {
                     system: SystemColors::default(),
                     colors: theme_colors,
                     status: status_colors,
-                    player: match user_theme.appearance {
-                        Appearance::Light => PlayerColors::light(),
-                        Appearance::Dark => PlayerColors::dark(),
-                    },
+                    player: player_colors,
                     syntax: Arc::new(syntax_colors),
                     accents: Vec::new(),
                 },

--- a/crates/theme2/src/styles/players.rs
+++ b/crates/theme2/src/styles/players.rs
@@ -1,8 +1,9 @@
 use gpui::Hsla;
+use serde_derive::Deserialize;
 
 use crate::{amber, blue, jade, lime, orange, pink, purple, red};
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
 pub struct PlayerColor {
     pub cursor: Hsla,
     pub background: Hsla,
@@ -15,7 +16,7 @@ pub struct PlayerColor {
 ///
 /// The rest of the default colors crisscross back and forth on the
 /// color wheel so that the colors are as distinct as possible.
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
 pub struct PlayerColors(pub Vec<PlayerColor>);
 
 impl Default for PlayerColors {

--- a/crates/theme2/src/themes/andromeda.rs
+++ b/crates/theme2/src/themes/andromeda.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn andromeda() -> UserThemeFamily {
@@ -75,6 +76,48 @@ pub fn andromeda() -> UserThemeFamily {
                     warning: Some(rgba(0xfee56dff).into()),
                     ..Default::default()
                 },
+                player: Some(PlayerColors(vec![
+                    PlayerColor {
+                        cursor: rgba(0x11a793ff).into(),
+                        background: rgba(0x11a793ff).into(),
+                        selection: rgba(0x11a7933d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xc74decff).into(),
+                        background: rgba(0xc74decff).into(),
+                        selection: rgba(0xc74dec3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xf29c14ff).into(),
+                        background: rgba(0xf29c14ff).into(),
+                        selection: rgba(0xf29c143d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x8a3fa6ff).into(),
+                        background: rgba(0x8a3fa6ff).into(),
+                        selection: rgba(0x8a3fa63d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x09e7c6ff).into(),
+                        background: rgba(0x09e7c6ff).into(),
+                        selection: rgba(0x09e7c63d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xf82872ff).into(),
+                        background: rgba(0xf82872ff).into(),
+                        selection: rgba(0xf828723d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xfee56dff).into(),
+                        background: rgba(0xfee56dff).into(),
+                        selection: rgba(0xfee56d3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x96df72ff).into(),
+                        background: rgba(0x96df72ff).into(),
+                        selection: rgba(0x96df723d).into(),
+                    },
+                ])),
                 syntax: Some(UserSyntaxTheme {
                     highlights: vec![
                         (

--- a/crates/theme2/src/themes/atelier.rs
+++ b/crates/theme2/src/themes/atelier.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn atelier() -> UserThemeFamily {
@@ -76,6 +77,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa59810ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x38a166ff).into(),
+                            background: rgba(0x38a166ff).into(),
+                            selection: rgba(0x38a1663d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d6c7cff).into(),
+                            background: rgba(0x9d6c7cff).into(),
+                            selection: rgba(0x9d6c7c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae7315ff).into(),
+                            background: rgba(0xae7315ff).into(),
+                            selection: rgba(0xae73153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x609182ff).into(),
+                            background: rgba(0x609182ff).into(),
+                            selection: rgba(0x6091823d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5c9d49ff).into(),
+                            background: rgba(0x5c9d49ff).into(),
+                            selection: rgba(0x5c9d493d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xba6337ff).into(),
+                            background: rgba(0xba6337ff).into(),
+                            selection: rgba(0xba63373d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa59810ff).into(),
+                            background: rgba(0xa59810ff).into(),
+                            selection: rgba(0xa598103d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7d9728ff).into(),
+                            background: rgba(0x7d9728ff).into(),
+                            selection: rgba(0x7d97283d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -436,6 +479,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xc38419ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x417ee6ff).into(),
+                            background: rgba(0x417ee6ff).into(),
+                            selection: rgba(0x417ee63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc340f2ff).into(),
+                            background: rgba(0xc340f2ff).into(),
+                            selection: rgba(0xc340f23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdf5321ff).into(),
+                            background: rgba(0xdf5321ff).into(),
+                            selection: rgba(0xdf53213d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6666e9ff).into(),
+                            background: rgba(0x6666e9ff).into(),
+                            selection: rgba(0x6666e93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3e97b8ff).into(),
+                            background: rgba(0x3e97b8ff).into(),
+                            selection: rgba(0x3e97b83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf22d40ff).into(),
+                            background: rgba(0xf22d40ff).into(),
+                            selection: rgba(0xf22d403d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc38419ff).into(),
+                            background: rgba(0xc38419ff).into(),
+                            selection: rgba(0xc384193d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b9727ff).into(),
+                            background: rgba(0x7b9727ff).into(),
+                            selection: rgba(0x7b97273d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -796,6 +881,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa07e3cff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x488c90ff).into(),
+                            background: rgba(0x488c90ff).into(),
+                            selection: rgba(0x488c903d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x867469ff).into(),
+                            background: rgba(0x867469ff).into(),
+                            selection: rgba(0x8674693d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9f713dff).into(),
+                            background: rgba(0x9f713dff).into(),
+                            selection: rgba(0x9f713d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x56859bff).into(),
+                            background: rgba(0x56859bff).into(),
+                            selection: rgba(0x56859b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x1f9aa0ff).into(),
+                            background: rgba(0x1f9aa0ff).into(),
+                            selection: rgba(0x1f9aa03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb1623aff).into(),
+                            background: rgba(0xb1623aff).into(),
+                            selection: rgba(0xb1623a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa07e3cff).into(),
+                            background: rgba(0xa07e3cff).into(),
+                            selection: rgba(0xa07e3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x499963ff).into(),
+                            background: rgba(0x499963ff).into(),
+                            selection: rgba(0x4999633d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -1156,6 +1283,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa06e3bff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x576ddaff).into(),
+                            background: rgba(0x576ddaff).into(),
+                            selection: rgba(0x576dda3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbf41bfff).into(),
+                            background: rgba(0xbf41bfff).into(),
+                            selection: rgba(0xbf41bf3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaa573cff).into(),
+                            background: rgba(0xaa573cff).into(),
+                            selection: rgba(0xaa573c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x955ae6ff).into(),
+                            background: rgba(0x955ae6ff).into(),
+                            selection: rgba(0x955ae63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3a8bc6ff).into(),
+                            background: rgba(0x3a8bc6ff).into(),
+                            selection: rgba(0x3a8bc63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbe4678ff).into(),
+                            background: rgba(0xbe4678ff).into(),
+                            selection: rgba(0xbe46783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3bff).into(),
+                            background: rgba(0xa06e3bff).into(),
+                            selection: rgba(0xa06e3b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2c9292ff).into(),
+                            background: rgba(0x2c9292ff).into(),
+                            selection: rgba(0x2c92923d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -1516,6 +1685,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa59810ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x37a166ff).into(),
+                            background: rgba(0x37a166ff).into(),
+                            selection: rgba(0x37a1663d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d6c7cff).into(),
+                            background: rgba(0x9d6c7cff).into(),
+                            selection: rgba(0x9d6c7c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae7315ff).into(),
+                            background: rgba(0xae7315ff).into(),
+                            selection: rgba(0xae73153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5f9182ff).into(),
+                            background: rgba(0x5f9182ff).into(),
+                            selection: rgba(0x5f91823d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5b9d48ff).into(),
+                            background: rgba(0x5b9d48ff).into(),
+                            selection: rgba(0x5b9d483d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xba6237ff).into(),
+                            background: rgba(0xba6237ff).into(),
+                            selection: rgba(0xba62373d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa59810ff).into(),
+                            background: rgba(0xa59810ff).into(),
+                            selection: rgba(0xa598103d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7d9727ff).into(),
+                            background: rgba(0x7d9727ff).into(),
+                            selection: rgba(0x7d97273d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -1876,6 +2087,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xc08b31ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x3e8fd0ff).into(),
+                            background: rgba(0x3e8fd0ff).into(),
+                            selection: rgba(0x3e8fd03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9c637aff).into(),
+                            background: rgba(0x9c637aff).into(),
+                            selection: rgba(0x9c637a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc76b2aff).into(),
+                            background: rgba(0xc76b2aff).into(),
+                            selection: rgba(0xc76b2a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6679ccff).into(),
+                            background: rgba(0x6679ccff).into(),
+                            selection: rgba(0x6679cc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x25a2c9ff).into(),
+                            background: rgba(0x25a2c9ff).into(),
+                            selection: rgba(0x25a2c93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc94923ff).into(),
+                            background: rgba(0xc94923ff).into(),
+                            selection: rgba(0xc949233d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc08b31ff).into(),
+                            background: rgba(0xc08b31ff).into(),
+                            selection: rgba(0xc08b313d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xac973aff).into(),
+                            background: rgba(0xac973aff).into(),
+                            selection: rgba(0xac973a3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -2236,6 +2489,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xc08b31ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x3f8fd0ff).into(),
+                            background: rgba(0x3f8fd0ff).into(),
+                            selection: rgba(0x3f8fd03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9c637aff).into(),
+                            background: rgba(0x9c637aff).into(),
+                            selection: rgba(0x9c637a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc76b2aff).into(),
+                            background: rgba(0xc76b2aff).into(),
+                            selection: rgba(0xc76b2a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6779ccff).into(),
+                            background: rgba(0x6779ccff).into(),
+                            selection: rgba(0x6779cc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x25a2c9ff).into(),
+                            background: rgba(0x25a2c9ff).into(),
+                            selection: rgba(0x25a2c93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc94a23ff).into(),
+                            background: rgba(0xc94a23ff).into(),
+                            selection: rgba(0xc94a233d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc08b31ff).into(),
+                            background: rgba(0xc08b31ff).into(),
+                            selection: rgba(0xc08b313d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xac973aff).into(),
+                            background: rgba(0xac973aff).into(),
+                            selection: rgba(0xac973a3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -2596,6 +2891,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xae9515ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x6684e0ff).into(),
+                            background: rgba(0x6684e0ff).into(),
+                            selection: rgba(0x6684e03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd43652ff).into(),
+                            background: rgba(0xd43652ff).into(),
+                            selection: rgba(0xd436523d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb65612ff).into(),
+                            background: rgba(0xb65612ff).into(),
+                            selection: rgba(0xb656123d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb854d3ff).into(),
+                            background: rgba(0xb854d3ff).into(),
+                            selection: rgba(0xb854d33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x21ad83ff).into(),
+                            background: rgba(0x21ad83ff).into(),
+                            selection: rgba(0x21ad833d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd73837ff).into(),
+                            background: rgba(0xd73837ff).into(),
+                            selection: rgba(0xd738373d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae9515ff).into(),
+                            background: rgba(0xae9515ff).into(),
+                            selection: rgba(0xae95153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x60ac3aff).into(),
+                            background: rgba(0x60ac3aff).into(),
+                            selection: rgba(0x60ac3a3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -2956,6 +3293,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0x98981cff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x3e62f4ff).into(),
+                            background: rgba(0x3e62f4ff).into(),
+                            selection: rgba(0x3e62f43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xe61cc3ff).into(),
+                            background: rgba(0xe61cc3ff).into(),
+                            selection: rgba(0xe61cc33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x87711eff).into(),
+                            background: rgba(0x87711eff).into(),
+                            selection: rgba(0x87711e3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xad2dedff).into(),
+                            background: rgba(0xad2dedff).into(),
+                            selection: rgba(0xad2ded3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x1c99b3ff).into(),
+                            background: rgba(0x1c99b3ff).into(),
+                            selection: rgba(0x1c99b33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xe61c3cff).into(),
+                            background: rgba(0xe61c3cff).into(),
+                            selection: rgba(0xe61c3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x98981cff).into(),
+                            background: rgba(0x98981cff).into(),
+                            selection: rgba(0x98981c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2ba32aff).into(),
+                            background: rgba(0x2ba32aff).into(),
+                            selection: rgba(0x2ba32a3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -3316,6 +3695,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa06e3cff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x586ddaff).into(),
+                            background: rgba(0x586ddaff).into(),
+                            selection: rgba(0x586dda3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbf41bfff).into(),
+                            background: rgba(0xbf41bfff).into(),
+                            selection: rgba(0xbf41bf3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaa583dff).into(),
+                            background: rgba(0xaa583dff).into(),
+                            selection: rgba(0xaa583d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x955be6ff).into(),
+                            background: rgba(0x955be6ff).into(),
+                            selection: rgba(0x955be63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3b8bc6ff).into(),
+                            background: rgba(0x3b8bc6ff).into(),
+                            selection: rgba(0x3b8bc63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbe4778ff).into(),
+                            background: rgba(0xbe4778ff).into(),
+                            selection: rgba(0xbe47783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3cff).into(),
+                            background: rgba(0xa06e3cff).into(),
+                            selection: rgba(0xa06e3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2c9292ff).into(),
+                            background: rgba(0x2c9292ff).into(),
+                            selection: rgba(0x2c92923d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -3676,6 +4097,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa06e3bff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x7272caff).into(),
+                            background: rgba(0x7272caff).into(),
+                            selection: rgba(0x7272ca3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbd5187ff).into(),
+                            background: rgba(0xbd5187ff).into(),
+                            selection: rgba(0xbd51873d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb45a3cff).into(),
+                            background: rgba(0xb45a3cff).into(),
+                            selection: rgba(0xb45a3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8464c4ff).into(),
+                            background: rgba(0x8464c4ff).into(),
+                            selection: rgba(0x8464c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5485b6ff).into(),
+                            background: rgba(0x5485b6ff).into(),
+                            selection: rgba(0x5485b63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca4949ff).into(),
+                            background: rgba(0xca4949ff).into(),
+                            selection: rgba(0xca49493d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3bff).into(),
+                            background: rgba(0xa06e3bff).into(),
+                            selection: rgba(0xa06e3b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x4b8b8bff).into(),
+                            background: rgba(0x4b8b8bff).into(),
+                            selection: rgba(0x4b8b8b3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -4036,6 +4499,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xbb8a36ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x526aebff).into(),
+                            background: rgba(0x526aebff).into(),
+                            selection: rgba(0x526aeb3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcc34ccff).into(),
+                            background: rgba(0xcc34ccff).into(),
+                            selection: rgba(0xcc34cc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa65927ff).into(),
+                            background: rgba(0xa65927ff).into(),
+                            selection: rgba(0xa659273d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b59c0ff).into(),
+                            background: rgba(0x7b59c0ff).into(),
+                            selection: rgba(0x7b59c03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x189393ff).into(),
+                            background: rgba(0x189393ff).into(),
+                            selection: rgba(0x1893933d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca402cff).into(),
+                            background: rgba(0xca402cff).into(),
+                            selection: rgba(0xca402c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbb8a36ff).into(),
+                            background: rgba(0xbb8a36ff).into(),
+                            selection: rgba(0xbb8a363d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x918b3bff).into(),
+                            background: rgba(0x918b3bff).into(),
+                            selection: rgba(0x918b3b3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -4396,6 +4901,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0x8a8a11ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x277fadff).into(),
+                            background: rgba(0x277fadff).into(),
+                            selection: rgba(0x277fad3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb72ed2ff).into(),
+                            background: rgba(0xb72ed2ff).into(),
+                            selection: rgba(0xb72ed23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x935c26ff).into(),
+                            background: rgba(0x935c26ff).into(),
+                            selection: rgba(0x935c263d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6b6bb8ff).into(),
+                            background: rgba(0x6b6bb8ff).into(),
+                            selection: rgba(0x6b6bb83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2e8f6fff).into(),
+                            background: rgba(0x2e8f6fff).into(),
+                            selection: rgba(0x2e8f6f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd22e72ff).into(),
+                            background: rgba(0xd22e72ff).into(),
+                            selection: rgba(0xd22e723d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8a8a11ff).into(),
+                            background: rgba(0x8a8a11ff).into(),
+                            selection: rgba(0x8a8a113d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x568c3bff).into(),
+                            background: rgba(0x568c3bff).into(),
+                            selection: rgba(0x568c3b3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -4756,6 +5303,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xc3841aff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x417ee6ff).into(),
+                            background: rgba(0x417ee6ff).into(),
+                            selection: rgba(0x417ee63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc340f2ff).into(),
+                            background: rgba(0xc340f2ff).into(),
+                            selection: rgba(0xc340f23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdf5421ff).into(),
+                            background: rgba(0xdf5421ff).into(),
+                            selection: rgba(0xdf54213d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6766e9ff).into(),
+                            background: rgba(0x6766e9ff).into(),
+                            selection: rgba(0x6766e93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3f97b8ff).into(),
+                            background: rgba(0x3f97b8ff).into(),
+                            selection: rgba(0x3f97b83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf22e41ff).into(),
+                            background: rgba(0xf22e41ff).into(),
+                            selection: rgba(0xf22e413d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc3841aff).into(),
+                            background: rgba(0xc3841aff).into(),
+                            selection: rgba(0xc3841a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b9728ff).into(),
+                            background: rgba(0x7b9728ff).into(),
+                            selection: rgba(0x7b97283d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -5116,6 +5705,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xae9515ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x6784e0ff).into(),
+                            background: rgba(0x6784e0ff).into(),
+                            selection: rgba(0x6784e03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd43753ff).into(),
+                            background: rgba(0xd43753ff).into(),
+                            selection: rgba(0xd437533d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb65713ff).into(),
+                            background: rgba(0xb65713ff).into(),
+                            selection: rgba(0xb657133d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb855d3ff).into(),
+                            background: rgba(0xb855d3ff).into(),
+                            selection: rgba(0xb855d33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x22ad83ff).into(),
+                            background: rgba(0x22ad83ff).into(),
+                            selection: rgba(0x22ad833d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd73838ff).into(),
+                            background: rgba(0xd73838ff).into(),
+                            selection: rgba(0xd738383d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae9515ff).into(),
+                            background: rgba(0xae9515ff).into(),
+                            selection: rgba(0xae95153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x61ac3aff).into(),
+                            background: rgba(0x61ac3aff).into(),
+                            selection: rgba(0x61ac3a3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -5476,6 +6107,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa06e3cff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x7372caff).into(),
+                            background: rgba(0x7372caff).into(),
+                            selection: rgba(0x7372ca3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbd5287ff).into(),
+                            background: rgba(0xbd5287ff).into(),
+                            selection: rgba(0xbd52873d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb45b3dff).into(),
+                            background: rgba(0xb45b3dff).into(),
+                            selection: rgba(0xb45b3d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8464c4ff).into(),
+                            background: rgba(0x8464c4ff).into(),
+                            selection: rgba(0x8464c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5585b6ff).into(),
+                            background: rgba(0x5585b6ff).into(),
+                            selection: rgba(0x5585b63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca4a4aff).into(),
+                            background: rgba(0xca4a4aff).into(),
+                            selection: rgba(0xca4a4a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3cff).into(),
+                            background: rgba(0xa06e3cff).into(),
+                            selection: rgba(0xa06e3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x4c8b8bff).into(),
+                            background: rgba(0x4c8b8bff).into(),
+                            selection: rgba(0x4c8b8b3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -5836,6 +6509,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0x98981dff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x3f62f4ff).into(),
+                            background: rgba(0x3f62f4ff).into(),
+                            selection: rgba(0x3f62f43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xe61dc3ff).into(),
+                            background: rgba(0xe61dc3ff).into(),
+                            selection: rgba(0xe61dc33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x87711fff).into(),
+                            background: rgba(0x87711fff).into(),
+                            selection: rgba(0x87711f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xad2dedff).into(),
+                            background: rgba(0xad2dedff).into(),
+                            selection: rgba(0xad2ded3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x1d99b3ff).into(),
+                            background: rgba(0x1d99b3ff).into(),
+                            selection: rgba(0x1d99b33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xe61c3dff).into(),
+                            background: rgba(0xe61c3dff).into(),
+                            selection: rgba(0xe61c3d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x98981dff).into(),
+                            background: rgba(0x98981dff).into(),
+                            selection: rgba(0x98981d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2ba32bff).into(),
+                            background: rgba(0x2ba32bff).into(),
+                            selection: rgba(0x2ba32b3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -6196,6 +6911,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xa07e3bff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x478c90ff).into(),
+                            background: rgba(0x478c90ff).into(),
+                            selection: rgba(0x478c903d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x867469ff).into(),
+                            background: rgba(0x867469ff).into(),
+                            selection: rgba(0x8674693d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9f713cff).into(),
+                            background: rgba(0x9f713cff).into(),
+                            selection: rgba(0x9f713c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x55859bff).into(),
+                            background: rgba(0x55859bff).into(),
+                            selection: rgba(0x55859b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x1e9aa0ff).into(),
+                            background: rgba(0x1e9aa0ff).into(),
+                            selection: rgba(0x1e9aa03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb16139ff).into(),
+                            background: rgba(0xb16139ff).into(),
+                            selection: rgba(0xb161393d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa07e3bff).into(),
+                            background: rgba(0xa07e3bff).into(),
+                            selection: rgba(0xa07e3b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x489963ff).into(),
+                            background: rgba(0x489963ff).into(),
+                            selection: rgba(0x4899633d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -6556,6 +7313,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0xbb8a36ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x526aebff).into(),
+                            background: rgba(0x526aebff).into(),
+                            selection: rgba(0x526aeb3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcc35ccff).into(),
+                            background: rgba(0xcc35ccff).into(),
+                            selection: rgba(0xcc35cc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa65a27ff).into(),
+                            background: rgba(0xa65a27ff).into(),
+                            selection: rgba(0xa65a273d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b5ac0ff).into(),
+                            background: rgba(0x7b5ac0ff).into(),
+                            selection: rgba(0x7b5ac03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x199393ff).into(),
+                            background: rgba(0x199393ff).into(),
+                            selection: rgba(0x1993933d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca412cff).into(),
+                            background: rgba(0xca412cff).into(),
+                            selection: rgba(0xca412c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbb8a36ff).into(),
+                            background: rgba(0xbb8a36ff).into(),
+                            selection: rgba(0xbb8a363d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x918b3cff).into(),
+                            background: rgba(0x918b3cff).into(),
+                            selection: rgba(0x918b3c3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -6916,6 +7715,48 @@ pub fn atelier() -> UserThemeFamily {
                         warning: Some(rgba(0x8a8a11ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x277fadff).into(),
+                            background: rgba(0x277fadff).into(),
+                            selection: rgba(0x277fad3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb72fd2ff).into(),
+                            background: rgba(0xb72fd2ff).into(),
+                            selection: rgba(0xb72fd23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x935d26ff).into(),
+                            background: rgba(0x935d26ff).into(),
+                            selection: rgba(0x935d263d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6c6bb8ff).into(),
+                            background: rgba(0x6c6bb8ff).into(),
+                            selection: rgba(0x6c6bb83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2f8f6fff).into(),
+                            background: rgba(0x2f8f6fff).into(),
+                            selection: rgba(0x2f8f6f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd22f72ff).into(),
+                            background: rgba(0xd22f72ff).into(),
+                            selection: rgba(0xd22f723d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8a8a11ff).into(),
+                            background: rgba(0x8a8a11ff).into(),
+                            selection: rgba(0x8a8a113d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x578c3cff).into(),
+                            background: rgba(0x578c3cff).into(),
+                            selection: rgba(0x578c3c3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (

--- a/crates/theme2/src/themes/ayu.rs
+++ b/crates/theme2/src/themes/ayu.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn ayu() -> UserThemeFamily {
@@ -76,6 +77,48 @@ pub fn ayu() -> UserThemeFamily {
                         warning: Some(rgba(0xfeb454ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x5ac2feff).into(),
+                            background: rgba(0x5ac2feff).into(),
+                            selection: rgba(0x5ac2fe3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3abae5ff).into(),
+                            background: rgba(0x3abae5ff).into(),
+                            selection: rgba(0x3abae53d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfe8f40ff).into(),
+                            background: rgba(0xfe8f40ff).into(),
+                            selection: rgba(0xfe8f403d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd2a6feff).into(),
+                            background: rgba(0xd2a6feff).into(),
+                            selection: rgba(0xd2a6fe3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x95e5cbff).into(),
+                            background: rgba(0x95e5cbff).into(),
+                            selection: rgba(0x95e5cb3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xef7178ff).into(),
+                            background: rgba(0xef7178ff).into(),
+                            selection: rgba(0xef71783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfeb454ff).into(),
+                            background: rgba(0xfeb454ff).into(),
+                            selection: rgba(0xfeb4543d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaad84cff).into(),
+                            background: rgba(0xaad84cff).into(),
+                            selection: rgba(0xaad84c3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -415,6 +458,48 @@ pub fn ayu() -> UserThemeFamily {
                         warning: Some(rgba(0xf1ae4aff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x3b9ee5ff).into(),
+                            background: rgba(0x3b9ee5ff).into(),
+                            selection: rgba(0x3b9ee53d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x56b4d3ff).into(),
+                            background: rgba(0x56b4d3ff).into(),
+                            selection: rgba(0x56b4d33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf98d3fff).into(),
+                            background: rgba(0xf98d3fff).into(),
+                            selection: rgba(0xf98d3f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa37accff).into(),
+                            background: rgba(0xa37accff).into(),
+                            selection: rgba(0xa37acc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x4dbf99ff).into(),
+                            background: rgba(0x4dbf99ff).into(),
+                            selection: rgba(0x4dbf993d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xef7271ff).into(),
+                            background: rgba(0xef7271ff).into(),
+                            selection: rgba(0xef72713d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf1ae4aff).into(),
+                            background: rgba(0xf1ae4aff).into(),
+                            selection: rgba(0xf1ae4a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x86b305ff).into(),
+                            background: rgba(0x86b305ff).into(),
+                            selection: rgba(0x86b3053d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -754,6 +839,48 @@ pub fn ayu() -> UserThemeFamily {
                         warning: Some(rgba(0xfed073ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x73cffeff).into(),
+                            background: rgba(0x73cffeff).into(),
+                            selection: rgba(0x73cffe3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5ccee5ff).into(),
+                            background: rgba(0x5ccee5ff).into(),
+                            selection: rgba(0x5ccee53d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfead66ff).into(),
+                            background: rgba(0xfead66ff).into(),
+                            selection: rgba(0xfead663d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdebffeff).into(),
+                            background: rgba(0xdebffeff).into(),
+                            selection: rgba(0xdebffe3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x95e5cbff).into(),
+                            background: rgba(0x95e5cbff).into(),
+                            selection: rgba(0x95e5cb3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf18779ff).into(),
+                            background: rgba(0xf18779ff).into(),
+                            selection: rgba(0xf187793d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfed073ff).into(),
+                            background: rgba(0xfed073ff).into(),
+                            selection: rgba(0xfed0733d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd5fe80ff).into(),
+                            background: rgba(0xd5fe80ff).into(),
+                            selection: rgba(0xd5fe803d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (

--- a/crates/theme2/src/themes/gruvbox.rs
+++ b/crates/theme2/src/themes/gruvbox.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn gruvbox() -> UserThemeFamily {
@@ -76,6 +77,48 @@ pub fn gruvbox() -> UserThemeFamily {
                         warning: Some(rgba(0xb57616ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x0b6678ff).into(),
+                            background: rgba(0x0b6678ff).into(),
+                            selection: rgba(0x0b66783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7c6f64ff).into(),
+                            background: rgba(0x7c6f64ff).into(),
+                            selection: rgba(0x7c6f643d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaf3b05ff).into(),
+                            background: rgba(0xaf3b05ff).into(),
+                            selection: rgba(0xaf3b053d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8f4071ff).into(),
+                            background: rgba(0x8f4071ff).into(),
+                            selection: rgba(0x8f40713d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x437b59ff).into(),
+                            background: rgba(0x437b59ff).into(),
+                            selection: rgba(0x437b593d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d0408ff).into(),
+                            background: rgba(0x9d0408ff).into(),
+                            selection: rgba(0x9d04083d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb57616ff).into(),
+                            background: rgba(0xb57616ff).into(),
+                            selection: rgba(0xb576163d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x797410ff).into(),
+                            background: rgba(0x797410ff).into(),
+                            selection: rgba(0x7974103d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -422,6 +465,48 @@ pub fn gruvbox() -> UserThemeFamily {
                         warning: Some(rgba(0xf9bd30ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x83a598ff).into(),
+                            background: rgba(0x83a598ff).into(),
+                            selection: rgba(0x83a5983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa89984ff).into(),
+                            background: rgba(0xa89984ff).into(),
+                            selection: rgba(0xa899843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfd801bff).into(),
+                            background: rgba(0xfd801bff).into(),
+                            selection: rgba(0xfd801b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd3869bff).into(),
+                            background: rgba(0xd3869bff).into(),
+                            selection: rgba(0xd3869b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8ec07cff).into(),
+                            background: rgba(0x8ec07cff).into(),
+                            selection: rgba(0x8ec07c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfb4a35ff).into(),
+                            background: rgba(0xfb4a35ff).into(),
+                            selection: rgba(0xfb4a353d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf9bd30ff).into(),
+                            background: rgba(0xf9bd30ff).into(),
+                            selection: rgba(0xf9bd303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb8bb27ff).into(),
+                            background: rgba(0xb8bb27ff).into(),
+                            selection: rgba(0xb8bb273d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -768,6 +853,48 @@ pub fn gruvbox() -> UserThemeFamily {
                         warning: Some(rgba(0xb57616ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x0b6678ff).into(),
+                            background: rgba(0x0b6678ff).into(),
+                            selection: rgba(0x0b66783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7c6f64ff).into(),
+                            background: rgba(0x7c6f64ff).into(),
+                            selection: rgba(0x7c6f643d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaf3b05ff).into(),
+                            background: rgba(0xaf3b05ff).into(),
+                            selection: rgba(0xaf3b053d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8f4071ff).into(),
+                            background: rgba(0x8f4071ff).into(),
+                            selection: rgba(0x8f40713d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x437b59ff).into(),
+                            background: rgba(0x437b59ff).into(),
+                            selection: rgba(0x437b593d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d0408ff).into(),
+                            background: rgba(0x9d0408ff).into(),
+                            selection: rgba(0x9d04083d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb57616ff).into(),
+                            background: rgba(0xb57616ff).into(),
+                            selection: rgba(0xb576163d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x797410ff).into(),
+                            background: rgba(0x797410ff).into(),
+                            selection: rgba(0x7974103d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -1114,6 +1241,48 @@ pub fn gruvbox() -> UserThemeFamily {
                         warning: Some(rgba(0xf9bd30ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x83a598ff).into(),
+                            background: rgba(0x83a598ff).into(),
+                            selection: rgba(0x83a5983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa89984ff).into(),
+                            background: rgba(0xa89984ff).into(),
+                            selection: rgba(0xa899843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfd801bff).into(),
+                            background: rgba(0xfd801bff).into(),
+                            selection: rgba(0xfd801b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd3869bff).into(),
+                            background: rgba(0xd3869bff).into(),
+                            selection: rgba(0xd3869b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8ec07cff).into(),
+                            background: rgba(0x8ec07cff).into(),
+                            selection: rgba(0x8ec07c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfb4a35ff).into(),
+                            background: rgba(0xfb4a35ff).into(),
+                            selection: rgba(0xfb4a353d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf9bd30ff).into(),
+                            background: rgba(0xf9bd30ff).into(),
+                            selection: rgba(0xf9bd303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb8bb27ff).into(),
+                            background: rgba(0xb8bb27ff).into(),
+                            selection: rgba(0xb8bb273d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -1460,6 +1629,48 @@ pub fn gruvbox() -> UserThemeFamily {
                         warning: Some(rgba(0xb57616ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x0b6678ff).into(),
+                            background: rgba(0x0b6678ff).into(),
+                            selection: rgba(0x0b66783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7c6f64ff).into(),
+                            background: rgba(0x7c6f64ff).into(),
+                            selection: rgba(0x7c6f643d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaf3b05ff).into(),
+                            background: rgba(0xaf3b05ff).into(),
+                            selection: rgba(0xaf3b053d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8f4071ff).into(),
+                            background: rgba(0x8f4071ff).into(),
+                            selection: rgba(0x8f40713d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x437b59ff).into(),
+                            background: rgba(0x437b59ff).into(),
+                            selection: rgba(0x437b593d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d0408ff).into(),
+                            background: rgba(0x9d0408ff).into(),
+                            selection: rgba(0x9d04083d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb57616ff).into(),
+                            background: rgba(0xb57616ff).into(),
+                            selection: rgba(0xb576163d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x797410ff).into(),
+                            background: rgba(0x797410ff).into(),
+                            selection: rgba(0x7974103d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -1806,6 +2017,48 @@ pub fn gruvbox() -> UserThemeFamily {
                         warning: Some(rgba(0xf9bd30ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x83a598ff).into(),
+                            background: rgba(0x83a598ff).into(),
+                            selection: rgba(0x83a5983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa89984ff).into(),
+                            background: rgba(0xa89984ff).into(),
+                            selection: rgba(0xa899843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfd801bff).into(),
+                            background: rgba(0xfd801bff).into(),
+                            selection: rgba(0xfd801b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd3869bff).into(),
+                            background: rgba(0xd3869bff).into(),
+                            selection: rgba(0xd3869b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8ec07cff).into(),
+                            background: rgba(0x8ec07cff).into(),
+                            selection: rgba(0x8ec07c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfb4a35ff).into(),
+                            background: rgba(0xfb4a35ff).into(),
+                            selection: rgba(0xfb4a353d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf9bd30ff).into(),
+                            background: rgba(0xf9bd30ff).into(),
+                            selection: rgba(0xf9bd303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb8bb27ff).into(),
+                            background: rgba(0xb8bb27ff).into(),
+                            selection: rgba(0xb8bb273d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (

--- a/crates/theme2/src/themes/one.rs
+++ b/crates/theme2/src/themes/one.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn one() -> UserThemeFamily {
@@ -76,6 +77,48 @@ pub fn one() -> UserThemeFamily {
                         warning: Some(rgba(0xdec184ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x5c79e2ff).into(),
+                            background: rgba(0x5c79e2ff).into(),
+                            selection: rgba(0x5c79e23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x994fa6ff).into(),
+                            background: rgba(0x994fa6ff).into(),
+                            selection: rgba(0x994fa63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xad6f27ff).into(),
+                            background: rgba(0xad6f27ff).into(),
+                            selection: rgba(0xad6f273d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa44aabff).into(),
+                            background: rgba(0xa44aabff).into(),
+                            selection: rgba(0xa44aab3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3b82b7ff).into(),
+                            background: rgba(0x3b82b7ff).into(),
+                            selection: rgba(0x3b82b73d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd36151ff).into(),
+                            background: rgba(0xd36151ff).into(),
+                            selection: rgba(0xd361513d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdec184ff).into(),
+                            background: rgba(0xdec184ff).into(),
+                            selection: rgba(0xdec1843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x669f59ff).into(),
+                            background: rgba(0x669f59ff).into(),
+                            selection: rgba(0x669f593d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -422,6 +465,48 @@ pub fn one() -> UserThemeFamily {
                         warning: Some(rgba(0xdec184ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x74ade8ff).into(),
+                            background: rgba(0x74ade8ff).into(),
+                            selection: rgba(0x74ade83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbe5046ff).into(),
+                            background: rgba(0xbe5046ff).into(),
+                            selection: rgba(0xbe50463d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc0966bff).into(),
+                            background: rgba(0xc0966bff).into(),
+                            selection: rgba(0xc0966b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb478cfff).into(),
+                            background: rgba(0xb478cfff).into(),
+                            selection: rgba(0xb478cf3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6fb4c0ff).into(),
+                            background: rgba(0x6fb4c0ff).into(),
+                            selection: rgba(0x6fb4c03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd07277ff).into(),
+                            background: rgba(0xd07277ff).into(),
+                            selection: rgba(0xd072773d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdec184ff).into(),
+                            background: rgba(0xdec184ff).into(),
+                            selection: rgba(0xdec1843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa1c181ff).into(),
+                            background: rgba(0xa1c181ff).into(),
+                            selection: rgba(0xa1c1813d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (

--- a/crates/theme2/src/themes/rose_pine.rs
+++ b/crates/theme2/src/themes/rose_pine.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn rose_pine() -> UserThemeFamily {
@@ -76,6 +77,48 @@ pub fn rose_pine() -> UserThemeFamily {
                         warning: Some(rgba(0xe99d35ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x57949fff).into(),
+                            background: rgba(0x57949fff).into(),
+                            selection: rgba(0x57949f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7c697fff).into(),
+                            background: rgba(0x7c697fff).into(),
+                            selection: rgba(0x7c697f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x907aa9ff).into(),
+                            background: rgba(0x907aa9ff).into(),
+                            selection: rgba(0x907aa93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x907aa9ff).into(),
+                            background: rgba(0x907aa9ff).into(),
+                            selection: rgba(0x907aa93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2a6983ff).into(),
+                            background: rgba(0x2a6983ff).into(),
+                            selection: rgba(0x2a69833d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb4647aff).into(),
+                            background: rgba(0xb4647aff).into(),
+                            selection: rgba(0xb4647a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xe99d35ff).into(),
+                            background: rgba(0xe99d35ff).into(),
+                            selection: rgba(0xe99d353d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3eaa8eff).into(),
+                            background: rgba(0x3eaa8eff).into(),
+                            selection: rgba(0x3eaa8e3d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -429,6 +472,48 @@ pub fn rose_pine() -> UserThemeFamily {
                         warning: Some(rgba(0xf5c177ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x9cced7ff).into(),
+                            background: rgba(0x9cced7ff).into(),
+                            selection: rgba(0x9cced73d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa784a1ff).into(),
+                            background: rgba(0xa784a1ff).into(),
+                            selection: rgba(0xa784a13d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc4a7e6ff).into(),
+                            background: rgba(0xc4a7e6ff).into(),
+                            selection: rgba(0xc4a7e63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc4a7e6ff).into(),
+                            background: rgba(0xc4a7e6ff).into(),
+                            selection: rgba(0xc4a7e63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3f8fb0ff).into(),
+                            background: rgba(0x3f8fb0ff).into(),
+                            selection: rgba(0x3f8fb03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xea6f92ff).into(),
+                            background: rgba(0xea6f92ff).into(),
+                            selection: rgba(0xea6f923d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf5c177ff).into(),
+                            background: rgba(0xf5c177ff).into(),
+                            selection: rgba(0xf5c1773d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5dc2a3ff).into(),
+                            background: rgba(0x5dc2a3ff).into(),
+                            selection: rgba(0x5dc2a33d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -782,6 +867,48 @@ pub fn rose_pine() -> UserThemeFamily {
                         warning: Some(rgba(0xf5c177ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x9cced7ff).into(),
+                            background: rgba(0x9cced7ff).into(),
+                            selection: rgba(0x9cced73d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d7691ff).into(),
+                            background: rgba(0x9d7691ff).into(),
+                            selection: rgba(0x9d76913d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc4a7e6ff).into(),
+                            background: rgba(0xc4a7e6ff).into(),
+                            selection: rgba(0xc4a7e63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc4a7e6ff).into(),
+                            background: rgba(0xc4a7e6ff).into(),
+                            selection: rgba(0xc4a7e63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x32748fff).into(),
+                            background: rgba(0x32748fff).into(),
+                            selection: rgba(0x32748f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xea6f92ff).into(),
+                            background: rgba(0xea6f92ff).into(),
+                            selection: rgba(0xea6f923d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf5c177ff).into(),
+                            background: rgba(0xf5c177ff).into(),
+                            selection: rgba(0xf5c1773d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5dc2a3ff).into(),
+                            background: rgba(0x5dc2a3ff).into(),
+                            selection: rgba(0x5dc2a33d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (

--- a/crates/theme2/src/themes/sandcastle.rs
+++ b/crates/theme2/src/themes/sandcastle.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn sandcastle() -> UserThemeFamily {
@@ -75,6 +76,48 @@ pub fn sandcastle() -> UserThemeFamily {
                     warning: Some(rgba(0xa07e3bff).into()),
                     ..Default::default()
                 },
+                player: Some(PlayerColors(vec![
+                    PlayerColor {
+                        cursor: rgba(0x528b8bff).into(),
+                        background: rgba(0x528b8bff).into(),
+                        selection: rgba(0x528b8b3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xa87323ff).into(),
+                        background: rgba(0xa87323ff).into(),
+                        selection: rgba(0xa873233d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xa07e3bff).into(),
+                        background: rgba(0xa07e3bff).into(),
+                        selection: rgba(0xa07e3b3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xd75f5fff).into(),
+                        background: rgba(0xd75f5fff).into(),
+                        selection: rgba(0xd75f5f3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x83a598ff).into(),
+                        background: rgba(0x83a598ff).into(),
+                        selection: rgba(0x83a5983d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xb4637aff).into(),
+                        background: rgba(0xb4637aff).into(),
+                        selection: rgba(0xb4637a3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xa07e3bff).into(),
+                        background: rgba(0xa07e3bff).into(),
+                        selection: rgba(0xa07e3b3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x83a598ff).into(),
+                        background: rgba(0x83a598ff).into(),
+                        selection: rgba(0x83a5983d).into(),
+                    },
+                ])),
                 syntax: Some(UserSyntaxTheme {
                     highlights: vec![
                         (

--- a/crates/theme2/src/themes/solarized.rs
+++ b/crates/theme2/src/themes/solarized.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn solarized() -> UserThemeFamily {
@@ -76,6 +77,48 @@ pub fn solarized() -> UserThemeFamily {
                         warning: Some(rgba(0xb58904ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x298bd1ff).into(),
+                            background: rgba(0x298bd1ff).into(),
+                            selection: rgba(0x298bd13d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd33882ff).into(),
+                            background: rgba(0xd33882ff).into(),
+                            selection: rgba(0xd338823d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcb4c18ff).into(),
+                            background: rgba(0xcb4c18ff).into(),
+                            selection: rgba(0xcb4c183d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6d71c4ff).into(),
+                            background: rgba(0x6d71c4ff).into(),
+                            selection: rgba(0x6d71c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2ca198ff).into(),
+                            background: rgba(0x2ca198ff).into(),
+                            selection: rgba(0x2ca1983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdc3330ff).into(),
+                            background: rgba(0xdc3330ff).into(),
+                            selection: rgba(0xdc33303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb58904ff).into(),
+                            background: rgba(0xb58904ff).into(),
+                            selection: rgba(0xb589043d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x859904ff).into(),
+                            background: rgba(0x859904ff).into(),
+                            selection: rgba(0x8599043d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (
@@ -415,6 +458,48 @@ pub fn solarized() -> UserThemeFamily {
                         warning: Some(rgba(0xb58903ff).into()),
                         ..Default::default()
                     },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x288bd1ff).into(),
+                            background: rgba(0x288bd1ff).into(),
+                            selection: rgba(0x288bd13d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd33782ff).into(),
+                            background: rgba(0xd33782ff).into(),
+                            selection: rgba(0xd337823d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcb4b17ff).into(),
+                            background: rgba(0xcb4b17ff).into(),
+                            selection: rgba(0xcb4b173d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6c71c4ff).into(),
+                            background: rgba(0x6c71c4ff).into(),
+                            selection: rgba(0x6c71c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2ca198ff).into(),
+                            background: rgba(0x2ca198ff).into(),
+                            selection: rgba(0x2ca1983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdc3330ff).into(),
+                            background: rgba(0xdc3330ff).into(),
+                            selection: rgba(0xdc33303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb58903ff).into(),
+                            background: rgba(0xb58903ff).into(),
+                            selection: rgba(0xb589033d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x859904ff).into(),
+                            background: rgba(0x859904ff).into(),
+                            selection: rgba(0x8599043d).into(),
+                        },
+                    ])),
                     syntax: Some(UserSyntaxTheme {
                         highlights: vec![
                             (

--- a/crates/theme2/src/themes/summercamp.rs
+++ b/crates/theme2/src/themes/summercamp.rs
@@ -5,8 +5,9 @@ use gpui::rgba;
 
 #[allow(unused)]
 use crate::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,
+    UserThemeStylesRefinement,
 };
 
 pub fn summercamp() -> UserThemeFamily {
@@ -75,6 +76,48 @@ pub fn summercamp() -> UserThemeFamily {
                     warning: Some(rgba(0xf1fe29ff).into()),
                     ..Default::default()
                 },
+                player: Some(PlayerColors(vec![
+                    PlayerColor {
+                        cursor: rgba(0x499befff).into(),
+                        background: rgba(0x499befff).into(),
+                        selection: rgba(0x499bef3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xf59be6ff).into(),
+                        background: rgba(0xf59be6ff).into(),
+                        selection: rgba(0xf59be63d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xfaa11dff).into(),
+                        background: rgba(0xfaa11dff).into(),
+                        selection: rgba(0xfaa11d3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xfe8080ff).into(),
+                        background: rgba(0xfe8080ff).into(),
+                        selection: rgba(0xfe80803d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x5beabcff).into(),
+                        background: rgba(0x5beabcff).into(),
+                        selection: rgba(0x5beabc3d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xe35142ff).into(),
+                        background: rgba(0xe35142ff).into(),
+                        selection: rgba(0xe351423d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0xf1fe29ff).into(),
+                        background: rgba(0xf1fe29ff).into(),
+                        selection: rgba(0xf1fe293d).into(),
+                    },
+                    PlayerColor {
+                        cursor: rgba(0x5dea5aff).into(),
+                        background: rgba(0x5dea5aff).into(),
+                        selection: rgba(0x5dea5a3d).into(),
+                    },
+                ])),
                 syntax: Some(UserSyntaxTheme {
                     highlights: vec![
                         (

--- a/crates/theme2/src/user_theme.rs
+++ b/crates/theme2/src/user_theme.rs
@@ -1,4 +1,7 @@
-use crate::{Appearance, StatusColors, StatusColorsRefinement, ThemeColors, ThemeColorsRefinement};
+use crate::{
+    Appearance, PlayerColors, StatusColors, StatusColorsRefinement, ThemeColors,
+    ThemeColorsRefinement,
+};
 use gpui::{FontStyle, FontWeight, Hsla};
 use refineable::Refineable;
 use serde::Deserialize;
@@ -24,6 +27,7 @@ pub struct UserThemeStyles {
     pub colors: ThemeColors,
     #[refineable]
     pub status: StatusColors,
+    pub player: PlayerColors,
     pub syntax: UserSyntaxTheme,
 }
 

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -316,8 +316,9 @@ fn main() -> Result<()> {
 
             #[allow(unused)]
             use crate::{{
-                Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserHighlightStyle, UserSyntaxTheme,
-                UserTheme, UserThemeFamily, UserThemeStylesRefinement, UserFontWeight, UserFontStyle
+                Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+                UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily, UserThemeStylesRefinement,
+                UserFontWeight, UserFontStyle
             }};
 
             pub fn {theme_family_slug}() -> UserThemeFamily {{

--- a/crates/theme_importer/src/theme_printer.rs
+++ b/crates/theme_importer/src/theme_printer.rs
@@ -108,6 +108,16 @@ impl<'a> Debug for UserThemeStylesRefinementPrinter<'a> {
             .field("colors", &ThemeColorsRefinementPrinter(&self.0.colors))
             .field("status", &StatusColorsRefinementPrinter(&self.0.status))
             .field(
+                "player",
+                &OptionPrinter(
+                    &self
+                        .0
+                        .player
+                        .as_ref()
+                        .map(|player_colors| PlayerColorsPrinter(player_colors)),
+                ),
+            )
+            .field(
                 "syntax",
                 &OptionPrinter(
                     &self

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -61,6 +61,7 @@ impl VsCodeThemeConverter {
             styles: UserThemeStylesRefinement {
                 colors: theme_colors_refinements,
                 status: status_color_refinements,
+                player: None,
                 syntax: Some(syntax_theme),
             },
         })

--- a/crates/theme_importer/src/zed1/converter.rs
+++ b/crates/theme_importer/src/zed1/converter.rs
@@ -3,8 +3,9 @@ use gpui::{Hsla, Rgba};
 use gpui1::color::Color as Zed1Color;
 use gpui1::fonts::HighlightStyle as Zed1HighlightStyle;
 use theme::{
-    Appearance, StatusColorsRefinement, ThemeColorsRefinement, UserFontStyle, UserFontWeight,
-    UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeStylesRefinement,
+    Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, ThemeColorsRefinement,
+    UserFontStyle, UserFontWeight, UserHighlightStyle, UserSyntaxTheme, UserTheme,
+    UserThemeStylesRefinement,
 };
 use theme1::Theme as Zed1Theme;
 
@@ -50,6 +51,7 @@ impl Zed1ThemeConverter {
 
         let status_colors_refinement = self.convert_status_colors()?;
         let theme_colors_refinement = self.convert_theme_colors()?;
+        let player_colors = self.convert_player_colors()?;
         let syntax_theme = self.convert_syntax_theme()?;
 
         Ok(UserTheme {
@@ -58,6 +60,7 @@ impl Zed1ThemeConverter {
             styles: UserThemeStylesRefinement {
                 colors: theme_colors_refinement,
                 status: status_colors_refinement,
+                player: Some(player_colors),
                 syntax: Some(syntax_theme),
             },
         })
@@ -80,6 +83,31 @@ impl Zed1ThemeConverter {
             error: convert(diagnostic_summary.icon_color_error),
             ..Default::default()
         })
+    }
+
+    fn convert_player_colors(&self) -> Result<PlayerColors> {
+        let player_one = self.theme.editor.selection;
+
+        let mut player_colors = vec![PlayerColor {
+            cursor: zed1_color_to_hsla(player_one.cursor),
+            selection: zed1_color_to_hsla(player_one.selection),
+            background: zed1_color_to_hsla(player_one.cursor),
+        }];
+
+        for index in 1..8 {
+            let player = self
+                .theme
+                .editor
+                .selection_style_for_room_participant(index);
+
+            player_colors.push(PlayerColor {
+                cursor: zed1_color_to_hsla(player.cursor),
+                selection: zed1_color_to_hsla(player.selection),
+                background: zed1_color_to_hsla(player.cursor),
+            });
+        }
+
+        Ok(PlayerColors(player_colors))
     }
 
     fn convert_theme_colors(&self) -> Result<ThemeColorsRefinement> {


### PR DESCRIPTION
This PR updates the `theme_importer` to pull in the player colors so that we can assign them based on the current theme.

Release Notes:

- N/A
