### PR TITLE
gpui: Use official taffy version 0.3.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,7 +4019,7 @@ dependencies = [
  "smol",
  "sqlez",
  "sum_tree",
- "taffy 0.3.11 (git+https://github.com/DioxusLabs/taffy?rev=4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e)",
+ "taffy 0.3.11",
  "thiserror",
  "time",
  "tiny-skia",
@@ -4083,7 +4083,7 @@ dependencies = [
  "smol",
  "sqlez",
  "sum_tree",
- "taffy 0.3.11 (git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b)",
+ "taffy 0.3.18",
  "thiserror",
  "time",
  "tiny-skia",
@@ -4117,12 +4117,6 @@ name = "grid"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eec1c01eb1de97451ee0d60de7d81cf1e72aabefb021616027f3d1c3ec1c723c"
-
-[[package]]
-name = "grid"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
 
 [[package]]
 name = "h2"
@@ -9523,21 +9517,22 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.3.11"
-source = "git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b#1876f72bee5e376023eaa518aa7b8a34c769bd1b"
+source = "git+https://github.com/DioxusLabs/taffy?rev=4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e#4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e"
 dependencies = [
  "arrayvec 0.7.4",
- "grid 0.11.0",
+ "grid",
  "num-traits",
  "slotmap",
 ]
 
 [[package]]
 name = "taffy"
-version = "0.3.11"
-source = "git+https://github.com/DioxusLabs/taffy?rev=4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e#4fb530bdd71609bb1d3f76c6a8bde1ba82805d5e"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2287b6d7f721ada4cddf61ade5e760b2c6207df041cac9bfaa192897362fd3"
 dependencies = [
  "arrayvec 0.7.4",
- "grid 0.10.0",
+ "grid",
  "num-traits",
  "slotmap",
 ]

--- a/crates/gpui2/Cargo.toml
+++ b/crates/gpui2/Cargo.toml
@@ -53,7 +53,7 @@ serde_derive.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
+taffy = "0.3.18"
 thiserror.workspace = true
 time.workspace = true
 tiny-skia = "0.5"


### PR DESCRIPTION
This should be a no-op, as 0.3.18 release contains just the commit we were pinned to previously (+ some release notes). https://github.com/DioxusLabs/taffy/pull/577
However, if we intend to publish gpui to crates.io, we cannot have path dependencies - so that change brings us a step closer.

Release Notes:

- N/A
