### PR TITLE
Remove `async_trait` from the only trait that allows it now

### DIFF
--- a/crates/fs/src/repository.rs
+++ b/crates/fs/src/repository.rs
@@ -23,7 +23,6 @@ pub struct Branch {
     pub unix_timestamp: Option<i64>,
 }
 
-#[async_trait::async_trait]
 pub trait GitRepository: Send {
     fn reload_index(&self);
     fn load_index_text(&self, relative_file_path: &Path) -> Option<String>;
@@ -248,7 +247,6 @@ impl FakeGitRepository {
     }
 }
 
-#[async_trait::async_trait]
 impl GitRepository for FakeGitRepository {
     fn reload_index(&self) {}
 

--- a/crates/fs2/src/repository.rs
+++ b/crates/fs2/src/repository.rs
@@ -23,7 +23,6 @@ pub struct Branch {
     pub unix_timestamp: Option<i64>,
 }
 
-#[async_trait::async_trait]
 pub trait GitRepository: Send {
     fn reload_index(&self);
     fn load_index_text(&self, relative_file_path: &Path) -> Option<String>;
@@ -248,7 +247,6 @@ impl FakeGitRepository {
     }
 }
 
-#[async_trait::async_trait]
 impl GitRepository for FakeGitRepository {
     fn reload_index(&self) {}
 


### PR DESCRIPTION
* `EmbeddingProvider`, `NodeRuntime`, `Fs`,  `live_kit_server::api::Client` produce messages similar to
```
error[E0038]: the trait `EmbeddingProvider` cannot be made into an object
    --> crates/semantic_index/src/semantic_index_tests.rs:1096:51
     |
1096 |     let mut retriever = CodeContextRetriever::new(embedding_provider);
     |                                                   ^^^^^^^^^^^^^^^^^^ `EmbeddingProvider` cannot be made into an object
     |
note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
    --> /Users/someonetoignore/work/zed/zed/crates/ai/src/embedding.rs:73:14
     |
73   |     async fn embed_batch(&self, spans: Vec<String>) -> Result<Vec<Embedding>>;
     |              ^^^^^^^^^^^ the trait cannot be made into an object because method `embed_batch` is `async`
     = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `EmbeddingProvider` for this new enum and using it instead:
               ai::providers::open_ai::OpenAIEmbeddingProvider
               ai::test::FakeEmbeddingProvider
```

* `LspAdapter` produces something even more obscure:

```
error[E0391]: cycle detected when checking effective visibilities
    |
note: ...which requires computing type of `<impl at crates/language2/src/language2.rs:122:1: 122:22>::new::{opaque#0}`...
   --> crates/language2/src/language2.rs:123:5
    |
123 |     pub async fn new(adapter: Arc<dyn LspAdapter>) -> Arc<Self> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: ...which requires type-checking `<impl at crates/language2/src/language2.rs:122:1: 122:22>::new`...
   --> crates/language2/src/language2.rs:123:5
    |
123 |     pub async fn new(adapter: Arc<dyn LspAdapter>) -> Arc<Self> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires checking effective visibilities, completing the cycle
note: cycle used when checking that `CachedLspAdapter` is well-formed
   --> crates/language2/src/language2.rs:111:1
    |
111 | pub struct CachedLspAdapter {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
```



Release Notes:

- N/A