### PR TITLE
Round tooltip co-ordinates

### DIFF
--- a/crates/gpui2/src/elements/overlay.rs
+++ b/crates/gpui2/src/elements/overlay.rs
@@ -147,7 +147,8 @@ impl Element for Overlay {
             desired.origin.y = limits.origin.y;
         }
 
-        cx.with_element_offset(desired.origin - bounds.origin, |cx| {
+        let offset = point(desired.origin.x.round(), desired.origin.y.round());
+        cx.with_absolute_element_offset(offset, |cx| {
             cx.break_content_mask(|cx| {
                 for child in &mut self.children {
                     child.paint(cx);


### PR DESCRIPTION
There was a hypothesis that this would fix border rendering.

It doesn't :D; but it does at least mean that they are always consistently
broken, so it may be easier to fix.

