### PR TITLE
Remove telemetry debounce time in zed 2

### DIFF
--- a/crates/client2/src/telemetry.rs
+++ b/crates/client2/src/telemetry.rs
@@ -28,7 +28,6 @@ struct TelemetryState {
     app_metadata: AppMetadata,
     architecture: &'static str,
     clickhouse_events_queue: Vec<ClickhouseEventWrapper>,
-    flush_clickhouse_events_task: Option<Task<()>>,
     log_file: Option<NamedTempFile>,
     is_staff: Option<bool>,
     first_event_datetime: Option<DateTime<Utc>>,
@@ -120,12 +119,6 @@ const MAX_QUEUE_LEN: usize = 1;
 #[cfg(not(debug_assertions))]
 const MAX_QUEUE_LEN: usize = 50;
 
-#[cfg(debug_assertions)]
-const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(1);
-
-#[cfg(not(debug_assertions))]
-const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(120);
-
 impl Telemetry {
     pub fn new(client: Arc<dyn HttpClient>, cx: &mut AppContext) -> Arc<Self> {
         let release_channel = if cx.has_global::<ReleaseChannel>() {
@@ -146,7 +139,6 @@ impl Telemetry {
                 metrics_id: None,
                 session_id: None,
                 clickhouse_events_queue: Default::default(),
-                flush_clickhouse_events_task: Default::default(),
                 log_file: None,
                 is_staff: None,
                 first_event_datetime: None,
@@ -412,13 +404,6 @@ impl Telemetry {
             if immediate_flush || state.clickhouse_events_queue.len() >= MAX_QUEUE_LEN {
                 drop(state);
                 self.flush_clickhouse_events();
-            } else {
-                let this = self.clone();
-                let executor = self.executor.clone();
-                state.flush_clickhouse_events_task = Some(self.executor.spawn(async move {
-                    executor.timer(DEBOUNCE_INTERVAL).await;
-                    this.flush_clickhouse_events();
-                }));
             }
         }
     }
@@ -439,7 +424,6 @@ impl Telemetry {
         let mut state = self.state.lock();
         state.first_event_datetime = None;
         let mut events = mem::take(&mut state.clickhouse_events_queue);
-        state.flush_clickhouse_events_task.take();
         drop(state);
 
         let this = self.clone();


### PR DESCRIPTION
Remove the event send timer in Zed 2 telemetry in effort to continue reducing the amount of stress the vercel endpoint receives. This allows the queues to fill up entirely before sending them off. I'm leaving the timer in for Zed 1 because we don't force the events queue to clear on app close in Zed 1, so it feels best to leave it in there, as it might catch some unsent events before closing.

Release Notes:

- N/A