### PR TITLE
Re-enable key bindings for `AssistantPanel`

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1157,6 +1157,7 @@ impl Render for AssistantPanel {
                 });
 
             v_stack()
+                .key_context("AssistantPanel")
                 .size_full()
                 .on_action(cx.listener(|this, _: &workspace::NewFile, cx| {
                     this.new_conversation(cx);


### PR DESCRIPTION
Release Notes:

- Fixed a bug that caused `cmd-g` and `cmd-shift-g` to not work anymore in the assistant panel.
