### PR TITLE
Stop following when project is unshared

### DIFF
--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -1225,7 +1225,12 @@ impl Room {
         };
 
         self.client.send(proto::UnshareProject { project_id })?;
-        project.update(cx, |this, cx| this.unshare(cx))
+        project.update(cx, |this, cx| this.unshare(cx))?;
+
+        if self.local_participant.active_project == Some(project.downgrade()) {
+            self.set_location(Some(&project), cx).detach_and_log_err(cx);
+        }
+        Ok(())
     }
 
     pub(crate) fn set_location(

--- a/crates/collab/src/tests/channel_guest_tests.rs
+++ b/crates/collab/src/tests/channel_guest_tests.rs
@@ -104,12 +104,10 @@ async fn test_channel_guest_promotion(cx_a: &mut TestAppContext, cx_b: &mut Test
     });
     assert!(project_b.read_with(cx_b, |project, _| project.is_read_only()));
     assert!(editor_b.update(cx_b, |e, cx| e.read_only(cx)));
-    assert!(dbg!(
-        room_b
-            .update(cx_b, |room, cx| room.share_microphone(cx))
-            .await
-    )
-    .is_err());
+    assert!(room_b
+        .update(cx_b, |room, cx| room.share_microphone(cx))
+        .await
+        .is_err());
 
     // B is promoted
     active_call_a

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -111,7 +111,6 @@ mod test {
 
         let mut cx1 = VisualTestContext::from_window(cx.window, &cx);
         let editor1 = cx.editor.clone();
-        dbg!(editor1.entity_id());
 
         let buffer = cx.new_model(|_| Buffer::new(0, 0, "a = 1\nb = 2\n"));
         let (editor2, cx2) = cx.add_window_view(|cx| Editor::for_buffer(buffer, None, cx));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -512,6 +512,11 @@ impl Workspace {
 
                 project::Event::DisconnectedFromHost => {
                     this.update_window_edited(cx);
+                    let panes_to_unfollow: Vec<View<Pane>> =
+                        this.follower_states.keys().map(|k| k.clone()).collect();
+                    for pane in panes_to_unfollow {
+                        this.unfollow(&pane, cx);
+                    }
                     cx.disable_focus();
                 }
 


### PR DESCRIPTION
Before this change the views would continue to update in the background
of the "disconnected" dialogue, which was disconcerting.

[[PR Description]]

Release Notes:

- Fixed an edge-case where following didn't handle unshare correctly
