### PR TITLE
Decouple theme license generation from TypeScript theme definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7839,6 +7839,7 @@ dependencies = [
  "convert_case 0.6.0",
  "gpui",
  "indexmap 1.9.3",
+ "indoc",
  "json_comments",
  "log",
  "palette",

--- a/crates/theme/src/themes/LICENSES
+++ b/crates/theme/src/themes/LICENSES
@@ -1,8 +1,8 @@
-## [Solarized Light](https://github.com/altercation/solarized)
+## [Andromeda](https://github.com/EliverLara/Andromeda)
 
 The MIT License (MIT)
 
-Copyright (c) 2011 Ethan Schoonover
+Copyright (c) 2017 <eliverlara@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,115 @@ SOFTWARE.
 
 ********************************************************************************
 
-## [Ayu Dark](https://github.com/dempfi/ayu)
+## [Atelier Cave Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
 
 The MIT License (MIT)
 
-Copyright (c) 2016 Ike Ku
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Cave Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Dune Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Dune Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Estuary Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -102,448 +206,6 @@ SOFTWARE.
 
 ********************************************************************************
 
-## [Gruvbox Light Hard](https://github.com/morhetz/gruvbox)
-
-The MIT License (MIT)
-
-Copyright (c) <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Savanna Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Cave Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Estuary Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Sulphurpool Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Gruvbox Dark Soft](https://github.com/morhetz/gruvbox)
-
-The MIT License (MIT)
-
-Copyright (c) <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Sulphurpool Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Dune Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [One Light](https://github.com/atom/atom/tree/master/packages/one-light-ui)
-
-The MIT License (MIT)
-
-Copyright (c) 2014 GitHub Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Seaside Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Cave Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Summercamp](https://github.com/zoefiri/base16-sc)
-
-The MIT License (MIT)
-
-Copyright (c) 2019 Zoe FiriH
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Plateau Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Andromeda](https://github.com/EliverLara/Andromeda)
-
-The MIT License (MIT)
-
-Copyright (c) 2017 <eliverlara@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Heath Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Lakeside Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Gruvbox Light](https://github.com/morhetz/gruvbox)
-
-The MIT License (MIT)
-
-Copyright (c) <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
 ## [Atelier Forest Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
 
 The MIT License (MIT)
@@ -570,371 +232,7 @@ SOFTWARE.
 
 ********************************************************************************
 
-## [Gruvbox Dark](https://github.com/morhetz/gruvbox)
-
-The MIT License (MIT)
-
-Copyright (c) <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [One Dark](https://github.com/atom/atom/tree/master/packages/one-dark-ui)
-
-The MIT License (MIT)
-
-Copyright (c) 2014 GitHub Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Sandcastle](https://github.com/gessig/base16-sandcastle-scheme)
-
-The MIT License (MIT)
-
-Copyright (c) 2019 George Essig
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Gruvbox Light Soft](https://github.com/morhetz/gruvbox)
-
-The MIT License (MIT)
-
-Copyright (c) <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Rosé Pine Dawn](https://github.com/edunfelt/base16-rose-pine-scheme)
-
-The MIT License (MIT)
-
-Copyright (c) 2021 Emilia Dunfelt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Gruvbox Dark Hard](https://github.com/morhetz/gruvbox)
-
-The MIT License (MIT)
-
-Copyright (c) <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Ayu Light](https://github.com/dempfi/ayu)
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Ike Ku
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Rosé Pine Moon](https://github.com/edunfelt/base16-rose-pine-scheme)
-
-The MIT License (MIT)
-
-Copyright (c) 2021 Emilia Dunfelt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Dune Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Solarized Dark](https://github.com/altercation/solarized)
-
-The MIT License (MIT)
-
-Copyright (c) 2011 Ethan Schoonover
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Ayu Mirage](https://github.com/dempfi/ayu)
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Ike Ku
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Plateau Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Rosé Pine](https://github.com/edunfelt/base16-rose-pine-scheme)
-
-The MIT License (MIT)
-
-Copyright (c) 2021 Emilia Dunfelt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Seaside Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
-
-The MIT License (MIT)
-
-Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-********************************************************************************
-
-## [Atelier Savanna Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+## [Atelier Heath Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
 
 The MIT License (MIT)
 
@@ -986,11 +284,713 @@ SOFTWARE.
 
 ********************************************************************************
 
+## [Atelier Lakeside Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
 ## [Atelier Lakeside Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
 
 The MIT License (MIT)
 
 Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Plateau Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Plateau Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Savanna Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Savanna Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Seaside Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Seaside Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Sulphurpool Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Sulphurpool Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Ayu Dark](https://github.com/dempfi/ayu)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Ike Ku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Ayu Light](https://github.com/dempfi/ayu)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Ike Ku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Ayu Mirage](https://github.com/dempfi/ayu)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Ike Ku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Dark](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Dark Hard](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Dark Soft](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Light](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Light Hard](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Light Soft](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [One Dark](https://github.com/atom/atom/tree/master/packages/one-dark-ui)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [One Light](https://github.com/atom/atom/tree/master/packages/one-light-ui)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Rosé Pine](https://github.com/edunfelt/base16-rose-pine-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Emilia Dunfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Rosé Pine Dawn](https://github.com/edunfelt/base16-rose-pine-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Emilia Dunfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Rosé Pine Moon](https://github.com/edunfelt/base16-rose-pine-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Emilia Dunfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Sandcastle](https://github.com/gessig/base16-sandcastle-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2019 George Essig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Solarized Dark](https://github.com/altercation/solarized)
+
+The MIT License (MIT)
+
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Solarized Light](https://github.com/altercation/solarized)
+
+The MIT License (MIT)
+
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Summercamp](https://github.com/zoefiri/base16-sc)
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Zoe FiriH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/theme/src/themes/LICENSES
+++ b/crates/theme/src/themes/LICENSES
@@ -1,0 +1,1013 @@
+## [Solarized Light](https://github.com/altercation/solarized)
+
+The MIT License (MIT)
+
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Ayu Dark](https://github.com/dempfi/ayu)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Ike Ku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Estuary Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Forest Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Light Hard](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Savanna Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Cave Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Estuary Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Sulphurpool Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Dark Soft](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Sulphurpool Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Dune Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [One Light](https://github.com/atom/atom/tree/master/packages/one-light-ui)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Seaside Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Cave Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Summercamp](https://github.com/zoefiri/base16-sc)
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Zoe FiriH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Plateau Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Andromeda](https://github.com/EliverLara/Andromeda)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 <eliverlara@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Heath Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Lakeside Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Light](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Forest Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Dark](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [One Dark](https://github.com/atom/atom/tree/master/packages/one-dark-ui)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Sandcastle](https://github.com/gessig/base16-sandcastle-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2019 George Essig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Light Soft](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Rosé Pine Dawn](https://github.com/edunfelt/base16-rose-pine-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Emilia Dunfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Gruvbox Dark Hard](https://github.com/morhetz/gruvbox)
+
+The MIT License (MIT)
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Ayu Light](https://github.com/dempfi/ayu)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Ike Ku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Rosé Pine Moon](https://github.com/edunfelt/base16-rose-pine-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Emilia Dunfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Dune Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Solarized Dark](https://github.com/altercation/solarized)
+
+The MIT License (MIT)
+
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Ayu Mirage](https://github.com/dempfi/ayu)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Ike Ku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Plateau Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Rosé Pine](https://github.com/edunfelt/base16-rose-pine-scheme)
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Emilia Dunfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Seaside Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Savanna Dark](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Heath Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************
+
+## [Atelier Lakeside Light](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/)
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+********************************************************************************

--- a/crates/theme/src/themes/atelier.rs
+++ b/crates/theme/src/themes/atelier.rs
@@ -16,6 +16,2331 @@ pub fn atelier() -> UserThemeFamily {
         author: "Zed Industries".into(),
         themes: vec![
             UserTheme {
+                name: "Atelier Cave Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x56505eff).into()),
+                        border_variant: Some(rgba(0x332f38ff).into()),
+                        border_focused: Some(rgba(0x222953ff).into()),
+                        border_selected: Some(rgba(0x222953ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x48434fff).into()),
+                        elevated_surface_background: Some(rgba(0x221f26ff).into()),
+                        surface_background: Some(rgba(0x221f26ff).into()),
+                        background: Some(rgba(0x3a353fff).into()),
+                        panel_background: Some(rgba(0x221f26ff).into()),
+                        element_background: Some(rgba(0x221f26ff).into()),
+                        element_hover: Some(rgba(0x332f38ff).into()),
+                        element_active: Some(rgba(0x544f5cff).into()),
+                        element_selected: Some(rgba(0x544f5cff).into()),
+                        element_disabled: Some(rgba(0x221f26ff).into()),
+                        drop_target_background: Some(rgba(0x89859180).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x332f38ff).into()),
+                        ghost_element_active: Some(rgba(0x544f5cff).into()),
+                        ghost_element_selected: Some(rgba(0x544f5cff).into()),
+                        ghost_element_disabled: Some(rgba(0x221f26ff).into()),
+                        text: Some(rgba(0xefecf4ff).into()),
+                        text_muted: Some(rgba(0x898591ff).into()),
+                        text_placeholder: Some(rgba(0x756f7eff).into()),
+                        text_disabled: Some(rgba(0x756f7eff).into()),
+                        text_accent: Some(rgba(0x576ddaff).into()),
+                        icon: Some(rgba(0xefecf4ff).into()),
+                        icon_muted: Some(rgba(0x898591ff).into()),
+                        icon_disabled: Some(rgba(0x756f7eff).into()),
+                        icon_placeholder: Some(rgba(0x898591ff).into()),
+                        icon_accent: Some(rgba(0x576ddaff).into()),
+                        status_bar_background: Some(rgba(0x3a353fff).into()),
+                        title_bar_background: Some(rgba(0x3a353fff).into()),
+                        toolbar_background: Some(rgba(0x19171cff).into()),
+                        tab_bar_background: Some(rgba(0x221f26ff).into()),
+                        tab_inactive_background: Some(rgba(0x221f26ff).into()),
+                        tab_active_background: Some(rgba(0x19171cff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xefecf44c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x332f38ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x332f38ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x201e24ff).into()),
+                        editor_foreground: Some(rgba(0xe2dfe7ff).into()),
+                        editor_background: Some(rgba(0x19171cff).into()),
+                        editor_gutter_background: Some(rgba(0x19171cff).into()),
+                        editor_subheader_background: Some(rgba(0x221f26ff).into()),
+                        editor_active_line_background: Some(rgba(0x221f26bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x221f26ff).into()),
+                        editor_line_number: Some(rgba(0xefecf459).into()),
+                        editor_active_line_number: Some(rgba(0xefecf4ff).into()),
+                        editor_invisible: Some(rgba(0x898591ff).into()),
+                        editor_wrap_guide: Some(rgba(0xefecf40d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xefecf41a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x576dda1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x726c7a66).into()),
+                        terminal_background: Some(rgba(0x19171cff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x635d6bff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x5c283cff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x1f4747ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x4e3821ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x2d376fff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x60255bff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x26445eff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xefecf4ff).into()),
+                        terminal_ansi_black: Some(rgba(0x19171cff).into()),
+                        terminal_ansi_red: Some(rgba(0xbe4678ff).into()),
+                        terminal_ansi_green: Some(rgba(0x2c9292ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xa06e3bff).into()),
+                        terminal_ansi_blue: Some(rgba(0x576ddaff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xbf41bfff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x3a8bc6ff).into()),
+                        terminal_ansi_white: Some(rgba(0xefecf4ff).into()),
+                        link_text_hover: Some(rgba(0x576ddaff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xa06e3bff).into()),
+                        conflict_background: Some(rgba(0x231a12ff).into()),
+                        conflict_border: Some(rgba(0x392a1aff).into()),
+                        created: Some(rgba(0x2c9292ff).into()),
+                        created_background: Some(rgba(0x132020ff).into()),
+                        created_border: Some(rgba(0x1a3434ff).into()),
+                        deleted: Some(rgba(0xbe4678ff).into()),
+                        deleted_background: Some(rgba(0x28151cff).into()),
+                        deleted_border: Some(rgba(0x421f2dff).into()),
+                        error: Some(rgba(0xbe4678ff).into()),
+                        error_background: Some(rgba(0x28151cff).into()),
+                        error_border: Some(rgba(0x421f2dff).into()),
+                        hidden: Some(rgba(0x756f7eff).into()),
+                        hidden_background: Some(rgba(0x3a353fff).into()),
+                        hidden_border: Some(rgba(0x48434fff).into()),
+                        hint: Some(rgba(0x716998ff).into()),
+                        hint_background: Some(rgba(0x161a36ff).into()),
+                        hint_border: Some(rgba(0x222953ff).into()),
+                        ignored: Some(rgba(0x898591ff).into()),
+                        ignored_background: Some(rgba(0x3a353fff).into()),
+                        ignored_border: Some(rgba(0x56505eff).into()),
+                        info: Some(rgba(0x576ddaff).into()),
+                        info_background: Some(rgba(0x161a36ff).into()),
+                        info_border: Some(rgba(0x222953ff).into()),
+                        modified: Some(rgba(0xa06e3bff).into()),
+                        modified_background: Some(rgba(0x231a12ff).into()),
+                        modified_border: Some(rgba(0x392a1aff).into()),
+                        predictive: Some(rgba(0x625887ff).into()),
+                        predictive_background: Some(rgba(0x132020ff).into()),
+                        predictive_border: Some(rgba(0x1a3434ff).into()),
+                        renamed: Some(rgba(0x576ddaff).into()),
+                        renamed_background: Some(rgba(0x161a36ff).into()),
+                        renamed_border: Some(rgba(0x222953ff).into()),
+                        success: Some(rgba(0x2c9292ff).into()),
+                        success_background: Some(rgba(0x132020ff).into()),
+                        success_border: Some(rgba(0x1a3434ff).into()),
+                        unreachable: Some(rgba(0x898591ff).into()),
+                        unreachable_background: Some(rgba(0x3a353fff).into()),
+                        unreachable_border: Some(rgba(0x56505eff).into()),
+                        warning: Some(rgba(0xa06e3bff).into()),
+                        warning_background: Some(rgba(0x231a12ff).into()),
+                        warning_border: Some(rgba(0x392a1aff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x576ddaff).into(),
+                            background: rgba(0x576ddaff).into(),
+                            selection: rgba(0x576dda3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbf41bfff).into(),
+                            background: rgba(0xbf41bfff).into(),
+                            selection: rgba(0xbf41bf3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaa573cff).into(),
+                            background: rgba(0xaa573cff).into(),
+                            selection: rgba(0xaa573c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x955ae6ff).into(),
+                            background: rgba(0x955ae6ff).into(),
+                            selection: rgba(0x955ae63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3a8bc6ff).into(),
+                            background: rgba(0x3a8bc6ff).into(),
+                            selection: rgba(0x3a8bc63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbe4678ff).into(),
+                            background: rgba(0xbe4678ff).into(),
+                            selection: rgba(0xbe46783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3bff).into(),
+                            background: rgba(0xa06e3bff).into(),
+                            selection: rgba(0xa06e3b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2c9292ff).into(),
+                            background: rgba(0x2c9292ff).into(),
+                            selection: rgba(0x2c92923d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x655f6dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8b8792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xefecf4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddaff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa573cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddbff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddbff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x716998ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x955ae7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa573cff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa573cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8b8792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x625887ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xefecf4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbe4678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8b8792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8b8792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbf40bfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2a9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8b8792ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x398bc6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbf40bfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2a9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa573cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xefecf4ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x955ae7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Cave Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x8f8b96ff).into()),
+                        border_variant: Some(rgba(0xcbc8d1ff).into()),
+                        border_focused: Some(rgba(0xc9c8f3ff).into()),
+                        border_selected: Some(rgba(0xc9c8f3ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xa7a3adff).into()),
+                        elevated_surface_background: Some(rgba(0xe6e3ebff).into()),
+                        surface_background: Some(rgba(0xe6e3ebff).into()),
+                        background: Some(rgba(0xbfbcc5ff).into()),
+                        panel_background: Some(rgba(0xe6e3ebff).into()),
+                        element_background: Some(rgba(0xe6e3ebff).into()),
+                        element_hover: Some(rgba(0xcbc8d1ff).into()),
+                        element_active: Some(rgba(0x918d98ff).into()),
+                        element_selected: Some(rgba(0x918d98ff).into()),
+                        element_disabled: Some(rgba(0xe6e3ebff).into()),
+                        drop_target_background: Some(rgba(0x5a546280).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xcbc8d1ff).into()),
+                        ghost_element_active: Some(rgba(0x918d98ff).into()),
+                        ghost_element_selected: Some(rgba(0x918d98ff).into()),
+                        ghost_element_disabled: Some(rgba(0xe6e3ebff).into()),
+                        text: Some(rgba(0x19171cff).into()),
+                        text_muted: Some(rgba(0x5a5462ff).into()),
+                        text_placeholder: Some(rgba(0x6e6876ff).into()),
+                        text_disabled: Some(rgba(0x6e6876ff).into()),
+                        text_accent: Some(rgba(0x586ddaff).into()),
+                        icon: Some(rgba(0x19171cff).into()),
+                        icon_muted: Some(rgba(0x5a5462ff).into()),
+                        icon_disabled: Some(rgba(0x6e6876ff).into()),
+                        icon_placeholder: Some(rgba(0x5a5462ff).into()),
+                        icon_accent: Some(rgba(0x586ddaff).into()),
+                        status_bar_background: Some(rgba(0xbfbcc5ff).into()),
+                        title_bar_background: Some(rgba(0xbfbcc5ff).into()),
+                        toolbar_background: Some(rgba(0xefecf4ff).into()),
+                        tab_bar_background: Some(rgba(0xe6e3ebff).into()),
+                        tab_inactive_background: Some(rgba(0xe6e3ebff).into()),
+                        tab_active_background: Some(rgba(0xefecf4ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x19171c4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xcbc8d1ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xcbc8d1ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xe8e5edff).into()),
+                        editor_foreground: Some(rgba(0x26232aff).into()),
+                        editor_background: Some(rgba(0xefecf4ff).into()),
+                        editor_gutter_background: Some(rgba(0xefecf4ff).into()),
+                        editor_subheader_background: Some(rgba(0xe6e3ebff).into()),
+                        editor_active_line_background: Some(rgba(0xe6e3ebbf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xe6e3ebff).into()),
+                        editor_line_number: Some(rgba(0x19171c59).into()),
+                        editor_active_line_number: Some(rgba(0x19171cff).into()),
+                        editor_invisible: Some(rgba(0x5a5462ff).into()),
+                        editor_wrap_guide: Some(rgba(0x19171c0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x19171c1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x586dda1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x726c7a66).into()),
+                        terminal_background: Some(rgba(0xefecf4ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x807b89ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xe3a4b9ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x9dc8c8ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xd4b499ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xb3b3eeff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xe3a4dfff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0xa6c4e3ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x19171cff).into()),
+                        terminal_ansi_black: Some(rgba(0xefecf4ff).into()),
+                        terminal_ansi_red: Some(rgba(0xbe4778ff).into()),
+                        terminal_ansi_green: Some(rgba(0x2c9292ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xa06e3cff).into()),
+                        terminal_ansi_blue: Some(rgba(0x586ddaff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xbf41bfff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x3b8bc6ff).into()),
+                        terminal_ansi_white: Some(rgba(0x19171cff).into()),
+                        link_text_hover: Some(rgba(0x586ddaff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xa06e3cff).into()),
+                        conflict_background: Some(rgba(0xeee0d5ff).into()),
+                        conflict_border: Some(rgba(0xe0c9b5ff).into()),
+                        created: Some(rgba(0x2c9292ff).into()),
+                        created_background: Some(rgba(0xd7e9e8ff).into()),
+                        created_border: Some(rgba(0xb9d7d6ff).into()),
+                        deleted: Some(rgba(0xbe4778ff).into()),
+                        deleted_background: Some(rgba(0xf5dae2ff).into()),
+                        deleted_border: Some(rgba(0xecbecdff).into()),
+                        error: Some(rgba(0xbe4778ff).into()),
+                        error_background: Some(rgba(0xf5dae2ff).into()),
+                        error_border: Some(rgba(0xecbecdff).into()),
+                        hidden: Some(rgba(0x6e6876ff).into()),
+                        hidden_background: Some(rgba(0xbfbcc5ff).into()),
+                        hidden_border: Some(rgba(0xa7a3adff).into()),
+                        hint: Some(rgba(0x786e9dff).into()),
+                        hint_background: Some(rgba(0xe1e0f9ff).into()),
+                        hint_border: Some(rgba(0xc9c8f3ff).into()),
+                        ignored: Some(rgba(0x5a5462ff).into()),
+                        ignored_background: Some(rgba(0xbfbcc5ff).into()),
+                        ignored_border: Some(rgba(0x8f8b96ff).into()),
+                        info: Some(rgba(0x586ddaff).into()),
+                        info_background: Some(rgba(0xe1e0f9ff).into()),
+                        info_border: Some(rgba(0xc9c8f3ff).into()),
+                        modified: Some(rgba(0xa06e3cff).into()),
+                        modified_background: Some(rgba(0xeee0d5ff).into()),
+                        modified_border: Some(rgba(0xe0c9b5ff).into()),
+                        predictive: Some(rgba(0x887fafff).into()),
+                        predictive_background: Some(rgba(0xd7e9e8ff).into()),
+                        predictive_border: Some(rgba(0xb9d7d6ff).into()),
+                        renamed: Some(rgba(0x586ddaff).into()),
+                        renamed_background: Some(rgba(0xe1e0f9ff).into()),
+                        renamed_border: Some(rgba(0xc9c8f3ff).into()),
+                        success: Some(rgba(0x2c9292ff).into()),
+                        success_background: Some(rgba(0xd7e9e8ff).into()),
+                        success_border: Some(rgba(0xb9d7d6ff).into()),
+                        unreachable: Some(rgba(0x5a5462ff).into()),
+                        unreachable_background: Some(rgba(0xbfbcc5ff).into()),
+                        unreachable_border: Some(rgba(0x8f8b96ff).into()),
+                        warning: Some(rgba(0xa06e3cff).into()),
+                        warning_background: Some(rgba(0xeee0d5ff).into()),
+                        warning_border: Some(rgba(0xe0c9b5ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x586ddaff).into(),
+                            background: rgba(0x586ddaff).into(),
+                            selection: rgba(0x586dda3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbf41bfff).into(),
+                            background: rgba(0xbf41bfff).into(),
+                            selection: rgba(0xbf41bf3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xaa583dff).into(),
+                            background: rgba(0xaa583dff).into(),
+                            selection: rgba(0xaa583d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x955be6ff).into(),
+                            background: rgba(0x955be6ff).into(),
+                            selection: rgba(0x955be63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3b8bc6ff).into(),
+                            background: rgba(0x3b8bc6ff).into(),
+                            selection: rgba(0x3b8bc63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbe4778ff).into(),
+                            background: rgba(0xbe4778ff).into(),
+                            selection: rgba(0xbe47783d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3cff).into(),
+                            background: rgba(0xa06e3cff).into(),
+                            selection: rgba(0xa06e3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2c9292ff).into(),
+                            background: rgba(0x2c9292ff).into(),
+                            selection: rgba(0x2c92923d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x586ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7e7887ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585260ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x586ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x19171cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x586ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x586ddaff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa583dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddbff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x576ddbff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x786e9dff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x955ae7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x586ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa583dff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa573cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585260ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x887fafff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x19171cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x26232aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbe4678ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x26232aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585260ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585260ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x26232aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbf40bfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2a9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585260ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x398bc6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbf40bfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2a9292ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x586ddaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xaa583dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x19171cff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x26232aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x955ae7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Dune Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x6c695cff).into()),
+                        border_variant: Some(rgba(0x3b3933ff).into()),
+                        border_focused: Some(rgba(0x263056ff).into()),
+                        border_selected: Some(rgba(0x263056ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x58564bff).into()),
+                        elevated_surface_background: Some(rgba(0x262622ff).into()),
+                        surface_background: Some(rgba(0x262622ff).into()),
+                        background: Some(rgba(0x45433bff).into()),
+                        panel_background: Some(rgba(0x262622ff).into()),
+                        element_background: Some(rgba(0x262622ff).into()),
+                        element_hover: Some(rgba(0x3b3933ff).into()),
+                        element_active: Some(rgba(0x6a675aff).into()),
+                        element_selected: Some(rgba(0x6a675aff).into()),
+                        element_disabled: Some(rgba(0x262622ff).into()),
+                        drop_target_background: Some(rgba(0xa4a08b80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x3b3933ff).into()),
+                        ghost_element_active: Some(rgba(0x6a675aff).into()),
+                        ghost_element_selected: Some(rgba(0x6a675aff).into()),
+                        ghost_element_disabled: Some(rgba(0x262622ff).into()),
+                        text: Some(rgba(0xfefbecff).into()),
+                        text_muted: Some(rgba(0xa4a08bff).into()),
+                        text_placeholder: Some(rgba(0x8f8b77ff).into()),
+                        text_disabled: Some(rgba(0x8f8b77ff).into()),
+                        text_accent: Some(rgba(0x6684e0ff).into()),
+                        icon: Some(rgba(0xfefbecff).into()),
+                        icon_muted: Some(rgba(0xa4a08bff).into()),
+                        icon_disabled: Some(rgba(0x8f8b77ff).into()),
+                        icon_placeholder: Some(rgba(0xa4a08bff).into()),
+                        icon_accent: Some(rgba(0x6684e0ff).into()),
+                        status_bar_background: Some(rgba(0x45433bff).into()),
+                        title_bar_background: Some(rgba(0x45433bff).into()),
+                        toolbar_background: Some(rgba(0x20201dff).into()),
+                        tab_bar_background: Some(rgba(0x262622ff).into()),
+                        tab_inactive_background: Some(rgba(0x262622ff).into()),
+                        tab_active_background: Some(rgba(0x20201dff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xfefbec4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x3b3933ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x3b3933ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x252521ff).into()),
+                        editor_foreground: Some(rgba(0xe8e4cfff).into()),
+                        editor_background: Some(rgba(0x20201dff).into()),
+                        editor_gutter_background: Some(rgba(0x20201dff).into()),
+                        editor_subheader_background: Some(rgba(0x262622ff).into()),
+                        editor_active_line_background: Some(rgba(0x262622bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x262622ff).into()),
+                        editor_line_number: Some(rgba(0xfefbec59).into()),
+                        editor_active_line_number: Some(rgba(0xfefbecff).into()),
+                        editor_invisible: Some(rgba(0xa4a08bff).into()),
+                        editor_wrap_guide: Some(rgba(0xfefbec0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xfefbec1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x6684e01a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x8b887466).into()),
+                        terminal_background: Some(rgba(0x20201dff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x7a7766ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x781c1fff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x335322ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x574815ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x334173ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x721d2bff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x1e5341ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xfefbecff).into()),
+                        terminal_ansi_black: Some(rgba(0x20201dff).into()),
+                        terminal_ansi_red: Some(rgba(0xd73837ff).into()),
+                        terminal_ansi_green: Some(rgba(0x60ac3aff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xae9515ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x6684e0ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xd43652ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x21ad83ff).into()),
+                        terminal_ansi_white: Some(rgba(0xfefbecff).into()),
+                        link_text_hover: Some(rgba(0x6684e0ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xae9515ff).into()),
+                        conflict_background: Some(rgba(0x2a200eff).into()),
+                        conflict_border: Some(rgba(0x413513ff).into()),
+                        created: Some(rgba(0x60ac3aff).into()),
+                        created_background: Some(rgba(0x1a2413ff).into()),
+                        created_border: Some(rgba(0x273c1bff).into()),
+                        deleted: Some(rgba(0xd73837ff).into()),
+                        deleted_background: Some(rgba(0x450d11ff).into()),
+                        deleted_border: Some(rgba(0x5f1519ff).into()),
+                        error: Some(rgba(0xd73837ff).into()),
+                        error_background: Some(rgba(0x450d11ff).into()),
+                        error_border: Some(rgba(0x5f1519ff).into()),
+                        hidden: Some(rgba(0x8f8b77ff).into()),
+                        hidden_background: Some(rgba(0x45433bff).into()),
+                        hidden_border: Some(rgba(0x58564bff).into()),
+                        hint: Some(rgba(0xb17272ff).into()),
+                        hint_background: Some(rgba(0x171e39ff).into()),
+                        hint_border: Some(rgba(0x263056ff).into()),
+                        ignored: Some(rgba(0xa4a08bff).into()),
+                        ignored_background: Some(rgba(0x45433bff).into()),
+                        ignored_border: Some(rgba(0x6c695cff).into()),
+                        info: Some(rgba(0x6684e0ff).into()),
+                        info_background: Some(rgba(0x171e39ff).into()),
+                        info_border: Some(rgba(0x263056ff).into()),
+                        modified: Some(rgba(0xae9515ff).into()),
+                        modified_background: Some(rgba(0x2a200eff).into()),
+                        modified_border: Some(rgba(0x413513ff).into()),
+                        predictive: Some(rgba(0x9c6262ff).into()),
+                        predictive_background: Some(rgba(0x1a2413ff).into()),
+                        predictive_border: Some(rgba(0x273c1bff).into()),
+                        renamed: Some(rgba(0x6684e0ff).into()),
+                        renamed_background: Some(rgba(0x171e39ff).into()),
+                        renamed_border: Some(rgba(0x263056ff).into()),
+                        success: Some(rgba(0x60ac3aff).into()),
+                        success_background: Some(rgba(0x1a2413ff).into()),
+                        success_border: Some(rgba(0x273c1bff).into()),
+                        unreachable: Some(rgba(0xa4a08bff).into()),
+                        unreachable_background: Some(rgba(0x45433bff).into()),
+                        unreachable_border: Some(rgba(0x6c695cff).into()),
+                        warning: Some(rgba(0xae9515ff).into()),
+                        warning_background: Some(rgba(0x2a200eff).into()),
+                        warning_border: Some(rgba(0x413513ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x6684e0ff).into(),
+                            background: rgba(0x6684e0ff).into(),
+                            selection: rgba(0x6684e03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd43652ff).into(),
+                            background: rgba(0xd43652ff).into(),
+                            selection: rgba(0xd436523d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb65612ff).into(),
+                            background: rgba(0xb65612ff).into(),
+                            selection: rgba(0xb656123d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb854d3ff).into(),
+                            background: rgba(0xb854d3ff).into(),
+                            selection: rgba(0xb854d33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x21ad83ff).into(),
+                            background: rgba(0x21ad83ff).into(),
+                            selection: rgba(0x21ad833d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd73837ff).into(),
+                            background: rgba(0xd73837ff).into(),
+                            selection: rgba(0xd738373d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae9515ff).into(),
+                            background: rgba(0xae9515ff).into(),
+                            selection: rgba(0xae95153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x60ac3aff).into(),
+                            background: rgba(0x60ac3aff).into(),
+                            selection: rgba(0x60ac3a3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac3aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7d7a68ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa6a28cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac3aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfefbecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e0ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65612ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae9513ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb17272ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb854d4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65612ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac3aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65611ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa6a28cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9c6262ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfefbecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe8e4cfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd73737ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe8e4cfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa6a28cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa6a28cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe8e4cfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd43552ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac39ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa6a28cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1fad83ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd43552ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac39ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65612ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfefbecff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae9513ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe8e4cfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb854d4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae9513ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Dune Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0xa8a48eff).into()),
+                        border_variant: Some(rgba(0xd7d3beff).into()),
+                        border_focused: Some(rgba(0xcdd1f5ff).into()),
+                        border_selected: Some(rgba(0xcdd1f5ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xbbb7a1ff).into()),
+                        elevated_surface_background: Some(rgba(0xeeebd7ff).into()),
+                        surface_background: Some(rgba(0xeeebd7ff).into()),
+                        background: Some(rgba(0xcecab4ff).into()),
+                        panel_background: Some(rgba(0xeeebd7ff).into()),
+                        element_background: Some(rgba(0xeeebd7ff).into()),
+                        element_hover: Some(rgba(0xd7d3beff).into()),
+                        element_active: Some(rgba(0xaaa690ff).into()),
+                        element_selected: Some(rgba(0xaaa690ff).into()),
+                        element_disabled: Some(rgba(0xeeebd7ff).into()),
+                        drop_target_background: Some(rgba(0x706d5f80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xd7d3beff).into()),
+                        ghost_element_active: Some(rgba(0xaaa690ff).into()),
+                        ghost_element_selected: Some(rgba(0xaaa690ff).into()),
+                        ghost_element_disabled: Some(rgba(0xeeebd7ff).into()),
+                        text: Some(rgba(0x20201dff).into()),
+                        text_muted: Some(rgba(0x706d5fff).into()),
+                        text_placeholder: Some(rgba(0x878471ff).into()),
+                        text_disabled: Some(rgba(0x878471ff).into()),
+                        text_accent: Some(rgba(0x6784e0ff).into()),
+                        icon: Some(rgba(0x20201dff).into()),
+                        icon_muted: Some(rgba(0x706d5fff).into()),
+                        icon_disabled: Some(rgba(0x878471ff).into()),
+                        icon_placeholder: Some(rgba(0x706d5fff).into()),
+                        icon_accent: Some(rgba(0x6784e0ff).into()),
+                        status_bar_background: Some(rgba(0xcecab4ff).into()),
+                        title_bar_background: Some(rgba(0xcecab4ff).into()),
+                        toolbar_background: Some(rgba(0xfefbecff).into()),
+                        tab_bar_background: Some(rgba(0xeeebd7ff).into()),
+                        tab_inactive_background: Some(rgba(0xeeebd7ff).into()),
+                        tab_active_background: Some(rgba(0xfefbecff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x20201d4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xd7d3beff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xd7d3beff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xf2eedcff).into()),
+                        editor_foreground: Some(rgba(0x292824ff).into()),
+                        editor_background: Some(rgba(0xfefbecff).into()),
+                        editor_gutter_background: Some(rgba(0xfefbecff).into()),
+                        editor_subheader_background: Some(rgba(0xeeebd7ff).into()),
+                        editor_active_line_background: Some(rgba(0xeeebd7bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xeeebd7ff).into()),
+                        editor_line_number: Some(rgba(0x20201d59).into()),
+                        editor_active_line_number: Some(rgba(0x20201dff).into()),
+                        editor_invisible: Some(rgba(0x706d5fff).into()),
+                        editor_wrap_guide: Some(rgba(0x20201d0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x20201d1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x6784e01a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x8b887466).into()),
+                        terminal_background: Some(rgba(0xfefbecff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x9b9782ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xf7a195ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xb3d69cff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xdcc98eff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xb8c0f1ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xf3a0a4ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x9ed7c0ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x20201dff).into()),
+                        terminal_ansi_black: Some(rgba(0xfefbecff).into()),
+                        terminal_ansi_red: Some(rgba(0xd73838ff).into()),
+                        terminal_ansi_green: Some(rgba(0x61ac3aff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xae9515ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x6784e0ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xd43753ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x22ad83ff).into()),
+                        terminal_ansi_white: Some(rgba(0x20201dff).into()),
+                        link_text_hover: Some(rgba(0x6784e0ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xae9515ff).into()),
+                        conflict_background: Some(rgba(0xf2e8d1ff).into()),
+                        conflict_border: Some(rgba(0xe7d7aeff).into()),
+                        created: Some(rgba(0x61ac3aff).into()),
+                        created_background: Some(rgba(0xe0eed6ff).into()),
+                        created_border: Some(rgba(0xc9e1b7ff).into()),
+                        deleted: Some(rgba(0xd73838ff).into()),
+                        deleted_background: Some(rgba(0xffd9d4ff).into()),
+                        deleted_border: Some(rgba(0xfcbcb2ff).into()),
+                        error: Some(rgba(0xd73838ff).into()),
+                        error_background: Some(rgba(0xffd9d4ff).into()),
+                        error_border: Some(rgba(0xfcbcb2ff).into()),
+                        hidden: Some(rgba(0x878471ff).into()),
+                        hidden_background: Some(rgba(0xcecab4ff).into()),
+                        hidden_border: Some(rgba(0xbbb7a1ff).into()),
+                        hint: Some(rgba(0xb37979ff).into()),
+                        hint_background: Some(rgba(0xe3e5faff).into()),
+                        hint_border: Some(rgba(0xcdd1f5ff).into()),
+                        ignored: Some(rgba(0x706d5fff).into()),
+                        ignored_background: Some(rgba(0xcecab4ff).into()),
+                        ignored_border: Some(rgba(0xa8a48eff).into()),
+                        info: Some(rgba(0x6784e0ff).into()),
+                        info_background: Some(rgba(0xe3e5faff).into()),
+                        info_border: Some(rgba(0xcdd1f5ff).into()),
+                        modified: Some(rgba(0xae9515ff).into()),
+                        modified_background: Some(rgba(0xf2e8d1ff).into()),
+                        modified_border: Some(rgba(0xe7d7aeff).into()),
+                        predictive: Some(rgba(0xc88a8aff).into()),
+                        predictive_background: Some(rgba(0xe0eed6ff).into()),
+                        predictive_border: Some(rgba(0xc9e1b7ff).into()),
+                        renamed: Some(rgba(0x6784e0ff).into()),
+                        renamed_background: Some(rgba(0xe3e5faff).into()),
+                        renamed_border: Some(rgba(0xcdd1f5ff).into()),
+                        success: Some(rgba(0x61ac3aff).into()),
+                        success_background: Some(rgba(0xe0eed6ff).into()),
+                        success_border: Some(rgba(0xc9e1b7ff).into()),
+                        unreachable: Some(rgba(0x706d5fff).into()),
+                        unreachable_background: Some(rgba(0xcecab4ff).into()),
+                        unreachable_border: Some(rgba(0xa8a48eff).into()),
+                        warning: Some(rgba(0xae9515ff).into()),
+                        warning_background: Some(rgba(0xf2e8d1ff).into()),
+                        warning_border: Some(rgba(0xe7d7aeff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x6784e0ff).into(),
+                            background: rgba(0x6784e0ff).into(),
+                            selection: rgba(0x6784e03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd43753ff).into(),
+                            background: rgba(0xd43753ff).into(),
+                            selection: rgba(0xd437533d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb65713ff).into(),
+                            background: rgba(0xb65713ff).into(),
+                            selection: rgba(0xb657133d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb855d3ff).into(),
+                            background: rgba(0xb855d3ff).into(),
+                            selection: rgba(0xb855d33d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x22ad83ff).into(),
+                            background: rgba(0x22ad83ff).into(),
+                            selection: rgba(0x22ad833d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd73838ff).into(),
+                            background: rgba(0xd73838ff).into(),
+                            selection: rgba(0xd738383d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae9515ff).into(),
+                            background: rgba(0xae9515ff).into(),
+                            selection: rgba(0xae95153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x61ac3aff).into(),
+                            background: rgba(0x61ac3aff).into(),
+                            selection: rgba(0x61ac3a3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6784e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x61ac3aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x999580ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6b5eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x61ac3aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6784e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x20201dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6784e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6784e0ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65713ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6684e1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae9513ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb37979ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb854d4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6784e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65713ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x61ac3aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65611ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6b5eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc88a8aff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x20201dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292824ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd73737ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292824ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6b5eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6b5eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292824ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd43552ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac39ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6b5eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1fad83ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd43552ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x60ac39ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6784e0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb65713ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x20201dff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae9513ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292824ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb854d4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae9513ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Estuary Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x5d5c4cff).into()),
+                        border_variant: Some(rgba(0x3c3b31ff).into()),
+                        border_focused: Some(rgba(0x1c3927ff).into()),
+                        border_selected: Some(rgba(0x1c3927ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x504f41ff).into()),
+                        elevated_surface_background: Some(rgba(0x2c2b23ff).into()),
+                        surface_background: Some(rgba(0x2c2b23ff).into()),
+                        background: Some(rgba(0x424136ff).into()),
+                        panel_background: Some(rgba(0x2c2b23ff).into()),
+                        element_background: Some(rgba(0x2c2b23ff).into()),
+                        element_hover: Some(rgba(0x3c3b31ff).into()),
+                        element_active: Some(rgba(0x5c5b4bff).into()),
+                        element_selected: Some(rgba(0x5c5b4bff).into()),
+                        element_disabled: Some(rgba(0x2c2b23ff).into()),
+                        drop_target_background: Some(rgba(0x91907f80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x3c3b31ff).into()),
+                        ghost_element_active: Some(rgba(0x5c5b4bff).into()),
+                        ghost_element_selected: Some(rgba(0x5c5b4bff).into()),
+                        ghost_element_disabled: Some(rgba(0x2c2b23ff).into()),
+                        text: Some(rgba(0xf4f3ecff).into()),
+                        text_muted: Some(rgba(0x91907fff).into()),
+                        text_placeholder: Some(rgba(0x7d7c6aff).into()),
+                        text_disabled: Some(rgba(0x7d7c6aff).into()),
+                        text_accent: Some(rgba(0x37a166ff).into()),
+                        icon: Some(rgba(0xf4f3ecff).into()),
+                        icon_muted: Some(rgba(0x91907fff).into()),
+                        icon_disabled: Some(rgba(0x7d7c6aff).into()),
+                        icon_placeholder: Some(rgba(0x91907fff).into()),
+                        icon_accent: Some(rgba(0x37a166ff).into()),
+                        status_bar_background: Some(rgba(0x424136ff).into()),
+                        title_bar_background: Some(rgba(0x424136ff).into()),
+                        toolbar_background: Some(rgba(0x22221bff).into()),
+                        tab_bar_background: Some(rgba(0x2c2b23ff).into()),
+                        tab_inactive_background: Some(rgba(0x2c2b23ff).into()),
+                        tab_active_background: Some(rgba(0x22221bff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xf4f3ec4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x3c3b31ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x3c3b31ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x2a2922ff).into()),
+                        editor_foreground: Some(rgba(0xe7e6dfff).into()),
+                        editor_background: Some(rgba(0x22221bff).into()),
+                        editor_gutter_background: Some(rgba(0x22221bff).into()),
+                        editor_subheader_background: Some(rgba(0x2c2b23ff).into()),
+                        editor_active_line_background: Some(rgba(0x2c2b23bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x2c2b23ff).into()),
+                        editor_line_number: Some(rgba(0xf4f3ec59).into()),
+                        editor_active_line_number: Some(rgba(0xf4f3ecff).into()),
+                        editor_invisible: Some(rgba(0x91907fff).into()),
+                        editor_wrap_guide: Some(rgba(0xf4f3ec0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xf4f3ec1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x37a1661a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x7a786766).into()),
+                        terminal_background: Some(rgba(0x22221bff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x6a6958ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x5c331fff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x3f491aff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x514a14ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x234e34ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x4c373eff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x314c27ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xf4f3ecff).into()),
+                        terminal_ansi_black: Some(rgba(0x22221bff).into()),
+                        terminal_ansi_red: Some(rgba(0xba6237ff).into()),
+                        terminal_ansi_green: Some(rgba(0x7d9727ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xa59810ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x37a166ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0x9d6c7cff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x5b9d48ff).into()),
+                        terminal_ansi_white: Some(rgba(0xf4f3ecff).into()),
+                        link_text_hover: Some(rgba(0x37a166ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xa59810ff).into()),
+                        conflict_background: Some(rgba(0x25210dff).into()),
+                        conflict_border: Some(rgba(0x3b3612ff).into()),
+                        created: Some(rgba(0x7d9727ff).into()),
+                        created_background: Some(rgba(0x1e2110ff).into()),
+                        created_border: Some(rgba(0x2f3516ff).into()),
+                        deleted: Some(rgba(0xba6237ff).into()),
+                        deleted_background: Some(rgba(0x2b1811ff).into()),
+                        deleted_border: Some(rgba(0x442619ff).into()),
+                        error: Some(rgba(0xba6237ff).into()),
+                        error_background: Some(rgba(0x2b1811ff).into()),
+                        error_border: Some(rgba(0x442619ff).into()),
+                        hidden: Some(rgba(0x7d7c6aff).into()),
+                        hidden_background: Some(rgba(0x424136ff).into()),
+                        hidden_border: Some(rgba(0x504f41ff).into()),
+                        hint: Some(rgba(0x70825bff).into()),
+                        hint_background: Some(rgba(0x142319ff).into()),
+                        hint_border: Some(rgba(0x1c3927ff).into()),
+                        ignored: Some(rgba(0x91907fff).into()),
+                        ignored_background: Some(rgba(0x424136ff).into()),
+                        ignored_border: Some(rgba(0x5d5c4cff).into()),
+                        info: Some(rgba(0x37a166ff).into()),
+                        info_background: Some(rgba(0x142319ff).into()),
+                        info_border: Some(rgba(0x1c3927ff).into()),
+                        modified: Some(rgba(0xa59810ff).into()),
+                        modified_background: Some(rgba(0x25210dff).into()),
+                        modified_border: Some(rgba(0x3b3612ff).into()),
+                        predictive: Some(rgba(0x5f724cff).into()),
+                        predictive_background: Some(rgba(0x1e2110ff).into()),
+                        predictive_border: Some(rgba(0x2f3516ff).into()),
+                        renamed: Some(rgba(0x37a166ff).into()),
+                        renamed_background: Some(rgba(0x142319ff).into()),
+                        renamed_border: Some(rgba(0x1c3927ff).into()),
+                        success: Some(rgba(0x7d9727ff).into()),
+                        success_background: Some(rgba(0x1e2110ff).into()),
+                        success_border: Some(rgba(0x2f3516ff).into()),
+                        unreachable: Some(rgba(0x91907fff).into()),
+                        unreachable_background: Some(rgba(0x424136ff).into()),
+                        unreachable_border: Some(rgba(0x5d5c4cff).into()),
+                        warning: Some(rgba(0xa59810ff).into()),
+                        warning_background: Some(rgba(0x25210dff).into()),
+                        warning_border: Some(rgba(0x3b3612ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x37a166ff).into(),
+                            background: rgba(0x37a166ff).into(),
+                            selection: rgba(0x37a1663d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d6c7cff).into(),
+                            background: rgba(0x9d6c7cff).into(),
+                            selection: rgba(0x9d6c7c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xae7315ff).into(),
+                            background: rgba(0xae7315ff).into(),
+                            selection: rgba(0xae73153d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5f9182ff).into(),
+                            background: rgba(0x5f9182ff).into(),
+                            selection: rgba(0x5f91823d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5b9d48ff).into(),
+                            background: rgba(0x5b9d48ff).into(),
+                            selection: rgba(0x5b9d483d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xba6237ff).into(),
+                            background: rgba(0xba6237ff).into(),
+                            selection: rgba(0xba62373d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa59810ff).into(),
+                            background: rgba(0xa59810ff).into(),
+                            selection: rgba(0xa598103d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7d9727ff).into(),
+                            background: rgba(0x7d9727ff).into(),
+                            selection: rgba(0x7d97273d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x37a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7d9727ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6c6b5aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x929181ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7d9727ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x37a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf4f3ecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x37a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x37a166ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae7315ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x36a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x36a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa5980dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x70825bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5f9182ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x37a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae7315ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7d9727ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae7313ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x929181ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5f724cff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf4f3ecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xba6236ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x929181ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x929181ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d6c7cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7d9726ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x929181ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b9d48ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d6c7cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7d9726ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x37a166ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xae7315ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf4f3ecff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa5980dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5f9182ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa5980dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
                 name: "Atelier Estuary Light".into(),
                 appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
@@ -946,6 +3271,3726 @@ pub fn atelier() -> UserThemeFamily {
                 },
             },
             UserTheme {
+                name: "Atelier Forest Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0xaaa3a1ff).into()),
+                        border_variant: Some(rgba(0xd6d1cfff).into()),
+                        border_focused: Some(rgba(0xc6cef7ff).into()),
+                        border_selected: Some(rgba(0xc6cef7ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xbcb6b4ff).into()),
+                        elevated_surface_background: Some(rgba(0xe9e6e4ff).into()),
+                        surface_background: Some(rgba(0xe9e6e4ff).into()),
+                        background: Some(rgba(0xcdc8c6ff).into()),
+                        panel_background: Some(rgba(0xe9e6e4ff).into()),
+                        element_background: Some(rgba(0xe9e6e4ff).into()),
+                        element_hover: Some(rgba(0xd6d1cfff).into()),
+                        element_active: Some(rgba(0xaca5a3ff).into()),
+                        element_selected: Some(rgba(0xaca5a3ff).into()),
+                        element_disabled: Some(rgba(0xe9e6e4ff).into()),
+                        drop_target_background: Some(rgba(0x6a636080).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xd6d1cfff).into()),
+                        ghost_element_active: Some(rgba(0xaca5a3ff).into()),
+                        ghost_element_selected: Some(rgba(0xaca5a3ff).into()),
+                        ghost_element_disabled: Some(rgba(0xe9e6e4ff).into()),
+                        text: Some(rgba(0x1b1918ff).into()),
+                        text_muted: Some(rgba(0x6a6360ff).into()),
+                        text_placeholder: Some(rgba(0x847c79ff).into()),
+                        text_disabled: Some(rgba(0x847c79ff).into()),
+                        text_accent: Some(rgba(0x417ee6ff).into()),
+                        icon: Some(rgba(0x1b1918ff).into()),
+                        icon_muted: Some(rgba(0x6a6360ff).into()),
+                        icon_disabled: Some(rgba(0x847c79ff).into()),
+                        icon_placeholder: Some(rgba(0x6a6360ff).into()),
+                        icon_accent: Some(rgba(0x417ee6ff).into()),
+                        status_bar_background: Some(rgba(0xcdc8c6ff).into()),
+                        title_bar_background: Some(rgba(0xcdc8c6ff).into()),
+                        toolbar_background: Some(rgba(0xf1efeeff).into()),
+                        tab_bar_background: Some(rgba(0xe9e6e4ff).into()),
+                        tab_inactive_background: Some(rgba(0xe9e6e4ff).into()),
+                        tab_active_background: Some(rgba(0xf1efeeff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x1b19184c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xd6d1cfff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xd6d1cfff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xebe8e6ff).into()),
+                        editor_foreground: Some(rgba(0x2c2421ff).into()),
+                        editor_background: Some(rgba(0xf1efeeff).into()),
+                        editor_gutter_background: Some(rgba(0xf1efeeff).into()),
+                        editor_subheader_background: Some(rgba(0xe9e6e4ff).into()),
+                        editor_active_line_background: Some(rgba(0xe9e6e4bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xe9e6e4ff).into()),
+                        editor_line_number: Some(rgba(0x1b191859).into()),
+                        editor_active_line_number: Some(rgba(0x1b1918ff).into()),
+                        editor_invisible: Some(rgba(0x6a6360ff).into()),
+                        editor_wrap_guide: Some(rgba(0x1b19180d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x1b19181a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x417ee61a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x89817e66).into()),
+                        terminal_background: Some(rgba(0xf1efeeff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x9e9693ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xffa29aff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xbfca93ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xe9c08eff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xaebcf4ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xe7a6fbff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0xa6cadbff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x1b1918ff).into()),
+                        terminal_ansi_black: Some(rgba(0xf1efeeff).into()),
+                        terminal_ansi_red: Some(rgba(0xf22e41ff).into()),
+                        terminal_ansi_green: Some(rgba(0x7b9728ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xc3841aff).into()),
+                        terminal_ansi_blue: Some(rgba(0x417ee6ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xc340f2ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x3f97b8ff).into()),
+                        terminal_ansi_white: Some(rgba(0x1b1918ff).into()),
+                        link_text_hover: Some(rgba(0x417ee6ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xc3841aff).into()),
+                        conflict_background: Some(rgba(0xf8e5d1ff).into()),
+                        conflict_border: Some(rgba(0xf0d1adff).into()),
+                        created: Some(rgba(0x7b9728ff).into()),
+                        created_background: Some(rgba(0xe5e9d3ff).into()),
+                        created_border: Some(rgba(0xd1d8b1ff).into()),
+                        deleted: Some(rgba(0xf22e41ff).into()),
+                        deleted_background: Some(rgba(0xffdad5ff).into()),
+                        deleted_border: Some(rgba(0xffbdb6ff).into()),
+                        error: Some(rgba(0xf22e41ff).into()),
+                        error_background: Some(rgba(0xffdad5ff).into()),
+                        error_border: Some(rgba(0xffbdb6ff).into()),
+                        hidden: Some(rgba(0x847c79ff).into()),
+                        hidden_background: Some(rgba(0xcdc8c6ff).into()),
+                        hidden_border: Some(rgba(0xbcb6b4ff).into()),
+                        hint: Some(rgba(0xa67287ff).into()),
+                        hint_background: Some(rgba(0xdfe3fbff).into()),
+                        hint_border: Some(rgba(0xc6cef7ff).into()),
+                        ignored: Some(rgba(0x6a6360ff).into()),
+                        ignored_background: Some(rgba(0xcdc8c6ff).into()),
+                        ignored_border: Some(rgba(0xaaa3a1ff).into()),
+                        info: Some(rgba(0x417ee6ff).into()),
+                        info_background: Some(rgba(0xdfe3fbff).into()),
+                        info_border: Some(rgba(0xc6cef7ff).into()),
+                        modified: Some(rgba(0xc3841aff).into()),
+                        modified_background: Some(rgba(0xf8e5d1ff).into()),
+                        modified_border: Some(rgba(0xf0d1adff).into()),
+                        predictive: Some(rgba(0xbe899eff).into()),
+                        predictive_background: Some(rgba(0xe5e9d3ff).into()),
+                        predictive_border: Some(rgba(0xd1d8b1ff).into()),
+                        renamed: Some(rgba(0x417ee6ff).into()),
+                        renamed_background: Some(rgba(0xdfe3fbff).into()),
+                        renamed_border: Some(rgba(0xc6cef7ff).into()),
+                        success: Some(rgba(0x7b9728ff).into()),
+                        success_background: Some(rgba(0xe5e9d3ff).into()),
+                        success_border: Some(rgba(0xd1d8b1ff).into()),
+                        unreachable: Some(rgba(0x6a6360ff).into()),
+                        unreachable_background: Some(rgba(0xcdc8c6ff).into()),
+                        unreachable_border: Some(rgba(0xaaa3a1ff).into()),
+                        warning: Some(rgba(0xc3841aff).into()),
+                        warning_background: Some(rgba(0xf8e5d1ff).into()),
+                        warning_border: Some(rgba(0xf0d1adff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x417ee6ff).into(),
+                            background: rgba(0x417ee6ff).into(),
+                            selection: rgba(0x417ee63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc340f2ff).into(),
+                            background: rgba(0xc340f2ff).into(),
+                            selection: rgba(0xc340f23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdf5421ff).into(),
+                            background: rgba(0xdf5421ff).into(),
+                            selection: rgba(0xdf54213d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6766e9ff).into(),
+                            background: rgba(0x6766e9ff).into(),
+                            selection: rgba(0x6766e93d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3f97b8ff).into(),
+                            background: rgba(0x3f97b8ff).into(),
+                            selection: rgba(0x3f97b83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf22e41ff).into(),
+                            background: rgba(0xf22e41ff).into(),
+                            selection: rgba(0xf22e413d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc3841aff).into(),
+                            background: rgba(0xc3841aff).into(),
+                            selection: rgba(0xc3841a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b9728ff).into(),
+                            background: rgba(0x7b9728ff).into(),
+                            selection: rgba(0x7b97283d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x417ee6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b9728ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9c9491ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x68615eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b9728ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x417ee6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b1918ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x417ee6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x417ee6ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf5421ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x407ee7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x407ee7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc38418ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa67287ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6666eaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x417ee6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf5421ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b9728ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf5320ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x68615eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbe899eff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b1918ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c2421ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf22c40ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c2421ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x68615eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x68615eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c2421ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc33ff3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b9726ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x68615eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3d97b8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc33ff3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b9726ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x417ee6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdf5421ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b1918ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc38418ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2c2421ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6666eaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc38418ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Heath Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x675b67ff).into()),
+                        border_variant: Some(rgba(0x393239ff).into()),
+                        border_focused: Some(rgba(0x1a2961ff).into()),
+                        border_selected: Some(rgba(0x1a2961ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x554a55ff).into()),
+                        elevated_surface_background: Some(rgba(0x252025ff).into()),
+                        surface_background: Some(rgba(0x252025ff).into()),
+                        background: Some(rgba(0x433a43ff).into()),
+                        panel_background: Some(rgba(0x252025ff).into()),
+                        element_background: Some(rgba(0x252025ff).into()),
+                        element_hover: Some(rgba(0x393239ff).into()),
+                        element_active: Some(rgba(0x655965ff).into()),
+                        element_selected: Some(rgba(0x655965ff).into()),
+                        element_disabled: Some(rgba(0x252025ff).into()),
+                        drop_target_background: Some(rgba(0xa99aa980).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x393239ff).into()),
+                        ghost_element_active: Some(rgba(0x655965ff).into()),
+                        ghost_element_selected: Some(rgba(0x655965ff).into()),
+                        ghost_element_disabled: Some(rgba(0x252025ff).into()),
+                        text: Some(rgba(0xf7f3f7ff).into()),
+                        text_muted: Some(rgba(0xa99aa9ff).into()),
+                        text_placeholder: Some(rgba(0x908190ff).into()),
+                        text_disabled: Some(rgba(0x908190ff).into()),
+                        text_accent: Some(rgba(0x526aebff).into()),
+                        icon: Some(rgba(0xf7f3f7ff).into()),
+                        icon_muted: Some(rgba(0xa99aa9ff).into()),
+                        icon_disabled: Some(rgba(0x908190ff).into()),
+                        icon_placeholder: Some(rgba(0xa99aa9ff).into()),
+                        icon_accent: Some(rgba(0x526aebff).into()),
+                        status_bar_background: Some(rgba(0x433a43ff).into()),
+                        title_bar_background: Some(rgba(0x433a43ff).into()),
+                        toolbar_background: Some(rgba(0x1b181bff).into()),
+                        tab_bar_background: Some(rgba(0x252025ff).into()),
+                        tab_inactive_background: Some(rgba(0x252025ff).into()),
+                        tab_active_background: Some(rgba(0x1b181bff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xf7f3f74c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x393239ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x393239ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x231e23ff).into()),
+                        editor_foreground: Some(rgba(0xd8cad8ff).into()),
+                        editor_background: Some(rgba(0x1b181bff).into()),
+                        editor_gutter_background: Some(rgba(0x1b181bff).into()),
+                        editor_subheader_background: Some(rgba(0x252025ff).into()),
+                        editor_active_line_background: Some(rgba(0x252025bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x252025ff).into()),
+                        editor_line_number: Some(rgba(0xf7f3f759).into()),
+                        editor_active_line_number: Some(rgba(0xf7f3f7ff).into()),
+                        editor_invisible: Some(rgba(0xa99aa9ff).into()),
+                        editor_wrap_guide: Some(rgba(0xf7f3f70d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xf7f3f71a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x526aeb1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x8b7c8b66).into()),
+                        terminal_background: Some(rgba(0x1b181bff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x756775ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x6d221aff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x474422ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x5e441fff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x26367eff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x6c1e67ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x1a4848ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xf7f3f7ff).into()),
+                        terminal_ansi_black: Some(rgba(0x1b181bff).into()),
+                        terminal_ansi_red: Some(rgba(0xca402cff).into()),
+                        terminal_ansi_green: Some(rgba(0x918b3bff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xbb8a36ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x526aebff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xcc34ccff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x189393ff).into()),
+                        terminal_ansi_white: Some(rgba(0xf7f3f7ff).into()),
+                        link_text_hover: Some(rgba(0x526aebff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xbb8a36ff).into()),
+                        conflict_background: Some(rgba(0x2d1e12ff).into()),
+                        conflict_border: Some(rgba(0x463219ff).into()),
+                        created: Some(rgba(0x918b3bff).into()),
+                        created_background: Some(rgba(0x211f12ff).into()),
+                        created_border: Some(rgba(0x34321bff).into()),
+                        deleted: Some(rgba(0xca402cff).into()),
+                        deleted_background: Some(rgba(0x3c110eff).into()),
+                        deleted_border: Some(rgba(0x551a15ff).into()),
+                        error: Some(rgba(0xca402cff).into()),
+                        error_background: Some(rgba(0x3c110eff).into()),
+                        error_border: Some(rgba(0x551a15ff).into()),
+                        hidden: Some(rgba(0x908190ff).into()),
+                        hidden_background: Some(rgba(0x433a43ff).into()),
+                        hidden_border: Some(rgba(0x554a55ff).into()),
+                        hint: Some(rgba(0x8d70a8ff).into()),
+                        hint_background: Some(rgba(0x0e1a43ff).into()),
+                        hint_border: Some(rgba(0x1a2961ff).into()),
+                        ignored: Some(rgba(0xa99aa9ff).into()),
+                        ignored_background: Some(rgba(0x433a43ff).into()),
+                        ignored_border: Some(rgba(0x675b67ff).into()),
+                        info: Some(rgba(0x526aebff).into()),
+                        info_background: Some(rgba(0x0e1a43ff).into()),
+                        info_border: Some(rgba(0x1a2961ff).into()),
+                        modified: Some(rgba(0xbb8a36ff).into()),
+                        modified_background: Some(rgba(0x2d1e12ff).into()),
+                        modified_border: Some(rgba(0x463219ff).into()),
+                        predictive: Some(rgba(0x765990ff).into()),
+                        predictive_background: Some(rgba(0x211f12ff).into()),
+                        predictive_border: Some(rgba(0x34321bff).into()),
+                        renamed: Some(rgba(0x526aebff).into()),
+                        renamed_background: Some(rgba(0x0e1a43ff).into()),
+                        renamed_border: Some(rgba(0x1a2961ff).into()),
+                        success: Some(rgba(0x918b3bff).into()),
+                        success_background: Some(rgba(0x211f12ff).into()),
+                        success_border: Some(rgba(0x34321bff).into()),
+                        unreachable: Some(rgba(0xa99aa9ff).into()),
+                        unreachable_background: Some(rgba(0x433a43ff).into()),
+                        unreachable_border: Some(rgba(0x675b67ff).into()),
+                        warning: Some(rgba(0xbb8a36ff).into()),
+                        warning_background: Some(rgba(0x2d1e12ff).into()),
+                        warning_border: Some(rgba(0x463219ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x526aebff).into(),
+                            background: rgba(0x526aebff).into(),
+                            selection: rgba(0x526aeb3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcc34ccff).into(),
+                            background: rgba(0xcc34ccff).into(),
+                            selection: rgba(0xcc34cc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa65927ff).into(),
+                            background: rgba(0xa65927ff).into(),
+                            selection: rgba(0xa659273d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b59c0ff).into(),
+                            background: rgba(0x7b59c0ff).into(),
+                            selection: rgba(0x7b59c03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x189393ff).into(),
+                            background: rgba(0x189393ff).into(),
+                            selection: rgba(0x1893933d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca402cff).into(),
+                            background: rgba(0xca402cff).into(),
+                            selection: rgba(0xca402c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbb8a36ff).into(),
+                            background: rgba(0xbb8a36ff).into(),
+                            selection: rgba(0xbb8a363d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x918b3bff).into(),
+                            background: rgba(0x918b3bff).into(),
+                            selection: rgba(0x918b3b3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x776977ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xab9babff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf7f3f7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65927ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516aecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516aecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbb8a35ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8d70a8ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b59c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65927ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65926ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xab9babff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x765990ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf7f3f7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd8cad8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xca402bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd8cad8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xab9babff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xab9babff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd8cad8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcc33ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xab9babff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x159393ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcc33ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65927ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf7f3f7ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbb8a35ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd8cad8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b59c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbb8a35ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Heath Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0xad9dadff).into()),
+                        border_variant: Some(rgba(0xcdbecdff).into()),
+                        border_focused: Some(rgba(0xcac7faff).into()),
+                        border_selected: Some(rgba(0xcac7faff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xbaaabaff).into()),
+                        elevated_surface_background: Some(rgba(0xe1d6e1ff).into()),
+                        surface_background: Some(rgba(0xe1d6e1ff).into()),
+                        background: Some(rgba(0xc6b8c6ff).into()),
+                        panel_background: Some(rgba(0xe1d6e1ff).into()),
+                        element_background: Some(rgba(0xe1d6e1ff).into()),
+                        element_hover: Some(rgba(0xcdbecdff).into()),
+                        element_active: Some(rgba(0xae9eaeff).into()),
+                        element_selected: Some(rgba(0xae9eaeff).into()),
+                        element_disabled: Some(rgba(0xe1d6e1ff).into()),
+                        drop_target_background: Some(rgba(0x6b5e6b80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xcdbecdff).into()),
+                        ghost_element_active: Some(rgba(0xae9eaeff).into()),
+                        ghost_element_selected: Some(rgba(0xae9eaeff).into()),
+                        ghost_element_disabled: Some(rgba(0xe1d6e1ff).into()),
+                        text: Some(rgba(0x1b181bff).into()),
+                        text_muted: Some(rgba(0x6b5e6bff).into()),
+                        text_placeholder: Some(rgba(0x857785ff).into()),
+                        text_disabled: Some(rgba(0x857785ff).into()),
+                        text_accent: Some(rgba(0x526aebff).into()),
+                        icon: Some(rgba(0x1b181bff).into()),
+                        icon_muted: Some(rgba(0x6b5e6bff).into()),
+                        icon_disabled: Some(rgba(0x857785ff).into()),
+                        icon_placeholder: Some(rgba(0x6b5e6bff).into()),
+                        icon_accent: Some(rgba(0x526aebff).into()),
+                        status_bar_background: Some(rgba(0xc6b8c6ff).into()),
+                        title_bar_background: Some(rgba(0xc6b8c6ff).into()),
+                        toolbar_background: Some(rgba(0xf7f3f7ff).into()),
+                        tab_bar_background: Some(rgba(0xe1d6e1ff).into()),
+                        tab_inactive_background: Some(rgba(0xe1d6e1ff).into()),
+                        tab_active_background: Some(rgba(0xf7f3f7ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x1b181b4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xcdbecdff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xcdbecdff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xe5dce5ff).into()),
+                        editor_foreground: Some(rgba(0x292329ff).into()),
+                        editor_background: Some(rgba(0xf7f3f7ff).into()),
+                        editor_gutter_background: Some(rgba(0xf7f3f7ff).into()),
+                        editor_subheader_background: Some(rgba(0xe1d6e1ff).into()),
+                        editor_active_line_background: Some(rgba(0xe1d6e1bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xe1d6e1ff).into()),
+                        editor_line_number: Some(rgba(0x1b181b59).into()),
+                        editor_active_line_number: Some(rgba(0x1b181bff).into()),
+                        editor_invisible: Some(rgba(0x6b5e6bff).into()),
+                        editor_wrap_guide: Some(rgba(0x1b181b0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x1b181b1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x526aeb1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x8b7c8b66).into()),
+                        terminal_background: Some(rgba(0xf7f3f7ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0xa091a0ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xf0a28fff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xcac49aff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xe2c398ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xb4b2f7ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xeba2e6ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x9ac9c8ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x1b181bff).into()),
+                        terminal_ansi_black: Some(rgba(0xf7f3f7ff).into()),
+                        terminal_ansi_red: Some(rgba(0xca412cff).into()),
+                        terminal_ansi_green: Some(rgba(0x918b3cff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xbb8a36ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x526aebff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xcc35ccff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x199393ff).into()),
+                        terminal_ansi_white: Some(rgba(0x1b181bff).into()),
+                        link_text_hover: Some(rgba(0x526aebff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xbb8a36ff).into()),
+                        conflict_background: Some(rgba(0xf5e6d5ff).into()),
+                        conflict_border: Some(rgba(0xebd3b5ff).into()),
+                        created: Some(rgba(0x918b3cff).into()),
+                        created_background: Some(rgba(0xeae6d6ff).into()),
+                        created_border: Some(rgba(0xd9d4b6ff).into()),
+                        deleted: Some(rgba(0xca412cff).into()),
+                        deleted_background: Some(rgba(0xfcd9d1ff).into()),
+                        deleted_border: Some(rgba(0xf7bcaeff).into()),
+                        error: Some(rgba(0xca412cff).into()),
+                        error_background: Some(rgba(0xfcd9d1ff).into()),
+                        error_border: Some(rgba(0xf7bcaeff).into()),
+                        hidden: Some(rgba(0x857785ff).into()),
+                        hidden_background: Some(rgba(0xc6b8c6ff).into()),
+                        hidden_border: Some(rgba(0xbaaabaff).into()),
+                        hint: Some(rgba(0x8c70a6ff).into()),
+                        hint_background: Some(rgba(0xe2dffcff).into()),
+                        hint_border: Some(rgba(0xcac7faff).into()),
+                        ignored: Some(rgba(0x6b5e6bff).into()),
+                        ignored_background: Some(rgba(0xc6b8c6ff).into()),
+                        ignored_border: Some(rgba(0xad9dadff).into()),
+                        info: Some(rgba(0x526aebff).into()),
+                        info_background: Some(rgba(0xe2dffcff).into()),
+                        info_border: Some(rgba(0xcac7faff).into()),
+                        modified: Some(rgba(0xbb8a36ff).into()),
+                        modified_background: Some(rgba(0xf5e6d5ff).into()),
+                        modified_border: Some(rgba(0xebd3b5ff).into()),
+                        predictive: Some(rgba(0xa587bfff).into()),
+                        predictive_background: Some(rgba(0xeae6d6ff).into()),
+                        predictive_border: Some(rgba(0xd9d4b6ff).into()),
+                        renamed: Some(rgba(0x526aebff).into()),
+                        renamed_background: Some(rgba(0xe2dffcff).into()),
+                        renamed_border: Some(rgba(0xcac7faff).into()),
+                        success: Some(rgba(0x918b3cff).into()),
+                        success_background: Some(rgba(0xeae6d6ff).into()),
+                        success_border: Some(rgba(0xd9d4b6ff).into()),
+                        unreachable: Some(rgba(0x6b5e6bff).into()),
+                        unreachable_background: Some(rgba(0xc6b8c6ff).into()),
+                        unreachable_border: Some(rgba(0xad9dadff).into()),
+                        warning: Some(rgba(0xbb8a36ff).into()),
+                        warning_background: Some(rgba(0xf5e6d5ff).into()),
+                        warning_border: Some(rgba(0xebd3b5ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x526aebff).into(),
+                            background: rgba(0x526aebff).into(),
+                            selection: rgba(0x526aeb3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcc35ccff).into(),
+                            background: rgba(0xcc35ccff).into(),
+                            selection: rgba(0xcc35cc3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa65a27ff).into(),
+                            background: rgba(0xa65a27ff).into(),
+                            selection: rgba(0xa65a273d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x7b5ac0ff).into(),
+                            background: rgba(0x7b5ac0ff).into(),
+                            selection: rgba(0x7b5ac03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x199393ff).into(),
+                            background: rgba(0x199393ff).into(),
+                            selection: rgba(0x1993933d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca412cff).into(),
+                            background: rgba(0xca412cff).into(),
+                            selection: rgba(0xca412c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbb8a36ff).into(),
+                            background: rgba(0xbb8a36ff).into(),
+                            selection: rgba(0xbb8a363d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x918b3cff).into(),
+                            background: rgba(0x918b3cff).into(),
+                            selection: rgba(0x918b3c3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9e8f9eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x695d69ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b181bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65a27ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516aecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516aecff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbb8a35ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8c70a6ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b59c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65a27ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65926ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x695d69ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa587bfff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b181bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292329ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xca402bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292329ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x695d69ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x695d69ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292329ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcc33ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x695d69ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x159393ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcc33ccff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x918b3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x526aebff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa65a27ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b181bff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbb8a35ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292329ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7b59c0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbb8a35ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Lakeside Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x4f6b78ff).into()),
+                        border_variant: Some(rgba(0x2c3b42ff).into()),
+                        border_focused: Some(rgba(0x1a2f3cff).into()),
+                        border_selected: Some(rgba(0x1a2f3cff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x415763ff).into()),
+                        elevated_surface_background: Some(rgba(0x1c2529ff).into()),
+                        surface_background: Some(rgba(0x1c2529ff).into()),
+                        background: Some(rgba(0x33444dff).into()),
+                        panel_background: Some(rgba(0x1c2529ff).into()),
+                        element_background: Some(rgba(0x1c2529ff).into()),
+                        element_hover: Some(rgba(0x2c3b42ff).into()),
+                        element_active: Some(rgba(0x4d6976ff).into()),
+                        element_selected: Some(rgba(0x4d6976ff).into()),
+                        element_disabled: Some(rgba(0x1c2529ff).into()),
+                        drop_target_background: Some(rgba(0x7ca0b380).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x2c3b42ff).into()),
+                        ghost_element_active: Some(rgba(0x4d6976ff).into()),
+                        ghost_element_selected: Some(rgba(0x4d6976ff).into()),
+                        ghost_element_disabled: Some(rgba(0x1c2529ff).into()),
+                        text: Some(rgba(0xebf8ffff).into()),
+                        text_muted: Some(rgba(0x7ca0b3ff).into()),
+                        text_placeholder: Some(rgba(0x698c9eff).into()),
+                        text_disabled: Some(rgba(0x698c9eff).into()),
+                        text_accent: Some(rgba(0x277fadff).into()),
+                        icon: Some(rgba(0xebf8ffff).into()),
+                        icon_muted: Some(rgba(0x7ca0b3ff).into()),
+                        icon_disabled: Some(rgba(0x698c9eff).into()),
+                        icon_placeholder: Some(rgba(0x7ca0b3ff).into()),
+                        icon_accent: Some(rgba(0x277fadff).into()),
+                        status_bar_background: Some(rgba(0x33444dff).into()),
+                        title_bar_background: Some(rgba(0x33444dff).into()),
+                        toolbar_background: Some(rgba(0x161b1dff).into()),
+                        tab_bar_background: Some(rgba(0x1c2529ff).into()),
+                        tab_inactive_background: Some(rgba(0x1c2529ff).into()),
+                        tab_active_background: Some(rgba(0x161b1dff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xebf8ff4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x2c3b42ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x2c3b42ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x1b2327ff).into()),
+                        editor_foreground: Some(rgba(0xc1e4f6ff).into()),
+                        editor_background: Some(rgba(0x161b1dff).into()),
+                        editor_gutter_background: Some(rgba(0x161b1dff).into()),
+                        editor_subheader_background: Some(rgba(0x1c2529ff).into()),
+                        editor_active_line_background: Some(rgba(0x1c2529bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x1c2529ff).into()),
+                        editor_line_number: Some(rgba(0xebf8ff59).into()),
+                        editor_active_line_number: Some(rgba(0xebf8ffff).into()),
+                        editor_invisible: Some(rgba(0x7ca0b3ff).into()),
+                        editor_wrap_guide: Some(rgba(0xebf8ff0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xebf8ff1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x277fad1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x66889a66).into()),
+                        terminal_background: Some(rgba(0x161b1dff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x587989ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x6f1c3aff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x2e4522ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x454413ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x1e3f53ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x5c1e6bff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x1f4638ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xebf8ffff).into()),
+                        terminal_ansi_black: Some(rgba(0x161b1dff).into()),
+                        terminal_ansi_red: Some(rgba(0xd22e72ff).into()),
+                        terminal_ansi_green: Some(rgba(0x568c3bff).into()),
+                        terminal_ansi_yellow: Some(rgba(0x8a8a11ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x277fadff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xb72ed2ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x2e8f6fff).into()),
+                        terminal_ansi_white: Some(rgba(0xebf8ffff).into()),
+                        link_text_hover: Some(rgba(0x277fadff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0x8a8a11ff).into()),
+                        conflict_background: Some(rgba(0x201f0cff).into()),
+                        conflict_border: Some(rgba(0x333211ff).into()),
+                        created: Some(rgba(0x568c3bff).into()),
+                        created_background: Some(rgba(0x171f12ff).into()),
+                        created_border: Some(rgba(0x23321bff).into()),
+                        deleted: Some(rgba(0xd22e72ff).into()),
+                        deleted_background: Some(rgba(0x3a101bff).into()),
+                        deleted_border: Some(rgba(0x55162bff).into()),
+                        error: Some(rgba(0xd22e72ff).into()),
+                        error_background: Some(rgba(0x3a101bff).into()),
+                        error_border: Some(rgba(0x55162bff).into()),
+                        hidden: Some(rgba(0x698c9eff).into()),
+                        hidden_background: Some(rgba(0x33444dff).into()),
+                        hidden_border: Some(rgba(0x415763ff).into()),
+                        hint: Some(rgba(0x52809aff).into()),
+                        hint_background: Some(rgba(0x131d24ff).into()),
+                        hint_border: Some(rgba(0x1a2f3cff).into()),
+                        ignored: Some(rgba(0x7ca0b3ff).into()),
+                        ignored_background: Some(rgba(0x33444dff).into()),
+                        ignored_border: Some(rgba(0x4f6b78ff).into()),
+                        info: Some(rgba(0x277fadff).into()),
+                        info_background: Some(rgba(0x131d24ff).into()),
+                        info_border: Some(rgba(0x1a2f3cff).into()),
+                        modified: Some(rgba(0x8a8a11ff).into()),
+                        modified_background: Some(rgba(0x201f0cff).into()),
+                        modified_border: Some(rgba(0x333211ff).into()),
+                        predictive: Some(rgba(0x427088ff).into()),
+                        predictive_background: Some(rgba(0x171f12ff).into()),
+                        predictive_border: Some(rgba(0x23321bff).into()),
+                        renamed: Some(rgba(0x277fadff).into()),
+                        renamed_background: Some(rgba(0x131d24ff).into()),
+                        renamed_border: Some(rgba(0x1a2f3cff).into()),
+                        success: Some(rgba(0x568c3bff).into()),
+                        success_background: Some(rgba(0x171f12ff).into()),
+                        success_border: Some(rgba(0x23321bff).into()),
+                        unreachable: Some(rgba(0x7ca0b3ff).into()),
+                        unreachable_background: Some(rgba(0x33444dff).into()),
+                        unreachable_border: Some(rgba(0x4f6b78ff).into()),
+                        warning: Some(rgba(0x8a8a11ff).into()),
+                        warning_background: Some(rgba(0x201f0cff).into()),
+                        warning_border: Some(rgba(0x333211ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x277fadff).into(),
+                            background: rgba(0x277fadff).into(),
+                            selection: rgba(0x277fad3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb72ed2ff).into(),
+                            background: rgba(0xb72ed2ff).into(),
+                            selection: rgba(0xb72ed23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x935c26ff).into(),
+                            background: rgba(0x935c26ff).into(),
+                            selection: rgba(0x935c263d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6b6bb8ff).into(),
+                            background: rgba(0x6b6bb8ff).into(),
+                            selection: rgba(0x6b6bb83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2e8f6fff).into(),
+                            background: rgba(0x2e8f6fff).into(),
+                            selection: rgba(0x2e8f6f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd22e72ff).into(),
+                            background: rgba(0xd22e72ff).into(),
+                            selection: rgba(0xd22e723d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8a8a11ff).into(),
+                            background: rgba(0x8a8a11ff).into(),
+                            selection: rgba(0x8a8a113d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x568c3bff).into(),
+                            background: rgba(0x568c3bff).into(),
+                            selection: rgba(0x568c3b3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5a7b8cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7ea2b4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebf8ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935c26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x257fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x257fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8a0fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x52809aff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6b6bb8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935c26ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935c25ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7ea2b4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x427088ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebf8ffff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc1e4f6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd22d72ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc1e4f6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7ea2b4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7ea2b4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc1e4f6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb72dd2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7ea2b4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2d8f6fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb72dd2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935c26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebf8ffff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8a0fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc1e4f6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6b6bb8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8a0fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Lakeside Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x80a4b6ff).into()),
+                        border_variant: Some(rgba(0xb0d3e5ff).into()),
+                        border_focused: Some(rgba(0xbacfe1ff).into()),
+                        border_selected: Some(rgba(0xbacfe1ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x93b7c9ff).into()),
+                        elevated_surface_background: Some(rgba(0xcdeaf9ff).into()),
+                        surface_background: Some(rgba(0xcdeaf9ff).into()),
+                        background: Some(rgba(0xa6cadcff).into()),
+                        panel_background: Some(rgba(0xcdeaf9ff).into()),
+                        element_background: Some(rgba(0xcdeaf9ff).into()),
+                        element_hover: Some(rgba(0xb0d3e5ff).into()),
+                        element_active: Some(rgba(0x82a6b8ff).into()),
+                        element_selected: Some(rgba(0x82a6b8ff).into()),
+                        element_disabled: Some(rgba(0xcdeaf9ff).into()),
+                        drop_target_background: Some(rgba(0x526f7d80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xb0d3e5ff).into()),
+                        ghost_element_active: Some(rgba(0x82a6b8ff).into()),
+                        ghost_element_selected: Some(rgba(0x82a6b8ff).into()),
+                        ghost_element_disabled: Some(rgba(0xcdeaf9ff).into()),
+                        text: Some(rgba(0x161b1dff).into()),
+                        text_muted: Some(rgba(0x526f7dff).into()),
+                        text_placeholder: Some(rgba(0x628496ff).into()),
+                        text_disabled: Some(rgba(0x628496ff).into()),
+                        text_accent: Some(rgba(0x277fadff).into()),
+                        icon: Some(rgba(0x161b1dff).into()),
+                        icon_muted: Some(rgba(0x526f7dff).into()),
+                        icon_disabled: Some(rgba(0x628496ff).into()),
+                        icon_placeholder: Some(rgba(0x526f7dff).into()),
+                        icon_accent: Some(rgba(0x277fadff).into()),
+                        status_bar_background: Some(rgba(0xa6cadcff).into()),
+                        title_bar_background: Some(rgba(0xa6cadcff).into()),
+                        toolbar_background: Some(rgba(0xebf8ffff).into()),
+                        tab_bar_background: Some(rgba(0xcdeaf9ff).into()),
+                        tab_inactive_background: Some(rgba(0xcdeaf9ff).into()),
+                        tab_active_background: Some(rgba(0xebf8ffff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x161b1d4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xb0d3e5ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xb0d3e5ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xd3edfaff).into()),
+                        editor_foreground: Some(rgba(0x1f292eff).into()),
+                        editor_background: Some(rgba(0xebf8ffff).into()),
+                        editor_gutter_background: Some(rgba(0xebf8ffff).into()),
+                        editor_subheader_background: Some(rgba(0xcdeaf9ff).into()),
+                        editor_active_line_background: Some(rgba(0xcdeaf9bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xcdeaf9ff).into()),
+                        editor_line_number: Some(rgba(0x161b1d59).into()),
+                        editor_active_line_number: Some(rgba(0x161b1dff).into()),
+                        editor_invisible: Some(rgba(0x526f7dff).into()),
+                        editor_wrap_guide: Some(rgba(0x161b1d0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x161b1d1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x277fad1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x66889a66).into()),
+                        terminal_background: Some(rgba(0xebf8ffff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x7397aaff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xf09fb6ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xabc59aff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xc8c38bff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x9ebdd6ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xe09fe9ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x9bc7b5ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x161b1dff).into()),
+                        terminal_ansi_black: Some(rgba(0xebf8ffff).into()),
+                        terminal_ansi_red: Some(rgba(0xd22f72ff).into()),
+                        terminal_ansi_green: Some(rgba(0x578c3cff).into()),
+                        terminal_ansi_yellow: Some(rgba(0x8a8a11ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x277fadff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xb72fd2ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x2f8f6fff).into()),
+                        terminal_ansi_white: Some(rgba(0x161b1dff).into()),
+                        link_text_hover: Some(rgba(0x277fadff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0x8a8a11ff).into()),
+                        conflict_background: Some(rgba(0xeae6d0ff).into()),
+                        conflict_border: Some(rgba(0xd8d3abff).into()),
+                        created: Some(rgba(0x578c3cff).into()),
+                        created_background: Some(rgba(0xdde7d5ff).into()),
+                        created_border: Some(rgba(0xc2d5b6ff).into()),
+                        deleted: Some(rgba(0xd22f72ff).into()),
+                        deleted_background: Some(rgba(0xfbd8e1ff).into()),
+                        deleted_border: Some(rgba(0xf6bacaff).into()),
+                        error: Some(rgba(0xd22f72ff).into()),
+                        error_background: Some(rgba(0xfbd8e1ff).into()),
+                        error_border: Some(rgba(0xf6bacaff).into()),
+                        hidden: Some(rgba(0x628496ff).into()),
+                        hidden_background: Some(rgba(0xa6cadcff).into()),
+                        hidden_border: Some(rgba(0x93b7c9ff).into()),
+                        hint: Some(rgba(0x5a87a0ff).into()),
+                        hint_background: Some(rgba(0xd8e4eeff).into()),
+                        hint_border: Some(rgba(0xbacfe1ff).into()),
+                        ignored: Some(rgba(0x526f7dff).into()),
+                        ignored_background: Some(rgba(0xa6cadcff).into()),
+                        ignored_border: Some(rgba(0x80a4b6ff).into()),
+                        info: Some(rgba(0x277fadff).into()),
+                        info_background: Some(rgba(0xd8e4eeff).into()),
+                        info_border: Some(rgba(0xbacfe1ff).into()),
+                        modified: Some(rgba(0x8a8a11ff).into()),
+                        modified_background: Some(rgba(0xeae6d0ff).into()),
+                        modified_border: Some(rgba(0xd8d3abff).into()),
+                        predictive: Some(rgba(0x6a97b2ff).into()),
+                        predictive_background: Some(rgba(0xdde7d5ff).into()),
+                        predictive_border: Some(rgba(0xc2d5b6ff).into()),
+                        renamed: Some(rgba(0x277fadff).into()),
+                        renamed_background: Some(rgba(0xd8e4eeff).into()),
+                        renamed_border: Some(rgba(0xbacfe1ff).into()),
+                        success: Some(rgba(0x578c3cff).into()),
+                        success_background: Some(rgba(0xdde7d5ff).into()),
+                        success_border: Some(rgba(0xc2d5b6ff).into()),
+                        unreachable: Some(rgba(0x526f7dff).into()),
+                        unreachable_background: Some(rgba(0xa6cadcff).into()),
+                        unreachable_border: Some(rgba(0x80a4b6ff).into()),
+                        warning: Some(rgba(0x8a8a11ff).into()),
+                        warning_background: Some(rgba(0xeae6d0ff).into()),
+                        warning_border: Some(rgba(0xd8d3abff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x277fadff).into(),
+                            background: rgba(0x277fadff).into(),
+                            selection: rgba(0x277fad3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb72fd2ff).into(),
+                            background: rgba(0xb72fd2ff).into(),
+                            selection: rgba(0xb72fd23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x935d26ff).into(),
+                            background: rgba(0x935d26ff).into(),
+                            selection: rgba(0x935d263d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6c6bb8ff).into(),
+                            background: rgba(0x6c6bb8ff).into(),
+                            selection: rgba(0x6c6bb83d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2f8f6fff).into(),
+                            background: rgba(0x2f8f6fff).into(),
+                            selection: rgba(0x2f8f6f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd22f72ff).into(),
+                            background: rgba(0xd22f72ff).into(),
+                            selection: rgba(0xd22f723d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8a8a11ff).into(),
+                            background: rgba(0x8a8a11ff).into(),
+                            selection: rgba(0x8a8a113d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x578c3cff).into(),
+                            background: rgba(0x578c3cff).into(),
+                            selection: rgba(0x578c3c3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x578c3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7195a8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516d7bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x578c3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x161b1dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935d26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x257fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x257fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8a0fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5a87a0ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6b6bb8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935d26ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x578c3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935c25ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516d7bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6a97b2ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x161b1dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1f292eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd22d72ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1f292eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516d7bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516d7bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1f292eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb72dd2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x516d7bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2d8f6fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb72dd2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x568c3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x277fadff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x935d26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x161b1dff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8a0fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1f292eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6b6bb8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8a0fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Plateau Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x564e4eff).into()),
+                        border_variant: Some(rgba(0x352f2fff).into()),
+                        border_focused: Some(rgba(0x2c2b45ff).into()),
+                        border_selected: Some(rgba(0x2c2b45ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x494242ff).into()),
+                        elevated_surface_background: Some(rgba(0x252020ff).into()),
+                        surface_background: Some(rgba(0x252020ff).into()),
+                        background: Some(rgba(0x3b3535ff).into()),
+                        panel_background: Some(rgba(0x252020ff).into()),
+                        element_background: Some(rgba(0x252020ff).into()),
+                        element_hover: Some(rgba(0x352f2fff).into()),
+                        element_active: Some(rgba(0x554d4dff).into()),
+                        element_selected: Some(rgba(0x554d4dff).into()),
+                        element_disabled: Some(rgba(0x252020ff).into()),
+                        drop_target_background: Some(rgba(0x89838380).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x352f2fff).into()),
+                        ghost_element_active: Some(rgba(0x554d4dff).into()),
+                        ghost_element_selected: Some(rgba(0x554d4dff).into()),
+                        ghost_element_disabled: Some(rgba(0x252020ff).into()),
+                        text: Some(rgba(0xf4ececff).into()),
+                        text_muted: Some(rgba(0x898383ff).into()),
+                        text_placeholder: Some(rgba(0x756e6eff).into()),
+                        text_disabled: Some(rgba(0x756e6eff).into()),
+                        text_accent: Some(rgba(0x7272caff).into()),
+                        icon: Some(rgba(0xf4ececff).into()),
+                        icon_muted: Some(rgba(0x898383ff).into()),
+                        icon_disabled: Some(rgba(0x756e6eff).into()),
+                        icon_placeholder: Some(rgba(0x898383ff).into()),
+                        icon_accent: Some(rgba(0x7272caff).into()),
+                        status_bar_background: Some(rgba(0x3b3535ff).into()),
+                        title_bar_background: Some(rgba(0x3b3535ff).into()),
+                        toolbar_background: Some(rgba(0x1b1818ff).into()),
+                        tab_bar_background: Some(rgba(0x252020ff).into()),
+                        tab_inactive_background: Some(rgba(0x252020ff).into()),
+                        tab_active_background: Some(rgba(0x1b1818ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xf4ecec4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x352f2fff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x352f2fff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x231f1fff).into()),
+                        editor_foreground: Some(rgba(0xe7dfdfff).into()),
+                        editor_background: Some(rgba(0x1b1818ff).into()),
+                        editor_gutter_background: Some(rgba(0x1b1818ff).into()),
+                        editor_subheader_background: Some(rgba(0x252020ff).into()),
+                        editor_active_line_background: Some(rgba(0x252020bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x252020ff).into()),
+                        editor_line_number: Some(rgba(0xf4ecec59).into()),
+                        editor_active_line_number: Some(rgba(0xf4ececff).into()),
+                        editor_invisible: Some(rgba(0x898383ff).into()),
+                        editor_wrap_guide: Some(rgba(0xf4ecec0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xf4ecec1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x7272ca1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x726a6a66).into()),
+                        terminal_background: Some(rgba(0x1b1818ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x635b5bff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x692727ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x2a4444ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x4e3821ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x3b3960ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x5b2c42ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x2e4257ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xf4ececff).into()),
+                        terminal_ansi_black: Some(rgba(0x1b1818ff).into()),
+                        terminal_ansi_red: Some(rgba(0xca4949ff).into()),
+                        terminal_ansi_green: Some(rgba(0x4b8b8bff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xa06e3bff).into()),
+                        terminal_ansi_blue: Some(rgba(0x7272caff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xbd5187ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x5485b6ff).into()),
+                        terminal_ansi_white: Some(rgba(0xf4ececff).into()),
+                        link_text_hover: Some(rgba(0x7272caff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xa06e3bff).into()),
+                        conflict_background: Some(rgba(0x231a12ff).into()),
+                        conflict_border: Some(rgba(0x392a1aff).into()),
+                        created: Some(rgba(0x4b8b8bff).into()),
+                        created_background: Some(rgba(0x161f1fff).into()),
+                        created_border: Some(rgba(0x203232ff).into()),
+                        deleted: Some(rgba(0xca4949ff).into()),
+                        deleted_background: Some(rgba(0x361414ff).into()),
+                        deleted_border: Some(rgba(0x501e1eff).into()),
+                        error: Some(rgba(0xca4949ff).into()),
+                        error_background: Some(rgba(0x361414ff).into()),
+                        error_border: Some(rgba(0x501e1eff).into()),
+                        hidden: Some(rgba(0x756e6eff).into()),
+                        hidden_background: Some(rgba(0x3b3535ff).into()),
+                        hidden_border: Some(rgba(0x494242ff).into()),
+                        hint: Some(rgba(0x8a647aff).into()),
+                        hint_background: Some(rgba(0x1c1b29ff).into()),
+                        hint_border: Some(rgba(0x2c2b45ff).into()),
+                        ignored: Some(rgba(0x898383ff).into()),
+                        ignored_background: Some(rgba(0x3b3535ff).into()),
+                        ignored_border: Some(rgba(0x564e4eff).into()),
+                        info: Some(rgba(0x7272caff).into()),
+                        info_background: Some(rgba(0x1c1b29ff).into()),
+                        info_border: Some(rgba(0x2c2b45ff).into()),
+                        modified: Some(rgba(0xa06e3bff).into()),
+                        modified_background: Some(rgba(0x231a12ff).into()),
+                        modified_border: Some(rgba(0x392a1aff).into()),
+                        predictive: Some(rgba(0x795369ff).into()),
+                        predictive_background: Some(rgba(0x161f1fff).into()),
+                        predictive_border: Some(rgba(0x203232ff).into()),
+                        renamed: Some(rgba(0x7272caff).into()),
+                        renamed_background: Some(rgba(0x1c1b29ff).into()),
+                        renamed_border: Some(rgba(0x2c2b45ff).into()),
+                        success: Some(rgba(0x4b8b8bff).into()),
+                        success_background: Some(rgba(0x161f1fff).into()),
+                        success_border: Some(rgba(0x203232ff).into()),
+                        unreachable: Some(rgba(0x898383ff).into()),
+                        unreachable_background: Some(rgba(0x3b3535ff).into()),
+                        unreachable_border: Some(rgba(0x564e4eff).into()),
+                        warning: Some(rgba(0xa06e3bff).into()),
+                        warning_background: Some(rgba(0x231a12ff).into()),
+                        warning_border: Some(rgba(0x392a1aff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x7272caff).into(),
+                            background: rgba(0x7272caff).into(),
+                            selection: rgba(0x7272ca3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbd5187ff).into(),
+                            background: rgba(0xbd5187ff).into(),
+                            selection: rgba(0xbd51873d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb45a3cff).into(),
+                            background: rgba(0xb45a3cff).into(),
+                            selection: rgba(0xb45a3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8464c4ff).into(),
+                            background: rgba(0x8464c4ff).into(),
+                            selection: rgba(0x8464c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5485b6ff).into(),
+                            background: rgba(0x5485b6ff).into(),
+                            selection: rgba(0x5485b63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca4949ff).into(),
+                            background: rgba(0xca4949ff).into(),
+                            selection: rgba(0xca49493d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3bff).into(),
+                            background: rgba(0xa06e3bff).into(),
+                            selection: rgba(0xa06e3b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x4b8b8bff).into(),
+                            background: rgba(0x4b8b8bff).into(),
+                            selection: rgba(0x4b8b8b3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x655d5dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8585ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf4ececff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45a3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a647aff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8464c4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45a3cff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45a3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8585ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x795369ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf4ececff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7dfdfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xca4949ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7dfdfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8585ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8585ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7dfdfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbd5187ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8a8585ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5485b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbd5187ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45a3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf4ececff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe7dfdfff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8464c4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Plateau Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x8e8989ff).into()),
+                        border_variant: Some(rgba(0xcfc7c7ff).into()),
+                        border_focused: Some(rgba(0xcecaecff).into()),
+                        border_selected: Some(rgba(0xcecaecff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xa8a2a2ff).into()),
+                        elevated_surface_background: Some(rgba(0xebe3e3ff).into()),
+                        surface_background: Some(rgba(0xebe3e3ff).into()),
+                        background: Some(rgba(0xc1bbbbff).into()),
+                        panel_background: Some(rgba(0xebe3e3ff).into()),
+                        element_background: Some(rgba(0xebe3e3ff).into()),
+                        element_hover: Some(rgba(0xcfc7c7ff).into()),
+                        element_active: Some(rgba(0x908b8bff).into()),
+                        element_selected: Some(rgba(0x908b8bff).into()),
+                        element_disabled: Some(rgba(0xebe3e3ff).into()),
+                        drop_target_background: Some(rgba(0x5a525280).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xcfc7c7ff).into()),
+                        ghost_element_active: Some(rgba(0x908b8bff).into()),
+                        ghost_element_selected: Some(rgba(0x908b8bff).into()),
+                        ghost_element_disabled: Some(rgba(0xebe3e3ff).into()),
+                        text: Some(rgba(0x1b1818ff).into()),
+                        text_muted: Some(rgba(0x5a5252ff).into()),
+                        text_placeholder: Some(rgba(0x6e6666ff).into()),
+                        text_disabled: Some(rgba(0x6e6666ff).into()),
+                        text_accent: Some(rgba(0x7372caff).into()),
+                        icon: Some(rgba(0x1b1818ff).into()),
+                        icon_muted: Some(rgba(0x5a5252ff).into()),
+                        icon_disabled: Some(rgba(0x6e6666ff).into()),
+                        icon_placeholder: Some(rgba(0x5a5252ff).into()),
+                        icon_accent: Some(rgba(0x7372caff).into()),
+                        status_bar_background: Some(rgba(0xc1bbbbff).into()),
+                        title_bar_background: Some(rgba(0xc1bbbbff).into()),
+                        toolbar_background: Some(rgba(0xf4ececff).into()),
+                        tab_bar_background: Some(rgba(0xebe3e3ff).into()),
+                        tab_inactive_background: Some(rgba(0xebe3e3ff).into()),
+                        tab_active_background: Some(rgba(0xf4ececff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x1b18184c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xcfc7c7ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xcfc7c7ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xede5e5ff).into()),
+                        editor_foreground: Some(rgba(0x292424ff).into()),
+                        editor_background: Some(rgba(0xf4ececff).into()),
+                        editor_gutter_background: Some(rgba(0xf4ececff).into()),
+                        editor_subheader_background: Some(rgba(0xebe3e3ff).into()),
+                        editor_active_line_background: Some(rgba(0xebe3e3bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xebe3e3ff).into()),
+                        editor_line_number: Some(rgba(0x1b181859).into()),
+                        editor_active_line_number: Some(rgba(0x1b1818ff).into()),
+                        editor_invisible: Some(rgba(0x5a5252ff).into()),
+                        editor_wrap_guide: Some(rgba(0x1b18180d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x1b18181a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x7372ca1a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x726a6a66).into()),
+                        terminal_background: Some(rgba(0xf4ececff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x807979ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xeda69fff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xa6c4c4ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xd4b499ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xbbb6e5ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xe2a9c2ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0xacc0daff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x1b1818ff).into()),
+                        terminal_ansi_black: Some(rgba(0xf4ececff).into()),
+                        terminal_ansi_red: Some(rgba(0xca4a4aff).into()),
+                        terminal_ansi_green: Some(rgba(0x4c8b8bff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xa06e3cff).into()),
+                        terminal_ansi_blue: Some(rgba(0x7372caff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xbd5287ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x5585b6ff).into()),
+                        terminal_ansi_white: Some(rgba(0x1b1818ff).into()),
+                        link_text_hover: Some(rgba(0x7372caff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xa06e3cff).into()),
+                        conflict_background: Some(rgba(0xeee0d5ff).into()),
+                        conflict_border: Some(rgba(0xe0c9b5ff).into()),
+                        created: Some(rgba(0x4c8b8bff).into()),
+                        created_background: Some(rgba(0xdae7e7ff).into()),
+                        created_border: Some(rgba(0xbfd4d4ff).into()),
+                        deleted: Some(rgba(0xca4a4aff).into()),
+                        deleted_background: Some(rgba(0xfadbd7ff).into()),
+                        deleted_border: Some(rgba(0xf4bfbaff).into()),
+                        error: Some(rgba(0xca4a4aff).into()),
+                        error_background: Some(rgba(0xfadbd7ff).into()),
+                        error_border: Some(rgba(0xf4bfbaff).into()),
+                        hidden: Some(rgba(0x6e6666ff).into()),
+                        hidden_background: Some(rgba(0xc1bbbbff).into()),
+                        hidden_border: Some(rgba(0xa8a2a2ff).into()),
+                        hint: Some(rgba(0x916a80ff).into()),
+                        hint_background: Some(rgba(0xe4e1f5ff).into()),
+                        hint_border: Some(rgba(0xcecaecff).into()),
+                        ignored: Some(rgba(0x5a5252ff).into()),
+                        ignored_background: Some(rgba(0xc1bbbbff).into()),
+                        ignored_border: Some(rgba(0x8e8989ff).into()),
+                        info: Some(rgba(0x7372caff).into()),
+                        info_background: Some(rgba(0xe4e1f5ff).into()),
+                        info_border: Some(rgba(0xcecaecff).into()),
+                        modified: Some(rgba(0xa06e3cff).into()),
+                        modified_background: Some(rgba(0xeee0d5ff).into()),
+                        modified_border: Some(rgba(0xe0c9b5ff).into()),
+                        predictive: Some(rgba(0xa27a91ff).into()),
+                        predictive_background: Some(rgba(0xdae7e7ff).into()),
+                        predictive_border: Some(rgba(0xbfd4d4ff).into()),
+                        renamed: Some(rgba(0x7372caff).into()),
+                        renamed_background: Some(rgba(0xe4e1f5ff).into()),
+                        renamed_border: Some(rgba(0xcecaecff).into()),
+                        success: Some(rgba(0x4c8b8bff).into()),
+                        success_background: Some(rgba(0xdae7e7ff).into()),
+                        success_border: Some(rgba(0xbfd4d4ff).into()),
+                        unreachable: Some(rgba(0x5a5252ff).into()),
+                        unreachable_background: Some(rgba(0xc1bbbbff).into()),
+                        unreachable_border: Some(rgba(0x8e8989ff).into()),
+                        warning: Some(rgba(0xa06e3cff).into()),
+                        warning_background: Some(rgba(0xeee0d5ff).into()),
+                        warning_border: Some(rgba(0xe0c9b5ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x7372caff).into(),
+                            background: rgba(0x7372caff).into(),
+                            selection: rgba(0x7372ca3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xbd5287ff).into(),
+                            background: rgba(0xbd5287ff).into(),
+                            selection: rgba(0xbd52873d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb45b3dff).into(),
+                            background: rgba(0xb45b3dff).into(),
+                            selection: rgba(0xb45b3d3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8464c4ff).into(),
+                            background: rgba(0x8464c4ff).into(),
+                            selection: rgba(0x8464c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5585b6ff).into(),
+                            background: rgba(0x5585b6ff).into(),
+                            selection: rgba(0x5585b63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xca4a4aff).into(),
+                            background: rgba(0xca4a4aff).into(),
+                            selection: rgba(0xca4a4a3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa06e3cff).into(),
+                            background: rgba(0xa06e3cff).into(),
+                            selection: rgba(0xa06e3c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x4c8b8bff).into(),
+                            background: rgba(0x4c8b8bff).into(),
+                            selection: rgba(0x4c8b8b3d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7372caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4c8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7e7777ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4c8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7372caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b1818ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7372caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7372caff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45b3dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7272caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x916a80ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8464c4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7372caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45b3dff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4c8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45a3cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa27a91ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b1818ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292424ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xca4949ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292424ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292424ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbd5187ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x585050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5485b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xbd5187ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4b8b8bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7372caff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb45b3dff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1b1818ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x292424ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8464c4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa06e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Atelier Savanna Dark".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x505e55ff).into()),
+                        border_variant: Some(rgba(0x2f3832ff).into()),
+                        border_focused: Some(rgba(0x1f3233ff).into()),
+                        border_selected: Some(rgba(0x1f3233ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x434f47ff).into()),
+                        elevated_surface_background: Some(rgba(0x1f2621ff).into()),
+                        surface_background: Some(rgba(0x1f2621ff).into()),
+                        background: Some(rgba(0x353f39ff).into()),
+                        panel_background: Some(rgba(0x1f2621ff).into()),
+                        element_background: Some(rgba(0x1f2621ff).into()),
+                        element_hover: Some(rgba(0x2f3832ff).into()),
+                        element_active: Some(rgba(0x4f5c53ff).into()),
+                        element_selected: Some(rgba(0x4f5c53ff).into()),
+                        element_disabled: Some(rgba(0x1f2621ff).into()),
+                        drop_target_background: Some(rgba(0x85918880).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x2f3832ff).into()),
+                        ghost_element_active: Some(rgba(0x4f5c53ff).into()),
+                        ghost_element_selected: Some(rgba(0x4f5c53ff).into()),
+                        ghost_element_disabled: Some(rgba(0x1f2621ff).into()),
+                        text: Some(rgba(0xecf4eeff).into()),
+                        text_muted: Some(rgba(0x859188ff).into()),
+                        text_placeholder: Some(rgba(0x6f7e74ff).into()),
+                        text_disabled: Some(rgba(0x6f7e74ff).into()),
+                        text_accent: Some(rgba(0x478c90ff).into()),
+                        icon: Some(rgba(0xecf4eeff).into()),
+                        icon_muted: Some(rgba(0x859188ff).into()),
+                        icon_disabled: Some(rgba(0x6f7e74ff).into()),
+                        icon_placeholder: Some(rgba(0x859188ff).into()),
+                        icon_accent: Some(rgba(0x478c90ff).into()),
+                        status_bar_background: Some(rgba(0x353f39ff).into()),
+                        title_bar_background: Some(rgba(0x353f39ff).into()),
+                        toolbar_background: Some(rgba(0x171c19ff).into()),
+                        tab_bar_background: Some(rgba(0x1f2621ff).into()),
+                        tab_inactive_background: Some(rgba(0x1f2621ff).into()),
+                        tab_active_background: Some(rgba(0x171c19ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xecf4ee4c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x2f3832ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x2f3832ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x1e2420ff).into()),
+                        editor_foreground: Some(rgba(0xdfe7e2ff).into()),
+                        editor_background: Some(rgba(0x171c19ff).into()),
+                        editor_gutter_background: Some(rgba(0x171c19ff).into()),
+                        editor_subheader_background: Some(rgba(0x1f2621ff).into()),
+                        editor_active_line_background: Some(rgba(0x1f2621bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x1f2621ff).into()),
+                        editor_line_number: Some(rgba(0xecf4ee59).into()),
+                        editor_active_line_number: Some(rgba(0xecf4eeff).into()),
+                        editor_invisible: Some(rgba(0x859188ff).into()),
+                        editor_wrap_guide: Some(rgba(0xecf4ee0d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xecf4ee1a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x478c901a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x6c7a7166).into()),
+                        terminal_background: Some(rgba(0x171c19ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x5d6b62ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x563220ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x294a33ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x4e3f22ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x284546ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x423a36ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x1d4b4dff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xecf4eeff).into()),
+                        terminal_ansi_black: Some(rgba(0x171c19ff).into()),
+                        terminal_ansi_red: Some(rgba(0xb16139ff).into()),
+                        terminal_ansi_green: Some(rgba(0x489963ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xa07e3bff).into()),
+                        terminal_ansi_blue: Some(rgba(0x478c90ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0x867469ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x1e9aa0ff).into()),
+                        terminal_ansi_white: Some(rgba(0xecf4eeff).into()),
+                        link_text_hover: Some(rgba(0x478c90ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xa07e3bff).into()),
+                        conflict_background: Some(rgba(0x231d12ff).into()),
+                        conflict_border: Some(rgba(0x392e1aff).into()),
+                        created: Some(rgba(0x489963ff).into()),
+                        created_background: Some(rgba(0x162119ff).into()),
+                        created_border: Some(rgba(0x203626ff).into()),
+                        deleted: Some(rgba(0xb16139ff).into()),
+                        deleted_background: Some(rgba(0x261811ff).into()),
+                        deleted_border: Some(rgba(0x3f2619ff).into()),
+                        error: Some(rgba(0xb16139ff).into()),
+                        error_background: Some(rgba(0x261811ff).into()),
+                        error_border: Some(rgba(0x3f2619ff).into()),
+                        hidden: Some(rgba(0x6f7e74ff).into()),
+                        hidden_background: Some(rgba(0x353f39ff).into()),
+                        hidden_border: Some(rgba(0x434f47ff).into()),
+                        hint: Some(rgba(0x607e76ff).into()),
+                        hint_background: Some(rgba(0x151f20ff).into()),
+                        hint_border: Some(rgba(0x1f3233ff).into()),
+                        ignored: Some(rgba(0x859188ff).into()),
+                        ignored_background: Some(rgba(0x353f39ff).into()),
+                        ignored_border: Some(rgba(0x505e55ff).into()),
+                        info: Some(rgba(0x478c90ff).into()),
+                        info_background: Some(rgba(0x151f20ff).into()),
+                        info_border: Some(rgba(0x1f3233ff).into()),
+                        modified: Some(rgba(0xa07e3bff).into()),
+                        modified_background: Some(rgba(0x231d12ff).into()),
+                        modified_border: Some(rgba(0x392e1aff).into()),
+                        predictive: Some(rgba(0x506d66ff).into()),
+                        predictive_background: Some(rgba(0x162119ff).into()),
+                        predictive_border: Some(rgba(0x203626ff).into()),
+                        renamed: Some(rgba(0x478c90ff).into()),
+                        renamed_background: Some(rgba(0x151f20ff).into()),
+                        renamed_border: Some(rgba(0x1f3233ff).into()),
+                        success: Some(rgba(0x489963ff).into()),
+                        success_background: Some(rgba(0x162119ff).into()),
+                        success_border: Some(rgba(0x203626ff).into()),
+                        unreachable: Some(rgba(0x859188ff).into()),
+                        unreachable_background: Some(rgba(0x353f39ff).into()),
+                        unreachable_border: Some(rgba(0x505e55ff).into()),
+                        warning: Some(rgba(0xa07e3bff).into()),
+                        warning_background: Some(rgba(0x231d12ff).into()),
+                        warning_border: Some(rgba(0x392e1aff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x478c90ff).into(),
+                            background: rgba(0x478c90ff).into(),
+                            selection: rgba(0x478c903d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x867469ff).into(),
+                            background: rgba(0x867469ff).into(),
+                            selection: rgba(0x8674693d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9f713cff).into(),
+                            background: rgba(0x9f713cff).into(),
+                            selection: rgba(0x9f713c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x55859bff).into(),
+                            background: rgba(0x55859bff).into(),
+                            selection: rgba(0x55859b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x1e9aa0ff).into(),
+                            background: rgba(0x1e9aa0ff).into(),
+                            selection: rgba(0x1e9aa03d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb16139ff).into(),
+                            background: rgba(0xb16139ff).into(),
+                            selection: rgba(0xb161393d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa07e3bff).into(),
+                            background: rgba(0xa07e3bff).into(),
+                            selection: rgba(0xa07e3b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x489963ff).into(),
+                            background: rgba(0x489963ff).into(),
+                            selection: rgba(0x4899633d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x489963ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5f6d64ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x87928aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x489963ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xecf4eeff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9f713cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.special.definition".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa07e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x607e76ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55859bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9f713cff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x489963ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9f713cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x87928aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x506d66ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xecf4eeff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdfe7e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb16139ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdfe7e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x87928aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x87928aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdfe7e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x867469ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x489963ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x87928aff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x1c9aa0ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x867469ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x489963ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x478c90ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9f713cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xecf4eeff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa07e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xdfe7e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x55859bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa07e3bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
                 name: "Atelier Savanna Light".into(),
                 appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
@@ -1411,170 +7456,170 @@ pub fn atelier() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Atelier Cave Dark".into(),
+                name: "Atelier Seaside Dark".into(),
                 appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x56505eff).into()),
-                        border_variant: Some(rgba(0x332f38ff).into()),
-                        border_focused: Some(rgba(0x222953ff).into()),
-                        border_selected: Some(rgba(0x222953ff).into()),
+                        border: Some(rgba(0x5c6c5cff).into()),
+                        border_variant: Some(rgba(0x333b33ff).into()),
+                        border_focused: Some(rgba(0x102668ff).into()),
+                        border_selected: Some(rgba(0x102668ff).into()),
                         border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x48434fff).into()),
-                        elevated_surface_background: Some(rgba(0x221f26ff).into()),
-                        surface_background: Some(rgba(0x221f26ff).into()),
-                        background: Some(rgba(0x3a353fff).into()),
-                        panel_background: Some(rgba(0x221f26ff).into()),
-                        element_background: Some(rgba(0x221f26ff).into()),
-                        element_hover: Some(rgba(0x332f38ff).into()),
-                        element_active: Some(rgba(0x544f5cff).into()),
-                        element_selected: Some(rgba(0x544f5cff).into()),
-                        element_disabled: Some(rgba(0x221f26ff).into()),
-                        drop_target_background: Some(rgba(0x89859180).into()),
+                        border_disabled: Some(rgba(0x4b584bff).into()),
+                        elevated_surface_background: Some(rgba(0x1f231fff).into()),
+                        surface_background: Some(rgba(0x1f231fff).into()),
+                        background: Some(rgba(0x3b453bff).into()),
+                        panel_background: Some(rgba(0x1f231fff).into()),
+                        element_background: Some(rgba(0x1f231fff).into()),
+                        element_hover: Some(rgba(0x333b33ff).into()),
+                        element_active: Some(rgba(0x5a6a5aff).into()),
+                        element_selected: Some(rgba(0x5a6a5aff).into()),
+                        element_disabled: Some(rgba(0x1f231fff).into()),
+                        drop_target_background: Some(rgba(0x8ba48b80).into()),
                         ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x332f38ff).into()),
-                        ghost_element_active: Some(rgba(0x544f5cff).into()),
-                        ghost_element_selected: Some(rgba(0x544f5cff).into()),
-                        ghost_element_disabled: Some(rgba(0x221f26ff).into()),
-                        text: Some(rgba(0xefecf4ff).into()),
-                        text_muted: Some(rgba(0x898591ff).into()),
-                        text_placeholder: Some(rgba(0x756f7eff).into()),
-                        text_disabled: Some(rgba(0x756f7eff).into()),
-                        text_accent: Some(rgba(0x576ddaff).into()),
-                        icon: Some(rgba(0xefecf4ff).into()),
-                        icon_muted: Some(rgba(0x898591ff).into()),
-                        icon_disabled: Some(rgba(0x756f7eff).into()),
-                        icon_placeholder: Some(rgba(0x898591ff).into()),
-                        icon_accent: Some(rgba(0x576ddaff).into()),
-                        status_bar_background: Some(rgba(0x3a353fff).into()),
-                        title_bar_background: Some(rgba(0x3a353fff).into()),
-                        toolbar_background: Some(rgba(0x19171cff).into()),
-                        tab_bar_background: Some(rgba(0x221f26ff).into()),
-                        tab_inactive_background: Some(rgba(0x221f26ff).into()),
-                        tab_active_background: Some(rgba(0x19171cff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xefecf44c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x332f38ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x332f38ff).into()),
+                        ghost_element_hover: Some(rgba(0x333b33ff).into()),
+                        ghost_element_active: Some(rgba(0x5a6a5aff).into()),
+                        ghost_element_selected: Some(rgba(0x5a6a5aff).into()),
+                        ghost_element_disabled: Some(rgba(0x1f231fff).into()),
+                        text: Some(rgba(0xf4fbf4ff).into()),
+                        text_muted: Some(rgba(0x8ba48bff).into()),
+                        text_placeholder: Some(rgba(0x778f77ff).into()),
+                        text_disabled: Some(rgba(0x778f77ff).into()),
+                        text_accent: Some(rgba(0x3e62f4ff).into()),
+                        icon: Some(rgba(0xf4fbf4ff).into()),
+                        icon_muted: Some(rgba(0x8ba48bff).into()),
+                        icon_disabled: Some(rgba(0x778f77ff).into()),
+                        icon_placeholder: Some(rgba(0x8ba48bff).into()),
+                        icon_accent: Some(rgba(0x3e62f4ff).into()),
+                        status_bar_background: Some(rgba(0x3b453bff).into()),
+                        title_bar_background: Some(rgba(0x3b453bff).into()),
+                        toolbar_background: Some(rgba(0x131513ff).into()),
+                        tab_bar_background: Some(rgba(0x1f231fff).into()),
+                        tab_inactive_background: Some(rgba(0x1f231fff).into()),
+                        tab_active_background: Some(rgba(0x131513ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xf4fbf44c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x333b33ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x333b33ff).into()),
                         scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x201e24ff).into()),
-                        editor_foreground: Some(rgba(0xe2dfe7ff).into()),
-                        editor_background: Some(rgba(0x19171cff).into()),
-                        editor_gutter_background: Some(rgba(0x19171cff).into()),
-                        editor_subheader_background: Some(rgba(0x221f26ff).into()),
-                        editor_active_line_background: Some(rgba(0x221f26bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x221f26ff).into()),
-                        editor_line_number: Some(rgba(0xefecf459).into()),
-                        editor_active_line_number: Some(rgba(0xefecf4ff).into()),
-                        editor_invisible: Some(rgba(0x898591ff).into()),
-                        editor_wrap_guide: Some(rgba(0xefecf40d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xefecf41a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x576dda1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x726c7a66).into()),
-                        terminal_background: Some(rgba(0x19171cff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x635d6bff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x5c283cff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x1f4747ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x4e3821ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x2d376fff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x60255bff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x26445eff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xefecf4ff).into()),
-                        terminal_ansi_black: Some(rgba(0x19171cff).into()),
-                        terminal_ansi_red: Some(rgba(0xbe4678ff).into()),
-                        terminal_ansi_green: Some(rgba(0x2c9292ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xa06e3bff).into()),
-                        terminal_ansi_blue: Some(rgba(0x576ddaff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xbf41bfff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x3a8bc6ff).into()),
-                        terminal_ansi_white: Some(rgba(0xefecf4ff).into()),
-                        link_text_hover: Some(rgba(0x576ddaff).into()),
+                        scrollbar_track_border: Some(rgba(0x1d201dff).into()),
+                        editor_foreground: Some(rgba(0xcfe8cfff).into()),
+                        editor_background: Some(rgba(0x131513ff).into()),
+                        editor_gutter_background: Some(rgba(0x131513ff).into()),
+                        editor_subheader_background: Some(rgba(0x1f231fff).into()),
+                        editor_active_line_background: Some(rgba(0x1f231fbf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x1f231fff).into()),
+                        editor_line_number: Some(rgba(0xf4fbf459).into()),
+                        editor_active_line_number: Some(rgba(0xf4fbf4ff).into()),
+                        editor_invisible: Some(rgba(0x8ba48bff).into()),
+                        editor_wrap_guide: Some(rgba(0xf4fbf40d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xf4fbf41a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x3e62f41a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x748b7466).into()),
+                        terminal_background: Some(rgba(0x131513ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x667a66ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x840b21ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x204f1bff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x4b4a17ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x193385ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x810e60ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x1d4a56ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xf4fbf4ff).into()),
+                        terminal_ansi_black: Some(rgba(0x131513ff).into()),
+                        terminal_ansi_red: Some(rgba(0xe61c3cff).into()),
+                        terminal_ansi_green: Some(rgba(0x2ba32aff).into()),
+                        terminal_ansi_yellow: Some(rgba(0x98981cff).into()),
+                        terminal_ansi_blue: Some(rgba(0x3e62f4ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xe61cc3ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x1c99b3ff).into()),
+                        terminal_ansi_white: Some(rgba(0xf4fbf4ff).into()),
+                        link_text_hover: Some(rgba(0x3e62f4ff).into()),
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xa06e3bff).into()),
-                        conflict_background: Some(rgba(0x231a12ff).into()),
-                        conflict_border: Some(rgba(0x392a1aff).into()),
-                        created: Some(rgba(0x2c9292ff).into()),
-                        created_background: Some(rgba(0x132020ff).into()),
-                        created_border: Some(rgba(0x1a3434ff).into()),
-                        deleted: Some(rgba(0xbe4678ff).into()),
-                        deleted_background: Some(rgba(0x28151cff).into()),
-                        deleted_border: Some(rgba(0x421f2dff).into()),
-                        error: Some(rgba(0xbe4678ff).into()),
-                        error_background: Some(rgba(0x28151cff).into()),
-                        error_border: Some(rgba(0x421f2dff).into()),
-                        hidden: Some(rgba(0x756f7eff).into()),
-                        hidden_background: Some(rgba(0x3a353fff).into()),
-                        hidden_border: Some(rgba(0x48434fff).into()),
-                        hint: Some(rgba(0x716998ff).into()),
-                        hint_background: Some(rgba(0x161a36ff).into()),
-                        hint_border: Some(rgba(0x222953ff).into()),
-                        ignored: Some(rgba(0x898591ff).into()),
-                        ignored_background: Some(rgba(0x3a353fff).into()),
-                        ignored_border: Some(rgba(0x56505eff).into()),
-                        info: Some(rgba(0x576ddaff).into()),
-                        info_background: Some(rgba(0x161a36ff).into()),
-                        info_border: Some(rgba(0x222953ff).into()),
-                        modified: Some(rgba(0xa06e3bff).into()),
-                        modified_background: Some(rgba(0x231a12ff).into()),
-                        modified_border: Some(rgba(0x392a1aff).into()),
-                        predictive: Some(rgba(0x625887ff).into()),
-                        predictive_background: Some(rgba(0x132020ff).into()),
-                        predictive_border: Some(rgba(0x1a3434ff).into()),
-                        renamed: Some(rgba(0x576ddaff).into()),
-                        renamed_background: Some(rgba(0x161a36ff).into()),
-                        renamed_border: Some(rgba(0x222953ff).into()),
-                        success: Some(rgba(0x2c9292ff).into()),
-                        success_background: Some(rgba(0x132020ff).into()),
-                        success_border: Some(rgba(0x1a3434ff).into()),
-                        unreachable: Some(rgba(0x898591ff).into()),
-                        unreachable_background: Some(rgba(0x3a353fff).into()),
-                        unreachable_border: Some(rgba(0x56505eff).into()),
-                        warning: Some(rgba(0xa06e3bff).into()),
-                        warning_background: Some(rgba(0x231a12ff).into()),
-                        warning_border: Some(rgba(0x392a1aff).into()),
+                        conflict: Some(rgba(0x98981cff).into()),
+                        conflict_background: Some(rgba(0x22210fff).into()),
+                        conflict_border: Some(rgba(0x373614ff).into()),
+                        created: Some(rgba(0x2ba32aff).into()),
+                        created_background: Some(rgba(0x142310ff).into()),
+                        created_border: Some(rgba(0x1b3917ff).into()),
+                        deleted: Some(rgba(0xe61c3cff).into()),
+                        deleted_background: Some(rgba(0x500412ff).into()),
+                        deleted_border: Some(rgba(0x6b071aff).into()),
+                        error: Some(rgba(0xe61c3cff).into()),
+                        error_background: Some(rgba(0x500412ff).into()),
+                        error_border: Some(rgba(0x6b071aff).into()),
+                        hidden: Some(rgba(0x778f77ff).into()),
+                        hidden_background: Some(rgba(0x3b453bff).into()),
+                        hidden_border: Some(rgba(0x4b584bff).into()),
+                        hint: Some(rgba(0x008b9fff).into()),
+                        hint_background: Some(rgba(0x061949ff).into()),
+                        hint_border: Some(rgba(0x102668ff).into()),
+                        ignored: Some(rgba(0x8ba48bff).into()),
+                        ignored_background: Some(rgba(0x3b453bff).into()),
+                        ignored_border: Some(rgba(0x5c6c5cff).into()),
+                        info: Some(rgba(0x3e62f4ff).into()),
+                        info_background: Some(rgba(0x061949ff).into()),
+                        info_border: Some(rgba(0x102668ff).into()),
+                        modified: Some(rgba(0x98981cff).into()),
+                        modified_background: Some(rgba(0x22210fff).into()),
+                        modified_border: Some(rgba(0x373614ff).into()),
+                        predictive: Some(rgba(0x00788bff).into()),
+                        predictive_background: Some(rgba(0x142310ff).into()),
+                        predictive_border: Some(rgba(0x1b3917ff).into()),
+                        renamed: Some(rgba(0x3e62f4ff).into()),
+                        renamed_background: Some(rgba(0x061949ff).into()),
+                        renamed_border: Some(rgba(0x102668ff).into()),
+                        success: Some(rgba(0x2ba32aff).into()),
+                        success_background: Some(rgba(0x142310ff).into()),
+                        success_border: Some(rgba(0x1b3917ff).into()),
+                        unreachable: Some(rgba(0x8ba48bff).into()),
+                        unreachable_background: Some(rgba(0x3b453bff).into()),
+                        unreachable_border: Some(rgba(0x5c6c5cff).into()),
+                        warning: Some(rgba(0x98981cff).into()),
+                        warning_background: Some(rgba(0x22210fff).into()),
+                        warning_border: Some(rgba(0x373614ff).into()),
                         ..Default::default()
                     },
                     player: Some(PlayerColors(vec![
                         PlayerColor {
-                            cursor: rgba(0x576ddaff).into(),
-                            background: rgba(0x576ddaff).into(),
-                            selection: rgba(0x576dda3d).into(),
+                            cursor: rgba(0x3e62f4ff).into(),
+                            background: rgba(0x3e62f4ff).into(),
+                            selection: rgba(0x3e62f43d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xbf41bfff).into(),
-                            background: rgba(0xbf41bfff).into(),
-                            selection: rgba(0xbf41bf3d).into(),
+                            cursor: rgba(0xe61cc3ff).into(),
+                            background: rgba(0xe61cc3ff).into(),
+                            selection: rgba(0xe61cc33d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xaa573cff).into(),
-                            background: rgba(0xaa573cff).into(),
-                            selection: rgba(0xaa573c3d).into(),
+                            cursor: rgba(0x87711eff).into(),
+                            background: rgba(0x87711eff).into(),
+                            selection: rgba(0x87711e3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x955ae6ff).into(),
-                            background: rgba(0x955ae6ff).into(),
-                            selection: rgba(0x955ae63d).into(),
+                            cursor: rgba(0xad2dedff).into(),
+                            background: rgba(0xad2dedff).into(),
+                            selection: rgba(0xad2ded3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x3a8bc6ff).into(),
-                            background: rgba(0x3a8bc6ff).into(),
-                            selection: rgba(0x3a8bc63d).into(),
+                            cursor: rgba(0x1c99b3ff).into(),
+                            background: rgba(0x1c99b3ff).into(),
+                            selection: rgba(0x1c99b33d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xbe4678ff).into(),
-                            background: rgba(0xbe4678ff).into(),
-                            selection: rgba(0xbe46783d).into(),
+                            cursor: rgba(0xe61c3cff).into(),
+                            background: rgba(0xe61c3cff).into(),
+                            selection: rgba(0xe61c3c3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xa06e3bff).into(),
-                            background: rgba(0xa06e3bff).into(),
-                            selection: rgba(0xa06e3b3d).into(),
+                            cursor: rgba(0x98981cff).into(),
+                            background: rgba(0x98981cff).into(),
+                            selection: rgba(0x98981c3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x2c9292ff).into(),
-                            background: rgba(0x2c9292ff).into(),
-                            selection: rgba(0x2c92923d).into(),
+                            cursor: rgba(0x2ba32aff).into(),
+                            background: rgba(0x2ba32aff).into(),
+                            selection: rgba(0x2ba32a3d).into(),
                         },
                     ])),
                     syntax: Some(UserSyntaxTheme {
@@ -1582,63 +7627,63 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddaff).into()),
+                                    color: Some(rgba(0x3e62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "boolean".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x2c9292ff).into()),
+                                    color: Some(rgba(0x2ba32aff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x655f6dff).into()),
+                                    color: Some(rgba(0x687d68ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b8792ff).into()),
+                                    color: Some(rgba(0x8ca68cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x2c9292ff).into()),
+                                    color: Some(rgba(0x2ba32aff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constructor".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddaff).into()),
+                                    color: Some(rgba(0x3e62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "embedded".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xefecf4ff).into()),
+                                    color: Some(rgba(0xf4fbf4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddaff).into()),
+                                    color: Some(rgba(0x3e62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddaff).into()),
+                                    color: Some(rgba(0x3e62f4ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -1646,35 +7691,35 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "enum".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xaa573cff).into()),
+                                    color: Some(rgba(0x87711eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddbff).into()),
+                                    color: Some(rgba(0x3d62f5ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function.method".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddbff).into()),
+                                    color: Some(rgba(0x3d62f5ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function.special.definition".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
+                                    color: Some(rgba(0x98981bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "hint".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x716998ff).into()),
+                                    color: Some(rgba(0x008b9fff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -1682,21 +7727,21 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x955ae7ff).into()),
+                                    color: Some(rgba(0xad2beeff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "label".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddaff).into()),
+                                    color: Some(rgba(0x3e62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xaa573cff).into()),
+                                    color: Some(rgba(0x87711eff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -1704,28 +7749,28 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x2c9292ff).into()),
+                                    color: Some(rgba(0x2ba32aff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "number".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xaa573cff).into()),
+                                    color: Some(rgba(0x87711dff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "operator".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b8792ff).into()),
+                                    color: Some(rgba(0x8ca68cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "predictive".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x625887ff).into()),
+                                    color: Some(rgba(0x00788bff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -1733,112 +7778,112 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "preproc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xefecf4ff).into()),
+                                    color: Some(rgba(0xf4fbf4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "primary".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    color: Some(rgba(0xcfe8cfff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xbe4678ff).into()),
+                                    color: Some(rgba(0xe6193cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    color: Some(rgba(0xcfe8cfff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.bracket".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b8792ff).into()),
+                                    color: Some(rgba(0x8ca68cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b8792ff).into()),
+                                    color: Some(rgba(0x8ca68cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.list_marker".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    color: Some(rgba(0xcfe8cfff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xbf40bfff).into()),
+                                    color: Some(rgba(0xe619c3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x2a9292ff).into()),
+                                    color: Some(rgba(0x29a329ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.escape".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8b8792ff).into()),
+                                    color: Some(rgba(0x8ca68cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.regex".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x398bc6ff).into()),
+                                    color: Some(rgba(0x1999b3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xbf40bfff).into()),
+                                    color: Some(rgba(0xe619c3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special.symbol".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x2a9292ff).into()),
+                                    color: Some(rgba(0x29a329ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x576ddaff).into()),
+                                    color: Some(rgba(0x3e62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "text.literal".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xaa573cff).into()),
+                                    color: Some(rgba(0x87711eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "title".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xefecf4ff).into()),
+                                    color: Some(rgba(0xf4fbf4ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -1846,28 +7891,28 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
+                                    color: Some(rgba(0x98981bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe2dfe7ff).into()),
+                                    color: Some(rgba(0xcfe8cfff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x955ae7ff).into()),
+                                    color: Some(rgba(0xad2beeff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
+                                    color: Some(rgba(0x98981bff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1876,170 +7921,170 @@ pub fn atelier() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Atelier Estuary Dark".into(),
-                appearance: Appearance::Dark,
+                name: "Atelier Seaside Light".into(),
+                appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x5d5c4cff).into()),
-                        border_variant: Some(rgba(0x3c3b31ff).into()),
-                        border_focused: Some(rgba(0x1c3927ff).into()),
-                        border_selected: Some(rgba(0x1c3927ff).into()),
+                        border: Some(rgba(0x8ea88eff).into()),
+                        border_variant: Some(rgba(0xbed7beff).into()),
+                        border_focused: Some(rgba(0xc9c4fdff).into()),
+                        border_selected: Some(rgba(0xc9c4fdff).into()),
                         border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x504f41ff).into()),
-                        elevated_surface_background: Some(rgba(0x2c2b23ff).into()),
-                        surface_background: Some(rgba(0x2c2b23ff).into()),
-                        background: Some(rgba(0x424136ff).into()),
-                        panel_background: Some(rgba(0x2c2b23ff).into()),
-                        element_background: Some(rgba(0x2c2b23ff).into()),
-                        element_hover: Some(rgba(0x3c3b31ff).into()),
-                        element_active: Some(rgba(0x5c5b4bff).into()),
-                        element_selected: Some(rgba(0x5c5b4bff).into()),
-                        element_disabled: Some(rgba(0x2c2b23ff).into()),
-                        drop_target_background: Some(rgba(0x91907f80).into()),
+                        border_disabled: Some(rgba(0xa1bba1ff).into()),
+                        elevated_surface_background: Some(rgba(0xdaeedaff).into()),
+                        surface_background: Some(rgba(0xdaeedaff).into()),
+                        background: Some(rgba(0xb4ceb4ff).into()),
+                        panel_background: Some(rgba(0xdaeedaff).into()),
+                        element_background: Some(rgba(0xdaeedaff).into()),
+                        element_hover: Some(rgba(0xbed7beff).into()),
+                        element_active: Some(rgba(0x90aa90ff).into()),
+                        element_selected: Some(rgba(0x90aa90ff).into()),
+                        element_disabled: Some(rgba(0xdaeedaff).into()),
+                        drop_target_background: Some(rgba(0x5f705f80).into()),
                         ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x3c3b31ff).into()),
-                        ghost_element_active: Some(rgba(0x5c5b4bff).into()),
-                        ghost_element_selected: Some(rgba(0x5c5b4bff).into()),
-                        ghost_element_disabled: Some(rgba(0x2c2b23ff).into()),
-                        text: Some(rgba(0xf4f3ecff).into()),
-                        text_muted: Some(rgba(0x91907fff).into()),
-                        text_placeholder: Some(rgba(0x7d7c6aff).into()),
-                        text_disabled: Some(rgba(0x7d7c6aff).into()),
-                        text_accent: Some(rgba(0x37a166ff).into()),
-                        icon: Some(rgba(0xf4f3ecff).into()),
-                        icon_muted: Some(rgba(0x91907fff).into()),
-                        icon_disabled: Some(rgba(0x7d7c6aff).into()),
-                        icon_placeholder: Some(rgba(0x91907fff).into()),
-                        icon_accent: Some(rgba(0x37a166ff).into()),
-                        status_bar_background: Some(rgba(0x424136ff).into()),
-                        title_bar_background: Some(rgba(0x424136ff).into()),
-                        toolbar_background: Some(rgba(0x22221bff).into()),
-                        tab_bar_background: Some(rgba(0x2c2b23ff).into()),
-                        tab_inactive_background: Some(rgba(0x2c2b23ff).into()),
-                        tab_active_background: Some(rgba(0x22221bff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xf4f3ec4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x3c3b31ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x3c3b31ff).into()),
+                        ghost_element_hover: Some(rgba(0xbed7beff).into()),
+                        ghost_element_active: Some(rgba(0x90aa90ff).into()),
+                        ghost_element_selected: Some(rgba(0x90aa90ff).into()),
+                        ghost_element_disabled: Some(rgba(0xdaeedaff).into()),
+                        text: Some(rgba(0x131513ff).into()),
+                        text_muted: Some(rgba(0x5f705fff).into()),
+                        text_placeholder: Some(rgba(0x718771ff).into()),
+                        text_disabled: Some(rgba(0x718771ff).into()),
+                        text_accent: Some(rgba(0x3f62f4ff).into()),
+                        icon: Some(rgba(0x131513ff).into()),
+                        icon_muted: Some(rgba(0x5f705fff).into()),
+                        icon_disabled: Some(rgba(0x718771ff).into()),
+                        icon_placeholder: Some(rgba(0x5f705fff).into()),
+                        icon_accent: Some(rgba(0x3f62f4ff).into()),
+                        status_bar_background: Some(rgba(0xb4ceb4ff).into()),
+                        title_bar_background: Some(rgba(0xb4ceb4ff).into()),
+                        toolbar_background: Some(rgba(0xf4fbf4ff).into()),
+                        tab_bar_background: Some(rgba(0xdaeedaff).into()),
+                        tab_inactive_background: Some(rgba(0xdaeedaff).into()),
+                        tab_active_background: Some(rgba(0xf4fbf4ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x1315134c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xbed7beff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xbed7beff).into()),
                         scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x2a2922ff).into()),
-                        editor_foreground: Some(rgba(0xe7e6dfff).into()),
-                        editor_background: Some(rgba(0x22221bff).into()),
-                        editor_gutter_background: Some(rgba(0x22221bff).into()),
-                        editor_subheader_background: Some(rgba(0x2c2b23ff).into()),
-                        editor_active_line_background: Some(rgba(0x2c2b23bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x2c2b23ff).into()),
-                        editor_line_number: Some(rgba(0xf4f3ec59).into()),
-                        editor_active_line_number: Some(rgba(0xf4f3ecff).into()),
-                        editor_invisible: Some(rgba(0x91907fff).into()),
-                        editor_wrap_guide: Some(rgba(0xf4f3ec0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xf4f3ec1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x37a1661a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x7a786766).into()),
-                        terminal_background: Some(rgba(0x22221bff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x6a6958ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x5c331fff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x3f491aff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x514a14ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x234e34ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x4c373eff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x314c27ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xf4f3ecff).into()),
-                        terminal_ansi_black: Some(rgba(0x22221bff).into()),
-                        terminal_ansi_red: Some(rgba(0xba6237ff).into()),
-                        terminal_ansi_green: Some(rgba(0x7d9727ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xa59810ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x37a166ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0x9d6c7cff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x5b9d48ff).into()),
-                        terminal_ansi_white: Some(rgba(0xf4f3ecff).into()),
-                        link_text_hover: Some(rgba(0x37a166ff).into()),
+                        scrollbar_track_border: Some(rgba(0xdff0dfff).into()),
+                        editor_foreground: Some(rgba(0x242924ff).into()),
+                        editor_background: Some(rgba(0xf4fbf4ff).into()),
+                        editor_gutter_background: Some(rgba(0xf4fbf4ff).into()),
+                        editor_subheader_background: Some(rgba(0xdaeedaff).into()),
+                        editor_active_line_background: Some(rgba(0xdaeedabf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xdaeedaff).into()),
+                        editor_line_number: Some(rgba(0x13151359).into()),
+                        editor_active_line_number: Some(rgba(0x131513ff).into()),
+                        editor_invisible: Some(rgba(0x5f705fff).into()),
+                        editor_wrap_guide: Some(rgba(0x1315130d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x1315131a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x3f62f41a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x748b7466).into()),
+                        terminal_background: Some(rgba(0xf4fbf4ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x829b82ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xff9d98ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xa0d294ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xd0ca90ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xb1adfcff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xf9a1e1ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x9fccd9ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x131513ff).into()),
+                        terminal_ansi_black: Some(rgba(0xf4fbf4ff).into()),
+                        terminal_ansi_red: Some(rgba(0xe61c3dff).into()),
+                        terminal_ansi_green: Some(rgba(0x2ba32bff).into()),
+                        terminal_ansi_yellow: Some(rgba(0x98981dff).into()),
+                        terminal_ansi_blue: Some(rgba(0x3f62f4ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xe61dc3ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x1d99b3ff).into()),
+                        terminal_ansi_white: Some(rgba(0x131513ff).into()),
+                        link_text_hover: Some(rgba(0x3f62f4ff).into()),
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xa59810ff).into()),
-                        conflict_background: Some(rgba(0x25210dff).into()),
-                        conflict_border: Some(rgba(0x3b3612ff).into()),
-                        created: Some(rgba(0x7d9727ff).into()),
-                        created_background: Some(rgba(0x1e2110ff).into()),
-                        created_border: Some(rgba(0x2f3516ff).into()),
-                        deleted: Some(rgba(0xba6237ff).into()),
-                        deleted_background: Some(rgba(0x2b1811ff).into()),
-                        deleted_border: Some(rgba(0x442619ff).into()),
-                        error: Some(rgba(0xba6237ff).into()),
-                        error_background: Some(rgba(0x2b1811ff).into()),
-                        error_border: Some(rgba(0x442619ff).into()),
-                        hidden: Some(rgba(0x7d7c6aff).into()),
-                        hidden_background: Some(rgba(0x424136ff).into()),
-                        hidden_border: Some(rgba(0x504f41ff).into()),
-                        hint: Some(rgba(0x70825bff).into()),
-                        hint_background: Some(rgba(0x142319ff).into()),
-                        hint_border: Some(rgba(0x1c3927ff).into()),
-                        ignored: Some(rgba(0x91907fff).into()),
-                        ignored_background: Some(rgba(0x424136ff).into()),
-                        ignored_border: Some(rgba(0x5d5c4cff).into()),
-                        info: Some(rgba(0x37a166ff).into()),
-                        info_background: Some(rgba(0x142319ff).into()),
-                        info_border: Some(rgba(0x1c3927ff).into()),
-                        modified: Some(rgba(0xa59810ff).into()),
-                        modified_background: Some(rgba(0x25210dff).into()),
-                        modified_border: Some(rgba(0x3b3612ff).into()),
-                        predictive: Some(rgba(0x5f724cff).into()),
-                        predictive_background: Some(rgba(0x1e2110ff).into()),
-                        predictive_border: Some(rgba(0x2f3516ff).into()),
-                        renamed: Some(rgba(0x37a166ff).into()),
-                        renamed_background: Some(rgba(0x142319ff).into()),
-                        renamed_border: Some(rgba(0x1c3927ff).into()),
-                        success: Some(rgba(0x7d9727ff).into()),
-                        success_background: Some(rgba(0x1e2110ff).into()),
-                        success_border: Some(rgba(0x2f3516ff).into()),
-                        unreachable: Some(rgba(0x91907fff).into()),
-                        unreachable_background: Some(rgba(0x424136ff).into()),
-                        unreachable_border: Some(rgba(0x5d5c4cff).into()),
-                        warning: Some(rgba(0xa59810ff).into()),
-                        warning_background: Some(rgba(0x25210dff).into()),
-                        warning_border: Some(rgba(0x3b3612ff).into()),
+                        conflict: Some(rgba(0x98981dff).into()),
+                        conflict_background: Some(rgba(0xede9d2ff).into()),
+                        conflict_border: Some(rgba(0xddd8afff).into()),
+                        created: Some(rgba(0x2ba32bff).into()),
+                        created_background: Some(rgba(0xd9edd4ff).into()),
+                        created_border: Some(rgba(0xbbdeb2ff).into()),
+                        deleted: Some(rgba(0xe61c3dff).into()),
+                        deleted_background: Some(rgba(0xffd8d4ff).into()),
+                        deleted_border: Some(rgba(0xffb9b4ff).into()),
+                        error: Some(rgba(0xe61c3dff).into()),
+                        error_background: Some(rgba(0xffd8d4ff).into()),
+                        error_border: Some(rgba(0xffb9b4ff).into()),
+                        hidden: Some(rgba(0x718771ff).into()),
+                        hidden_background: Some(rgba(0xb4ceb4ff).into()),
+                        hidden_border: Some(rgba(0xa1bba1ff).into()),
+                        hint: Some(rgba(0x008fa1ff).into()),
+                        hint_background: Some(rgba(0xe1ddfeff).into()),
+                        hint_border: Some(rgba(0xc9c4fdff).into()),
+                        ignored: Some(rgba(0x5f705fff).into()),
+                        ignored_background: Some(rgba(0xb4ceb4ff).into()),
+                        ignored_border: Some(rgba(0x8ea88eff).into()),
+                        info: Some(rgba(0x3f62f4ff).into()),
+                        info_background: Some(rgba(0xe1ddfeff).into()),
+                        info_border: Some(rgba(0xc9c4fdff).into()),
+                        modified: Some(rgba(0x98981dff).into()),
+                        modified_background: Some(rgba(0xede9d2ff).into()),
+                        modified_border: Some(rgba(0xddd8afff).into()),
+                        predictive: Some(rgba(0x00a2b5ff).into()),
+                        predictive_background: Some(rgba(0xd9edd4ff).into()),
+                        predictive_border: Some(rgba(0xbbdeb2ff).into()),
+                        renamed: Some(rgba(0x3f62f4ff).into()),
+                        renamed_background: Some(rgba(0xe1ddfeff).into()),
+                        renamed_border: Some(rgba(0xc9c4fdff).into()),
+                        success: Some(rgba(0x2ba32bff).into()),
+                        success_background: Some(rgba(0xd9edd4ff).into()),
+                        success_border: Some(rgba(0xbbdeb2ff).into()),
+                        unreachable: Some(rgba(0x5f705fff).into()),
+                        unreachable_background: Some(rgba(0xb4ceb4ff).into()),
+                        unreachable_border: Some(rgba(0x8ea88eff).into()),
+                        warning: Some(rgba(0x98981dff).into()),
+                        warning_background: Some(rgba(0xede9d2ff).into()),
+                        warning_border: Some(rgba(0xddd8afff).into()),
                         ..Default::default()
                     },
                     player: Some(PlayerColors(vec![
                         PlayerColor {
-                            cursor: rgba(0x37a166ff).into(),
-                            background: rgba(0x37a166ff).into(),
-                            selection: rgba(0x37a1663d).into(),
+                            cursor: rgba(0x3f62f4ff).into(),
+                            background: rgba(0x3f62f4ff).into(),
+                            selection: rgba(0x3f62f43d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x9d6c7cff).into(),
-                            background: rgba(0x9d6c7cff).into(),
-                            selection: rgba(0x9d6c7c3d).into(),
+                            cursor: rgba(0xe61dc3ff).into(),
+                            background: rgba(0xe61dc3ff).into(),
+                            selection: rgba(0xe61dc33d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xae7315ff).into(),
-                            background: rgba(0xae7315ff).into(),
-                            selection: rgba(0xae73153d).into(),
+                            cursor: rgba(0x87711fff).into(),
+                            background: rgba(0x87711fff).into(),
+                            selection: rgba(0x87711f3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x5f9182ff).into(),
-                            background: rgba(0x5f9182ff).into(),
-                            selection: rgba(0x5f91823d).into(),
+                            cursor: rgba(0xad2dedff).into(),
+                            background: rgba(0xad2dedff).into(),
+                            selection: rgba(0xad2ded3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x5b9d48ff).into(),
-                            background: rgba(0x5b9d48ff).into(),
-                            selection: rgba(0x5b9d483d).into(),
+                            cursor: rgba(0x1d99b3ff).into(),
+                            background: rgba(0x1d99b3ff).into(),
+                            selection: rgba(0x1d99b33d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xba6237ff).into(),
-                            background: rgba(0xba6237ff).into(),
-                            selection: rgba(0xba62373d).into(),
+                            cursor: rgba(0xe61c3dff).into(),
+                            background: rgba(0xe61c3dff).into(),
+                            selection: rgba(0xe61c3d3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xa59810ff).into(),
-                            background: rgba(0xa59810ff).into(),
-                            selection: rgba(0xa598103d).into(),
+                            cursor: rgba(0x98981dff).into(),
+                            background: rgba(0x98981dff).into(),
+                            selection: rgba(0x98981d3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x7d9727ff).into(),
-                            background: rgba(0x7d9727ff).into(),
-                            selection: rgba(0x7d97273d).into(),
+                            cursor: rgba(0x2ba32bff).into(),
+                            background: rgba(0x2ba32bff).into(),
+                            selection: rgba(0x2ba32b3d).into(),
                         },
                     ])),
                     syntax: Some(UserSyntaxTheme {
@@ -2047,63 +8092,63 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x37a166ff).into()),
+                                    color: Some(rgba(0x3f62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "boolean".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7d9727ff).into()),
+                                    color: Some(rgba(0x2ba32bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x6c6b5aff).into()),
+                                    color: Some(rgba(0x809980ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x929181ff).into()),
+                                    color: Some(rgba(0x5e6e5eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7d9727ff).into()),
+                                    color: Some(rgba(0x2ba32bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constructor".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x37a166ff).into()),
+                                    color: Some(rgba(0x3f62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "embedded".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf4f3ecff).into()),
+                                    color: Some(rgba(0x131513ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x37a166ff).into()),
+                                    color: Some(rgba(0x3f62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x37a166ff).into()),
+                                    color: Some(rgba(0x3f62f4ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -2111,35 +8156,35 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "enum".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xae7315ff).into()),
+                                    color: Some(rgba(0x87711fff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x36a166ff).into()),
+                                    color: Some(rgba(0x3d62f5ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function.method".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x36a166ff).into()),
+                                    color: Some(rgba(0x3d62f5ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function.special.definition".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa5980dff).into()),
+                                    color: Some(rgba(0x98981bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "hint".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x70825bff).into()),
+                                    color: Some(rgba(0x008fa1ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -2147,21 +8192,21 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5f9182ff).into()),
+                                    color: Some(rgba(0xad2beeff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "label".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x37a166ff).into()),
+                                    color: Some(rgba(0x3f62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xae7315ff).into()),
+                                    color: Some(rgba(0x87711fff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -2169,28 +8214,28 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7d9727ff).into()),
+                                    color: Some(rgba(0x2ba32bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "number".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xae7313ff).into()),
+                                    color: Some(rgba(0x87711dff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "operator".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x929181ff).into()),
+                                    color: Some(rgba(0x5e6e5eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "predictive".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5f724cff).into()),
+                                    color: Some(rgba(0x00a2b5ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -2198,112 +8243,112 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "preproc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf4f3ecff).into()),
+                                    color: Some(rgba(0x131513ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "primary".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    color: Some(rgba(0x242924ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xba6236ff).into()),
+                                    color: Some(rgba(0xe6193cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    color: Some(rgba(0x242924ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.bracket".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x929181ff).into()),
+                                    color: Some(rgba(0x5e6e5eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x929181ff).into()),
+                                    color: Some(rgba(0x5e6e5eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.list_marker".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    color: Some(rgba(0x242924ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x9d6c7cff).into()),
+                                    color: Some(rgba(0xe619c3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7d9726ff).into()),
+                                    color: Some(rgba(0x29a329ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.escape".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x929181ff).into()),
+                                    color: Some(rgba(0x5e6e5eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.regex".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5b9d48ff).into()),
+                                    color: Some(rgba(0x1999b3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x9d6c7cff).into()),
+                                    color: Some(rgba(0xe619c3ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special.symbol".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7d9726ff).into()),
+                                    color: Some(rgba(0x29a329ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x37a166ff).into()),
+                                    color: Some(rgba(0x3f62f4ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "text.literal".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xae7315ff).into()),
+                                    color: Some(rgba(0x87711fff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "title".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xf4f3ecff).into()),
+                                    color: Some(rgba(0x131513ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -2311,28 +8356,28 @@ pub fn atelier() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa5980dff).into()),
+                                    color: Some(rgba(0x98981bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe7e6dfff).into()),
+                                    color: Some(rgba(0x242924ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5f9182ff).into()),
+                                    color: Some(rgba(0xad2beeff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa5980dff).into()),
+                                    color: Some(rgba(0x98981bff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -3263,6051 +9308,6 @@ pub fn atelier() -> UserThemeFamily {
                                 "variant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0xc08b30ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Dune Dark".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x6c695cff).into()),
-                        border_variant: Some(rgba(0x3b3933ff).into()),
-                        border_focused: Some(rgba(0x263056ff).into()),
-                        border_selected: Some(rgba(0x263056ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x58564bff).into()),
-                        elevated_surface_background: Some(rgba(0x262622ff).into()),
-                        surface_background: Some(rgba(0x262622ff).into()),
-                        background: Some(rgba(0x45433bff).into()),
-                        panel_background: Some(rgba(0x262622ff).into()),
-                        element_background: Some(rgba(0x262622ff).into()),
-                        element_hover: Some(rgba(0x3b3933ff).into()),
-                        element_active: Some(rgba(0x6a675aff).into()),
-                        element_selected: Some(rgba(0x6a675aff).into()),
-                        element_disabled: Some(rgba(0x262622ff).into()),
-                        drop_target_background: Some(rgba(0xa4a08b80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x3b3933ff).into()),
-                        ghost_element_active: Some(rgba(0x6a675aff).into()),
-                        ghost_element_selected: Some(rgba(0x6a675aff).into()),
-                        ghost_element_disabled: Some(rgba(0x262622ff).into()),
-                        text: Some(rgba(0xfefbecff).into()),
-                        text_muted: Some(rgba(0xa4a08bff).into()),
-                        text_placeholder: Some(rgba(0x8f8b77ff).into()),
-                        text_disabled: Some(rgba(0x8f8b77ff).into()),
-                        text_accent: Some(rgba(0x6684e0ff).into()),
-                        icon: Some(rgba(0xfefbecff).into()),
-                        icon_muted: Some(rgba(0xa4a08bff).into()),
-                        icon_disabled: Some(rgba(0x8f8b77ff).into()),
-                        icon_placeholder: Some(rgba(0xa4a08bff).into()),
-                        icon_accent: Some(rgba(0x6684e0ff).into()),
-                        status_bar_background: Some(rgba(0x45433bff).into()),
-                        title_bar_background: Some(rgba(0x45433bff).into()),
-                        toolbar_background: Some(rgba(0x20201dff).into()),
-                        tab_bar_background: Some(rgba(0x262622ff).into()),
-                        tab_inactive_background: Some(rgba(0x262622ff).into()),
-                        tab_active_background: Some(rgba(0x20201dff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xfefbec4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x3b3933ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x3b3933ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x252521ff).into()),
-                        editor_foreground: Some(rgba(0xe8e4cfff).into()),
-                        editor_background: Some(rgba(0x20201dff).into()),
-                        editor_gutter_background: Some(rgba(0x20201dff).into()),
-                        editor_subheader_background: Some(rgba(0x262622ff).into()),
-                        editor_active_line_background: Some(rgba(0x262622bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x262622ff).into()),
-                        editor_line_number: Some(rgba(0xfefbec59).into()),
-                        editor_active_line_number: Some(rgba(0xfefbecff).into()),
-                        editor_invisible: Some(rgba(0xa4a08bff).into()),
-                        editor_wrap_guide: Some(rgba(0xfefbec0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xfefbec1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x6684e01a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x8b887466).into()),
-                        terminal_background: Some(rgba(0x20201dff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x7a7766ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x781c1fff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x335322ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x574815ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x334173ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x721d2bff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x1e5341ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xfefbecff).into()),
-                        terminal_ansi_black: Some(rgba(0x20201dff).into()),
-                        terminal_ansi_red: Some(rgba(0xd73837ff).into()),
-                        terminal_ansi_green: Some(rgba(0x60ac3aff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xae9515ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x6684e0ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xd43652ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x21ad83ff).into()),
-                        terminal_ansi_white: Some(rgba(0xfefbecff).into()),
-                        link_text_hover: Some(rgba(0x6684e0ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xae9515ff).into()),
-                        conflict_background: Some(rgba(0x2a200eff).into()),
-                        conflict_border: Some(rgba(0x413513ff).into()),
-                        created: Some(rgba(0x60ac3aff).into()),
-                        created_background: Some(rgba(0x1a2413ff).into()),
-                        created_border: Some(rgba(0x273c1bff).into()),
-                        deleted: Some(rgba(0xd73837ff).into()),
-                        deleted_background: Some(rgba(0x450d11ff).into()),
-                        deleted_border: Some(rgba(0x5f1519ff).into()),
-                        error: Some(rgba(0xd73837ff).into()),
-                        error_background: Some(rgba(0x450d11ff).into()),
-                        error_border: Some(rgba(0x5f1519ff).into()),
-                        hidden: Some(rgba(0x8f8b77ff).into()),
-                        hidden_background: Some(rgba(0x45433bff).into()),
-                        hidden_border: Some(rgba(0x58564bff).into()),
-                        hint: Some(rgba(0xb17272ff).into()),
-                        hint_background: Some(rgba(0x171e39ff).into()),
-                        hint_border: Some(rgba(0x263056ff).into()),
-                        ignored: Some(rgba(0xa4a08bff).into()),
-                        ignored_background: Some(rgba(0x45433bff).into()),
-                        ignored_border: Some(rgba(0x6c695cff).into()),
-                        info: Some(rgba(0x6684e0ff).into()),
-                        info_background: Some(rgba(0x171e39ff).into()),
-                        info_border: Some(rgba(0x263056ff).into()),
-                        modified: Some(rgba(0xae9515ff).into()),
-                        modified_background: Some(rgba(0x2a200eff).into()),
-                        modified_border: Some(rgba(0x413513ff).into()),
-                        predictive: Some(rgba(0x9c6262ff).into()),
-                        predictive_background: Some(rgba(0x1a2413ff).into()),
-                        predictive_border: Some(rgba(0x273c1bff).into()),
-                        renamed: Some(rgba(0x6684e0ff).into()),
-                        renamed_background: Some(rgba(0x171e39ff).into()),
-                        renamed_border: Some(rgba(0x263056ff).into()),
-                        success: Some(rgba(0x60ac3aff).into()),
-                        success_background: Some(rgba(0x1a2413ff).into()),
-                        success_border: Some(rgba(0x273c1bff).into()),
-                        unreachable: Some(rgba(0xa4a08bff).into()),
-                        unreachable_background: Some(rgba(0x45433bff).into()),
-                        unreachable_border: Some(rgba(0x6c695cff).into()),
-                        warning: Some(rgba(0xae9515ff).into()),
-                        warning_background: Some(rgba(0x2a200eff).into()),
-                        warning_border: Some(rgba(0x413513ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x6684e0ff).into(),
-                            background: rgba(0x6684e0ff).into(),
-                            selection: rgba(0x6684e03d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd43652ff).into(),
-                            background: rgba(0xd43652ff).into(),
-                            selection: rgba(0xd436523d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb65612ff).into(),
-                            background: rgba(0xb65612ff).into(),
-                            selection: rgba(0xb656123d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb854d3ff).into(),
-                            background: rgba(0xb854d3ff).into(),
-                            selection: rgba(0xb854d33d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x21ad83ff).into(),
-                            background: rgba(0x21ad83ff).into(),
-                            selection: rgba(0x21ad833d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd73837ff).into(),
-                            background: rgba(0xd73837ff).into(),
-                            selection: rgba(0xd738373d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xae9515ff).into(),
-                            background: rgba(0xae9515ff).into(),
-                            selection: rgba(0xae95153d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x60ac3aff).into(),
-                            background: rgba(0x60ac3aff).into(),
-                            selection: rgba(0x60ac3a3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac3aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7d7a68ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa6a28cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac3aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfefbecff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e0ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65612ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xae9513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb17272ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb854d4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65612ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac3aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65611ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa6a28cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9c6262ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfefbecff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe8e4cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd73737ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe8e4cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa6a28cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa6a28cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe8e4cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd43552ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac39ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa6a28cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1fad83ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd43552ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac39ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65612ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfefbecff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xae9513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe8e4cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb854d4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xae9513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Seaside Dark".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x5c6c5cff).into()),
-                        border_variant: Some(rgba(0x333b33ff).into()),
-                        border_focused: Some(rgba(0x102668ff).into()),
-                        border_selected: Some(rgba(0x102668ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x4b584bff).into()),
-                        elevated_surface_background: Some(rgba(0x1f231fff).into()),
-                        surface_background: Some(rgba(0x1f231fff).into()),
-                        background: Some(rgba(0x3b453bff).into()),
-                        panel_background: Some(rgba(0x1f231fff).into()),
-                        element_background: Some(rgba(0x1f231fff).into()),
-                        element_hover: Some(rgba(0x333b33ff).into()),
-                        element_active: Some(rgba(0x5a6a5aff).into()),
-                        element_selected: Some(rgba(0x5a6a5aff).into()),
-                        element_disabled: Some(rgba(0x1f231fff).into()),
-                        drop_target_background: Some(rgba(0x8ba48b80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x333b33ff).into()),
-                        ghost_element_active: Some(rgba(0x5a6a5aff).into()),
-                        ghost_element_selected: Some(rgba(0x5a6a5aff).into()),
-                        ghost_element_disabled: Some(rgba(0x1f231fff).into()),
-                        text: Some(rgba(0xf4fbf4ff).into()),
-                        text_muted: Some(rgba(0x8ba48bff).into()),
-                        text_placeholder: Some(rgba(0x778f77ff).into()),
-                        text_disabled: Some(rgba(0x778f77ff).into()),
-                        text_accent: Some(rgba(0x3e62f4ff).into()),
-                        icon: Some(rgba(0xf4fbf4ff).into()),
-                        icon_muted: Some(rgba(0x8ba48bff).into()),
-                        icon_disabled: Some(rgba(0x778f77ff).into()),
-                        icon_placeholder: Some(rgba(0x8ba48bff).into()),
-                        icon_accent: Some(rgba(0x3e62f4ff).into()),
-                        status_bar_background: Some(rgba(0x3b453bff).into()),
-                        title_bar_background: Some(rgba(0x3b453bff).into()),
-                        toolbar_background: Some(rgba(0x131513ff).into()),
-                        tab_bar_background: Some(rgba(0x1f231fff).into()),
-                        tab_inactive_background: Some(rgba(0x1f231fff).into()),
-                        tab_active_background: Some(rgba(0x131513ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xf4fbf44c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x333b33ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x333b33ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x1d201dff).into()),
-                        editor_foreground: Some(rgba(0xcfe8cfff).into()),
-                        editor_background: Some(rgba(0x131513ff).into()),
-                        editor_gutter_background: Some(rgba(0x131513ff).into()),
-                        editor_subheader_background: Some(rgba(0x1f231fff).into()),
-                        editor_active_line_background: Some(rgba(0x1f231fbf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x1f231fff).into()),
-                        editor_line_number: Some(rgba(0xf4fbf459).into()),
-                        editor_active_line_number: Some(rgba(0xf4fbf4ff).into()),
-                        editor_invisible: Some(rgba(0x8ba48bff).into()),
-                        editor_wrap_guide: Some(rgba(0xf4fbf40d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xf4fbf41a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x3e62f41a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x748b7466).into()),
-                        terminal_background: Some(rgba(0x131513ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x667a66ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x840b21ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x204f1bff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x4b4a17ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x193385ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x810e60ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x1d4a56ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xf4fbf4ff).into()),
-                        terminal_ansi_black: Some(rgba(0x131513ff).into()),
-                        terminal_ansi_red: Some(rgba(0xe61c3cff).into()),
-                        terminal_ansi_green: Some(rgba(0x2ba32aff).into()),
-                        terminal_ansi_yellow: Some(rgba(0x98981cff).into()),
-                        terminal_ansi_blue: Some(rgba(0x3e62f4ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xe61cc3ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x1c99b3ff).into()),
-                        terminal_ansi_white: Some(rgba(0xf4fbf4ff).into()),
-                        link_text_hover: Some(rgba(0x3e62f4ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0x98981cff).into()),
-                        conflict_background: Some(rgba(0x22210fff).into()),
-                        conflict_border: Some(rgba(0x373614ff).into()),
-                        created: Some(rgba(0x2ba32aff).into()),
-                        created_background: Some(rgba(0x142310ff).into()),
-                        created_border: Some(rgba(0x1b3917ff).into()),
-                        deleted: Some(rgba(0xe61c3cff).into()),
-                        deleted_background: Some(rgba(0x500412ff).into()),
-                        deleted_border: Some(rgba(0x6b071aff).into()),
-                        error: Some(rgba(0xe61c3cff).into()),
-                        error_background: Some(rgba(0x500412ff).into()),
-                        error_border: Some(rgba(0x6b071aff).into()),
-                        hidden: Some(rgba(0x778f77ff).into()),
-                        hidden_background: Some(rgba(0x3b453bff).into()),
-                        hidden_border: Some(rgba(0x4b584bff).into()),
-                        hint: Some(rgba(0x008b9fff).into()),
-                        hint_background: Some(rgba(0x061949ff).into()),
-                        hint_border: Some(rgba(0x102668ff).into()),
-                        ignored: Some(rgba(0x8ba48bff).into()),
-                        ignored_background: Some(rgba(0x3b453bff).into()),
-                        ignored_border: Some(rgba(0x5c6c5cff).into()),
-                        info: Some(rgba(0x3e62f4ff).into()),
-                        info_background: Some(rgba(0x061949ff).into()),
-                        info_border: Some(rgba(0x102668ff).into()),
-                        modified: Some(rgba(0x98981cff).into()),
-                        modified_background: Some(rgba(0x22210fff).into()),
-                        modified_border: Some(rgba(0x373614ff).into()),
-                        predictive: Some(rgba(0x00788bff).into()),
-                        predictive_background: Some(rgba(0x142310ff).into()),
-                        predictive_border: Some(rgba(0x1b3917ff).into()),
-                        renamed: Some(rgba(0x3e62f4ff).into()),
-                        renamed_background: Some(rgba(0x061949ff).into()),
-                        renamed_border: Some(rgba(0x102668ff).into()),
-                        success: Some(rgba(0x2ba32aff).into()),
-                        success_background: Some(rgba(0x142310ff).into()),
-                        success_border: Some(rgba(0x1b3917ff).into()),
-                        unreachable: Some(rgba(0x8ba48bff).into()),
-                        unreachable_background: Some(rgba(0x3b453bff).into()),
-                        unreachable_border: Some(rgba(0x5c6c5cff).into()),
-                        warning: Some(rgba(0x98981cff).into()),
-                        warning_background: Some(rgba(0x22210fff).into()),
-                        warning_border: Some(rgba(0x373614ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x3e62f4ff).into(),
-                            background: rgba(0x3e62f4ff).into(),
-                            selection: rgba(0x3e62f43d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xe61cc3ff).into(),
-                            background: rgba(0xe61cc3ff).into(),
-                            selection: rgba(0xe61cc33d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x87711eff).into(),
-                            background: rgba(0x87711eff).into(),
-                            selection: rgba(0x87711e3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xad2dedff).into(),
-                            background: rgba(0xad2dedff).into(),
-                            selection: rgba(0xad2ded3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x1c99b3ff).into(),
-                            background: rgba(0x1c99b3ff).into(),
-                            selection: rgba(0x1c99b33d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xe61c3cff).into(),
-                            background: rgba(0xe61c3cff).into(),
-                            selection: rgba(0xe61c3c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x98981cff).into(),
-                            background: rgba(0x98981cff).into(),
-                            selection: rgba(0x98981c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x2ba32aff).into(),
-                            background: rgba(0x2ba32aff).into(),
-                            selection: rgba(0x2ba32a3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3e62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ba32aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x687d68ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ca68cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ba32aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3e62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf4fbf4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3e62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3e62f4ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3d62f5ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3d62f5ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x98981bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x008b9fff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad2beeff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3e62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711eff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ba32aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ca68cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x00788bff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf4fbf4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcfe8cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe6193cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcfe8cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ca68cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ca68cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcfe8cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe619c3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x29a329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ca68cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1999b3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe619c3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x29a329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3e62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf4fbf4ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x98981bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcfe8cfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad2beeff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x98981bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Cave Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x8f8b96ff).into()),
-                        border_variant: Some(rgba(0xcbc8d1ff).into()),
-                        border_focused: Some(rgba(0xc9c8f3ff).into()),
-                        border_selected: Some(rgba(0xc9c8f3ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xa7a3adff).into()),
-                        elevated_surface_background: Some(rgba(0xe6e3ebff).into()),
-                        surface_background: Some(rgba(0xe6e3ebff).into()),
-                        background: Some(rgba(0xbfbcc5ff).into()),
-                        panel_background: Some(rgba(0xe6e3ebff).into()),
-                        element_background: Some(rgba(0xe6e3ebff).into()),
-                        element_hover: Some(rgba(0xcbc8d1ff).into()),
-                        element_active: Some(rgba(0x918d98ff).into()),
-                        element_selected: Some(rgba(0x918d98ff).into()),
-                        element_disabled: Some(rgba(0xe6e3ebff).into()),
-                        drop_target_background: Some(rgba(0x5a546280).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xcbc8d1ff).into()),
-                        ghost_element_active: Some(rgba(0x918d98ff).into()),
-                        ghost_element_selected: Some(rgba(0x918d98ff).into()),
-                        ghost_element_disabled: Some(rgba(0xe6e3ebff).into()),
-                        text: Some(rgba(0x19171cff).into()),
-                        text_muted: Some(rgba(0x5a5462ff).into()),
-                        text_placeholder: Some(rgba(0x6e6876ff).into()),
-                        text_disabled: Some(rgba(0x6e6876ff).into()),
-                        text_accent: Some(rgba(0x586ddaff).into()),
-                        icon: Some(rgba(0x19171cff).into()),
-                        icon_muted: Some(rgba(0x5a5462ff).into()),
-                        icon_disabled: Some(rgba(0x6e6876ff).into()),
-                        icon_placeholder: Some(rgba(0x5a5462ff).into()),
-                        icon_accent: Some(rgba(0x586ddaff).into()),
-                        status_bar_background: Some(rgba(0xbfbcc5ff).into()),
-                        title_bar_background: Some(rgba(0xbfbcc5ff).into()),
-                        toolbar_background: Some(rgba(0xefecf4ff).into()),
-                        tab_bar_background: Some(rgba(0xe6e3ebff).into()),
-                        tab_inactive_background: Some(rgba(0xe6e3ebff).into()),
-                        tab_active_background: Some(rgba(0xefecf4ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x19171c4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xcbc8d1ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xcbc8d1ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xe8e5edff).into()),
-                        editor_foreground: Some(rgba(0x26232aff).into()),
-                        editor_background: Some(rgba(0xefecf4ff).into()),
-                        editor_gutter_background: Some(rgba(0xefecf4ff).into()),
-                        editor_subheader_background: Some(rgba(0xe6e3ebff).into()),
-                        editor_active_line_background: Some(rgba(0xe6e3ebbf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xe6e3ebff).into()),
-                        editor_line_number: Some(rgba(0x19171c59).into()),
-                        editor_active_line_number: Some(rgba(0x19171cff).into()),
-                        editor_invisible: Some(rgba(0x5a5462ff).into()),
-                        editor_wrap_guide: Some(rgba(0x19171c0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x19171c1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x586dda1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x726c7a66).into()),
-                        terminal_background: Some(rgba(0xefecf4ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x807b89ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xe3a4b9ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x9dc8c8ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xd4b499ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xb3b3eeff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xe3a4dfff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0xa6c4e3ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x19171cff).into()),
-                        terminal_ansi_black: Some(rgba(0xefecf4ff).into()),
-                        terminal_ansi_red: Some(rgba(0xbe4778ff).into()),
-                        terminal_ansi_green: Some(rgba(0x2c9292ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xa06e3cff).into()),
-                        terminal_ansi_blue: Some(rgba(0x586ddaff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xbf41bfff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x3b8bc6ff).into()),
-                        terminal_ansi_white: Some(rgba(0x19171cff).into()),
-                        link_text_hover: Some(rgba(0x586ddaff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xa06e3cff).into()),
-                        conflict_background: Some(rgba(0xeee0d5ff).into()),
-                        conflict_border: Some(rgba(0xe0c9b5ff).into()),
-                        created: Some(rgba(0x2c9292ff).into()),
-                        created_background: Some(rgba(0xd7e9e8ff).into()),
-                        created_border: Some(rgba(0xb9d7d6ff).into()),
-                        deleted: Some(rgba(0xbe4778ff).into()),
-                        deleted_background: Some(rgba(0xf5dae2ff).into()),
-                        deleted_border: Some(rgba(0xecbecdff).into()),
-                        error: Some(rgba(0xbe4778ff).into()),
-                        error_background: Some(rgba(0xf5dae2ff).into()),
-                        error_border: Some(rgba(0xecbecdff).into()),
-                        hidden: Some(rgba(0x6e6876ff).into()),
-                        hidden_background: Some(rgba(0xbfbcc5ff).into()),
-                        hidden_border: Some(rgba(0xa7a3adff).into()),
-                        hint: Some(rgba(0x786e9dff).into()),
-                        hint_background: Some(rgba(0xe1e0f9ff).into()),
-                        hint_border: Some(rgba(0xc9c8f3ff).into()),
-                        ignored: Some(rgba(0x5a5462ff).into()),
-                        ignored_background: Some(rgba(0xbfbcc5ff).into()),
-                        ignored_border: Some(rgba(0x8f8b96ff).into()),
-                        info: Some(rgba(0x586ddaff).into()),
-                        info_background: Some(rgba(0xe1e0f9ff).into()),
-                        info_border: Some(rgba(0xc9c8f3ff).into()),
-                        modified: Some(rgba(0xa06e3cff).into()),
-                        modified_background: Some(rgba(0xeee0d5ff).into()),
-                        modified_border: Some(rgba(0xe0c9b5ff).into()),
-                        predictive: Some(rgba(0x887fafff).into()),
-                        predictive_background: Some(rgba(0xd7e9e8ff).into()),
-                        predictive_border: Some(rgba(0xb9d7d6ff).into()),
-                        renamed: Some(rgba(0x586ddaff).into()),
-                        renamed_background: Some(rgba(0xe1e0f9ff).into()),
-                        renamed_border: Some(rgba(0xc9c8f3ff).into()),
-                        success: Some(rgba(0x2c9292ff).into()),
-                        success_background: Some(rgba(0xd7e9e8ff).into()),
-                        success_border: Some(rgba(0xb9d7d6ff).into()),
-                        unreachable: Some(rgba(0x5a5462ff).into()),
-                        unreachable_background: Some(rgba(0xbfbcc5ff).into()),
-                        unreachable_border: Some(rgba(0x8f8b96ff).into()),
-                        warning: Some(rgba(0xa06e3cff).into()),
-                        warning_background: Some(rgba(0xeee0d5ff).into()),
-                        warning_border: Some(rgba(0xe0c9b5ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x586ddaff).into(),
-                            background: rgba(0x586ddaff).into(),
-                            selection: rgba(0x586dda3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xbf41bfff).into(),
-                            background: rgba(0xbf41bfff).into(),
-                            selection: rgba(0xbf41bf3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xaa583dff).into(),
-                            background: rgba(0xaa583dff).into(),
-                            selection: rgba(0xaa583d3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x955be6ff).into(),
-                            background: rgba(0x955be6ff).into(),
-                            selection: rgba(0x955be63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x3b8bc6ff).into(),
-                            background: rgba(0x3b8bc6ff).into(),
-                            selection: rgba(0x3b8bc63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xbe4778ff).into(),
-                            background: rgba(0xbe4778ff).into(),
-                            selection: rgba(0xbe47783d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa06e3cff).into(),
-                            background: rgba(0xa06e3cff).into(),
-                            selection: rgba(0xa06e3c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x2c9292ff).into(),
-                            background: rgba(0x2c9292ff).into(),
-                            selection: rgba(0x2c92923d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x586ddaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c9292ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7e7887ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585260ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c9292ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x586ddaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x19171cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x586ddaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x586ddaff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xaa583dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x576ddbff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x576ddbff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x786e9dff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x955ae7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x586ddaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xaa583dff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c9292ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xaa573cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585260ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x887fafff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x19171cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x26232aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbe4678ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x26232aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585260ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585260ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x26232aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbf40bfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2a9292ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585260ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x398bc6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbf40bfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2a9292ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x586ddaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xaa583dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x19171cff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x26232aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x955ae7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Plateau Dark".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x564e4eff).into()),
-                        border_variant: Some(rgba(0x352f2fff).into()),
-                        border_focused: Some(rgba(0x2c2b45ff).into()),
-                        border_selected: Some(rgba(0x2c2b45ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x494242ff).into()),
-                        elevated_surface_background: Some(rgba(0x252020ff).into()),
-                        surface_background: Some(rgba(0x252020ff).into()),
-                        background: Some(rgba(0x3b3535ff).into()),
-                        panel_background: Some(rgba(0x252020ff).into()),
-                        element_background: Some(rgba(0x252020ff).into()),
-                        element_hover: Some(rgba(0x352f2fff).into()),
-                        element_active: Some(rgba(0x554d4dff).into()),
-                        element_selected: Some(rgba(0x554d4dff).into()),
-                        element_disabled: Some(rgba(0x252020ff).into()),
-                        drop_target_background: Some(rgba(0x89838380).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x352f2fff).into()),
-                        ghost_element_active: Some(rgba(0x554d4dff).into()),
-                        ghost_element_selected: Some(rgba(0x554d4dff).into()),
-                        ghost_element_disabled: Some(rgba(0x252020ff).into()),
-                        text: Some(rgba(0xf4ececff).into()),
-                        text_muted: Some(rgba(0x898383ff).into()),
-                        text_placeholder: Some(rgba(0x756e6eff).into()),
-                        text_disabled: Some(rgba(0x756e6eff).into()),
-                        text_accent: Some(rgba(0x7272caff).into()),
-                        icon: Some(rgba(0xf4ececff).into()),
-                        icon_muted: Some(rgba(0x898383ff).into()),
-                        icon_disabled: Some(rgba(0x756e6eff).into()),
-                        icon_placeholder: Some(rgba(0x898383ff).into()),
-                        icon_accent: Some(rgba(0x7272caff).into()),
-                        status_bar_background: Some(rgba(0x3b3535ff).into()),
-                        title_bar_background: Some(rgba(0x3b3535ff).into()),
-                        toolbar_background: Some(rgba(0x1b1818ff).into()),
-                        tab_bar_background: Some(rgba(0x252020ff).into()),
-                        tab_inactive_background: Some(rgba(0x252020ff).into()),
-                        tab_active_background: Some(rgba(0x1b1818ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xf4ecec4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x352f2fff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x352f2fff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x231f1fff).into()),
-                        editor_foreground: Some(rgba(0xe7dfdfff).into()),
-                        editor_background: Some(rgba(0x1b1818ff).into()),
-                        editor_gutter_background: Some(rgba(0x1b1818ff).into()),
-                        editor_subheader_background: Some(rgba(0x252020ff).into()),
-                        editor_active_line_background: Some(rgba(0x252020bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x252020ff).into()),
-                        editor_line_number: Some(rgba(0xf4ecec59).into()),
-                        editor_active_line_number: Some(rgba(0xf4ececff).into()),
-                        editor_invisible: Some(rgba(0x898383ff).into()),
-                        editor_wrap_guide: Some(rgba(0xf4ecec0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xf4ecec1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x7272ca1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x726a6a66).into()),
-                        terminal_background: Some(rgba(0x1b1818ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x635b5bff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x692727ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x2a4444ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x4e3821ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x3b3960ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x5b2c42ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x2e4257ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xf4ececff).into()),
-                        terminal_ansi_black: Some(rgba(0x1b1818ff).into()),
-                        terminal_ansi_red: Some(rgba(0xca4949ff).into()),
-                        terminal_ansi_green: Some(rgba(0x4b8b8bff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xa06e3bff).into()),
-                        terminal_ansi_blue: Some(rgba(0x7272caff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xbd5187ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x5485b6ff).into()),
-                        terminal_ansi_white: Some(rgba(0xf4ececff).into()),
-                        link_text_hover: Some(rgba(0x7272caff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xa06e3bff).into()),
-                        conflict_background: Some(rgba(0x231a12ff).into()),
-                        conflict_border: Some(rgba(0x392a1aff).into()),
-                        created: Some(rgba(0x4b8b8bff).into()),
-                        created_background: Some(rgba(0x161f1fff).into()),
-                        created_border: Some(rgba(0x203232ff).into()),
-                        deleted: Some(rgba(0xca4949ff).into()),
-                        deleted_background: Some(rgba(0x361414ff).into()),
-                        deleted_border: Some(rgba(0x501e1eff).into()),
-                        error: Some(rgba(0xca4949ff).into()),
-                        error_background: Some(rgba(0x361414ff).into()),
-                        error_border: Some(rgba(0x501e1eff).into()),
-                        hidden: Some(rgba(0x756e6eff).into()),
-                        hidden_background: Some(rgba(0x3b3535ff).into()),
-                        hidden_border: Some(rgba(0x494242ff).into()),
-                        hint: Some(rgba(0x8a647aff).into()),
-                        hint_background: Some(rgba(0x1c1b29ff).into()),
-                        hint_border: Some(rgba(0x2c2b45ff).into()),
-                        ignored: Some(rgba(0x898383ff).into()),
-                        ignored_background: Some(rgba(0x3b3535ff).into()),
-                        ignored_border: Some(rgba(0x564e4eff).into()),
-                        info: Some(rgba(0x7272caff).into()),
-                        info_background: Some(rgba(0x1c1b29ff).into()),
-                        info_border: Some(rgba(0x2c2b45ff).into()),
-                        modified: Some(rgba(0xa06e3bff).into()),
-                        modified_background: Some(rgba(0x231a12ff).into()),
-                        modified_border: Some(rgba(0x392a1aff).into()),
-                        predictive: Some(rgba(0x795369ff).into()),
-                        predictive_background: Some(rgba(0x161f1fff).into()),
-                        predictive_border: Some(rgba(0x203232ff).into()),
-                        renamed: Some(rgba(0x7272caff).into()),
-                        renamed_background: Some(rgba(0x1c1b29ff).into()),
-                        renamed_border: Some(rgba(0x2c2b45ff).into()),
-                        success: Some(rgba(0x4b8b8bff).into()),
-                        success_background: Some(rgba(0x161f1fff).into()),
-                        success_border: Some(rgba(0x203232ff).into()),
-                        unreachable: Some(rgba(0x898383ff).into()),
-                        unreachable_background: Some(rgba(0x3b3535ff).into()),
-                        unreachable_border: Some(rgba(0x564e4eff).into()),
-                        warning: Some(rgba(0xa06e3bff).into()),
-                        warning_background: Some(rgba(0x231a12ff).into()),
-                        warning_border: Some(rgba(0x392a1aff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x7272caff).into(),
-                            background: rgba(0x7272caff).into(),
-                            selection: rgba(0x7272ca3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xbd5187ff).into(),
-                            background: rgba(0xbd5187ff).into(),
-                            selection: rgba(0xbd51873d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb45a3cff).into(),
-                            background: rgba(0xb45a3cff).into(),
-                            selection: rgba(0xb45a3c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x8464c4ff).into(),
-                            background: rgba(0x8464c4ff).into(),
-                            selection: rgba(0x8464c43d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x5485b6ff).into(),
-                            background: rgba(0x5485b6ff).into(),
-                            selection: rgba(0x5485b63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xca4949ff).into(),
-                            background: rgba(0xca4949ff).into(),
-                            selection: rgba(0xca49493d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa06e3bff).into(),
-                            background: rgba(0xa06e3bff).into(),
-                            selection: rgba(0xa06e3b3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x4b8b8bff).into(),
-                            background: rgba(0x4b8b8bff).into(),
-                            selection: rgba(0x4b8b8b3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x655d5dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8585ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf4ececff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45a3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a647aff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8464c4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45a3cff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45a3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8585ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x795369ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf4ececff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe7dfdfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xca4949ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe7dfdfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8585ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8585ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe7dfdfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbd5187ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8585ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5485b6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbd5187ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45a3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf4ececff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe7dfdfff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8464c4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Heath Dark".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x675b67ff).into()),
-                        border_variant: Some(rgba(0x393239ff).into()),
-                        border_focused: Some(rgba(0x1a2961ff).into()),
-                        border_selected: Some(rgba(0x1a2961ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x554a55ff).into()),
-                        elevated_surface_background: Some(rgba(0x252025ff).into()),
-                        surface_background: Some(rgba(0x252025ff).into()),
-                        background: Some(rgba(0x433a43ff).into()),
-                        panel_background: Some(rgba(0x252025ff).into()),
-                        element_background: Some(rgba(0x252025ff).into()),
-                        element_hover: Some(rgba(0x393239ff).into()),
-                        element_active: Some(rgba(0x655965ff).into()),
-                        element_selected: Some(rgba(0x655965ff).into()),
-                        element_disabled: Some(rgba(0x252025ff).into()),
-                        drop_target_background: Some(rgba(0xa99aa980).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x393239ff).into()),
-                        ghost_element_active: Some(rgba(0x655965ff).into()),
-                        ghost_element_selected: Some(rgba(0x655965ff).into()),
-                        ghost_element_disabled: Some(rgba(0x252025ff).into()),
-                        text: Some(rgba(0xf7f3f7ff).into()),
-                        text_muted: Some(rgba(0xa99aa9ff).into()),
-                        text_placeholder: Some(rgba(0x908190ff).into()),
-                        text_disabled: Some(rgba(0x908190ff).into()),
-                        text_accent: Some(rgba(0x526aebff).into()),
-                        icon: Some(rgba(0xf7f3f7ff).into()),
-                        icon_muted: Some(rgba(0xa99aa9ff).into()),
-                        icon_disabled: Some(rgba(0x908190ff).into()),
-                        icon_placeholder: Some(rgba(0xa99aa9ff).into()),
-                        icon_accent: Some(rgba(0x526aebff).into()),
-                        status_bar_background: Some(rgba(0x433a43ff).into()),
-                        title_bar_background: Some(rgba(0x433a43ff).into()),
-                        toolbar_background: Some(rgba(0x1b181bff).into()),
-                        tab_bar_background: Some(rgba(0x252025ff).into()),
-                        tab_inactive_background: Some(rgba(0x252025ff).into()),
-                        tab_active_background: Some(rgba(0x1b181bff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xf7f3f74c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x393239ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x393239ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x231e23ff).into()),
-                        editor_foreground: Some(rgba(0xd8cad8ff).into()),
-                        editor_background: Some(rgba(0x1b181bff).into()),
-                        editor_gutter_background: Some(rgba(0x1b181bff).into()),
-                        editor_subheader_background: Some(rgba(0x252025ff).into()),
-                        editor_active_line_background: Some(rgba(0x252025bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x252025ff).into()),
-                        editor_line_number: Some(rgba(0xf7f3f759).into()),
-                        editor_active_line_number: Some(rgba(0xf7f3f7ff).into()),
-                        editor_invisible: Some(rgba(0xa99aa9ff).into()),
-                        editor_wrap_guide: Some(rgba(0xf7f3f70d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xf7f3f71a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x526aeb1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x8b7c8b66).into()),
-                        terminal_background: Some(rgba(0x1b181bff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x756775ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x6d221aff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x474422ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x5e441fff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x26367eff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x6c1e67ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x1a4848ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xf7f3f7ff).into()),
-                        terminal_ansi_black: Some(rgba(0x1b181bff).into()),
-                        terminal_ansi_red: Some(rgba(0xca402cff).into()),
-                        terminal_ansi_green: Some(rgba(0x918b3bff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xbb8a36ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x526aebff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xcc34ccff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x189393ff).into()),
-                        terminal_ansi_white: Some(rgba(0xf7f3f7ff).into()),
-                        link_text_hover: Some(rgba(0x526aebff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xbb8a36ff).into()),
-                        conflict_background: Some(rgba(0x2d1e12ff).into()),
-                        conflict_border: Some(rgba(0x463219ff).into()),
-                        created: Some(rgba(0x918b3bff).into()),
-                        created_background: Some(rgba(0x211f12ff).into()),
-                        created_border: Some(rgba(0x34321bff).into()),
-                        deleted: Some(rgba(0xca402cff).into()),
-                        deleted_background: Some(rgba(0x3c110eff).into()),
-                        deleted_border: Some(rgba(0x551a15ff).into()),
-                        error: Some(rgba(0xca402cff).into()),
-                        error_background: Some(rgba(0x3c110eff).into()),
-                        error_border: Some(rgba(0x551a15ff).into()),
-                        hidden: Some(rgba(0x908190ff).into()),
-                        hidden_background: Some(rgba(0x433a43ff).into()),
-                        hidden_border: Some(rgba(0x554a55ff).into()),
-                        hint: Some(rgba(0x8d70a8ff).into()),
-                        hint_background: Some(rgba(0x0e1a43ff).into()),
-                        hint_border: Some(rgba(0x1a2961ff).into()),
-                        ignored: Some(rgba(0xa99aa9ff).into()),
-                        ignored_background: Some(rgba(0x433a43ff).into()),
-                        ignored_border: Some(rgba(0x675b67ff).into()),
-                        info: Some(rgba(0x526aebff).into()),
-                        info_background: Some(rgba(0x0e1a43ff).into()),
-                        info_border: Some(rgba(0x1a2961ff).into()),
-                        modified: Some(rgba(0xbb8a36ff).into()),
-                        modified_background: Some(rgba(0x2d1e12ff).into()),
-                        modified_border: Some(rgba(0x463219ff).into()),
-                        predictive: Some(rgba(0x765990ff).into()),
-                        predictive_background: Some(rgba(0x211f12ff).into()),
-                        predictive_border: Some(rgba(0x34321bff).into()),
-                        renamed: Some(rgba(0x526aebff).into()),
-                        renamed_background: Some(rgba(0x0e1a43ff).into()),
-                        renamed_border: Some(rgba(0x1a2961ff).into()),
-                        success: Some(rgba(0x918b3bff).into()),
-                        success_background: Some(rgba(0x211f12ff).into()),
-                        success_border: Some(rgba(0x34321bff).into()),
-                        unreachable: Some(rgba(0xa99aa9ff).into()),
-                        unreachable_background: Some(rgba(0x433a43ff).into()),
-                        unreachable_border: Some(rgba(0x675b67ff).into()),
-                        warning: Some(rgba(0xbb8a36ff).into()),
-                        warning_background: Some(rgba(0x2d1e12ff).into()),
-                        warning_border: Some(rgba(0x463219ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x526aebff).into(),
-                            background: rgba(0x526aebff).into(),
-                            selection: rgba(0x526aeb3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xcc34ccff).into(),
-                            background: rgba(0xcc34ccff).into(),
-                            selection: rgba(0xcc34cc3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa65927ff).into(),
-                            background: rgba(0xa65927ff).into(),
-                            selection: rgba(0xa659273d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x7b59c0ff).into(),
-                            background: rgba(0x7b59c0ff).into(),
-                            selection: rgba(0x7b59c03d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x189393ff).into(),
-                            background: rgba(0x189393ff).into(),
-                            selection: rgba(0x1893933d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xca402cff).into(),
-                            background: rgba(0xca402cff).into(),
-                            selection: rgba(0xca402c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xbb8a36ff).into(),
-                            background: rgba(0xbb8a36ff).into(),
-                            selection: rgba(0xbb8a363d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x918b3bff).into(),
-                            background: rgba(0x918b3bff).into(),
-                            selection: rgba(0x918b3b3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x776977ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xab9babff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf7f3f7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65927ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516aecff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516aecff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbb8a35ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8d70a8ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b59c0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65927ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65926ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xab9babff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x765990ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf7f3f7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd8cad8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xca402bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd8cad8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xab9babff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xab9babff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd8cad8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcc33ccff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xab9babff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x159393ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcc33ccff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65927ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf7f3f7ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbb8a35ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd8cad8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b59c0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbb8a35ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Lakeside Dark".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x4f6b78ff).into()),
-                        border_variant: Some(rgba(0x2c3b42ff).into()),
-                        border_focused: Some(rgba(0x1a2f3cff).into()),
-                        border_selected: Some(rgba(0x1a2f3cff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x415763ff).into()),
-                        elevated_surface_background: Some(rgba(0x1c2529ff).into()),
-                        surface_background: Some(rgba(0x1c2529ff).into()),
-                        background: Some(rgba(0x33444dff).into()),
-                        panel_background: Some(rgba(0x1c2529ff).into()),
-                        element_background: Some(rgba(0x1c2529ff).into()),
-                        element_hover: Some(rgba(0x2c3b42ff).into()),
-                        element_active: Some(rgba(0x4d6976ff).into()),
-                        element_selected: Some(rgba(0x4d6976ff).into()),
-                        element_disabled: Some(rgba(0x1c2529ff).into()),
-                        drop_target_background: Some(rgba(0x7ca0b380).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x2c3b42ff).into()),
-                        ghost_element_active: Some(rgba(0x4d6976ff).into()),
-                        ghost_element_selected: Some(rgba(0x4d6976ff).into()),
-                        ghost_element_disabled: Some(rgba(0x1c2529ff).into()),
-                        text: Some(rgba(0xebf8ffff).into()),
-                        text_muted: Some(rgba(0x7ca0b3ff).into()),
-                        text_placeholder: Some(rgba(0x698c9eff).into()),
-                        text_disabled: Some(rgba(0x698c9eff).into()),
-                        text_accent: Some(rgba(0x277fadff).into()),
-                        icon: Some(rgba(0xebf8ffff).into()),
-                        icon_muted: Some(rgba(0x7ca0b3ff).into()),
-                        icon_disabled: Some(rgba(0x698c9eff).into()),
-                        icon_placeholder: Some(rgba(0x7ca0b3ff).into()),
-                        icon_accent: Some(rgba(0x277fadff).into()),
-                        status_bar_background: Some(rgba(0x33444dff).into()),
-                        title_bar_background: Some(rgba(0x33444dff).into()),
-                        toolbar_background: Some(rgba(0x161b1dff).into()),
-                        tab_bar_background: Some(rgba(0x1c2529ff).into()),
-                        tab_inactive_background: Some(rgba(0x1c2529ff).into()),
-                        tab_active_background: Some(rgba(0x161b1dff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xebf8ff4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x2c3b42ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x2c3b42ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x1b2327ff).into()),
-                        editor_foreground: Some(rgba(0xc1e4f6ff).into()),
-                        editor_background: Some(rgba(0x161b1dff).into()),
-                        editor_gutter_background: Some(rgba(0x161b1dff).into()),
-                        editor_subheader_background: Some(rgba(0x1c2529ff).into()),
-                        editor_active_line_background: Some(rgba(0x1c2529bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x1c2529ff).into()),
-                        editor_line_number: Some(rgba(0xebf8ff59).into()),
-                        editor_active_line_number: Some(rgba(0xebf8ffff).into()),
-                        editor_invisible: Some(rgba(0x7ca0b3ff).into()),
-                        editor_wrap_guide: Some(rgba(0xebf8ff0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xebf8ff1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x277fad1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x66889a66).into()),
-                        terminal_background: Some(rgba(0x161b1dff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x587989ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x6f1c3aff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x2e4522ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x454413ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x1e3f53ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x5c1e6bff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x1f4638ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xebf8ffff).into()),
-                        terminal_ansi_black: Some(rgba(0x161b1dff).into()),
-                        terminal_ansi_red: Some(rgba(0xd22e72ff).into()),
-                        terminal_ansi_green: Some(rgba(0x568c3bff).into()),
-                        terminal_ansi_yellow: Some(rgba(0x8a8a11ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x277fadff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xb72ed2ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x2e8f6fff).into()),
-                        terminal_ansi_white: Some(rgba(0xebf8ffff).into()),
-                        link_text_hover: Some(rgba(0x277fadff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0x8a8a11ff).into()),
-                        conflict_background: Some(rgba(0x201f0cff).into()),
-                        conflict_border: Some(rgba(0x333211ff).into()),
-                        created: Some(rgba(0x568c3bff).into()),
-                        created_background: Some(rgba(0x171f12ff).into()),
-                        created_border: Some(rgba(0x23321bff).into()),
-                        deleted: Some(rgba(0xd22e72ff).into()),
-                        deleted_background: Some(rgba(0x3a101bff).into()),
-                        deleted_border: Some(rgba(0x55162bff).into()),
-                        error: Some(rgba(0xd22e72ff).into()),
-                        error_background: Some(rgba(0x3a101bff).into()),
-                        error_border: Some(rgba(0x55162bff).into()),
-                        hidden: Some(rgba(0x698c9eff).into()),
-                        hidden_background: Some(rgba(0x33444dff).into()),
-                        hidden_border: Some(rgba(0x415763ff).into()),
-                        hint: Some(rgba(0x52809aff).into()),
-                        hint_background: Some(rgba(0x131d24ff).into()),
-                        hint_border: Some(rgba(0x1a2f3cff).into()),
-                        ignored: Some(rgba(0x7ca0b3ff).into()),
-                        ignored_background: Some(rgba(0x33444dff).into()),
-                        ignored_border: Some(rgba(0x4f6b78ff).into()),
-                        info: Some(rgba(0x277fadff).into()),
-                        info_background: Some(rgba(0x131d24ff).into()),
-                        info_border: Some(rgba(0x1a2f3cff).into()),
-                        modified: Some(rgba(0x8a8a11ff).into()),
-                        modified_background: Some(rgba(0x201f0cff).into()),
-                        modified_border: Some(rgba(0x333211ff).into()),
-                        predictive: Some(rgba(0x427088ff).into()),
-                        predictive_background: Some(rgba(0x171f12ff).into()),
-                        predictive_border: Some(rgba(0x23321bff).into()),
-                        renamed: Some(rgba(0x277fadff).into()),
-                        renamed_background: Some(rgba(0x131d24ff).into()),
-                        renamed_border: Some(rgba(0x1a2f3cff).into()),
-                        success: Some(rgba(0x568c3bff).into()),
-                        success_background: Some(rgba(0x171f12ff).into()),
-                        success_border: Some(rgba(0x23321bff).into()),
-                        unreachable: Some(rgba(0x7ca0b3ff).into()),
-                        unreachable_background: Some(rgba(0x33444dff).into()),
-                        unreachable_border: Some(rgba(0x4f6b78ff).into()),
-                        warning: Some(rgba(0x8a8a11ff).into()),
-                        warning_background: Some(rgba(0x201f0cff).into()),
-                        warning_border: Some(rgba(0x333211ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x277fadff).into(),
-                            background: rgba(0x277fadff).into(),
-                            selection: rgba(0x277fad3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb72ed2ff).into(),
-                            background: rgba(0xb72ed2ff).into(),
-                            selection: rgba(0xb72ed23d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x935c26ff).into(),
-                            background: rgba(0x935c26ff).into(),
-                            selection: rgba(0x935c263d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x6b6bb8ff).into(),
-                            background: rgba(0x6b6bb8ff).into(),
-                            selection: rgba(0x6b6bb83d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x2e8f6fff).into(),
-                            background: rgba(0x2e8f6fff).into(),
-                            selection: rgba(0x2e8f6f3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd22e72ff).into(),
-                            background: rgba(0xd22e72ff).into(),
-                            selection: rgba(0xd22e723d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x8a8a11ff).into(),
-                            background: rgba(0x8a8a11ff).into(),
-                            selection: rgba(0x8a8a113d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x568c3bff).into(),
-                            background: rgba(0x568c3bff).into(),
-                            selection: rgba(0x568c3b3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5a7b8cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7ea2b4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebf8ffff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935c26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x257fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x257fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8a0fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x52809aff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6b6bb8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935c26ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935c25ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7ea2b4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x427088ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebf8ffff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc1e4f6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd22d72ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc1e4f6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7ea2b4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7ea2b4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc1e4f6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb72dd2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7ea2b4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2d8f6fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb72dd2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935c26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebf8ffff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8a0fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc1e4f6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6b6bb8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8a0fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Forest Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0xaaa3a1ff).into()),
-                        border_variant: Some(rgba(0xd6d1cfff).into()),
-                        border_focused: Some(rgba(0xc6cef7ff).into()),
-                        border_selected: Some(rgba(0xc6cef7ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xbcb6b4ff).into()),
-                        elevated_surface_background: Some(rgba(0xe9e6e4ff).into()),
-                        surface_background: Some(rgba(0xe9e6e4ff).into()),
-                        background: Some(rgba(0xcdc8c6ff).into()),
-                        panel_background: Some(rgba(0xe9e6e4ff).into()),
-                        element_background: Some(rgba(0xe9e6e4ff).into()),
-                        element_hover: Some(rgba(0xd6d1cfff).into()),
-                        element_active: Some(rgba(0xaca5a3ff).into()),
-                        element_selected: Some(rgba(0xaca5a3ff).into()),
-                        element_disabled: Some(rgba(0xe9e6e4ff).into()),
-                        drop_target_background: Some(rgba(0x6a636080).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xd6d1cfff).into()),
-                        ghost_element_active: Some(rgba(0xaca5a3ff).into()),
-                        ghost_element_selected: Some(rgba(0xaca5a3ff).into()),
-                        ghost_element_disabled: Some(rgba(0xe9e6e4ff).into()),
-                        text: Some(rgba(0x1b1918ff).into()),
-                        text_muted: Some(rgba(0x6a6360ff).into()),
-                        text_placeholder: Some(rgba(0x847c79ff).into()),
-                        text_disabled: Some(rgba(0x847c79ff).into()),
-                        text_accent: Some(rgba(0x417ee6ff).into()),
-                        icon: Some(rgba(0x1b1918ff).into()),
-                        icon_muted: Some(rgba(0x6a6360ff).into()),
-                        icon_disabled: Some(rgba(0x847c79ff).into()),
-                        icon_placeholder: Some(rgba(0x6a6360ff).into()),
-                        icon_accent: Some(rgba(0x417ee6ff).into()),
-                        status_bar_background: Some(rgba(0xcdc8c6ff).into()),
-                        title_bar_background: Some(rgba(0xcdc8c6ff).into()),
-                        toolbar_background: Some(rgba(0xf1efeeff).into()),
-                        tab_bar_background: Some(rgba(0xe9e6e4ff).into()),
-                        tab_inactive_background: Some(rgba(0xe9e6e4ff).into()),
-                        tab_active_background: Some(rgba(0xf1efeeff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x1b19184c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xd6d1cfff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xd6d1cfff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xebe8e6ff).into()),
-                        editor_foreground: Some(rgba(0x2c2421ff).into()),
-                        editor_background: Some(rgba(0xf1efeeff).into()),
-                        editor_gutter_background: Some(rgba(0xf1efeeff).into()),
-                        editor_subheader_background: Some(rgba(0xe9e6e4ff).into()),
-                        editor_active_line_background: Some(rgba(0xe9e6e4bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xe9e6e4ff).into()),
-                        editor_line_number: Some(rgba(0x1b191859).into()),
-                        editor_active_line_number: Some(rgba(0x1b1918ff).into()),
-                        editor_invisible: Some(rgba(0x6a6360ff).into()),
-                        editor_wrap_guide: Some(rgba(0x1b19180d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x1b19181a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x417ee61a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x89817e66).into()),
-                        terminal_background: Some(rgba(0xf1efeeff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x9e9693ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xffa29aff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xbfca93ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xe9c08eff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xaebcf4ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xe7a6fbff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0xa6cadbff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x1b1918ff).into()),
-                        terminal_ansi_black: Some(rgba(0xf1efeeff).into()),
-                        terminal_ansi_red: Some(rgba(0xf22e41ff).into()),
-                        terminal_ansi_green: Some(rgba(0x7b9728ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xc3841aff).into()),
-                        terminal_ansi_blue: Some(rgba(0x417ee6ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xc340f2ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x3f97b8ff).into()),
-                        terminal_ansi_white: Some(rgba(0x1b1918ff).into()),
-                        link_text_hover: Some(rgba(0x417ee6ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xc3841aff).into()),
-                        conflict_background: Some(rgba(0xf8e5d1ff).into()),
-                        conflict_border: Some(rgba(0xf0d1adff).into()),
-                        created: Some(rgba(0x7b9728ff).into()),
-                        created_background: Some(rgba(0xe5e9d3ff).into()),
-                        created_border: Some(rgba(0xd1d8b1ff).into()),
-                        deleted: Some(rgba(0xf22e41ff).into()),
-                        deleted_background: Some(rgba(0xffdad5ff).into()),
-                        deleted_border: Some(rgba(0xffbdb6ff).into()),
-                        error: Some(rgba(0xf22e41ff).into()),
-                        error_background: Some(rgba(0xffdad5ff).into()),
-                        error_border: Some(rgba(0xffbdb6ff).into()),
-                        hidden: Some(rgba(0x847c79ff).into()),
-                        hidden_background: Some(rgba(0xcdc8c6ff).into()),
-                        hidden_border: Some(rgba(0xbcb6b4ff).into()),
-                        hint: Some(rgba(0xa67287ff).into()),
-                        hint_background: Some(rgba(0xdfe3fbff).into()),
-                        hint_border: Some(rgba(0xc6cef7ff).into()),
-                        ignored: Some(rgba(0x6a6360ff).into()),
-                        ignored_background: Some(rgba(0xcdc8c6ff).into()),
-                        ignored_border: Some(rgba(0xaaa3a1ff).into()),
-                        info: Some(rgba(0x417ee6ff).into()),
-                        info_background: Some(rgba(0xdfe3fbff).into()),
-                        info_border: Some(rgba(0xc6cef7ff).into()),
-                        modified: Some(rgba(0xc3841aff).into()),
-                        modified_background: Some(rgba(0xf8e5d1ff).into()),
-                        modified_border: Some(rgba(0xf0d1adff).into()),
-                        predictive: Some(rgba(0xbe899eff).into()),
-                        predictive_background: Some(rgba(0xe5e9d3ff).into()),
-                        predictive_border: Some(rgba(0xd1d8b1ff).into()),
-                        renamed: Some(rgba(0x417ee6ff).into()),
-                        renamed_background: Some(rgba(0xdfe3fbff).into()),
-                        renamed_border: Some(rgba(0xc6cef7ff).into()),
-                        success: Some(rgba(0x7b9728ff).into()),
-                        success_background: Some(rgba(0xe5e9d3ff).into()),
-                        success_border: Some(rgba(0xd1d8b1ff).into()),
-                        unreachable: Some(rgba(0x6a6360ff).into()),
-                        unreachable_background: Some(rgba(0xcdc8c6ff).into()),
-                        unreachable_border: Some(rgba(0xaaa3a1ff).into()),
-                        warning: Some(rgba(0xc3841aff).into()),
-                        warning_background: Some(rgba(0xf8e5d1ff).into()),
-                        warning_border: Some(rgba(0xf0d1adff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x417ee6ff).into(),
-                            background: rgba(0x417ee6ff).into(),
-                            selection: rgba(0x417ee63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xc340f2ff).into(),
-                            background: rgba(0xc340f2ff).into(),
-                            selection: rgba(0xc340f23d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xdf5421ff).into(),
-                            background: rgba(0xdf5421ff).into(),
-                            selection: rgba(0xdf54213d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x6766e9ff).into(),
-                            background: rgba(0x6766e9ff).into(),
-                            selection: rgba(0x6766e93d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x3f97b8ff).into(),
-                            background: rgba(0x3f97b8ff).into(),
-                            selection: rgba(0x3f97b83d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xf22e41ff).into(),
-                            background: rgba(0xf22e41ff).into(),
-                            selection: rgba(0xf22e413d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xc3841aff).into(),
-                            background: rgba(0xc3841aff).into(),
-                            selection: rgba(0xc3841a3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x7b9728ff).into(),
-                            background: rgba(0x7b9728ff).into(),
-                            selection: rgba(0x7b97283d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x417ee6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b9728ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9c9491ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x68615eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b9728ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x417ee6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b1918ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x417ee6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x417ee6ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdf5421ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x407ee7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x407ee7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc38418ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa67287ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6666eaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x417ee6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdf5421ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b9728ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdf5320ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x68615eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbe899eff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b1918ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c2421ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf22c40ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c2421ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x68615eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x68615eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c2421ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc33ff3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b9726ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x68615eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3d97b8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc33ff3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b9726ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x417ee6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdf5421ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b1918ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc38418ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2c2421ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6666eaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc38418ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Dune Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0xa8a48eff).into()),
-                        border_variant: Some(rgba(0xd7d3beff).into()),
-                        border_focused: Some(rgba(0xcdd1f5ff).into()),
-                        border_selected: Some(rgba(0xcdd1f5ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xbbb7a1ff).into()),
-                        elevated_surface_background: Some(rgba(0xeeebd7ff).into()),
-                        surface_background: Some(rgba(0xeeebd7ff).into()),
-                        background: Some(rgba(0xcecab4ff).into()),
-                        panel_background: Some(rgba(0xeeebd7ff).into()),
-                        element_background: Some(rgba(0xeeebd7ff).into()),
-                        element_hover: Some(rgba(0xd7d3beff).into()),
-                        element_active: Some(rgba(0xaaa690ff).into()),
-                        element_selected: Some(rgba(0xaaa690ff).into()),
-                        element_disabled: Some(rgba(0xeeebd7ff).into()),
-                        drop_target_background: Some(rgba(0x706d5f80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xd7d3beff).into()),
-                        ghost_element_active: Some(rgba(0xaaa690ff).into()),
-                        ghost_element_selected: Some(rgba(0xaaa690ff).into()),
-                        ghost_element_disabled: Some(rgba(0xeeebd7ff).into()),
-                        text: Some(rgba(0x20201dff).into()),
-                        text_muted: Some(rgba(0x706d5fff).into()),
-                        text_placeholder: Some(rgba(0x878471ff).into()),
-                        text_disabled: Some(rgba(0x878471ff).into()),
-                        text_accent: Some(rgba(0x6784e0ff).into()),
-                        icon: Some(rgba(0x20201dff).into()),
-                        icon_muted: Some(rgba(0x706d5fff).into()),
-                        icon_disabled: Some(rgba(0x878471ff).into()),
-                        icon_placeholder: Some(rgba(0x706d5fff).into()),
-                        icon_accent: Some(rgba(0x6784e0ff).into()),
-                        status_bar_background: Some(rgba(0xcecab4ff).into()),
-                        title_bar_background: Some(rgba(0xcecab4ff).into()),
-                        toolbar_background: Some(rgba(0xfefbecff).into()),
-                        tab_bar_background: Some(rgba(0xeeebd7ff).into()),
-                        tab_inactive_background: Some(rgba(0xeeebd7ff).into()),
-                        tab_active_background: Some(rgba(0xfefbecff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x20201d4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xd7d3beff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xd7d3beff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xf2eedcff).into()),
-                        editor_foreground: Some(rgba(0x292824ff).into()),
-                        editor_background: Some(rgba(0xfefbecff).into()),
-                        editor_gutter_background: Some(rgba(0xfefbecff).into()),
-                        editor_subheader_background: Some(rgba(0xeeebd7ff).into()),
-                        editor_active_line_background: Some(rgba(0xeeebd7bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xeeebd7ff).into()),
-                        editor_line_number: Some(rgba(0x20201d59).into()),
-                        editor_active_line_number: Some(rgba(0x20201dff).into()),
-                        editor_invisible: Some(rgba(0x706d5fff).into()),
-                        editor_wrap_guide: Some(rgba(0x20201d0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x20201d1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x6784e01a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x8b887466).into()),
-                        terminal_background: Some(rgba(0xfefbecff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x9b9782ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xf7a195ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xb3d69cff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xdcc98eff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xb8c0f1ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xf3a0a4ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x9ed7c0ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x20201dff).into()),
-                        terminal_ansi_black: Some(rgba(0xfefbecff).into()),
-                        terminal_ansi_red: Some(rgba(0xd73838ff).into()),
-                        terminal_ansi_green: Some(rgba(0x61ac3aff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xae9515ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x6784e0ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xd43753ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x22ad83ff).into()),
-                        terminal_ansi_white: Some(rgba(0x20201dff).into()),
-                        link_text_hover: Some(rgba(0x6784e0ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xae9515ff).into()),
-                        conflict_background: Some(rgba(0xf2e8d1ff).into()),
-                        conflict_border: Some(rgba(0xe7d7aeff).into()),
-                        created: Some(rgba(0x61ac3aff).into()),
-                        created_background: Some(rgba(0xe0eed6ff).into()),
-                        created_border: Some(rgba(0xc9e1b7ff).into()),
-                        deleted: Some(rgba(0xd73838ff).into()),
-                        deleted_background: Some(rgba(0xffd9d4ff).into()),
-                        deleted_border: Some(rgba(0xfcbcb2ff).into()),
-                        error: Some(rgba(0xd73838ff).into()),
-                        error_background: Some(rgba(0xffd9d4ff).into()),
-                        error_border: Some(rgba(0xfcbcb2ff).into()),
-                        hidden: Some(rgba(0x878471ff).into()),
-                        hidden_background: Some(rgba(0xcecab4ff).into()),
-                        hidden_border: Some(rgba(0xbbb7a1ff).into()),
-                        hint: Some(rgba(0xb37979ff).into()),
-                        hint_background: Some(rgba(0xe3e5faff).into()),
-                        hint_border: Some(rgba(0xcdd1f5ff).into()),
-                        ignored: Some(rgba(0x706d5fff).into()),
-                        ignored_background: Some(rgba(0xcecab4ff).into()),
-                        ignored_border: Some(rgba(0xa8a48eff).into()),
-                        info: Some(rgba(0x6784e0ff).into()),
-                        info_background: Some(rgba(0xe3e5faff).into()),
-                        info_border: Some(rgba(0xcdd1f5ff).into()),
-                        modified: Some(rgba(0xae9515ff).into()),
-                        modified_background: Some(rgba(0xf2e8d1ff).into()),
-                        modified_border: Some(rgba(0xe7d7aeff).into()),
-                        predictive: Some(rgba(0xc88a8aff).into()),
-                        predictive_background: Some(rgba(0xe0eed6ff).into()),
-                        predictive_border: Some(rgba(0xc9e1b7ff).into()),
-                        renamed: Some(rgba(0x6784e0ff).into()),
-                        renamed_background: Some(rgba(0xe3e5faff).into()),
-                        renamed_border: Some(rgba(0xcdd1f5ff).into()),
-                        success: Some(rgba(0x61ac3aff).into()),
-                        success_background: Some(rgba(0xe0eed6ff).into()),
-                        success_border: Some(rgba(0xc9e1b7ff).into()),
-                        unreachable: Some(rgba(0x706d5fff).into()),
-                        unreachable_background: Some(rgba(0xcecab4ff).into()),
-                        unreachable_border: Some(rgba(0xa8a48eff).into()),
-                        warning: Some(rgba(0xae9515ff).into()),
-                        warning_background: Some(rgba(0xf2e8d1ff).into()),
-                        warning_border: Some(rgba(0xe7d7aeff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x6784e0ff).into(),
-                            background: rgba(0x6784e0ff).into(),
-                            selection: rgba(0x6784e03d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd43753ff).into(),
-                            background: rgba(0xd43753ff).into(),
-                            selection: rgba(0xd437533d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb65713ff).into(),
-                            background: rgba(0xb65713ff).into(),
-                            selection: rgba(0xb657133d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb855d3ff).into(),
-                            background: rgba(0xb855d3ff).into(),
-                            selection: rgba(0xb855d33d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x22ad83ff).into(),
-                            background: rgba(0x22ad83ff).into(),
-                            selection: rgba(0x22ad833d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd73838ff).into(),
-                            background: rgba(0xd73838ff).into(),
-                            selection: rgba(0xd738383d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xae9515ff).into(),
-                            background: rgba(0xae9515ff).into(),
-                            selection: rgba(0xae95153d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x61ac3aff).into(),
-                            background: rgba(0x61ac3aff).into(),
-                            selection: rgba(0x61ac3a3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6784e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x61ac3aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x999580ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6e6b5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x61ac3aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6784e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x20201dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6784e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6784e0ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65713ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6684e1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xae9513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb37979ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb854d4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6784e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65713ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x61ac3aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65611ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6e6b5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc88a8aff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x20201dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292824ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd73737ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292824ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6e6b5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6e6b5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292824ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd43552ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac39ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6e6b5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1fad83ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd43552ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x60ac39ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6784e0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb65713ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x20201dff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xae9513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292824ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb854d4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xae9513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Plateau Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x8e8989ff).into()),
-                        border_variant: Some(rgba(0xcfc7c7ff).into()),
-                        border_focused: Some(rgba(0xcecaecff).into()),
-                        border_selected: Some(rgba(0xcecaecff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xa8a2a2ff).into()),
-                        elevated_surface_background: Some(rgba(0xebe3e3ff).into()),
-                        surface_background: Some(rgba(0xebe3e3ff).into()),
-                        background: Some(rgba(0xc1bbbbff).into()),
-                        panel_background: Some(rgba(0xebe3e3ff).into()),
-                        element_background: Some(rgba(0xebe3e3ff).into()),
-                        element_hover: Some(rgba(0xcfc7c7ff).into()),
-                        element_active: Some(rgba(0x908b8bff).into()),
-                        element_selected: Some(rgba(0x908b8bff).into()),
-                        element_disabled: Some(rgba(0xebe3e3ff).into()),
-                        drop_target_background: Some(rgba(0x5a525280).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xcfc7c7ff).into()),
-                        ghost_element_active: Some(rgba(0x908b8bff).into()),
-                        ghost_element_selected: Some(rgba(0x908b8bff).into()),
-                        ghost_element_disabled: Some(rgba(0xebe3e3ff).into()),
-                        text: Some(rgba(0x1b1818ff).into()),
-                        text_muted: Some(rgba(0x5a5252ff).into()),
-                        text_placeholder: Some(rgba(0x6e6666ff).into()),
-                        text_disabled: Some(rgba(0x6e6666ff).into()),
-                        text_accent: Some(rgba(0x7372caff).into()),
-                        icon: Some(rgba(0x1b1818ff).into()),
-                        icon_muted: Some(rgba(0x5a5252ff).into()),
-                        icon_disabled: Some(rgba(0x6e6666ff).into()),
-                        icon_placeholder: Some(rgba(0x5a5252ff).into()),
-                        icon_accent: Some(rgba(0x7372caff).into()),
-                        status_bar_background: Some(rgba(0xc1bbbbff).into()),
-                        title_bar_background: Some(rgba(0xc1bbbbff).into()),
-                        toolbar_background: Some(rgba(0xf4ececff).into()),
-                        tab_bar_background: Some(rgba(0xebe3e3ff).into()),
-                        tab_inactive_background: Some(rgba(0xebe3e3ff).into()),
-                        tab_active_background: Some(rgba(0xf4ececff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x1b18184c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xcfc7c7ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xcfc7c7ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xede5e5ff).into()),
-                        editor_foreground: Some(rgba(0x292424ff).into()),
-                        editor_background: Some(rgba(0xf4ececff).into()),
-                        editor_gutter_background: Some(rgba(0xf4ececff).into()),
-                        editor_subheader_background: Some(rgba(0xebe3e3ff).into()),
-                        editor_active_line_background: Some(rgba(0xebe3e3bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xebe3e3ff).into()),
-                        editor_line_number: Some(rgba(0x1b181859).into()),
-                        editor_active_line_number: Some(rgba(0x1b1818ff).into()),
-                        editor_invisible: Some(rgba(0x5a5252ff).into()),
-                        editor_wrap_guide: Some(rgba(0x1b18180d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x1b18181a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x7372ca1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x726a6a66).into()),
-                        terminal_background: Some(rgba(0xf4ececff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x807979ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xeda69fff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xa6c4c4ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xd4b499ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xbbb6e5ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xe2a9c2ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0xacc0daff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x1b1818ff).into()),
-                        terminal_ansi_black: Some(rgba(0xf4ececff).into()),
-                        terminal_ansi_red: Some(rgba(0xca4a4aff).into()),
-                        terminal_ansi_green: Some(rgba(0x4c8b8bff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xa06e3cff).into()),
-                        terminal_ansi_blue: Some(rgba(0x7372caff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xbd5287ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x5585b6ff).into()),
-                        terminal_ansi_white: Some(rgba(0x1b1818ff).into()),
-                        link_text_hover: Some(rgba(0x7372caff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xa06e3cff).into()),
-                        conflict_background: Some(rgba(0xeee0d5ff).into()),
-                        conflict_border: Some(rgba(0xe0c9b5ff).into()),
-                        created: Some(rgba(0x4c8b8bff).into()),
-                        created_background: Some(rgba(0xdae7e7ff).into()),
-                        created_border: Some(rgba(0xbfd4d4ff).into()),
-                        deleted: Some(rgba(0xca4a4aff).into()),
-                        deleted_background: Some(rgba(0xfadbd7ff).into()),
-                        deleted_border: Some(rgba(0xf4bfbaff).into()),
-                        error: Some(rgba(0xca4a4aff).into()),
-                        error_background: Some(rgba(0xfadbd7ff).into()),
-                        error_border: Some(rgba(0xf4bfbaff).into()),
-                        hidden: Some(rgba(0x6e6666ff).into()),
-                        hidden_background: Some(rgba(0xc1bbbbff).into()),
-                        hidden_border: Some(rgba(0xa8a2a2ff).into()),
-                        hint: Some(rgba(0x916a80ff).into()),
-                        hint_background: Some(rgba(0xe4e1f5ff).into()),
-                        hint_border: Some(rgba(0xcecaecff).into()),
-                        ignored: Some(rgba(0x5a5252ff).into()),
-                        ignored_background: Some(rgba(0xc1bbbbff).into()),
-                        ignored_border: Some(rgba(0x8e8989ff).into()),
-                        info: Some(rgba(0x7372caff).into()),
-                        info_background: Some(rgba(0xe4e1f5ff).into()),
-                        info_border: Some(rgba(0xcecaecff).into()),
-                        modified: Some(rgba(0xa06e3cff).into()),
-                        modified_background: Some(rgba(0xeee0d5ff).into()),
-                        modified_border: Some(rgba(0xe0c9b5ff).into()),
-                        predictive: Some(rgba(0xa27a91ff).into()),
-                        predictive_background: Some(rgba(0xdae7e7ff).into()),
-                        predictive_border: Some(rgba(0xbfd4d4ff).into()),
-                        renamed: Some(rgba(0x7372caff).into()),
-                        renamed_background: Some(rgba(0xe4e1f5ff).into()),
-                        renamed_border: Some(rgba(0xcecaecff).into()),
-                        success: Some(rgba(0x4c8b8bff).into()),
-                        success_background: Some(rgba(0xdae7e7ff).into()),
-                        success_border: Some(rgba(0xbfd4d4ff).into()),
-                        unreachable: Some(rgba(0x5a5252ff).into()),
-                        unreachable_background: Some(rgba(0xc1bbbbff).into()),
-                        unreachable_border: Some(rgba(0x8e8989ff).into()),
-                        warning: Some(rgba(0xa06e3cff).into()),
-                        warning_background: Some(rgba(0xeee0d5ff).into()),
-                        warning_border: Some(rgba(0xe0c9b5ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x7372caff).into(),
-                            background: rgba(0x7372caff).into(),
-                            selection: rgba(0x7372ca3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xbd5287ff).into(),
-                            background: rgba(0xbd5287ff).into(),
-                            selection: rgba(0xbd52873d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb45b3dff).into(),
-                            background: rgba(0xb45b3dff).into(),
-                            selection: rgba(0xb45b3d3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x8464c4ff).into(),
-                            background: rgba(0x8464c4ff).into(),
-                            selection: rgba(0x8464c43d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x5585b6ff).into(),
-                            background: rgba(0x5585b6ff).into(),
-                            selection: rgba(0x5585b63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xca4a4aff).into(),
-                            background: rgba(0xca4a4aff).into(),
-                            selection: rgba(0xca4a4a3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa06e3cff).into(),
-                            background: rgba(0xa06e3cff).into(),
-                            selection: rgba(0xa06e3c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x4c8b8bff).into(),
-                            background: rgba(0x4c8b8bff).into(),
-                            selection: rgba(0x4c8b8b3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7372caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4c8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7e7777ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4c8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7372caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b1818ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7372caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7372caff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45b3dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7272caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x916a80ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8464c4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7372caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45b3dff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4c8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45a3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa27a91ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b1818ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292424ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xca4949ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292424ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292424ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbd5187ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x585050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5485b6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbd5187ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4b8b8bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7372caff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb45b3dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b1818ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292424ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8464c4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa06e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Seaside Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x8ea88eff).into()),
-                        border_variant: Some(rgba(0xbed7beff).into()),
-                        border_focused: Some(rgba(0xc9c4fdff).into()),
-                        border_selected: Some(rgba(0xc9c4fdff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xa1bba1ff).into()),
-                        elevated_surface_background: Some(rgba(0xdaeedaff).into()),
-                        surface_background: Some(rgba(0xdaeedaff).into()),
-                        background: Some(rgba(0xb4ceb4ff).into()),
-                        panel_background: Some(rgba(0xdaeedaff).into()),
-                        element_background: Some(rgba(0xdaeedaff).into()),
-                        element_hover: Some(rgba(0xbed7beff).into()),
-                        element_active: Some(rgba(0x90aa90ff).into()),
-                        element_selected: Some(rgba(0x90aa90ff).into()),
-                        element_disabled: Some(rgba(0xdaeedaff).into()),
-                        drop_target_background: Some(rgba(0x5f705f80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xbed7beff).into()),
-                        ghost_element_active: Some(rgba(0x90aa90ff).into()),
-                        ghost_element_selected: Some(rgba(0x90aa90ff).into()),
-                        ghost_element_disabled: Some(rgba(0xdaeedaff).into()),
-                        text: Some(rgba(0x131513ff).into()),
-                        text_muted: Some(rgba(0x5f705fff).into()),
-                        text_placeholder: Some(rgba(0x718771ff).into()),
-                        text_disabled: Some(rgba(0x718771ff).into()),
-                        text_accent: Some(rgba(0x3f62f4ff).into()),
-                        icon: Some(rgba(0x131513ff).into()),
-                        icon_muted: Some(rgba(0x5f705fff).into()),
-                        icon_disabled: Some(rgba(0x718771ff).into()),
-                        icon_placeholder: Some(rgba(0x5f705fff).into()),
-                        icon_accent: Some(rgba(0x3f62f4ff).into()),
-                        status_bar_background: Some(rgba(0xb4ceb4ff).into()),
-                        title_bar_background: Some(rgba(0xb4ceb4ff).into()),
-                        toolbar_background: Some(rgba(0xf4fbf4ff).into()),
-                        tab_bar_background: Some(rgba(0xdaeedaff).into()),
-                        tab_inactive_background: Some(rgba(0xdaeedaff).into()),
-                        tab_active_background: Some(rgba(0xf4fbf4ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x1315134c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xbed7beff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xbed7beff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xdff0dfff).into()),
-                        editor_foreground: Some(rgba(0x242924ff).into()),
-                        editor_background: Some(rgba(0xf4fbf4ff).into()),
-                        editor_gutter_background: Some(rgba(0xf4fbf4ff).into()),
-                        editor_subheader_background: Some(rgba(0xdaeedaff).into()),
-                        editor_active_line_background: Some(rgba(0xdaeedabf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xdaeedaff).into()),
-                        editor_line_number: Some(rgba(0x13151359).into()),
-                        editor_active_line_number: Some(rgba(0x131513ff).into()),
-                        editor_invisible: Some(rgba(0x5f705fff).into()),
-                        editor_wrap_guide: Some(rgba(0x1315130d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x1315131a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x3f62f41a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x748b7466).into()),
-                        terminal_background: Some(rgba(0xf4fbf4ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x829b82ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xff9d98ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xa0d294ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xd0ca90ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xb1adfcff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xf9a1e1ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x9fccd9ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x131513ff).into()),
-                        terminal_ansi_black: Some(rgba(0xf4fbf4ff).into()),
-                        terminal_ansi_red: Some(rgba(0xe61c3dff).into()),
-                        terminal_ansi_green: Some(rgba(0x2ba32bff).into()),
-                        terminal_ansi_yellow: Some(rgba(0x98981dff).into()),
-                        terminal_ansi_blue: Some(rgba(0x3f62f4ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xe61dc3ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x1d99b3ff).into()),
-                        terminal_ansi_white: Some(rgba(0x131513ff).into()),
-                        link_text_hover: Some(rgba(0x3f62f4ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0x98981dff).into()),
-                        conflict_background: Some(rgba(0xede9d2ff).into()),
-                        conflict_border: Some(rgba(0xddd8afff).into()),
-                        created: Some(rgba(0x2ba32bff).into()),
-                        created_background: Some(rgba(0xd9edd4ff).into()),
-                        created_border: Some(rgba(0xbbdeb2ff).into()),
-                        deleted: Some(rgba(0xe61c3dff).into()),
-                        deleted_background: Some(rgba(0xffd8d4ff).into()),
-                        deleted_border: Some(rgba(0xffb9b4ff).into()),
-                        error: Some(rgba(0xe61c3dff).into()),
-                        error_background: Some(rgba(0xffd8d4ff).into()),
-                        error_border: Some(rgba(0xffb9b4ff).into()),
-                        hidden: Some(rgba(0x718771ff).into()),
-                        hidden_background: Some(rgba(0xb4ceb4ff).into()),
-                        hidden_border: Some(rgba(0xa1bba1ff).into()),
-                        hint: Some(rgba(0x008fa1ff).into()),
-                        hint_background: Some(rgba(0xe1ddfeff).into()),
-                        hint_border: Some(rgba(0xc9c4fdff).into()),
-                        ignored: Some(rgba(0x5f705fff).into()),
-                        ignored_background: Some(rgba(0xb4ceb4ff).into()),
-                        ignored_border: Some(rgba(0x8ea88eff).into()),
-                        info: Some(rgba(0x3f62f4ff).into()),
-                        info_background: Some(rgba(0xe1ddfeff).into()),
-                        info_border: Some(rgba(0xc9c4fdff).into()),
-                        modified: Some(rgba(0x98981dff).into()),
-                        modified_background: Some(rgba(0xede9d2ff).into()),
-                        modified_border: Some(rgba(0xddd8afff).into()),
-                        predictive: Some(rgba(0x00a2b5ff).into()),
-                        predictive_background: Some(rgba(0xd9edd4ff).into()),
-                        predictive_border: Some(rgba(0xbbdeb2ff).into()),
-                        renamed: Some(rgba(0x3f62f4ff).into()),
-                        renamed_background: Some(rgba(0xe1ddfeff).into()),
-                        renamed_border: Some(rgba(0xc9c4fdff).into()),
-                        success: Some(rgba(0x2ba32bff).into()),
-                        success_background: Some(rgba(0xd9edd4ff).into()),
-                        success_border: Some(rgba(0xbbdeb2ff).into()),
-                        unreachable: Some(rgba(0x5f705fff).into()),
-                        unreachable_background: Some(rgba(0xb4ceb4ff).into()),
-                        unreachable_border: Some(rgba(0x8ea88eff).into()),
-                        warning: Some(rgba(0x98981dff).into()),
-                        warning_background: Some(rgba(0xede9d2ff).into()),
-                        warning_border: Some(rgba(0xddd8afff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x3f62f4ff).into(),
-                            background: rgba(0x3f62f4ff).into(),
-                            selection: rgba(0x3f62f43d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xe61dc3ff).into(),
-                            background: rgba(0xe61dc3ff).into(),
-                            selection: rgba(0xe61dc33d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x87711fff).into(),
-                            background: rgba(0x87711fff).into(),
-                            selection: rgba(0x87711f3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xad2dedff).into(),
-                            background: rgba(0xad2dedff).into(),
-                            selection: rgba(0xad2ded3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x1d99b3ff).into(),
-                            background: rgba(0x1d99b3ff).into(),
-                            selection: rgba(0x1d99b33d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xe61c3dff).into(),
-                            background: rgba(0xe61c3dff).into(),
-                            selection: rgba(0xe61c3d3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x98981dff).into(),
-                            background: rgba(0x98981dff).into(),
-                            selection: rgba(0x98981d3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x2ba32bff).into(),
-                            background: rgba(0x2ba32bff).into(),
-                            selection: rgba(0x2ba32b3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3f62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ba32bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x809980ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5e6e5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ba32bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3f62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x131513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3f62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3f62f4ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3d62f5ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3d62f5ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x98981bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x008fa1ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad2beeff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3f62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711fff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ba32bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5e6e5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x00a2b5ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x131513ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x242924ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe6193cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x242924ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5e6e5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5e6e5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x242924ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe619c3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x29a329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5e6e5eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1999b3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe619c3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x29a329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3f62f4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87711fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x131513ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x98981bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x242924ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad2beeff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x98981bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Savanna Dark".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x505e55ff).into()),
-                        border_variant: Some(rgba(0x2f3832ff).into()),
-                        border_focused: Some(rgba(0x1f3233ff).into()),
-                        border_selected: Some(rgba(0x1f3233ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x434f47ff).into()),
-                        elevated_surface_background: Some(rgba(0x1f2621ff).into()),
-                        surface_background: Some(rgba(0x1f2621ff).into()),
-                        background: Some(rgba(0x353f39ff).into()),
-                        panel_background: Some(rgba(0x1f2621ff).into()),
-                        element_background: Some(rgba(0x1f2621ff).into()),
-                        element_hover: Some(rgba(0x2f3832ff).into()),
-                        element_active: Some(rgba(0x4f5c53ff).into()),
-                        element_selected: Some(rgba(0x4f5c53ff).into()),
-                        element_disabled: Some(rgba(0x1f2621ff).into()),
-                        drop_target_background: Some(rgba(0x85918880).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x2f3832ff).into()),
-                        ghost_element_active: Some(rgba(0x4f5c53ff).into()),
-                        ghost_element_selected: Some(rgba(0x4f5c53ff).into()),
-                        ghost_element_disabled: Some(rgba(0x1f2621ff).into()),
-                        text: Some(rgba(0xecf4eeff).into()),
-                        text_muted: Some(rgba(0x859188ff).into()),
-                        text_placeholder: Some(rgba(0x6f7e74ff).into()),
-                        text_disabled: Some(rgba(0x6f7e74ff).into()),
-                        text_accent: Some(rgba(0x478c90ff).into()),
-                        icon: Some(rgba(0xecf4eeff).into()),
-                        icon_muted: Some(rgba(0x859188ff).into()),
-                        icon_disabled: Some(rgba(0x6f7e74ff).into()),
-                        icon_placeholder: Some(rgba(0x859188ff).into()),
-                        icon_accent: Some(rgba(0x478c90ff).into()),
-                        status_bar_background: Some(rgba(0x353f39ff).into()),
-                        title_bar_background: Some(rgba(0x353f39ff).into()),
-                        toolbar_background: Some(rgba(0x171c19ff).into()),
-                        tab_bar_background: Some(rgba(0x1f2621ff).into()),
-                        tab_inactive_background: Some(rgba(0x1f2621ff).into()),
-                        tab_active_background: Some(rgba(0x171c19ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xecf4ee4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x2f3832ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x2f3832ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x1e2420ff).into()),
-                        editor_foreground: Some(rgba(0xdfe7e2ff).into()),
-                        editor_background: Some(rgba(0x171c19ff).into()),
-                        editor_gutter_background: Some(rgba(0x171c19ff).into()),
-                        editor_subheader_background: Some(rgba(0x1f2621ff).into()),
-                        editor_active_line_background: Some(rgba(0x1f2621bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x1f2621ff).into()),
-                        editor_line_number: Some(rgba(0xecf4ee59).into()),
-                        editor_active_line_number: Some(rgba(0xecf4eeff).into()),
-                        editor_invisible: Some(rgba(0x859188ff).into()),
-                        editor_wrap_guide: Some(rgba(0xecf4ee0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xecf4ee1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x478c901a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x6c7a7166).into()),
-                        terminal_background: Some(rgba(0x171c19ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x5d6b62ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x563220ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x294a33ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x4e3f22ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x284546ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x423a36ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x1d4b4dff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xecf4eeff).into()),
-                        terminal_ansi_black: Some(rgba(0x171c19ff).into()),
-                        terminal_ansi_red: Some(rgba(0xb16139ff).into()),
-                        terminal_ansi_green: Some(rgba(0x489963ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xa07e3bff).into()),
-                        terminal_ansi_blue: Some(rgba(0x478c90ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0x867469ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x1e9aa0ff).into()),
-                        terminal_ansi_white: Some(rgba(0xecf4eeff).into()),
-                        link_text_hover: Some(rgba(0x478c90ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xa07e3bff).into()),
-                        conflict_background: Some(rgba(0x231d12ff).into()),
-                        conflict_border: Some(rgba(0x392e1aff).into()),
-                        created: Some(rgba(0x489963ff).into()),
-                        created_background: Some(rgba(0x162119ff).into()),
-                        created_border: Some(rgba(0x203626ff).into()),
-                        deleted: Some(rgba(0xb16139ff).into()),
-                        deleted_background: Some(rgba(0x261811ff).into()),
-                        deleted_border: Some(rgba(0x3f2619ff).into()),
-                        error: Some(rgba(0xb16139ff).into()),
-                        error_background: Some(rgba(0x261811ff).into()),
-                        error_border: Some(rgba(0x3f2619ff).into()),
-                        hidden: Some(rgba(0x6f7e74ff).into()),
-                        hidden_background: Some(rgba(0x353f39ff).into()),
-                        hidden_border: Some(rgba(0x434f47ff).into()),
-                        hint: Some(rgba(0x607e76ff).into()),
-                        hint_background: Some(rgba(0x151f20ff).into()),
-                        hint_border: Some(rgba(0x1f3233ff).into()),
-                        ignored: Some(rgba(0x859188ff).into()),
-                        ignored_background: Some(rgba(0x353f39ff).into()),
-                        ignored_border: Some(rgba(0x505e55ff).into()),
-                        info: Some(rgba(0x478c90ff).into()),
-                        info_background: Some(rgba(0x151f20ff).into()),
-                        info_border: Some(rgba(0x1f3233ff).into()),
-                        modified: Some(rgba(0xa07e3bff).into()),
-                        modified_background: Some(rgba(0x231d12ff).into()),
-                        modified_border: Some(rgba(0x392e1aff).into()),
-                        predictive: Some(rgba(0x506d66ff).into()),
-                        predictive_background: Some(rgba(0x162119ff).into()),
-                        predictive_border: Some(rgba(0x203626ff).into()),
-                        renamed: Some(rgba(0x478c90ff).into()),
-                        renamed_background: Some(rgba(0x151f20ff).into()),
-                        renamed_border: Some(rgba(0x1f3233ff).into()),
-                        success: Some(rgba(0x489963ff).into()),
-                        success_background: Some(rgba(0x162119ff).into()),
-                        success_border: Some(rgba(0x203626ff).into()),
-                        unreachable: Some(rgba(0x859188ff).into()),
-                        unreachable_background: Some(rgba(0x353f39ff).into()),
-                        unreachable_border: Some(rgba(0x505e55ff).into()),
-                        warning: Some(rgba(0xa07e3bff).into()),
-                        warning_background: Some(rgba(0x231d12ff).into()),
-                        warning_border: Some(rgba(0x392e1aff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x478c90ff).into(),
-                            background: rgba(0x478c90ff).into(),
-                            selection: rgba(0x478c903d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x867469ff).into(),
-                            background: rgba(0x867469ff).into(),
-                            selection: rgba(0x8674693d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x9f713cff).into(),
-                            background: rgba(0x9f713cff).into(),
-                            selection: rgba(0x9f713c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x55859bff).into(),
-                            background: rgba(0x55859bff).into(),
-                            selection: rgba(0x55859b3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x1e9aa0ff).into(),
-                            background: rgba(0x1e9aa0ff).into(),
-                            selection: rgba(0x1e9aa03d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb16139ff).into(),
-                            background: rgba(0xb16139ff).into(),
-                            selection: rgba(0xb161393d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa07e3bff).into(),
-                            background: rgba(0xa07e3bff).into(),
-                            selection: rgba(0xa07e3b3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x489963ff).into(),
-                            background: rgba(0x489963ff).into(),
-                            selection: rgba(0x4899633d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x489963ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5f6d64ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87928aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x489963ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xecf4eeff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9f713cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa07e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x607e76ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x55859bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9f713cff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x489963ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9f713cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87928aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x506d66ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xecf4eeff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdfe7e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb16139ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdfe7e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87928aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87928aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdfe7e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x867469ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x489963ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x87928aff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1c9aa0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x867469ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x489963ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x478c90ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9f713cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xecf4eeff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa07e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xdfe7e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x55859bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa07e3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Heath Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0xad9dadff).into()),
-                        border_variant: Some(rgba(0xcdbecdff).into()),
-                        border_focused: Some(rgba(0xcac7faff).into()),
-                        border_selected: Some(rgba(0xcac7faff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xbaaabaff).into()),
-                        elevated_surface_background: Some(rgba(0xe1d6e1ff).into()),
-                        surface_background: Some(rgba(0xe1d6e1ff).into()),
-                        background: Some(rgba(0xc6b8c6ff).into()),
-                        panel_background: Some(rgba(0xe1d6e1ff).into()),
-                        element_background: Some(rgba(0xe1d6e1ff).into()),
-                        element_hover: Some(rgba(0xcdbecdff).into()),
-                        element_active: Some(rgba(0xae9eaeff).into()),
-                        element_selected: Some(rgba(0xae9eaeff).into()),
-                        element_disabled: Some(rgba(0xe1d6e1ff).into()),
-                        drop_target_background: Some(rgba(0x6b5e6b80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xcdbecdff).into()),
-                        ghost_element_active: Some(rgba(0xae9eaeff).into()),
-                        ghost_element_selected: Some(rgba(0xae9eaeff).into()),
-                        ghost_element_disabled: Some(rgba(0xe1d6e1ff).into()),
-                        text: Some(rgba(0x1b181bff).into()),
-                        text_muted: Some(rgba(0x6b5e6bff).into()),
-                        text_placeholder: Some(rgba(0x857785ff).into()),
-                        text_disabled: Some(rgba(0x857785ff).into()),
-                        text_accent: Some(rgba(0x526aebff).into()),
-                        icon: Some(rgba(0x1b181bff).into()),
-                        icon_muted: Some(rgba(0x6b5e6bff).into()),
-                        icon_disabled: Some(rgba(0x857785ff).into()),
-                        icon_placeholder: Some(rgba(0x6b5e6bff).into()),
-                        icon_accent: Some(rgba(0x526aebff).into()),
-                        status_bar_background: Some(rgba(0xc6b8c6ff).into()),
-                        title_bar_background: Some(rgba(0xc6b8c6ff).into()),
-                        toolbar_background: Some(rgba(0xf7f3f7ff).into()),
-                        tab_bar_background: Some(rgba(0xe1d6e1ff).into()),
-                        tab_inactive_background: Some(rgba(0xe1d6e1ff).into()),
-                        tab_active_background: Some(rgba(0xf7f3f7ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x1b181b4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xcdbecdff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xcdbecdff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xe5dce5ff).into()),
-                        editor_foreground: Some(rgba(0x292329ff).into()),
-                        editor_background: Some(rgba(0xf7f3f7ff).into()),
-                        editor_gutter_background: Some(rgba(0xf7f3f7ff).into()),
-                        editor_subheader_background: Some(rgba(0xe1d6e1ff).into()),
-                        editor_active_line_background: Some(rgba(0xe1d6e1bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xe1d6e1ff).into()),
-                        editor_line_number: Some(rgba(0x1b181b59).into()),
-                        editor_active_line_number: Some(rgba(0x1b181bff).into()),
-                        editor_invisible: Some(rgba(0x6b5e6bff).into()),
-                        editor_wrap_guide: Some(rgba(0x1b181b0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x1b181b1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x526aeb1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x8b7c8b66).into()),
-                        terminal_background: Some(rgba(0xf7f3f7ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0xa091a0ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xf0a28fff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xcac49aff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xe2c398ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xb4b2f7ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xeba2e6ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x9ac9c8ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x1b181bff).into()),
-                        terminal_ansi_black: Some(rgba(0xf7f3f7ff).into()),
-                        terminal_ansi_red: Some(rgba(0xca412cff).into()),
-                        terminal_ansi_green: Some(rgba(0x918b3cff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xbb8a36ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x526aebff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xcc35ccff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x199393ff).into()),
-                        terminal_ansi_white: Some(rgba(0x1b181bff).into()),
-                        link_text_hover: Some(rgba(0x526aebff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xbb8a36ff).into()),
-                        conflict_background: Some(rgba(0xf5e6d5ff).into()),
-                        conflict_border: Some(rgba(0xebd3b5ff).into()),
-                        created: Some(rgba(0x918b3cff).into()),
-                        created_background: Some(rgba(0xeae6d6ff).into()),
-                        created_border: Some(rgba(0xd9d4b6ff).into()),
-                        deleted: Some(rgba(0xca412cff).into()),
-                        deleted_background: Some(rgba(0xfcd9d1ff).into()),
-                        deleted_border: Some(rgba(0xf7bcaeff).into()),
-                        error: Some(rgba(0xca412cff).into()),
-                        error_background: Some(rgba(0xfcd9d1ff).into()),
-                        error_border: Some(rgba(0xf7bcaeff).into()),
-                        hidden: Some(rgba(0x857785ff).into()),
-                        hidden_background: Some(rgba(0xc6b8c6ff).into()),
-                        hidden_border: Some(rgba(0xbaaabaff).into()),
-                        hint: Some(rgba(0x8c70a6ff).into()),
-                        hint_background: Some(rgba(0xe2dffcff).into()),
-                        hint_border: Some(rgba(0xcac7faff).into()),
-                        ignored: Some(rgba(0x6b5e6bff).into()),
-                        ignored_background: Some(rgba(0xc6b8c6ff).into()),
-                        ignored_border: Some(rgba(0xad9dadff).into()),
-                        info: Some(rgba(0x526aebff).into()),
-                        info_background: Some(rgba(0xe2dffcff).into()),
-                        info_border: Some(rgba(0xcac7faff).into()),
-                        modified: Some(rgba(0xbb8a36ff).into()),
-                        modified_background: Some(rgba(0xf5e6d5ff).into()),
-                        modified_border: Some(rgba(0xebd3b5ff).into()),
-                        predictive: Some(rgba(0xa587bfff).into()),
-                        predictive_background: Some(rgba(0xeae6d6ff).into()),
-                        predictive_border: Some(rgba(0xd9d4b6ff).into()),
-                        renamed: Some(rgba(0x526aebff).into()),
-                        renamed_background: Some(rgba(0xe2dffcff).into()),
-                        renamed_border: Some(rgba(0xcac7faff).into()),
-                        success: Some(rgba(0x918b3cff).into()),
-                        success_background: Some(rgba(0xeae6d6ff).into()),
-                        success_border: Some(rgba(0xd9d4b6ff).into()),
-                        unreachable: Some(rgba(0x6b5e6bff).into()),
-                        unreachable_background: Some(rgba(0xc6b8c6ff).into()),
-                        unreachable_border: Some(rgba(0xad9dadff).into()),
-                        warning: Some(rgba(0xbb8a36ff).into()),
-                        warning_background: Some(rgba(0xf5e6d5ff).into()),
-                        warning_border: Some(rgba(0xebd3b5ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x526aebff).into(),
-                            background: rgba(0x526aebff).into(),
-                            selection: rgba(0x526aeb3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xcc35ccff).into(),
-                            background: rgba(0xcc35ccff).into(),
-                            selection: rgba(0xcc35cc3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa65a27ff).into(),
-                            background: rgba(0xa65a27ff).into(),
-                            selection: rgba(0xa65a273d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x7b5ac0ff).into(),
-                            background: rgba(0x7b5ac0ff).into(),
-                            selection: rgba(0x7b5ac03d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x199393ff).into(),
-                            background: rgba(0x199393ff).into(),
-                            selection: rgba(0x1993933d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xca412cff).into(),
-                            background: rgba(0xca412cff).into(),
-                            selection: rgba(0xca412c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xbb8a36ff).into(),
-                            background: rgba(0xbb8a36ff).into(),
-                            selection: rgba(0xbb8a363d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x918b3cff).into(),
-                            background: rgba(0x918b3cff).into(),
-                            selection: rgba(0x918b3c3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9e8f9eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x695d69ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b181bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65a27ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516aecff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516aecff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbb8a35ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8c70a6ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b59c0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65a27ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65926ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x695d69ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa587bfff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b181bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xca402bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x695d69ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x695d69ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcc33ccff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x695d69ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x159393ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcc33ccff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x918b3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x526aebff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa65a27ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1b181bff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbb8a35ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x292329ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7b59c0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xbb8a35ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Atelier Lakeside Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x80a4b6ff).into()),
-                        border_variant: Some(rgba(0xb0d3e5ff).into()),
-                        border_focused: Some(rgba(0xbacfe1ff).into()),
-                        border_selected: Some(rgba(0xbacfe1ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x93b7c9ff).into()),
-                        elevated_surface_background: Some(rgba(0xcdeaf9ff).into()),
-                        surface_background: Some(rgba(0xcdeaf9ff).into()),
-                        background: Some(rgba(0xa6cadcff).into()),
-                        panel_background: Some(rgba(0xcdeaf9ff).into()),
-                        element_background: Some(rgba(0xcdeaf9ff).into()),
-                        element_hover: Some(rgba(0xb0d3e5ff).into()),
-                        element_active: Some(rgba(0x82a6b8ff).into()),
-                        element_selected: Some(rgba(0x82a6b8ff).into()),
-                        element_disabled: Some(rgba(0xcdeaf9ff).into()),
-                        drop_target_background: Some(rgba(0x526f7d80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xb0d3e5ff).into()),
-                        ghost_element_active: Some(rgba(0x82a6b8ff).into()),
-                        ghost_element_selected: Some(rgba(0x82a6b8ff).into()),
-                        ghost_element_disabled: Some(rgba(0xcdeaf9ff).into()),
-                        text: Some(rgba(0x161b1dff).into()),
-                        text_muted: Some(rgba(0x526f7dff).into()),
-                        text_placeholder: Some(rgba(0x628496ff).into()),
-                        text_disabled: Some(rgba(0x628496ff).into()),
-                        text_accent: Some(rgba(0x277fadff).into()),
-                        icon: Some(rgba(0x161b1dff).into()),
-                        icon_muted: Some(rgba(0x526f7dff).into()),
-                        icon_disabled: Some(rgba(0x628496ff).into()),
-                        icon_placeholder: Some(rgba(0x526f7dff).into()),
-                        icon_accent: Some(rgba(0x277fadff).into()),
-                        status_bar_background: Some(rgba(0xa6cadcff).into()),
-                        title_bar_background: Some(rgba(0xa6cadcff).into()),
-                        toolbar_background: Some(rgba(0xebf8ffff).into()),
-                        tab_bar_background: Some(rgba(0xcdeaf9ff).into()),
-                        tab_inactive_background: Some(rgba(0xcdeaf9ff).into()),
-                        tab_active_background: Some(rgba(0xebf8ffff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x161b1d4c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xb0d3e5ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xb0d3e5ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xd3edfaff).into()),
-                        editor_foreground: Some(rgba(0x1f292eff).into()),
-                        editor_background: Some(rgba(0xebf8ffff).into()),
-                        editor_gutter_background: Some(rgba(0xebf8ffff).into()),
-                        editor_subheader_background: Some(rgba(0xcdeaf9ff).into()),
-                        editor_active_line_background: Some(rgba(0xcdeaf9bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xcdeaf9ff).into()),
-                        editor_line_number: Some(rgba(0x161b1d59).into()),
-                        editor_active_line_number: Some(rgba(0x161b1dff).into()),
-                        editor_invisible: Some(rgba(0x526f7dff).into()),
-                        editor_wrap_guide: Some(rgba(0x161b1d0d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x161b1d1a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x277fad1a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x66889a66).into()),
-                        terminal_background: Some(rgba(0xebf8ffff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x7397aaff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xf09fb6ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xabc59aff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xc8c38bff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x9ebdd6ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xe09fe9ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x9bc7b5ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x161b1dff).into()),
-                        terminal_ansi_black: Some(rgba(0xebf8ffff).into()),
-                        terminal_ansi_red: Some(rgba(0xd22f72ff).into()),
-                        terminal_ansi_green: Some(rgba(0x578c3cff).into()),
-                        terminal_ansi_yellow: Some(rgba(0x8a8a11ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x277fadff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xb72fd2ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x2f8f6fff).into()),
-                        terminal_ansi_white: Some(rgba(0x161b1dff).into()),
-                        link_text_hover: Some(rgba(0x277fadff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0x8a8a11ff).into()),
-                        conflict_background: Some(rgba(0xeae6d0ff).into()),
-                        conflict_border: Some(rgba(0xd8d3abff).into()),
-                        created: Some(rgba(0x578c3cff).into()),
-                        created_background: Some(rgba(0xdde7d5ff).into()),
-                        created_border: Some(rgba(0xc2d5b6ff).into()),
-                        deleted: Some(rgba(0xd22f72ff).into()),
-                        deleted_background: Some(rgba(0xfbd8e1ff).into()),
-                        deleted_border: Some(rgba(0xf6bacaff).into()),
-                        error: Some(rgba(0xd22f72ff).into()),
-                        error_background: Some(rgba(0xfbd8e1ff).into()),
-                        error_border: Some(rgba(0xf6bacaff).into()),
-                        hidden: Some(rgba(0x628496ff).into()),
-                        hidden_background: Some(rgba(0xa6cadcff).into()),
-                        hidden_border: Some(rgba(0x93b7c9ff).into()),
-                        hint: Some(rgba(0x5a87a0ff).into()),
-                        hint_background: Some(rgba(0xd8e4eeff).into()),
-                        hint_border: Some(rgba(0xbacfe1ff).into()),
-                        ignored: Some(rgba(0x526f7dff).into()),
-                        ignored_background: Some(rgba(0xa6cadcff).into()),
-                        ignored_border: Some(rgba(0x80a4b6ff).into()),
-                        info: Some(rgba(0x277fadff).into()),
-                        info_background: Some(rgba(0xd8e4eeff).into()),
-                        info_border: Some(rgba(0xbacfe1ff).into()),
-                        modified: Some(rgba(0x8a8a11ff).into()),
-                        modified_background: Some(rgba(0xeae6d0ff).into()),
-                        modified_border: Some(rgba(0xd8d3abff).into()),
-                        predictive: Some(rgba(0x6a97b2ff).into()),
-                        predictive_background: Some(rgba(0xdde7d5ff).into()),
-                        predictive_border: Some(rgba(0xc2d5b6ff).into()),
-                        renamed: Some(rgba(0x277fadff).into()),
-                        renamed_background: Some(rgba(0xd8e4eeff).into()),
-                        renamed_border: Some(rgba(0xbacfe1ff).into()),
-                        success: Some(rgba(0x578c3cff).into()),
-                        success_background: Some(rgba(0xdde7d5ff).into()),
-                        success_border: Some(rgba(0xc2d5b6ff).into()),
-                        unreachable: Some(rgba(0x526f7dff).into()),
-                        unreachable_background: Some(rgba(0xa6cadcff).into()),
-                        unreachable_border: Some(rgba(0x80a4b6ff).into()),
-                        warning: Some(rgba(0x8a8a11ff).into()),
-                        warning_background: Some(rgba(0xeae6d0ff).into()),
-                        warning_border: Some(rgba(0xd8d3abff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x277fadff).into(),
-                            background: rgba(0x277fadff).into(),
-                            selection: rgba(0x277fad3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb72fd2ff).into(),
-                            background: rgba(0xb72fd2ff).into(),
-                            selection: rgba(0xb72fd23d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x935d26ff).into(),
-                            background: rgba(0x935d26ff).into(),
-                            selection: rgba(0x935d263d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x6c6bb8ff).into(),
-                            background: rgba(0x6c6bb8ff).into(),
-                            selection: rgba(0x6c6bb83d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x2f8f6fff).into(),
-                            background: rgba(0x2f8f6fff).into(),
-                            selection: rgba(0x2f8f6f3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd22f72ff).into(),
-                            background: rgba(0xd22f72ff).into(),
-                            selection: rgba(0xd22f723d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x8a8a11ff).into(),
-                            background: rgba(0x8a8a11ff).into(),
-                            selection: rgba(0x8a8a113d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x578c3cff).into(),
-                            background: rgba(0x578c3cff).into(),
-                            selection: rgba(0x578c3c3d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x578c3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7195a8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516d7bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x578c3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x161b1dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935d26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x257fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x257fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.special.definition".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8a0fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5a87a0ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6b6bb8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935d26ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x578c3cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935c25ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516d7bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6a97b2ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x161b1dff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1f292eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd22d72ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1f292eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516d7bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516d7bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1f292eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb72dd2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x516d7bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2d8f6fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb72dd2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x568c3bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x277fadff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x935d26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x161b1dff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8a0fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x1f292eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6b6bb8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8a8a0fff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme/src/themes/gruvbox.rs
+++ b/crates/theme/src/themes/gruvbox.rs
@@ -16,170 +16,170 @@ pub fn gruvbox() -> UserThemeFamily {
         author: "Zed Industries".into(),
         themes: vec![
             UserTheme {
-                name: "Gruvbox Light Hard".into(),
-                appearance: Appearance::Light,
+                name: "Gruvbox Dark".into(),
+                appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {
-                        border: Some(rgba(0xc9b99aff).into()),
-                        border_variant: Some(rgba(0xddcca7ff).into()),
-                        border_focused: Some(rgba(0xaec6cdff).into()),
-                        border_selected: Some(rgba(0xaec6cdff).into()),
+                        border: Some(rgba(0x5b534dff).into()),
+                        border_variant: Some(rgba(0x494340ff).into()),
+                        border_focused: Some(rgba(0x303a36ff).into()),
+                        border_selected: Some(rgba(0x303a36ff).into()),
                         border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xd1c09eff).into()),
-                        elevated_surface_background: Some(rgba(0xecddb5ff).into()),
-                        surface_background: Some(rgba(0xecddb5ff).into()),
-                        background: Some(rgba(0xd9c8a4ff).into()),
-                        panel_background: Some(rgba(0xecddb5ff).into()),
-                        element_background: Some(rgba(0xecddb5ff).into()),
-                        element_hover: Some(rgba(0xddcca7ff).into()),
-                        element_active: Some(rgba(0xc9b99aff).into()),
-                        element_selected: Some(rgba(0xc9b99aff).into()),
-                        element_disabled: Some(rgba(0xecddb5ff).into()),
-                        drop_target_background: Some(rgba(0x5f565080).into()),
+                        border_disabled: Some(rgba(0x544c48ff).into()),
+                        elevated_surface_background: Some(rgba(0x3a3735ff).into()),
+                        surface_background: Some(rgba(0x3a3735ff).into()),
+                        background: Some(rgba(0x4c4642ff).into()),
+                        panel_background: Some(rgba(0x3a3735ff).into()),
+                        element_background: Some(rgba(0x3a3735ff).into()),
+                        element_hover: Some(rgba(0x494340ff).into()),
+                        element_active: Some(rgba(0x5b524cff).into()),
+                        element_selected: Some(rgba(0x5b524cff).into()),
+                        element_disabled: Some(rgba(0x3a3735ff).into()),
+                        drop_target_background: Some(rgba(0xc5b59780).into()),
                         ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xddcca7ff).into()),
-                        ghost_element_active: Some(rgba(0xc9b99aff).into()),
-                        ghost_element_selected: Some(rgba(0xc9b99aff).into()),
-                        ghost_element_disabled: Some(rgba(0xecddb5ff).into()),
-                        text: Some(rgba(0x282828ff).into()),
-                        text_muted: Some(rgba(0x5f5650ff).into()),
-                        text_placeholder: Some(rgba(0x8a7c6fff).into()),
-                        text_disabled: Some(rgba(0x8a7c6fff).into()),
-                        text_accent: Some(rgba(0x0b6678ff).into()),
-                        icon: Some(rgba(0x282828ff).into()),
-                        icon_muted: Some(rgba(0x5f5650ff).into()),
-                        icon_disabled: Some(rgba(0x8a7c6fff).into()),
-                        icon_placeholder: Some(rgba(0x5f5650ff).into()),
-                        icon_accent: Some(rgba(0x0b6678ff).into()),
-                        status_bar_background: Some(rgba(0xd9c8a4ff).into()),
-                        title_bar_background: Some(rgba(0xd9c8a4ff).into()),
-                        toolbar_background: Some(rgba(0xf9f5d7ff).into()),
-                        tab_bar_background: Some(rgba(0xecddb5ff).into()),
-                        tab_inactive_background: Some(rgba(0xecddb5ff).into()),
-                        tab_active_background: Some(rgba(0xf9f5d7ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x2828284c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xddcca7ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xddcca7ff).into()),
+                        ghost_element_hover: Some(rgba(0x494340ff).into()),
+                        ghost_element_active: Some(rgba(0x5b524cff).into()),
+                        ghost_element_selected: Some(rgba(0x5b524cff).into()),
+                        ghost_element_disabled: Some(rgba(0x3a3735ff).into()),
+                        text: Some(rgba(0xfbf1c7ff).into()),
+                        text_muted: Some(rgba(0xc5b597ff).into()),
+                        text_placeholder: Some(rgba(0x9a8c79ff).into()),
+                        text_disabled: Some(rgba(0x9a8c79ff).into()),
+                        text_accent: Some(rgba(0x83a598ff).into()),
+                        icon: Some(rgba(0xfbf1c7ff).into()),
+                        icon_muted: Some(rgba(0xc5b597ff).into()),
+                        icon_disabled: Some(rgba(0x9a8c79ff).into()),
+                        icon_placeholder: Some(rgba(0xc5b597ff).into()),
+                        icon_accent: Some(rgba(0x83a598ff).into()),
+                        status_bar_background: Some(rgba(0x4c4642ff).into()),
+                        title_bar_background: Some(rgba(0x4c4642ff).into()),
+                        toolbar_background: Some(rgba(0x282828ff).into()),
+                        tab_bar_background: Some(rgba(0x3a3735ff).into()),
+                        tab_inactive_background: Some(rgba(0x3a3735ff).into()),
+                        tab_active_background: Some(rgba(0x282828ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xfbf1c74c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x494340ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x494340ff).into()),
                         scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xefe2bcff).into()),
-                        editor_foreground: Some(rgba(0x282828ff).into()),
-                        editor_background: Some(rgba(0xf9f5d7ff).into()),
-                        editor_gutter_background: Some(rgba(0xf9f5d7ff).into()),
-                        editor_subheader_background: Some(rgba(0xecddb5ff).into()),
-                        editor_active_line_background: Some(rgba(0xecddb5bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xecddb5ff).into()),
-                        editor_line_number: Some(rgba(0x28282859).into()),
-                        editor_active_line_number: Some(rgba(0x282828ff).into()),
-                        editor_invisible: Some(rgba(0x5f5650ff).into()),
-                        editor_wrap_guide: Some(rgba(0x2828280d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x2828281a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x0b66781a).into()),
+                        scrollbar_track_border: Some(rgba(0x373432ff).into()),
+                        editor_foreground: Some(rgba(0xebdbb2ff).into()),
+                        editor_background: Some(rgba(0x282828ff).into()),
+                        editor_gutter_background: Some(rgba(0x282828ff).into()),
+                        editor_subheader_background: Some(rgba(0x3a3735ff).into()),
+                        editor_active_line_background: Some(rgba(0x3a3735bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x3a3735ff).into()),
+                        editor_line_number: Some(rgba(0xfbf1c759).into()),
+                        editor_active_line_number: Some(rgba(0xfbf1c7ff).into()),
+                        editor_invisible: Some(rgba(0xc5b597ff).into()),
+                        editor_wrap_guide: Some(rgba(0xfbf1c70d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xfbf1c71a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x83a5981a).into()),
                         editor_document_highlight_write_background: Some(rgba(0x92847466).into()),
-                        terminal_background: Some(rgba(0xf9f5d7ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0xb1a28aff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xdc8c7bff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xbfb787ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xe2b88bff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x8fb0baff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xbcb5afff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x9fbca8ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x282828ff).into()),
-                        terminal_ansi_black: Some(rgba(0xf9f5d7ff).into()),
-                        terminal_ansi_red: Some(rgba(0x9d0408ff).into()),
-                        terminal_ansi_green: Some(rgba(0x797410ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xb57616ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x0b6678ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0x7c6f64ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x437b59ff).into()),
-                        terminal_ansi_white: Some(rgba(0x282828ff).into()),
-                        link_text_hover: Some(rgba(0x0b6678ff).into()),
+                        terminal_background: Some(rgba(0x282828ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x73675eff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x93211eff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x615d1bff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x91611cff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x414f4aff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x514a41ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x45603eff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xfbf1c7ff).into()),
+                        terminal_ansi_black: Some(rgba(0x282828ff).into()),
+                        terminal_ansi_red: Some(rgba(0xfb4a35ff).into()),
+                        terminal_ansi_green: Some(rgba(0xb8bb27ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xf9bd30ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x83a598ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xa89984ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x8ec07cff).into()),
+                        terminal_ansi_white: Some(rgba(0xfbf1c7ff).into()),
+                        link_text_hover: Some(rgba(0x83a598ff).into()),
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xb57616ff).into()),
-                        conflict_background: Some(rgba(0xf5e2d0ff).into()),
-                        conflict_border: Some(rgba(0xebccabff).into()),
-                        created: Some(rgba(0x797410ff).into()),
-                        created_background: Some(rgba(0xe5e1ceff).into()),
-                        created_border: Some(rgba(0xd1cba8ff).into()),
-                        deleted: Some(rgba(0x9d0408ff).into()),
-                        deleted_background: Some(rgba(0xf4d1c9ff).into()),
-                        deleted_border: Some(rgba(0xe8ac9eff).into()),
-                        error: Some(rgba(0x9d0408ff).into()),
-                        error_background: Some(rgba(0xf4d1c9ff).into()),
-                        error_border: Some(rgba(0xe8ac9eff).into()),
-                        hidden: Some(rgba(0x8a7c6fff).into()),
-                        hidden_background: Some(rgba(0xd9c8a4ff).into()),
-                        hidden_border: Some(rgba(0xd1c09eff).into()),
-                        hint: Some(rgba(0x677562ff).into()),
-                        hint_background: Some(rgba(0xd2dee2ff).into()),
-                        hint_border: Some(rgba(0xaec6cdff).into()),
-                        ignored: Some(rgba(0x5f5650ff).into()),
-                        ignored_background: Some(rgba(0xd9c8a4ff).into()),
-                        ignored_border: Some(rgba(0xc9b99aff).into()),
-                        info: Some(rgba(0x0b6678ff).into()),
-                        info_background: Some(rgba(0xd2dee2ff).into()),
-                        info_border: Some(rgba(0xaec6cdff).into()),
-                        modified: Some(rgba(0xb57616ff).into()),
-                        modified_background: Some(rgba(0xf5e2d0ff).into()),
-                        modified_border: Some(rgba(0xebccabff).into()),
-                        predictive: Some(rgba(0x7d9881ff).into()),
-                        predictive_background: Some(rgba(0xe5e1ceff).into()),
-                        predictive_border: Some(rgba(0xd1cba8ff).into()),
-                        renamed: Some(rgba(0x0b6678ff).into()),
-                        renamed_background: Some(rgba(0xd2dee2ff).into()),
-                        renamed_border: Some(rgba(0xaec6cdff).into()),
-                        success: Some(rgba(0x797410ff).into()),
-                        success_background: Some(rgba(0xe5e1ceff).into()),
-                        success_border: Some(rgba(0xd1cba8ff).into()),
-                        unreachable: Some(rgba(0x5f5650ff).into()),
-                        unreachable_background: Some(rgba(0xd9c8a4ff).into()),
-                        unreachable_border: Some(rgba(0xc9b99aff).into()),
-                        warning: Some(rgba(0xb57616ff).into()),
-                        warning_background: Some(rgba(0xf5e2d0ff).into()),
-                        warning_border: Some(rgba(0xebccabff).into()),
+                        conflict: Some(rgba(0xf9bd30ff).into()),
+                        conflict_background: Some(rgba(0x582f10ff).into()),
+                        conflict_border: Some(rgba(0x754916ff).into()),
+                        created: Some(rgba(0xb8bb27ff).into()),
+                        created_background: Some(rgba(0x332b11ff).into()),
+                        created_border: Some(rgba(0x4a4516ff).into()),
+                        deleted: Some(rgba(0xfb4a35ff).into()),
+                        deleted_background: Some(rgba(0x5a0a10ff).into()),
+                        deleted_border: Some(rgba(0x771618ff).into()),
+                        error: Some(rgba(0xfb4a35ff).into()),
+                        error_background: Some(rgba(0x5a0a10ff).into()),
+                        error_border: Some(rgba(0x771618ff).into()),
+                        hidden: Some(rgba(0x9a8c79ff).into()),
+                        hidden_background: Some(rgba(0x4c4642ff).into()),
+                        hidden_border: Some(rgba(0x544c48ff).into()),
+                        hint: Some(rgba(0x8d957eff).into()),
+                        hint_background: Some(rgba(0x1e2321ff).into()),
+                        hint_border: Some(rgba(0x303a36ff).into()),
+                        ignored: Some(rgba(0xc5b597ff).into()),
+                        ignored_background: Some(rgba(0x4c4642ff).into()),
+                        ignored_border: Some(rgba(0x5b534dff).into()),
+                        info: Some(rgba(0x83a598ff).into()),
+                        info_background: Some(rgba(0x1e2321ff).into()),
+                        info_border: Some(rgba(0x303a36ff).into()),
+                        modified: Some(rgba(0xf9bd30ff).into()),
+                        modified_background: Some(rgba(0x582f10ff).into()),
+                        modified_border: Some(rgba(0x754916ff).into()),
+                        predictive: Some(rgba(0x717363ff).into()),
+                        predictive_background: Some(rgba(0x332b11ff).into()),
+                        predictive_border: Some(rgba(0x4a4516ff).into()),
+                        renamed: Some(rgba(0x83a598ff).into()),
+                        renamed_background: Some(rgba(0x1e2321ff).into()),
+                        renamed_border: Some(rgba(0x303a36ff).into()),
+                        success: Some(rgba(0xb8bb27ff).into()),
+                        success_background: Some(rgba(0x332b11ff).into()),
+                        success_border: Some(rgba(0x4a4516ff).into()),
+                        unreachable: Some(rgba(0xc5b597ff).into()),
+                        unreachable_background: Some(rgba(0x4c4642ff).into()),
+                        unreachable_border: Some(rgba(0x5b534dff).into()),
+                        warning: Some(rgba(0xf9bd30ff).into()),
+                        warning_background: Some(rgba(0x582f10ff).into()),
+                        warning_border: Some(rgba(0x754916ff).into()),
                         ..Default::default()
                     },
                     player: Some(PlayerColors(vec![
                         PlayerColor {
-                            cursor: rgba(0x0b6678ff).into(),
-                            background: rgba(0x0b6678ff).into(),
-                            selection: rgba(0x0b66783d).into(),
+                            cursor: rgba(0x83a598ff).into(),
+                            background: rgba(0x83a598ff).into(),
+                            selection: rgba(0x83a5983d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x7c6f64ff).into(),
-                            background: rgba(0x7c6f64ff).into(),
-                            selection: rgba(0x7c6f643d).into(),
+                            cursor: rgba(0xa89984ff).into(),
+                            background: rgba(0xa89984ff).into(),
+                            selection: rgba(0xa899843d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xaf3b05ff).into(),
-                            background: rgba(0xaf3b05ff).into(),
-                            selection: rgba(0xaf3b053d).into(),
+                            cursor: rgba(0xfd801bff).into(),
+                            background: rgba(0xfd801bff).into(),
+                            selection: rgba(0xfd801b3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x8f4071ff).into(),
-                            background: rgba(0x8f4071ff).into(),
-                            selection: rgba(0x8f40713d).into(),
+                            cursor: rgba(0xd3869bff).into(),
+                            background: rgba(0xd3869bff).into(),
+                            selection: rgba(0xd3869b3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x437b59ff).into(),
-                            background: rgba(0x437b59ff).into(),
-                            selection: rgba(0x437b593d).into(),
+                            cursor: rgba(0x8ec07cff).into(),
+                            background: rgba(0x8ec07cff).into(),
+                            selection: rgba(0x8ec07c3d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x9d0408ff).into(),
-                            background: rgba(0x9d0408ff).into(),
-                            selection: rgba(0x9d04083d).into(),
+                            cursor: rgba(0xfb4a35ff).into(),
+                            background: rgba(0xfb4a35ff).into(),
+                            selection: rgba(0xfb4a353d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xb57616ff).into(),
-                            background: rgba(0xb57616ff).into(),
-                            selection: rgba(0xb576163d).into(),
+                            cursor: rgba(0xf9bd30ff).into(),
+                            background: rgba(0xf9bd30ff).into(),
+                            selection: rgba(0xf9bd303d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x797410ff).into(),
-                            background: rgba(0x797410ff).into(),
-                            selection: rgba(0x7974103d).into(),
+                            cursor: rgba(0xb8bb27ff).into(),
+                            background: rgba(0xb8bb27ff).into(),
+                            selection: rgba(0xb8bb273d).into(),
                         },
                     ])),
                     syntax: Some(UserSyntaxTheme {
@@ -187,63 +187,63 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0b6678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "boolean".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    color: Some(rgba(0xd3869bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7c6f64ff).into()),
+                                    color: Some(rgba(0xa89984ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5d544eff).into()),
+                                    color: Some(rgba(0xc7b798ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
+                                    color: Some(rgba(0xfabd2fff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constructor".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0b6678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "embedded".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
+                                    color: Some(rgba(0x8ec07cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0b6678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0b6678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -251,28 +251,28 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "enum".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xaf3a03ff).into()),
+                                    color: Some(rgba(0xfe8019ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x79740eff).into()),
+                                    color: Some(rgba(0xb8bb26ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function.builtin".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x9d0006ff).into()),
+                                    color: Some(rgba(0xfb4934ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "hint".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x677562ff).into()),
+                                    color: Some(rgba(0x8d957eff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -280,21 +280,21 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x9d0006ff).into()),
+                                    color: Some(rgba(0xfb4934ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "label".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0b6678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
+                                    color: Some(rgba(0x8ec07cff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -302,28 +302,28 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    color: Some(rgba(0xd3869bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "number".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    color: Some(rgba(0xd3869bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "operator".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
+                                    color: Some(rgba(0x8ec07cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "predictive".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x7d9881ff).into()),
+                                    color: Some(rgba(0x717363ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -331,112 +331,112 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "preproc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x282828ff).into()),
+                                    color: Some(rgba(0xfbf1c7ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "primary".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x282828ff).into()),
+                                    color: Some(rgba(0xebdbb2ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x282828ff).into()),
+                                    color: Some(rgba(0xebdbb2ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x3c3836ff).into()),
+                                    color: Some(rgba(0xd5c4a1ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.bracket".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x665c54ff).into()),
+                                    color: Some(rgba(0xa89984ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x413d3aff).into()),
+                                    color: Some(rgba(0xe5d5adff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.list_marker".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x282828ff).into()),
+                                    color: Some(rgba(0xebdbb2ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x413d3aff).into()),
+                                    color: Some(rgba(0xe5d5adff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x79740eff).into()),
+                                    color: Some(rgba(0xb8bb26ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.escape".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x5d544eff).into()),
+                                    color: Some(rgba(0xc7b798ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.regex".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xaf3a03ff).into()),
+                                    color: Some(rgba(0xfe8019ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8f3f71ff).into()),
+                                    color: Some(rgba(0xd3869bff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special.symbol".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
+                                    color: Some(rgba(0x8ec07cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x427b58ff).into()),
+                                    color: Some(rgba(0x8ec07cff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "text.literal".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x076678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "title".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x79740eff).into()),
+                                    color: Some(rgba(0xb8bb26ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -444,21 +444,472 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb57614ff).into()),
+                                    color: Some(rgba(0xfabd2fff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x076678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x0b6678ff).into()),
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Gruvbox Dark Hard".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x5b534dff).into()),
+                        border_variant: Some(rgba(0x494340ff).into()),
+                        border_focused: Some(rgba(0x303a36ff).into()),
+                        border_selected: Some(rgba(0x303a36ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x544c48ff).into()),
+                        elevated_surface_background: Some(rgba(0x393634ff).into()),
+                        surface_background: Some(rgba(0x393634ff).into()),
+                        background: Some(rgba(0x4c4642ff).into()),
+                        panel_background: Some(rgba(0x393634ff).into()),
+                        element_background: Some(rgba(0x393634ff).into()),
+                        element_hover: Some(rgba(0x494340ff).into()),
+                        element_active: Some(rgba(0x5b524cff).into()),
+                        element_selected: Some(rgba(0x5b524cff).into()),
+                        element_disabled: Some(rgba(0x393634ff).into()),
+                        drop_target_background: Some(rgba(0xc5b59780).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x494340ff).into()),
+                        ghost_element_active: Some(rgba(0x5b524cff).into()),
+                        ghost_element_selected: Some(rgba(0x5b524cff).into()),
+                        ghost_element_disabled: Some(rgba(0x393634ff).into()),
+                        text: Some(rgba(0xfbf1c7ff).into()),
+                        text_muted: Some(rgba(0xc5b597ff).into()),
+                        text_placeholder: Some(rgba(0x9a8c79ff).into()),
+                        text_disabled: Some(rgba(0x9a8c79ff).into()),
+                        text_accent: Some(rgba(0x83a598ff).into()),
+                        icon: Some(rgba(0xfbf1c7ff).into()),
+                        icon_muted: Some(rgba(0xc5b597ff).into()),
+                        icon_disabled: Some(rgba(0x9a8c79ff).into()),
+                        icon_placeholder: Some(rgba(0xc5b597ff).into()),
+                        icon_accent: Some(rgba(0x83a598ff).into()),
+                        status_bar_background: Some(rgba(0x4c4642ff).into()),
+                        title_bar_background: Some(rgba(0x4c4642ff).into()),
+                        toolbar_background: Some(rgba(0x1d2021ff).into()),
+                        tab_bar_background: Some(rgba(0x393634ff).into()),
+                        tab_inactive_background: Some(rgba(0x393634ff).into()),
+                        tab_active_background: Some(rgba(0x1d2021ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xfbf1c74c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x494340ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x494340ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x343130ff).into()),
+                        editor_foreground: Some(rgba(0xebdbb2ff).into()),
+                        editor_background: Some(rgba(0x1d2021ff).into()),
+                        editor_gutter_background: Some(rgba(0x1d2021ff).into()),
+                        editor_subheader_background: Some(rgba(0x393634ff).into()),
+                        editor_active_line_background: Some(rgba(0x393634bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x393634ff).into()),
+                        editor_line_number: Some(rgba(0xfbf1c759).into()),
+                        editor_active_line_number: Some(rgba(0xfbf1c7ff).into()),
+                        editor_invisible: Some(rgba(0xc5b597ff).into()),
+                        editor_wrap_guide: Some(rgba(0xfbf1c70d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xfbf1c71a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x83a5981a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x92847466).into()),
+                        terminal_background: Some(rgba(0x1d2021ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x73675eff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x93211eff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x615d1bff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x91611cff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x414f4aff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x514a41ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x45603eff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xfbf1c7ff).into()),
+                        terminal_ansi_black: Some(rgba(0x1d2021ff).into()),
+                        terminal_ansi_red: Some(rgba(0xfb4a35ff).into()),
+                        terminal_ansi_green: Some(rgba(0xb8bb27ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xf9bd30ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x83a598ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xa89984ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x8ec07cff).into()),
+                        terminal_ansi_white: Some(rgba(0xfbf1c7ff).into()),
+                        link_text_hover: Some(rgba(0x83a598ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xf9bd30ff).into()),
+                        conflict_background: Some(rgba(0x582f10ff).into()),
+                        conflict_border: Some(rgba(0x754916ff).into()),
+                        created: Some(rgba(0xb8bb27ff).into()),
+                        created_background: Some(rgba(0x332b11ff).into()),
+                        created_border: Some(rgba(0x4a4516ff).into()),
+                        deleted: Some(rgba(0xfb4a35ff).into()),
+                        deleted_background: Some(rgba(0x5a0a10ff).into()),
+                        deleted_border: Some(rgba(0x771618ff).into()),
+                        error: Some(rgba(0xfb4a35ff).into()),
+                        error_background: Some(rgba(0x5a0a10ff).into()),
+                        error_border: Some(rgba(0x771618ff).into()),
+                        hidden: Some(rgba(0x9a8c79ff).into()),
+                        hidden_background: Some(rgba(0x4c4642ff).into()),
+                        hidden_border: Some(rgba(0x544c48ff).into()),
+                        hint: Some(rgba(0x8d957eff).into()),
+                        hint_background: Some(rgba(0x1e2321ff).into()),
+                        hint_border: Some(rgba(0x303a36ff).into()),
+                        ignored: Some(rgba(0xc5b597ff).into()),
+                        ignored_background: Some(rgba(0x4c4642ff).into()),
+                        ignored_border: Some(rgba(0x5b534dff).into()),
+                        info: Some(rgba(0x83a598ff).into()),
+                        info_background: Some(rgba(0x1e2321ff).into()),
+                        info_border: Some(rgba(0x303a36ff).into()),
+                        modified: Some(rgba(0xf9bd30ff).into()),
+                        modified_background: Some(rgba(0x582f10ff).into()),
+                        modified_border: Some(rgba(0x754916ff).into()),
+                        predictive: Some(rgba(0x717363ff).into()),
+                        predictive_background: Some(rgba(0x332b11ff).into()),
+                        predictive_border: Some(rgba(0x4a4516ff).into()),
+                        renamed: Some(rgba(0x83a598ff).into()),
+                        renamed_background: Some(rgba(0x1e2321ff).into()),
+                        renamed_border: Some(rgba(0x303a36ff).into()),
+                        success: Some(rgba(0xb8bb27ff).into()),
+                        success_background: Some(rgba(0x332b11ff).into()),
+                        success_border: Some(rgba(0x4a4516ff).into()),
+                        unreachable: Some(rgba(0xc5b597ff).into()),
+                        unreachable_background: Some(rgba(0x4c4642ff).into()),
+                        unreachable_border: Some(rgba(0x5b534dff).into()),
+                        warning: Some(rgba(0xf9bd30ff).into()),
+                        warning_background: Some(rgba(0x582f10ff).into()),
+                        warning_border: Some(rgba(0x754916ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x83a598ff).into(),
+                            background: rgba(0x83a598ff).into(),
+                            selection: rgba(0x83a5983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa89984ff).into(),
+                            background: rgba(0xa89984ff).into(),
+                            selection: rgba(0xa899843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfd801bff).into(),
+                            background: rgba(0xfd801bff).into(),
+                            selection: rgba(0xfd801b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd3869bff).into(),
+                            background: rgba(0xd3869bff).into(),
+                            selection: rgba(0xd3869b3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x8ec07cff).into(),
+                            background: rgba(0x8ec07cff).into(),
+                            selection: rgba(0x8ec07c3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xfb4a35ff).into(),
+                            background: rgba(0xfb4a35ff).into(),
+                            selection: rgba(0xfb4a353d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf9bd30ff).into(),
+                            background: rgba(0xf9bd30ff).into(),
+                            selection: rgba(0xf9bd303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb8bb27ff).into(),
+                            background: rgba(0xb8bb27ff).into(),
+                            selection: rgba(0xb8bb273d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa89984ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc7b798ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfe8019ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8bb26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.builtin".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfb4934ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8d957eff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfb4934ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x717363ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfbf1c7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebdbb2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebdbb2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd5c4a1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa89984ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe5d5adff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebdbb2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe5d5adff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8bb26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc7b798ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfe8019ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd3869bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x8ec07cff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb8bb26ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xfabd2fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -1369,170 +1820,170 @@ pub fn gruvbox() -> UserThemeFamily {
                 },
             },
             UserTheme {
-                name: "Gruvbox Dark".into(),
-                appearance: Appearance::Dark,
+                name: "Gruvbox Light Hard".into(),
+                appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
                     colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x5b534dff).into()),
-                        border_variant: Some(rgba(0x494340ff).into()),
-                        border_focused: Some(rgba(0x303a36ff).into()),
-                        border_selected: Some(rgba(0x303a36ff).into()),
+                        border: Some(rgba(0xc9b99aff).into()),
+                        border_variant: Some(rgba(0xddcca7ff).into()),
+                        border_focused: Some(rgba(0xaec6cdff).into()),
+                        border_selected: Some(rgba(0xaec6cdff).into()),
                         border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x544c48ff).into()),
-                        elevated_surface_background: Some(rgba(0x3a3735ff).into()),
-                        surface_background: Some(rgba(0x3a3735ff).into()),
-                        background: Some(rgba(0x4c4642ff).into()),
-                        panel_background: Some(rgba(0x3a3735ff).into()),
-                        element_background: Some(rgba(0x3a3735ff).into()),
-                        element_hover: Some(rgba(0x494340ff).into()),
-                        element_active: Some(rgba(0x5b524cff).into()),
-                        element_selected: Some(rgba(0x5b524cff).into()),
-                        element_disabled: Some(rgba(0x3a3735ff).into()),
-                        drop_target_background: Some(rgba(0xc5b59780).into()),
+                        border_disabled: Some(rgba(0xd1c09eff).into()),
+                        elevated_surface_background: Some(rgba(0xecddb5ff).into()),
+                        surface_background: Some(rgba(0xecddb5ff).into()),
+                        background: Some(rgba(0xd9c8a4ff).into()),
+                        panel_background: Some(rgba(0xecddb5ff).into()),
+                        element_background: Some(rgba(0xecddb5ff).into()),
+                        element_hover: Some(rgba(0xddcca7ff).into()),
+                        element_active: Some(rgba(0xc9b99aff).into()),
+                        element_selected: Some(rgba(0xc9b99aff).into()),
+                        element_disabled: Some(rgba(0xecddb5ff).into()),
+                        drop_target_background: Some(rgba(0x5f565080).into()),
                         ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x494340ff).into()),
-                        ghost_element_active: Some(rgba(0x5b524cff).into()),
-                        ghost_element_selected: Some(rgba(0x5b524cff).into()),
-                        ghost_element_disabled: Some(rgba(0x3a3735ff).into()),
-                        text: Some(rgba(0xfbf1c7ff).into()),
-                        text_muted: Some(rgba(0xc5b597ff).into()),
-                        text_placeholder: Some(rgba(0x9a8c79ff).into()),
-                        text_disabled: Some(rgba(0x9a8c79ff).into()),
-                        text_accent: Some(rgba(0x83a598ff).into()),
-                        icon: Some(rgba(0xfbf1c7ff).into()),
-                        icon_muted: Some(rgba(0xc5b597ff).into()),
-                        icon_disabled: Some(rgba(0x9a8c79ff).into()),
-                        icon_placeholder: Some(rgba(0xc5b597ff).into()),
-                        icon_accent: Some(rgba(0x83a598ff).into()),
-                        status_bar_background: Some(rgba(0x4c4642ff).into()),
-                        title_bar_background: Some(rgba(0x4c4642ff).into()),
-                        toolbar_background: Some(rgba(0x282828ff).into()),
-                        tab_bar_background: Some(rgba(0x3a3735ff).into()),
-                        tab_inactive_background: Some(rgba(0x3a3735ff).into()),
-                        tab_active_background: Some(rgba(0x282828ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xfbf1c74c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x494340ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x494340ff).into()),
+                        ghost_element_hover: Some(rgba(0xddcca7ff).into()),
+                        ghost_element_active: Some(rgba(0xc9b99aff).into()),
+                        ghost_element_selected: Some(rgba(0xc9b99aff).into()),
+                        ghost_element_disabled: Some(rgba(0xecddb5ff).into()),
+                        text: Some(rgba(0x282828ff).into()),
+                        text_muted: Some(rgba(0x5f5650ff).into()),
+                        text_placeholder: Some(rgba(0x8a7c6fff).into()),
+                        text_disabled: Some(rgba(0x8a7c6fff).into()),
+                        text_accent: Some(rgba(0x0b6678ff).into()),
+                        icon: Some(rgba(0x282828ff).into()),
+                        icon_muted: Some(rgba(0x5f5650ff).into()),
+                        icon_disabled: Some(rgba(0x8a7c6fff).into()),
+                        icon_placeholder: Some(rgba(0x5f5650ff).into()),
+                        icon_accent: Some(rgba(0x0b6678ff).into()),
+                        status_bar_background: Some(rgba(0xd9c8a4ff).into()),
+                        title_bar_background: Some(rgba(0xd9c8a4ff).into()),
+                        toolbar_background: Some(rgba(0xf9f5d7ff).into()),
+                        tab_bar_background: Some(rgba(0xecddb5ff).into()),
+                        tab_inactive_background: Some(rgba(0xecddb5ff).into()),
+                        tab_active_background: Some(rgba(0xf9f5d7ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x2828284c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xddcca7ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xddcca7ff).into()),
                         scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x373432ff).into()),
-                        editor_foreground: Some(rgba(0xebdbb2ff).into()),
-                        editor_background: Some(rgba(0x282828ff).into()),
-                        editor_gutter_background: Some(rgba(0x282828ff).into()),
-                        editor_subheader_background: Some(rgba(0x3a3735ff).into()),
-                        editor_active_line_background: Some(rgba(0x3a3735bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x3a3735ff).into()),
-                        editor_line_number: Some(rgba(0xfbf1c759).into()),
-                        editor_active_line_number: Some(rgba(0xfbf1c7ff).into()),
-                        editor_invisible: Some(rgba(0xc5b597ff).into()),
-                        editor_wrap_guide: Some(rgba(0xfbf1c70d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xfbf1c71a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x83a5981a).into()),
+                        scrollbar_track_border: Some(rgba(0xefe2bcff).into()),
+                        editor_foreground: Some(rgba(0x282828ff).into()),
+                        editor_background: Some(rgba(0xf9f5d7ff).into()),
+                        editor_gutter_background: Some(rgba(0xf9f5d7ff).into()),
+                        editor_subheader_background: Some(rgba(0xecddb5ff).into()),
+                        editor_active_line_background: Some(rgba(0xecddb5bf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xecddb5ff).into()),
+                        editor_line_number: Some(rgba(0x28282859).into()),
+                        editor_active_line_number: Some(rgba(0x282828ff).into()),
+                        editor_invisible: Some(rgba(0x5f5650ff).into()),
+                        editor_wrap_guide: Some(rgba(0x2828280d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x2828281a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x0b66781a).into()),
                         editor_document_highlight_write_background: Some(rgba(0x92847466).into()),
-                        terminal_background: Some(rgba(0x282828ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x73675eff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x93211eff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x615d1bff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x91611cff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x414f4aff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x514a41ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x45603eff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xfbf1c7ff).into()),
-                        terminal_ansi_black: Some(rgba(0x282828ff).into()),
-                        terminal_ansi_red: Some(rgba(0xfb4a35ff).into()),
-                        terminal_ansi_green: Some(rgba(0xb8bb27ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xf9bd30ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x83a598ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xa89984ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x8ec07cff).into()),
-                        terminal_ansi_white: Some(rgba(0xfbf1c7ff).into()),
-                        link_text_hover: Some(rgba(0x83a598ff).into()),
+                        terminal_background: Some(rgba(0xf9f5d7ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0xb1a28aff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xdc8c7bff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xbfb787ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xe2b88bff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x8fb0baff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xbcb5afff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x9fbca8ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x282828ff).into()),
+                        terminal_ansi_black: Some(rgba(0xf9f5d7ff).into()),
+                        terminal_ansi_red: Some(rgba(0x9d0408ff).into()),
+                        terminal_ansi_green: Some(rgba(0x797410ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xb57616ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x0b6678ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0x7c6f64ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x437b59ff).into()),
+                        terminal_ansi_white: Some(rgba(0x282828ff).into()),
+                        link_text_hover: Some(rgba(0x0b6678ff).into()),
                         ..Default::default()
                     },
                     status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xf9bd30ff).into()),
-                        conflict_background: Some(rgba(0x582f10ff).into()),
-                        conflict_border: Some(rgba(0x754916ff).into()),
-                        created: Some(rgba(0xb8bb27ff).into()),
-                        created_background: Some(rgba(0x332b11ff).into()),
-                        created_border: Some(rgba(0x4a4516ff).into()),
-                        deleted: Some(rgba(0xfb4a35ff).into()),
-                        deleted_background: Some(rgba(0x5a0a10ff).into()),
-                        deleted_border: Some(rgba(0x771618ff).into()),
-                        error: Some(rgba(0xfb4a35ff).into()),
-                        error_background: Some(rgba(0x5a0a10ff).into()),
-                        error_border: Some(rgba(0x771618ff).into()),
-                        hidden: Some(rgba(0x9a8c79ff).into()),
-                        hidden_background: Some(rgba(0x4c4642ff).into()),
-                        hidden_border: Some(rgba(0x544c48ff).into()),
-                        hint: Some(rgba(0x8d957eff).into()),
-                        hint_background: Some(rgba(0x1e2321ff).into()),
-                        hint_border: Some(rgba(0x303a36ff).into()),
-                        ignored: Some(rgba(0xc5b597ff).into()),
-                        ignored_background: Some(rgba(0x4c4642ff).into()),
-                        ignored_border: Some(rgba(0x5b534dff).into()),
-                        info: Some(rgba(0x83a598ff).into()),
-                        info_background: Some(rgba(0x1e2321ff).into()),
-                        info_border: Some(rgba(0x303a36ff).into()),
-                        modified: Some(rgba(0xf9bd30ff).into()),
-                        modified_background: Some(rgba(0x582f10ff).into()),
-                        modified_border: Some(rgba(0x754916ff).into()),
-                        predictive: Some(rgba(0x717363ff).into()),
-                        predictive_background: Some(rgba(0x332b11ff).into()),
-                        predictive_border: Some(rgba(0x4a4516ff).into()),
-                        renamed: Some(rgba(0x83a598ff).into()),
-                        renamed_background: Some(rgba(0x1e2321ff).into()),
-                        renamed_border: Some(rgba(0x303a36ff).into()),
-                        success: Some(rgba(0xb8bb27ff).into()),
-                        success_background: Some(rgba(0x332b11ff).into()),
-                        success_border: Some(rgba(0x4a4516ff).into()),
-                        unreachable: Some(rgba(0xc5b597ff).into()),
-                        unreachable_background: Some(rgba(0x4c4642ff).into()),
-                        unreachable_border: Some(rgba(0x5b534dff).into()),
-                        warning: Some(rgba(0xf9bd30ff).into()),
-                        warning_background: Some(rgba(0x582f10ff).into()),
-                        warning_border: Some(rgba(0x754916ff).into()),
+                        conflict: Some(rgba(0xb57616ff).into()),
+                        conflict_background: Some(rgba(0xf5e2d0ff).into()),
+                        conflict_border: Some(rgba(0xebccabff).into()),
+                        created: Some(rgba(0x797410ff).into()),
+                        created_background: Some(rgba(0xe5e1ceff).into()),
+                        created_border: Some(rgba(0xd1cba8ff).into()),
+                        deleted: Some(rgba(0x9d0408ff).into()),
+                        deleted_background: Some(rgba(0xf4d1c9ff).into()),
+                        deleted_border: Some(rgba(0xe8ac9eff).into()),
+                        error: Some(rgba(0x9d0408ff).into()),
+                        error_background: Some(rgba(0xf4d1c9ff).into()),
+                        error_border: Some(rgba(0xe8ac9eff).into()),
+                        hidden: Some(rgba(0x8a7c6fff).into()),
+                        hidden_background: Some(rgba(0xd9c8a4ff).into()),
+                        hidden_border: Some(rgba(0xd1c09eff).into()),
+                        hint: Some(rgba(0x677562ff).into()),
+                        hint_background: Some(rgba(0xd2dee2ff).into()),
+                        hint_border: Some(rgba(0xaec6cdff).into()),
+                        ignored: Some(rgba(0x5f5650ff).into()),
+                        ignored_background: Some(rgba(0xd9c8a4ff).into()),
+                        ignored_border: Some(rgba(0xc9b99aff).into()),
+                        info: Some(rgba(0x0b6678ff).into()),
+                        info_background: Some(rgba(0xd2dee2ff).into()),
+                        info_border: Some(rgba(0xaec6cdff).into()),
+                        modified: Some(rgba(0xb57616ff).into()),
+                        modified_background: Some(rgba(0xf5e2d0ff).into()),
+                        modified_border: Some(rgba(0xebccabff).into()),
+                        predictive: Some(rgba(0x7d9881ff).into()),
+                        predictive_background: Some(rgba(0xe5e1ceff).into()),
+                        predictive_border: Some(rgba(0xd1cba8ff).into()),
+                        renamed: Some(rgba(0x0b6678ff).into()),
+                        renamed_background: Some(rgba(0xd2dee2ff).into()),
+                        renamed_border: Some(rgba(0xaec6cdff).into()),
+                        success: Some(rgba(0x797410ff).into()),
+                        success_background: Some(rgba(0xe5e1ceff).into()),
+                        success_border: Some(rgba(0xd1cba8ff).into()),
+                        unreachable: Some(rgba(0x5f5650ff).into()),
+                        unreachable_background: Some(rgba(0xd9c8a4ff).into()),
+                        unreachable_border: Some(rgba(0xc9b99aff).into()),
+                        warning: Some(rgba(0xb57616ff).into()),
+                        warning_background: Some(rgba(0xf5e2d0ff).into()),
+                        warning_border: Some(rgba(0xebccabff).into()),
                         ..Default::default()
                     },
                     player: Some(PlayerColors(vec![
                         PlayerColor {
-                            cursor: rgba(0x83a598ff).into(),
-                            background: rgba(0x83a598ff).into(),
-                            selection: rgba(0x83a5983d).into(),
+                            cursor: rgba(0x0b6678ff).into(),
+                            background: rgba(0x0b6678ff).into(),
+                            selection: rgba(0x0b66783d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xa89984ff).into(),
-                            background: rgba(0xa89984ff).into(),
-                            selection: rgba(0xa899843d).into(),
+                            cursor: rgba(0x7c6f64ff).into(),
+                            background: rgba(0x7c6f64ff).into(),
+                            selection: rgba(0x7c6f643d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xfd801bff).into(),
-                            background: rgba(0xfd801bff).into(),
-                            selection: rgba(0xfd801b3d).into(),
+                            cursor: rgba(0xaf3b05ff).into(),
+                            background: rgba(0xaf3b05ff).into(),
+                            selection: rgba(0xaf3b053d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xd3869bff).into(),
-                            background: rgba(0xd3869bff).into(),
-                            selection: rgba(0xd3869b3d).into(),
+                            cursor: rgba(0x8f4071ff).into(),
+                            background: rgba(0x8f4071ff).into(),
+                            selection: rgba(0x8f40713d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0x8ec07cff).into(),
-                            background: rgba(0x8ec07cff).into(),
-                            selection: rgba(0x8ec07c3d).into(),
+                            cursor: rgba(0x437b59ff).into(),
+                            background: rgba(0x437b59ff).into(),
+                            selection: rgba(0x437b593d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xfb4a35ff).into(),
-                            background: rgba(0xfb4a35ff).into(),
-                            selection: rgba(0xfb4a353d).into(),
+                            cursor: rgba(0x9d0408ff).into(),
+                            background: rgba(0x9d0408ff).into(),
+                            selection: rgba(0x9d04083d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xf9bd30ff).into(),
-                            background: rgba(0xf9bd30ff).into(),
-                            selection: rgba(0xf9bd303d).into(),
+                            cursor: rgba(0xb57616ff).into(),
+                            background: rgba(0xb57616ff).into(),
+                            selection: rgba(0xb576163d).into(),
                         },
                         PlayerColor {
-                            cursor: rgba(0xb8bb27ff).into(),
-                            background: rgba(0xb8bb27ff).into(),
-                            selection: rgba(0xb8bb273d).into(),
+                            cursor: rgba(0x797410ff).into(),
+                            background: rgba(0x797410ff).into(),
+                            selection: rgba(0x7974103d).into(),
                         },
                     ])),
                     syntax: Some(UserSyntaxTheme {
@@ -1540,63 +1991,63 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "attribute".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x0b6678ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "boolean".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
+                                    color: Some(rgba(0x8f3f71ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
+                                    color: Some(rgba(0x7c6f64ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "comment.doc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc7b798ff).into()),
+                                    color: Some(rgba(0x5d544eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfabd2fff).into()),
+                                    color: Some(rgba(0xb57614ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "constructor".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x0b6678ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "embedded".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
+                                    color: Some(rgba(0x427b58ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x0b6678ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "emphasis.strong".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x0b6678ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -1604,28 +2055,28 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "enum".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfe8019ff).into()),
+                                    color: Some(rgba(0xaf3a03ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb8bb26ff).into()),
+                                    color: Some(rgba(0x79740eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "function.builtin".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfb4934ff).into()),
+                                    color: Some(rgba(0x9d0006ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "hint".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8d957eff).into()),
+                                    color: Some(rgba(0x677562ff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -1633,21 +2084,21 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "keyword".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfb4934ff).into()),
+                                    color: Some(rgba(0x9d0006ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "label".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x0b6678ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "link_text".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
+                                    color: Some(rgba(0x427b58ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -1655,28 +2106,28 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "link_uri".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
+                                    color: Some(rgba(0x8f3f71ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "number".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
+                                    color: Some(rgba(0x8f3f71ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "operator".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
+                                    color: Some(rgba(0x427b58ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "predictive".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x717363ff).into()),
+                                    color: Some(rgba(0x7d9881ff).into()),
                                     font_style: Some(UserFontStyle::Italic),
                                     ..Default::default()
                                 },
@@ -1684,112 +2135,112 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "preproc".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfbf1c7ff).into()),
+                                    color: Some(rgba(0x282828ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "primary".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xebdbb2ff).into()),
+                                    color: Some(rgba(0x282828ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "property".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xebdbb2ff).into()),
+                                    color: Some(rgba(0x282828ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd5c4a1ff).into()),
+                                    color: Some(rgba(0x3c3836ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.bracket".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
+                                    color: Some(rgba(0x665c54ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.delimiter".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe5d5adff).into()),
+                                    color: Some(rgba(0x413d3aff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.list_marker".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xebdbb2ff).into()),
+                                    color: Some(rgba(0x282828ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "punctuation.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xe5d5adff).into()),
+                                    color: Some(rgba(0x413d3aff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb8bb26ff).into()),
+                                    color: Some(rgba(0x79740eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.escape".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xc7b798ff).into()),
+                                    color: Some(rgba(0x5d544eff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.regex".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfe8019ff).into()),
+                                    color: Some(rgba(0xaf3a03ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
+                                    color: Some(rgba(0x8f3f71ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "string.special.symbol".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
+                                    color: Some(rgba(0x427b58ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "tag".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
+                                    color: Some(rgba(0x427b58ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "text.literal".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "title".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xb8bb26ff).into()),
+                                    color: Some(rgba(0x79740eff).into()),
                                     font_weight: Some(UserFontWeight(700.0)),
                                     ..Default::default()
                                 },
@@ -1797,21 +2248,21 @@ pub fn gruvbox() -> UserThemeFamily {
                             (
                                 "type".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0xfabd2fff).into()),
+                                    color: Some(rgba(0xb57614ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variable".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x076678ff).into()),
                                     ..Default::default()
                                 },
                             ),
                             (
                                 "variant".into(),
                                 UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
+                                    color: Some(rgba(0x0b6678ff).into()),
                                     ..Default::default()
                                 },
                             ),
@@ -2263,457 +2714,6 @@ pub fn gruvbox() -> UserThemeFamily {
                                 "variant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x0b6678ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Gruvbox Dark Hard".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x5b534dff).into()),
-                        border_variant: Some(rgba(0x494340ff).into()),
-                        border_focused: Some(rgba(0x303a36ff).into()),
-                        border_selected: Some(rgba(0x303a36ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x544c48ff).into()),
-                        elevated_surface_background: Some(rgba(0x393634ff).into()),
-                        surface_background: Some(rgba(0x393634ff).into()),
-                        background: Some(rgba(0x4c4642ff).into()),
-                        panel_background: Some(rgba(0x393634ff).into()),
-                        element_background: Some(rgba(0x393634ff).into()),
-                        element_hover: Some(rgba(0x494340ff).into()),
-                        element_active: Some(rgba(0x5b524cff).into()),
-                        element_selected: Some(rgba(0x5b524cff).into()),
-                        element_disabled: Some(rgba(0x393634ff).into()),
-                        drop_target_background: Some(rgba(0xc5b59780).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x494340ff).into()),
-                        ghost_element_active: Some(rgba(0x5b524cff).into()),
-                        ghost_element_selected: Some(rgba(0x5b524cff).into()),
-                        ghost_element_disabled: Some(rgba(0x393634ff).into()),
-                        text: Some(rgba(0xfbf1c7ff).into()),
-                        text_muted: Some(rgba(0xc5b597ff).into()),
-                        text_placeholder: Some(rgba(0x9a8c79ff).into()),
-                        text_disabled: Some(rgba(0x9a8c79ff).into()),
-                        text_accent: Some(rgba(0x83a598ff).into()),
-                        icon: Some(rgba(0xfbf1c7ff).into()),
-                        icon_muted: Some(rgba(0xc5b597ff).into()),
-                        icon_disabled: Some(rgba(0x9a8c79ff).into()),
-                        icon_placeholder: Some(rgba(0xc5b597ff).into()),
-                        icon_accent: Some(rgba(0x83a598ff).into()),
-                        status_bar_background: Some(rgba(0x4c4642ff).into()),
-                        title_bar_background: Some(rgba(0x4c4642ff).into()),
-                        toolbar_background: Some(rgba(0x1d2021ff).into()),
-                        tab_bar_background: Some(rgba(0x393634ff).into()),
-                        tab_inactive_background: Some(rgba(0x393634ff).into()),
-                        tab_active_background: Some(rgba(0x1d2021ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xfbf1c74c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x494340ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x494340ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x343130ff).into()),
-                        editor_foreground: Some(rgba(0xebdbb2ff).into()),
-                        editor_background: Some(rgba(0x1d2021ff).into()),
-                        editor_gutter_background: Some(rgba(0x1d2021ff).into()),
-                        editor_subheader_background: Some(rgba(0x393634ff).into()),
-                        editor_active_line_background: Some(rgba(0x393634bf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x393634ff).into()),
-                        editor_line_number: Some(rgba(0xfbf1c759).into()),
-                        editor_active_line_number: Some(rgba(0xfbf1c7ff).into()),
-                        editor_invisible: Some(rgba(0xc5b597ff).into()),
-                        editor_wrap_guide: Some(rgba(0xfbf1c70d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xfbf1c71a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x83a5981a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x92847466).into()),
-                        terminal_background: Some(rgba(0x1d2021ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x73675eff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x93211eff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x615d1bff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x91611cff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x414f4aff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x514a41ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x45603eff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xfbf1c7ff).into()),
-                        terminal_ansi_black: Some(rgba(0x1d2021ff).into()),
-                        terminal_ansi_red: Some(rgba(0xfb4a35ff).into()),
-                        terminal_ansi_green: Some(rgba(0xb8bb27ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xf9bd30ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x83a598ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xa89984ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x8ec07cff).into()),
-                        terminal_ansi_white: Some(rgba(0xfbf1c7ff).into()),
-                        link_text_hover: Some(rgba(0x83a598ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xf9bd30ff).into()),
-                        conflict_background: Some(rgba(0x582f10ff).into()),
-                        conflict_border: Some(rgba(0x754916ff).into()),
-                        created: Some(rgba(0xb8bb27ff).into()),
-                        created_background: Some(rgba(0x332b11ff).into()),
-                        created_border: Some(rgba(0x4a4516ff).into()),
-                        deleted: Some(rgba(0xfb4a35ff).into()),
-                        deleted_background: Some(rgba(0x5a0a10ff).into()),
-                        deleted_border: Some(rgba(0x771618ff).into()),
-                        error: Some(rgba(0xfb4a35ff).into()),
-                        error_background: Some(rgba(0x5a0a10ff).into()),
-                        error_border: Some(rgba(0x771618ff).into()),
-                        hidden: Some(rgba(0x9a8c79ff).into()),
-                        hidden_background: Some(rgba(0x4c4642ff).into()),
-                        hidden_border: Some(rgba(0x544c48ff).into()),
-                        hint: Some(rgba(0x8d957eff).into()),
-                        hint_background: Some(rgba(0x1e2321ff).into()),
-                        hint_border: Some(rgba(0x303a36ff).into()),
-                        ignored: Some(rgba(0xc5b597ff).into()),
-                        ignored_background: Some(rgba(0x4c4642ff).into()),
-                        ignored_border: Some(rgba(0x5b534dff).into()),
-                        info: Some(rgba(0x83a598ff).into()),
-                        info_background: Some(rgba(0x1e2321ff).into()),
-                        info_border: Some(rgba(0x303a36ff).into()),
-                        modified: Some(rgba(0xf9bd30ff).into()),
-                        modified_background: Some(rgba(0x582f10ff).into()),
-                        modified_border: Some(rgba(0x754916ff).into()),
-                        predictive: Some(rgba(0x717363ff).into()),
-                        predictive_background: Some(rgba(0x332b11ff).into()),
-                        predictive_border: Some(rgba(0x4a4516ff).into()),
-                        renamed: Some(rgba(0x83a598ff).into()),
-                        renamed_background: Some(rgba(0x1e2321ff).into()),
-                        renamed_border: Some(rgba(0x303a36ff).into()),
-                        success: Some(rgba(0xb8bb27ff).into()),
-                        success_background: Some(rgba(0x332b11ff).into()),
-                        success_border: Some(rgba(0x4a4516ff).into()),
-                        unreachable: Some(rgba(0xc5b597ff).into()),
-                        unreachable_background: Some(rgba(0x4c4642ff).into()),
-                        unreachable_border: Some(rgba(0x5b534dff).into()),
-                        warning: Some(rgba(0xf9bd30ff).into()),
-                        warning_background: Some(rgba(0x582f10ff).into()),
-                        warning_border: Some(rgba(0x754916ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x83a598ff).into(),
-                            background: rgba(0x83a598ff).into(),
-                            selection: rgba(0x83a5983d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa89984ff).into(),
-                            background: rgba(0xa89984ff).into(),
-                            selection: rgba(0xa899843d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xfd801bff).into(),
-                            background: rgba(0xfd801bff).into(),
-                            selection: rgba(0xfd801b3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd3869bff).into(),
-                            background: rgba(0xd3869bff).into(),
-                            selection: rgba(0xd3869b3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x8ec07cff).into(),
-                            background: rgba(0x8ec07cff).into(),
-                            selection: rgba(0x8ec07c3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xfb4a35ff).into(),
-                            background: rgba(0xfb4a35ff).into(),
-                            selection: rgba(0xfb4a353d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xf9bd30ff).into(),
-                            background: rgba(0xf9bd30ff).into(),
-                            selection: rgba(0xf9bd303d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb8bb27ff).into(),
-                            background: rgba(0xb8bb27ff).into(),
-                            selection: rgba(0xb8bb273d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc7b798ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfabd2fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfe8019ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb8bb26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.builtin".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfb4934ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8d957eff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfb4934ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x717363ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfbf1c7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebdbb2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebdbb2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd5c4a1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa89984ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe5d5adff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebdbb2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe5d5adff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb8bb26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc7b798ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfe8019ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd3869bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x8ec07cff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb8bb26ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xfabd2fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x83a598ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme/src/themes/one.rs
+++ b/crates/theme/src/themes/one.rs
@@ -16,457 +16,6 @@ pub fn one() -> UserThemeFamily {
         author: "Zed Industries".into(),
         themes: vec![
             UserTheme {
-                name: "One Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0xc9c9caff).into()),
-                        border_variant: Some(rgba(0xdfdfe0ff).into()),
-                        border_focused: Some(rgba(0xcbcdf6ff).into()),
-                        border_selected: Some(rgba(0xcbcdf6ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xd3d3d4ff).into()),
-                        elevated_surface_background: Some(rgba(0xebebecff).into()),
-                        surface_background: Some(rgba(0xebebecff).into()),
-                        background: Some(rgba(0xdcdcddff).into()),
-                        panel_background: Some(rgba(0xebebecff).into()),
-                        element_background: Some(rgba(0xebebecff).into()),
-                        element_hover: Some(rgba(0xdfdfe0ff).into()),
-                        element_active: Some(rgba(0xcacacaff).into()),
-                        element_selected: Some(rgba(0xcacacaff).into()),
-                        element_disabled: Some(rgba(0xebebecff).into()),
-                        drop_target_background: Some(rgba(0x7f818880).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xdfdfe0ff).into()),
-                        ghost_element_active: Some(rgba(0xcacacaff).into()),
-                        ghost_element_selected: Some(rgba(0xcacacaff).into()),
-                        ghost_element_disabled: Some(rgba(0xebebecff).into()),
-                        text: Some(rgba(0x383a41ff).into()),
-                        text_muted: Some(rgba(0x7f8188ff).into()),
-                        text_placeholder: Some(rgba(0xa1a1a3ff).into()),
-                        text_disabled: Some(rgba(0xa1a1a3ff).into()),
-                        text_accent: Some(rgba(0x5c79e2ff).into()),
-                        icon: Some(rgba(0x383a41ff).into()),
-                        icon_muted: Some(rgba(0x7f8188ff).into()),
-                        icon_disabled: Some(rgba(0xa1a1a3ff).into()),
-                        icon_placeholder: Some(rgba(0x7f8188ff).into()),
-                        icon_accent: Some(rgba(0x5c79e2ff).into()),
-                        status_bar_background: Some(rgba(0xdcdcddff).into()),
-                        title_bar_background: Some(rgba(0xdcdcddff).into()),
-                        toolbar_background: Some(rgba(0xfafafaff).into()),
-                        tab_bar_background: Some(rgba(0xebebecff).into()),
-                        tab_inactive_background: Some(rgba(0xebebecff).into()),
-                        tab_active_background: Some(rgba(0xfafafaff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x383a414c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xdfdfe0ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xdfdfe0ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xeeeeeeff).into()),
-                        editor_foreground: Some(rgba(0x383a41ff).into()),
-                        editor_background: Some(rgba(0xfafafaff).into()),
-                        editor_gutter_background: Some(rgba(0xfafafaff).into()),
-                        editor_subheader_background: Some(rgba(0xebebecff).into()),
-                        editor_active_line_background: Some(rgba(0xebebecbf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xebebecff).into()),
-                        editor_line_number: Some(rgba(0x383a4159).into()),
-                        editor_active_line_number: Some(rgba(0x383a41ff).into()),
-                        editor_invisible: Some(rgba(0x7f8188ff).into()),
-                        editor_wrap_guide: Some(rgba(0x383a410d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x383a411a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x5c79e21a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0xa3a3a466).into()),
-                        terminal_background: Some(rgba(0xfafafaff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0xaaaaaaff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xf0b0a4ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xb2cfa9ff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xf1dfc1ff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xb5baf2ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xcea6d3ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0xa4bfdbff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x383a41ff).into()),
-                        terminal_ansi_black: Some(rgba(0xfafafaff).into()),
-                        terminal_ansi_red: Some(rgba(0xd36151ff).into()),
-                        terminal_ansi_green: Some(rgba(0x669f59ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xdec184ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x5c79e2ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0x994fa6ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x3b82b7ff).into()),
-                        terminal_ansi_white: Some(rgba(0x383a41ff).into()),
-                        link_text_hover: Some(rgba(0x5c79e2ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xdec184ff).into()),
-                        conflict_background: Some(rgba(0xfaf2e6ff).into()),
-                        conflict_border: Some(rgba(0xf5e8d2ff).into()),
-                        created: Some(rgba(0x669f59ff).into()),
-                        created_background: Some(rgba(0xe0ebdcff).into()),
-                        created_border: Some(rgba(0xc8dcc1ff).into()),
-                        deleted: Some(rgba(0xd36151ff).into()),
-                        deleted_background: Some(rgba(0xfbdfd9ff).into()),
-                        deleted_border: Some(rgba(0xf6c6bdff).into()),
-                        error: Some(rgba(0xd36151ff).into()),
-                        error_background: Some(rgba(0xfbdfd9ff).into()),
-                        error_border: Some(rgba(0xf6c6bdff).into()),
-                        hidden: Some(rgba(0xa1a1a3ff).into()),
-                        hidden_background: Some(rgba(0xdcdcddff).into()),
-                        hidden_border: Some(rgba(0xd3d3d4ff).into()),
-                        hint: Some(rgba(0x9295beff).into()),
-                        hint_background: Some(rgba(0xe2e2faff).into()),
-                        hint_border: Some(rgba(0xcbcdf6ff).into()),
-                        ignored: Some(rgba(0x7f8188ff).into()),
-                        ignored_background: Some(rgba(0xdcdcddff).into()),
-                        ignored_border: Some(rgba(0xc9c9caff).into()),
-                        info: Some(rgba(0x5c79e2ff).into()),
-                        info_background: Some(rgba(0xe2e2faff).into()),
-                        info_border: Some(rgba(0xcbcdf6ff).into()),
-                        modified: Some(rgba(0xdec184ff).into()),
-                        modified_background: Some(rgba(0xfaf2e6ff).into()),
-                        modified_border: Some(rgba(0xf5e8d2ff).into()),
-                        predictive: Some(rgba(0x9c9fc7ff).into()),
-                        predictive_background: Some(rgba(0xe0ebdcff).into()),
-                        predictive_border: Some(rgba(0xc8dcc1ff).into()),
-                        renamed: Some(rgba(0x5c79e2ff).into()),
-                        renamed_background: Some(rgba(0xe2e2faff).into()),
-                        renamed_border: Some(rgba(0xcbcdf6ff).into()),
-                        success: Some(rgba(0x669f59ff).into()),
-                        success_background: Some(rgba(0xe0ebdcff).into()),
-                        success_border: Some(rgba(0xc8dcc1ff).into()),
-                        unreachable: Some(rgba(0x7f8188ff).into()),
-                        unreachable_background: Some(rgba(0xdcdcddff).into()),
-                        unreachable_border: Some(rgba(0xc9c9caff).into()),
-                        warning: Some(rgba(0xdec184ff).into()),
-                        warning_background: Some(rgba(0xfaf2e6ff).into()),
-                        warning_border: Some(rgba(0xf5e8d2ff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x5c79e2ff).into(),
-                            background: rgba(0x5c79e2ff).into(),
-                            selection: rgba(0x5c79e23d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x994fa6ff).into(),
-                            background: rgba(0x994fa6ff).into(),
-                            selection: rgba(0x994fa63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xad6f27ff).into(),
-                            background: rgba(0xad6f27ff).into(),
-                            selection: rgba(0xad6f273d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xa44aabff).into(),
-                            background: rgba(0xa44aabff).into(),
-                            selection: rgba(0xa44aab3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x3b82b7ff).into(),
-                            background: rgba(0x3b82b7ff).into(),
-                            selection: rgba(0x3b82b73d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd36151ff).into(),
-                            background: rgba(0xd36151ff).into(),
-                            selection: rgba(0xd361513d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xdec184ff).into(),
-                            background: rgba(0xdec184ff).into(),
-                            selection: rgba(0xdec1843d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x669f59ff).into(),
-                            background: rgba(0x669f59ff).into(),
-                            selection: rgba(0x669f593d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5c79e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa2a3a7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7c7e86ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x669f59ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5c79e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x383a41ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5c79e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f26ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd36050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5b79e3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9295beff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xa449abff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5c79e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5b79e3ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3982b7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3982b7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9c9fc7ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x383a41ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x383a41ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd36050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x383a41ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4d4f52ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x4d4f52ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd36050ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb92c46ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x659f58ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x7c7e86ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f27ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f27ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f27ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5c79e2ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x659f58ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xd36050ff).into()),
-                                    font_weight: Some(UserFontWeight(400.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x3982b7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x383a41ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xad6f26ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5b79e3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
                 name: "One Dark".into(),
                 appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
@@ -910,6 +459,457 @@ pub fn one() -> UserThemeFamily {
                                 "variant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x74ade9ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "One Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0xc9c9caff).into()),
+                        border_variant: Some(rgba(0xdfdfe0ff).into()),
+                        border_focused: Some(rgba(0xcbcdf6ff).into()),
+                        border_selected: Some(rgba(0xcbcdf6ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xd3d3d4ff).into()),
+                        elevated_surface_background: Some(rgba(0xebebecff).into()),
+                        surface_background: Some(rgba(0xebebecff).into()),
+                        background: Some(rgba(0xdcdcddff).into()),
+                        panel_background: Some(rgba(0xebebecff).into()),
+                        element_background: Some(rgba(0xebebecff).into()),
+                        element_hover: Some(rgba(0xdfdfe0ff).into()),
+                        element_active: Some(rgba(0xcacacaff).into()),
+                        element_selected: Some(rgba(0xcacacaff).into()),
+                        element_disabled: Some(rgba(0xebebecff).into()),
+                        drop_target_background: Some(rgba(0x7f818880).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xdfdfe0ff).into()),
+                        ghost_element_active: Some(rgba(0xcacacaff).into()),
+                        ghost_element_selected: Some(rgba(0xcacacaff).into()),
+                        ghost_element_disabled: Some(rgba(0xebebecff).into()),
+                        text: Some(rgba(0x383a41ff).into()),
+                        text_muted: Some(rgba(0x7f8188ff).into()),
+                        text_placeholder: Some(rgba(0xa1a1a3ff).into()),
+                        text_disabled: Some(rgba(0xa1a1a3ff).into()),
+                        text_accent: Some(rgba(0x5c79e2ff).into()),
+                        icon: Some(rgba(0x383a41ff).into()),
+                        icon_muted: Some(rgba(0x7f8188ff).into()),
+                        icon_disabled: Some(rgba(0xa1a1a3ff).into()),
+                        icon_placeholder: Some(rgba(0x7f8188ff).into()),
+                        icon_accent: Some(rgba(0x5c79e2ff).into()),
+                        status_bar_background: Some(rgba(0xdcdcddff).into()),
+                        title_bar_background: Some(rgba(0xdcdcddff).into()),
+                        toolbar_background: Some(rgba(0xfafafaff).into()),
+                        tab_bar_background: Some(rgba(0xebebecff).into()),
+                        tab_inactive_background: Some(rgba(0xebebecff).into()),
+                        tab_active_background: Some(rgba(0xfafafaff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x383a414c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xdfdfe0ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xdfdfe0ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xeeeeeeff).into()),
+                        editor_foreground: Some(rgba(0x383a41ff).into()),
+                        editor_background: Some(rgba(0xfafafaff).into()),
+                        editor_gutter_background: Some(rgba(0xfafafaff).into()),
+                        editor_subheader_background: Some(rgba(0xebebecff).into()),
+                        editor_active_line_background: Some(rgba(0xebebecbf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xebebecff).into()),
+                        editor_line_number: Some(rgba(0x383a4159).into()),
+                        editor_active_line_number: Some(rgba(0x383a41ff).into()),
+                        editor_invisible: Some(rgba(0x7f8188ff).into()),
+                        editor_wrap_guide: Some(rgba(0x383a410d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x383a411a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x5c79e21a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0xa3a3a466).into()),
+                        terminal_background: Some(rgba(0xfafafaff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0xaaaaaaff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xf0b0a4ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xb2cfa9ff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xf1dfc1ff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xb5baf2ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xcea6d3ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0xa4bfdbff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x383a41ff).into()),
+                        terminal_ansi_black: Some(rgba(0xfafafaff).into()),
+                        terminal_ansi_red: Some(rgba(0xd36151ff).into()),
+                        terminal_ansi_green: Some(rgba(0x669f59ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xdec184ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x5c79e2ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0x994fa6ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x3b82b7ff).into()),
+                        terminal_ansi_white: Some(rgba(0x383a41ff).into()),
+                        link_text_hover: Some(rgba(0x5c79e2ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xdec184ff).into()),
+                        conflict_background: Some(rgba(0xfaf2e6ff).into()),
+                        conflict_border: Some(rgba(0xf5e8d2ff).into()),
+                        created: Some(rgba(0x669f59ff).into()),
+                        created_background: Some(rgba(0xe0ebdcff).into()),
+                        created_border: Some(rgba(0xc8dcc1ff).into()),
+                        deleted: Some(rgba(0xd36151ff).into()),
+                        deleted_background: Some(rgba(0xfbdfd9ff).into()),
+                        deleted_border: Some(rgba(0xf6c6bdff).into()),
+                        error: Some(rgba(0xd36151ff).into()),
+                        error_background: Some(rgba(0xfbdfd9ff).into()),
+                        error_border: Some(rgba(0xf6c6bdff).into()),
+                        hidden: Some(rgba(0xa1a1a3ff).into()),
+                        hidden_background: Some(rgba(0xdcdcddff).into()),
+                        hidden_border: Some(rgba(0xd3d3d4ff).into()),
+                        hint: Some(rgba(0x9295beff).into()),
+                        hint_background: Some(rgba(0xe2e2faff).into()),
+                        hint_border: Some(rgba(0xcbcdf6ff).into()),
+                        ignored: Some(rgba(0x7f8188ff).into()),
+                        ignored_background: Some(rgba(0xdcdcddff).into()),
+                        ignored_border: Some(rgba(0xc9c9caff).into()),
+                        info: Some(rgba(0x5c79e2ff).into()),
+                        info_background: Some(rgba(0xe2e2faff).into()),
+                        info_border: Some(rgba(0xcbcdf6ff).into()),
+                        modified: Some(rgba(0xdec184ff).into()),
+                        modified_background: Some(rgba(0xfaf2e6ff).into()),
+                        modified_border: Some(rgba(0xf5e8d2ff).into()),
+                        predictive: Some(rgba(0x9c9fc7ff).into()),
+                        predictive_background: Some(rgba(0xe0ebdcff).into()),
+                        predictive_border: Some(rgba(0xc8dcc1ff).into()),
+                        renamed: Some(rgba(0x5c79e2ff).into()),
+                        renamed_background: Some(rgba(0xe2e2faff).into()),
+                        renamed_border: Some(rgba(0xcbcdf6ff).into()),
+                        success: Some(rgba(0x669f59ff).into()),
+                        success_background: Some(rgba(0xe0ebdcff).into()),
+                        success_border: Some(rgba(0xc8dcc1ff).into()),
+                        unreachable: Some(rgba(0x7f8188ff).into()),
+                        unreachable_background: Some(rgba(0xdcdcddff).into()),
+                        unreachable_border: Some(rgba(0xc9c9caff).into()),
+                        warning: Some(rgba(0xdec184ff).into()),
+                        warning_background: Some(rgba(0xfaf2e6ff).into()),
+                        warning_border: Some(rgba(0xf5e8d2ff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x5c79e2ff).into(),
+                            background: rgba(0x5c79e2ff).into(),
+                            selection: rgba(0x5c79e23d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x994fa6ff).into(),
+                            background: rgba(0x994fa6ff).into(),
+                            selection: rgba(0x994fa63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xad6f27ff).into(),
+                            background: rgba(0xad6f27ff).into(),
+                            selection: rgba(0xad6f273d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xa44aabff).into(),
+                            background: rgba(0xa44aabff).into(),
+                            selection: rgba(0xa44aab3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x3b82b7ff).into(),
+                            background: rgba(0x3b82b7ff).into(),
+                            selection: rgba(0x3b82b73d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd36151ff).into(),
+                            background: rgba(0xd36151ff).into(),
+                            selection: rgba(0xd361513d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdec184ff).into(),
+                            background: rgba(0xdec184ff).into(),
+                            selection: rgba(0xdec1843d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x669f59ff).into(),
+                            background: rgba(0x669f59ff).into(),
+                            selection: rgba(0x669f593d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c79e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa2a3a7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7c7e86ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x669f59ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c79e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x383a41ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c79e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f26ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd36050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b79e3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9295beff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xa449abff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c79e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b79e3ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3982b7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3982b7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9c9fc7ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x383a41ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x383a41ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd36050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x383a41ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4d4f52ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x4d4f52ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd36050ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb92c46ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x659f58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x7c7e86ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f27ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f27ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f27ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5c79e2ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x659f58ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xd36050ff).into()),
+                                    font_weight: Some(UserFontWeight(400.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x3982b7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x383a41ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xad6f26ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5b79e3ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme/src/themes/rose_pine.rs
+++ b/crates/theme/src/themes/rose_pine.rs
@@ -16,6 +16,464 @@ pub fn rose_pine() -> UserThemeFamily {
         author: "Zed Industries".into(),
         themes: vec![
             UserTheme {
+                name: "Rosé Pine".into(),
+                appearance: Appearance::Dark,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x423f55ff).into()),
+                        border_variant: Some(rgba(0x232132ff).into()),
+                        border_focused: Some(rgba(0x435255ff).into()),
+                        border_selected: Some(rgba(0x435255ff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0x353347ff).into()),
+                        elevated_surface_background: Some(rgba(0x1d1b2aff).into()),
+                        surface_background: Some(rgba(0x1d1b2aff).into()),
+                        background: Some(rgba(0x292739ff).into()),
+                        panel_background: Some(rgba(0x1d1b2aff).into()),
+                        element_background: Some(rgba(0x1d1b2aff).into()),
+                        element_hover: Some(rgba(0x232132ff).into()),
+                        element_active: Some(rgba(0x403e53ff).into()),
+                        element_selected: Some(rgba(0x403e53ff).into()),
+                        element_disabled: Some(rgba(0x1d1b2aff).into()),
+                        drop_target_background: Some(rgba(0x75718e80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0x232132ff).into()),
+                        ghost_element_active: Some(rgba(0x403e53ff).into()),
+                        ghost_element_selected: Some(rgba(0x403e53ff).into()),
+                        ghost_element_disabled: Some(rgba(0x1d1b2aff).into()),
+                        text: Some(rgba(0xe0def4ff).into()),
+                        text_muted: Some(rgba(0x75718eff).into()),
+                        text_placeholder: Some(rgba(0x2f2b43ff).into()),
+                        text_disabled: Some(rgba(0x2f2b43ff).into()),
+                        text_accent: Some(rgba(0x9cced7ff).into()),
+                        icon: Some(rgba(0xe0def4ff).into()),
+                        icon_muted: Some(rgba(0x75718eff).into()),
+                        icon_disabled: Some(rgba(0x2f2b43ff).into()),
+                        icon_placeholder: Some(rgba(0x75718eff).into()),
+                        icon_accent: Some(rgba(0x9cced7ff).into()),
+                        status_bar_background: Some(rgba(0x292739ff).into()),
+                        title_bar_background: Some(rgba(0x292739ff).into()),
+                        toolbar_background: Some(rgba(0x191724ff).into()),
+                        tab_bar_background: Some(rgba(0x1d1b2aff).into()),
+                        tab_inactive_background: Some(rgba(0x1d1b2aff).into()),
+                        tab_active_background: Some(rgba(0x191724ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0xe0def44c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0x232132ff).into()),
+                        scrollbar_thumb_border: Some(rgba(0x232132ff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0x1c1a29ff).into()),
+                        editor_foreground: Some(rgba(0xe0def4ff).into()),
+                        editor_background: Some(rgba(0x191724ff).into()),
+                        editor_gutter_background: Some(rgba(0x191724ff).into()),
+                        editor_subheader_background: Some(rgba(0x1d1b2aff).into()),
+                        editor_active_line_background: Some(rgba(0x1d1b2abf).into()),
+                        editor_highlighted_line_background: Some(rgba(0x1d1b2aff).into()),
+                        editor_line_number: Some(rgba(0xe0def459).into()),
+                        editor_active_line_number: Some(rgba(0xe0def4ff).into()),
+                        editor_invisible: Some(rgba(0x75718eff).into()),
+                        editor_wrap_guide: Some(rgba(0xe0def40d).into()),
+                        editor_active_wrap_guide: Some(rgba(0xe0def41a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x9cced71a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x28253c66).into()),
+                        terminal_background: Some(rgba(0x191724ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x403d55ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0x7e3647ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0x31614fff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0x8a653bff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0x566c70ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0x4c3b47ff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x203a46ff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0xe0def4ff).into()),
+                        terminal_ansi_black: Some(rgba(0x191724ff).into()),
+                        terminal_ansi_red: Some(rgba(0xea6f92ff).into()),
+                        terminal_ansi_green: Some(rgba(0x5dc2a3ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xf5c177ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x9cced7ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0x9d7691ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x32748fff).into()),
+                        terminal_ansi_white: Some(rgba(0xe0def4ff).into()),
+                        link_text_hover: Some(rgba(0x9cced7ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xf5c177ff).into()),
+                        conflict_background: Some(rgba(0x50341aff).into()),
+                        conflict_border: Some(rgba(0x6d4d2bff).into()),
+                        created: Some(rgba(0x5dc2a3ff).into()),
+                        created_background: Some(rgba(0x182e23ff).into()),
+                        created_border: Some(rgba(0x254839ff).into()),
+                        deleted: Some(rgba(0xea6f92ff).into()),
+                        deleted_background: Some(rgba(0x431820ff).into()),
+                        deleted_border: Some(rgba(0x612834ff).into()),
+                        error: Some(rgba(0xea6f92ff).into()),
+                        error_background: Some(rgba(0x431820ff).into()),
+                        error_border: Some(rgba(0x612834ff).into()),
+                        hidden: Some(rgba(0x2f2b43ff).into()),
+                        hidden_background: Some(rgba(0x292739ff).into()),
+                        hidden_border: Some(rgba(0x353347ff).into()),
+                        hint: Some(rgba(0x5e768cff).into()),
+                        hint_background: Some(rgba(0x2f3739ff).into()),
+                        hint_border: Some(rgba(0x435255ff).into()),
+                        ignored: Some(rgba(0x75718eff).into()),
+                        ignored_background: Some(rgba(0x292739ff).into()),
+                        ignored_border: Some(rgba(0x423f55ff).into()),
+                        info: Some(rgba(0x9cced7ff).into()),
+                        info_background: Some(rgba(0x2f3739ff).into()),
+                        info_border: Some(rgba(0x435255ff).into()),
+                        modified: Some(rgba(0xf5c177ff).into()),
+                        modified_background: Some(rgba(0x50341aff).into()),
+                        modified_border: Some(rgba(0x6d4d2bff).into()),
+                        predictive: Some(rgba(0x556b81ff).into()),
+                        predictive_background: Some(rgba(0x182e23ff).into()),
+                        predictive_border: Some(rgba(0x254839ff).into()),
+                        renamed: Some(rgba(0x9cced7ff).into()),
+                        renamed_background: Some(rgba(0x2f3739ff).into()),
+                        renamed_border: Some(rgba(0x435255ff).into()),
+                        success: Some(rgba(0x5dc2a3ff).into()),
+                        success_background: Some(rgba(0x182e23ff).into()),
+                        success_border: Some(rgba(0x254839ff).into()),
+                        unreachable: Some(rgba(0x75718eff).into()),
+                        unreachable_background: Some(rgba(0x292739ff).into()),
+                        unreachable_border: Some(rgba(0x423f55ff).into()),
+                        warning: Some(rgba(0xf5c177ff).into()),
+                        warning_background: Some(rgba(0x50341aff).into()),
+                        warning_border: Some(rgba(0x6d4d2bff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x9cced7ff).into(),
+                            background: rgba(0x9cced7ff).into(),
+                            selection: rgba(0x9cced73d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x9d7691ff).into(),
+                            background: rgba(0x9d7691ff).into(),
+                            selection: rgba(0x9d76913d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc4a7e6ff).into(),
+                            background: rgba(0xc4a7e6ff).into(),
+                            selection: rgba(0xc4a7e63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xc4a7e6ff).into(),
+                            background: rgba(0xc4a7e6ff).into(),
+                            selection: rgba(0xc4a7e63d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x32748fff).into(),
+                            background: rgba(0x32748fff).into(),
+                            selection: rgba(0x32748f3d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xea6f92ff).into(),
+                            background: rgba(0xea6f92ff).into(),
+                            selection: rgba(0xea6f923d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xf5c177ff).into(),
+                            background: rgba(0xf5c177ff).into(),
+                            selection: rgba(0xf5c1773d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x5dc2a3ff).into(),
+                            background: rgba(0x5dc2a3ff).into(),
+                            selection: rgba(0x5dc2a33d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x6e6a86ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x777390ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5dc2a3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe0def4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc4a7e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function.method".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5e768cff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x31748fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9ccfd8ff).into()),
+                                    font_style: Some(UserFontStyle::Normal),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xebbcbaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5dc2a3ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x31748fff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x556b81ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe0def4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe0def4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x908caaff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d99b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d99b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d99b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9d99b6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf6c177ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x777390ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc4a7e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc4a7e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc4a7e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9ccfd8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xc4a7e6ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xf6c177ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9ccfd8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type.builtin".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9ccfd8ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xe0def4ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x9cced7ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
                 name: "Rosé Pine Dawn".into(),
                 appearance: Appearance::Light,
                 styles: UserThemeStylesRefinement {
@@ -853,464 +1311,6 @@ pub fn rose_pine() -> UserThemeFamily {
                                 "string.escape".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x8682a0ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc4a7e6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc4a7e6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc4a7e6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9ccfd8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc4a7e6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf6c177ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9ccfd8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type.builtin".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9ccfd8ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
-                name: "Rosé Pine".into(),
-                appearance: Appearance::Dark,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x423f55ff).into()),
-                        border_variant: Some(rgba(0x232132ff).into()),
-                        border_focused: Some(rgba(0x435255ff).into()),
-                        border_selected: Some(rgba(0x435255ff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0x353347ff).into()),
-                        elevated_surface_background: Some(rgba(0x1d1b2aff).into()),
-                        surface_background: Some(rgba(0x1d1b2aff).into()),
-                        background: Some(rgba(0x292739ff).into()),
-                        panel_background: Some(rgba(0x1d1b2aff).into()),
-                        element_background: Some(rgba(0x1d1b2aff).into()),
-                        element_hover: Some(rgba(0x232132ff).into()),
-                        element_active: Some(rgba(0x403e53ff).into()),
-                        element_selected: Some(rgba(0x403e53ff).into()),
-                        element_disabled: Some(rgba(0x1d1b2aff).into()),
-                        drop_target_background: Some(rgba(0x75718e80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0x232132ff).into()),
-                        ghost_element_active: Some(rgba(0x403e53ff).into()),
-                        ghost_element_selected: Some(rgba(0x403e53ff).into()),
-                        ghost_element_disabled: Some(rgba(0x1d1b2aff).into()),
-                        text: Some(rgba(0xe0def4ff).into()),
-                        text_muted: Some(rgba(0x75718eff).into()),
-                        text_placeholder: Some(rgba(0x2f2b43ff).into()),
-                        text_disabled: Some(rgba(0x2f2b43ff).into()),
-                        text_accent: Some(rgba(0x9cced7ff).into()),
-                        icon: Some(rgba(0xe0def4ff).into()),
-                        icon_muted: Some(rgba(0x75718eff).into()),
-                        icon_disabled: Some(rgba(0x2f2b43ff).into()),
-                        icon_placeholder: Some(rgba(0x75718eff).into()),
-                        icon_accent: Some(rgba(0x9cced7ff).into()),
-                        status_bar_background: Some(rgba(0x292739ff).into()),
-                        title_bar_background: Some(rgba(0x292739ff).into()),
-                        toolbar_background: Some(rgba(0x191724ff).into()),
-                        tab_bar_background: Some(rgba(0x1d1b2aff).into()),
-                        tab_inactive_background: Some(rgba(0x1d1b2aff).into()),
-                        tab_active_background: Some(rgba(0x191724ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0xe0def44c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0x232132ff).into()),
-                        scrollbar_thumb_border: Some(rgba(0x232132ff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0x1c1a29ff).into()),
-                        editor_foreground: Some(rgba(0xe0def4ff).into()),
-                        editor_background: Some(rgba(0x191724ff).into()),
-                        editor_gutter_background: Some(rgba(0x191724ff).into()),
-                        editor_subheader_background: Some(rgba(0x1d1b2aff).into()),
-                        editor_active_line_background: Some(rgba(0x1d1b2abf).into()),
-                        editor_highlighted_line_background: Some(rgba(0x1d1b2aff).into()),
-                        editor_line_number: Some(rgba(0xe0def459).into()),
-                        editor_active_line_number: Some(rgba(0xe0def4ff).into()),
-                        editor_invisible: Some(rgba(0x75718eff).into()),
-                        editor_wrap_guide: Some(rgba(0xe0def40d).into()),
-                        editor_active_wrap_guide: Some(rgba(0xe0def41a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x9cced71a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x28253c66).into()),
-                        terminal_background: Some(rgba(0x191724ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x403d55ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0x7e3647ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0x31614fff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0x8a653bff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0x566c70ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0x4c3b47ff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x203a46ff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0xe0def4ff).into()),
-                        terminal_ansi_black: Some(rgba(0x191724ff).into()),
-                        terminal_ansi_red: Some(rgba(0xea6f92ff).into()),
-                        terminal_ansi_green: Some(rgba(0x5dc2a3ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xf5c177ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x9cced7ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0x9d7691ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x32748fff).into()),
-                        terminal_ansi_white: Some(rgba(0xe0def4ff).into()),
-                        link_text_hover: Some(rgba(0x9cced7ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xf5c177ff).into()),
-                        conflict_background: Some(rgba(0x50341aff).into()),
-                        conflict_border: Some(rgba(0x6d4d2bff).into()),
-                        created: Some(rgba(0x5dc2a3ff).into()),
-                        created_background: Some(rgba(0x182e23ff).into()),
-                        created_border: Some(rgba(0x254839ff).into()),
-                        deleted: Some(rgba(0xea6f92ff).into()),
-                        deleted_background: Some(rgba(0x431820ff).into()),
-                        deleted_border: Some(rgba(0x612834ff).into()),
-                        error: Some(rgba(0xea6f92ff).into()),
-                        error_background: Some(rgba(0x431820ff).into()),
-                        error_border: Some(rgba(0x612834ff).into()),
-                        hidden: Some(rgba(0x2f2b43ff).into()),
-                        hidden_background: Some(rgba(0x292739ff).into()),
-                        hidden_border: Some(rgba(0x353347ff).into()),
-                        hint: Some(rgba(0x5e768cff).into()),
-                        hint_background: Some(rgba(0x2f3739ff).into()),
-                        hint_border: Some(rgba(0x435255ff).into()),
-                        ignored: Some(rgba(0x75718eff).into()),
-                        ignored_background: Some(rgba(0x292739ff).into()),
-                        ignored_border: Some(rgba(0x423f55ff).into()),
-                        info: Some(rgba(0x9cced7ff).into()),
-                        info_background: Some(rgba(0x2f3739ff).into()),
-                        info_border: Some(rgba(0x435255ff).into()),
-                        modified: Some(rgba(0xf5c177ff).into()),
-                        modified_background: Some(rgba(0x50341aff).into()),
-                        modified_border: Some(rgba(0x6d4d2bff).into()),
-                        predictive: Some(rgba(0x556b81ff).into()),
-                        predictive_background: Some(rgba(0x182e23ff).into()),
-                        predictive_border: Some(rgba(0x254839ff).into()),
-                        renamed: Some(rgba(0x9cced7ff).into()),
-                        renamed_background: Some(rgba(0x2f3739ff).into()),
-                        renamed_border: Some(rgba(0x435255ff).into()),
-                        success: Some(rgba(0x5dc2a3ff).into()),
-                        success_background: Some(rgba(0x182e23ff).into()),
-                        success_border: Some(rgba(0x254839ff).into()),
-                        unreachable: Some(rgba(0x75718eff).into()),
-                        unreachable_background: Some(rgba(0x292739ff).into()),
-                        unreachable_border: Some(rgba(0x423f55ff).into()),
-                        warning: Some(rgba(0xf5c177ff).into()),
-                        warning_background: Some(rgba(0x50341aff).into()),
-                        warning_border: Some(rgba(0x6d4d2bff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x9cced7ff).into(),
-                            background: rgba(0x9cced7ff).into(),
-                            selection: rgba(0x9cced73d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x9d7691ff).into(),
-                            background: rgba(0x9d7691ff).into(),
-                            selection: rgba(0x9d76913d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xc4a7e6ff).into(),
-                            background: rgba(0xc4a7e6ff).into(),
-                            selection: rgba(0xc4a7e63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xc4a7e6ff).into(),
-                            background: rgba(0xc4a7e6ff).into(),
-                            selection: rgba(0xc4a7e63d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x32748fff).into(),
-                            background: rgba(0x32748fff).into(),
-                            selection: rgba(0x32748f3d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xea6f92ff).into(),
-                            background: rgba(0xea6f92ff).into(),
-                            selection: rgba(0xea6f923d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xf5c177ff).into(),
-                            background: rgba(0xf5c177ff).into(),
-                            selection: rgba(0xf5c1773d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x5dc2a3ff).into(),
-                            background: rgba(0x5dc2a3ff).into(),
-                            selection: rgba(0x5dc2a33d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebbcbaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x6e6a86ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x777390ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5dc2a3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xc4a7e6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebbcbaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function.method".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebbcbaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5e768cff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x31748fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9ccfd8ff).into()),
-                                    font_style: Some(UserFontStyle::Normal),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xebbcbaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5dc2a3ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x31748fff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x556b81ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xe0def4ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9cced7ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x908caaff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9d99b6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9d99b6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9d99b6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x9d99b6ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xf6c177ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x777390ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme/src/themes/solarized.rs
+++ b/crates/theme/src/themes/solarized.rs
@@ -16,450 +16,6 @@ pub fn solarized() -> UserThemeFamily {
         author: "Zed Industries".into(),
         themes: vec![
             UserTheme {
-                name: "Solarized Light".into(),
-                appearance: Appearance::Light,
-                styles: UserThemeStylesRefinement {
-                    colors: ThemeColorsRefinement {
-                        border: Some(rgba(0x9faaa8ff).into()),
-                        border_variant: Some(rgba(0xdcdacbff).into()),
-                        border_focused: Some(rgba(0xbfd3efff).into()),
-                        border_selected: Some(rgba(0xbfd3efff).into()),
-                        border_transparent: Some(rgba(0x00000000).into()),
-                        border_disabled: Some(rgba(0xb7bdb6ff).into()),
-                        elevated_surface_background: Some(rgba(0xf3eddaff).into()),
-                        surface_background: Some(rgba(0xf3eddaff).into()),
-                        background: Some(rgba(0xcfd0c4ff).into()),
-                        panel_background: Some(rgba(0xf3eddaff).into()),
-                        element_background: Some(rgba(0xf3eddaff).into()),
-                        element_hover: Some(rgba(0xdcdacbff).into()),
-                        element_active: Some(rgba(0xa2aca9ff).into()),
-                        element_selected: Some(rgba(0xa2aca9ff).into()),
-                        element_disabled: Some(rgba(0xf3eddaff).into()),
-                        drop_target_background: Some(rgba(0x34555e80).into()),
-                        ghost_element_background: Some(rgba(0x00000000).into()),
-                        ghost_element_hover: Some(rgba(0xdcdacbff).into()),
-                        ghost_element_active: Some(rgba(0xa2aca9ff).into()),
-                        ghost_element_selected: Some(rgba(0xa2aca9ff).into()),
-                        ghost_element_disabled: Some(rgba(0xf3eddaff).into()),
-                        text: Some(rgba(0x002b36ff).into()),
-                        text_muted: Some(rgba(0x34555eff).into()),
-                        text_placeholder: Some(rgba(0x6a7f86ff).into()),
-                        text_disabled: Some(rgba(0x6a7f86ff).into()),
-                        text_accent: Some(rgba(0x298bd1ff).into()),
-                        icon: Some(rgba(0x002b36ff).into()),
-                        icon_muted: Some(rgba(0x34555eff).into()),
-                        icon_disabled: Some(rgba(0x6a7f86ff).into()),
-                        icon_placeholder: Some(rgba(0x34555eff).into()),
-                        icon_accent: Some(rgba(0x298bd1ff).into()),
-                        status_bar_background: Some(rgba(0xcfd0c4ff).into()),
-                        title_bar_background: Some(rgba(0xcfd0c4ff).into()),
-                        toolbar_background: Some(rgba(0xfdf6e3ff).into()),
-                        tab_bar_background: Some(rgba(0xf3eddaff).into()),
-                        tab_inactive_background: Some(rgba(0xf3eddaff).into()),
-                        tab_active_background: Some(rgba(0xfdf6e3ff).into()),
-                        scrollbar_thumb_background: Some(rgba(0x002b364c).into()),
-                        scrollbar_thumb_hover_background: Some(rgba(0xdcdacbff).into()),
-                        scrollbar_thumb_border: Some(rgba(0xdcdacbff).into()),
-                        scrollbar_track_background: Some(rgba(0x00000000).into()),
-                        scrollbar_track_border: Some(rgba(0xf5eedbff).into()),
-                        editor_foreground: Some(rgba(0x002b36ff).into()),
-                        editor_background: Some(rgba(0xfdf6e3ff).into()),
-                        editor_gutter_background: Some(rgba(0xfdf6e3ff).into()),
-                        editor_subheader_background: Some(rgba(0xf3eddaff).into()),
-                        editor_active_line_background: Some(rgba(0xf3eddabf).into()),
-                        editor_highlighted_line_background: Some(rgba(0xf3eddaff).into()),
-                        editor_line_number: Some(rgba(0x002b3659).into()),
-                        editor_active_line_number: Some(rgba(0x002b36ff).into()),
-                        editor_invisible: Some(rgba(0x34555eff).into()),
-                        editor_wrap_guide: Some(rgba(0x002b360d).into()),
-                        editor_active_wrap_guide: Some(rgba(0x002b361a).into()),
-                        editor_document_highlight_read_background: Some(rgba(0x298bd11a).into()),
-                        editor_document_highlight_write_background: Some(rgba(0x6d828866).into()),
-                        terminal_background: Some(rgba(0xfdf6e3ff).into()),
-                        terminal_ansi_bright_black: Some(rgba(0x7b8e91ff).into()),
-                        terminal_ansi_bright_red: Some(rgba(0xfaa091ff).into()),
-                        terminal_ansi_bright_green: Some(rgba(0xc6cb8bff).into()),
-                        terminal_ansi_bright_yellow: Some(rgba(0xe1c28aff).into()),
-                        terminal_ansi_bright_blue: Some(rgba(0xa5c3e9ff).into()),
-                        terminal_ansi_bright_magenta: Some(rgba(0xf0a2bfff).into()),
-                        terminal_ansi_bright_cyan: Some(rgba(0x9fd0cbff).into()),
-                        terminal_ansi_bright_white: Some(rgba(0x002b36ff).into()),
-                        terminal_ansi_black: Some(rgba(0xfdf6e3ff).into()),
-                        terminal_ansi_red: Some(rgba(0xdc3330ff).into()),
-                        terminal_ansi_green: Some(rgba(0x859904ff).into()),
-                        terminal_ansi_yellow: Some(rgba(0xb58904ff).into()),
-                        terminal_ansi_blue: Some(rgba(0x298bd1ff).into()),
-                        terminal_ansi_magenta: Some(rgba(0xd33882ff).into()),
-                        terminal_ansi_cyan: Some(rgba(0x2ca198ff).into()),
-                        terminal_ansi_white: Some(rgba(0x002b36ff).into()),
-                        link_text_hover: Some(rgba(0x298bd1ff).into()),
-                        ..Default::default()
-                    },
-                    status: StatusColorsRefinement {
-                        conflict: Some(rgba(0xb58904ff).into()),
-                        conflict_background: Some(rgba(0xf5e6d0ff).into()),
-                        conflict_border: Some(rgba(0xebd3aaff).into()),
-                        created: Some(rgba(0x859904ff).into()),
-                        created_background: Some(rgba(0xe9ead0ff).into()),
-                        created_border: Some(rgba(0xd6d9abff).into()),
-                        deleted: Some(rgba(0xdc3330ff).into()),
-                        deleted_background: Some(rgba(0xffd9d2ff).into()),
-                        deleted_border: Some(rgba(0xffbbafff).into()),
-                        error: Some(rgba(0xdc3330ff).into()),
-                        error_background: Some(rgba(0xffd9d2ff).into()),
-                        error_border: Some(rgba(0xffbbafff).into()),
-                        hidden: Some(rgba(0x6a7f86ff).into()),
-                        hidden_background: Some(rgba(0xcfd0c4ff).into()),
-                        hidden_border: Some(rgba(0xb7bdb6ff).into()),
-                        hint: Some(rgba(0x5889a3ff).into()),
-                        hint_background: Some(rgba(0xdbe6f6ff).into()),
-                        hint_border: Some(rgba(0xbfd3efff).into()),
-                        ignored: Some(rgba(0x34555eff).into()),
-                        ignored_background: Some(rgba(0xcfd0c4ff).into()),
-                        ignored_border: Some(rgba(0x9faaa8ff).into()),
-                        info: Some(rgba(0x298bd1ff).into()),
-                        info_background: Some(rgba(0xdbe6f6ff).into()),
-                        info_border: Some(rgba(0xbfd3efff).into()),
-                        modified: Some(rgba(0xb58904ff).into()),
-                        modified_background: Some(rgba(0xf5e6d0ff).into()),
-                        modified_border: Some(rgba(0xebd3aaff).into()),
-                        predictive: Some(rgba(0x679aafff).into()),
-                        predictive_background: Some(rgba(0xe9ead0ff).into()),
-                        predictive_border: Some(rgba(0xd6d9abff).into()),
-                        renamed: Some(rgba(0x298bd1ff).into()),
-                        renamed_background: Some(rgba(0xdbe6f6ff).into()),
-                        renamed_border: Some(rgba(0xbfd3efff).into()),
-                        success: Some(rgba(0x859904ff).into()),
-                        success_background: Some(rgba(0xe9ead0ff).into()),
-                        success_border: Some(rgba(0xd6d9abff).into()),
-                        unreachable: Some(rgba(0x34555eff).into()),
-                        unreachable_background: Some(rgba(0xcfd0c4ff).into()),
-                        unreachable_border: Some(rgba(0x9faaa8ff).into()),
-                        warning: Some(rgba(0xb58904ff).into()),
-                        warning_background: Some(rgba(0xf5e6d0ff).into()),
-                        warning_border: Some(rgba(0xebd3aaff).into()),
-                        ..Default::default()
-                    },
-                    player: Some(PlayerColors(vec![
-                        PlayerColor {
-                            cursor: rgba(0x298bd1ff).into(),
-                            background: rgba(0x298bd1ff).into(),
-                            selection: rgba(0x298bd13d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xd33882ff).into(),
-                            background: rgba(0xd33882ff).into(),
-                            selection: rgba(0xd338823d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xcb4c18ff).into(),
-                            background: rgba(0xcb4c18ff).into(),
-                            selection: rgba(0xcb4c183d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x6d71c4ff).into(),
-                            background: rgba(0x6d71c4ff).into(),
-                            selection: rgba(0x6d71c43d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x2ca198ff).into(),
-                            background: rgba(0x2ca198ff).into(),
-                            selection: rgba(0x2ca1983d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xdc3330ff).into(),
-                            background: rgba(0xdc3330ff).into(),
-                            selection: rgba(0xdc33303d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0xb58904ff).into(),
-                            background: rgba(0xb58904ff).into(),
-                            selection: rgba(0xb589043d).into(),
-                        },
-                        PlayerColor {
-                            cursor: rgba(0x859904ff).into(),
-                            background: rgba(0x859904ff).into(),
-                            selection: rgba(0x8599043d).into(),
-                        },
-                    ])),
-                    syntax: Some(UserSyntaxTheme {
-                        highlights: vec![
-                            (
-                                "attribute".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "boolean".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x859904ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x30525bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "comment.doc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x30525bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x859904ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "constructor".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "embedded".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x002b36ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "emphasis.strong".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "enum".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "function".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xb58904ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "hint".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x5889a3ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "keyword".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "label".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_text".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "link_uri".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x859904ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "number".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x859904ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "operator".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "predictive".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x679aafff).into()),
-                                    font_style: Some(UserFontStyle::Italic),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "preproc".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x002b36ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "primary".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x002b36ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "property".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x05333eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.bracket".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x05333eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.delimiter".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x05333eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.list_marker".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x05333eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "punctuation.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x05333eff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.escape".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x30525bff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.regex".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "string.special.symbol".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "tag".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "text.literal".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0xcb4c18ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "title".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x002b36ff).into()),
-                                    font_weight: Some(UserFontWeight(700.0)),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "type".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x2ca198ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variable".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x002b36ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                            (
-                                "variant".into(),
-                                UserHighlightStyle {
-                                    color: Some(rgba(0x298bd1ff).into()),
-                                    ..Default::default()
-                                },
-                            ),
-                        ],
-                    }),
-                },
-            },
-            UserTheme {
                 name: "Solarized Dark".into(),
                 appearance: Appearance::Dark,
                 styles: UserThemeStylesRefinement {
@@ -896,6 +452,450 @@ pub fn solarized() -> UserThemeFamily {
                                 "variant".into(),
                                 UserHighlightStyle {
                                     color: Some(rgba(0x288bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            },
+            UserTheme {
+                name: "Solarized Light".into(),
+                appearance: Appearance::Light,
+                styles: UserThemeStylesRefinement {
+                    colors: ThemeColorsRefinement {
+                        border: Some(rgba(0x9faaa8ff).into()),
+                        border_variant: Some(rgba(0xdcdacbff).into()),
+                        border_focused: Some(rgba(0xbfd3efff).into()),
+                        border_selected: Some(rgba(0xbfd3efff).into()),
+                        border_transparent: Some(rgba(0x00000000).into()),
+                        border_disabled: Some(rgba(0xb7bdb6ff).into()),
+                        elevated_surface_background: Some(rgba(0xf3eddaff).into()),
+                        surface_background: Some(rgba(0xf3eddaff).into()),
+                        background: Some(rgba(0xcfd0c4ff).into()),
+                        panel_background: Some(rgba(0xf3eddaff).into()),
+                        element_background: Some(rgba(0xf3eddaff).into()),
+                        element_hover: Some(rgba(0xdcdacbff).into()),
+                        element_active: Some(rgba(0xa2aca9ff).into()),
+                        element_selected: Some(rgba(0xa2aca9ff).into()),
+                        element_disabled: Some(rgba(0xf3eddaff).into()),
+                        drop_target_background: Some(rgba(0x34555e80).into()),
+                        ghost_element_background: Some(rgba(0x00000000).into()),
+                        ghost_element_hover: Some(rgba(0xdcdacbff).into()),
+                        ghost_element_active: Some(rgba(0xa2aca9ff).into()),
+                        ghost_element_selected: Some(rgba(0xa2aca9ff).into()),
+                        ghost_element_disabled: Some(rgba(0xf3eddaff).into()),
+                        text: Some(rgba(0x002b36ff).into()),
+                        text_muted: Some(rgba(0x34555eff).into()),
+                        text_placeholder: Some(rgba(0x6a7f86ff).into()),
+                        text_disabled: Some(rgba(0x6a7f86ff).into()),
+                        text_accent: Some(rgba(0x298bd1ff).into()),
+                        icon: Some(rgba(0x002b36ff).into()),
+                        icon_muted: Some(rgba(0x34555eff).into()),
+                        icon_disabled: Some(rgba(0x6a7f86ff).into()),
+                        icon_placeholder: Some(rgba(0x34555eff).into()),
+                        icon_accent: Some(rgba(0x298bd1ff).into()),
+                        status_bar_background: Some(rgba(0xcfd0c4ff).into()),
+                        title_bar_background: Some(rgba(0xcfd0c4ff).into()),
+                        toolbar_background: Some(rgba(0xfdf6e3ff).into()),
+                        tab_bar_background: Some(rgba(0xf3eddaff).into()),
+                        tab_inactive_background: Some(rgba(0xf3eddaff).into()),
+                        tab_active_background: Some(rgba(0xfdf6e3ff).into()),
+                        scrollbar_thumb_background: Some(rgba(0x002b364c).into()),
+                        scrollbar_thumb_hover_background: Some(rgba(0xdcdacbff).into()),
+                        scrollbar_thumb_border: Some(rgba(0xdcdacbff).into()),
+                        scrollbar_track_background: Some(rgba(0x00000000).into()),
+                        scrollbar_track_border: Some(rgba(0xf5eedbff).into()),
+                        editor_foreground: Some(rgba(0x002b36ff).into()),
+                        editor_background: Some(rgba(0xfdf6e3ff).into()),
+                        editor_gutter_background: Some(rgba(0xfdf6e3ff).into()),
+                        editor_subheader_background: Some(rgba(0xf3eddaff).into()),
+                        editor_active_line_background: Some(rgba(0xf3eddabf).into()),
+                        editor_highlighted_line_background: Some(rgba(0xf3eddaff).into()),
+                        editor_line_number: Some(rgba(0x002b3659).into()),
+                        editor_active_line_number: Some(rgba(0x002b36ff).into()),
+                        editor_invisible: Some(rgba(0x34555eff).into()),
+                        editor_wrap_guide: Some(rgba(0x002b360d).into()),
+                        editor_active_wrap_guide: Some(rgba(0x002b361a).into()),
+                        editor_document_highlight_read_background: Some(rgba(0x298bd11a).into()),
+                        editor_document_highlight_write_background: Some(rgba(0x6d828866).into()),
+                        terminal_background: Some(rgba(0xfdf6e3ff).into()),
+                        terminal_ansi_bright_black: Some(rgba(0x7b8e91ff).into()),
+                        terminal_ansi_bright_red: Some(rgba(0xfaa091ff).into()),
+                        terminal_ansi_bright_green: Some(rgba(0xc6cb8bff).into()),
+                        terminal_ansi_bright_yellow: Some(rgba(0xe1c28aff).into()),
+                        terminal_ansi_bright_blue: Some(rgba(0xa5c3e9ff).into()),
+                        terminal_ansi_bright_magenta: Some(rgba(0xf0a2bfff).into()),
+                        terminal_ansi_bright_cyan: Some(rgba(0x9fd0cbff).into()),
+                        terminal_ansi_bright_white: Some(rgba(0x002b36ff).into()),
+                        terminal_ansi_black: Some(rgba(0xfdf6e3ff).into()),
+                        terminal_ansi_red: Some(rgba(0xdc3330ff).into()),
+                        terminal_ansi_green: Some(rgba(0x859904ff).into()),
+                        terminal_ansi_yellow: Some(rgba(0xb58904ff).into()),
+                        terminal_ansi_blue: Some(rgba(0x298bd1ff).into()),
+                        terminal_ansi_magenta: Some(rgba(0xd33882ff).into()),
+                        terminal_ansi_cyan: Some(rgba(0x2ca198ff).into()),
+                        terminal_ansi_white: Some(rgba(0x002b36ff).into()),
+                        link_text_hover: Some(rgba(0x298bd1ff).into()),
+                        ..Default::default()
+                    },
+                    status: StatusColorsRefinement {
+                        conflict: Some(rgba(0xb58904ff).into()),
+                        conflict_background: Some(rgba(0xf5e6d0ff).into()),
+                        conflict_border: Some(rgba(0xebd3aaff).into()),
+                        created: Some(rgba(0x859904ff).into()),
+                        created_background: Some(rgba(0xe9ead0ff).into()),
+                        created_border: Some(rgba(0xd6d9abff).into()),
+                        deleted: Some(rgba(0xdc3330ff).into()),
+                        deleted_background: Some(rgba(0xffd9d2ff).into()),
+                        deleted_border: Some(rgba(0xffbbafff).into()),
+                        error: Some(rgba(0xdc3330ff).into()),
+                        error_background: Some(rgba(0xffd9d2ff).into()),
+                        error_border: Some(rgba(0xffbbafff).into()),
+                        hidden: Some(rgba(0x6a7f86ff).into()),
+                        hidden_background: Some(rgba(0xcfd0c4ff).into()),
+                        hidden_border: Some(rgba(0xb7bdb6ff).into()),
+                        hint: Some(rgba(0x5889a3ff).into()),
+                        hint_background: Some(rgba(0xdbe6f6ff).into()),
+                        hint_border: Some(rgba(0xbfd3efff).into()),
+                        ignored: Some(rgba(0x34555eff).into()),
+                        ignored_background: Some(rgba(0xcfd0c4ff).into()),
+                        ignored_border: Some(rgba(0x9faaa8ff).into()),
+                        info: Some(rgba(0x298bd1ff).into()),
+                        info_background: Some(rgba(0xdbe6f6ff).into()),
+                        info_border: Some(rgba(0xbfd3efff).into()),
+                        modified: Some(rgba(0xb58904ff).into()),
+                        modified_background: Some(rgba(0xf5e6d0ff).into()),
+                        modified_border: Some(rgba(0xebd3aaff).into()),
+                        predictive: Some(rgba(0x679aafff).into()),
+                        predictive_background: Some(rgba(0xe9ead0ff).into()),
+                        predictive_border: Some(rgba(0xd6d9abff).into()),
+                        renamed: Some(rgba(0x298bd1ff).into()),
+                        renamed_background: Some(rgba(0xdbe6f6ff).into()),
+                        renamed_border: Some(rgba(0xbfd3efff).into()),
+                        success: Some(rgba(0x859904ff).into()),
+                        success_background: Some(rgba(0xe9ead0ff).into()),
+                        success_border: Some(rgba(0xd6d9abff).into()),
+                        unreachable: Some(rgba(0x34555eff).into()),
+                        unreachable_background: Some(rgba(0xcfd0c4ff).into()),
+                        unreachable_border: Some(rgba(0x9faaa8ff).into()),
+                        warning: Some(rgba(0xb58904ff).into()),
+                        warning_background: Some(rgba(0xf5e6d0ff).into()),
+                        warning_border: Some(rgba(0xebd3aaff).into()),
+                        ..Default::default()
+                    },
+                    player: Some(PlayerColors(vec![
+                        PlayerColor {
+                            cursor: rgba(0x298bd1ff).into(),
+                            background: rgba(0x298bd1ff).into(),
+                            selection: rgba(0x298bd13d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xd33882ff).into(),
+                            background: rgba(0xd33882ff).into(),
+                            selection: rgba(0xd338823d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xcb4c18ff).into(),
+                            background: rgba(0xcb4c18ff).into(),
+                            selection: rgba(0xcb4c183d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x6d71c4ff).into(),
+                            background: rgba(0x6d71c4ff).into(),
+                            selection: rgba(0x6d71c43d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x2ca198ff).into(),
+                            background: rgba(0x2ca198ff).into(),
+                            selection: rgba(0x2ca1983d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xdc3330ff).into(),
+                            background: rgba(0xdc3330ff).into(),
+                            selection: rgba(0xdc33303d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0xb58904ff).into(),
+                            background: rgba(0xb58904ff).into(),
+                            selection: rgba(0xb589043d).into(),
+                        },
+                        PlayerColor {
+                            cursor: rgba(0x859904ff).into(),
+                            background: rgba(0x859904ff).into(),
+                            selection: rgba(0x8599043d).into(),
+                        },
+                    ])),
+                    syntax: Some(UserSyntaxTheme {
+                        highlights: vec![
+                            (
+                                "attribute".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "boolean".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x859904ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x30525bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "comment.doc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x30525bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x859904ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "constructor".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "embedded".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x002b36ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "emphasis.strong".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "enum".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "function".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xb58904ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "hint".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x5889a3ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "keyword".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "label".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_text".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "link_uri".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x859904ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "number".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x859904ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "operator".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "predictive".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x679aafff).into()),
+                                    font_style: Some(UserFontStyle::Italic),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "preproc".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x002b36ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "primary".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x002b36ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "property".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x05333eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.bracket".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x05333eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.delimiter".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x05333eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.list_marker".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x05333eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "punctuation.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x05333eff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.escape".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x30525bff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.regex".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "string.special.symbol".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "tag".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "text.literal".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0xcb4c18ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "title".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x002b36ff).into()),
+                                    font_weight: Some(UserFontWeight(700.0)),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "type".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x2ca198ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variable".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x002b36ff).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "variant".into(),
+                                UserHighlightStyle {
+                                    color: Some(rgba(0x298bd1ff).into()),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.4", features = ["derive"] }
 convert_case = "0.6.0"
 gpui = { path = "../gpui" }
 indexmap = { version = "1.6.2", features = ["serde"] }
+indoc.workspace = true
 json_comments = "0.2.2"
 log.workspace = true
 palette = { version = "0.7.3", default-features = false, features = ["std"] }

--- a/crates/theme_importer/src/zed1.rs
+++ b/crates/theme_importer/src/zed1.rs
@@ -1,4 +1,6 @@
 mod converter;
+mod licenses;
 pub mod theme;
 
 pub use converter::*;
+pub use licenses::*;

--- a/crates/theme_importer/src/zed1/licenses.rs
+++ b/crates/theme_importer/src/zed1/licenses.rs
@@ -1,0 +1,1192 @@
+use std::fmt::Display;
+
+use indoc::indoc;
+
+#[derive(Debug)]
+pub enum License {
+    Mit,
+    // We don't currently have any themes using the Apache 2.0 license.
+    #[allow(unused)]
+    Apache2,
+}
+
+impl Display for License {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                License::Mit => "MIT",
+                License::Apache2 => "Apache License 2.0",
+            }
+        )
+    }
+}
+
+pub struct Zed1ThemeLicense {
+    pub theme: String,
+    pub license: License,
+    pub license_url: Option<String>,
+    pub license_text: &'static str,
+}
+
+pub fn zed1_theme_licenses() -> Vec<Zed1ThemeLicense> {
+    vec![
+        Zed1ThemeLicense {
+            theme: "One Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://github.com/atom/atom/tree/master/packages/one-dark-ui".to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2014 GitHub Inc.
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "One Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://github.com/atom/atom/tree/master/packages/one-light-ui".to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2014 GitHub Inc.
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Ayu Light".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/dempfi/ayu".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2016 Ike Ku
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Ayu Dark".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/dempfi/ayu".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2016 Ike Ku
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Ayu Mirage".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/dempfi/ayu".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2016 Ike Ku
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Gruvbox Dark".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/morhetz/gruvbox".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Gruvbox Dark Hard".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/morhetz/gruvbox".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Gruvbox Dark Soft".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/morhetz/gruvbox".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Gruvbox Light".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/morhetz/gruvbox".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Gruvbox Light Hard".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/morhetz/gruvbox".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Gruvbox Light Soft".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/morhetz/gruvbox".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Rosé Pine".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/edunfelt/base16-rose-pine-scheme".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2021 Emilia Dunfelt
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Rosé Pine Dawn".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/edunfelt/base16-rose-pine-scheme".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2021 Emilia Dunfelt
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Rosé Pine Moon".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/edunfelt/base16-rose-pine-scheme".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2021 Emilia Dunfelt
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Sandcastle".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/gessig/base16-sandcastle-scheme".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2019 George Essig
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Solarized Dark".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/altercation/solarized".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2011 Ethan Schoonover
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Solarized Light".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/altercation/solarized".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2011 Ethan Schoonover
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Andromeda".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/EliverLara/Andromeda".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2017 <eliverlara@gmail.com>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Summercamp".to_string(),
+            license: License::Mit,
+            license_url: Some("https://github.com/zoefiri/base16-sc".to_string()),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2019 Zoe FiriH
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Cave Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Cave Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Dune Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Dune Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Estuary Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Estuary Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Forest Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Forest Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Heath Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Heath Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Lakeside Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Lakeside Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Plateau Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Plateau Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Savanna Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Savanna Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Seaside Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Seaside Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Sulphurpool Dark".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+        Zed1ThemeLicense {
+            theme: "Atelier Sulphurpool Light".to_string(),
+            license: License::Mit,
+            license_url: Some(
+                "https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/"
+                    .to_string(),
+            ),
+            license_text: indoc! {r#"
+                The MIT License (MIT)
+
+                Copyright (c) 2023 Bram de Haan, http://atelierbramdehaan.nl
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            "#},
+        },
+    ]
+}

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -9,10 +9,7 @@ OUTPUT_FILE=$(pwd)/assets/licenses.md
 echo -e "# ###### THEME LICENSES ######\n" >> $OUTPUT_FILE
 
 echo "Generating theme licenses"
-cd styles
-npm --silent ci
-npm run --silent build-licenses >> $OUTPUT_FILE
-cd ..
+cat crates/theme/src/themes/LICENSES >> $OUTPUT_FILE
 
 echo -e "# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
 


### PR DESCRIPTION
This PR decouples the generation of licenses for the themes we ship from the TypeScript theme definitions.

For now, we are embedding the license information for the themes in the `theme_importer`, and emit a combined `LICENSES` file in the `theme` crate whenever we import themes. This is also where we check that each theme has a valid license.

We then use this `LICENSES` file when building up the global license file for Zed.

This decoupling is one step towards us being able to delete the old Zed1 styles.

Release Notes:

- N/A