### PR TITLE
Use correct color for folded diff indicator

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -795,7 +795,7 @@ impl EditorElement {
                     cx.paint_quad(quad(
                         highlight_bounds,
                         Corners::all(1. * line_height),
-                        gpui::yellow(), // todo!("use the right color")
+                        cx.theme().status().modified,
                         Edges::default(),
                         transparent_black(),
                     ));


### PR DESCRIPTION
This PR updates the indicator for changes within a fold to use the correct color from the theme:

<img width="380" alt="Screenshot 2024-01-08 at 12 52 56 PM" src="https://github.com/zed-industries/zed/assets/1486634/b8bf6bf3-6acc-43a4-8c4b-a02c975c7f02">

Release Notes:

- Updated the color of the indicator for a fold containing modified lines.
