### PR TITLE
gpui: Sweep through cargo doc output and mark dubious items as non-public

### DIFF
--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -47,7 +47,7 @@ pub use element::*;
 pub use elements::*;
 pub use executor::*;
 pub use geometry::*;
-pub use gpui_macros::{register_action, IntoElement, Render};
+pub use gpui_macros::{register_action, test, IntoElement, Render};
 pub use image_cache::*;
 pub use input::*;
 pub use interactive::*;

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -47,7 +47,7 @@ pub use element::*;
 pub use elements::*;
 pub use executor::*;
 pub use geometry::*;
-pub use gpui_macros::*;
+pub use gpui_macros::{register_action, IntoElement, Render};
 pub use image_cache::*;
 pub use input::*;
 pub use interactive::*;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -37,7 +37,7 @@ pub use keystroke::*;
 pub use mac::*;
 #[cfg(any(test, feature = "test-support"))]
 pub use test::*;
-pub use time::UtcOffset;
+use time::UtcOffset;
 
 #[cfg(target_os = "macos")]
 pub(crate) fn current_platform() -> Rc<dyn Platform> {

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -106,11 +106,6 @@ impl From<NSSize> for Size<Pixels> {
     }
 }
 
-pub trait NSRectExt {
-    fn size(&self) -> Size<Pixels>;
-    fn intersects(&self, other: Self) -> bool;
-}
-
 impl From<NSRect> for Size<Pixels> {
     fn from(rect: NSRect) -> Self {
         let NSSize { width, height } = rect.size;
@@ -124,16 +119,3 @@ impl From<NSRect> for Size<GlobalPixels> {
         size(width.into(), height.into())
     }
 }
-
-// impl NSRectExt for NSRect {
-//     fn intersects(&self, other: Self) -> bool {
-//         self.size.width > 0.
-//             && self.size.height > 0.
-//             && other.size.width > 0.
-//             && other.size.height > 0.
-//             && self.origin.x <= other.origin.x + other.size.width
-//             && self.origin.x + self.size.width >= other.origin.x
-//             && self.origin.y <= other.origin.y + other.size.height
-//             && self.origin.y + self.size.height >= other.origin.y
-//     }
-// }

--- a/crates/gpui/src/platform/mac/dispatcher.rs
+++ b/crates/gpui/src/platform/mac/dispatcher.rs
@@ -13,9 +13,14 @@ use parking::{Parker, Unparker};
 use parking_lot::Mutex;
 use std::{ffi::c_void, ptr::NonNull, sync::Arc, time::Duration};
 
-include!(concat!(env!("OUT_DIR"), "/dispatch_sys.rs"));
+/// All items in the generated file are marked as pub, so we're gonna wrap it in a separate mod to prevent
+/// these pub items from leaking into public API.
+pub(crate) mod dispatch_sys {
+    include!(concat!(env!("OUT_DIR"), "/dispatch_sys.rs"));
+}
 
-pub fn dispatch_get_main_queue() -> dispatch_queue_t {
+use dispatch_sys::*;
+pub(crate) fn dispatch_get_main_queue() -> dispatch_queue_t {
     unsafe { &_dispatch_main_q as *const _ as dispatch_queue_t }
 }
 

--- a/crates/gpui/src/platform/mac/display.rs
+++ b/crates/gpui/src/platform/mac/display.rs
@@ -51,7 +51,7 @@ impl MacDisplay {
 
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
-    pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
+    fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
 }
 
 /// Convert the given rectangle from CoreGraphics' native coordinate space to GPUI's coordinate space.

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -56,9 +56,6 @@ use time::UtcOffset;
 #[allow(non_upper_case_globals)]
 const NSUTF8StringEncoding: NSUInteger = 4;
 
-#[allow(non_upper_case_globals)]
-pub const NSViewLayerContentsRedrawDuringViewResize: NSInteger = 2;
-
 const MAC_PLATFORM_IVAR: &str = "platform";
 static mut APP_CLASS: *const Class = ptr::null();
 static mut APP_DELEGATE_CLASS: *const Class = ptr::null();
@@ -404,7 +401,7 @@ impl Platform for MacPlatform {
         // this, we make quitting the application asynchronous so that we aren't holding borrows to
         // the app state on the stack when we actually terminate the app.
 
-        use super::dispatcher::{dispatch_async_f, dispatch_get_main_queue};
+        use super::dispatcher::{dispatch_get_main_queue, dispatch_sys::dispatch_async_f};
 
         unsafe {
             dispatch_async_f(dispatch_get_main_queue(), ptr::null_mut(), Some(quit));

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -500,9 +500,9 @@ impl<'a> StringIndexConverter<'a> {
 }
 
 #[repr(C)]
-pub struct __CFTypesetter(c_void);
+pub(crate) struct __CFTypesetter(c_void);
 
-pub type CTTypesetterRef = *const __CFTypesetter;
+type CTTypesetterRef = *const __CFTypesetter;
 
 #[link(name = "CoreText", kind = "framework")]
 extern "C" {

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -33,7 +33,7 @@ pub struct FontId(pub usize);
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
 pub struct FontFamilyId(pub usize);
 
-pub const SUBPIXEL_VARIANTS: u8 = 4;
+pub(crate) const SUBPIXEL_VARIANTS: u8 = 4;
 
 pub struct TextSystem {
     line_layout_cache: Arc<LineLayoutCache>,


### PR DESCRIPTION
I essentially went through the publicly exported items and marked these that are e.g. leaky reexports as pub(crate). I expect that'd be done on Tuesday anyways.

Release Notes:
- N/A
