### PR TITLE
Fix quitting Zed when project was unshared

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1095,19 +1095,21 @@ impl Workspace {
     }
 
     pub fn close_global(_: &CloseWindow, cx: &mut AppContext) {
-        cx.windows().iter().find(|window| {
-            window
-                .update(cx, |_, window| {
-                    if window.is_window_active() {
-                        //This can only get called when the window's project connection has been lost
-                        //so we don't need to prompt the user for anything and instead just close the window
-                        window.remove_window();
-                        true
-                    } else {
-                        false
-                    }
-                })
-                .unwrap_or(false)
+        cx.defer(|cx| {
+            cx.windows().iter().find(|window| {
+                window
+                    .update(cx, |_, window| {
+                        if window.is_window_active() {
+                            //This can only get called when the window's project connection has been lost
+                            //so we don't need to prompt the user for anything and instead just close the window
+                            window.remove_window();
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                    .unwrap_or(false)
+            });
         });
     }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -144,6 +144,7 @@ fn main() {
 
         cx.set_global(client.clone());
 
+        zed::init(cx);
         theme::init(theme::LoadThemes::All, cx);
         project::Project::init(&client, cx);
         client::init(&client, cx);
@@ -158,7 +159,6 @@ fn main() {
             cx,
         );
         assistant::init(cx);
-        // component_test::init(cx);
 
         cx.spawn(|_| watch_languages(fs.clone(), languages.clone()))
             .detach();


### PR DESCRIPTION
Release Notes:

- Fixed a bug that would disable `cmd-q` after a remote project was unshared.
