### PR TITLE
Upgrade `ctor` to v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,11 +1926,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
-source = "git+https://github.com/zed-industries/rust-ctor?rev=7f824cf6a7943885a649b579f33f9ac53f0d1db6#7f824cf6a7943885a649b579f33f9ac53f0d1db6"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,10 +92,7 @@ resolver = "2"
 anyhow = { version = "1.0.57" }
 async-trait = { version = "0.1" }
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
-# TODO: Switch back to the published version of `ctor` once:
-#       1. A new version of `ctor` is published with this change: https://github.com/mmastrac/rust-ctor/pull/295
-#       2. We've confirmed it's fine to update to the latest version of `ctor` (we're currently on v0.1.20).
-ctor = { git = "https://github.com/zed-industries/rust-ctor", rev = "7f824cf6a7943885a649b579f33f9ac53f0d1db6" }
+ctor = "0.2.6"
 derive_more = { version = "0.99.17" }
 env_logger = { version = "0.9" }
 futures = { version = "0.3" }


### PR DESCRIPTION
This PR upgrades our version of `ctor` to v0.2.6.

We were previously using a fork that contained this fix: https://github.com/mmastrac/rust-ctor/pull/295.

A new version of `ctor` has now been released with that change, so we can switch back to the mainline version.

I scanned through the diff between versions (since we're upgrading from effectively v0.1.20) and didn't notice anything that seemed obviously breaking: https://github.com/mmastrac/rust-ctor/compare/564b87f1dc13cf061ef9997ee501fa5378f35ba1...ee6b4b1c7bd3c9c1edad3b6f4d906e767767ba3d

Release Notes:

- N/A
