### PR TITLE
editor: Account for excerpt headers in git diff range calculation

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -780,7 +780,7 @@ impl EditorElement {
 
                 //TODO: This rendering is entirely a horrible hack
                 DiffHunkStatus::Removed => {
-                    let row = *display_row_range.start();
+                    let row = display_row_range.start;
 
                     let offset = line_height / 2.;
                     let start_y = row as f32 * line_height - offset - scroll_top;
@@ -802,8 +802,8 @@ impl EditorElement {
                 }
             };
 
-            let start_row = *display_row_range.start();
-            let end_row = *display_row_range.end();
+            let start_row = display_row_range.start;
+            let end_row = display_row_range.end;
             let start_y = start_row as f32 * line_height - scroll_top;
             let end_y = (end_row + 1) as f32 * line_height - scroll_top;
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -804,9 +804,21 @@ impl EditorElement {
 
             let start_row = display_row_range.start;
             let end_row = display_row_range.end;
+            // If we're in a multibuffer, row range span might include an excerpt header
+            // when we're in multibuffer.
+            // Making the range inclusive doesn't quite cut it, as we rely on the exclusivity for the soft wrap.
+            // Instead, we simply check whether the range we're dealing with includes
+            // any custom elements and if so, we stop painting the diff hunk on the first row of that custom element
+            let end_row_in_current_excerpt = layout
+                .position_map
+                .snapshot
+                .blocks_in_range(start_row..end_row)
+                .next()
+                .map(|(start_row, _)| start_row)
+                .unwrap_or(end_row);
 
             let start_y = start_row as f32 * line_height - scroll_top;
-            let end_y = end_row as f32 * line_height - scroll_top;
+            let end_y = end_row_in_current_excerpt as f32 * line_height - scroll_top;
 
             let width = 0.275 * line_height;
             let highlight_origin = bounds.origin + point(-width, start_y);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -804,8 +804,9 @@ impl EditorElement {
 
             let start_row = display_row_range.start;
             let end_row = display_row_range.end;
+
             let start_y = start_row as f32 * line_height - scroll_top;
-            let end_y = (end_row + 1) as f32 * line_height - scroll_top;
+            let end_y = end_row as f32 * line_height - scroll_top;
 
             let width = 0.275 * line_height;
             let highlight_origin = bounds.origin + point(-width, start_y);
@@ -1544,6 +1545,7 @@ impl EditorElement {
         let buffer_end_row = DisplayPoint::new(display_rows.end, 0)
             .to_point(snapshot)
             .row;
+
         buffer_snapshot
             .git_diff_hunks_in_range(buffer_start_row..buffer_end_row)
             .map(|hunk| diff_hunk_to_display(hunk, snapshot))

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -804,9 +804,8 @@ impl EditorElement {
 
             let start_row = display_row_range.start;
             let end_row = display_row_range.end;
-
             let start_y = start_row as f32 * line_height - scroll_top;
-            let end_y = end_row as f32 * line_height - scroll_top;
+            let end_y = (end_row + 1) as f32 * line_height - scroll_top;
 
             let width = 0.275 * line_height;
             let highlight_origin = bounds.origin + point(-width, start_y);
@@ -1545,7 +1544,6 @@ impl EditorElement {
         let buffer_end_row = DisplayPoint::new(display_rows.end, 0)
             .to_point(snapshot)
             .row;
-
         buffer_snapshot
             .git_diff_hunks_in_range(buffer_start_row..buffer_end_row)
             .map(|hunk| diff_hunk_to_display(hunk, snapshot))

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -804,11 +804,12 @@ impl EditorElement {
 
             let start_row = display_row_range.start;
             let end_row = display_row_range.end;
-            // If we're in a multibuffer, row range span might include an excerpt header
-            // when we're in multibuffer.
+            // If we're in a multibuffer, row range span might include an
+            // excerpt header, so if we were to draw the marker straight away,
+            // the hunk might include the rows of that header.
             // Making the range inclusive doesn't quite cut it, as we rely on the exclusivity for the soft wrap.
             // Instead, we simply check whether the range we're dealing with includes
-            // any custom elements and if so, we stop painting the diff hunk on the first row of that custom element
+            // any custom elements and if so, we stop painting the diff hunk on the first row of that custom element.
             let end_row_in_current_excerpt = layout
                 .position_map
                 .snapshot

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -780,7 +780,7 @@ impl EditorElement {
 
                 //TODO: This rendering is entirely a horrible hack
                 DiffHunkStatus::Removed => {
-                    let row = display_row_range.start;
+                    let row = *display_row_range.start();
 
                     let offset = line_height / 2.;
                     let start_y = row as f32 * line_height - offset - scroll_top;
@@ -802,8 +802,8 @@ impl EditorElement {
                 }
             };
 
-            let start_row = display_row_range.start;
-            let end_row = display_row_range.end;
+            let start_row = *display_row_range.start();
+            let end_row = *display_row_range.end();
             let start_y = start_row as f32 * line_height - scroll_top;
             let end_y = (end_row + 1) as f32 * line_height - scroll_top;
 

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -26,7 +26,7 @@ impl DisplayDiffHunk {
             &DisplayDiffHunk::Folded { display_row } => display_row,
             DisplayDiffHunk::Unfolded {
                 display_row_range, ..
-            } => display_row_range.start,
+            } => *display_row_range.start(),
         }
     }
 
@@ -36,7 +36,7 @@ impl DisplayDiffHunk {
 
             DisplayDiffHunk::Unfolded {
                 display_row_range, ..
-            } => display_row_range.start..=display_row_range.end,
+            } => display_row_range.clone(),
         };
 
         range.contains(&display_row)

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -26,7 +26,7 @@ impl DisplayDiffHunk {
             &DisplayDiffHunk::Folded { display_row } => display_row,
             DisplayDiffHunk::Unfolded {
                 display_row_range, ..
-            } => *display_row_range.start(),
+            } => display_row_range.start,
         }
     }
 
@@ -36,7 +36,7 @@ impl DisplayDiffHunk {
 
             DisplayDiffHunk::Unfolded {
                 display_row_range, ..
-            } => display_row_range.clone(),
+            } => display_row_range.start..=display_row_range.end,
         };
 
         range.contains(&display_row)

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use git::diff::{DiffHunk, DiffHunkStatus};
 use language::Point;
@@ -15,7 +15,7 @@ pub enum DisplayDiffHunk {
     },
 
     Unfolded {
-        display_row_range: RangeInclusive<u32>,
+        display_row_range: Range<u32>,
         status: DiffHunkStatus,
     },
 }
@@ -76,11 +76,13 @@ pub fn diff_hunk_to_display(hunk: DiffHunk<u32>, snapshot: &DisplaySnapshot) -> 
         DisplayDiffHunk::Folded { display_row: row }
     } else {
         let start = hunk_start_point.to_display_point(snapshot).row();
+
         let hunk_end_row = hunk.buffer_range.end.max(hunk.buffer_range.start);
-        let hunk_end_point = Point::new(hunk_end_row.saturating_sub(1), 0);
+        let hunk_end_point = Point::new(hunk_end_row, 0);
         let end = hunk_end_point.to_display_point(snapshot).row();
+
         DisplayDiffHunk::Unfolded {
-            display_row_range: start..=end,
+            display_row_range: start..end,
             status: hunk.status(),
         }
     }

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 use git::diff::{DiffHunk, DiffHunkStatus};
 use language::Point;
