### PR TITLE
pass installation id to datadog

### DIFF
--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -125,7 +125,7 @@ struct Panic {
 // NOTE: this is called via zed.dev
 #[instrument(skip(panic))]
 async fn trace_panic(panic: Json<Panic>) -> Result<()> {
-    tracing::error!(version = %panic.version, release_channel = %panic.release_channel, backtrace_hash = %panic.backtrace_hash, text = %panic.text, insatllation_id = %panic.installation_id, "panic report");
+    tracing::error!(version = %panic.version, release_channel = %panic.release_channel, backtrace_hash = %panic.backtrace_hash, text = %panic.text, installation_id = %panic.installation_id, "panic report");
     Ok(())
 }
 

--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -119,11 +119,13 @@ struct Panic {
     release_channel: String,
     backtrace_hash: String,
     text: String,
+    installation_id: String,
 }
 
+// NOTE: this is called via zed.dev
 #[instrument(skip(panic))]
 async fn trace_panic(panic: Json<Panic>) -> Result<()> {
-    tracing::error!(version = %panic.version, release_channel = %panic.release_channel, backtrace_hash = %panic.backtrace_hash, text = %panic.text, "panic report");
+    tracing::error!(version = %panic.version, release_channel = %panic.release_channel, backtrace_hash = %panic.backtrace_hash, text = %panic.text, insatllation_id = %panic.installation_id, "panic report");
     Ok(())
 }
 


### PR DESCRIPTION
I'd like to know for some panics the number of users affected

Release Notes:

- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/community/issues/<public_issue_number_if_exists>)).
