### PR TITLE
Stop propagation when deploying the context menu for a project panel entry

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1433,6 +1433,9 @@ impl ProjectPanel {
                     }))
                     .on_secondary_mouse_down(cx.listener(
                         move |this, event: &MouseDownEvent, cx| {
+                            // Stop propagation to prevent the catch-all context menu for the project
+                            // panel from being deployed.
+                            cx.stop_propagation();
                             this.deploy_context_menu(event.position, entry_id, cx);
                         },
                     )),


### PR DESCRIPTION
This PR fixes an issue where right-click on any project panel entry would cause the context menu on the root of the project panel (introduced in #3954) to deploy.

We need to stop propagation in the handler on the inner project panel list items so that the click event doesn't bubble up the tree.

Release Notes:

- Fixed an issue where the project panel was always deploying the root context menu rather than on the clicked item.