### PR TITLE
Disable Dangerous Downtime-causing Default

### DIFF
--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
     service.beta.kubernetes.io/do-loadbalancer-certificate-id: ${ZED_DO_CERTIFICATE_ID}
+    service.beta.kubernetes.io/do-loadbalancer-disable-lets-encrypt-dns-records: true
 spec:
   type: LoadBalancer
   selector:

--- a/crates/collab/k8s/postgrest.template.yml
+++ b/crates/collab/k8s/postgrest.template.yml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
     service.beta.kubernetes.io/do-loadbalancer-certificate-id: ${ZED_DO_CERTIFICATE_ID}
+    service.beta.kubernetes.io/do-loadbalancer-disable-lets-encrypt-dns-records: true
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
According to https://docs.digitalocean.com/products/kubernetes/how-to/configure-load-balancers/#ssl-certificates

you can specify whether to disable automatic DNS record
creation for the certificate upon the load balancer’s creation using the
do-loadbalancer-disable-lets-encrypt-dns-records annotation. If you
specify true, we will not automatically create a DNS A record at the
apex of your domain to support the SSL certificate.
