### PR TITLE
Take into account multiple scroll deltas within a single frame

### DIFF
--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -178,6 +178,20 @@ impl ScrollDelta {
             ScrollDelta::Lines(delta) => point(line_height * delta.x, line_height * delta.y),
         }
     }
+
+    pub fn coalesce(self, other: ScrollDelta) -> ScrollDelta {
+        match (self, other) {
+            (ScrollDelta::Pixels(px_a), ScrollDelta::Pixels(px_b)) => {
+                ScrollDelta::Pixels(px_a + px_b)
+            }
+
+            (ScrollDelta::Lines(lines_a), ScrollDelta::Lines(lines_b)) => {
+                ScrollDelta::Lines(lines_a + lines_b)
+            }
+
+            _ => other,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION


Release Notes:

- Fixed an issue where all but the last scroll event would be dropped if there were multiple within a single frame.
