### PR TITLE
Fixes for search in terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
  "postage",
  "project",
  "regex",
- "search",
  "serde",
  "serde_derive",
  "settings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7762,6 +7762,7 @@ dependencies = [
  "procinfo",
  "project",
  "rand 0.8.5",
+ "search",
  "serde",
  "serde_derive",
  "settings",

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -18,7 +18,6 @@ gpui = { path = "../gpui" }
 language = { path = "../language" }
 menu = { path = "../menu" }
 project = { path = "../project" }
-search = { path = "../search" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
 ui = { path = "../ui" }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -431,57 +431,42 @@ pub trait SearchActionsRegistrar {
 }
 
 impl BufferSearchBar {
-    pub fn register_inner(
-        registrar: &mut impl SearchActionsRegistrar,
-        supported_options: &workspace::searchable::SearchOptions,
-    ) {
-        // supported_options controls whether the action is registered in the first place,
-        // but we still perform dynamic checks as e.g. if a view (like Workspace) uses SearchableItemHandle, they cannot know in advance
-        // whether a given option is supported.
-        if supported_options.case {
-            registrar.register_handler(|this, action: &ToggleCaseSensitive, cx| {
-                if this.supported_options().case {
-                    this.toggle_case_sensitive(action, cx);
-                }
-            });
-        }
-        if supported_options.word {
-            registrar.register_handler(|this, action: &ToggleWholeWord, cx| {
-                if this.supported_options().word {
-                    this.toggle_whole_word(action, cx);
-                }
-            });
-        }
+    pub fn register_inner(registrar: &mut impl SearchActionsRegistrar) {
+        registrar.register_handler(|this, action: &ToggleCaseSensitive, cx| {
+            if this.supported_options().case {
+                this.toggle_case_sensitive(action, cx);
+            }
+        });
 
-        if supported_options.replacement {
-            registrar.register_handler(|this, action: &ToggleReplace, cx| {
-                if this.supported_options().replacement {
-                    this.toggle_replace(action, cx);
-                }
-            });
-        }
+        registrar.register_handler(|this, action: &ToggleWholeWord, cx| {
+            if this.supported_options().word {
+                this.toggle_whole_word(action, cx);
+            }
+        });
 
-        if supported_options.regex {
-            registrar.register_handler(|this, _: &ActivateRegexMode, cx| {
-                if this.supported_options().regex {
-                    this.activate_search_mode(SearchMode::Regex, cx);
-                }
-            });
-        }
+        registrar.register_handler(|this, action: &ToggleReplace, cx| {
+            if this.supported_options().replacement {
+                this.toggle_replace(action, cx);
+            }
+        });
+
+        registrar.register_handler(|this, _: &ActivateRegexMode, cx| {
+            if this.supported_options().regex {
+                this.activate_search_mode(SearchMode::Regex, cx);
+            }
+        });
 
         registrar.register_handler(|this, _: &ActivateTextMode, cx| {
             this.activate_search_mode(SearchMode::Text, cx);
         });
 
-        if supported_options.regex {
-            registrar.register_handler(|this, action: &CycleMode, cx| {
-                if this.supported_options().regex {
-                    // If regex is not supported then search has just one mode (text) - in that case there's no point in supporting
-                    // cycling.
-                    this.cycle_mode(action, cx)
-                }
-            });
-        }
+        registrar.register_handler(|this, action: &CycleMode, cx| {
+            if this.supported_options().regex {
+                // If regex is not supported then search has just one mode (text) - in that case there's no point in supporting
+                // cycling.
+                this.cycle_mode(action, cx)
+            }
+        });
 
         registrar.register_handler(|this, action: &SelectNextMatch, cx| {
             this.select_next_match(action, cx);
@@ -500,6 +485,7 @@ impl BufferSearchBar {
             cx.propagate();
         });
         registrar.register_handler(|this, deploy, cx| {
+            dbg!("Deploying?");
             this.deploy(deploy, cx);
         })
     }
@@ -522,15 +508,7 @@ impl BufferSearchBar {
                 });
             }
         }
-        Self::register_inner(
-            workspace,
-            &workspace::searchable::SearchOptions {
-                case: true,
-                word: true,
-                regex: true,
-                replacement: true,
-            },
-        );
+        Self::register_inner(workspace);
     }
     pub fn new(cx: &mut ViewContext<Self>) -> Self {
         let query_editor = cx.new_view(|cx| Editor::single_line(cx));

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -485,7 +485,6 @@ impl BufferSearchBar {
             cx.propagate();
         });
         registrar.register_handler(|this, deploy, cx| {
-            dbg!("Deploying?");
             this.deploy(deploy, cx);
         })
     }

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -13,7 +13,7 @@ editor = { path = "../editor" }
 language = { path = "../language" }
 gpui = { path = "../gpui" }
 project = { path = "../project" }
-# search = { path = "../search" }
+search = { path = "../search" }
 settings = { path = "../settings" }
 theme = { path = "../theme" }
 util = { path = "../util" }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -19,7 +19,6 @@ use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
     item::Item,
     pane,
-    searchable::SearchableItem,
     ui::Icon,
     Pane, Workspace,
 };
