### PR TITLE
Remove or fix stale todos

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -77,9 +77,6 @@ impl ActivityIndicator {
                 cx.observe(auto_updater, |_, _, cx| cx.notify()).detach();
             }
 
-            // cx.observe_active_labeled_tasks(|_, cx| cx.notify())
-            //     .detach();
-
             Self {
                 statuses: Default::default(),
                 project: project.clone(),
@@ -287,15 +284,6 @@ impl ActivityIndicator {
                 AutoUpdateStatus::Idle => Default::default(),
             };
         }
-
-        // todo!(show active tasks)
-        // if let Some(most_recent_active_task) = cx.active_labeled_tasks().last() {
-        //     return Content {
-        //         icon: None,
-        //         message: most_recent_active_task.to_string(),
-        //         on_click: None,
-        //     };
-        // }
 
         Default::default()
     }

--- a/crates/collab/src/tests/channel_message_tests.rs
+++ b/crates/collab/src/tests/channel_message_tests.rs
@@ -262,7 +262,6 @@ async fn test_remove_channel_message(
 
 #[track_caller]
 fn assert_messages(chat: &Model<ChannelChat>, messages: &[&str], cx: &mut TestAppContext) {
-    // todo!(don't directly borrow here)
     assert_eq!(
         chat.read_with(cx, |chat, _| {
             chat.messages()

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -41,12 +41,6 @@ pub fn init(cx: &mut AppContext) {
         workspace.set_titlebar_item(titlebar_item.into(), cx)
     })
     .detach();
-    // todo!()
-    // cx.add_action(CollabTitlebarItem::share_project);
-    // cx.add_action(CollabTitlebarItem::unshare_project);
-    // cx.add_action(CollabTitlebarItem::toggle_user_menu);
-    // cx.add_action(CollabTitlebarItem::toggle_vcs_menu);
-    // cx.add_action(CollabTitlebarItem::toggle_project_menu);
 }
 
 pub struct CollabTitlebarItem {

--- a/crates/collab_ui/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui/src/notifications/incoming_call_notification.rs
@@ -19,7 +19,6 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
             for window in notification_windows.drain(..) {
                 window
                     .update(&mut cx, |_, cx| {
-                        // todo!()
                         cx.remove_window();
                     })
                     .log_err();

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -51,7 +51,6 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
                 for window in windows {
                     window
                         .update(cx, |_, cx| {
-                            // todo!()
                             cx.remove_window();
                         })
                         .ok();
@@ -64,7 +63,6 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
                 for window in windows {
                     window
                         .update(cx, |_, cx| {
-                            // todo!()
                             cx.remove_window();
                         })
                         .ok();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1829,10 +1829,6 @@ impl Editor {
         this.end_selection(cx);
         this.scroll_manager.show_scrollbar(cx);
 
-        // todo!("use a different mechanism")
-        // let editor_created_event = EditorCreated(cx.handle());
-        // cx.emit_global(editor_created_event);
-
         if mode == EditorMode::Full {
             let should_auto_hide_scrollbars = cx.should_auto_hide_scrollbars();
             cx.set_global(ScrollbarAutoHide(should_auto_hide_scrollbars));

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -539,7 +539,6 @@ fn test_clone(cx: &mut TestAppContext) {
     );
 }
 
-//todo!(editor navigate)
 #[gpui::test]
 async fn test_navigation_history(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
@@ -993,7 +992,6 @@ fn test_move_cursor_multibyte(cx: &mut TestAppContext) {
     });
 }
 
-//todo!(finish editor tests)
 #[gpui::test]
 fn test_move_cursor_different_line_lengths(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
@@ -1259,7 +1257,6 @@ fn test_prev_next_word_boundary(cx: &mut TestAppContext) {
     });
 }
 
-//todo!(finish editor tests)
 #[gpui::test]
 fn test_prev_next_word_bounds_with_soft_wrap(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
@@ -1318,7 +1315,6 @@ fn test_prev_next_word_bounds_with_soft_wrap(cx: &mut TestAppContext) {
     });
 }
 
-//todo!(simulate_resize)
 #[gpui::test]
 async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
@@ -2546,7 +2542,6 @@ fn test_delete_line(cx: &mut TestAppContext) {
     });
 }
 
-//todo!(select_anchor_ranges)
 #[gpui::test]
 fn test_join_lines_with_single_selection(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
@@ -3114,7 +3109,6 @@ fn test_move_line_up_down_with_blocks(cx: &mut TestAppContext) {
     });
 }
 
-//todo!(test_transpose)
 #[gpui::test]
 fn test_transpose(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
@@ -4860,7 +4854,6 @@ async fn test_delete_autoclose_pair(cx: &mut gpui::TestAppContext) {
     });
 }
 
-// todo!(select_anchor_ranges)
 #[gpui::test]
 async fn test_snippets(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
@@ -6455,7 +6448,6 @@ fn test_highlighted_ranges(cx: &mut TestAppContext) {
     });
 }
 
-// todo!(following)
 #[gpui::test]
 async fn test_following(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
@@ -7094,7 +7086,6 @@ async fn test_move_to_enclosing_bracket(cx: &mut gpui::TestAppContext) {
     );
 }
 
