### PR TITLE
Fix layout shift when renaming a channel

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2394,12 +2394,7 @@ impl CollabPanel {
         {
             item.child(Label::new(pending_name))
         } else {
-            item.child(
-                div()
-                    .w_full()
-                    .py_1() // todo!() @nate this is a px off at the default font size.
-                    .child(self.channel_name_editor.clone()),
-            )
+            item.child(self.channel_name_editor.clone())
         }
     }
 }


### PR DESCRIPTION
This PR fixes the layout shift that would occur in the channel list when opening a rename editor for a channel.

Release Notes:

- Fixed layout shift when opening a rename editor for a channel.
