### PR TITLE
Set a minimum size for the search input field

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -223,6 +223,7 @@ impl Render for BufferSearchBar {
                     .gap_2()
                     .border_1()
                     .border_color(editor_border)
+                    .min_w(rems(384. / 16.))
                     .rounded_lg()
                     .child(IconElement::new(Icon::MagnifyingGlass))
                     .child(self.render_text_input(&self.query_editor, cx))


### PR DESCRIPTION
Release Notes:

- Show search input field wider for narrow panes
