### PR TITLE
Always show full command on terminal tab hover

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1311,34 +1311,33 @@ impl Terminal {
         })
     }
 
-    pub fn title(&self) -> String {
+    pub fn title(&self, truncate: bool) -> String {
         self.foreground_process_info
             .as_ref()
             .map(|fpi| {
-                format!(
-                    "{} — {}",
-                    truncate_and_trailoff(
-                        &fpi.cwd
-                            .file_name()
-                            .map(|name| name.to_string_lossy().to_string())
-                            .unwrap_or_default(),
-                        25
-                    ),
-                    truncate_and_trailoff(
-                        &{
-                            format!(
-                                "{}{}",
-                                fpi.name,
-                                if fpi.argv.len() >= 1 {
-                                    format!(" {}", (&fpi.argv[1..]).join(" "))
-                                } else {
-                                    "".to_string()
-                                }
-                            )
-                        },
-                        25
+                let process_file = fpi
+                    .cwd
+                    .file_name()
+                    .map(|name| name.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let process_name = format!(
+                    "{}{}",
+                    fpi.name,
+                    if fpi.argv.len() >= 1 {
+                        format!(" {}", (&fpi.argv[1..]).join(" "))
+                    } else {
+                        "".to_string()
+                    }
+                );
+                let (process_file, process_name) = if truncate {
+                    (
+                        truncate_and_trailoff(&process_file, 25),
+                        truncate_and_trailoff(&process_name, 25),
                     )
-                )
+                } else {
+                    (process_file, process_name)
+                };
+                format!("{process_file} — {process_name}")
             })
             .unwrap_or_else(|| "Terminal".to_string())
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -665,7 +665,7 @@ impl Item for TerminalView {
     type Event = ItemEvent;
 
     fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
-        Some(self.terminal().read(cx).title().into())
+        Some(self.terminal().read(cx).title(false).into())
     }
 
     fn tab_content(
@@ -674,8 +674,7 @@ impl Item for TerminalView {
         selected: bool,
         cx: &WindowContext,
     ) -> AnyElement {
-        let title = self.terminal().read(cx).title();
-
+        let title = self.terminal().read(cx).title(true);
         h_stack()
             .gap_2()
             .child(IconElement::new(Icon::Terminal))


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/issues/6243

Release Notes:

- Fixed terminal tab tooltip being truncated