### PR TITLE
Revert "Round tooltip co-ordinates (#3836)"

### DIFF
--- a/crates/gpui2/src/elements/overlay.rs
+++ b/crates/gpui2/src/elements/overlay.rs
@@ -149,8 +149,7 @@ impl Element for Overlay {
             desired.origin.y = limits.origin.y;
         }
 
-        let offset = point(desired.origin.x.round(), desired.origin.y.round());
-        cx.with_absolute_element_offset(offset, |cx| {
+        cx.with_element_offset(desired.origin - bounds.origin, |cx| {
             cx.break_content_mask(|cx| {
                 for child in &mut self.children {
                     child.paint(cx);


### PR DESCRIPTION
This reverts commit 09951208a78c9933159c68c6f8105eda40e8bd7e, reversing changes made to 93a818d0186dce098cae4ae08dd368c23b895a4b.

I noticed an issue where context menus were appearing in the wrong location (shifted to the right) as a result of this change.

Release Notes:

- N/A
