### PR TITLE
gpui: Make TextSystem::line_wrapper non-fallible.

### DIFF
--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -1053,7 +1053,7 @@ mod tests {
         };
         let tab_size = NonZeroU32::new(rng.gen_range(1..=4)).unwrap();
         let font = font("Helvetica");
-        let _font_id = text_system.font_id(&font).unwrap();
+        let _font_id = text_system.font_id(&font);
         let font_size = px(14.0);
 
         log::info!("Tab size: {}", tab_size);
@@ -1080,7 +1080,7 @@ mod tests {
         let tabs_snapshot = tab_map.set_max_expansion_column(32);
         log::info!("TabMap text: {:?}", tabs_snapshot.text());
 
-        let mut line_wrapper = text_system.line_wrapper(font.clone(), font_size).unwrap();
+        let mut line_wrapper = text_system.line_wrapper(font.clone(), font_size);
         let unwrapped_text = tabs_snapshot.text();
         let expected_text = wrap_text(&unwrapped_text, wrap_width, &mut line_wrapper);
 

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -364,28 +364,20 @@ impl TextSystem {
         self.line_layout_cache.start_frame()
     }
 
-    pub fn line_wrapper(
-        self: &Arc<Self>,
-        font: Font,
-        font_size: Pixels,
-    ) -> Result<LineWrapperHandle> {
+    pub fn line_wrapper(self: &Arc<Self>, font: Font, font_size: Pixels) -> LineWrapperHandle {
         let lock = &mut self.wrapper_pool.lock();
-        let font_id = self.font_id(&font)?;
+        let font_id = self.resolve_font(&font);
         let wrappers = lock
             .entry(FontIdWithSize { font_id, font_size })
             .or_default();
-        let wrapper = wrappers.pop().map(anyhow::Ok).unwrap_or_else(|| {
-            Ok(LineWrapper::new(
-                font_id,
-                font_size,
-                self.platform_text_system.clone(),
-            ))
-        })?;
+        let wrapper = wrappers.pop().unwrap_or_else(|| {
+            LineWrapper::new(font_id, font_size, self.platform_text_system.clone())
+        });
 
-        Ok(LineWrapperHandle {
+        LineWrapperHandle {
             wrapper: Some(wrapper),
             text_system: self.clone(),
-        })
+        }
     }
 
     pub fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {


### PR DESCRIPTION
Editors WrapMap could become desynchronised if user had an invalid font specified in their config. Compared to Zed1, WrapMap ignored the resolution failure instead of panicking. Now, if there's an invalid font in the user config, we just fall back to an arbitrary default.


Release Notes:
- Fixed the editor panic in presence of invalid font name in the config (fixes https://github.com/zed-industries/zed/issues/6405)
