### PR TITLE
Fix off by 1 error when computing available key bindings

### DIFF
--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -192,8 +192,8 @@ impl DispatchTree {
         keymap
             .bindings_for_action(action)
             .filter(|binding| {
-                for i in 1..context_stack.len() {
-                    let context = &context_stack[0..i];
+                for i in 0..context_stack.len() {
+                    let context = &context_stack[0..=i];
                     if keymap.binding_enabled(binding, context) {
                         return true;
                     }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/6396

Release Notes:

- Fixed issue where keybindings in some context menus would not show reliably.