### PR TITLE
Avoid playing newly published audio tracks when deafened

### DIFF
--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -248,7 +248,6 @@ impl TestServer {
             language::init(cx);
             editor::init(cx);
             workspace::init(app_state.clone(), cx);
-            audio::init((), cx);
             call::init(client.clone(), user_store.clone(), cx);
             channel::init(&client, user_store.clone(), cx);
             notifications::init(client.clone(), user_store, cx);

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -102,7 +102,7 @@ impl Render for CollabTitlebarItem {
                                 peer_id,
                                 true,
                                 room.is_speaking(),
-                                room.is_muted(cx),
+                                room.is_muted(),
                                 &room,
                                 project_id,
                                 &current_user,
@@ -168,7 +168,7 @@ impl Render for CollabTitlebarItem {
                         let project = self.project.read(cx);
                         let is_local = project.is_local();
                         let is_shared = is_local && project.is_shared();
-                        let is_muted = room.is_muted(cx);
+                        let is_muted = room.is_muted();
                         let is_deafened = room.is_deafened().unwrap_or(false);
                         let is_screen_sharing = room.is_screen_sharing();
                         let read_only = room.read_only();

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -9,7 +9,7 @@ mod panel_settings;
 
 use std::{rc::Rc, sync::Arc};
 
-use call::{report_call_event_for_room, ActiveCall, Room};
+use call::{report_call_event_for_room, ActiveCall};
 pub use collab_panel::CollabPanel;
 pub use collab_titlebar_item::CollabTitlebarItem;
 use feature_flags::{ChannelsAlpha, FeatureFlagAppExt};
@@ -21,7 +21,6 @@ pub use panel_settings::{
     ChatPanelSettings, CollaborationPanelSettings, NotificationPanelSettings,
 };
 use settings::Settings;
-use util::ResultExt;
 use workspace::AppState;
 
 actions!(
@@ -79,7 +78,7 @@ pub fn toggle_mute(_: &ToggleMute, cx: &mut AppContext) {
     if let Some(room) = call.room().cloned() {
         let client = call.client();
         room.update(cx, |room, cx| {
-            let operation = if room.is_muted(cx) {
+            let operation = if room.is_muted() {
                 "enable microphone"
             } else {
                 "disable microphone"
@@ -87,17 +86,13 @@ pub fn toggle_mute(_: &ToggleMute, cx: &mut AppContext) {
             report_call_event_for_room(operation, room.id(), room.channel_id(), &client);
 
             room.toggle_mute(cx)
-        })
-        .map(|task| task.detach_and_log_err(cx))
-        .log_err();
+        });
     }
 }
 
 pub fn toggle_deafen(_: &ToggleDeafen, cx: &mut AppContext) {
     if let Some(room) = ActiveCall::global(cx).read(cx).room().cloned() {
-        room.update(cx, Room::toggle_deafen)
-            .map(|task| task.detach_and_log_err(cx))
-            .log_err();
+        room.update(cx, |room, cx| room.toggle_deafen(cx));
     }
 }
 

--- a/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
+++ b/crates/live_kit_client/LiveKitBridge/Sources/LiveKitBridge/LiveKitBridge.swift
@@ -286,6 +286,18 @@ public func LKRemoteAudioTrackGetSid(track: UnsafeRawPointer) -> CFString {
     return track.sid! as CFString
 }
 
+@_cdecl("LKRemoteAudioTrackStart")
+public func LKRemoteAudioTrackStart(track: UnsafeRawPointer) {
+    let track = Unmanaged<RemoteAudioTrack>.fromOpaque(track).takeUnretainedValue()
+    track.start()
+}
+
+@_cdecl("LKRemoteAudioTrackStop")
+public func LKRemoteAudioTrackStop(track: UnsafeRawPointer) {
+    let track = Unmanaged<RemoteAudioTrack>.fromOpaque(track).takeUnretainedValue()
+    track.stop()
+}
+
 @_cdecl("LKDisplaySources")
 public func LKDisplaySources(data: UnsafeRawPointer, callback: @escaping @convention(c) (UnsafeRawPointer, CFArray?, CFString?) -> Void) {
     MacOSScreenCapturer.sources(for: .display, includeCurrentApplication: false, preferredMethod: .legacy).then { displaySources in

--- a/crates/live_kit_client/src/prod.rs
+++ b/crates/live_kit_client/src/prod.rs
@@ -18,8 +18,6 @@ use std::{
     sync::{Arc, Weak},
 };
 
-// SAFETY: Most live kit types are threadsafe:
-// https://github.com/livekit/client-sdk-swift#thread-safety
 macro_rules! pointer_type {
     ($pointer_name:ident) => {
         #[repr(transparent)]
@@ -134,8 +132,10 @@ extern "C" {
     ) -> *const c_void;
 
     fn LKRemoteAudioTrackGetSid(track: swift::RemoteAudioTrack) -> CFStringRef;
-    fn LKVideoTrackAddRenderer(track: swift::RemoteVideoTrack, renderer: *const c_void);
     fn LKRemoteVideoTrackGetSid(track: swift::RemoteVideoTrack) -> CFStringRef;
+    fn LKRemoteAudioTrackStart(track: swift::RemoteAudioTrack);
+    fn LKRemoteAudioTrackStop(track: swift::RemoteAudioTrack);
+    fn LKVideoTrackAddRenderer(track: swift::RemoteVideoTrack, renderer: *const c_void);
 
     fn LKDisplaySources(
         callback_data: *mut c_void,
@@ -853,12 +853,12 @@ impl RemoteAudioTrack {
         &self.publisher_id
     }
 
-    pub fn enable(&self) -> impl Future<Output = Result<()>> {
-        async { Ok(()) }
+    pub fn start(&self) {
+        unsafe { LKRemoteAudioTrackStart(self.native_track) }
     }
 
-    pub fn disable(&self) -> impl Future<Output = Result<()>> {
-        async { Ok(()) }
+    pub fn stop(&self) {
+        unsafe { LKRemoteAudioTrackStop(self.native_track) }
     }
 }
 

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -262,6 +262,7 @@ impl TestServer {
         let track = Arc::new(RemoteAudioTrack {
             sid: sid.clone(),
             publisher_id: identity.clone(),
+            running: AtomicBool::new(true),
         });
 
         let publication = Arc::new(RemoteTrackPublication);
@@ -644,6 +645,7 @@ impl RemoteVideoTrack {
 pub struct RemoteAudioTrack {
     sid: Sid,
     publisher_id: Sid,
+    running: AtomicBool,
 }
 
 impl RemoteAudioTrack {
@@ -655,12 +657,12 @@ impl RemoteAudioTrack {
         &self.publisher_id
     }
 
-    pub fn enable(&self) -> impl Future<Output = Result<()>> {
-        async { Ok(()) }
+    pub fn start(&self) {
+        self.running.store(true, SeqCst);
     }
 
-    pub fn disable(&self) -> impl Future<Output = Result<()>> {
-        async { Ok(()) }
+    pub fn stop(&self) {
+        self.running.store(false, SeqCst);
     }
 }
 

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -1,7 +1,7 @@
 use crate::{ConnectionState, RoomUpdate, Sid};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use collections::{BTreeMap, HashMap};
+use collections::{BTreeMap, HashMap, HashSet};
 use futures::Stream;
 use gpui::BackgroundExecutor;
 use live_kit_server::{proto, token};
@@ -13,7 +13,7 @@ use std::{
     mem,
     sync::{
         atomic::{AtomicBool, Ordering::SeqCst},
-        Arc,
+        Arc, Weak,
     },
 };
 
@@ -113,7 +113,25 @@ impl TestServer {
                     .0
                     .lock()
                     .updates_tx
-                    .try_broadcast(RoomUpdate::SubscribedToRemoteVideoTrack(track.clone()))
+                    .try_broadcast(RoomUpdate::SubscribedToRemoteVideoTrack(Arc::new(
+                        RemoteVideoTrack {
+                            server_track: track.clone(),
+                        },
+                    )))
+                    .unwrap();
+            }
+            for track in &room.audio_tracks {
+                client_room
+                    .0
+                    .lock()
+                    .updates_tx
+                    .try_broadcast(RoomUpdate::SubscribedToRemoteAudioTrack(
+                        Arc::new(RemoteAudioTrack {
+                            server_track: track.clone(),
+                            room: Arc::downgrade(&client_room),
+                        }),
+                        Arc::new(RemoteTrackPublication),
+                    ))
                     .unwrap();
             }
             room.client_rooms.insert(identity, client_room);
@@ -210,7 +228,7 @@ impl TestServer {
         }
 
         let sid = nanoid::nanoid!(17);
-        let track = Arc::new(RemoteVideoTrack {
+        let track = Arc::new(TestServerVideoTrack {
             sid: sid.clone(),
             publisher_id: identity.clone(),
             frames_rx: local_track.frames_rx.clone(),
@@ -224,7 +242,11 @@ impl TestServer {
                     .0
                     .lock()
                     .updates_tx
-                    .try_broadcast(RoomUpdate::SubscribedToRemoteVideoTrack(track.clone()))
+                    .try_broadcast(RoomUpdate::SubscribedToRemoteVideoTrack(Arc::new(
+                        RemoteVideoTrack {
+                            server_track: track.clone(),
+                        },
+                    )))
                     .unwrap();
             }
         }
@@ -259,10 +281,10 @@ impl TestServer {
         }
 
         let sid = nanoid::nanoid!(17);
-        let track = Arc::new(RemoteAudioTrack {
+        let track = Arc::new(TestServerAudioTrack {
             sid: sid.clone(),
             publisher_id: identity.clone(),
-            running: AtomicBool::new(true),
+            muted: AtomicBool::new(false),
         });
 
         let publication = Arc::new(RemoteTrackPublication);
@@ -276,7 +298,10 @@ impl TestServer {
                     .lock()
                     .updates_tx
                     .try_broadcast(RoomUpdate::SubscribedToRemoteAudioTrack(
-                        track.clone(),
+                        Arc::new(RemoteAudioTrack {
+                            server_track: track.clone(),
+                            room: Arc::downgrade(&client_room),
+                        }),
                         publication.clone(),
                     ))
                     .unwrap();
@@ -286,35 +311,121 @@ impl TestServer {
         Ok(sid)
     }
 
+    fn set_track_muted(&self, token: &str, track_sid: &str, muted: bool) -> Result<()> {
+        let claims = live_kit_server::token::validate(&token, &self.secret_key)?;
+        let room_name = claims.video.room.unwrap();
+        let identity = claims.sub.unwrap();
+        let mut server_rooms = self.rooms.lock();
+        let room = server_rooms
+            .get_mut(&*room_name)
+            .ok_or_else(|| anyhow!("room {} does not exist", room_name))?;
+        if let Some(track) = room
+            .audio_tracks
+            .iter_mut()
+            .find(|track| track.sid == track_sid)
+        {
+            track.muted.store(muted, SeqCst);
+            for (id, client_room) in room.client_rooms.iter() {
+                if *id != identity {
+                    client_room
+                        .0
+                        .lock()
+                        .updates_tx
+                        .try_broadcast(RoomUpdate::RemoteAudioTrackMuteChanged {
+                            track_id: track_sid.to_string(),
+                            muted,
+                        })
+                        .unwrap();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn is_track_muted(&self, token: &str, track_sid: &str) -> Option<bool> {
+        let claims = live_kit_server::token::validate(&token, &self.secret_key).ok()?;
+        let room_name = claims.video.room.unwrap();
+
+        let mut server_rooms = self.rooms.lock();
+        let room = server_rooms.get_mut(&*room_name)?;
+        room.audio_tracks.iter().find_map(|track| {
+            if track.sid == track_sid {
+                Some(track.muted.load(SeqCst))
+            } else {
+                None
+            }
+        })
+    }
+
     fn video_tracks(&self, token: String) -> Result<Vec<Arc<RemoteVideoTrack>>> {
         let claims = live_kit_server::token::validate(&token, &self.secret_key)?;
         let room_name = claims.video.room.unwrap();
+        let identity = claims.sub.unwrap();
 
         let mut server_rooms = self.rooms.lock();
         let room = server_rooms
             .get_mut(&*room_name)
             .ok_or_else(|| anyhow!("room {} does not exist", room_name))?;
-        Ok(room.video_tracks.clone())
+        room.client_rooms
+            .get(identity.as_ref())
+            .ok_or_else(|| anyhow!("not a participant in room"))?;
+        Ok(room
+            .video_tracks
+            .iter()
+            .map(|track| {
+                Arc::new(RemoteVideoTrack {
+                    server_track: track.clone(),
+                })
+            })
+            .collect())
     }
 
     fn audio_tracks(&self, token: String) -> Result<Vec<Arc<RemoteAudioTrack>>> {
         let claims = live_kit_server::token::validate(&token, &self.secret_key)?;
         let room_name = claims.video.room.unwrap();
+        let identity = claims.sub.unwrap();
 
         let mut server_rooms = self.rooms.lock();
         let room = server_rooms
             .get_mut(&*room_name)
             .ok_or_else(|| anyhow!("room {} does not exist", room_name))?;
-        Ok(room.audio_tracks.clone())
+        let client_room = room
+            .client_rooms
+            .get(identity.as_ref())
+            .ok_or_else(|| anyhow!("not a participant in room"))?;
+        Ok(room
+            .audio_tracks
+            .iter()
+            .map(|track| {
+                Arc::new(RemoteAudioTrack {
+                    server_track: track.clone(),
+                    room: Arc::downgrade(&client_room),
+                })
+            })
+            .collect())
     }
 }
 
 #[derive(Default)]
 struct TestServerRoom {
     client_rooms: HashMap<Sid, Arc<Room>>,
-    video_tracks: Vec<Arc<RemoteVideoTrack>>,
-    audio_tracks: Vec<Arc<RemoteAudioTrack>>,
+    video_tracks: Vec<Arc<TestServerVideoTrack>>,
+    audio_tracks: Vec<Arc<TestServerAudioTrack>>,
     participant_permissions: HashMap<Sid, proto::ParticipantPermission>,
+}
+
+#[derive(Debug)]
+struct TestServerVideoTrack {
+    sid: Sid,
+    publisher_id: Sid,
+    frames_rx: async_broadcast::Receiver<Frame>,
+}
+
+#[derive(Debug)]
+struct TestServerAudioTrack {
+    sid: Sid,
+    publisher_id: Sid,
+    muted: AtomicBool,
 }
 
 impl TestServerRoom {}
@@ -387,6 +498,7 @@ struct RoomState {
         watch::Receiver<ConnectionState>,
     ),
     display_sources: Vec<MacOSDisplay>,
+    paused_audio_tracks: HashSet<Sid>,
     updates_tx: async_broadcast::Sender<RoomUpdate>,
     updates_rx: async_broadcast::Receiver<RoomUpdate>,
 }
@@ -399,6 +511,7 @@ impl Room {
         Arc::new(Self(Mutex::new(RoomState {
             connection: watch::channel_with(ConnectionState::Disconnected),
             display_sources: Default::default(),
+            paused_audio_tracks: Default::default(),
             updates_tx,
             updates_rx,
         })))
@@ -444,11 +557,12 @@ impl Room {
                 .publish_video_track(this.token(), track)
                 .await?;
             Ok(LocalTrackPublication {
-                muted: Default::default(),
+                room: Arc::downgrade(&this),
                 sid,
             })
         }
     }
+
     pub fn publish_audio_track(
         self: &Arc<Self>,
         track: LocalAudioTrack,
@@ -461,7 +575,7 @@ impl Room {
                 .publish_audio_track(this.token(), &track)
                 .await?;
             Ok(LocalTrackPublication {
-                muted: Default::default(),
+                room: Arc::downgrade(&this),
                 sid,
             })
         }
@@ -561,20 +675,31 @@ impl Drop for Room {
 #[derive(Clone)]
 pub struct LocalTrackPublication {
     sid: String,
-    muted: Arc<AtomicBool>,
+    room: Weak<Room>,
 }
 
 impl LocalTrackPublication {
     pub fn set_mute(&self, mute: bool) -> impl Future<Output = Result<()>> {
-        let muted = self.muted.clone();
+        let sid = self.sid.clone();
+        let room = self.room.clone();
         async move {
-            muted.store(mute, SeqCst);
-            Ok(())
+            if let Some(room) = room.upgrade() {
+                room.test_server()
+                    .set_track_muted(&room.token(), &sid, mute)
+            } else {
+                Err(anyhow!("no such room"))
+            }
         }
     }
 
     pub fn is_muted(&self) -> bool {
-        self.muted.load(SeqCst)
+        if let Some(room) = self.room.upgrade() {
+            room.test_server()
+                .is_track_muted(&room.token(), &self.sid)
+                .unwrap_or(false)
+        } else {
+            false
+        }
     }
 
     pub fn sid(&self) -> String {
@@ -622,47 +747,65 @@ impl LocalAudioTrack {
 
 #[derive(Debug)]
 pub struct RemoteVideoTrack {
-    sid: Sid,
-    publisher_id: Sid,
-    frames_rx: async_broadcast::Receiver<Frame>,
+    server_track: Arc<TestServerVideoTrack>,
 }
 
 impl RemoteVideoTrack {
     pub fn sid(&self) -> &str {
-        &self.sid
+        &self.server_track.sid
     }
 
     pub fn publisher_id(&self) -> &str {
-        &self.publisher_id
+        &self.server_track.publisher_id
     }
 
     pub fn frames(&self) -> async_broadcast::Receiver<Frame> {
-        self.frames_rx.clone()
+        self.server_track.frames_rx.clone()
     }
 }
 
 #[derive(Debug)]
 pub struct RemoteAudioTrack {
-    sid: Sid,
-    publisher_id: Sid,
-    running: AtomicBool,
+    server_track: Arc<TestServerAudioTrack>,
+    room: Weak<Room>,
 }
 
 impl RemoteAudioTrack {
     pub fn sid(&self) -> &str {
-        &self.sid
+        &self.server_track.sid
     }
 
     pub fn publisher_id(&self) -> &str {
-        &self.publisher_id
+        &self.server_track.publisher_id
     }
 
     pub fn start(&self) {
-        self.running.store(true, SeqCst);
+        if let Some(room) = self.room.upgrade() {
+            room.0
+                .lock()
+                .paused_audio_tracks
+                .remove(&self.server_track.sid);
+        }
     }
 
     pub fn stop(&self) {
-        self.running.store(false, SeqCst);
+        if let Some(room) = self.room.upgrade() {
+            room.0
+                .lock()
+                .paused_audio_tracks
+                .insert(self.server_track.sid.clone());
+        }
+    }
+
+    pub fn is_playing(&self) -> bool {
+        !self
+            .room
+            .upgrade()
+            .unwrap()
+            .0
+            .lock()
+            .paused_audio_tracks
+            .contains(&self.server_track.sid)
     }
 }
 


### PR DESCRIPTION
Release Notes:

- Fixed a bug where the 'deafen' button would only apply to audio from the call's current participants, but not any participants who joined after the button was pressed.
- Fixed a bug where after being granted write access to a channel, the microphone icon appeared non-muted, even though audio was not shared.