### PR TITLE
Stop following on escape key press

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -412,7 +412,8 @@
       "cmd-shift-e": "project_panel::ToggleFocus",
       "cmd-?": "assistant::ToggleFocus",
       "cmd-alt-s": "workspace::SaveAll",
-      "cmd-k m": "language_selector::Toggle"
+      "cmd-k m": "language_selector::Toggle",
+      "escape": "workspace::Unfollow"
     }
   },
   // Bindings from Sublime Text


### PR DESCRIPTION

Release Notes:

- Added a default keyboard shortcut to stop following by pressing the escape key.
