### PR TITLE
Use dense spacing for completion menu items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "0.119.0"
+version = "0.120.0"
 dependencies = [
  "activity_indicator",
  "ai",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -98,10 +98,7 @@ pub use sum_tree::Bias;
 use sum_tree::TreeMap;
 use text::{OffsetUtf16, Rope};
 use theme::{ActiveTheme, PlayerColor, StatusColors, SyntaxTheme, ThemeColors, ThemeSettings};
-use ui::{
-    h_stack, ButtonSize, ButtonStyle, Icon, IconButton, ListItem, ListItemSpacing, Popover, Tooltip,
-};
-use ui::{prelude::*, IconSize};
+use ui::{h_stack, prelude::*, IconSize, ButtonSize, ButtonStyle, Icon, IconButton, ListItem, Popover, Tooltip};
 use util::{post_inc, RangeExt, ResultExt, TryFutureExt};
 use workspace::{searchable::SearchEvent, ItemNavHistory, Pane, SplitDirection, ViewId, Workspace};
 
@@ -1259,7 +1256,6 @@ impl CompletionsMenu {
                         div().min_w(px(220.)).max_w(px(540.)).child(
                             ListItem::new(mat.candidate_id)
                                 .inset(true)
-                                .spacing(ListItemSpacing::Sparse)
                                 .selected(item_ix == selected_item)
                                 .on_click(cx.listener(move |editor, _event, cx| {
                                     cx.stop_propagation();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -98,7 +98,10 @@ pub use sum_tree::Bias;
 use sum_tree::TreeMap;
 use text::{OffsetUtf16, Rope};
 use theme::{ActiveTheme, PlayerColor, StatusColors, SyntaxTheme, ThemeColors, ThemeSettings};
-use ui::{h_stack, prelude::*, IconSize, ButtonSize, ButtonStyle, Icon, IconButton, ListItem, Popover, Tooltip};
+use ui::{
+    h_stack, prelude::*, ButtonSize, ButtonStyle, Icon, IconButton, IconSize, ListItem, Popover,
+    Tooltip,
+};
 use util::{post_inc, RangeExt, ResultExt, TryFutureExt};
 use workspace::{searchable::SearchEvent, ItemNavHistory, Pane, SplitDirection, ViewId, Workspace};
 


### PR DESCRIPTION
This PR updates the completion menu to use dense spacing for its items.

Release Notes:

- Adjusted styling of completion menu entries.
