### PR TITLE
Fix failure to write to keychain when signing in or failing to sign in

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1371,10 +1371,7 @@ fn read_credentials_from_keychain(cx: &AsyncAppContext) -> Option<Credentials> {
     })
 }
 
-async fn write_credentials_to_keychain(
-    credentials: Credentials,
-    cx: &AsyncAppContext,
-) -> Result<()> {
+fn write_credentials_to_keychain(credentials: Credentials, cx: &AsyncAppContext) -> Result<()> {
     cx.update(move |cx| {
         cx.write_credentials(
             &ZED_SERVER_URL,
@@ -1384,7 +1381,7 @@ async fn write_credentials_to_keychain(
     })?
 }
 
-async fn delete_credentials_from_keychain(cx: &AsyncAppContext) -> Result<()> {
+fn delete_credentials_from_keychain(cx: &AsyncAppContext) -> Result<()> {
     cx.update(move |cx| cx.delete_credentials(&ZED_SERVER_URL))?
 }
 

--- a/crates/live_kit_client/src/prod.rs
+++ b/crates/live_kit_client/src/prod.rs
@@ -868,6 +868,7 @@ impl Drop for RemoteAudioTrack {
         // the crash in the `livekit.multicast` thread.
         //
         // unsafe { CFRelease(self.native_track.0) }
+        let _ = self.native_track;
     }
 }
 

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -244,6 +244,7 @@ where
     }
 }
 
+#[must_use]
 pub struct LogErrorFuture<F>(F, log::Level, core::panic::Location<'static>);
 
 impl<F, T, E> Future for LogErrorFuture<F>


### PR DESCRIPTION
Release Notes:

- Fixed an error where Zed would not save credentials to the keychain after signing in ([#2382](https://github.com/zed-industries/zed/issues/6397)).