### PR TITLE
Temporarily avoid releasing livekit RemoteAudioTracks on drop

### DIFF
--- a/crates/live_kit_client/src/prod.rs
+++ b/crates/live_kit_client/src/prod.rs
@@ -864,7 +864,10 @@ impl RemoteAudioTrack {
 
 impl Drop for RemoteAudioTrack {
     fn drop(&mut self) {
-        unsafe { CFRelease(self.native_track.0) }
+        // todo: uncomment this `CFRelease`, unless we find that it was causing
+        // the crash in the `livekit.multicast` thread.
+        //
+        // unsafe { CFRelease(self.native_track.0) }
     }
 }
 


### PR DESCRIPTION
This release call was added during the conversion to gpui2. I think it is probably valid, but want to remove it on the off chance that it is causing the crash that we're seeing in the `livekit.multicast` thread when leaving a room.

Most likely, this is not going to fix anything, and is just introducing a small memory leak, but it is a step back to  how the app worked with gpui 1.