### PR TITLE
More zed2 fixes

### DIFF
--- a/crates/file_finder2/src/file_finder.rs
+++ b/crates/file_finder2/src/file_finder.rs
@@ -546,7 +546,7 @@ impl PickerDelegate for FileFinderDelegate {
 
     fn separators_after_indices(&self) -> Vec<usize> {
         let history_items = self.matches.history.len();
-        if history_items == 0 {
+        if history_items == 0 || self.matches.search.is_empty() {
             Vec::new()
         } else {
             vec![history_items - 1]

--- a/crates/project2/src/terminals.rs
+++ b/crates/project2/src/terminals.rs
@@ -37,7 +37,6 @@ impl Project {
                 Some(settings.blinking.clone()),
                 settings.alternate_scroll,
                 window,
-                |_, _| todo!("color_for_index"),
             )
             .map(|builder| {
                 let terminal_handle = cx.build_model(|cx| builder.subscribe(cx));

--- a/crates/project2/src/worktree.rs
+++ b/crates/project2/src/worktree.rs
@@ -2184,7 +2184,6 @@ impl LocalSnapshot {
         ignore_stack
     }
 
-    #[allow(dead_code)] // todo!("remove this when we use it")
     #[cfg(test)]
     pub(crate) fn expanded_entries(&self) -> impl Iterator<Item = &Entry> {
         self.entries_by_path


### PR DESCRIPTION
* removes a color-related `todo!` in terminal that caused a crash on terminal line edit (ctrl-x;ctrl-e)
* fixes zed2 file finder history items always having a separator, even if no query matches are present 
* added back breadcrumbs into multibuffers (there's a bug still, they are not being displayed until re-activated)

Release Notes:

- N/A