### PR TITLE
Restore the terminal cursor settings

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -451,6 +451,18 @@ impl TerminalElement {
             }
         });
 
+        let interactive_text_bounds = InteractiveBounds {
+            bounds,
+            stacking_order: cx.stacking_order().clone(),
+        };
+        if interactive_text_bounds.visibly_contains(&cx.mouse_position(), cx) {
+            if self.can_navigate_to_selected_word && last_hovered_word.is_some() {
+                cx.set_cursor_style(gpui::CursorStyle::PointingHand)
+            } else {
+                cx.set_cursor_style(gpui::CursorStyle::IBeam)
+            }
+        }
+
         let hyperlink_tooltip = last_hovered_word.clone().map(|hovered_word| {
             div()
                 .size_full()


### PR DESCRIPTION
As it says on the tin

Release Notes:

- Restored the terminal cursor's I-beam and pointing hand when hovering the mouse over the terminal content and terminal links.