### PR TITLE
Gracefully prevent submitting feedback while in a shared project

### DIFF
--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -17,7 +17,7 @@ use regex::Regex;
 use serde_derive::Serialize;
 use ui::{prelude::*, Button, ButtonStyle, IconPosition, Tooltip};
 use util::ResultExt;
-use workspace::{ModalView, Workspace};
+use workspace::{ModalView, Toast, Workspace};
 
 use crate::{system_specs::SystemSpecs, GiveFeedback, OpenZedCommunityRepo};
 
@@ -125,6 +125,20 @@ impl FeedbackModal {
                 .language_for_name("Markdown");
 
             let project = workspace.project().clone();
+            let is_local_project = project.read(cx).is_local();
+
+            if !is_local_project {
+                const TOAST_ID: usize = 0xdeadbeef;
+
+                workspace.show_toast(
+                    Toast::new(
+                        TOAST_ID,
+                        "You can only submit feedback in your own project.",
+                    ),
+                    cx,
+                );
+                return;
+            }
 
             cx.spawn(|workspace, mut cx| async move {
                 let markdown = markdown.await.log_err();


### PR DESCRIPTION
This PR fixes a panic that would occur when trying to submit feedback while within a shared project.

There may be a way we want to support this in the future, but for now we just show a toast letting the user know this is not supported:

<img width="415" alt="Screenshot 2024-01-05 at 2 46 02 PM" src="https://github.com/zed-industries/zed/assets/1486634/d3eff4d9-90ba-4257-9857-19b1bc933cf3">

Release Notes:

- Fixed a panic when attempting to open the feedback modal while in a shared project.
