### PR TITLE
Render an empty placeholder when not showing file icons in the project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1395,7 +1395,7 @@ impl ProjectPanel {
                     .child(if let Some(icon) = &icon {
                         div().child(IconElement::from_path(icon.to_string()).color(Color::Muted))
                     } else {
-                        div()
+                        div().size(IconSize::default().rems()).invisible()
                     })
                     .child(
                         if let (Some(editor), true) = (Some(&self.filename_editor), show_editor) {


### PR DESCRIPTION
This PR makes it so when we're not showing file icons in the project panel we render an empty placeholder instead of nothing.

This prevents the indentation of the items in the file tree from changing based on the presence of the icon.

Release Notes:

- Fixed layout shift when `project_panel.file_icons` is set to `false`.
