### PR TITLE
Attempt to return `impl Element` from render in `Render` trait

### DIFF
--- a/crates/activity_indicator2/src/activity_indicator.rs
+++ b/crates/activity_indicator2/src/activity_indicator.rs
@@ -2,8 +2,8 @@ use auto_update::{AutoUpdateStatus, AutoUpdater, DismissErrorMessage};
 use editor::Editor;
 use futures::StreamExt;
 use gpui::{
-    actions, svg, AppContext, CursorStyle, Div, EventEmitter, InteractiveElement as _, Model,
-    ParentElement as _, Render, SharedString, Stateful, StatefulInteractiveElement, Styled, View,
+    actions, svg, AppContext, CursorStyle, EventEmitter, InteractiveElement as _, Model,
+    ParentElement as _, Render, SharedString, StatefulInteractiveElement, Styled, View,
     ViewContext, VisualContext as _,
 };
 use language::{LanguageRegistry, LanguageServerBinaryStatus};
@@ -304,9 +304,7 @@ impl ActivityIndicator {
 impl EventEmitter<Event> for ActivityIndicator {}
 
 impl Render for ActivityIndicator {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let content = self.content_to_render(cx);
 
         let mut result = h_stack()

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -30,9 +30,9 @@ use fs::Fs;
 use futures::StreamExt;
 use gpui::{
     canvas, div, point, relative, rems, uniform_list, Action, AnyElement, AppContext,
-    AsyncWindowContext, AvailableSpace, ClipboardItem, Context, Div, EventEmitter, FocusHandle,
-    Focusable, FocusableView, FontStyle, FontWeight, HighlightStyle, InteractiveElement,
-    IntoElement, Model, ModelContext, ParentElement, Pixels, PromptLevel, Render, SharedString,
+    AsyncWindowContext, AvailableSpace, ClipboardItem, Context, EventEmitter, FocusHandle,
+    FocusableView, FontStyle, FontWeight, HighlightStyle, InteractiveElement, IntoElement, Model,
+    ModelContext, ParentElement, Pixels, PromptLevel, Render, SharedString,
     StatefulInteractiveElement, Styled, Subscription, Task, TextStyle, UniformListScrollHandle,
     View, ViewContext, VisualContext, WeakModel, WeakView, WhiteSpace, WindowContext,
 };
@@ -1101,9 +1101,7 @@ fn build_api_key_editor(cx: &mut ViewContext<AssistantPanel>) -> View<Editor> {
 }
 
 impl Render for AssistantPanel {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         if let Some(api_key_editor) = self.api_key_editor.clone() {
             v_stack()
                 .on_action(cx.listener(AssistantPanel::save_credentials))
@@ -2513,9 +2511,7 @@ impl ConversationEditor {
 impl EventEmitter<ConversationEditorEvent> for ConversationEditor {}
 
 impl Render for ConversationEditor {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         div()
             .key_context("ConversationEditor")
             .capture_action(cx.listener(ConversationEditor::cancel_last_assist))
@@ -2618,9 +2614,7 @@ struct InlineAssistant {
 impl EventEmitter<InlineAssistantEvent> for InlineAssistant {}
 
 impl Render for InlineAssistant {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let measurements = self.measurements.get();
         h_stack()
             .w_full()

--- a/crates/auto_update2/src/update_notification.rs
+++ b/crates/auto_update2/src/update_notification.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    div, DismissEvent, Div, EventEmitter, InteractiveElement, ParentElement, Render,
+    div, DismissEvent, Element, EventEmitter, InteractiveElement, ParentElement, Render,
     SemanticVersion, StatefulInteractiveElement, Styled, ViewContext,
 };
 use menu::Cancel;
@@ -13,9 +13,7 @@ pub struct UpdateNotification {
 impl EventEmitter<DismissEvent> for UpdateNotification {}
 
 impl Render for UpdateNotification {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         let app_name = cx.global::<ReleaseChannel>().display_name();
 
         v_stack()

--- a/crates/breadcrumbs2/src/breadcrumbs.rs
+++ b/crates/breadcrumbs2/src/breadcrumbs.rs
@@ -1,6 +1,6 @@
 use editor::Editor;
 use gpui::{
-    Div, Element, EventEmitter, IntoElement, ParentElement, Render, StyledText, Subscription,
+    Element, EventEmitter, IntoElement, ParentElement, Render, StyledText, Subscription,
     ViewContext,
 };
 use itertools::Itertools;
@@ -30,9 +30,7 @@ impl Breadcrumbs {
 impl EventEmitter<ToolbarItemEvent> for Breadcrumbs {}
 
 impl Render for Breadcrumbs {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let element = h_stack().text_ui();
         let Some(active_item) = self.active_item.as_ref() else {
             return element;

--- a/crates/collab_ui2/src/channel_view.rs
+++ b/crates/collab_ui2/src/channel_view.rs
@@ -222,10 +222,8 @@ impl ChannelView {
 impl EventEmitter<EditorEvent> for ChannelView {}
 
 impl Render for ChannelView {
-    type Element = AnyView;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
-        self.editor.clone().into()
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
+        self.editor.clone()
     }
 }
 

--- a/crates/collab_ui2/src/chat_panel.rs
+++ b/crates/collab_ui2/src/chat_panel.rs
@@ -8,8 +8,8 @@ use db::kvp::KEY_VALUE_STORE;
 use editor::Editor;
 use gpui::{
     actions, div, list, prelude::*, px, serde_json, AnyElement, AppContext, AsyncWindowContext,
-    ClickEvent, Div, ElementId, EventEmitter, FocusableView, ListOffset, ListScrollEvent,
-    ListState, Model, Render, Subscription, Task, View, ViewContext, VisualContext, WeakView,
+    ClickEvent, ElementId, EventEmitter, FocusableView, ListOffset, ListScrollEvent, ListState,
+    Model, Render, Subscription, Task, View, ViewContext, VisualContext, WeakView,
 };
 use language::LanguageRegistry;
 use menu::Confirm;
@@ -549,9 +549,7 @@ impl ChatPanel {
 impl EventEmitter<Event> for ChatPanel {}
 
 impl Render for ChatPanel {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         div()
             .full()
             .child(if self.client.user_id().is_some() {

--- a/crates/collab_ui2/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui2/src/chat_panel/message_editor.rs
@@ -3,7 +3,7 @@ use client::UserId;
 use collections::HashMap;
 use editor::{AnchorRangeExt, Editor};
 use gpui::{
-    AnyView, AsyncWindowContext, FocusableView, Model, Render, SharedString, Task, View,
+    AsyncWindowContext, Element, FocusableView, Model, Render, SharedString, Task, View,
     ViewContext, WeakView,
 };
 use language::{language_settings::SoftWrap, Buffer, BufferSnapshot, LanguageRegistry};
@@ -196,9 +196,7 @@ impl MessageEditor {
 }
 
 impl Render for MessageEditor {
-    type Element = AnyView;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         self.editor.to_any()
     }
 }

--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -17,9 +17,9 @@ use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{
     actions, canvas, div, fill, list, overlay, point, prelude::*, px, serde_json, AnyElement,
     AppContext, AsyncWindowContext, Bounds, ClipboardItem, DismissEvent, Div, EventEmitter,
-    FocusHandle, Focusable, FocusableView, InteractiveElement, IntoElement, ListOffset, ListState,
-    Model, MouseDownEvent, ParentElement, Pixels, Point, PromptLevel, Render, RenderOnce,
-    SharedString, Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
+    FocusHandle, FocusableView, InteractiveElement, IntoElement, ListOffset, ListState, Model,
+    MouseDownEvent, ParentElement, Pixels, Point, PromptLevel, Render, RenderOnce, SharedString,
+    Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
 };
 use menu::{Cancel, Confirm, SelectNext, SelectPrev};
 use project::{Fs, Project};
@@ -2263,9 +2263,7 @@ fn render_tree_branch(is_last: bool, cx: &mut WindowContext) -> impl IntoElement
 }
 
 impl Render for CollabPanel {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         v_stack()
             .key_context("CollabPanel")
             .on_action(cx.listener(CollabPanel::cancel))
@@ -2453,9 +2451,7 @@ struct DraggedChannelView {
 }
 
 impl Render for DraggedChannelView {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let ui_font = ThemeSettings::get_global(cx).ui_font.family.clone();
         h_stack()
             .font(ui_font)

--- a/crates/collab_ui2/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui2/src/collab_panel/channel_modal.rs
@@ -5,9 +5,9 @@ use client::{
 };
 use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{
-    actions, div, overlay, AppContext, ClipboardItem, DismissEvent, Div, EventEmitter,
-    FocusableView, Model, ParentElement, Render, Styled, Subscription, Task, View, ViewContext,
-    VisualContext, WeakView,
+    actions, div, overlay, AppContext, ClipboardItem, DismissEvent, EventEmitter, FocusableView,
+    Model, ParentElement, Render, Styled, Subscription, Task, View, ViewContext, VisualContext,
+    WeakView,
 };
 use picker::{Picker, PickerDelegate};
 use std::sync::Arc;
@@ -142,9 +142,7 @@ impl FocusableView for ChannelModal {
 }
 
 impl Render for ChannelModal {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let channel_store = self.channel_store.read(cx);
         let Some(channel) = channel_store.channel_for_id(self.channel_id) else {
             return div();

--- a/crates/collab_ui2/src/collab_panel/contact_finder.rs
+++ b/crates/collab_ui2/src/collab_panel/contact_finder.rs
@@ -1,7 +1,7 @@
 use client::{ContactRequestStatus, User, UserStore};
 use gpui::{
-    AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView, Model,
-    ParentElement as _, Render, Styled, Task, View, ViewContext, VisualContext, WeakView,
+    AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Model, ParentElement as _,
+    Render, Styled, Task, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
 use std::sync::Arc;
@@ -35,7 +35,7 @@ impl ContactFinder {
 }
 
 impl Render for ContactFinder {
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         v_stack()
             .elevation_3(cx)
             .child(
@@ -51,8 +51,6 @@ impl Render for ContactFinder {
             .child(self.picker.clone())
             .w(rems(34.))
     }
-
-    type Element = Div;
 }
 
 pub struct ContactFinderDelegate {

--- a/crates/collab_ui2/src/collab_titlebar_item.rs
+++ b/crates/collab_ui2/src/collab_titlebar_item.rs
@@ -3,8 +3,8 @@ use auto_update::AutoUpdateStatus;
 use call::{ActiveCall, ParticipantLocation, Room};
 use client::{proto::PeerId, Client, ParticipantIndex, User, UserStore};
 use gpui::{
-    actions, canvas, div, point, px, rems, Action, AnyElement, AppContext, Div, Element, Hsla,
-    InteractiveElement, IntoElement, Model, ParentElement, Path, Render, Stateful,
+    actions, canvas, div, point, px, rems, Action, AnyElement, AppContext, Element, Hsla,
+    InteractiveElement, IntoElement, Model, ParentElement, Path, Render,
     StatefulInteractiveElement, Styled, Subscription, View, ViewContext, VisualContext, WeakView,
     WindowBounds,
 };
@@ -56,9 +56,7 @@ pub struct CollabTitlebarItem {
 }
 
 impl Render for CollabTitlebarItem {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let room = ActiveCall::global(cx).read(cx).room().cloned();
         let current_user = self.user_store.read(cx).current_user();
         let client = self.client.clone();

--- a/crates/collab_ui2/src/notification_panel.rs
+++ b/crates/collab_ui2/src/notification_panel.rs
@@ -7,9 +7,9 @@ use db::kvp::KEY_VALUE_STORE;
 use futures::StreamExt;
 use gpui::{
     actions, div, img, list, px, serde_json, AnyElement, AppContext, AsyncWindowContext,
-    CursorStyle, DismissEvent, Div, Element, EventEmitter, FocusHandle, FocusableView,
+    CursorStyle, DismissEvent, Element, EventEmitter, FocusHandle, FocusableView,
     InteractiveElement, IntoElement, ListAlignment, ListScrollEvent, ListState, Model,
-    ParentElement, Render, Stateful, StatefulInteractiveElement, Styled, Task, View, ViewContext,
+    ParentElement, Render, StatefulInteractiveElement, Styled, Task, View, ViewContext,
     VisualContext, WeakView, WindowContext,
 };
 use notifications::{NotificationEntry, NotificationEvent, NotificationStore};
@@ -540,9 +540,7 @@ impl NotificationPanel {
 }
 
 impl Render for NotificationPanel {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Div {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         v_stack()
             .size_full()
             .child(
@@ -706,9 +704,7 @@ impl NotificationToast {
 }
 
 impl Render for NotificationToast {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let user = self.actor.clone();
 
         h_stack()

--- a/crates/collab_ui2/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui2/src/notifications/incoming_call_notification.rs
@@ -2,7 +2,7 @@ use crate::notification_window_options;
 use call::{ActiveCall, IncomingCall};
 use futures::StreamExt;
 use gpui::{
-    img, px, AppContext, Div, ParentElement, Render, RenderOnce, Styled, ViewContext,
+    img, px, AppContext, ParentElement, Render, RenderOnce, Styled, ViewContext,
     VisualContext as _, WindowHandle,
 };
 use settings::Settings;
@@ -117,9 +117,7 @@ impl IncomingCallNotification {
 }
 
 impl Render for IncomingCallNotification {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         // TODO: Is there a better place for us to initialize the font?
         let (ui_font, ui_font_size) = {
             let theme_settings = ThemeSettings::get_global(cx);

--- a/crates/collab_ui2/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui2/src/notifications/project_shared_notification.rs
@@ -2,9 +2,7 @@ use crate::notification_window_options;
 use call::{room, ActiveCall};
 use client::User;
 use collections::HashMap;
-use gpui::{
-    img, px, AppContext, Div, ParentElement, Render, Size, Styled, ViewContext, VisualContext,
-};
+use gpui::{img, px, AppContext, ParentElement, Render, Size, Styled, ViewContext, VisualContext};
 use settings::Settings;
 use std::sync::{Arc, Weak};
 use theme::ThemeSettings;
@@ -120,9 +118,7 @@ impl ProjectSharedNotification {
 }
 
 impl Render for ProjectSharedNotification {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         // TODO: Is there a better place for us to initialize the font?
         let (ui_font, ui_font_size) = {
             let theme_settings = ThemeSettings::get_global(cx);

--- a/crates/command_palette2/src/command_palette.rs
+++ b/crates/command_palette2/src/command_palette.rs
@@ -6,7 +6,7 @@ use std::{
 use collections::{CommandPaletteFilter, HashMap};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, Action, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView,
+    actions, Action, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView,
     ParentElement, Render, Styled, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
@@ -83,9 +83,7 @@ impl FocusableView for CommandPalette {
 }
 
 impl Render for CommandPalette {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         v_stack().w(rems(34.)).child(self.picker.clone())
     }
 }

--- a/crates/copilot2/src/sign_in.rs
+++ b/crates/copilot2/src/sign_in.rs
@@ -1,8 +1,8 @@
 use crate::{request::PromptUserDeviceFlow, Copilot, Status};
 use gpui::{
-    div, size, AppContext, Bounds, ClipboardItem, Div, Element, GlobalPixels, InteractiveElement,
-    IntoElement, ParentElement, Point, Render, Stateful, Styled, ViewContext, VisualContext,
-    WindowBounds, WindowHandle, WindowKind, WindowOptions,
+    div, size, AppContext, Bounds, ClipboardItem, Element, GlobalPixels, InteractiveElement,
+    IntoElement, ParentElement, Point, Render, Styled, ViewContext, VisualContext, WindowBounds,
+    WindowHandle, WindowKind, WindowOptions,
 };
 use theme::ActiveTheme;
 use ui::{prelude::*, Button, Icon, IconElement, Label};
@@ -181,9 +181,7 @@ impl CopilotCodeVerification {
 }
 
 impl Render for CopilotCodeVerification {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let prompt = match &self.status {
             Status::SigningIn {
                 prompt: Some(prompt),

--- a/crates/copilot_button2/src/copilot_button.rs
+++ b/crates/copilot_button2/src/copilot_button.rs
@@ -3,8 +3,8 @@ use copilot::{Copilot, SignOut, Status};
 use editor::{scroll::autoscroll::Autoscroll, Editor};
 use fs::Fs;
 use gpui::{
-    div, Action, AnchorCorner, AppContext, AsyncWindowContext, Div, Entity, ParentElement, Render,
-    Subscription, View, ViewContext, WeakView, WindowContext,
+    div, Action, AnchorCorner, AppContext, AsyncWindowContext, Element, Entity, ParentElement,
+    Render, Subscription, View, ViewContext, WeakView, WindowContext,
 };
 use language::{
     language_settings::{self, all_language_settings, AllLanguageSettings},
@@ -34,9 +34,7 @@ pub struct CopilotButton {
 }
 
 impl Render for CopilotButton {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let all_language_settings = all_language_settings(None, cx);
         if !all_language_settings.copilot.feature_enabled {
             return div();

--- a/crates/diagnostics2/src/diagnostics.rs
+++ b/crates/diagnostics2/src/diagnostics.rs
@@ -13,10 +13,10 @@ use editor::{
 };
 use futures::future::try_join_all;
 use gpui::{
-    actions, div, AnyElement, AnyView, AppContext, Context, Div, EventEmitter, FocusHandle,
-    Focusable, FocusableView, HighlightStyle, InteractiveElement, IntoElement, Model,
-    ParentElement, Render, SharedString, Styled, StyledText, Subscription, Task, View, ViewContext,
-    VisualContext, WeakView, WindowContext,
+    actions, div, AnyElement, AnyView, AppContext, Context, EventEmitter, FocusHandle,
+    FocusableView, HighlightStyle, InteractiveElement, IntoElement, Model, ParentElement, Render,
+    SharedString, Styled, StyledText, Subscription, Task, View, ViewContext, VisualContext,
+    WeakView, WindowContext,
 };
 use language::{
     Anchor, Bias, Buffer, Diagnostic, DiagnosticEntry, DiagnosticSeverity, Point, Selection,
@@ -91,9 +91,7 @@ struct DiagnosticGroupState {
 impl EventEmitter<EditorEvent> for ProjectDiagnosticsEditor {}
 
 impl Render for ProjectDiagnosticsEditor {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let child = if self.path_states.is_empty() {
             div()
                 .bg(cx.theme().colors().editor_background)

--- a/crates/diagnostics2/src/items.rs
+++ b/crates/diagnostics2/src/items.rs
@@ -1,7 +1,7 @@
 use collections::HashSet;
 use editor::Editor;
 use gpui::{
-    rems, Div, EventEmitter, IntoElement, ParentElement, Render, Styled, Subscription, View,
+    rems, EventEmitter, IntoElement, ParentElement, Render, Styled, Subscription, View,
     ViewContext, WeakView,
 };
 use language::Diagnostic;
@@ -21,9 +21,7 @@ pub struct DiagnosticIndicator {
 }
 
 impl Render for DiagnosticIndicator {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let diagnostic_indicator = match (self.summary.error_count, self.summary.warning_count) {
             (0, 0) => h_stack().child(
                 IconElement::new(Icon::Check)

--- a/crates/diagnostics2/src/toolbar_controls.rs
+++ b/crates/diagnostics2/src/toolbar_controls.rs
@@ -1,5 +1,5 @@
 use crate::ProjectDiagnosticsEditor;
-use gpui::{div, Div, EventEmitter, ParentElement, Render, ViewContext, WeakView};
+use gpui::{div, EventEmitter, ParentElement, Render, ViewContext, WeakView};
 use ui::prelude::*;
 use ui::{Icon, IconButton, Tooltip};
 use workspace::{item::ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
@@ -9,9 +9,7 @@ pub struct ToolbarControls {
 }
 
 impl Render for ToolbarControls {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let include_warnings = self
             .editor
             .as_ref()

--- a/crates/editor2/src/editor.rs
+++ b/crates/editor2/src/editor.rs
@@ -9291,9 +9291,7 @@ impl FocusableView for Editor {
 }
 
 impl Render for Editor {
-    type Element = EditorElement;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render<'a>(&mut self, cx: &mut ViewContext<'a, Self>) -> impl 'static + Element {
         let settings = ThemeSettings::get_global(cx);
         let text_style = match self.mode {
             EditorMode::SingleLine | EditorMode::AutoHeight { .. } => TextStyle {

--- a/crates/editor2/src/items.rs
+++ b/crates/editor2/src/items.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context as _, Result};
 use collections::HashSet;
 use futures::future::try_join_all;
 use gpui::{
-    div, point, AnyElement, AppContext, AsyncWindowContext, Context, Div, Entity, EntityId,
+    div, point, AnyElement, AppContext, AsyncWindowContext, Context, Entity, EntityId,
     EventEmitter, IntoElement, Model, ParentElement, Pixels, Render, SharedString, Styled,
     Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
@@ -1193,9 +1193,7 @@ impl CursorPosition {
 }
 
 impl Render for CursorPosition {
-    type Element = Div;
-
-    fn render(&mut self, _: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _: &mut ViewContext<Self>) -> impl Element {
         div().when_some(self.position, |el, position| {
             let mut text = format!(
                 "{}{FILE_ROW_COLUMN_DELIMITER}{}",

--- a/crates/feedback2/src/deploy_feedback_button.rs
+++ b/crates/feedback2/src/deploy_feedback_button.rs
@@ -1,4 +1,4 @@
-use gpui::{AnyElement, Render, ViewContext, WeakView};
+use gpui::{Render, ViewContext, WeakView};
 use ui::{prelude::*, ButtonCommon, Icon, IconButton, Tooltip};
 use workspace::{item::ItemHandle, StatusItemView, Workspace};
 
@@ -17,9 +17,7 @@ impl DeployFeedbackButton {
 }
 
 impl Render for DeployFeedbackButton {
-    type Element = AnyElement;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let is_open = self
             .workspace
             .upgrade()

--- a/crates/feedback2/src/feedback_modal.rs
+++ b/crates/feedback2/src/feedback_modal.rs
@@ -7,8 +7,8 @@ use db::kvp::KEY_VALUE_STORE;
 use editor::{Editor, EditorEvent};
 use futures::AsyncReadExt;
 use gpui::{
-    div, red, rems, serde_json, AppContext, DismissEvent, Div, EventEmitter, FocusHandle,
-    FocusableView, Model, PromptLevel, Render, Task, View, ViewContext,
+    div, red, rems, serde_json, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView,
+    Model, PromptLevel, Render, Task, View, ViewContext,
 };
 use isahc::Request;
 use language::Buffer;
@@ -396,9 +396,7 @@ impl FeedbackModal {
 }
 
 impl Render for FeedbackModal {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         self.update_submission_state(cx);
 
         let submit_button_text = if self.awaiting_submission() {

--- a/crates/file_finder2/src/file_finder.rs
+++ b/crates/file_finder2/src/file_finder.rs
@@ -2,7 +2,7 @@ use collections::HashMap;
 use editor::{scroll::autoscroll::Autoscroll, Bias, Editor};
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
-    actions, rems, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView, Model,
+    actions, rems, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Model,
     ParentElement, Render, Styled, Task, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
@@ -118,9 +118,7 @@ impl FocusableView for FileFinder {
     }
 }
 impl Render for FileFinder {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         v_stack().w(rems(34.)).child(self.picker.clone())
     }
 }

--- a/crates/go_to_line2/src/go_to_line.rs
+++ b/crates/go_to_line2/src/go_to_line.rs
@@ -1,8 +1,7 @@
 use editor::{display_map::ToDisplayPoint, scroll::autoscroll::Autoscroll, Editor};
 use gpui::{
-    actions, div, prelude::*, AnyWindowHandle, AppContext, DismissEvent, Div, EventEmitter,
-    FocusHandle, FocusableView, Render, SharedString, Styled, Subscription, View, ViewContext,
-    VisualContext,
+    actions, div, prelude::*, AnyWindowHandle, AppContext, DismissEvent, EventEmitter, FocusHandle,
+    FocusableView, Render, SharedString, Styled, Subscription, View, ViewContext, VisualContext,
 };
 use text::{Bias, Point};
 use theme::ActiveTheme;
@@ -153,9 +152,7 @@ impl GoToLine {
 }
 
 impl Render for GoToLine {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         div()
             .elevation_2(cx)
             .key_context("GoToLine")

--- a/crates/gpui2/src/app/test_context.rs
+++ b/crates/gpui2/src/app/test_context.rs
@@ -1,6 +1,6 @@
 use crate::{
     div, Action, AnyView, AnyWindowHandle, AppCell, AppContext, AsyncAppContext,
-    BackgroundExecutor, Bounds, ClipboardItem, Context, Div, Entity, EventEmitter,
+    BackgroundExecutor, Bounds, ClipboardItem, Context, Element, Entity, EventEmitter,
     ForegroundExecutor, InputEvent, KeyDownEvent, Keystroke, Model, ModelContext, Pixels, Platform,
     PlatformWindow, Point, Render, Result, Size, Task, TestDispatcher, TestPlatform, TestWindow,
     TestWindowHandlers, TextSystem, View, ViewContext, VisualContext, WindowBounds, WindowContext,
@@ -733,9 +733,7 @@ impl AnyWindowHandle {
 pub struct EmptyView {}
 
 impl Render for EmptyView {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut crate::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut crate::ViewContext<Self>) -> impl Element {
         div()
     }
 }

--- a/crates/gpui2/src/element.rs
+++ b/crates/gpui2/src/element.rs
@@ -7,9 +7,7 @@ pub(crate) use smallvec::SmallVec;
 use std::{any::Any, fmt::Debug};
 
 pub trait Render: 'static + Sized {
-    type Element: Element + 'static;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element;
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element;
 }
 
 pub trait IntoElement: Sized {

--- a/crates/gpui2/src/interactive.rs
+++ b/crates/gpui2/src/interactive.rs
@@ -1,5 +1,5 @@
 use crate::{
-    div, point, Div, Element, IntoElement, Keystroke, Modifiers, Pixels, Point, Render, ViewContext,
+    div, point, Element, IntoElement, Keystroke, Modifiers, Pixels, Point, Render, ViewContext,
 };
 use smallvec::SmallVec;
 use std::{any::Any, fmt::Debug, marker::PhantomData, ops::Deref, path::PathBuf};
@@ -205,9 +205,7 @@ impl ExternalPaths {
 }
 
 impl Render for ExternalPaths {
-    type Element = Div;
-
-    fn render(&mut self, _: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _: &mut ViewContext<Self>) -> impl Element {
         div() // Intentionally left empty because the platform will render icons for the dragged files
     }
 }
@@ -292,8 +290,8 @@ impl InputEvent {
 #[cfg(test)]
 mod test {
     use crate::{
-        self as gpui, div, Div, FocusHandle, InteractiveElement, IntoElement, KeyBinding,
-        Keystroke, ParentElement, Render, Stateful, TestAppContext, VisualContext,
+        self as gpui, div, Element, FocusHandle, InteractiveElement, IntoElement, KeyBinding,
+        Keystroke, ParentElement, Render, TestAppContext, VisualContext,
     };
 
     struct TestView {
@@ -305,9 +303,7 @@ mod test {
     actions!(test, [TestAction]);
 
     impl Render for TestView {
-        type Element = Stateful<Div>;
-
-        fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+        fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
             div().id("testview").child(
                 div()
                     .key_context("parent")

--- a/crates/gpui2/src/view.rs
+++ b/crates/gpui2/src/view.rs
@@ -312,18 +312,6 @@ impl std::fmt::Debug for AnyWeakView {
     }
 }
 
-impl<T, E> Render for T
-where
-    T: 'static + FnMut(&mut WindowContext) -> E,
-    E: 'static + Send + Element,
-{
-    type Element = E;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
-        (self)(cx)
-    }
-}
-
 mod any_view {
     use crate::{AnyElement, AnyView, Element, LayoutId, Render, WindowContext};
 

--- a/crates/gpui2_macros/src/derive_render.rs
+++ b/crates/gpui2_macros/src/derive_render.rs
@@ -11,9 +11,7 @@ pub fn derive_render(input: TokenStream) -> TokenStream {
         impl #impl_generics gpui::Render for #type_name #type_generics
         #where_clause
         {
-            type Element = ();
-
-            fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+            fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
                 ()
             }
         }

--- a/crates/language_selector2/src/active_buffer_language.rs
+++ b/crates/language_selector2/src/active_buffer_language.rs
@@ -1,6 +1,6 @@
 use editor::Editor;
 use gpui::{
-    div, Div, IntoElement, ParentElement, Render, Subscription, View, ViewContext, WeakView,
+    div, Element, IntoElement, ParentElement, Render, Subscription, View, ViewContext, WeakView,
 };
 use std::sync::Arc;
 use ui::{Button, ButtonCommon, Clickable, LabelSize, Tooltip};
@@ -38,9 +38,7 @@ impl ActiveBufferLanguage {
 }
 
 impl Render for ActiveBufferLanguage {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Div {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         div().when_some(self.active_language.as_ref(), |el, active_language| {
             let active_language_text = if let Some(active_language_text) = active_language {
                 active_language_text.to_string()

--- a/crates/language_selector2/src/language_selector.rs
+++ b/crates/language_selector2/src/language_selector.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use editor::Editor;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView, Model,
+    actions, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Model,
     ParentElement, Render, Styled, View, ViewContext, VisualContext, WeakView,
 };
 use language::{Buffer, LanguageRegistry};
@@ -67,9 +67,7 @@ impl LanguageSelector {
 }
 
 impl Render for LanguageSelector {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         v_stack().w(rems(34.)).child(self.picker.clone())
     }
 }

--- a/crates/language_tools2/src/lsp_log.rs
+++ b/crates/language_tools2/src/lsp_log.rs
@@ -596,8 +596,7 @@ fn log_contents(lines: &VecDeque<String>) -> String {
 
 impl Render for LspLogView {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
-        self
-            .editor
+        self.editor
             .update(cx, |editor, cx| editor.render(cx).into_any())
     }
 }

--- a/crates/language_tools2/src/lsp_log.rs
+++ b/crates/language_tools2/src/lsp_log.rs
@@ -596,9 +596,9 @@ fn log_contents(lines: &VecDeque<String>) -> String {
 
 impl Render for LspLogView {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
-        let _x = self.editor.update(cx, |editor, cx| editor.render(cx));
-
-        div()
+        self
+            .editor
+            .update(cx, |editor, cx| editor.render(cx).into_any())
     }
 }
 

--- a/crates/language_tools2/src/lsp_log.rs
+++ b/crates/language_tools2/src/lsp_log.rs
@@ -1,10 +1,10 @@
 use collections::{HashMap, VecDeque};
-use editor::{Editor, EditorElement, EditorEvent, MoveToEnd};
+use editor::{Editor, EditorEvent, MoveToEnd};
 use futures::{channel::mpsc, StreamExt};
 use gpui::{
-    actions, div, AnchorCorner, AnyElement, AppContext, Context, Div, EventEmitter, FocusHandle,
-    FocusableView, IntoElement, Model, ModelContext, ParentElement, Render, Styled, Subscription,
-    View, ViewContext, VisualContext, WeakModel, WindowContext,
+    actions, div, AnchorCorner, AnyElement, AppContext, Context, Element, EventEmitter,
+    FocusHandle, FocusableView, IntoElement, Model, ModelContext, ParentElement, Render, Styled,
+    Subscription, View, ViewContext, VisualContext, WeakModel, WindowContext,
 };
 use language::{LanguageServerId, LanguageServerName};
 use lsp::IoKind;
@@ -595,10 +595,10 @@ fn log_contents(lines: &VecDeque<String>) -> String {
 }
 
 impl Render for LspLogView {
-    type Element = EditorElement;
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
+        let _x = self.editor.update(cx, |editor, cx| editor.render(cx));
 
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
-        self.editor.update(cx, |editor, cx| editor.render(cx))
+        div()
     }
 }
 
@@ -709,9 +709,7 @@ impl ToolbarItemView for LspLogToolbarItemView {
 }
 
 impl Render for LspLogToolbarItemView {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let Some(log_view) = self.log_view.clone() else {
             return div();
         };

--- a/crates/language_tools2/src/syntax_tree_view.rs
+++ b/crates/language_tools2/src/syntax_tree_view.rs
@@ -1,6 +1,6 @@
 use editor::{scroll::autoscroll::Autoscroll, Anchor, Editor, ExcerptId};
 use gpui::{
-    actions, canvas, div, rems, uniform_list, AnyElement, AppContext, AvailableSpace, Div,
+    actions, canvas, div, rems, uniform_list, AnyElement, AppContext, AvailableSpace, Div, Element,
     EventEmitter, FocusHandle, FocusableView, Hsla, InteractiveElement, IntoElement, Model,
     MouseButton, MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Render, Styled,
     UniformListScrollHandle, View, ViewContext, VisualContext, WeakView, WindowContext,
@@ -305,9 +305,7 @@ impl SyntaxTreeView {
 }
 
 impl Render for SyntaxTreeView {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<'_, Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<'_, Self>) -> impl Element {
         let settings = ThemeSettings::get_global(cx);
         let line_height = cx
             .text_style()
@@ -507,9 +505,7 @@ fn format_node_range(node: Node) -> String {
 }
 
 impl Render for SyntaxTreeToolbarItemView {
-    type Element = PopoverMenu<ContextMenu>;
-
-    fn render(&mut self, cx: &mut ViewContext<'_, Self>) -> PopoverMenu<ContextMenu> {
+    fn render(&mut self, cx: &mut ViewContext<'_, Self>) -> impl Element {
         self.render_menu(cx)
             .unwrap_or_else(|| popover_menu("Empty Syntax Tree"))
     }

--- a/crates/outline2/src/outline.rs
+++ b/crates/outline2/src/outline.rs
@@ -4,7 +4,7 @@ use editor::{
 };
 use fuzzy::StringMatch;
 use gpui::{
-    actions, div, rems, AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView,
+    actions, div, rems, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView,
     FontStyle, FontWeight, HighlightStyle, ParentElement, Point, Render, Styled, StyledText, Task,
     TextStyle, View, ViewContext, VisualContext, WeakView, WhiteSpace, WindowContext,
 };
@@ -57,9 +57,7 @@ impl EventEmitter<DismissEvent> for OutlineView {}
 impl ModalView for OutlineView {}
 
 impl Render for OutlineView {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         v_stack().w(rems(34.)).child(self.picker.clone())
     }
 }

--- a/crates/picker2/src/picker2.rs
+++ b/crates/picker2/src/picker2.rs
@@ -1,8 +1,8 @@
 use editor::Editor;
 use gpui::{
-    div, prelude::*, uniform_list, AnyElement, AppContext, DismissEvent, Div, EventEmitter,
-    FocusHandle, FocusableView, Length, MouseButton, MouseDownEvent, Render, Task,
-    UniformListScrollHandle, View, ViewContext, WindowContext,
+    div, prelude::*, uniform_list, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle,
+    FocusableView, Length, MouseButton, MouseDownEvent, Render, Task, UniformListScrollHandle,
+    View, ViewContext, WindowContext,
 };
 use std::{cmp, sync::Arc};
 use ui::{prelude::*, v_stack, Color, Divider, Label, ListItem, ListItemSpacing, ListSeparator};
@@ -228,9 +228,7 @@ impl<D: PickerDelegate> EventEmitter<DismissEvent> for Picker<D> {}
 impl<D: PickerDelegate> ModalView for Picker<D> {}
 
 impl<D: PickerDelegate> Render for Picker<D> {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let picker_editor = h_stack()
             .overflow_hidden()
             .flex_none()

--- a/crates/project_panel2/src/project_panel.rs
+++ b/crates/project_panel2/src/project_panel.rs
@@ -9,10 +9,10 @@ use file_associations::FileAssociations;
 use anyhow::{anyhow, Result};
 use gpui::{
     actions, div, overlay, px, uniform_list, Action, AppContext, AssetSource, AsyncWindowContext,
-    ClipboardItem, DismissEvent, Div, EventEmitter, FocusHandle, Focusable, FocusableView,
-    InteractiveElement, KeyContext, Model, MouseButton, MouseDownEvent, ParentElement, Pixels,
-    Point, PromptLevel, Render, Stateful, Styled, Subscription, Task, UniformListScrollHandle,
-    View, ViewContext, VisualContext as _, WeakView, WindowContext,
+    ClipboardItem, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
+    KeyContext, Model, MouseButton, MouseDownEvent, ParentElement, Pixels, Point, PromptLevel,
+    Render, Stateful, Styled, Subscription, Task, UniformListScrollHandle, View, ViewContext,
+    VisualContext as _, WeakView, WindowContext,
 };
 use menu::{Confirm, SelectNext, SelectPrev};
 use project::{
@@ -1480,9 +1480,7 @@ impl ProjectPanel {
 }
 
 impl Render for ProjectPanel {
-    type Element = Focusable<Stateful<Div>>;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         let has_worktree = self.visible_entries.len() != 0;
 
         if has_worktree {
@@ -1548,9 +1546,7 @@ impl Render for ProjectPanel {
 }
 
 impl Render for DraggedProjectEntryView {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let settings = ProjectPanelSettings::get_global(cx);
         let ui_font = ThemeSettings::get_global(cx).ui_font.family.clone();
         h_stack()

--- a/crates/quick_action_bar2/src/quick_action_bar.rs
+++ b/crates/quick_action_bar2/src/quick_action_bar.rs
@@ -2,8 +2,8 @@ use assistant::{AssistantPanel, InlineAssist};
 use editor::Editor;
 
 use gpui::{
-    Action, ClickEvent, Div, ElementId, EventEmitter, InteractiveElement, ParentElement, Render,
-    Stateful, Styled, Subscription, View, ViewContext, WeakView,
+    Action, ClickEvent, ElementId, EventEmitter, InteractiveElement, ParentElement, Render, Styled,
+    Subscription, View, ViewContext, WeakView,
 };
 use search::{buffer_search, BufferSearchBar};
 use ui::{prelude::*, ButtonSize, ButtonStyle, Icon, IconButton, IconSize, Tooltip};
@@ -36,9 +36,7 @@ impl QuickActionBar {
 }
 
 impl Render for QuickActionBar {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let Some(editor) = self.active_editor() else {
             return div().id("empty quick action bar");
         };

--- a/crates/recent_projects2/src/recent_projects.rs
+++ b/crates/recent_projects2/src/recent_projects.rs
@@ -3,8 +3,8 @@ mod projects;
 
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    AppContext, DismissEvent, Div, EventEmitter, FocusHandle, FocusableView, Result, Subscription,
-    Task, View, ViewContext, WeakView,
+    AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Result, Subscription, Task,
+    View, ViewContext, WeakView,
 };
 use highlighted_workspace_location::HighlightedWorkspaceLocation;
 use ordered_float::OrderedFloat;
@@ -103,9 +103,7 @@ impl FocusableView for RecentProjects {
 }
 
 impl Render for RecentProjects {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         v_stack()
             .w(rems(self.rem_width))
             .child(self.picker.clone())

--- a/crates/search2/src/buffer_search.rs
+++ b/crates/search2/src/buffer_search.rs
@@ -10,7 +10,7 @@ use collections::HashMap;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::channel::oneshot;
 use gpui::{
-    actions, div, impl_actions, Action, AppContext, ClickEvent, Div, EventEmitter, FocusableView,
+    actions, div, impl_actions, Action, AppContext, ClickEvent, EventEmitter, FocusableView,
     FontStyle, FontWeight, InteractiveElement as _, IntoElement, KeyContext, ParentElement as _,
     Render, Styled, Subscription, Task, TextStyle, View, ViewContext, VisualContext as _,
     WhiteSpace, WindowContext,
@@ -101,9 +101,7 @@ impl BufferSearchBar {
 impl EventEmitter<Event> for BufferSearchBar {}
 impl EventEmitter<workspace::ToolbarItemEvent> for BufferSearchBar {}
 impl Render for BufferSearchBar {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         if self.dismissed {
             return div();
         }

--- a/crates/search2/src/project_search.rs
+++ b/crates/search2/src/project_search.rs
@@ -12,11 +12,11 @@ use editor::{
 };
 use editor::{EditorElement, EditorStyle};
 use gpui::{
-    actions, div, AnyElement, AnyView, AppContext, Context as _, Div, Element, EntityId,
-    EventEmitter, FocusHandle, FocusableView, FontStyle, FontWeight, InteractiveElement,
-    IntoElement, KeyContext, Model, ModelContext, ParentElement, PromptLevel, Render, SharedString,
-    Styled, Subscription, Task, TextStyle, View, ViewContext, VisualContext, WeakModel, WeakView,
-    WhiteSpace, WindowContext,
+    actions, div, AnyElement, AnyView, AppContext, Context as _, Element, EntityId, EventEmitter,
+    FocusHandle, FocusableView, FontStyle, FontWeight, InteractiveElement, IntoElement, KeyContext,
+    Model, ModelContext, ParentElement, PromptLevel, Render, SharedString, Styled, Subscription,
+    Task, TextStyle, View, ViewContext, VisualContext, WeakModel, WeakView, WhiteSpace,
+    WindowContext,
 };
 use menu::Confirm;
 use project::{
@@ -279,9 +279,7 @@ pub enum ViewEvent {
 impl EventEmitter<ViewEvent> for ProjectSearchView {}
 
 impl Render for ProjectSearchView {
-    type Element = AnyElement;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         if self.has_matches() {
             div()
                 .flex_1()
@@ -1494,9 +1492,7 @@ impl ProjectSearchBar {
 }
 
 impl Render for ProjectSearchBar {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let Some(search) = self.active_project_search.clone() else {
             return div();
         };

--- a/crates/storybook2/src/stories/auto_height_editor.rs
+++ b/crates/storybook2/src/stories/auto_height_editor.rs
@@ -1,7 +1,7 @@
 use editor::Editor;
 use gpui::{
-    div, white, Div, KeyBinding, ParentElement, Render, Styled, View, ViewContext, VisualContext,
-    WindowContext,
+    div, white, Element, KeyBinding, ParentElement, Render, Styled, View, ViewContext,
+    VisualContext, WindowContext,
 };
 
 pub struct AutoHeightEditorStory {
@@ -22,9 +22,7 @@ impl AutoHeightEditorStory {
 }
 
 impl Render for AutoHeightEditorStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         div()
             .size_full()
             .bg(white())

--- a/crates/storybook2/src/stories/cursor.rs
+++ b/crates/storybook2/src/stories/cursor.rs
@@ -5,9 +5,7 @@ use ui::prelude::*;
 pub struct CursorStory;
 
 impl Render for CursorStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         let all_cursors: [(&str, Box<dyn Fn(Stateful<Div>) -> Stateful<Div>>); 19] = [
             (
                 "cursor_default",

--- a/crates/storybook2/src/stories/focus.rs
+++ b/crates/storybook2/src/stories/focus.rs
@@ -1,6 +1,5 @@
 use gpui::{
-    actions, div, prelude::*, Div, FocusHandle, Focusable, KeyBinding, Render, Stateful,
-    Subscription, View, WindowContext,
+    actions, div, prelude::*, FocusHandle, KeyBinding, Render, Subscription, View, WindowContext,
 };
 use ui::prelude::*;
 
@@ -57,9 +56,7 @@ impl FocusStory {
 }
 
 impl Render for FocusStory {
-    type Element = Focusable<Stateful<Div>>;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         let theme = cx.theme();
         let color_1 = theme.status().created;
         let color_2 = theme.status().modified;

--- a/crates/storybook2/src/stories/kitchen_sink.rs
+++ b/crates/storybook2/src/stories/kitchen_sink.rs
@@ -1,4 +1,4 @@
-use gpui::{prelude::*, Div, Render, Stateful, View};
+use gpui::{prelude::*, Render, View};
 use story::Story;
 use strum::IntoEnumIterator;
 use ui::prelude::*;
@@ -14,9 +14,7 @@ impl KitchenSinkStory {
 }
 
 impl Render for KitchenSinkStory {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let component_stories = ComponentStory::iter()
             .map(|selector| selector.story(cx))
             .collect::<Vec<_>>();

--- a/crates/storybook2/src/stories/overflow_scroll.rs
+++ b/crates/storybook2/src/stories/overflow_scroll.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use ui::prelude::*;
@@ -6,9 +6,7 @@ use ui::prelude::*;
 pub struct OverflowScrollStory;
 
 impl Render for OverflowScrollStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title("Overflow Scroll"))
             .child(Story::label("`overflow_x_scroll`"))

--- a/crates/storybook2/src/stories/picker.rs
+++ b/crates/storybook2/src/stories/picker.rs
@@ -1,7 +1,5 @@
 use fuzzy::StringMatchCandidate;
-use gpui::{
-    div, prelude::*, Div, KeyBinding, Render, SharedString, Styled, Task, View, WindowContext,
-};
+use gpui::{div, prelude::*, KeyBinding, Render, SharedString, Styled, Task, View, WindowContext};
 use picker::{Picker, PickerDelegate};
 use std::sync::Arc;
 use ui::{prelude::*, ListItemSpacing};
@@ -202,9 +200,7 @@ impl PickerStory {
 }
 
 impl Render for PickerStory {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         div()
             .bg(cx.theme().styles.colors.background)
             .size_full()

--- a/crates/storybook2/src/stories/scroll.rs
+++ b/crates/storybook2/src/stories/scroll.rs
@@ -1,4 +1,4 @@
-use gpui::{div, prelude::*, px, Div, Render, SharedString, Stateful, Styled, View, WindowContext};
+use gpui::{div, prelude::*, px, Render, SharedString, Styled, View, WindowContext};
 use ui::prelude::*;
 use ui::Tooltip;
 
@@ -11,9 +11,7 @@ impl ScrollStory {
 }
 
 impl Render for ScrollStory {
-    type Element = Stateful<Div>;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         let theme = cx.theme();
         let color_1 = theme.status().created;
         let color_2 = theme.status().modified;

--- a/crates/storybook2/src/stories/text.rs
+++ b/crates/storybook2/src/stories/text.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    div, green, red, Component, HighlightStyle, InteractiveText, IntoElement, ParentElement,
-    Render, Styled, StyledText, View, VisualContext, WindowContext,
+    div, green, red, Element, HighlightStyle, InteractiveText, IntoElement, ParentElement, Render,
+    Styled, StyledText, View, VisualContext, WindowContext,
 };
 use indoc::indoc;
 use story::*;
@@ -14,9 +14,7 @@ impl TextStory {
 }
 
 impl Render for TextStory {
-    type Element = Component<StoryContainer>;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         StoryContainer::new("Text Story", "crates/storybook2/src/stories/text.rs")
             .children(
                 vec![

--- a/crates/storybook2/src/stories/viewport_units.rs
+++ b/crates/storybook2/src/stories/viewport_units.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use ui::prelude::*;
@@ -6,9 +6,7 @@ use ui::prelude::*;
 pub struct ViewportUnitsStory;
 
 impl Render for ViewportUnitsStory {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         Story::container().child(
             div()
                 .flex()

--- a/crates/storybook2/src/stories/z_index.rs
+++ b/crates/storybook2/src/stories/z_index.rs
@@ -7,9 +7,7 @@ use ui::prelude::*;
 pub struct ZIndexStory;
 
 impl Render for ZIndexStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container().child(Story::title("z-index")).child(
             div()
                 .flex()

--- a/crates/storybook2/src/storybook2.rs
+++ b/crates/storybook2/src/storybook2.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use clap::Parser;
 use dialoguer::FuzzySelect;
 use gpui::{
-    div, px, size, AnyView, AppContext, Bounds, Div, Render, ViewContext, VisualContext,
-    WindowBounds, WindowOptions,
+    div, px, size, AnyView, AppContext, Bounds, Render, ViewContext, VisualContext, WindowBounds,
+    WindowOptions,
 };
 use log::LevelFilter;
 use settings2::{default_settings, Settings, SettingsStore};
@@ -113,9 +113,7 @@ impl StoryWrapper {
 }
 
 impl Render for StoryWrapper {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         div()
             .flex()
             .flex_col()

--- a/crates/terminal_view2/src/terminal_panel.rs
+++ b/crates/terminal_view2/src/terminal_panel.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use crate::TerminalView;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
-    actions, div, serde_json, AppContext, AsyncWindowContext, Div, Entity, EventEmitter,
+    actions, div, serde_json, AppContext, AsyncWindowContext, Element, Entity, EventEmitter,
     ExternalPaths, FocusHandle, FocusableView, IntoElement, ParentElement, Pixels, Render, Styled,
     Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
@@ -329,9 +329,7 @@ impl TerminalPanel {
 impl EventEmitter<PanelEvent> for TerminalPanel {}
 
 impl Render for TerminalPanel {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         div().size_full().child(self.pane.clone())
     }
 }

--- a/crates/terminal_view2/src/terminal_view.rs
+++ b/crates/terminal_view2/src/terminal_view.rs
@@ -6,9 +6,9 @@ pub mod terminal_panel;
 // use crate::terminal_element::TerminalElement;
 use editor::{scroll::autoscroll::Autoscroll, Editor};
 use gpui::{
-    div, impl_actions, overlay, AnyElement, AppContext, DismissEvent, Div, EventEmitter,
-    FocusHandle, Focusable, FocusableView, KeyContext, KeyDownEvent, Keystroke, Model, MouseButton,
-    MouseDownEvent, Pixels, Render, Styled, Subscription, Task, View, VisualContext, WeakView,
+    div, impl_actions, overlay, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle,
+    FocusableView, KeyContext, KeyDownEvent, Keystroke, Model, MouseButton, MouseDownEvent, Pixels,
+    Render, Styled, Subscription, Task, View, VisualContext, WeakView,
 };
 use language::Bias;
 use persistence::TERMINAL_DB;
@@ -617,9 +617,7 @@ impl TerminalView {
 }
 
 impl Render for TerminalView {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let terminal_handle = self.terminal.clone();
 
         let focused = self.focus_handle.is_focused(cx);

--- a/crates/theme2/src/styles/stories/color.rs
+++ b/crates/theme2/src/styles/stories/color.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{div, px, Div, ViewContext};
+use gpui::{div, px, ViewContext};
 use story::Story;
 
 use crate::{default_color_scales, ColorScaleStep};
@@ -7,9 +7,7 @@ use crate::{default_color_scales, ColorScaleStep};
 pub struct ColorsStory;
 
 impl Render for ColorsStory {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let color_scales = default_color_scales();
 
         Story::container().child(Story::title("Colors")).child(

--- a/crates/theme2/src/styles/stories/players.rs
+++ b/crates/theme2/src/styles/stories/players.rs
@@ -1,4 +1,4 @@
-use gpui::{div, img, px, Div, ParentElement, Render, Styled, ViewContext};
+use gpui::{div, img, px, Element, ParentElement, Render, Styled, ViewContext};
 use story::Story;
 
 use crate::{ActiveTheme, PlayerColors};
@@ -6,9 +6,7 @@ use crate::{ActiveTheme, PlayerColors};
 pub struct PlayerStory;
 
 impl Render for PlayerStory {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         Story::container().child(
             div()
                 .flex()

--- a/crates/theme_selector2/src/theme_selector.rs
+++ b/crates/theme_selector2/src/theme_selector.rs
@@ -2,7 +2,7 @@ use feature_flags::FeatureFlagAppExt;
 use fs::Fs;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, AppContext, DismissEvent, Div, EventEmitter, FocusableView, Render, View, ViewContext,
+    actions, AppContext, DismissEvent, EventEmitter, FocusableView, Render, View, ViewContext,
     VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
@@ -67,9 +67,7 @@ impl FocusableView for ThemeSelector {
 }
 
 impl Render for ThemeSelector {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         v_stack().w(rems(34.)).child(self.picker.clone())
     }
 }

--- a/crates/ui2/src/components/context_menu.rs
+++ b/crates/ui2/src/components/context_menu.rs
@@ -3,8 +3,8 @@ use crate::{
     ListSeparator, ListSubHeader,
 };
 use gpui::{
-    px, Action, AnyElement, AppContext, DismissEvent, Div, EventEmitter, FocusHandle,
-    FocusableView, IntoElement, Render, Subscription, View, VisualContext,
+    px, Action, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView,
+    IntoElement, Render, Subscription, View, VisualContext,
 };
 use menu::{SelectFirst, SelectLast, SelectNext, SelectPrev};
 use std::{rc::Rc, time::Duration};
@@ -232,9 +232,7 @@ impl ContextMenuItem {
 }
 
 impl Render for ContextMenu {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         div().elevation_2(cx).flex().flex_row().child(
             v_stack()
                 .min_w(px(200.))

--- a/crates/ui2/src/components/stories/avatar.rs
+++ b/crates/ui2/src/components/stories/avatar.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::prelude::*;
@@ -7,9 +7,7 @@ use crate::Avatar;
 pub struct AvatarStory;
 
 impl Render for AvatarStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<Avatar>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/button.rs
+++ b/crates/ui2/src/components/stories/button.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::{prelude::*, Icon};
@@ -7,9 +7,7 @@ use crate::{Button, ButtonStyle};
 pub struct ButtonStory;
 
 impl Render for ButtonStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<Button>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/checkbox.rs
+++ b/crates/ui2/src/components/stories/checkbox.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render, ViewContext};
+use gpui::{Render, ViewContext};
 use story::Story;
 
 use crate::prelude::*;
@@ -7,9 +7,7 @@ use crate::{h_stack, Checkbox};
 pub struct CheckboxStory;
 
 impl Render for CheckboxStory {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<Checkbox>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/context_menu.rs
+++ b/crates/ui2/src/components/stories/context_menu.rs
@@ -1,4 +1,4 @@
-use gpui::{actions, AnchorCorner, Div, Render, View};
+use gpui::{actions, AnchorCorner, Render, View};
 use story::Story;
 
 use crate::prelude::*;
@@ -20,9 +20,7 @@ fn build_menu(cx: &mut WindowContext, header: impl Into<SharedString>) -> View<C
 pub struct ContextMenuStory;
 
 impl Render for ContextMenuStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .on_action(|_: &PrintCurrentDate, _| {
                 println!("printing unix time!");

--- a/crates/ui2/src/components/stories/disclosure.rs
+++ b/crates/ui2/src/components/stories/disclosure.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::prelude::*;
@@ -7,9 +7,7 @@ use crate::Disclosure;
 pub struct DisclosureStory;
 
 impl Render for DisclosureStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<Disclosure>())
             .child(Story::label("Toggled"))

--- a/crates/ui2/src/components/stories/icon.rs
+++ b/crates/ui2/src/components/stories/icon.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 use strum::IntoEnumIterator;
 
@@ -8,9 +8,7 @@ use crate::{Icon, IconElement};
 pub struct IconStory;
 
 impl Render for IconStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         let icons = Icon::iter();
 
         Story::container()

--- a/crates/ui2/src/components/stories/icon_button.rs
+++ b/crates/ui2/src/components/stories/icon_button.rs
@@ -1,4 +1,4 @@
-use gpui::{Component, Render};
+use gpui::Render;
 use story::{StoryContainer, StoryItem, StorySection};
 
 use crate::{prelude::*, Tooltip};
@@ -7,9 +7,7 @@ use crate::{Icon, IconButton};
 pub struct IconButtonStory;
 
 impl Render for IconButtonStory {
-    type Element = Component<StoryContainer>;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         let default_button = StoryItem::new(
             "Default",
             IconButton::new("default_icon_button", Icon::Hash),

--- a/crates/ui2/src/components/stories/keybinding.rs
+++ b/crates/ui2/src/components/stories/keybinding.rs
@@ -1,5 +1,5 @@
 use gpui::NoAction;
-use gpui::{Div, Render};
+use gpui::Render;
 use itertools::Itertools;
 use story::Story;
 
@@ -13,9 +13,7 @@ pub fn binding(key: &str) -> gpui::KeyBinding {
 }
 
 impl Render for KeybindingStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         let all_modifier_permutations = ["ctrl", "alt", "cmd", "shift"].into_iter().permutations(2);
 
         Story::container()

--- a/crates/ui2/src/components/stories/label.rs
+++ b/crates/ui2/src/components/stories/label.rs
@@ -1,15 +1,11 @@
-use gpui::{Div, Render};
+use crate::{prelude::*, HighlightedLabel, Label};
+use gpui::Render;
 use story::Story;
-
-use crate::prelude::*;
-use crate::{HighlightedLabel, Label};
 
 pub struct LabelStory;
 
 impl Render for LabelStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<Label>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/list.rs
+++ b/crates/ui2/src/components/stories/list.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::{prelude::*, ListHeader, ListSeparator, ListSubHeader};
@@ -7,9 +7,7 @@ use crate::{List, ListItem};
 pub struct ListStory;
 
 impl Render for ListStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<List>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/list_header.rs
+++ b/crates/ui2/src/components/stories/list_header.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::{prelude::*, IconButton};
@@ -7,9 +7,7 @@ use crate::{Icon, ListHeader};
 pub struct ListHeaderStory;
 
 impl Render for ListHeaderStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<ListHeader>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/list_item.rs
+++ b/crates/ui2/src/components/stories/list_item.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::{prelude::*, Avatar};
@@ -7,9 +7,7 @@ use crate::{Icon, ListItem};
 pub struct ListItemStory;
 
 impl Render for ListItemStory {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .bg(cx.theme().colors().background)
             .child(Story::title_for::<ListItem>())

--- a/crates/ui2/src/components/stories/tab.rs
+++ b/crates/ui2/src/components/stories/tab.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::{prelude::*, TabPosition};
@@ -9,9 +9,7 @@ use crate::{Indicator, Tab};
 pub struct TabStory;
 
 impl Render for TabStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         Story::container()
             .child(Story::title_for::<Tab>())
             .child(Story::label("Default"))

--- a/crates/ui2/src/components/stories/tab_bar.rs
+++ b/crates/ui2/src/components/stories/tab_bar.rs
@@ -1,4 +1,4 @@
-use gpui::{Div, Render};
+use gpui::Render;
 use story::Story;
 
 use crate::{prelude::*, Tab, TabBar, TabPosition};
@@ -6,9 +6,7 @@ use crate::{prelude::*, Tab, TabBar, TabPosition};
 pub struct TabBarStory;
 
 impl Render for TabBarStory {
-    type Element = Div;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         let tab_count = 20;
         let selected_tab_index = 3;
 

--- a/crates/ui2/src/components/stories/toggle_button.rs
+++ b/crates/ui2/src/components/stories/toggle_button.rs
@@ -1,4 +1,4 @@
-use gpui::{Component, Render};
+use gpui::Render;
 use story::{StoryContainer, StoryItem, StorySection};
 
 use crate::{prelude::*, ToggleButton};
@@ -6,9 +6,7 @@ use crate::{prelude::*, ToggleButton};
 pub struct ToggleButtonStory;
 
 impl Render for ToggleButtonStory {
-    type Element = Component<StoryContainer>;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         StoryContainer::new(
             "Toggle Button",
             "crates/ui2/src/components/stories/toggle_button.rs",

--- a/crates/ui2/src/components/tooltip.rs
+++ b/crates/ui2/src/components/tooltip.rs
@@ -1,4 +1,4 @@
-use gpui::{overlay, Action, AnyView, IntoElement, Overlay, Render, VisualContext};
+use gpui::{overlay, Action, AnyView, IntoElement, Render, VisualContext};
 use settings::Settings;
 use theme::ThemeSettings;
 
@@ -68,9 +68,7 @@ impl Tooltip {
 }
 
 impl Render for Tooltip {
-    type Element = Overlay;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let ui_font = ThemeSettings::get_global(cx).ui_font.family.clone();
         overlay().child(
             // padding to avoid mouse cursor

--- a/crates/vcs_menu2/src/lib.rs
+++ b/crates/vcs_menu2/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Result};
 use fs::repository::Branch;
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, rems, AnyElement, AppContext, DismissEvent, Div, Element, EventEmitter, FocusHandle,
+    actions, rems, AnyElement, AppContext, DismissEvent, Element, EventEmitter, FocusHandle,
     FocusableView, InteractiveElement, IntoElement, ParentElement, Render, SharedString, Styled,
     Subscription, Task, View, ViewContext, VisualContext, WindowContext,
 };
@@ -65,9 +65,7 @@ impl FocusableView for BranchList {
 }
 
 impl Render for BranchList {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         v_stack()
             .w(rems(self.rem_width))
             .child(self.picker.clone())

--- a/crates/vim2/src/mode_indicator.rs
+++ b/crates/vim2/src/mode_indicator.rs
@@ -1,4 +1,4 @@
-use gpui::{div, AnyElement, Element, Render, Subscription, ViewContext};
+use gpui::{div, Element, Render, Subscription, ViewContext};
 use settings::SettingsStore;
 use workspace::{item::ItemHandle, ui::prelude::*, StatusItemView};
 
@@ -47,9 +47,7 @@ impl ModeIndicator {
 }
 
 impl Render for ModeIndicator {
-    type Element = AnyElement;
-
-    fn render(&mut self, _: &mut ViewContext<Self>) -> AnyElement {
+    fn render(&mut self, _: &mut ViewContext<Self>) -> impl Element {
         let Some(mode) = self.mode.as_ref() else {
             return div().into_any();
         };

--- a/crates/welcome2/src/base_keymap_picker.rs
+++ b/crates/welcome2/src/base_keymap_picker.rs
@@ -64,9 +64,7 @@ impl BaseKeymapSelector {
 }
 
 impl Render for BaseKeymapSelector {
-    type Element = View<Picker<BaseKeymapSelectorDelegate>>;
-
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
         self.picker.clone()
     }
 }

--- a/crates/welcome2/src/welcome.rs
+++ b/crates/welcome2/src/welcome.rs
@@ -4,9 +4,9 @@ mod base_keymap_setting;
 use client::TelemetrySettings;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
-    svg, AnyElement, AppContext, Div, EventEmitter, FocusHandle, Focusable, FocusableView,
-    InteractiveElement, ParentElement, Render, Styled, Subscription, View, ViewContext,
-    VisualContext, WeakView, WindowContext,
+    svg, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
+    ParentElement, Render, Styled, Subscription, View, ViewContext, VisualContext, WeakView,
+    WindowContext,
 };
 use settings::{Settings, SettingsStore};
 use std::sync::Arc;
@@ -58,9 +58,7 @@ pub struct WelcomePage {
 }
 
 impl Render for WelcomePage {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl Element {
         h_stack().full().track_focus(&self.focus_handle).child(
             v_stack()
                 .w_96()

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -1,7 +1,7 @@
 use crate::DraggedDock;
 use crate::{status_bar::StatusItemView, Workspace};
 use gpui::{
-    div, px, Action, AnchorCorner, AnyView, AppContext, Axis, ClickEvent, Div, Entity, EntityId,
+    div, px, Action, AnchorCorner, AnyView, AppContext, Axis, ClickEvent, Entity, EntityId,
     EventEmitter, FocusHandle, FocusableView, IntoElement, MouseButton, ParentElement, Render,
     SharedString, Styled, Subscription, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
@@ -505,9 +505,7 @@ impl Dock {
 }
 
 impl Render for Dock {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         if let Some(entry) = self.visible_entry() {
             let size = entry.panel.size(cx);
 
@@ -594,9 +592,7 @@ impl PanelButtons {
 }
 
 impl Render for PanelButtons {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         // todo!()
         let dock = self.dock.read(cx);
         let active_index = dock.active_panel_index;
@@ -691,7 +687,7 @@ impl StatusItemView for PanelButtons {
 #[cfg(any(test, feature = "test-support"))]
 pub mod test {
     use super::*;
-    use gpui::{actions, div, Div, ViewContext, WindowContext};
+    use gpui::{actions, div, ViewContext, WindowContext};
 
     pub struct TestPanel {
         pub position: DockPosition,
@@ -717,9 +713,7 @@ pub mod test {
     }
 
     impl Render for TestPanel {
-        type Element = Div;
-
-        fn render(&mut self, _cx: &mut ViewContext<Self>) -> Self::Element {
+        fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl Element {
             div()
         }
     }

--- a/crates/workspace2/src/item.rs
+++ b/crates/workspace2/src/item.rs
@@ -760,9 +760,9 @@ pub mod test {
     use super::{Item, ItemEvent};
     use crate::{ItemId, ItemNavHistory, Pane, Workspace, WorkspaceId};
     use gpui::{
-        AnyElement, AppContext, Context as _, Div, EntityId, EventEmitter, Focusable,
-        FocusableView, InteractiveElement, IntoElement, Model, Render, SharedString, Task, View,
-        ViewContext, VisualContext, WeakView,
+        AnyElement, AppContext, Context as _, Element, EntityId, EventEmitter, FocusableView,
+        InteractiveElement, IntoElement, Model, Render, SharedString, Task, View, ViewContext,
+        VisualContext, WeakView,
     };
     use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
     use std::{any::Any, cell::Cell, path::Path};
@@ -910,9 +910,7 @@ pub mod test {
     }
 
     impl Render for TestItem {
-        type Element = Focusable<Div>;
-
-        fn render(&mut self, _: &mut ViewContext<Self>) -> Self::Element {
+        fn render(&mut self, _: &mut ViewContext<Self>) -> impl Element {
             gpui::div().track_focus(&self.focus_handle)
         }
     }

--- a/crates/workspace2/src/modal_layer.rs
+++ b/crates/workspace2/src/modal_layer.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    div, prelude::*, px, AnyView, DismissEvent, Div, FocusHandle, ManagedView, Render,
-    Subscription, View, ViewContext, WindowContext,
+    div, prelude::*, px, AnyView, DismissEvent, FocusHandle, ManagedView, Render, Subscription,
+    View, ViewContext, WindowContext,
 };
 use ui::{h_stack, v_stack};
 
@@ -104,9 +104,7 @@ impl ModalLayer {
 }
 
 impl Render for ModalLayer {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let Some(active_modal) = &self.active_modal else {
             return div();
         };

--- a/crates/workspace2/src/notifications.rs
+++ b/crates/workspace2/src/notifications.rs
@@ -170,8 +170,8 @@ impl Workspace {
 
 pub mod simple_message_notification {
     use gpui::{
-        div, DismissEvent, Div, EventEmitter, InteractiveElement, ParentElement, Render,
-        SharedString, StatefulInteractiveElement, Styled, ViewContext,
+        div, DismissEvent, EventEmitter, InteractiveElement, ParentElement, Render, SharedString,
+        StatefulInteractiveElement, Styled, ViewContext,
     };
     use std::sync::Arc;
     use ui::prelude::*;
@@ -219,9 +219,7 @@ pub mod simple_message_notification {
     }
 
     impl Render for MessageNotification {
-        type Element = Div;
-
-        fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+        fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
             v_stack()
                 .elevation_3(cx)
                 .p_4()

--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -9,9 +9,8 @@ use collections::{HashMap, HashSet, VecDeque};
 use gpui::{
     actions, impl_actions, overlay, prelude::*, Action, AnchorCorner, AnyElement, AppContext,
     AsyncWindowContext, DismissEvent, Div, DragMoveEvent, EntityId, EventEmitter, FocusHandle,
-    Focusable, FocusableView, Model, MouseButton, NavigationDirection, Pixels, Point, PromptLevel,
-    Render, ScrollHandle, Subscription, Task, View, ViewContext, VisualContext, WeakView,
-    WindowContext,
+    FocusableView, Model, MouseButton, NavigationDirection, Pixels, Point, PromptLevel, Render,
+    ScrollHandle, Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use parking_lot::Mutex;
 use project::{Project, ProjectEntryId, ProjectPath};
@@ -1868,9 +1867,7 @@ impl FocusableView for Pane {
 }
 
 impl Render for Pane {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         v_stack()
             .key_context("Pane")
             .track_focus(&self.focus_handle)
@@ -2750,9 +2747,7 @@ mod tests {
 }
 
 impl Render for DraggedTab {
-    type Element = <Tab as RenderOnce>::Rendered;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let ui_font = ThemeSettings::get_global(cx).ui_font.family.clone();
         let item = &self.pane.read(cx).items[self.ix];
         let label = item.tab_content(Some(self.detail), false, cx);

--- a/crates/workspace2/src/shared_screen.rs
+++ b/crates/workspace2/src/shared_screen.rs
@@ -7,9 +7,9 @@ use call::participant::{Frame, RemoteVideoTrack};
 use client::{proto::PeerId, User};
 use futures::StreamExt;
 use gpui::{
-    div, img, AppContext, Div, Element, EventEmitter, FocusHandle, Focusable, FocusableView,
-    InteractiveElement, ParentElement, Render, SharedString, Styled, Task, View, ViewContext,
-    VisualContext, WindowContext,
+    div, img, AppContext, Element, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
+    ParentElement, Render, SharedString, Styled, Task, View, ViewContext, VisualContext,
+    WindowContext,
 };
 use std::sync::{Arc, Weak};
 use ui::{h_stack, prelude::*, Icon, IconElement, Label};
@@ -66,9 +66,7 @@ impl FocusableView for SharedScreen {
     }
 }
 impl Render for SharedScreen {
-    type Element = Focusable<Div>;
-
-    fn render(&mut self, _: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, _: &mut ViewContext<Self>) -> impl Element {
         div().track_focus(&self.focus).size_full().children(
             self.frame
                 .as_ref()

--- a/crates/workspace2/src/status_bar.rs
+++ b/crates/workspace2/src/status_bar.rs
@@ -1,6 +1,6 @@
 use crate::{ItemHandle, Pane};
 use gpui::{
-    div, AnyView, Div, IntoElement, ParentElement, Render, Styled, Subscription, View, ViewContext,
+    div, AnyView, IntoElement, ParentElement, Render, Styled, Subscription, View, ViewContext,
     WindowContext,
 };
 use std::any::TypeId;
@@ -33,9 +33,7 @@ pub struct StatusBar {
 }
 
 impl Render for StatusBar {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         div()
             .py_0p5()
             .px_1()

--- a/crates/workspace2/src/toolbar.rs
+++ b/crates/workspace2/src/toolbar.rs
@@ -1,7 +1,7 @@
 use crate::ItemHandle;
 use gpui::{
-    AnyView, Div, Entity, EntityId, EventEmitter, ParentElement as _, Render, Styled, View,
-    ViewContext, WindowContext,
+    AnyView, Entity, EntityId, EventEmitter, ParentElement as _, Render, Styled, View, ViewContext,
+    WindowContext,
 };
 use ui::prelude::*;
 use ui::{h_stack, v_stack};
@@ -93,9 +93,7 @@ impl Toolbar {
 }
 
 impl Render for Toolbar {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         if !self.has_any_visible_items() {
             return div();
         }

--- a/crates/workspace2/src/workspace2.rs
+++ b/crates/workspace2/src/workspace2.rs
@@ -3489,9 +3489,7 @@ impl FocusableView for Workspace {
 struct DraggedDock(DockPosition);
 
 impl Render for Workspace {
-    type Element = Div;
-
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> Self::Element {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl Element {
         let mut context = KeyContext::default();
         context.add("Workspace");
 


### PR DESCRIPTION
This PR uses the new Rust 1.75 "impl trait in trait" feature to simplify the `Render` trait.

However, I'm getting a borrow checker error that doesn't make sense to me. If anybody else wants to take a look, maybe they can figure it out. Not sure if it's a bug in the new feature.

Release Notes:

- N/A