### PR TITLE
Don't duplicate project search on `cmd-shift-f`

### DIFF
--- a/crates/workspace2/src/pane.rs
+++ b/crates/workspace2/src/pane.rs
@@ -720,6 +720,10 @@ impl Pane {
         self.items.iter()
     }
 
+    pub fn item_of_type<T: Item>(&self) -> Option<View<T>> {
+        self.items_of_type().max_by_key(|item| item.item_id())
+    }
+
     pub fn items_of_type<T: Render>(&self) -> impl '_ + Iterator<Item = View<T>> {
         self.items
             .iter()


### PR DESCRIPTION
After this pull request, when hitting `cmd-shift-f` on a pane that already contains a project search, Zed will focus that project search instead and will automatically populate the query editor with a query suggestion. If `cmd-shift-f` is hit while the results of a project search are focused, Zed will transfer focus back to the query editor. If `cmd-shift-f` is hit while the query editor is focused, Zed will transfer focus to the results editor.

Release Notes:

- N/A
