### PR TITLE
Fix Checking Indicator (Diagnostics)

### DIFF
--- a/assets/icons/arrow_circle.svg
+++ b/assets/icons/arrow_circle.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-refresh-cw"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 8C3 6.67392 3.52678 5.40215 4.46446 4.46447C5.40214 3.52679 6.67391 3.00001 7.99999 3.00001C9.39779 3.00527 10.7394 3.55069 11.7444 4.52223L13 5.77778" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13 3.00001V5.77778H10.2222" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13 8C13 9.32608 12.4732 10.5978 11.5355 11.5355C10.5978 12.4732 9.32607 13 7.99999 13C6.60219 12.9947 5.26054 12.4493 4.25555 11.4778L3 10.2222" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.77777 10.2222H3V13" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -25,11 +25,7 @@ impl Render for DiagnosticIndicator {
         let diagnostic_indicator = match (self.summary.error_count, self.summary.warning_count) {
             (0, 0) => h_stack().map(|this| {
                 if !self.in_progress_checks.is_empty() {
-                    this.child(
-                        IconElement::new(Icon::ArrowCircle)
-                            .size(IconSize::Small)
-                            .color(Color::Muted),
-                    )
+                    this.child(IconElement::new(Icon::ArrowCircle).size(IconSize::Small))
                 } else {
                     this.child(
                         IconElement::new(Icon::Check)
@@ -74,7 +70,6 @@ impl Render for DiagnosticIndicator {
             Some(
                 Label::new("Checking…")
                     .size(LabelSize::Small)
-                    .color(Color::Muted)
                     .into_any_element(),
             )
         } else if let Some(diagnostic) = &self.current_diagnostic {

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -24,15 +24,11 @@ impl Render for DiagnosticIndicator {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let diagnostic_indicator = match (self.summary.error_count, self.summary.warning_count) {
             (0, 0) => h_stack().map(|this| {
-                if !self.in_progress_checks.is_empty() {
-                    this.child(IconElement::new(Icon::ArrowCircle).size(IconSize::Small))
-                } else {
-                    this.child(
-                        IconElement::new(Icon::Check)
-                            .size(IconSize::Small)
-                            .color(Color::Default),
-                    )
-                }
+                this.child(
+                    IconElement::new(Icon::Check)
+                        .size(IconSize::Small)
+                        .color(Color::Default),
+                )
             }),
             (0, warning_count) => h_stack()
                 .gap_1()
@@ -68,8 +64,14 @@ impl Render for DiagnosticIndicator {
 
         let status = if !self.in_progress_checks.is_empty() {
             Some(
-                Label::new("Checking…")
-                    .size(LabelSize::Small)
+                h_stack()
+                    .gap_2()
+                    .child(IconElement::new(Icon::ArrowCircle).size(IconSize::Small))
+                    .child(
+                        Label::new("Checking…")
+                            .size(LabelSize::Small)
+                            .into_any_element(),
+                    )
                     .into_any_element(),
             )
         } else if let Some(diagnostic) = &self.current_diagnostic {


### PR DESCRIPTION
Fixes some issues with the Checking icon I added last week.

- Use default text color for "Checking..." text and icon
- Always show text and icon while checks are running

I think we should probably remove the `✅` while checks are running as it incorrectly indicates nothing is wrong when we don't yet know that – but that is a larger change so I'll keep this fix contained.

Release Notes:

- Fixes "Checking" diagnostics icon only showing until the first diagnostics item is found.