### PR TITLE
chore: Fix spurious rebuilds of Zed library and binary

### DIFF
--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -22,7 +22,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-ObjC");
 
     // Populate git sha environment variable if git is available
-    println!("cargo:rerun-if-changed=.git/logs/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
     if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         if output.status.success() {
             let git_sha = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
Currently when one runs `cargo build` twice without changing anything, zed lib and binary are gonna get rebuilt every time. I checked out cargo logs and it turns out we were querying wrong path to `.git/logs/HEAD` in our build.rs, causing it to rerun on every build and thus marking zed lib as dirty.

See logs (`CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo build`):
```
0.501173792s  INFO cargo::core::compiler::fingerprint: fingerprint dirty for zed v0.120.0 (/Users/hiro/Projects/zed/crates/zed)/RunCustomBuild/TargetInner { ..: custom_build_target("build-script-build", "/Users/hiro/Projects/zed/crates/zed/build.rs", Edition2021) }
0.501180417s  INFO cargo::core::compiler::fingerprint:     dirty: FsStatusOutdated(StaleItem(MissingFile("/Users/hiro/Projects/zed/crates/zed/.git/logs/HEAD")))
```
The path to .git directory is relative to crates/zed and not to the workspace's root.

/cc @maxbrunsfeld 

Release Notes:
- N/A
