### PR TITLE
Fix anti-aliasing artifacts in GPUI 2 borders

### DIFF
--- a/crates/gpui2/src/style.rs
+++ b/crates/gpui2/src/style.rs
@@ -386,12 +386,14 @@ impl Style {
         let background_color = self.background.as_ref().and_then(Fill::color);
         if background_color.map_or(false, |color| !color.is_transparent()) {
             cx.with_z_index(1, |cx| {
+                let mut border_color = background_color.unwrap_or_default();
+                border_color.a = 0.;
                 cx.paint_quad(quad(
                     bounds,
                     self.corner_radii.to_pixels(bounds.size, rem_size),
                     background_color.unwrap_or_default(),
                     Edges::default(),
-                    Hsla::transparent_black(),
+                    border_color,
                 ));
             });
         }
@@ -426,10 +428,12 @@ impl Style {
                     bottom_bounds.upper_right(),
                 );
 
+                let mut background = self.border_color.unwrap_or_default();
+                background.a = 0.;
                 let quad = quad(
                     bounds,
                     corner_radii,
-                    Hsla::transparent_black(),
+                    background,
                     border_widths,
                     self.border_color.unwrap_or_default(),
                 );


### PR DESCRIPTION
Previously, we changed borders to be drawn after content, so they are no longer part of the same quads as the background. In our change, we gave the background quad a transparent black border and the border quads transparent black backgrounds. However, this caused the other channels to blend toward that black color before becoming fully transparent, causing them to become darker.

In this PR, I source the "placeholder" color by duplicating the values for the other channels and only adjust the alpha down to zero.

Release Notes:

- N/A