### PR TITLE
channels: Move name of the channel to the same line as the hash icon.

### DIFF
--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -164,8 +164,14 @@ impl Render for ChannelModal {
                     .py_1()
                     .rounded_t(px(8.))
                     .bg(cx.theme().colors().element_background)
-                    .child(IconElement::new(Icon::Hash).size(IconSize::Medium))
-                    .child(Label::new(channel_name))
+                    .child(
+                        h_stack()
+                            .w_px()
+                            .flex_1()
+                            .gap_1()
+                            .child(IconElement::new(Icon::Hash).size(IconSize::Medium))
+                            .child(Label::new(channel_name)),
+                    )
                     .child(
                         h_stack()
                             .w_full()


### PR DESCRIPTION
Fixes: Channel membership management, channel title shows on separate line from # symbol
Release Notes:

- N/A
