### PR TITLE
Restore collab button tooltips, make screenshare item background of editor background's color

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -184,6 +184,16 @@ impl Render for CollabTitlebarItem {
                                     "toggle_sharing",
                                     if is_shared { "Unshare" } else { "Share" },
                                 )
+                                .tooltip(move |cx| {
+                                    Tooltip::text(
+                                        if is_shared {
+                                            "Stop sharing project with call participants"
+                                        } else {
+                                            "Share project with call participants"
+                                        },
+                                        cx,
+                                    )
+                                })
                                 .style(ButtonStyle::Subtle)
                                 .selected_style(ButtonStyle::Tinted(TintColor::Accent))
                                 .selected(is_shared)
@@ -202,6 +212,7 @@ impl Render for CollabTitlebarItem {
                         .child(
                             IconButton::new("leave-call", ui::Icon::Exit)
                                 .style(ButtonStyle::Subtle)
+                                .tooltip(|cx| Tooltip::text("Leave call", cx))
                                 .icon_size(IconSize::Small)
                                 .on_click(move |_, cx| {
                                     ActiveCall::global(cx)
@@ -219,6 +230,16 @@ impl Render for CollabTitlebarItem {
                                         ui::Icon::Mic
                                     },
                                 )
+                                .tooltip(move |cx| {
+                                    Tooltip::text(
+                                        if is_muted {
+                                            "Unmute microphone"
+                                        } else {
+                                            "Mute microphone"
+                                        },
+                                        cx,
+                                    )
+                                })
                                 .style(ButtonStyle::Subtle)
                                 .icon_size(IconSize::Small)
                                 .selected(is_muted)
@@ -260,6 +281,16 @@ impl Render for CollabTitlebarItem {
                                     .icon_size(IconSize::Small)
                                     .selected(is_screen_sharing)
                                     .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                                    .tooltip(move |cx| {
+                                        Tooltip::text(
+                                            if is_screen_sharing {
+                                                "Stop Sharing Screen"
+                                            } else {
+                                                "Share Screen"
+                                            },
+                                            cx,
+                                        )
+                                    })
                                     .on_click(move |_, cx| {
                                         crate::toggle_screen_sharing(&Default::default(), cx)
                                     }),

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -66,12 +66,16 @@ impl FocusableView for SharedScreen {
     }
 }
 impl Render for SharedScreen {
-    fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
-        div().track_focus(&self.focus).size_full().children(
-            self.frame
-                .as_ref()
-                .map(|frame| img(frame.image()).size_full()),
-        )
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        div()
+            .bg(cx.theme().colors().editor_background)
+            .track_focus(&self.focus)
+            .size_full()
+            .children(
+                self.frame
+                    .as_ref()
+                    .map(|frame| img(frame.image()).size_full()),
+            )
     }
 }
 


### PR DESCRIPTION
Release Notes:

- Restored collab button tooltips, made screenshare item background of editor background's color