### PR TITLE
Use the `.selected` style for buffer search option buttons

### DIFF
--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -98,7 +98,7 @@ impl SearchOptions {
         IconButton::new(self.label(), self.icon())
             .on_click(action)
             .style(ButtonStyle::Subtle)
-            .when(active, |button| button.style(ButtonStyle::Filled))
+            .selected(active)
             .tooltip({
                 let action = self.to_toggle_action();
                 let label: SharedString = format!("Toggle {}", self.label()).into();


### PR DESCRIPTION
This PR updates the `IconButton`s used to control the buffer search options to use the `.selected` state to denote when they are active. This matches what we are doing in the project search.

This should improve the contrast in certain themes.

Release Notes:

- Improved the active style for the search options in buffer search.
