### PR TITLE
Display setting documentation in settings.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,7 @@ dependencies = [
  "log",
  "menu",
  "project",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -76,7 +76,7 @@
   // or waits for a `copilot::Toggle`
   "show_copilot_suggestions": true,
   // Whether to show tabs and spaces in the editor.
-  // This setting can take two values:
+  // This setting can take three values:
   //
   // 1. Draw tabs and spaces only for the selected text (default):
   //    "selection"
@@ -183,7 +183,7 @@
     // Default height when the assistant is docked to the bottom.
     "default_height": 320,
     // The default OpenAI model to use when starting new conversations. This
-    // setting can take two values:
+    // setting can take three values:
     //
     // 1. "gpt-3.5-turbo-0613""
     // 2. "gpt-4-0613""
@@ -351,7 +351,7 @@
     //      }
     "working_directory": "current_project_directory",
     // Set the cursor blinking behavior in the terminal.
-    // May take 4 values:
+    // May take 3 values:
     //  1. Never blink the cursor, ignoring the terminal mode
     //         "blinking": "off",
     //  2. Default the cursor blink to off, but allow the terminal to

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -57,12 +57,28 @@ pub struct AssistantSettings {
     pub default_open_ai_model: OpenAIModel,
 }
 
+/// Assistant panel settings
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct AssistantSettingsContent {
+    /// Whether to show the assistant panel button in the status bar.
+    ///
+    /// Default: true
     pub button: Option<bool>,
+    /// Where to dock the assistant.
+    ///
+    /// Default: right
     pub dock: Option<AssistantDockPosition>,
+    /// Default width in pixels when the assistant is docked to the left or right.
+    ///
+    /// Default: 640
     pub default_width: Option<f32>,
+    /// Default height in pixels when the assistant is docked to the bottom.
+    ///
+    /// Default: 320
     pub default_height: Option<f32>,
+    /// The default OpenAI model to use when starting new conversations.
+    ///
+    /// Default: gpt-4-1106-preview
     pub default_open_ai_model: Option<OpenAIModel>,
 }
 

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -22,6 +22,7 @@ anyhow.workspace = true
 isahc.workspace = true
 lazy_static.workspace = true
 log.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -10,6 +10,7 @@ use gpui::{
 };
 use isahc::AsyncBody;
 
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_derive::Serialize;
 use smol::io::AsyncReadExt;
@@ -61,18 +62,27 @@ struct JsonRelease {
 
 struct AutoUpdateSetting(bool);
 
+/// Whether or not to automatically check for updates.
+///
+/// Default: true
+#[derive(Clone, Default, JsonSchema, Deserialize, Serialize)]
+#[serde(transparent)]
+struct AutoUpdateSettingOverride(Option<bool>);
+
 impl Settings for AutoUpdateSetting {
     const KEY: Option<&'static str> = Some("auto_update");
 
-    type FileContent = Option<bool>;
+    type FileContent = AutoUpdateSettingOverride;
 
     fn load(
-        default_value: &Option<bool>,
-        user_values: &[&Option<bool>],
+        default_value: &Self::FileContent,
+        user_values: &[&Self::FileContent],
         _: &mut AppContext,
     ) -> Result<Self> {
         Ok(Self(
-            Self::json_merge(default_value, user_values)?.ok_or_else(Self::missing_default)?,
+            Self::json_merge(default_value, user_values)?
+                .0
+                .ok_or_else(Self::missing_default)?,
         ))
     }
 }

--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -11,6 +11,7 @@ pub struct CallSettings {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct CallSettingsContent {
+    /// Whether the microphone should be muted when joining a channel or a call.
     pub mute_on_join: Option<bool>,
 }
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -352,9 +352,16 @@ pub struct TelemetrySettings {
     pub metrics: bool,
 }
 
+/// Control what info is collected by Zed.
 #[derive(Default, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TelemetrySettingsContent {
+    /// Send debug info like crash reports.
+    ///
+    /// Default: true
     pub diagnostics: Option<bool>,
+    /// Send anonymized usage data like what languages you're using Zed with.
+    ///
+    /// Default: true
     pub metrics: Option<bool>,
 }
 

--- a/crates/collab_ui/src/panel_settings.rs
+++ b/crates/collab_ui/src/panel_settings.rs
@@ -28,8 +28,17 @@ pub struct NotificationPanelSettings {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct PanelSettingsContent {
+    /// Whether to show the panel button in the status bar.
+    ///
+    /// Default: true
     pub button: Option<bool>,
+    /// Where to dock the panel.
+    ///
+    /// Default: left
     pub dock: Option<DockPosition>,
+    /// Default width of the panel in pixels.
+    ///
+    /// Default: 240
     pub default_width: Option<f32>,
 }
 

--- a/crates/diagnostics/src/project_diagnostics_settings.rs
+++ b/crates/diagnostics/src/project_diagnostics_settings.rs
@@ -6,8 +6,12 @@ pub struct ProjectDiagnosticsSettings {
     pub include_warnings: bool,
 }
 
+/// Diagnostics configuration.
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ProjectDiagnosticsSettingsContent {
+    /// Whether to show warnings or not by default.
+    ///
+    /// Default: true
     include_warnings: Option<bool>,
 }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -14,11 +14,15 @@ pub struct EditorSettings {
     pub seed_search_query_from_cursor: SeedQuerySetting,
 }
 
+/// When to populate a new search's query based on the text under the cursor.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SeedQuerySetting {
+    /// Always populate the search query with the word under the cursor.
     Always,
+    /// Only populate the search query when there is text selected.
     Selection,
+    /// Never populate the search query
     Never,
 }
 
@@ -29,31 +33,75 @@ pub struct Scrollbar {
     pub selections: bool,
 }
 
+/// When to show the scrollbar in the editor.
+///
+/// Default: auto
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ShowScrollbar {
+    /// Show the scrollbar if there's important information or
+    /// follow the system's configured behavior.
     Auto,
+    /// Match the system's configured behavior.
     System,
+    /// Always show the scrollbar.
     Always,
+    /// Never show the scrollbar.
     Never,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
+    /// Whether the cursor blinks in the editor.
+    ///
+    /// Default: true
     pub cursor_blink: Option<bool>,
+    /// Whether to show the informational hover box when moving the mouse
+    /// over symbols in the editor.
+    ///
+    /// Default: true
     pub hover_popover_enabled: Option<bool>,
+    /// Whether to pop the completions menu while typing in an editor without
+    /// explicitly requesting it.
+    ///
+    /// Default: true
     pub show_completions_on_input: Option<bool>,
+    /// Whether to display inline and alongside documentation for items in the
+    /// completions menu.
+    ///
+    /// Default: true
     pub show_completion_documentation: Option<bool>,
+    /// Whether to use additional LSP queries to format (and amend) the code after
+    /// every "trigger" symbol input, defined by LSP server capabilities.
+    ///
+    /// Default: true
     pub use_on_type_format: Option<bool>,
+    /// Scrollbar related settings
     pub scrollbar: Option<ScrollbarContent>,
+    /// Whether the line numbers on editors gutter are relative or not.
+    ///
+    /// Default: false
     pub relative_line_numbers: Option<bool>,
+    /// When to populate a new search's query based on the text under the cursor.
+    ///
+    /// Default: always
     pub seed_search_query_from_cursor: Option<SeedQuerySetting>,
 }
 
+/// Scrollbar related settings
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ScrollbarContent {
+    /// When to show the scrollbar in the editor.
+    ///
+    /// Default: auto
     pub show: Option<ShowScrollbar>,
+    /// Whether to show git diff indicators in the scrollbar.
+    ///
+    /// Default: true
     pub git_diff: Option<bool>,
+    /// Whether to show buffer search result markers in the scrollbar.
+    ///
+    /// Default: true
     pub selections: Option<bool>,
 }
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -15,9 +15,16 @@ use workspace::{AppState, OpenVisible, Workspace};
 
 actions!(journal, [NewJournalEntry]);
 
+/// // Settings specific to journaling
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct JournalSettings {
+    /// The path of the directory where journal entries are stored.
+    ///
+    /// Default: `~`
     pub path: Option<String>,
+    /// What format to display the hours in.
+    ///
+    /// Default: hour12
     pub hour_format: Option<HourFormat>,
 }
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -15,7 +15,7 @@ use workspace::{AppState, OpenVisible, Workspace};
 
 actions!(journal, [NewJournalEntry]);
 
-/// // Settings specific to journaling
+/// Settings specific to journaling
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct JournalSettings {
     /// The path of the directory where journal entries are stored.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -79,36 +79,90 @@ pub struct AllLanguageSettingsContent {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct LanguageSettingsContent {
+    /// How many columns a tab should occupy.
+    ///
+    /// Default: 4
     #[serde(default)]
     pub tab_size: Option<NonZeroU32>,
+    /// Whether to indent lines using tab characters, as opposed to multiple
+    /// spaces.
+    ///
+    /// Default: false
     #[serde(default)]
     pub hard_tabs: Option<bool>,
+    /// How to soft-wrap long lines of text.
+    ///
+    /// Default: none
     #[serde(default)]
     pub soft_wrap: Option<SoftWrap>,
+    /// The column at which to soft-wrap lines, for buffers where soft-wrap
+    /// is enabled.
+    ///
+    /// Default: 80
     #[serde(default)]
     pub preferred_line_length: Option<u32>,
+    /// Whether to show wrap guides in the editor. Setting this to true will
+    /// show a guide at the 'preferred_line_length' value if softwrap is set to
+    /// 'preferred_line_length', and will show any additional guides as specified
+    /// by the 'wrap_guides' setting.
+    ///
+    /// Default: true
     #[serde(default)]
     pub show_wrap_guides: Option<bool>,
+    /// Character counts at which to show wrap guides in the editor.
+    ///
+    /// Default: []
     #[serde(default)]
     pub wrap_guides: Option<Vec<usize>>,
+    /// Whether or not to perform a buffer format before saving.
+    ///
+    /// Default: on
     #[serde(default)]
     pub format_on_save: Option<FormatOnSave>,
+    /// Whether or not to remove any trailing whitespace from lines of a buffer
+    /// before saving it.
+    ///
+    /// Default: true
     #[serde(default)]
     pub remove_trailing_whitespace_on_save: Option<bool>,
+    /// Whether or not to ensure there's a single newline at the end of a buffer
+    /// when saving it.
+    ///
+    /// Default: true
     #[serde(default)]
     pub ensure_final_newline_on_save: Option<bool>,
+    /// How to perform a buffer format.
+    ///
+    /// Default: auto
     #[serde(default)]
     pub formatter: Option<Formatter>,
+    /// Zed's Prettier integration settings.
+    /// If Prettier is enabled, Zed will use this its Prettier instance for any applicable file, if
+    /// project has no other Prettier installed.
+    ///
+    /// Default: {}
     #[serde(default)]
     pub prettier: Option<HashMap<String, serde_json::Value>>,
+    /// Whether to use language servers to provide code intelligence.
+    ///
+    /// Default: true
     #[serde(default)]
     pub enable_language_server: Option<bool>,
+    /// Controls whether copilot provides suggestion immediately (true)
+    /// or waits for a `copilot::Toggle` (false).
+    ///
+    /// Default: true
     #[serde(default)]
     pub show_copilot_suggestions: Option<bool>,
+    /// Whether to show tabs and spaces in the editor.
     #[serde(default)]
     pub show_whitespaces: Option<ShowWhitespaceSetting>,
+    /// Whether to start a new line with a comment when a previous line is a comment as well.
+    ///
+    /// Default: true
     #[serde(default)]
     pub extend_comment_on_newline: Option<bool>,
+    /// Inlay hint related settings.
     #[serde(default)]
     pub inlay_hints: Option<InlayHintSettings>,
 }
@@ -128,8 +182,11 @@ pub struct FeaturesContent {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SoftWrap {
+    /// Do not soft wrap.
     None,
+    /// Soft wrap lines that overflow the editor
     EditorWidth,
+    /// Soft wrap lines at the preferred line length
     PreferredLineLength,
 }
 
@@ -148,18 +205,26 @@ pub enum FormatOnSave {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ShowWhitespaceSetting {
+    /// Draw tabs and spaces only for the selected text.
     Selection,
+    /// Do not draw any tabs or spaces
     None,
+    /// Draw all invisible symbols
     All,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Formatter {
+    /// Format files using Zed's Prettier integration (if applicable),
+    /// or falling back to formatting via language server.
     #[default]
     Auto,
+    /// Format code using the current language server.
     LanguageServer,
+    /// Format code using Zed's Prettier integration.
     Prettier,
+    /// Format code using an external command.
     External {
         command: Arc<str>,
         arguments: Arc<[String]>,
@@ -168,6 +233,9 @@ pub enum Formatter {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct InlayHintSettings {
+    /// Global switch to toggle hints on and off.
+    ///
+    /// Default: false
     #[serde(default)]
     pub enabled: bool,
     #[serde(default = "default_true")]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -7,16 +7,40 @@ use std::sync::Arc;
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ProjectSettings {
+    /// Configuration for language servers.
+    ///
+    /// The following settings can be overriden for specific language servers:
+    /// - initialization_options
+    /// To override settings for a language, add an entry for that language server's
+    /// name to the lsp value.
+    /// Default: null
     #[serde(default)]
     pub lsp: HashMap<Arc<str>, LspSettings>,
+
+    /// Configuration for Git-related features
     #[serde(default)]
     pub git: GitSettings,
+    /// Completely ignore files matching globs from `file_scan_exclusions`
+    ///
+    /// Default: [
+    ///   "**/.git",
+    ///   "**/.svn",
+    ///   "**/.hg",
+    ///   "**/CVS",
+    ///   "**/.DS_Store",
+    ///   "**/Thumbs.db",
+    ///   "**/.classpath",
+    ///   "**/.settings"
+    /// ]
     #[serde(default)]
     pub file_scan_exclusions: Option<Vec<String>>,
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct GitSettings {
+    /// Whether or not to show the git gutter.
+    ///
+    /// Default: tracked_files
     pub git_gutter: Option<GitGutterSetting>,
     pub gutter_debounce: Option<u64>,
 }
@@ -24,8 +48,10 @@ pub struct GitSettings {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum GitGutterSetting {
+    /// Show git gutter in tracked files.
     #[default]
     TrackedFiles,
+    /// Hide git gutter
     Hide,
 }
 

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -24,12 +24,35 @@ pub struct ProjectPanelSettings {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ProjectPanelSettingsContent {
+    /// Customise default width (in pixels) taken by project panel
+    ///
+    /// Default: 240
     pub default_width: Option<f32>,
+    /// The position of project panel
+    ///
+    /// Default: left
     pub dock: Option<ProjectPanelDockPosition>,
+    /// Whether to show file icons in the project panel.
+    ///
+    /// Default: true
     pub file_icons: Option<bool>,
+    /// Whether to show folder icons or chevrons for directories in the project panel.
+    ///
+    /// Default: true
     pub folder_icons: Option<bool>,
+    /// Whether to show the git status in the project panel.
+    ///
+    /// Default: true
     pub git_status: Option<bool>,
+    /// Amount of indentation (in pixels) for nested items.
+    ///
+    /// Default: 20
     pub indent_size: Option<f32>,
+    /// Whether to reveal it in the project panel automatically,
+    /// when a corresponding project entry becomes active.
+    /// Gitignored entries are never auto revealed.
+    ///
+    /// Default: true
     pub auto_reveal_entries: Option<bool>,
 }
 

--- a/crates/semantic_index/src/semantic_index_settings.rs
+++ b/crates/semantic_index/src/semantic_index_settings.rs
@@ -8,8 +8,13 @@ pub struct SemanticIndexSettings {
     pub enabled: bool,
 }
 
+/// Configuration of semantic index, an alternate search engine available in
+/// project search.
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct SemanticIndexSettingsContent {
+    /// Whether or not to display the Semantic mode in project search.
+    ///
+    /// Default: true
     pub enabled: Option<bool>,
 }
 

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -84,10 +84,14 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: current_project_directory
     pub working_directory: Option<WorkingDirectory>,
-    /// Set the terminal's font size. If this option is not included,
+    /// Set the terminal's font size.
+    ///
+    /// If this option is not included,
     /// the terminal will default to matching the buffer's font size.
     pub font_size: Option<f32>,
-    /// Set the terminal's font family. If this option is not included,
+    /// Set the terminal's font family.
+    ///
+    /// If this option is not included,
     /// the terminal will default to matching the buffer's font family.
     pub font_family: Option<String>,
     /// Set the terminal's line height.

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -36,6 +36,9 @@ pub enum VenvSettings {
     #[default]
     Off,
     On {
+        /// Default directories to search for virtual environments, relative
+        /// to the current working directory. We recommend overriding this
+        /// in your project's settings, rather than globally.
         activate_script: Option<ActivateScript>,
         directories: Option<Vec<PathBuf>>,
     },
@@ -73,20 +76,64 @@ pub enum ActivateScript {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct TerminalSettingsContent {
+    /// What shell to use when opening a terminal.
+    ///
+    /// Default: system
     pub shell: Option<Shell>,
+    /// What working directory to use when launching the terminal
+    ///
+    /// Default: current_project_directory
     pub working_directory: Option<WorkingDirectory>,
+    /// Set the terminal's font size. If this option is not included,
+    /// the terminal will default to matching the buffer's font size.
     pub font_size: Option<f32>,
+    /// Set the terminal's font family. If this option is not included,
+    /// the terminal will default to matching the buffer's font family.
     pub font_family: Option<String>,
+    /// Set the terminal's line height.
+    ///
+    /// Default: comfortable
     pub line_height: Option<TerminalLineHeight>,
     pub font_features: Option<FontFeatures>,
+    /// Any key-value pairs added to this list will be added to the terminal's
+    /// environment. Use `:` to separate multiple values.
+    ///
+    /// Default: {}
     pub env: Option<HashMap<String, String>>,
+    /// Set the cursor blinking behavior in the terminal.
+    ///
+    /// Default: terminal_controlled
     pub blinking: Option<TerminalBlink>,
+    /// Set whether Alternate Scroll mode (code: ?1007) is active by default.
+    /// Alternate Scroll mode converts mouse scroll events into up / down key
+    /// presses when in the alternate screen (e.g. when running applications
+    /// like vim or  less). The terminal can still set and unset this mode.
+    ///
+    /// Default: off
     pub alternate_scroll: Option<AlternateScroll>,
+    /// Set whether the option key behaves as the meta key.
+    ///
+    /// Default: false
     pub option_as_meta: Option<bool>,
+    /// Whether or not selecting text in the terminal will automatically
+    /// copy to the system clipboard.
+    ///
+    /// Default: false
     pub copy_on_select: Option<bool>,
     pub dock: Option<TerminalDockPosition>,
+    /// Default width when the terminal is docked to the left or right.
+    ///
+    /// Default: 640
     pub default_width: Option<f32>,
+    /// Default height when the terminal is docked to the bottom.
+    ///
+    /// Default: 320
     pub default_height: Option<f32>,
+    /// Activate the python virtual environment, if one is found, in the
+    /// terminal's working directory (as resolved by the working_directory
+    /// setting). Set this to "off" to disable this behavior.
+    ///
+    /// Default: on
     pub detect_venv: Option<VenvSettings>,
 }
 
@@ -107,9 +154,13 @@ impl settings::Settings for TerminalSettings {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum TerminalLineHeight {
+    /// Use a line height that's comfortable for reading, 1.618
     #[default]
     Comfortable,
+    /// Use a standard line height, 1.3. This option is useful for TUIs,
+    /// particularly if they use box characters
     Standard,
+    /// Use a custom line height.
     Custom(f32),
 }
 
@@ -127,17 +178,25 @@ impl TerminalLineHeight {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TerminalBlink {
+    /// Never blink the cursor, ignoring the terminal mode.
     Off,
+    /// Default the cursor blink to off, but allow the terminal to
+    /// set blinking.
     TerminalControlled,
+    /// Always blink the cursor, ignoring the terminal mode.
     On,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Shell {
+    /// Use the system's default terminal configuration in /etc/passwd
     System,
     Program(String),
-    WithArguments { program: String, args: Vec<String> },
+    WithArguments {
+        program: String,
+        args: Vec<String>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -150,8 +209,15 @@ pub enum AlternateScroll {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkingDirectory {
+    /// Use the current file's project directory.  Will Fallback to the
+    /// first project directory strategy if unsuccessful.
     CurrentProjectDirectory,
+    /// Use the first project in this workspace's directory.
     FirstProjectDirectory,
+    /// Always use this platform's home directory (if it can be found).
     AlwaysHome,
+    /// Slways use a specific directory. This value will be shell expanded.
+    /// If this path is not a valid directory the terminal will default to
+    /// this platform's home directory  (if it can be found).
     Always { directory: String },
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -33,6 +33,9 @@ use workspace::{self, Workspace};
 
 use crate::state::ReplayableAction;
 
+/// Whether or not to enable Vim mode (work in progress).
+///
+/// Default: false
 pub struct VimModeSetting(pub bool);
 
 #[derive(Clone, Deserialize, PartialEq)]

--- a/crates/welcome/src/base_keymap_setting.rs
+++ b/crates/welcome/src/base_keymap_setting.rs
@@ -4,6 +4,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 
+/// Base key bindings scheme. Base keymaps can be overriden with user keymaps.
+///
+/// Default: VSCode
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 pub enum BaseKeymap {
     #[default]

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -60,7 +60,13 @@ impl ClosePosition {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ItemSettingsContent {
+    /// Whether to show the Git file status on a tab item.
+    ///
+    /// Default: true
     git_status: Option<bool>,
+    /// Position of the close button in a tab.
+    ///
+    /// Default: right
     close_position: Option<ClosePosition>,
 }
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -12,33 +12,37 @@ pub struct WorkspaceSettings {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct WorkspaceSettingsContent {
+    /// Scale by which to zoom the active pane.
+    /// When set to 1.0, the active pane has the same size as others,
+    /// but when set to a larger value, the active pane takes up more space.
+    ///
+    /// Default: `1.0`
     pub active_pane_magnification: Option<f32>,
+    /// Whether or not to prompt the user to confirm before closing the application.
+    ///
+    /// Default: false
     pub confirm_quit: Option<bool>,
+    /// Whether or not to show the call status icon in the status bar.
+    ///
+    /// Default: true
     pub show_call_status_icon: Option<bool>,
+    /// When to automatically save edited buffers.
+    ///
+    /// Default: off
     pub autosave: Option<AutosaveSetting>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AutosaveSetting {
+    /// Disable autosave.
     Off,
+    /// Save after inactivity period of `milliseconds`.
     AfterDelay { milliseconds: u64 },
+    /// Autosave when focus changes.
     OnFocusChange,
+    /// Autosave when the active window changes.
     OnWindowChange,
-}
-
-#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-pub struct GitSettings {
-    pub git_gutter: Option<GitGutterSetting>,
-    pub gutter_debounce: Option<u64>,
-}
-
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum GitGutterSetting {
-    #[default]
-    TrackedFiles,
-    Hide,
 }
 
 impl Settings for WorkspaceSettings {


### PR DESCRIPTION
Let this screenshot of settings.json speak for itself: 
![image](https://github.com/zed-industries/zed/assets/24362066/fca60383-1788-43f9-803b-00f083394c8a)

Release Notes:
- Added code completion & on-hover documentation to Zed's settings.json file.
