### PR TITLE
Restore ability to reset pane split size by double clicking drag handle.

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -742,9 +742,16 @@ mod element {
 
                 cx.on_mouse_event({
                     let dragged_handle = dragged_handle.clone();
-                    move |e: &MouseDownEvent, phase, _cx| {
+                    let flexes = flexes.clone();
+                    move |e: &MouseDownEvent, phase, cx| {
                         if phase.bubble() && handle_bounds.contains(&e.position) {
                             dragged_handle.replace(Some(ix));
+                            if e.click_count >= 2 {
+                                let mut borrow = flexes.lock();
+                                *borrow = vec![1.; borrow.len()];
+
+                                cx.notify();
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
We do not serialize workspace state after reseting pane split size, though normal resize seems to suffer from the same issue.
Edit: That's now fixed (for normal resizes as well) with 2nd commit. 
Release Notes:
- Fixed double clicking on pane drag handle not resetting pane's split
size.
- Fixed pane group sizes not being serialized.
