### PR TITLE
search: Remove newlines from query used for tab_content.

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -424,7 +424,8 @@ impl Item for ProjectSearchView {
             .current()
             .as_ref()
             .map(|query| {
-                let query_text = util::truncate_and_trailoff(query, MAX_TAB_TITLE_LEN);
+                let query = query.replace('\n', "");
+                let query_text = util::truncate_and_trailoff(&query, MAX_TAB_TITLE_LEN);
                 query_text.into()
             });
         let tab_name = last_query


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/6400
Release Notes:

- Fixed tab content of project search overflowing the tab for queries with newlines.
