### PR TITLE
Fix error border color for email input in feedback dialog

### DIFF
--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -7,7 +7,7 @@ use db::kvp::KEY_VALUE_STORE;
 use editor::{Editor, EditorEvent};
 use futures::AsyncReadExt;
 use gpui::{
-    div, red, rems, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Model,
+    div, rems, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Model,
     PromptLevel, Render, Task, View, ViewContext,
 };
 use isahc::Request;
@@ -476,7 +476,7 @@ impl Render for FeedbackModal {
                     .border_color(if self.valid_email_address() {
                         cx.theme().colors().border
                     } else {
-                        red()
+                        cx.theme().status().error_border
                     })
                     .child(self.email_address_editor.clone()),
             )


### PR DESCRIPTION
This PR fixes the border color used when the email input in the feedback dialog is invalid.

Previously this was hardcoded just to `red` instead of using the appropriate color from the theme.

<img width="653" alt="Screenshot 2024-01-08 at 5 40 07 PM" src="https://github.com/zed-industries/zed/assets/1486634/ea01cd76-d661-4512-b668-c82b8d00d84e">

Release Notes:

- Fixed the border color used for the email input in the feedback dialog when an invalid email is entered.
