### PR TITLE
Fix font resolution for UI text so we render with the fallback font

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -288,7 +288,7 @@ impl TextSystem {
                     last_font = Some(run.font.clone());
                     font_runs.push(FontRun {
                         len: run_len_within_line,
-                        font_id: self.platform_text_system.font_id(&run.font)?,
+                        font_id: self.resolve_font(&run.font),
                     });
                 }
 


### PR DESCRIPTION
This PR updates the font resolution for shaped text to use the new `resolve_font` method on the text system.

This makes it so we use the fallback font if the desired font cannot be found rather than rendering nothing.

Release Notes:

- Fixed an issue where nothing would render when the font set in `ui_font_family` was not found.
