### PR TITLE
Fix spacing in diagnostics tab

### DIFF
--- a/crates/diagnostics2/src/diagnostics.rs
+++ b/crates/diagnostics2/src/diagnostics.rs
@@ -663,6 +663,7 @@ impl Item for ProjectDiagnosticsEditor {
                 .when(self.summary.warning_count > 0, |then| {
                     then.child(
                         h_stack()
+                            .gap_1()
                             .child(
                                 IconElement::new(Icon::ExclamationTriangle).color(Color::Warning),
                             )


### PR DESCRIPTION
This PR fixes the spacing in the diagnostics tab.

#### Before

<img width="108" alt="Screenshot 2024-01-02 at 3 40 51 PM" src="https://github.com/zed-industries/zed/assets/1486634/9508d867-5b5d-45b0-8b16-be35a23e3e7a">

#### After

<img width="121" alt="Screenshot 2024-01-02 at 3 40 54 PM" src="https://github.com/zed-industries/zed/assets/1486634/33e665e7-2935-4d4f-b1d0-9cb655235867">

Release Notes:

- N/A
