### PR TITLE
Fix inconsistent sizing between the buffer search and the project search

### DIFF
--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -67,7 +67,10 @@ impl Render for Breadcrumbs {
                     })
                     .tooltip(|cx| Tooltip::for_action("Show symbol outline", &outline::Toggle, cx)),
             ),
-            None => element.child(breadcrumbs_stack),
+            None => element
+                // Match the height of the `ButtonLike` in the other arm.
+                .h(rems(22. / 16.))
+                .child(breadcrumbs_stack),
         }
     }
 }

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -95,7 +95,6 @@ impl Render for QuickActionBar {
 
         h_stack()
             .id("quick action bar")
-            .p_1()
             .gap_2()
             .children(inlay_hints_button)
             .children(search_button)


### PR DESCRIPTION
This PR fixes the inconsistent sizing between the buffer search and the project search when both elements have both a primary and secondary item shown in the toolbar.

Release Notes:

- Fixed some inconsistent sizing in the buffer search and project search when both have two rows of tools in the toolbar.
