### PR TITLE
Font name suggestions

### DIFF
--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -190,6 +190,9 @@ impl MacTextSystemState {
         for font in family.fonts() {
             let mut font = font.load()?;
             open_type::apply_features(&mut font, features);
+            let Some(_) = font.glyph_for_char('m') else {
+                continue;
+            };
             let font_id = FontId(self.fonts.len());
             font_ids.push(font_id);
             let postscript_name = font.postscript_name().unwrap();

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -65,6 +65,9 @@ impl TextSystem {
         }
     }
 
+    pub fn all_font_families(&self) -> Vec<String> {
+        self.platform_text_system.all_font_families()
+    }
     pub fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> Result<()> {
         self.platform_text_system.add_fonts(fonts)
     }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -194,9 +194,21 @@ impl settings::Settings for ThemeSettings {
             ..Default::default()
         };
 
-        root_schema
-            .definitions
-            .extend([("ThemeName".into(), theme_name_schema.into())]);
+        let available_fonts = cx
+            .text_system()
+            .all_font_families()
+            .into_iter()
+            .map(Value::String)
+            .collect();
+        let fonts_schema = SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            enum_values: Some(available_fonts),
+            ..Default::default()
+        };
+        root_schema.definitions.extend([
+            ("ThemeName".into(), theme_name_schema.into()),
+            ("FontFamilies".into(), fonts_schema.into()),
+        ]);
 
         root_schema
             .schema
@@ -204,10 +216,16 @@ impl settings::Settings for ThemeSettings {
             .as_mut()
             .unwrap()
             .properties
-            .extend([(
-                "theme".to_owned(),
-                Schema::new_ref("#/definitions/ThemeName".into()),
-            )]);
+            .extend([
+                (
+                    "theme".to_owned(),
+                    Schema::new_ref("#/definitions/ThemeName".into()),
+                ),
+                (
+                    "buffer_font_family".to_owned(),
+                    Schema::new_ref("#/definitions/FontFamilies".into()),
+                ),
+            ]);
 
         root_schema
     }


### PR DESCRIPTION
This also fixes a crash that occurs with some of these fonts (e.g. Al Bayan). As is, Zed crashes when using fonts without Latin characters. With this PR, we do not register a font that will later on cause a crash in EditorElement layout. 
To be specific, the crash in question is in https://github.com/zed-industries/zed/blob/7c817642b8e2fa304c0d9e9ca42ee1e04ceb3936/crates/editor/src/element.rs#L1772 where we expect a font to contain a glyph for 'm' character, which might not necessarily be the case.

Note that this is not a problem/crash introduced in this PR; an user could just set a faulty font themselves. The difference is, I expect users to try out fonts suggested by autocomplete and I don't want them to (kind of) brick their Zed. The only way out of having a faulty font set as the buffer_font_family is to edit the `settings.json` manually and remove the faulty setting - and you can't do it in Zed, because, duh, it crashes on startup.

As for the completions..
![image](https://github.com/zed-industries/zed/assets/24362066/c4ed2b71-52f4-4ed9-91e6-109cf0cc04e1)

Release Notes:

- Fixed a crash that could occur when `buffer_font_family` was set to a font family without Latin characters.
- Added autocomplete support to font families names (`buffer_font_family`) in settings.json file.