@@ -359,7 +358,7 @@ impl Render for TerminalPanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let div = div();
         let mut registrar = ActionsRegistrar { div: Some(div), cx };
-        BufferSearchBar::register_inner(&mut registrar, &TerminalView::supported_options());
+        BufferSearchBar::register_inner(&mut registrar);
         registrar.div.unwrap().size_full().child(self.pane.clone())
     }
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -101,7 +101,7 @@ impl TerminalPanel {
                     })
                     .into_any_element()
             });
-            let buffer_search_bar = cx.add_view(search::BufferSearchBar::new);
+            let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
             pane.toolbar()
                 .update(cx, |toolbar, cx| toolbar.add_item(buffer_search_bar, cx));
             pane

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -3,13 +3,12 @@ use std::{path::PathBuf, sync::Arc};
 use crate::TerminalView;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
-    actions, div, serde_json, AppContext, AsyncWindowContext, Div, Entity, EventEmitter,
-    ExternalPaths, FocusHandle, FocusableView, InteractiveElement, IntoElement, ParentElement,
-    Pixels, Render, Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
-    WindowContext,
+    actions, serde_json, AppContext, AsyncWindowContext, Entity, EventEmitter, ExternalPaths,
+    FocusHandle, FocusableView, IntoElement, ParentElement, Pixels, Render, Styled, Subscription,
+    Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use project::Fs;
-use search::{buffer_search::SearchActionsRegistrar, BufferSearchBar};
+use search::{buffer_search::DivRegistrar, BufferSearchBar};
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use terminal::terminal_settings::{TerminalDockPosition, TerminalSettings};
@@ -330,36 +329,21 @@ impl TerminalPanel {
 
 impl EventEmitter<PanelEvent> for TerminalPanel {}
 
-struct ActionsRegistrar<'a, 'b>
-where
-    'b: 'a,
-{
-    div: Option<Div>,
-    cx: &'a mut ViewContext<'b, TerminalPanel>,
-}
-impl SearchActionsRegistrar for ActionsRegistrar<'_, '_> {
-    fn register_handler<A: gpui::Action>(
-        &mut self,
-        callback: fn(&mut BufferSearchBar, &A, &mut ViewContext<BufferSearchBar>),
-    ) {
-        self.div = self.div.take().map(|div| {
-            div.on_action(self.cx.listener(move |this, action, cx| {
-                this.pane
+impl Render for TerminalPanel {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let mut registrar = DivRegistrar::new(
+            |panel, cx| {
+                panel
+                    .pane
                     .read(cx)
                     .toolbar()
                     .read(cx)
                     .item_of_type::<BufferSearchBar>()
-                    .map(|search_bar| search_bar.update(cx, |this, cx| callback(this, action, cx)));
-            }))
-        });
-    }
-}
-impl Render for TerminalPanel {
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let div = div();
-        let mut registrar = ActionsRegistrar { div: Some(div), cx };
+            },
+            cx,
+        );
         BufferSearchBar::register_inner(&mut registrar);
-        registrar.div.unwrap().size_full().child(self.pane.clone())
+        registrar.into_div().size_full().child(self.pane.clone())
     }
 }
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -101,9 +101,9 @@ impl TerminalPanel {
                     })
                     .into_any_element()
             });
-            // let buffer_search_bar = cx.build_view(search::BufferSearchBar::new);
-            // pane.toolbar()
-            //     .update(cx, |toolbar, cx| toolbar.add_item(buffer_search_bar, cx));
+            let buffer_search_bar = cx.add_view(search::BufferSearchBar::new);
+            pane.toolbar()
+                .update(cx, |toolbar, cx| toolbar.add_item(buffer_search_bar, cx));
             pane
         });
         let subscriptions = vec![

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -28,7 +28,7 @@ use workspace::{
     item::{BreadcrumbText, Item, ItemEvent},
     notifications::NotifyResultExt,
     register_deserializable_item,
-    searchable::{SearchEvent, SearchOptions, SearchableItem},
+    searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
     CloseActiveItem, NewCenterTerminal, Pane, ToolbarItemLocation, Workspace, WorkspaceId,
 };
 
@@ -714,10 +714,9 @@ impl Item for TerminalView {
         false
     }
 
-    // todo!(search)
-    // fn as_searchable(&self, handle: &View<Self>) -> Option<Box<dyn SearchableItemHandle>> {
-    //     Some(Box::new(handle.clone()))
-    // }
+    fn as_searchable(&self, handle: &View<Self>) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(handle.clone()))
+    }
 
     fn breadcrumb_location(&self) -> ToolbarItemLocation {
         ToolbarItemLocation::PrimaryLeft


### PR DESCRIPTION
With this PR, Search should be usable in terminal. I've noticed other issues with selections though, so this PR might grow.
Namely:
- ~When searching, only the next search result is highlighted in Terminal~.
- When clearing search query, a single-character selection from the last match remains in place. Edit: this was the case in Zed1 as well.
- ~(a problem with this PR it seems): when one hides terminal panel, it's pane stays focused~.

Do not merge yet (prior to today's release).

Release Notes:
- Re-added search to terminal.