### PR TITLE
Fix bug that was causing `Editor` to notify on every mouse move

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -240,7 +240,7 @@ impl DisplayMap {
     }
     pub fn clear_highlights(&mut self, type_id: TypeId) -> bool {
         let mut cleared = self.text_highlights.remove(&Some(type_id)).is_some();
-        cleared |= self.inlay_highlights.remove(&type_id).is_none();
+        cleared |= self.inlay_highlights.remove(&type_id).is_some();
         cleared
     }
 


### PR DESCRIPTION
Release Notes:

- Fixed a bug that was causing Zed to use a lot of energy when moving the mouse.
