### PR TITLE
Use auto formatter settings for Zed repo

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,5 +1,6 @@
 {
     "JSON": {
         "tab_size": 4
-    }
+    },
+    "formatter": "auto"
 }


### PR DESCRIPTION
Some users might have a language server formatter set in their settings, which is exclusive with prettier formatting. That causes disruptions in the way whitespaces and other things are formatted, esp. in json and yaml files, hence enforce one formatter settings for the entire Zed repo.

Release Notes:

- N/A