### PR TITLE
Ensure focus_in and focus_out fire on window activation

### DIFF
--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -76,6 +76,10 @@ async fn test_basic_following(
     let (workspace_a, cx_a) = client_a.build_workspace(&project_a, cx_a);
     let (workspace_b, cx_b) = client_b.build_workspace(&project_b, cx_b);
 
+    cx_b.update(|cx| {
+        assert!(cx.is_window_active());
+    });
+
     // Client A opens some editors.
     let pane_a = workspace_a.update(cx_a, |workspace, _| workspace.active_pane().clone());
     let editor_a1 = workspace_a

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -617,7 +617,10 @@ impl TestClient {
         project: &Model<Project>,
         cx: &'a mut TestAppContext,
     ) -> (View<Workspace>, &'a mut VisualTestContext) {
-        cx.add_window_view(|cx| Workspace::new(0, project.clone(), self.app_state.clone(), cx))
+        cx.add_window_view(|cx| {
+            cx.activate_window();
+            Workspace::new(0, project.clone(), self.app_state.clone(), cx)
+        })
     }
 }
 

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -174,6 +174,7 @@ impl TestAppContext {
         drop(cx);
         let view = window.root_view(self).unwrap();
         let cx = Box::new(VisualTestContext::from_window(*window.deref(), self));
+        cx.run_until_parked();
         // it might be nice to try and cleanup these at the end of each test.
         (view, Box::leak(cx))
     }

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -82,11 +82,13 @@ mod test {
         let editor2 = cx
             .update(|cx| {
                 window2.update(cx, |_, cx| {
+                    cx.activate_window();
                     cx.focus_self();
                     cx.view().clone()
                 })
             })
             .unwrap();
+        cx.run_until_parked();
 
         cx.update(|cx| {
             let vim = Vim::read(cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -537,7 +537,7 @@ impl Workspace {
         })
         .detach();
 
-        cx.on_blur_window(|this, cx| {
+        cx.on_focus_lost(|this, cx| {
             let focus_handle = this.focus_handle(cx);
             cx.focus(&focus_handle);
         })


### PR DESCRIPTION
Also:
- Rename cx.on_blur to cx.on_focus_lost
- Fix a bug where notify calls in focus handlers were ignored
- Fix a bug where vim would get stuck in the wrong mode when switching
  windows

Release Notes:

- (preview only) vim: fix switching between multiple windows
