### PR TITLE
Clean up references in doc comments in `ui` and `theme` crates

### DIFF
--- a/crates/theme/src/scale.rs
+++ b/crates/theme/src/scale.rs
@@ -39,10 +39,10 @@ impl ColorScaleStep {
     ];
 }
 
-/// A scale of colors for a given [ColorScaleSet].
+/// A scale of colors for a given [`ColorScaleSet`].
 ///
-/// Each [ColorScale] contains exactly 12 colors. Refer to
-/// [ColorScaleStep] for a reference of what each step is used for.
+/// Each [`ColorScale`] contains exactly 12 colors. Refer to
+/// [`ColorScaleStep`] for a reference of what each step is used for.
 pub struct ColorScale(Vec<Hsla>);
 
 impl FromIterator<Hsla> for ColorScale {
@@ -235,7 +235,7 @@ impl IntoIterator for ColorScales {
     }
 }
 
-/// Provides groups of [ColorScale]s for light and dark themes, as well as transparent versions of each scale.
+/// Provides groups of [`ColorScale`]s for light and dark themes, as well as transparent versions of each scale.
 pub struct ColorScaleSet {
     name: SharedString,
     light: ColorScale,

--- a/crates/ui/src/components/avatar.rs
+++ b/crates/ui/src/components/avatar.rs
@@ -78,7 +78,7 @@ impl Avatar {
 
     /// Sets the shape of the avatar image.
     ///
-    /// This method allows the shape of the avatar to be specified using the [Shape] enum.
+    /// This method allows the shape of the avatar to be specified using a [`Shape`].
     /// It modifies the corner radius of the image to match the specified shape.
     ///
     /// # Examples

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -10,12 +10,12 @@ use super::button_icon::ButtonIcon;
 /// An element that creates a button with a label and an optional icon.
 ///
 /// Common buttons:
-/// - Label, Icon + Label: [Button] (this component)
-/// - Icon only: [IconButton]
-/// - Custom: [ButtonLike]
+/// - Label, Icon + Label: [`Button`] (this component)
+/// - Icon only: [`IconButton`]
+/// - Custom: [`ButtonLike`]
 ///
-/// To create a more complex button than what the [Button] or [IconButton] components provide, use
-/// [ButtonLike] directly.
+/// To create a more complex button than what the [`Button`] or [`IconButton`] components provide, use
+/// [`ButtonLike`] directly.
 ///
 /// # Examples
 ///
@@ -42,7 +42,7 @@ use super::button_icon::ButtonIcon;
 ///     });
 /// ```
 ///
-/// To change the style of the button when it is selected use the [selected_style][Button::selected_style] method.
+/// To change the style of the button when it is selected use the [`selected_style`][Button::selected_style] method.
 ///
 /// ```
 /// Button::new("button_id", "Click me!")
@@ -81,9 +81,9 @@ pub struct Button {
 }
 
 impl Button {
-    /// Creates a new [Button] with a specified identifier and label.
+    /// Creates a new [`Button`] with a specified identifier and label.
     ///
-    /// This is the primary constructor for a `Button` component. It initializes
+    /// This is the primary constructor for a [`Button`] component. It initializes
     /// the button with the provided identifier and label text, setting all other
     /// properties to their default values, which can be customized using the
     /// builder pattern methods provided by this struct.
@@ -174,7 +174,7 @@ impl Selectable for Button {
     ///     });
     /// ```
     ///
-    /// Use [selected_style](Button::selected_style) to change the style of the button when it is selected.
+    /// Use [`selected_style`](Button::selected_style) to change the style of the button when it is selected.
     fn selected(mut self, selected: bool) -> Self {
         self.base = self.base.selected(selected);
         self
@@ -282,13 +282,13 @@ impl ButtonCommon for Button {
         self.base.id()
     }
 
-    /// Sets the visual style of the button using a [ButtonStyle].
+    /// Sets the visual style of the button using a [`ButtonStyle`].
     fn style(mut self, style: ButtonStyle) -> Self {
         self.base = self.base.style(style);
         self
     }
 
-    /// Sets the button's size using a [ButtonSize].
+    /// Sets the button's size using a [`ButtonSize`].
     fn size(mut self, size: ButtonSize) -> Self {
         self.base = self.base.size(size);
         self
@@ -297,7 +297,7 @@ impl ButtonCommon for Button {
     /// Sets a tooltip for the button.
     ///
     /// This method allows a tooltip to be set for the button. The tooltip is a function that
-    /// takes a mutable reference to a [WindowContext] and returns an [AnyView]. The tooltip
+    /// takes a mutable reference to a [`WindowContext`] and returns an [`AnyView`]. The tooltip
     /// is displayed when the user hovers over the button.
     ///
     /// # Examples

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 use crate::prelude::*;
 
-/// A trait for buttons that can be Selected. Enables setting the [ButtonStyle] of a button when it is selected.
+/// A trait for buttons that can be Selected. Enables setting the [`ButtonStyle`] of a button when it is selected.
 pub trait SelectableButton: Selectable {
     fn selected_style(self, style: ButtonStyle) -> Self;
 }
@@ -95,7 +95,7 @@ impl From<ButtonStyle> for Color {
     }
 }
 
-/// Sets the visual appearance of a button.
+/// The visual appearance of a button.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
 pub enum ButtonStyle {
     /// A filled button with a solid background color. Provides emphasis versus
@@ -263,7 +263,9 @@ impl ButtonStyle {
     }
 }
 
-/// Sets the height of a button. Can also be used to size  non-button elements to align with [Button]s.
+/// The height of a button.
+///
+/// Can also be used to size non-button elements to align with [`Button`]s.
 #[derive(Default, PartialEq, Clone, Copy)]
 pub enum ButtonSize {
     Large,

--- a/crates/ui/src/components/divider.rs
+++ b/crates/ui/src/components/divider.rs
@@ -7,7 +7,7 @@ enum DividerDirection {
     Vertical,
 }
 
-/// Sets the color of a [Divider].
+/// The color of a [`Divider`].
 #[derive(Default)]
 pub enum DividerColor {
     Border,

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -47,7 +47,7 @@ impl Label {
 }
 
 impl LabelCommon for Label {
-    /// Sets the size of the label using a [LabelSize].
+    /// Sets the size of the label using a [`LabelSize`].
     ///
     /// # Examples
     ///
@@ -59,7 +59,7 @@ impl LabelCommon for Label {
         self
     }
 
-    /// Sets the line height style of the label using a [LineHeightStyle].
+    /// Sets the line height style of the label using a [`LineHeightStyle`].
     ///
     /// # Examples
     ///
@@ -71,7 +71,7 @@ impl LabelCommon for Label {
         self
     }
 
-    /// Sets the color of the label using a [Color].
+    /// Sets the color of the label using a [`Color`].
     ///
     /// # Examples
     ///

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -108,7 +108,7 @@ impl<M: ManagedView> PopoverMenu<M> {
     }
 }
 
-/// Creates a [PopoverMenu]
+/// Creates a [`PopoverMenu`]
 pub fn popover_menu<M: ManagedView>(id: impl Into<ElementId>) -> PopoverMenu<M> {
     PopoverMenu {
         id: id.into(),

--- a/crates/ui/src/components/right_click_menu.rs
+++ b/crates/ui/src/components/right_click_menu.rs
@@ -39,7 +39,7 @@ impl<M: ManagedView> RightClickMenu<M> {
     }
 }
 
-/// Creates a [RightClickMenu]
+/// Creates a [`RightClickMenu`]
 pub fn right_click_menu<M: ManagedView>(id: impl Into<ElementId>) -> RightClickMenu<M> {
     RightClickMenu {
         id: id.into(),

--- a/crates/ui/src/prelude.rs
+++ b/crates/ui/src/prelude.rs
@@ -1,4 +1,4 @@
-//! The prelude of this crate. When building UI in zed you almost always want to import this.
+//! The prelude of this crate. When building UI in Zed you almost always want to import this.
 
 pub use gpui::prelude::*;
 pub use gpui::{

--- a/crates/ui/src/selectable.rs
+++ b/crates/ui/src/selectable.rs
@@ -1,4 +1,6 @@
-/// A trait for elements that can be selected. Generally used to enable "toggle" or "active" behavior and styles on an element through the [Selection] status.
+/// A trait for elements that can be selected.
+///
+/// Generally used to enable "toggle" or "active" behavior and styles on an element through the [`Selection`] status.
 pub trait Selectable {
     /// Sets whether the element is selected.
     fn selected(self, selected: bool) -> Self;

--- a/crates/ui/src/styled_ext.rs
+++ b/crates/ui/src/styled_ext.rs
@@ -14,7 +14,7 @@ fn elevated<E: Styled>(this: E, cx: &mut WindowContext, index: ElevationIndex) -
         .shadow(index.shadow())
 }
 
-/// Extends [gpui::Styled] with Zed specific styling methods.
+/// Extends [`gpui::Styled`] with Zed-specific styling methods.
 pub trait StyledExt: Styled + Sized {
     /// Horizontally stacks elements.
     ///
@@ -30,7 +30,7 @@ pub trait StyledExt: Styled + Sized {
         self.flex().flex_col()
     }
 
-    /// Sets the text size using a [UiTextSize].
+    /// Sets the text size using a [`UiTextSize`].
     fn text_ui_size(self, size: UiTextSize) -> Self {
         self.text_size(size.rems())
     }
@@ -79,7 +79,7 @@ pub trait StyledExt: Styled + Sized {
         self.text_size(settings.buffer_font_size(cx))
     }
 
-    /// The [`Surface`](ui::ElevationIndex::Surface) elevation level, located above the app background, is the standard level for all elements
+    /// The [`Surface`](ElevationIndex::Surface) elevation level, located above the app background, is the standard level for all elements
     ///
     /// Sets `bg()`, `rounded_lg()`, `border()`, `border_color()`, `shadow()`
     ///
@@ -88,7 +88,7 @@ pub trait StyledExt: Styled + Sized {
         elevated(self, cx, ElevationIndex::Surface)
     }
 
-    /// Non-Modal Elevated Surfaces appear above the [`Surface`](ui::ElevationIndex::Surface) layer and is used for things that should appear above most UI elements like an editor or panel, but not elements like popovers, context menus, modals, etc.
+    /// Non-Modal Elevated Surfaces appear above the [`Surface`](ElevationIndex::Surface) layer and is used for things that should appear above most UI elements like an editor or panel, but not elements like popovers, context menus, modals, etc.
     ///
     /// Sets `bg()`, `rounded_lg()`, `border()`, `border_color()`, `shadow()`
     ///
@@ -101,7 +101,7 @@ pub trait StyledExt: Styled + Sized {
     ///
     /// Elements rendered at this layer should have an enforced behavior: Any interaction outside of the modal will either dismiss the modal or prompt an action (Save your progress, etc) then dismiss the modal.
     ///
-    /// If the element does not have this behavior, it should be rendered at the [`Elevated Surface`](ui::ElevationIndex::ElevatedSurface) layer.
+    /// If the element does not have this behavior, it should be rendered at the [`Elevated Surface`](ElevationIndex::ElevatedSurface) layer.
     ///
     /// Sets `bg()`, `rounded_lg()`, `border()`, `border_color()`, `shadow()`
     ///

--- a/crates/ui/src/styles/elevation.rs
+++ b/crates/ui/src/styles/elevation.rs
@@ -85,7 +85,7 @@ impl LayerIndex {
     }
 }
 
-/// Sets ann appropriate z-index for the given layer based on it's intended useage.
+/// An appropriate z-index for the given layer based on its intended useage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElementIndex {
     Effect,

--- a/crates/ui/src/styles/typography.rs
+++ b/crates/ui/src/styles/typography.rs
@@ -38,7 +38,7 @@ impl UiTextSize {
     }
 }
 
-/// Sets the size of a [Headline] element
+/// The size of a [`Headline`] element
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
 pub enum HeadlineSize {
     XSmall,

--- a/crates/ui/src/utils/format_distance.rs
+++ b/crates/ui/src/utils/format_distance.rs
@@ -7,10 +7,10 @@ pub enum DateTimeType {
 }
 
 impl DateTimeType {
-    /// Converts the DateTimeType to a NaiveDateTime.
+    /// Converts the [`DateTimeType`] to a [`NaiveDateTime`].
     ///
-    /// If the DateTimeType is already a NaiveDateTime, it will be returned as is.
-    /// If the DateTimeType is a DateTime<Local>, it will be converted to a NaiveDateTime.
+    /// If the [`DateTimeType`] is already a [`NaiveDateTime`], it will be returned as is.
+    /// If the [`DateTimeType`] is a [`DateTime<Local>`], it will be converted to a [`NaiveDateTime`].
     pub fn to_naive(&self) -> NaiveDateTime {
         match self {
             DateTimeType::Naive(naive) => *naive,
@@ -68,13 +68,13 @@ impl FormatDistance {
     }
 }
 
-/// Calculates the distance in seconds between two NaiveDateTime objects.
+/// Calculates the distance in seconds between two [`NaiveDateTime`] objects.
 /// It returns a signed integer denoting the difference. If `date` is earlier than `base_date`, the returned value will be negative.
 ///
 /// ## Arguments
 ///
-/// * `date` - A NaiveDateTime object representing the date of interest
-/// * `base_date` - A NaiveDateTime object representing the base date against which the comparison is made
+/// * `date` - A [NaiveDateTime`] object representing the date of interest
+/// * `base_date` - A [NaiveDateTime`] object representing the base date against which the comparison is made
 fn distance_in_seconds(date: NaiveDateTime, base_date: NaiveDateTime) -> i64 {
     let duration = date.signed_duration_since(base_date);
     -duration.num_seconds()
@@ -233,12 +233,12 @@ fn distance_string(
 ///
 /// For example, "less than a minute ago", "about 2 hours ago", "3 months from now", etc.
 ///
-/// Use [naive_format_distance_from_now] to compare a NaiveDateTime against now.
+/// Use [`format_distance_from_now`] to compare a NaiveDateTime against now.
 ///
 /// # Arguments
 ///
-/// * `date` - The NaiveDateTime to compare.
-/// * `base_date` - The NaiveDateTime to compare against.
+/// * `date` - The [`NaiveDateTime`] to compare.
+/// * `base_date` - The [`NaiveDateTime`] to compare against.
 /// * `include_seconds` - A boolean. If true, distances less than a minute are more detailed
 /// * `add_suffix` - A boolean. If true, result indicates if the time is in the past or future
 ///
@@ -274,7 +274,7 @@ pub fn format_distance(
 ///
 /// # Arguments
 ///
-/// * `datetime` - The NaiveDateTime to compare with the current time.
+/// * `datetime` - The [`NaiveDateTime`] to compare with the current time.
 /// * `include_seconds` - A boolean. If true, distances less than a minute are more detailed
 /// * `add_suffix` - A boolean. If true, result indicates if the time is in the past or future
 ///


### PR DESCRIPTION
This PR cleans up a number of references in doc comments in the `ui` and `theme` crates so that `rustdoc` will link and display them correctly.

Release Notes:

- N/A
