### PR TITLE
Fix the alignment of the assistant

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -29,7 +29,7 @@ use editor::{
 use fs::Fs;
 use futures::StreamExt;
 use gpui::{
-    canvas, div, point, relative, rems, rgba, uniform_list, Action, AnyElement, AppContext,
+    canvas, div, point, relative, rems, uniform_list, Action, AnyElement, AppContext,
     AsyncWindowContext, AvailableSpace, ClipboardItem, Context, EventEmitter, FocusHandle,
     FocusableView, FontStyle, FontWeight, HighlightStyle, InteractiveElement, IntoElement, Model,
     ModelContext, ParentElement, Pixels, PromptLevel, Render, SharedString,

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -29,7 +29,7 @@ use editor::{
 use fs::Fs;
 use futures::StreamExt;
 use gpui::{
-    canvas, div, point, relative, rems, uniform_list, Action, AnyElement, AppContext,
+    canvas, div, point, relative, rems, rgba, uniform_list, Action, AnyElement, AppContext,
     AsyncWindowContext, AvailableSpace, ClipboardItem, Context, EventEmitter, FocusHandle,
     FocusableView, FontStyle, FontWeight, HighlightStyle, InteractiveElement, IntoElement, Model,
     ModelContext, ParentElement, Pixels, PromptLevel, Render, SharedString,
@@ -2325,12 +2325,16 @@ impl ConversationEditor {
                                     }
                                 });
 
-                            h_stack()
+                            div()
+                                .h_flex()
                                 .id(("message_header", message_id.0))
                                 .h_11()
+                                .relative()
                                 .gap_1()
-                                .p_1()
-                                .child(sender)
+                                // Sender is a button with a padding of 1, but only has a background on hover,
+                                // so we shift it left by the same amount to align the text with the content
+                                // in the un-hovered state.
+                                .child(div().child(sender).relative().neg_left_1())
                                 // TODO: Only show this if the message if the message has been sent
                                 .child(
                                     Label::new(
@@ -2538,7 +2542,7 @@ impl Render for ConversationEditor {
             .child(
                 div()
                     .size_full()
-                    .pl_2()
+                    .pl_4()
                     .bg(cx.theme().colors().editor_background)
                     .child(self.editor.clone()),
             )

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -561,6 +561,12 @@ impl From<Hsla> for Fill {
     }
 }
 
+impl From<Rgba> for Fill {
+    fn from(color: Rgba) -> Self {
+        Self::Color(color.into())
+    }
+}
+
 impl From<TextStyle> for HighlightStyle {
     fn from(other: TextStyle) -> Self {
         Self::from(&other)


### PR DESCRIPTION
![CleanShot 2024-01-05 at 17 30 11@2x](https://github.com/zed-industries/zed/assets/1789/b70226d0-bc07-4ce3-b45d-c25aace998c2)

Release Notes:

- Fixed the alignment of the assistant headers and text
- Increased the left padding on the assistant.