### PR TITLE
theme: Removed commented-out `ActiveTheme` impl

### DIFF
--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -73,13 +73,6 @@ impl ActiveTheme for AppContext {
     }
 }
 
-// todo!()
-// impl<'a> ActiveTheme for WindowContext<'a> {
-//     fn theme(&self) -> &Arc<Theme> {
-//         &ThemeSettings::get_global(self.app()).active_theme
-//     }
-// }
-
 pub struct ThemeFamily {
     pub id: String,
     pub name: SharedString,


### PR DESCRIPTION
This PR removes a commented-out implementation for the `ActiveTheme` trait on the `WindowContext`.

We don't need this implementation as we can go through the `AppContext`'s implementation.

Release Notes:

- N/A
