### PR TITLE
Clean up outline selections when its modal gets closed

### DIFF
--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -54,7 +54,13 @@ impl FocusableView for OutlineView {
 }
 
 impl EventEmitter<DismissEvent> for OutlineView {}
-impl ModalView for OutlineView {}
+impl ModalView for OutlineView {
+    fn on_before_dismiss(&mut self, cx: &mut ViewContext<Self>) -> bool {
+        self.picker
+            .update(cx, |picker, cx| picker.delegate.restore_active_editor(cx));
+        true
+    }
+}
 
 impl Render for OutlineView {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {


### PR DESCRIPTION
Release Notes:

- Fixed outline selections not being cleared on certain modal dismiss actions