### PR TITLE
Add `icon_tooltip` for panel buttons rather than using persistent name

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -1281,6 +1281,10 @@ impl Panel for AssistantPanel {
         Some(Icon::Ai)
     }
 
+    fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
+        Some("Assistant Panel")
+    }
+
     fn toggle_action(&self) -> Box<dyn Action> {
         Box::new(ToggleFocus)
     }

--- a/crates/collab_ui2/src/chat_panel.rs
+++ b/crates/collab_ui2/src/chat_panel.rs
@@ -611,6 +611,10 @@ impl Panel for ChatPanel {
         Some(ui::Icon::MessageBubbles)
     }
 
+    fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
+        Some("Chat Panel")
+    }
+
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
         Box::new(ToggleFocus)
     }

--- a/crates/collab_ui2/src/collab_panel.rs
+++ b/crates/collab_ui2/src/collab_panel.rs
@@ -2347,6 +2347,10 @@ impl Panel for CollabPanel {
             .then(|| ui::Icon::Collab)
     }
 
+    fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
+        Some("Collab Panel")
+    }
+
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
         Box::new(ToggleFocus)
     }

--- a/crates/collab_ui2/src/notification_panel.rs
+++ b/crates/collab_ui2/src/notification_panel.rs
@@ -661,6 +661,10 @@ impl Panel for NotificationPanel {
             .then(|| Icon::Bell)
     }
 
+    fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
+        Some("Notification Panel")
+    }
+
     fn icon_label(&self, cx: &WindowContext) -> Option<String> {
         let count = self.notification_store.read(cx).unread_notification_count();
         if count == 0 {

--- a/crates/project_panel2/src/project_panel.rs
+++ b/crates/project_panel2/src/project_panel.rs
@@ -1612,6 +1612,10 @@ impl Panel for ProjectPanel {
         Some(ui::Icon::FileTree)
     }
 
+    fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
+        Some("Project Panel")
+    }
+
     fn toggle_action(&self) -> Box<dyn Action> {
         Box::new(ToggleFocus)
     }

--- a/crates/terminal_view2/src/terminal_panel.rs
+++ b/crates/terminal_view2/src/terminal_panel.rs
@@ -419,6 +419,10 @@ impl Panel for TerminalPanel {
         Some(Icon::Terminal)
     }
 
+    fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
+        Some("Terminal Panel")
+    }
+
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
         Box::new(ToggleFocus)
     }

--- a/crates/workspace2/src/dock.rs
+++ b/crates/workspace2/src/dock.rs
@@ -29,8 +29,8 @@ pub trait Panel: FocusableView + EventEmitter<PanelEvent> {
     fn set_position(&mut self, position: DockPosition, cx: &mut ViewContext<Self>);
     fn size(&self, cx: &WindowContext) -> Pixels;
     fn set_size(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>);
-    // todo!("We should have a icon tooltip method, rather than using persistant_name")
     fn icon(&self, cx: &WindowContext) -> Option<ui::Icon>;
+    fn icon_tooltip(&self, cx: &WindowContext) -> Option<&'static str>;
     fn toggle_action(&self) -> Box<dyn Action>;
     fn icon_label(&self, _: &WindowContext) -> Option<String> {
         None
@@ -54,6 +54,7 @@ pub trait PanelHandle: Send + Sync {
     fn size(&self, cx: &WindowContext) -> Pixels;
     fn set_size(&self, size: Option<Pixels>, cx: &mut WindowContext);
     fn icon(&self, cx: &WindowContext) -> Option<ui::Icon>;
+    fn icon_tooltip(&self, cx: &WindowContext) -> Option<&'static str>;
     fn toggle_action(&self, cx: &WindowContext) -> Box<dyn Action>;
     fn icon_label(&self, cx: &WindowContext) -> Option<String>;
     fn focus_handle(&self, cx: &AppContext) -> FocusHandle;
@@ -106,6 +107,10 @@ where
 
     fn icon(&self, cx: &WindowContext) -> Option<ui::Icon> {
         self.read(cx).icon(cx)
+    }
+
+    fn icon_tooltip(&self, cx: &WindowContext) -> Option<&'static str> {
+        self.read(cx).icon_tooltip(cx)
     }
 
     fn toggle_action(&self, cx: &WindowContext) -> Box<dyn Action> {
@@ -612,6 +617,7 @@ impl Render for PanelButtons {
             .enumerate()
             .filter_map(|(i, entry)| {
                 let icon = entry.panel.icon(cx)?;
+                let icon_tooltip = entry.panel.icon_tooltip(cx)?;
                 let name = entry.panel.persistent_name();
                 let panel = entry.panel.clone();
 
@@ -627,7 +633,7 @@ impl Render for PanelButtons {
                 } else {
                     let action = entry.panel.toggle_action(cx);
 
-                    (action, name.into())
+                    (action, icon_tooltip.into())
                 };
 
                 Some(
@@ -745,6 +751,10 @@ pub mod test {
         }
 
         fn icon(&self, _: &WindowContext) -> Option<ui::Icon> {
+            None
+        }
+
+        fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {
             None
         }
 


### PR DESCRIPTION
Fixes missing spaces in these tooltips

Release Notes:

- N/A
