### PR TITLE
Disable searches for '.' in the terminal.

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -600,6 +600,9 @@ fn possible_open_targets(
 
 pub fn regex_search_for_query(query: &project::search::SearchQuery) -> Option<RegexSearch> {
     let query = query.as_str();
+    if query == "." {
+        return None;
+    }
     let searcher = RegexSearch::new(&query);
     searcher.ok()
 }


### PR DESCRIPTION
Release Notes:

- N/A A crash that could occur when searching for '.' in the terminal with a large monitor.