-// todo!(completions)
 #[gpui::test(iterations = 10)]
 async fn test_copilot(executor: BackgroundExecutor, cx: &mut gpui::TestAppContext) {
     // flaky

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -95,7 +95,7 @@ pub fn up_by_rows(
     text_layout_details: &TextLayoutDetails,
 ) -> (DisplayPoint, SelectionGoal) {
     let mut goal_x = match goal {
-        SelectionGoal::HorizontalPosition(x) => x.into(), // todo!("Can the fields in SelectionGoal by Pixels? We should extract a geometry crate and depend on that.")
+        SelectionGoal::HorizontalPosition(x) => x.into(),
         SelectionGoal::WrappedHorizontalPosition((_, x)) => x.into(),
         SelectionGoal::HorizontalRange { end, .. } => end.into(),
         _ => map.x_for_display_point(start, text_layout_details),

--- a/crates/editor/src/scroll/actions.rs
+++ b/crates/editor/src/scroll/actions.rs
@@ -11,10 +11,9 @@ impl Editor {
             return;
         }
 
-        // todo!()
-        // if self.mouse_context_menu.read(cx).visible() {
-        //     return None;
-        // }
+        if self.mouse_context_menu.is_some() {
+            return;
+        }
 
         if matches!(self.mode, EditorMode::SingleLine) {
             cx.propagate();

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -481,7 +481,7 @@ impl<V> View<V> {
         use postage::prelude::{Sink as _, Stream as _};
 
         let (tx, mut rx) = postage::mpsc::channel(1024);
-        let timeout_duration = Duration::from_millis(100); //todo!() cx.condition_duration();
+        let timeout_duration = Duration::from_millis(100);
 
         let mut cx = cx.app.borrow_mut();
         let subscriptions = (

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -111,6 +111,11 @@ impl TestAppContext {
         self.fn_name
     }
 
+    /// Checks whether there have been any new path prompts received by the platform.
+    pub fn did_prompt_for_new_path(&self) -> bool {
+        self.test_platform.did_prompt_for_new_path()
+    }
+
     /// returns a new `TestAppContext` re-using the same executors to interleave tasks.
     pub fn new_app(&self) -> TestAppContext {
         Self::new(self.dispatcher.clone(), self.fn_name)

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -25,6 +25,7 @@ pub struct TestAppContext {
     pub dispatcher: TestDispatcher,
     test_platform: Rc<TestPlatform>,
     text_system: Arc<TextSystem>,
+    fn_name: Option<&'static str>,
 }
 
 impl Context for TestAppContext {
@@ -85,7 +86,7 @@ impl Context for TestAppContext {
 
 impl TestAppContext {
     /// Creates a new `TestAppContext`. Usually you can rely on `#[gpui::test]` to do this for you.
-    pub fn new(dispatcher: TestDispatcher) -> Self {
+    pub fn new(dispatcher: TestDispatcher, fn_name: Option<&'static str>) -> Self {
         let arc_dispatcher = Arc::new(dispatcher.clone());
         let background_executor = BackgroundExecutor::new(arc_dispatcher.clone());
         let foreground_executor = ForegroundExecutor::new(arc_dispatcher);
@@ -101,12 +102,18 @@ impl TestAppContext {
             dispatcher: dispatcher.clone(),
             test_platform: platform,
             text_system,
+            fn_name,
         }
+    }
+
+    /// The name of the test function that created this `TestAppContext`
+    pub fn test_function_name(&self) -> Option<&'static str> {
+        self.fn_name
     }
 
     /// returns a new `TestAppContext` re-using the same executors to interleave tasks.
     pub fn new_app(&self) -> TestAppContext {
-        Self::new(self.dispatcher.clone())
+        Self::new(self.dispatcher.clone(), self.fn_name)
     }
 
     /// Simulates quitting the app.

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1003,7 +1003,7 @@ impl Interactivity {
                                 if let Some(text) = cx
                                     .text_system()
                                     .shape_text(
-                                        &element_id,
+                                        element_id.into(),
                                         FONT_SIZE,
                                         &[cx.text_style().to_run(str_len)],
                                         None,
@@ -1055,22 +1055,11 @@ impl Interactivity {
                                                     };
 
                                                     eprintln!(
-                                                        "This element is created at:\n{}:{}:{}",
-                                                        location.file(),
+                                                        "This element was created at:\n{}:{}:{}",
+                                                        dir.join(location.file()).to_string_lossy(),
                                                         location.line(),
                                                         location.column()
                                                     );
-
-                                                    std::process::Command::new("zed")
-                                                        .arg(format!(
-                                                            "{}/{}:{}:{}",
-                                                            dir.to_string_lossy(),
-                                                            location.file(),
-                                                            location.line(),
-                                                            location.column()
-                                                        ))
-                                                        .spawn()
-                                                        .ok();
                                                 }
                                             }
                                         });

--- a/crates/gpui/src/elements/overlay.rs
+++ b/crates/gpui/src/elements/overlay.rs
@@ -15,8 +15,7 @@ pub struct Overlay {
     anchor_corner: AnchorCorner,
     fit_mode: OverlayFitMode,
     anchor_position: Option<Point<Pixels>>,
-    // todo!();
-    // position_mode: OverlayPositionMode,
+    position_mode: OverlayPositionMode,
 }
 
 /// overlay gives you a floating element that will avoid overflowing the window bounds.
@@ -27,6 +26,7 @@ pub fn overlay() -> Overlay {
         anchor_corner: AnchorCorner::TopLeft,
         fit_mode: OverlayFitMode::SwitchAnchor,
         anchor_position: None,
+        position_mode: OverlayPositionMode::Window,
     }
 }
 
@@ -41,6 +41,14 @@ impl Overlay {
     /// (otherwise the location the overlay is rendered is used)
     pub fn position(mut self, anchor: Point<Pixels>) -> Self {
         self.anchor_position = Some(anchor);
+        self
+    }
+
+    /// Sets the position mode for this overlay. Local will have this
+    /// interpret it's [Overlay::position] as relative to the parent element.
+    /// While Window will have it interpret the position as relative to the window.
+    pub fn position_mode(mut self, mode: OverlayPositionMode) -> Self {
+        self.position_mode = mode;
         self
     }
 
@@ -100,9 +108,14 @@ impl Element for Overlay {
             child_max = child_max.max(&child_bounds.lower_right());
         }
         let size: Size<Pixels> = (child_max - child_min).into();
-        let origin = self.anchor_position.unwrap_or(bounds.origin);
 
-        let mut desired = self.anchor_corner.get_bounds(origin, size);
+        let (origin, mut desired) = self.position_mode.get_position_and_bounds(
+            self.anchor_position,
+            self.anchor_corner,
+            size,
+            bounds,
+        );
+
         let limits = Bounds {
             origin: Point::default(),
             size: cx.viewport_size(),
@@ -182,6 +195,35 @@ enum Axis {
 pub enum OverlayFitMode {
     SnapToWindow,
     SwitchAnchor,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum OverlayPositionMode {
+    Window,
+    Local,
+}
+
+impl OverlayPositionMode {
+    fn get_position_and_bounds(
+        &self,
+        anchor_position: Option<Point<Pixels>>,
+        anchor_corner: AnchorCorner,
+        size: Size<Pixels>,
+        bounds: Bounds<Pixels>,
+    ) -> (Point<Pixels>, Bounds<Pixels>) {
+        match self {
+            OverlayPositionMode::Window => {
+                let anchor_position = anchor_position.unwrap_or_else(|| bounds.origin);
+                let bounds = anchor_corner.get_bounds(anchor_position, size);
+                (anchor_position, bounds)
+            }
+            OverlayPositionMode::Local => {
+                let anchor_position = anchor_position.unwrap_or_default();
+                let bounds = anchor_corner.get_bounds(bounds.origin + anchor_position, size);
+                (anchor_position, bounds)
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -202,7 +202,10 @@ impl TextState {
                 let Some(lines) = cx
                     .text_system()
                     .shape_text(
-                        &text, font_size, &runs, wrap_width, // Wrap if we know the width.
+                        text.clone(),
+                        font_size,
+                        &runs,
+                        wrap_width, // Wrap if we know the width.
                     )
                     .log_err()
                 else {

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -102,6 +102,10 @@ impl TestPlatform {
             })
             .detach();
     }
+
+    pub(crate) fn did_prompt_for_new_path(&self) -> bool {
+        self.prompts.borrow().new_path.len() > 0
+    }
 }
 
 impl Platform for TestPlatform {

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -282,8 +282,7 @@ impl Platform for TestPlatform {
     }
 
     fn should_auto_hide_scrollbars(&self) -> bool {
-        // todo()
-        true
+        false
     }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -165,7 +165,8 @@ impl Default for TextStyle {
     fn default() -> Self {
         TextStyle {
             color: black(),
-            font_family: "Helvetica".into(), // todo!("Get a font we know exists on the system")
+            // Helvetica is a web safe font, so it should be available
+            font_family: "Helvetica".into(),
             font_features: FontFeatures::default(),
             font_size: rems(1.).into(),
             line_height: phi(),

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -39,7 +39,6 @@ pub fn run_test(
     max_retries: usize,
     test_fn: &mut (dyn RefUnwindSafe + Fn(TestDispatcher, u64)),
     on_fail_fn: Option<fn()>,
-    _fn_name: String, // todo!("re-enable fn_name")
 ) {
     let starting_seed = env::var("SEED")
         .map(|seed| seed.parse().expect("invalid SEED variable"))

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn test_wrap_line() {
         let dispatcher = TestDispatcher::new(StdRng::seed_from_u64(0));
-        let cx = TestAppContext::new(dispatcher);
+        let cx = TestAppContext::new(dispatcher, None);
 
         cx.update(|cx| {
             let text_system = cx.text_system().clone();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1474,9 +1474,7 @@ impl<'a> WindowContext<'a> {
                 InputEvent::MouseUp(mouse_up)
             }
             InputEvent::MouseExited(mouse_exited) => {
-                // todo!("Should we record that the mouse is outside of the window somehow? Or are these global pixels?")
                 self.window.modifiers = mouse_exited.modifiers;
-
                 InputEvent::MouseExited(mouse_exited)
             }
             InputEvent::ModifiersChanged(modifiers_changed) => {

--- a/crates/gpui_macros/src/test.rs
+++ b/crates/gpui_macros/src/test.rs
@@ -106,7 +106,8 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                             let cx_varname = format_ident!("cx_{}", ix);
                             cx_vars.extend(quote!(
                                 let mut #cx_varname = gpui::TestAppContext::new(
-                                    dispatcher.clone()
+                                    dispatcher.clone(),
+                                    Some(stringify!(#outer_fn_name)),
                                 );
                             ));
                             cx_teardowns.extend(quote!(
@@ -140,8 +141,7 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                         executor.block_test(#inner_fn_name(#inner_fn_args));
                         #cx_teardowns
                     },
-                    #on_failure_fn_name,
-                    stringify!(#outer_fn_name).to_string(),
+                    #on_failure_fn_name
                 );
             }
         }
@@ -169,7 +169,8 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                                 let cx_varname_lock = format_ident!("cx_{}_lock", ix);
                                 cx_vars.extend(quote!(
                                     let mut #cx_varname = gpui::TestAppContext::new(
-                                       dispatcher.clone()
+                                       dispatcher.clone(),
+                                       Some(stringify!(#outer_fn_name))
                                     );
                                     let mut #cx_varname_lock = #cx_varname.app.borrow_mut();
                                 ));
@@ -186,7 +187,8 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                                 let cx_varname = format_ident!("cx_{}", ix);
                                 cx_vars.extend(quote!(
                                     let mut #cx_varname = gpui::TestAppContext::new(
-                                        dispatcher.clone()
+                                        dispatcher.clone(),
+                                        Some(stringify!(#outer_fn_name))
                                     );
                                 ));
                                 cx_teardowns.extend(quote!(
@@ -222,7 +224,6 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
                         #cx_teardowns
                     },
                     #on_failure_fn_name,
-                    stringify!(#outer_fn_name).to_string(),
                 );
             }
         }

--- a/crates/live_kit_client/examples/test_app.rs
+++ b/crates/live_kit_client/examples/test_app.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
-use gpui::{actions, KeyBinding};
+use gpui::{actions, KeyBinding, Menu, MenuItem};
 use live_kit_client::{
     LocalAudioTrack, LocalVideoTrack, RemoteAudioTrackUpdate, RemoteVideoTrackUpdate, Room,
 };
@@ -26,15 +26,14 @@ fn main() {
         cx.on_action(quit);
         cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
 
-        // todo!()
-        // cx.set_menus(vec![Menu {
-        //     name: "Zed",
-        //     items: vec![MenuItem::Action {
-        //         name: "Quit",
-        //         action: Box::new(Quit),
-        //         os_action: None,
-        //     }],
-        // }]);
+        cx.set_menus(vec![Menu {
+            name: "Zed",
+            items: vec![MenuItem::Action {
+                name: "Quit",
+                action: Box::new(Quit),
+                os_action: None,
+            }],
+        }]);
 
         let live_kit_url = std::env::var("LIVE_KIT_URL").unwrap_or("http://localhost:7880".into());
         let live_kit_key = std::env::var("LIVE_KIT_KEY").unwrap_or("devkey".into());

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -242,7 +242,6 @@ impl PickerDelegate for ProjectSymbolsDelegate {
                 .spacing(ListItemSpacing::Sparse)
                 .selected(selected)
                 .child(
-                    // todo!() combine_syntax_and_fuzzy_match_highlights()
                     v_stack()
                         .child(
                             LabelLike::new().child(

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -424,7 +424,6 @@ impl TerminalElement {
             let line_height = font_pixels * line_height.to_pixels(rem_size);
             let font_id = cx.text_system().resolve_font(&text_style.font());
 
-            // todo!(do we need to keep this unwrap?)
             let cell_width = text_system
                 .advance(font_id, font_pixels, 'm')
                 .unwrap()
@@ -524,7 +523,6 @@ impl TerminalElement {
                             underline: Default::default(),
                         }],
                     )
-                    //todo!(do we need to keep this unwrap?)
                     .unwrap()
             };
 
@@ -664,21 +662,6 @@ impl TerminalElement {
                 },
             ),
         );
-        self.interactivity.on_click({
-            let terminal = terminal.clone();
-            move |e, cx| {
-                if e.down.button == MouseButton::Right {
-                    let mouse_mode = terminal.update(cx, |terminal, _cx| {
-                        terminal.mouse_mode(e.down.modifiers.shift)
-                    });
-
-                    if !mouse_mode {
-                        //todo!(context menu)
-                        // view.deploy_context_menu(e.position, cx);
-                    }
-                }
-            }
-        });
         self.interactivity.on_scroll_wheel({
             let terminal = terminal.clone();
             move |e, cx| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -651,8 +651,10 @@ impl Render for TerminalView {
             .on_mouse_down(
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseDownEvent, cx| {
-                    this.deploy_context_menu(event.position, cx);
-                    cx.notify();
+                    if !this.terminal.read(cx).mouse_mode(event.modifiers.shift) {
+                        this.deploy_context_menu(event.position, cx);
+                        cx.notify();
+                    }
                 }),
             )
             .child(

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum SelectionGoal {
     None,
-    HorizontalPosition(f32), // todo!("Can we use pixels here without adding a runtime gpui dependency?")
+    HorizontalPosition(f32),
     HorizontalRange { start: f32, end: f32 },
     WrappedHorizontalPosition((u32, f32)),
 }

--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -222,6 +222,7 @@ pub struct ThemeStyles {
 
     #[refineable]
     pub status: StatusColors,
+
     pub player: PlayerColors,
     pub syntax: Arc<SyntaxTheme>,
 }

--- a/crates/theme/src/styles/players.rs
+++ b/crates/theme/src/styles/players.rs
@@ -122,12 +122,10 @@ impl PlayerColors {
 
 impl PlayerColors {
     pub fn local(&self) -> PlayerColor {
-        // todo!("use a valid color");
         *self.0.first().unwrap()
     }
 
     pub fn absent(&self) -> PlayerColor {
-        // todo!("use a valid color");
         *self.0.last().unwrap()
     }
 

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -18,7 +18,6 @@ use workspace::{ModalView, Toast, Workspace};
 actions!(branches, [OpenRecent]);
 
 pub fn init(cx: &mut AppContext) {
-    // todo!() po
     cx.observe_new_views(|workspace: &mut Workspace, _| {
         workspace.register_action(|workspace, action, cx| {
             BranchList::toggle_modal(workspace, action, cx).log_err();

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -6,7 +6,7 @@ use editor::test::{
 use futures::Future;
 use gpui::{Context, View, VisualContext};
 use lsp::request;
-use search::BufferSearchBar;
+use search::{project_search::ProjectSearchBar, BufferSearchBar};
 
 use crate::{state::Operator, *};
 
@@ -59,9 +59,9 @@ impl VimTestContext {
                 pane.toolbar().update(cx, |toolbar, cx| {
                     let buffer_search_bar = cx.new_view(BufferSearchBar::new);
                     toolbar.add_item(buffer_search_bar, cx);
-                    // todo!();
-                    // let project_search_bar = cx.add_view(|_| ProjectSearchBar::new());
-                    // toolbar.add_item(project_search_bar, cx);
+
+                    let project_search_bar = cx.new_view(|_| ProjectSearchBar::new());
+                    toolbar.add_item(project_search_bar, cx);
                 })
             });
             workspace.status_bar().update(cx, |status_bar, cx| {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -167,15 +167,6 @@ impl DockPosition {
         }
     }
 
-    // todo!()
-    // fn to_resize_handle_side(self) -> HandleSide {
-    //     match self {
-    //         Self::Left => HandleSide::Right,
-    //         Self::Bottom => HandleSide::Top,
-    //         Self::Right => HandleSide::Left,
-    //     }
-    // }
-
     pub fn axis(&self) -> Axis {
         match self {
             Self::Left | Self::Right => Axis::Horizontal,
@@ -186,8 +177,6 @@ impl DockPosition {
 
 struct PanelEntry {
     panel: Arc<dyn PanelHandle>,
-    // todo!()
-    // context_menu: View<ContextMenu>,
     _subscriptions: [Subscription; 2],
 }
 
@@ -264,12 +253,6 @@ impl Dock {
     pub fn is_open(&self) -> bool {
         self.is_open
     }
-
-    // todo!()
-    //     pub fn has_focus(&self, cx: &WindowContext) -> bool {
-    //         self.visible_panel()
-    //             .map_or(false, |panel| panel.has_focus(cx))
-    //     }
 
     pub fn panel<T: Panel>(&self) -> Option<View<T>> {
         self.panel_entries
@@ -417,16 +400,8 @@ impl Dock {
             }),
         ];
 
-        // todo!()
-        // let dock_view_id = cx.view_id();
         self.panel_entries.push(PanelEntry {
             panel: Arc::new(panel),
-            // todo!()
-            // context_menu: cx.add_view(|cx| {
-            //     let mut menu = ContextMenu::new(dock_view_id, cx);
-            //     menu.set_position_mode(OverlayPositionMode::Local);
-            //     menu
-            // }),
             _subscriptions: subscriptions,
         });
         cx.notify()
@@ -618,7 +593,6 @@ impl PanelButtons {
 
 impl Render for PanelButtons {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        // todo!()
         let dock = self.dock.read(cx);
         let active_index = dock.active_panel_index;
         let is_open = dock.is_open;

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -8,8 +8,6 @@ use std::{any::TypeId, ops::DerefMut};
 
 pub fn init(cx: &mut AppContext) {
     cx.set_global(NotificationTracker::new());
-    // todo!()
-    // simple_message_notification::init(cx);
 }
 
 pub trait Notification: EventEmitter<DismissEvent> + Render {}

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -242,87 +242,6 @@ pub struct DraggedTab {
     pub is_active: bool,
 }
 
-// pub struct DraggedItem {
-//     pub handle: Box<dyn ItemHandle>,
-//     pub pane: WeakView<Pane>,
-// }
-
-// pub enum ReorderBehavior {
-//     None,
-//     MoveAfterActive,
-//     MoveToIndex(usize),
-// }
-
-// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// enum TabBarContextMenuKind {
-//     New,
-//     Split,
-// }
-
-// struct TabBarContextMenu {
-//     kind: TabBarContextMenuKind,
-//     handle: View<ContextMenu>,
-// }
-
-// impl TabBarContextMenu {
-//     fn handle_if_kind(&self, kind: TabBarContextMenuKind) -> Option<View<ContextMenu>> {
-//         if self.kind == kind {
-//             return Some(self.handle.clone());
-//         }
-//         None
-//     }
-// }
-
-// #[allow(clippy::too_many_arguments)]
-// fn nav_button<A: Action, F: 'static + Fn(&mut Pane, &mut ViewContext<Pane>)>(
-//     svg_path: &'static str,
-//     style: theme::Interactive<theme2::IconButton>,
-//     nav_button_height: f32,
-//     tooltip_style: TooltipStyle,
-//     enabled: bool,
-//     on_click: F,
-//     tooltip_action: A,
-//     action_name: &str,
-//     cx: &mut ViewContext<Pane>,
-// ) -> AnyElement<Pane> {
-//     MouseEventHandler::new::<A, _>(0, cx, |state, _| {
-//         let style = if enabled {
-//             style.style_for(state)
-//         } else {
-//             style.disabled_style()
-//         };
-//         Svg::new(svg_path)
-//             .with_color(style.color)
-//             .constrained()
-//             .with_width(style.icon_width)
-//             .aligned()
-//             .contained()
-//             .with_style(style.container)
-//             .constrained()
-//             .with_width(style.button_width)
-//             .with_height(nav_button_height)
-//             .aligned()
-//             .top()
-//     })
-//     .with_cursor_style(if enabled {
-//         CursorStyle::PointingHand
-//     } else {
-//         CursorStyle::default()
-//     })
-//     .on_click(MouseButton::Left, move |_, toolbar, cx| {
-//         on_click(toolbar, cx)
-//     })
-//     .with_tooltip::<A>(
-//         0,
-//         action_name.to_string(),
-//         Some(Box::new(tooltip_action)),
-//         tooltip_style,
-//         cx,
-//     )
-//     .contained()
-//     .into_any_named("nav button")
-// }
-
 impl EventEmitter<Event> for Pane {}
 
 impl Pane {
@@ -333,13 +252,6 @@ impl Pane {
         can_drop_predicate: Option<Arc<dyn Fn(&dyn Any, &mut WindowContext) -> bool + 'static>>,
         cx: &mut ViewContext<Self>,
     ) -> Self {
-        // todo!("context menu")
-        // let pane_view_id = cx.view_id();
-        // let context_menu = cx.build_view(|cx| ContextMenu::new(pane_view_id, cx));
-        // context_menu.update(cx, |menu, _| {
-        //     menu.set_position_mode(OverlayPositionMode::Local)
-        // });
-        //
         let focus_handle = cx.focus_handle();
 
         let subscriptions = vec![
@@ -370,11 +282,6 @@ impl Pane {
             split_item_menu: None,
             tab_bar_scroll_handle: ScrollHandle::new(),
             drag_split_direction: None,
-            // tab_bar_context_menu: TabBarContextMenu {
-            //     kind: TabBarContextMenuKind::New,
-            //     handle: context_menu,
-            // },
-            // tab_context_menu: cx.build_view(|_| ContextMenu::new(pane_view_id, cx)),
             workspace,
             project,
             can_drop_predicate,
@@ -450,7 +357,6 @@ impl Pane {
     }
 
     pub fn has_focus(&self, cx: &WindowContext) -> bool {
-        // todo!(); // inline this manually
         self.focus_handle.contains_focused(cx)
     }
 

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use ui::{prelude::*, Button};
 
-const HANDLE_HITBOX_SIZE: f32 = 4.0;
+pub const HANDLE_HITBOX_SIZE: f32 = 4.0;
 const HORIZONTAL_MIN_SIZE: f32 = 80.;
 const VERTICAL_MIN_SIZE: f32 = 100.;
 
@@ -268,15 +268,6 @@ impl Member {
                         )
                     })
                     .into_any()
-
-                // let el = div()
-                //     .flex()
-                //     .flex_1()
-                //     .gap_px()
-                //     .w_full()
-                //     .h_full()
-                //     .bg(cx.theme().colors().editor)
-                //     .children();
             }
             Member::Axis(axis) => axis
                 .render(

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -1,8 +1,8 @@
 use std::{any::Any, sync::Arc};
 
 use gpui::{
-    AnyView, AppContext, EventEmitter, Subscription, Task, View, ViewContext, WeakView,
-    WindowContext,
+    AnyView, AnyWeakView, AppContext, EventEmitter, Subscription, Task, View, ViewContext,
+    WeakView, WindowContext,
 };
 use project::search::SearchQuery;
 
@@ -127,7 +127,6 @@ pub trait SearchableItemHandle: ItemHandle {
     ) -> Option<usize>;
 }
 
-// todo!("here is where we need to use AnyWeakView");
 impl<T: SearchableItem> SearchableItemHandle for View<T> {
     fn downgrade(&self) -> Box<dyn WeakSearchableItemHandle> {
         Box::new(self.downgrade())
@@ -249,7 +248,7 @@ impl Eq for Box<dyn SearchableItemHandle> {}
 pub trait WeakSearchableItemHandle: WeakItemHandle {
     fn upgrade(&self, cx: &AppContext) -> Option<Box<dyn SearchableItemHandle>>;
 
-    // fn into_any(self) -> AnyWeakView;
+    fn into_any(self) -> AnyWeakView;
 }
 
 impl<T: SearchableItem> WeakSearchableItemHandle for WeakView<T> {
@@ -257,9 +256,9 @@ impl<T: SearchableItem> WeakSearchableItemHandle for WeakView<T> {
         Some(Box::new(self.upgrade()?))
     }
 
-    // fn into_any(self) -> AnyView {
-    //     self.into_any()
-    // }
+    fn into_any(self) -> AnyWeakView {
+        self.into()
+    }
 }
 
 impl PartialEq for Box<dyn WeakSearchableItemHandle> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -852,6 +852,10 @@ impl Workspace {
         &self.right_dock
     }
 
+    pub fn is_edited(&self) -> bool {
+        self.window_edited
+    }
+
     pub fn add_panel<T: Panel>(&mut self, panel: View<T>, cx: &mut ViewContext<Self>) {
         let dock = match panel.position(cx) {
             DockPosition::Left => &self.left_dock,
@@ -2055,7 +2059,7 @@ impl Workspace {
             _ => bounding_box.center(),
         };
 
-        let distance_to_next = 8.; //todo(pane dividers styling)
+        let distance_to_next = pane_group::HANDLE_HITBOX_SIZE;
 
         let target = match direction {
             SplitDirection::Left => {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1143,7 +1143,6 @@ impl Workspace {
         quitting: bool,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<bool>> {
-        //todo!(saveing)
         let active_call = self.active_call().cloned();
         let window = cx.window_handle();
 
@@ -1693,28 +1692,6 @@ impl Workspace {
         }
         None
     }
-
-    // todo!("implement zoom")
-    #[allow(unused)]
-    fn zoom_out(&mut self, cx: &mut ViewContext<Self>) {
-        for pane in &self.panes {
-            pane.update(cx, |pane, cx| pane.set_zoomed(false, cx));
-        }
-
-        self.left_dock.update(cx, |dock, cx| dock.zoom_out(cx));
-        self.bottom_dock.update(cx, |dock, cx| dock.zoom_out(cx));
-        self.right_dock.update(cx, |dock, cx| dock.zoom_out(cx));
-        self.zoomed = None;
-        self.zoomed_position = None;
-
-        cx.notify();
-    }
-
-    // todo!()
-    //     #[cfg(any(test, feature = "test-support"))]
-    //     pub fn zoomed_view(&self, cx: &AppContext) -> Option<AnyViewHandle> {
-    //         self.zoomed.and_then(|view| view.upgrade(cx))
-    //     }
 
     fn dismiss_zoomed_items_to_reveal(
         &mut self,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -23,7 +23,7 @@ use quick_action_bar::QuickActionBar;
 use search::project_search::ProjectSearchBar;
 use settings::{initial_local_settings_content, KeymapFile, Settings, SettingsStore};
 use std::{borrow::Cow, ops::Deref, sync::Arc};
-use terminal_view::terminal_panel::TerminalPanel;
+use terminal_view::terminal_panel::{self, TerminalPanel};
 use util::{
     asset_str,
     channel::{AppCommitSha, ReleaseChannel},
@@ -299,79 +299,42 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
                     );
                 },
             )
-            //todo!()
-            // cx.add_action({
-            //     move |workspace: &mut Workspace, _: &DebugElements, cx: &mut ViewContext<Workspace>| {
-            //         let app_state = workspace.app_state().clone();
-            //         let markdown = app_state.languages.language_for_name("JSON");
-            //         let window = cx.window();
-            //         cx.spawn(|workspace, mut cx| async move {
-            //             let markdown = markdown.await.log_err();
-            //             let content = to_string_pretty(&window.debug_elements(&cx).ok_or_else(|| {
-            //                 anyhow!("could not debug elements for window {}", window.id())
-            //             })?)
-            //             .unwrap();
-            //             workspace
-            //                 .update(&mut cx, |workspace, cx| {
-            //                     workspace.with_local_workspace(cx, move |workspace, cx| {
-            //                         let project = workspace.project().clone();
-            //                         let buffer = project
-            //                             .update(cx, |project, cx| {
-            //                                 project.create_buffer(&content, markdown, cx)
-            //                             })
-            //                             .expect("creating buffers on a local workspace always succeeds");
-            //                         let buffer = cx.add_model(|cx| {
-            //                             MultiBuffer::singleton(buffer, cx)
-            //                                 .with_title("Debug Elements".into())
-            //                         });
-            //                         workspace.add_item(
-            //                             Box::new(cx.add_view(|cx| {
-            //                                 Editor::for_multibuffer(buffer, Some(project.clone()), cx)
-            //                             })),
-            //                             cx,
-            //                         );
-            //                     })
-            //                 })?
-            //                 .await
-            //         })
-            //         .detach_and_log_err(cx);
-            //     }
-            // });
-            // .register_action(
-            //     |workspace: &mut Workspace,
-            //      _: &project_panel::ToggleFocus,
-            //      cx: &mut ViewContext<Workspace>| {
-            //         workspace.toggle_panel_focus::<ProjectPanel>(cx);
-            //     },
-            // );
-            // cx.add_action(
-            //     |workspace: &mut Workspace,
-            //      _: &collab_ui::collab_panel::ToggleFocus,
-            //      cx: &mut ViewContext<Workspace>| {
-            //         workspace.toggle_panel_focus::<collab_ui::collab_panel::CollabPanel>(cx);
-            //     },
-            // );
-            // cx.add_action(
-            //     |workspace: &mut Workspace,
-            //      _: &collab_ui::chat_panel::ToggleFocus,
-            //      cx: &mut ViewContext<Workspace>| {
-            //         workspace.toggle_panel_focus::<collab_ui::chat_panel::ChatPanel>(cx);
-            //     },
-            // );
-            // cx.add_action(
-            //     |workspace: &mut Workspace,
-            //      _: &collab_ui::notification_panel::ToggleFocus,
-            //      cx: &mut ViewContext<Workspace>| {
-            //         workspace.toggle_panel_focus::<collab_ui::notification_panel::NotificationPanel>(cx);
-            //     },
-            // );
-            // cx.add_action(
-            //     |workspace: &mut Workspace,
-            //      _: &terminal_panel::ToggleFocus,
-            //      cx: &mut ViewContext<Workspace>| {
-            //         workspace.toggle_panel_focus::<TerminalPanel>(cx);
-            //     },
-            // );
+            .register_action(
+                |workspace: &mut Workspace,
+                 _: &project_panel::ToggleFocus,
+                 cx: &mut ViewContext<Workspace>| {
+                    workspace.toggle_panel_focus::<ProjectPanel>(cx);
+                },
+            )
+            .register_action(
+                |workspace: &mut Workspace,
+                 _: &collab_ui::collab_panel::ToggleFocus,
+                 cx: &mut ViewContext<Workspace>| {
+                    workspace.toggle_panel_focus::<collab_ui::collab_panel::CollabPanel>(cx);
+                },
+            )
+            .register_action(
+                |workspace: &mut Workspace,
+                 _: &collab_ui::chat_panel::ToggleFocus,
+                 cx: &mut ViewContext<Workspace>| {
+                    workspace.toggle_panel_focus::<collab_ui::chat_panel::ChatPanel>(cx);
+                },
+            )
+            .register_action(
+                |workspace: &mut Workspace,
+                 _: &collab_ui::notification_panel::ToggleFocus,
+                 cx: &mut ViewContext<Workspace>| {
+                    workspace
+                        .toggle_panel_focus::<collab_ui::notification_panel::NotificationPanel>(cx);
+                },
+            )
+            .register_action(
+                |workspace: &mut Workspace,
+                 _: &terminal_panel::ToggleFocus,
+                 cx: &mut ViewContext<Workspace>| {
+                    workspace.toggle_panel_focus::<TerminalPanel>(cx);
+                },
+            )
             .register_action({
                 let app_state = Arc::downgrade(&app_state);
                 move |_, _: &NewWindow, cx| {
@@ -1658,8 +1621,8 @@ mod tests {
             })
             .unwrap();
         save_task.await.unwrap();
-        // todo!() po
-        //assert!(!cx.did_prompt_for_new_path());
+
+        assert!(!cx.did_prompt_for_new_path());
         window
             .update(cx, |_, cx| {
                 editor.update(cx, |editor, cx| {

--- a/script/bundle
+++ b/script/bundle
@@ -132,7 +132,7 @@ else
     cp -R target/${target_dir}/WebRTC.framework "${app_path}/Contents/Frameworks/"
 fi
 
-#todo!(The app identifier has been set to 'Dev', but the channel is nightly, RATIONALIZE ALL OF THIS MESS)
+# Note: The app identifier for our development builds is the same as the app identifier for nightly.
 cp crates/${zed_crate}/contents/$channel/embedded.provisionprofile "${app_path}/Contents/"
 
 if [[ -n $MACOS_CERTIFICATE && -n $MACOS_CERTIFICATE_PASSWORD && -n $APPLE_NOTARIZATION_USERNAME && -n $APPLE_NOTARIZATION_PASSWORD ]]; then


### PR DESCRIPTION
The software equivalent of dusting

Release Notes:

- Restored the 'focus panel' related key bindings, like `terminal_panel::ToggleFocus`