### PR TITLE
Adjust spacing of extra call participant count indicator

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2211,8 +2211,12 @@ impl CollabPanel {
                     .map(|user| Avatar::new(user.avatar_uri.clone()).into_any_element())
                     .take(FACEPILE_LIMIT)
                     .chain(if extra_count > 0 {
-                        // todo!() @nate - this label looks wrong.
-                        Some(Label::new(format!("+{}", extra_count)).into_any_element())
+                        Some(
+                            div()
+                                .ml_1()
+                                .child(Label::new(format!("+{extra_count}")))
+                                .into_any_element(),
+                        )
                     } else {
                         None
                     })


### PR DESCRIPTION
This PR adjusts the spacing of the indicator showing the number of extra call participants that appears after the facepile:

<img width="242" alt="Screenshot 2024-01-08 at 1 09 39 PM" src="https://github.com/zed-industries/zed/assets/1486634/6d9cbefa-3b4e-4501-ab11-51026dfb5b6c">

Release Notes:

- Added more space between the call participant facepile and the number indicating additional call participants.
