### PR TITLE
chore: Extract `assets` module out of zed crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "assets"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "rust-embed",
+]
+
+[[package]]
 name = "assistant"
 version = "0.1.0"
 dependencies = [
@@ -9529,6 +9538,7 @@ dependencies = [
  "activity_indicator",
  "ai",
  "anyhow",
+ "assets",
  "assistant",
  "async-compression",
  "async-recursion 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/assets",
     "crates/activity_indicator",
     "crates/ai",
     "crates/assistant",

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "assets"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+gpui = {path = "../gpui"}
+rust-embed.workspace = true
+anyhow.workspace = true

--- a/crates/assets/src/lib.rs
+++ b/crates/assets/src/lib.rs
@@ -1,3 +1,4 @@
+// This crate was essentially pulled out verbatim from main `zed` crate to avoid having to run RustEmbed macro whenever zed has to be rebuilt. It saves a second or two on an incremental build.
 use anyhow::anyhow;
 
 use gpui::{AssetSource, Result, SharedString};

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -74,6 +74,7 @@ vim = { path = "../vim" }
 workspace = { path = "../workspace" }
 welcome = { path = "../welcome" }
 zed_actions = {path = "../zed_actions"}
+assets = {path = "../assets"}
 anyhow.workspace = true
 async-compression.workspace = true
 async-tar = "0.4.2"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -16,6 +16,7 @@ use isahc::{prelude::Configurable, Request};
 use language::LanguageRegistry;
 use log::LevelFilter;
 
+use assets::Assets;
 use node_runtime::RealNodeRuntime;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -49,8 +50,8 @@ use welcome::{show_welcome_view, BaseKeymap, FIRST_OPEN};
 use workspace::{AppState, WorkspaceStore};
 use zed::{
     app_menus, build_window_options, ensure_only_instance, handle_cli_connection,
-    handle_keymap_file_changes, initialize_workspace, languages, Assets, IsOnlyInstance,
-    OpenListener, OpenRequest,
+    handle_keymap_file_changes, initialize_workspace, languages, IsOnlyInstance, OpenListener,
+    OpenRequest,
 };
 
 fn main() {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1,11 +1,9 @@
 mod app_menus;
-mod assets;
 pub mod languages;
 mod only_instance;
 mod open_listener;
 
 pub use app_menus::*;
-pub use assets::*;
 use assistant::AssistantPanel;
 use breadcrumbs::Breadcrumbs;
 use collections::VecDeque;
@@ -18,6 +16,7 @@ pub use only_instance::*;
 pub use open_listener::*;
 
 use anyhow::{anyhow, Context as _};
+use assets::Assets;
 use futures::{channel::mpsc, select_biased, StreamExt};
 use project_panel::ProjectPanel;
 use quick_action_bar::QuickActionBar;


### PR DESCRIPTION
This essentially shaves off about 10% off of an incremental build after project change and potentially more if you're changing stuff like `welcome` that's very close to the `zed` crate in the dep graph. That's because macro expansion takes place even in incremental builds it seems? And zed (lib) + zed (bin) could take up to 4 seconds out of an incremental build, which is a *lot* in a 10s build. In reality though it shaves 1 second off of 5 seconds incremental 'welcome'/  1s off of 10s 'project' builds.

Note that we had `assets` crate in the past (removed in #2575 /cc @maxbrunsfeld), but this is a bit different, because `assets` is a dependency of *just* zed and nothing else. We essentially cache macro expansion results ourselves.

Release Notes:

- N/A
