### PR TITLE
Increase outline picker max height

### DIFF
--- a/crates/outline2/src/outline.rs
+++ b/crates/outline2/src/outline.rs
@@ -79,8 +79,12 @@ impl OutlineView {
         editor: View<Editor>,
         cx: &mut ViewContext<Self>,
     ) -> OutlineView {
+        const MAX_HEIGHT_IN_VH: f32 = 0.75;
+
         let delegate = OutlineViewDelegate::new(cx.view().downgrade(), outline, editor, cx);
-        let picker = cx.new_view(|cx| Picker::new(delegate, cx));
+        let picker = cx.new_view(|cx| {
+            Picker::new(delegate, cx).max_height(cx.viewport_size().height * MAX_HEIGHT_IN_VH)
+        });
         OutlineView { picker }
     }
 }

--- a/crates/picker2/src/picker2.rs
+++ b/crates/picker2/src/picker2.rs
@@ -15,6 +15,7 @@ pub struct Picker<D: PickerDelegate> {
     pending_update_matches: Option<Task<()>>,
     confirm_on_update: Option<bool>,
     width: Option<Length>,
+    max_height: Option<Length>,
 
     /// Whether the `Picker` is rendered as a self-contained modal.
     ///
@@ -72,6 +73,7 @@ impl<D: PickerDelegate> Picker<D> {
             pending_update_matches: None,
             confirm_on_update: None,
             width: None,
+            max_height: None,
             is_modal: true,
         };
         this.update_matches("".to_string(), cx);
@@ -80,6 +82,11 @@ impl<D: PickerDelegate> Picker<D> {
 
     pub fn width(mut self, width: impl Into<gpui::Length>) -> Self {
         self.width = Some(width.into());
+        self
+    }
+
+    pub fn max_height(mut self, max_height: impl Into<gpui::Length>) -> Self {
+        self.max_height = Some(max_height.into());
         self
     }
 
@@ -260,6 +267,8 @@ impl<D: PickerDelegate> Render for Picker<D> {
                     v_stack()
                         .flex_grow()
                         .py_2()
+                        .max_h(self.max_height.unwrap_or(rems(18.).into()))
+                        .overflow_hidden()
                         .children(self.delegate.render_header(cx))
                         .child(
                             uniform_list(
@@ -296,8 +305,6 @@ impl<D: PickerDelegate> Render for Picker<D> {
                             .track_scroll(self.scroll_handle.clone())
                         )
 
-                        .max_h_72()
-                        .overflow_hidden(),
                 )
             })
             .when(self.delegate.match_count() == 0, |el| {


### PR DESCRIPTION
This PR increases the max height of the outline picker so that it can take up a larger area of the screen when there are lots of results.

This behavior is similar to the way it was in Zed1.

Release Notes:

- N/A
