### PR TITLE
Show abs path matches in file finder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
 name = "file_finder"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "collections",
  "ctor",
  "editor",

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -23,6 +23,7 @@ theme = { path = "../theme" }
 ui = { path = "../ui" }
 workspace = { path = "../workspace" }
 postage.workspace = true
+anyhow.workspace = true
 serde.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/issues/6341

Release Notes:

- Make File finder to show matching file for the abs path queries
