### PR TITLE
Pane: Fix flicker when opening/closing tabs

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -1687,7 +1687,7 @@ impl Pane {
                         ),
                 )
             })
-            .when(self.has_focus(cx), |tab_bar| {
+            .when(self.was_focused || self.has_focus(cx), |tab_bar| {
                 tab_bar.end_child({
                     let render_tab_buttons = self.render_tab_bar_buttons.clone();
                     render_tab_buttons(self, cx)


### PR DESCRIPTION
Tab bar was losing focus for one frame which led to it skipping rendering of tab controls & flickering. It also occured when opening new tabs.

Before this PR (that's on official nightly build):

https://github.com/zed-industries/zed/assets/24362066/500e5ea1-de9a-4874-92e3-605c6cc5d1fc

And after:

https://github.com/zed-industries/zed/assets/24362066/4e8d1aef-a622-4b00-a134-cf2d293ec86a

This PR also fixes the following bullet point from our issue tracker that mentioned terminal - though the culprit lied elsewhere:
Icons flicker in terminal panel when tabs are closed
Release Notes:

- N/A
