### PR TITLE
editor: extend diff hunk range for custom transform blocks.

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -809,7 +809,7 @@ impl EditorElement {
             // the hunk might include the rows of that header.
             // Making the range inclusive doesn't quite cut it, as we rely on the exclusivity for the soft wrap.
             // Instead, we simply check whether the range we're dealing with includes
-            // any custom elements and if so, we stop painting the diff hunk on the first row of that custom element.
+            // any excerpt headers and if so, we stop painting the diff hunk on the first row of that header.
             let end_row_in_current_excerpt = layout
                 .position_map
                 .snapshot

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -814,8 +814,13 @@ impl EditorElement {
                 .position_map
                 .snapshot
                 .blocks_in_range(start_row..end_row)
-                .next()
-                .map(|(start_row, _)| start_row)
+                .find_map(|(start_row, block)| {
+                    if matches!(block, TransformBlock::ExcerptHeader { .. }) {
+                        Some(start_row)
+                    } else {
+                        None
+                    }
+                })
                 .unwrap_or(end_row);
 
             let start_y = start_row as f32 * line_height - scroll_top;


### PR DESCRIPTION
Reported by Mikayla:
![image](https://github.com/zed-industries/zed/assets/24362066/b744d82e-328f-4554-becf-96f9fa92bfc8)
Note how the line with rust analyzer error does not have a git diff hunk.
vs:
![image](https://github.com/zed-industries/zed/assets/24362066/e285af7a-b8ab-40e9-a9c6-b4ab8d6c4cd0)

Release Notes:
- N/A
