### PR TITLE
Remove `Default` impl for `StatusColors`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -507,7 +507,7 @@ pub enum SoftWrap {
     Column(u32),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct EditorStyle {
     pub background: Hsla,
     pub local_player: PlayerColor,
@@ -517,6 +517,24 @@ pub struct EditorStyle {
     pub status: StatusColors,
     pub inlays_style: HighlightStyle,
     pub suggestions_style: HighlightStyle,
+}
+
+impl Default for EditorStyle {
+    fn default() -> Self {
+        Self {
+            background: Hsla::default(),
+            local_player: PlayerColor::default(),
+            text: TextStyle::default(),
+            scrollbar_width: Pixels::default(),
+            syntax: Default::default(),
+            // HACK: Status colors don't have a real default.
+            // We should look into removing the status colors from the editor
+            // style and retrieve them directly from the theme.
+            status: StatusColors::dark(),
+            inlays_style: HighlightStyle::default(),
+            suggestions_style: HighlightStyle::default(),
+        }
+    }
 }
 
 type CompletionId = usize;

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -16,7 +16,7 @@ use lsp::DiagnosticSeverity;
 use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart, Project};
 use settings::Settings;
 use std::{ops::Range, sync::Arc, time::Duration};
-use ui::{StyledExt, Tooltip};
+use ui::{prelude::*, Tooltip};
 use util::TryFutureExt;
 use workspace::Workspace;
 
@@ -514,6 +514,8 @@ impl DiagnosticPopover {
             None => self.local_diagnostic.diagnostic.message.clone(),
         };
 
+        let status_colors = cx.theme().status();
+
         struct DiagnosticColors {
             pub background: Hsla,
             pub border: Hsla,
@@ -521,24 +523,24 @@ impl DiagnosticPopover {
 
         let diagnostic_colors = match self.local_diagnostic.diagnostic.severity {
             DiagnosticSeverity::ERROR => DiagnosticColors {
-                background: style.status.error_background,
-                border: style.status.error_border,
+                background: status_colors.error_background,
+                border: status_colors.error_border,
             },
             DiagnosticSeverity::WARNING => DiagnosticColors {
-                background: style.status.warning_background,
-                border: style.status.warning_border,
+                background: status_colors.warning_background,
+                border: status_colors.warning_border,
             },
             DiagnosticSeverity::INFORMATION => DiagnosticColors {
-                background: style.status.info_background,
-                border: style.status.info_border,
+                background: status_colors.info_background,
+                border: status_colors.info_border,
             },
             DiagnosticSeverity::HINT => DiagnosticColors {
-                background: style.status.hint_background,
-                border: style.status.hint_border,
+                background: status_colors.hint_background,
+                border: status_colors.hint_border,
             },
             _ => DiagnosticColors {
-                background: style.status.ignored_background,
-                border: style.status.ignored_border,
+                background: status_colors.ignored_background,
+                border: status_colors.ignored_border,
             },
         };
 

--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -2,7 +2,7 @@ use gpui::Hsla;
 use refineable::Refineable;
 use std::sync::Arc;
 
-use crate::{PlayerColors, StatusColors, SyntaxTheme, SystemColors};
+use crate::{PlayerColors, StatusColors, StatusColorsRefinement, SyntaxTheme, SystemColors};
 
 #[derive(Refineable, Clone, Debug)]
 #[refineable(Debug, serde::Deserialize)]
@@ -219,6 +219,8 @@ pub struct ThemeStyles {
 
     #[refineable]
     pub colors: ThemeColors,
+
+    #[refineable]
     pub status: StatusColors,
     pub player: PlayerColors,
     pub syntax: Arc<SyntaxTheme>,

--- a/crates/theme/src/styles/status.rs
+++ b/crates/theme/src/styles/status.rs
@@ -78,15 +78,6 @@ pub struct StatusColors {
     pub warning_border: Hsla,
 }
 
-impl Default for StatusColors {
-    /// Don't use this!
-    /// We have to have a default to be `[refineable::Refinable]`.
-    /// todo!("Find a way to not need this for Refinable")
-    fn default() -> Self {
-        Self::dark()
-    }
-}
-
 pub struct DiagnosticColors {
     pub error: Hsla,
     pub warning: Hsla,


### PR DESCRIPTION
This PR removes the `Default` impl for `StatusColors`.

Since we need default light and dark variants for `StatusColors`, we can't use a single `Default` impl.

Release Notes:

- N/A