@@ -15,7 +15,7 @@ pub enum DisplayDiffHunk {
     },
 
     Unfolded {
-        display_row_range: Range<u32>,
+        display_row_range: RangeInclusive<u32>,
         status: DiffHunkStatus,
     },
 }
@@ -76,13 +76,11 @@ pub fn diff_hunk_to_display(hunk: DiffHunk<u32>, snapshot: &DisplaySnapshot) -> 
         DisplayDiffHunk::Folded { display_row: row }
     } else {
         let start = hunk_start_point.to_display_point(snapshot).row();
-
         let hunk_end_row = hunk.buffer_range.end.max(hunk.buffer_range.start);
-        let hunk_end_point = Point::new(hunk_end_row, 0);
+        let hunk_end_point = Point::new(hunk_end_row.saturating_sub(1), 0);
         let end = hunk_end_point.to_display_point(snapshot).row();
-
         DisplayDiffHunk::Unfolded {
-            display_row_range: start..end,
+            display_row_range: start..=end,
             status: hunk.status(),
         }
     }


### PR DESCRIPTION
The culprit was in display map which was resolving next valid point for the editor. ~We've kinda misused it's API, as we were looking for the end Y coordinate for a hunk by trying to resolve next line after the end of a hunk, which didn't play well with multibuffers~. Now, instead of resolving lines leniently, we essentially resolve position for "true" last line of a diff and not next line after the diff ended.
Scrap the mention about API misuse, it was there to handle soft wraps. :)
This bug existed in Zed1 as well.

Fixes: Diff markers in multibuffer search overlap with dividers between excepts (shouldn't extend all the way into the divider region)


Release Notes:
- Fixed diff markers being drawn incorrectly near headers in multibuffer views.
