### PR TITLE
Disentangle the rendering of editor hover and mouse context menu

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1473,7 +1473,7 @@ impl CodeActionsMenu {
                     .collect()
             },
         )
-        .elevation_1(cx)
+        .elevation_2(cx)
         .px_2()
         .py_1()
         .max_h(max_height)

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -39,7 +39,8 @@ pub fn hover(editor: &mut Editor, _: &Hover, cx: &mut ViewContext<Editor>) {
 /// depending on whether a point to hover over is provided.
 pub fn hover_at(editor: &mut Editor, point: Option<DisplayPoint>, cx: &mut ViewContext<Editor>) {
     if EditorSettings::get_global(cx).hover_popover_enabled {
-        if let Some(point) = point {
+        let has_context_menu = editor.mouse_context_menu.is_some();
+        if let (Some(point), false) = (point, has_context_menu) {
             show_hover(editor, point, false, cx);
         } else {
             hide_hover(editor, cx);
@@ -477,7 +478,7 @@ impl InfoPopover {
     ) -> AnyElement {
         div()
             .id("info_popover")
-            .elevation_2(cx)
+            .elevation_1(cx)
             .p_2()
             .overflow_y_scroll()
             .max_w(max_size.width)
@@ -547,6 +548,7 @@ impl DiagnosticPopover {
         div()
             .id("diagnostic")
             .overflow_y_scroll()
+            .elevation_1(cx)
             .px_2()
             .py_1()
             .bg(diagnostic_colors.background)

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -233,7 +233,7 @@ impl ContextMenuItem {
 
 impl Render for ContextMenu {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        div().elevation_2(cx).flex().flex_row().child(
+        div().elevation_3(cx).flex().flex_row().child(
             v_stack()
                 .min_w(px(200.))
                 .track_focus(&self.focus_handle)

--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -42,12 +42,12 @@ impl RenderOnce for Popover {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         div()
             .flex()
+            .elevation_2(cx)
             .gap_1()
-            .child(v_stack().elevation_2(cx).px_1().children(self.children))
+            .child(v_stack().px_1().children(self.children))
             .when_some(self.aside, |this, aside| {
                 this.child(
                     v_stack()
-                        .elevation_2(cx)
                         .bg(cx.theme().colors().surface_background)
                         .px_1()
                         .child(aside),


### PR DESCRIPTION
Also prevent hover while mouse context menu is deployed

Release Notes:

- Fixed an issue where hover docs and editor context menu would not overlap correctly.