### PR TITLE
Fix icon path for `Icon::AudioOn`

### DIFF
--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -121,7 +121,7 @@ impl Icon {
             Icon::ArrowUpRight => "icons/arrow_up_right.svg",
             Icon::AtSign => "icons/at_sign.svg",
             Icon::AudioOff => "icons/speaker_off.svg",
-            Icon::AudioOn => "icons/speaker-loud.svg",
+            Icon::AudioOn => "icons/speaker_loud.svg",
             Icon::Backspace => "icons/backspace.svg",
             Icon::Bell => "icons/bell.svg",
             Icon::BellOff => "icons/bell_off.svg",


### PR DESCRIPTION
This PR fixes the icon path for `Icon::AudioOn` so that it points to a file that exists.

Release Notes:

- Fixed the loading of the deafen icon in the call controls.
