### PR TITLE
terminal: Remove resolved TODO

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2,8 +2,6 @@ mod persistence;
 pub mod terminal_element;
 pub mod terminal_panel;
 
-// todo!()
-// use crate::terminal_element::TerminalElement;
 use editor::{scroll::autoscroll::Autoscroll, Editor};
 use gpui::{
     div, impl_actions, overlay, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle,


### PR DESCRIPTION
This PR removes a resolved TODO in the `terminal` crate.

Release Notes:

- N/A
