### PR TITLE
External file drag and drop

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1099,12 +1099,6 @@ impl AppContext {
     pub fn has_active_drag(&self) -> bool {
         self.active_drag.is_some()
     }
-
-    pub fn active_drag<T: 'static>(&self) -> Option<&T> {
-        self.active_drag
-            .as_ref()
-            .and_then(|drag| drag.value.downcast_ref())
-    }
 }
 
 impl Context for AppContext {

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -214,7 +214,7 @@ impl Render for ExternalPaths {
 pub enum FileDropEvent {
     Entered {
         position: Point<Pixels>,
-        files: ExternalPaths,
+        paths: ExternalPaths,
     },
     Pending {
         position: Point<Pixels>,

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1673,10 +1673,7 @@ extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDr
     if send_new_event(&window_state, {
         let position = drag_event_position(&window_state, dragging_info);
         let paths = external_paths_from_event(dragging_info);
-        InputEvent::FileDrop(FileDropEvent::Entered {
-            position,
-            files: paths,
-        })
+        InputEvent::FileDrop(FileDropEvent::Entered { position, paths })
     }) {
         NSDragOperationCopy
     } else {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1462,12 +1462,12 @@ impl<'a> WindowContext<'a> {
             // Translate dragging and dropping of external files from the operating system
             // to internal drag and drop events.
             InputEvent::FileDrop(file_drop) => match file_drop {
-                FileDropEvent::Entered { position, files } => {
+                FileDropEvent::Entered { position, paths } => {
                     self.window.mouse_position = position;
                     if self.active_drag.is_none() {
                         self.active_drag = Some(AnyDrag {
-                            value: Box::new(files.clone()),
-                            view: self.new_view(|_| files).into(),
+                            value: Box::new(paths.clone()),
+                            view: self.new_view(|_| paths).into(),
                             cursor_offset: position,
                         });
                     }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use workspace::{AppState, Workspace};
+use workspace::{AppState, OpenVisible, Workspace};
 
 actions!(journal, [NewJournalEntry]);
 
@@ -100,7 +100,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut WindowContext) {
 
         let opened = workspace
             .update(&mut cx, |workspace, cx| {
-                workspace.open_paths(vec![entry_path], true, None, cx)
+                workspace.open_paths(vec![entry_path], OpenVisible::All, None, cx)
             })?
             .await;
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -100,7 +100,7 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut WindowContext) {
 
         let opened = workspace
             .update(&mut cx, |workspace, cx| {
-                workspace.open_paths(vec![entry_path], true, cx)
+                workspace.open_paths(vec![entry_path], true, None, cx)
             })?
             .await;
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1,12 +1,12 @@
 use editor::{Cursor, HighlightedRange, HighlightedRangeLine};
 use gpui::{
     div, fill, point, px, red, relative, AnyElement, AsyncWindowContext, AvailableSpace,
-    BorrowWindow, Bounds, DispatchPhase, Element, ElementId, ExternalPaths, FocusHandle, Font,
-    FontStyle, FontWeight, HighlightStyle, Hsla, InteractiveBounds, InteractiveElement,
+    BorrowWindow, Bounds, DispatchPhase, Element, ElementId, FocusHandle, Font, FontStyle,
+    FontWeight, HighlightStyle, Hsla, InteractiveBounds, InteractiveElement,
     InteractiveElementState, Interactivity, IntoElement, LayoutId, Model, ModelContext,
     ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels, PlatformInputHandler, Point,
-    ShapedLine, StatefulInteractiveElement, StyleRefinement, Styled, TextRun, TextStyle,
-    TextSystem, UnderlineStyle, WhiteSpace, WindowContext,
+    ShapedLine, StatefulInteractiveElement, Styled, TextRun, TextStyle, TextSystem, UnderlineStyle,
+    WhiteSpace, WindowContext,
 };
 use itertools::Itertools;
 use language::CursorShape;
@@ -25,7 +25,7 @@ use terminal::{
 use theme::{ActiveTheme, Theme, ThemeSettings};
 use ui::Tooltip;
 
-use std::{any::TypeId, mem};
+use std::mem;
 use std::{fmt::Debug, ops::RangeInclusive};
 
 ///The information generated during layout that is necessary for painting
@@ -674,28 +674,6 @@ impl TerminalElement {
                     terminal.scroll_wheel(e, origin);
                     cx.notify();
                 })
-            }
-        });
-
-        self.interactivity.drag_over_styles.push((
-            TypeId::of::<ExternalPaths>(),
-            StyleRefinement::default().bg(cx.theme().colors().drop_target_background),
-        ));
-        self.interactivity.on_drop::<ExternalPaths>({
-            let focus = focus.clone();
-            let terminal = terminal.clone();
-            move |external_paths, cx| {
-                cx.focus(&focus);
-                let mut new_text = external_paths
-                    .paths()
-                    .iter()
-                    .map(|path| format!(" {path:?}"))
-                    .join("");
-                new_text.push(' ');
-                terminal.update(cx, |terminal, _| {
-                    terminal.paste(&new_text);
-                });
-                cx.stop_propagation();
             }
         });
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -693,9 +693,9 @@ impl TerminalElement {
                     .join("");
                 new_text.push(' ');
                 terminal.update(cx, |terminal, _| {
-                    // todo!() long paths are not displayed properly albeit the text is there
                     terminal.paste(&new_text);
                 });
+                cx.stop_propagation();
             }
         });
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -65,11 +65,8 @@ impl TerminalPanel {
                             return item.downcast::<TerminalView>().is_some();
                         }
                     }
-                    if a.downcast_ref::<ExternalPaths>().is_some() {
-                        return true;
-                    }
 
-                    false
+                    a.downcast_ref::<ExternalPaths>().is_some()
                 })),
                 cx,
             );

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -99,7 +99,12 @@ impl TerminalPanel {
             let workspace = workspace.weak_handle();
             pane.set_custom_drop_handle(cx, move |pane, dropped_item, cx| {
                 if let Some(tab) = dropped_item.downcast_ref::<DraggedTab>() {
-                    if let Some(item) = tab.pane.read(cx).item_for_index(tab.ix) {
+                    let item = if &tab.pane == cx.view() {
+                        pane.item_for_index(tab.ix)
+                    } else {
+                        tab.pane.read(cx).item_for_index(tab.ix)
+                    };
+                    if let Some(item) = item {
                         if item.downcast::<TerminalView>().is_some() {
                             return ControlFlow::Continue(());
                         } else if let Some(project_path) = item.project_path(cx) {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -197,7 +197,7 @@ impl TerminalView {
                         cx.spawn(|_, mut cx| async move {
                             let opened_items = task_workspace
                                 .update(&mut cx, |workspace, cx| {
-                                    workspace.open_paths(vec![path.path_like], is_dir, cx)
+                                    workspace.open_paths(vec![path.path_like], is_dir, None, cx)
                                 })
                                 .context("workspace update")?
                                 .await;

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -29,7 +29,8 @@ use workspace::{
     notifications::NotifyResultExt,
     register_deserializable_item,
     searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
-    CloseActiveItem, NewCenterTerminal, Pane, ToolbarItemLocation, Workspace, WorkspaceId,
+    CloseActiveItem, NewCenterTerminal, OpenVisible, Pane, ToolbarItemLocation, Workspace,
+    WorkspaceId,
 };
 
 use anyhow::Context;
@@ -192,12 +193,18 @@ impl TerminalView {
                     }
                     let potential_abs_paths = possible_open_targets(&workspace, maybe_path, cx);
                     if let Some(path) = potential_abs_paths.into_iter().next() {
+                        // TODO kb wrong lib call
                         let is_dir = path.path_like.is_dir();
                         let task_workspace = workspace.clone();
                         cx.spawn(|_, mut cx| async move {
                             let opened_items = task_workspace
                                 .update(&mut cx, |workspace, cx| {
-                                    workspace.open_paths(vec![path.path_like], is_dir, None, cx)
+                                    workspace.open_paths(
+                                        vec![path.path_like],
+                                        OpenVisible::OnlyDirectories,
+                                        None,
+                                        cx,
+                                    )
                                 })
                                 .context("workspace update")?
                                 .await;

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2,7 +2,7 @@ use crate::{
     item::{ClosePosition, Item, ItemHandle, ItemSettings, WeakItemHandle},
     toolbar::Toolbar,
     workspace_settings::{AutosaveSetting, WorkspaceSettings},
-    NewCenterTerminal, NewFile, NewSearch, SplitDirection, ToggleZoom, Workspace,
+    NewCenterTerminal, NewFile, NewSearch, OpenVisible, SplitDirection, ToggleZoom, Workspace,
 };
 use anyhow::Result;
 use collections::{HashMap, HashSet, VecDeque};
@@ -1899,7 +1899,12 @@ impl Pane {
                         to_pane = workspace.split_pane(to_pane, split_direction, cx);
                     }
                     workspace
-                        .open_paths(paths, true, Some(to_pane.downgrade()), cx)
+                        .open_paths(
+                            paths,
+                            OpenVisible::OnlyDirectories,
+                            Some(to_pane.downgrade()),
+                            cx,
+                        )
                         .detach();
                 });
             })

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1869,28 +1869,21 @@ impl Pane {
         paths: &ExternalPaths,
         cx: &mut ViewContext<'_, Pane>,
     ) {
-        // let mut to_pane = cx.view().clone();
-        // let split_direction = self.drag_split_direction;
-        // let project_entry_id = *project_entry_id;
-        // self.workspace
-        //     .update(cx, |_, cx| {
-        //         cx.defer(move |workspace, cx| {
-        //             if let Some(path) = workspace
-        //                 .project()
-        //                 .read(cx)
-        //                 .path_for_entry(project_entry_id, cx)
-        //             {
-        //                 if let Some(split_direction) = split_direction {
-        //                     to_pane = workspace.split_pane(to_pane, split_direction, cx);
-        //                 }
-        //                 workspace
-        //                     .open_path(path, Some(to_pane.downgrade()), true, cx)
-        //                     .detach_and_log_err(cx);
-        //             }
-        //         });
-        //     })
-        //     .log_err();
-        dbg!("@@@@@@@@@@@@@@", paths);
+        let mut to_pane = cx.view().clone();
+        let split_direction = self.drag_split_direction;
+        let paths = paths.paths().to_vec();
+        self.workspace
+            .update(cx, |_, cx| {
+                cx.defer(move |workspace, cx| {
+                    if let Some(split_direction) = split_direction {
+                        to_pane = workspace.split_pane(to_pane, split_direction, cx);
+                    }
+                    workspace
+                        .open_paths(paths, true, Some(to_pane.downgrade()), cx)
+                        .detach();
+                });
+            })
+            .log_err();
     }
 
     pub fn display_nav_history_buttons(&mut self, display: bool) {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -27,11 +27,11 @@ use futures::{
 use gpui::{
     actions, canvas, div, impl_actions, point, size, Action, AnyElement, AnyModel, AnyView,
     AnyWeakView, AnyWindowHandle, AppContext, AsyncAppContext, AsyncWindowContext, BorrowWindow,
-    Bounds, Context, Div, DragMoveEvent, Element, Entity, EntityId, EventEmitter, FocusHandle,
-    FocusableView, GlobalPixels, InteractiveElement, IntoElement, KeyContext, LayoutId,
-    ManagedView, Model, ModelContext, ParentElement, PathPromptOptions, Pixels, Point, PromptLevel,
-    Render, Size, Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
-    WindowBounds, WindowContext, WindowHandle, WindowOptions,
+    Bounds, Context, Div, DragMoveEvent, Element, Entity, EntityId, EventEmitter, ExternalPaths,
+    FocusHandle, FocusableView, GlobalPixels, InteractiveElement, IntoElement, KeyContext,
+    LayoutId, ManagedView, Model, ModelContext, ParentElement, PathPromptOptions, Pixels, Point,
+    PromptLevel, Render, Size, Styled, Subscription, Task, View, ViewContext, VisualContext,
+    WeakView, WindowBounds, WindowContext, WindowHandle, WindowOptions,
 };
 use item::{FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, ProjectItem};
 use itertools::Itertools;
@@ -544,7 +544,11 @@ impl Workspace {
                 weak_handle.clone(),
                 project.clone(),
                 pane_history_timestamp.clone(),
-                None,
+                Some(Arc::new(|a, _| {
+                    a.downcast_ref::<ExternalPaths>().is_some()
+                        || a.downcast_ref::<DraggedTab>().is_some()
+                        || a.downcast_ref::<ProjectEntryId>().is_some()
+                })),
                 cx,
             )
         });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -27,11 +27,11 @@ use futures::{
 use gpui::{
     actions, canvas, div, impl_actions, point, size, Action, AnyElement, AnyModel, AnyView,
     AnyWeakView, AnyWindowHandle, AppContext, AsyncAppContext, AsyncWindowContext, BorrowWindow,
-    Bounds, Context, Div, DragMoveEvent, Element, Entity, EntityId, EventEmitter, ExternalPaths,
-    FocusHandle, FocusableView, GlobalPixels, InteractiveElement, IntoElement, KeyContext,
-    LayoutId, ManagedView, Model, ModelContext, ParentElement, PathPromptOptions, Pixels, Point,
-    PromptLevel, Render, Size, Styled, Subscription, Task, View, ViewContext, VisualContext,
-    WeakView, WindowBounds, WindowContext, WindowHandle, WindowOptions,
+    Bounds, Context, Div, DragMoveEvent, Element, Entity, EntityId, EventEmitter, FocusHandle,
+    FocusableView, GlobalPixels, InteractiveElement, IntoElement, KeyContext, LayoutId,
+    ManagedView, Model, ModelContext, ParentElement, PathPromptOptions, Pixels, Point, PromptLevel,
+    Render, Size, Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
+    WindowBounds, WindowContext, WindowHandle, WindowOptions,
 };
 use item::{FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, ProjectItem};
 use itertools::Itertools;
@@ -544,11 +544,7 @@ impl Workspace {
                 weak_handle.clone(),
                 project.clone(),
                 pane_history_timestamp.clone(),
-                Some(Arc::new(|a, _| {
-                    a.downcast_ref::<ExternalPaths>().is_some()
-                        || a.downcast_ref::<DraggedTab>().is_some()
-                        || a.downcast_ref::<ProjectEntryId>().is_some()
-                })),
+                None,
                 cx,
             )
         });


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/issues/6069
Deals with https://github.com/zed-industries/zed/issues/5700

Reworks pane drag and drop code to support 
* dropping external files into main pane (supports splits same as tabs and project entries drop) — this will open the file dropped
* dropping external files, tabs and project entries drop into the terminal — this will add file abs path into the terminal

Release Notes:

- Added a way to drag and drop external files into Zed main & terminal panes; support tabs and project entries drop into terminal pane