### PR TITLE
chat panel ++

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -192,17 +192,6 @@ impl AssistantPanel {
                         retrieve_context_in_next_inline_assist: false,
                     };
 
-                    let mut old_dock_position = this.position(cx);
-                    this.subscriptions =
-                        vec![cx.observe_global::<SettingsStore>(move |this, cx| {
-                            let new_dock_position = this.position(cx);
-                            if new_dock_position != old_dock_position {
-                                old_dock_position = new_dock_position;
-                                cx.emit(PanelEvent::ChangePosition);
-                            }
-                            cx.notify();
-                        })];
-
                     this
                 })
             })

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -40,7 +40,7 @@ use language::{language_settings::SoftWrap, Buffer, LanguageRegistry, ToOffset a
 use project::Project;
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
 use semantic_index::{SemanticIndex, SemanticIndexStatus};
-use settings::{Settings, SettingsStore};
+use settings::Settings;
 use std::{
     cell::Cell,
     cmp,
@@ -165,7 +165,7 @@ impl AssistantPanel {
                     cx.on_focus_in(&focus_handle, Self::focus_in).detach();
                     cx.on_focus_out(&focus_handle, Self::focus_out).detach();
 
-                    let mut this = Self {
+                    Self {
                         workspace: workspace_handle,
                         active_editor_index: Default::default(),
                         prev_active_editor_index: Default::default(),
@@ -190,9 +190,7 @@ impl AssistantPanel {
                         _watch_saved_conversations,
                         semantic_index,
                         retrieve_context_in_next_inline_assist: false,
-                    };
-
-                    this
+                    }
                 })
             })
         })
@@ -3122,6 +3120,7 @@ mod tests {
     use crate::MessageId;
     use ai::test::FakeCompletionProvider;
     use gpui::AppContext;
+    use settings::SettingsStore;
 
     #[gpui::test]
     fn test_inserting_and_removing_messages(cx: &mut AppContext) {

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -442,8 +442,10 @@ impl ActiveCall {
                         .location
                         .as_ref()
                         .and_then(|location| location.upgrade());
-                    let channel_id = room.update(cx, |room, cx| room.channel_id());
-                    cx.emit(Event::RoomJoined { channel_id });
+                    let (channel_id, role) = room.update(cx, |room, _| {
+                        (room.channel_id(), room.local_participant().role)
+                    });
+                    cx.emit(Event::RoomJoined { channel_id, role });
                     room.update(cx, |room, cx| room.set_location(location.as_ref(), cx))
                 }
             } else {

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -442,6 +442,8 @@ impl ActiveCall {
                         .location
                         .as_ref()
                         .and_then(|location| location.upgrade());
+                    let channel_id = room.update(cx, |room, cx| room.channel_id());
+                    cx.emit(Event::RoomJoined { channel_id });
                     room.update(cx, |room, cx| room.set_location(location.as_ref(), cx))
                 }
             } else {

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -442,10 +442,8 @@ impl ActiveCall {
                         .location
                         .as_ref()
                         .and_then(|location| location.upgrade());
-                    let (channel_id, role) = room.update(cx, |room, _| {
-                        (room.channel_id(), room.local_participant().role)
-                    });
-                    cx.emit(Event::RoomJoined { channel_id, role });
+                    let channel_id = room.read(cx).channel_id();
+                    cx.emit(Event::RoomJoined { channel_id });
                     room.update(cx, |room, cx| room.set_location(location.as_ref(), cx))
                 }
             } else {

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -28,7 +28,6 @@ pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 pub enum Event {
     RoomJoined {
         channel_id: Option<u64>,
-        role: proto::ChannelRole,
     },
     ParticipantLocationChanged {
         participant_id: proto::PeerId,
@@ -53,7 +52,9 @@ pub enum Event {
     RemoteProjectInvitationDiscarded {
         project_id: u64,
     },
-    Left,
+    Left {
+        channel_id: Option<u64>,
+    },
 }
 
 pub struct Room {
@@ -361,7 +362,9 @@ impl Room {
 
     pub(crate) fn leave(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         cx.notify();
-        cx.emit(Event::Left);
+        cx.emit(Event::Left {
+            channel_id: self.channel_id(),
+        });
         self.leave_internal(cx)
     }
 
@@ -600,6 +603,14 @@ impl Room {
         self.remote_participants
             .get(&user_id)
             .map(|participant| participant.role)
+    }
+
+    pub fn contains_guests(&self) -> bool {
+        self.local_participant.role == proto::ChannelRole::Guest
+            || self
+                .remote_participants
+                .values()
+                .any(|p| p.role == proto::ChannelRole::Guest)
     }
 
     pub fn local_participant_is_admin(&self) -> bool {

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -28,6 +28,7 @@ pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 pub enum Event {
     RoomJoined {
         channel_id: Option<u64>,
+        role: proto::ChannelRole,
     },
     ParticipantLocationChanged {
         participant_id: proto::PeerId,

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -26,6 +26,9 @@ pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
+    RoomJoined {
+        channel_id: Option<u64>,
+    },
     ParticipantLocationChanged {
         participant_id: proto::PeerId,
     },

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -144,7 +144,7 @@ impl ChannelChat {
         message: MessageParams,
         cx: &mut ModelContext<Self>,
     ) -> Result<Task<Result<u64>>> {
-        if message.text.is_empty() {
+        if message.text.trim().is_empty() {
             Err(anyhow!("message body can't be empty"))?;
         }
 
@@ -174,6 +174,8 @@ impl ChannelChat {
         let user_store = self.user_store.clone();
         let rpc = self.rpc.clone();
         let outgoing_messages_lock = self.outgoing_messages_lock.clone();
+
+        // todo - handle messages that fail to send (e.g. >1024 chars)
         Ok(cx.spawn(move |this, mut cx| async move {
             let outgoing_message_guard = outgoing_messages_lock.lock().await;
             let request = rpc.request(proto::SendChannelMessage {

--- a/crates/collab/src/db/queries/messages.rs
+++ b/crates/collab/src/db/queries/messages.rs
@@ -256,6 +256,7 @@ impl Database {
                     message_id = result.last_insert_id;
                     let mentioned_user_ids =
                         mentions.iter().map(|m| m.user_id).collect::<HashSet<_>>();
+
                     let mentions = mentions
                         .iter()
                         .filter_map(|mention| {

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -1,6 +1,6 @@
 use crate::{channel_view::ChannelView, is_channels_feature_enabled, ChatPanelSettings};
 use anyhow::Result;
-use call::ActiveCall;
+use call::{room, ActiveCall};
 use channel::{ChannelChat, ChannelChatEvent, ChannelMessageId, ChannelStore};
 use client::Client;
 use collections::HashMap;
@@ -138,6 +138,18 @@ impl ChatPanel {
                         cx.emit(Event::DockPositionChanged);
                     }
                     cx.notify();
+                },
+            ));
+            this.subscriptions.push(cx.subscribe(
+                &ActiveCall::global(cx),
+                move |this: &mut Self, _, event: &room::Event, cx| match event {
+                    room::Event::RoomJoined { channel_id } => {
+                        if let Some(channel_id) = channel_id {
+                            this.select_channel(*channel_id, None, cx)
+                                .detach_and_log_err(cx)
+                        }
+                    }
+                    _ => {}
                 },
             ));
 

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -143,15 +143,24 @@ impl ChatPanel {
             ));
             this.subscriptions.push(cx.subscribe(
                 &ActiveCall::global(cx),
-                move |this: &mut Self, _, event: &room::Event, cx| match event {
-                    room::Event::RoomJoined { channel_id, role } => {
+                move |this: &mut Self, call, event: &room::Event, cx| match event {
+                    room::Event::RoomJoined { channel_id } => {
                         if let Some(channel_id) = channel_id {
                             this.select_channel(*channel_id, None, cx)
                                 .detach_and_log_err(cx);
 
-                            if *role == proto::ChannelRole::Guest {
+                            if call
+                                .read(cx)
+                                .room()
+                                .is_some_and(|room| room.read(cx).contains_guests())
+                            {
                                 cx.emit(PanelEvent::Activate)
                             }
+                        }
+                    }
+                    room::Event::Left { channel_id } => {
+                        if channel_id == &this.channel_id(cx) {
+                            cx.emit(PanelEvent::Close)
                         }
                     }
                     _ => {}
@@ -160,6 +169,12 @@ impl ChatPanel {
 
             this
         })
+    }
+
+    pub fn channel_id(&self, cx: &AppContext) -> Option<u64> {
+        self.active_chat
+            .as_ref()
+            .map(|(chat, _)| chat.read(cx).channel_id)
     }
 
     pub fn is_scrolled_to_bottom(&self) -> bool {

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -127,17 +127,6 @@ impl ChatPanel {
                 open_context_menu: None,
             };
 
-            let mut old_dock_position = this.position(cx);
-            this.subscriptions.push(cx.observe_global::<SettingsStore>(
-                move |this: &mut Self, cx| {
-                    let new_dock_position = this.position(cx);
-                    if new_dock_position != old_dock_position {
-                        old_dock_position = new_dock_position;
-                        cx.emit(PanelEvent::ChangePosition);
-                    }
-                    cx.notify();
-                },
-            ));
             this.subscriptions.push(cx.subscribe(
                 &ActiveCall::global(cx),
                 move |this: &mut Self, call, event: &room::Event, cx| match event {

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -1,4 +1,4 @@
-use crate::{collab_panel, is_channels_feature_enabled, ChatPanelSettings, CollabPanel};
+use crate::{collab_panel, is_channels_feature_enabled, ChatPanelSettings};
 use anyhow::Result;
 use call::{room, ActiveCall};
 use channel::{ChannelChat, ChannelChatEvent, ChannelMessageId, ChannelStore};
@@ -7,24 +7,22 @@ use collections::HashMap;
 use db::kvp::KEY_VALUE_STORE;
 use editor::Editor;
 use gpui::{
-    actions, div, list, prelude::*, px, Action, AnyElement, AppContext, AsyncWindowContext,
-    ClickEvent, DismissEvent, ElementId, EventEmitter, FocusHandle, FocusableView, FontWeight,
-    ListOffset, ListScrollEvent, ListState, Model, Render, Subscription, Task, View, ViewContext,
-    VisualContext, WeakView,
+    actions, div, list, prelude::*, px, Action, AppContext, AsyncWindowContext, DismissEvent,
+    ElementId, EventEmitter, FocusHandle, FocusableView, FontWeight, ListOffset, ListScrollEvent,
+    ListState, Model, Render, Subscription, Task, View, ViewContext, VisualContext, WeakView,
 };
 use language::LanguageRegistry;
 use menu::Confirm;
 use message_editor::MessageEditor;
 use project::Fs;
 use rich_text::RichText;
-use rpc::proto;
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsStore};
+use settings::Settings;
 use std::sync::Arc;
 use time::{OffsetDateTime, UtcOffset};
 use ui::{
-    popover_menu, prelude::*, Avatar, Button, ContextMenu, IconButton, IconName, Key, KeyBinding,
-    Label, TabBar, Tooltip,
+    popover_menu, prelude::*, Avatar, Button, ContextMenu, IconButton, IconName, KeyBinding, Label,
+    TabBar,
 };
 use util::{ResultExt, TryFutureExt};
 use workspace::{
@@ -279,7 +277,7 @@ impl ChatPanel {
 
     fn render_message(&mut self, ix: usize, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let active_chat = &self.active_chat.as_ref().unwrap().0;
-        let (message, is_continuation_from_previous, is_continuation_to_next, is_admin) =
+        let (message, is_continuation_from_previous, is_admin) =
             active_chat.update(cx, |active_chat, cx| {
                 let is_admin = self
                     .channel_store
@@ -288,13 +286,9 @@ impl ChatPanel {
 
                 let last_message = active_chat.message(ix.saturating_sub(1));
                 let this_message = active_chat.message(ix).clone();
-                let next_message =
-                    active_chat.message(ix.saturating_add(1).min(active_chat.message_count() - 1));
 
                 let is_continuation_from_previous = last_message.id != this_message.id
                     && last_message.sender.id == this_message.sender.id;
-                let is_continuation_to_next = this_message.id != next_message.id
-                    && this_message.sender.id == next_message.sender.id;
 
                 if let ChannelMessageId::Saved(id) = this_message.id {
                     if this_message
@@ -306,12 +300,7 @@ impl ChatPanel {
                     }
                 }
 
-                (
-                    this_message,
-                    is_continuation_from_previous,
-                    is_continuation_to_next,
-                    is_admin,
-                )
+                (this_message, is_continuation_from_previous, is_admin)
             });
 
         let _is_pending = message.is_pending();

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -16,6 +16,7 @@ use menu::Confirm;
 use message_editor::MessageEditor;
 use project::Fs;
 use rich_text::RichText;
+use rpc::proto;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use std::sync::Arc;
@@ -143,10 +144,14 @@ impl ChatPanel {
             this.subscriptions.push(cx.subscribe(
                 &ActiveCall::global(cx),
                 move |this: &mut Self, _, event: &room::Event, cx| match event {
-                    room::Event::RoomJoined { channel_id } => {
+                    room::Event::RoomJoined { channel_id, role } => {
                         if let Some(channel_id) = channel_id {
                             this.select_channel(*channel_id, None, cx)
-                                .detach_and_log_err(cx)
+                                .detach_and_log_err(cx);
+
+                            if *role == proto::ChannelRole::Guest {
+                                cx.emit(PanelEvent::Activate)
+                            }
                         }
                     }
                     _ => {}

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -70,13 +70,6 @@ struct SerializedChatPanel {
     width: Option<Pixels>,
 }
 
-#[derive(Debug)]
-pub enum Event {
-    DockPositionChanged,
-    Focus,
-    Dismissed,
-}
-
 actions!(chat_panel, [ToggleFocus]);
 
 impl ChatPanel {
@@ -140,7 +133,7 @@ impl ChatPanel {
                     let new_dock_position = this.position(cx);
                     if new_dock_position != old_dock_position {
                         old_dock_position = new_dock_position;
-                        cx.emit(Event::DockPositionChanged);
+                        cx.emit(PanelEvent::ChangePosition);
                     }
                     cx.notify();
                 },
@@ -541,8 +534,6 @@ impl ChatPanel {
     }
 }
 
-impl EventEmitter<Event> for ChatPanel {}
-
 impl Render for ChatPanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_stack()
@@ -662,7 +653,7 @@ impl Panel for ChatPanel {
         if active {
             self.acknowledge_last_message(cx);
             if !is_channels_feature_enabled(cx) {
-                cx.emit(Event::Dismissed);
+                cx.emit(PanelEvent::Close);
             }
         }
     }

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -112,7 +112,7 @@ impl ChatPanel {
                 if event.visible_range.start < MESSAGE_LOADING_THRESHOLD {
                     this.load_more_messages(cx);
                 }
-                this.is_scrolled_to_bottom = event.visible_range.end == event.count;
+                this.is_scrolled_to_bottom = !event.is_scrolled;
             }));
 
             let mut this = Self {
@@ -567,7 +567,7 @@ impl Render for ChatPanel {
                     ),
                 ),
             )
-            .child(div().flex_grow().px_2().py_1().map(|this| {
+            .child(div().flex_grow().px_2().pt_1().map(|this| {
                 if self.active_chat.is_some() {
                     this.child(list(self.message_list.clone()).full())
                 } else {
@@ -597,19 +597,26 @@ impl Render for ChatPanel {
                     )
                 }
             }))
-            .child(h_stack().p_2().map(|el| {
-                if self.active_chat.is_some() {
-                    el.child(self.message_editor.clone())
-                } else {
-                    el.child(
-                        div()
-                            .rounded_md()
-                            .h_7()
-                            .w_full()
-                            .bg(cx.theme().colors().editor_background),
-                    )
-                }
-            }))
+            .child(
+                h_stack()
+                    .when(!self.is_scrolled_to_bottom, |el| {
+                        el.border_t_1().border_color(cx.theme().colors().border)
+                    })
+                    .p_2()
+                    .map(|el| {
+                        if self.active_chat.is_some() {
+                            el.child(self.message_editor.clone())
+                        } else {
+                            el.child(
+                                div()
+                                    .rounded_md()
+                                    .h_7()
+                                    .w_full()
+                                    .bg(cx.theme().colors().editor_background),
+                            )
+                        }
+                    }),
+            )
             .into_any()
     }
 }

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -59,6 +59,7 @@ pub struct ChatPanel {
     subscriptions: Vec<gpui::Subscription>,
     is_scrolled_to_bottom: bool,
     markdown_data: HashMap<ChannelMessageId, RichText>,
+    focus_handle: FocusHandle,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -126,6 +127,7 @@ impl ChatPanel {
                 active: false,
                 width: None,
                 markdown_data: Default::default(),
+                focus_handle: cx.focus_handle(),
             };
 
             let mut old_dock_position = this.position(cx);
@@ -490,6 +492,7 @@ impl EventEmitter<Event> for ChatPanel {}
 impl Render for ChatPanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_stack()
+            .track_focus(&self.focus_handle)
             .full()
             .on_action(cx.listener(Self::send))
             .child(
@@ -559,7 +562,11 @@ impl Render for ChatPanel {
 
 impl FocusableView for ChatPanel {
     fn focus_handle(&self, cx: &AppContext) -> gpui::FocusHandle {
-        self.message_editor.read(cx).focus_handle(cx)
+        if self.active_chat.is_some() {
+            self.message_editor.read(cx).focus_handle(cx)
+        } else {
+            self.focus_handle.clone()
+        }
     }
 }
 

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -26,7 +26,7 @@ use menu::{Cancel, Confirm, SelectNext, SelectPrev};
 use project::{Fs, Project};
 use rpc::proto::{self, PeerId};
 use serde_derive::{Deserialize, Serialize};
-use settings::{Settings, SettingsStore};
+use settings::Settings;
 use smallvec::SmallVec;
 use std::{mem, sync::Arc};
 use theme::{ActiveTheme, ThemeSettings};

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -254,19 +254,6 @@ impl CollabPanel {
 
             this.update_entries(false, cx);
 
-            // Update the dock position when the setting changes.
-            let mut old_dock_position = this.position(cx);
-            this.subscriptions.push(cx.observe_global::<SettingsStore>(
-                move |this: &mut Self, cx| {
-                    let new_dock_position = this.position(cx);
-                    if new_dock_position != old_dock_position {
-                        old_dock_position = new_dock_position;
-                        cx.emit(PanelEvent::ChangePosition);
-                    }
-                    cx.notify();
-                },
-            ));
-
             let active_call = ActiveCall::global(cx);
             this.subscriptions
                 .push(cx.observe(&this.user_store, |this, _, cx| {

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -58,7 +58,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
             }
         }
 
-        room::Event::Left => {
+        room::Event::Left { .. } => {
             for (_, windows) in notification_windows.drain() {
                 for window in windows {
                     window

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -43,6 +43,7 @@ pub enum ListAlignment {
 pub struct ListScrollEvent {
     pub visible_range: Range<usize>,
     pub count: usize,
+    pub is_scrolled: bool,
 }
 
 #[derive(Clone)]
@@ -253,6 +254,7 @@ impl StateInner {
                 &ListScrollEvent {
                     visible_range,
                     count: self.items.summary().count,
+                    is_scrolled: self.logical_scroll_top.is_some(),
                 },
                 cx,
             );

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,7 +1,7 @@
 use crate::{
     self as gpui, hsla, point, px, relative, rems, AbsoluteLength, AlignItems, CursorStyle,
-    DefiniteLength, Display, Fill, FlexDirection, Hsla, JustifyContent, Length, Position,
-    SharedString, StyleRefinement, Visibility, WhiteSpace,
+    DefiniteLength, Display, Fill, FlexDirection, FontWeight, Hsla, JustifyContent, Length,
+    Position, SharedString, StyleRefinement, Visibility, WhiteSpace,
 };
 use crate::{BoxShadow, TextStyleRefinement};
 use smallvec::{smallvec, SmallVec};
@@ -491,6 +491,13 @@ pub trait Styled: Sized {
 
     fn text_color(mut self, color: impl Into<Hsla>) -> Self {
         self.text_style().get_or_insert_with(Default::default).color = Some(color.into());
+        self
+    }
+
+    fn font_weight(mut self, weight: FontWeight) -> Self {
+        self.text_style()
+            .get_or_insert_with(Default::default)
+            .font_weight = Some(weight);
         self
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1,6 +1,6 @@
 pub mod file_associations;
 mod project_panel_settings;
-use settings::{Settings, SettingsStore};
+use settings::Settings;
 
 use db::kvp::KEY_VALUE_STORE;
 use editor::{scroll::autoscroll::Autoscroll, Cancel, Editor};

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -246,18 +246,6 @@ impl ProjectPanel {
             };
             this.update_visible_entries(None, cx);
 
-            // Update the dock position when the setting changes.
-            let mut old_dock_position = this.position(cx);
-            ProjectPanelSettings::register(cx);
-            cx.observe_global::<SettingsStore>(move |this, cx| {
-                let new_dock_position = this.position(cx);
-                if new_dock_position != old_dock_position {
-                    old_dock_position = new_dock_position;
-                    cx.emit(PanelEvent::ChangePosition);
-                }
-            })
-            .detach();
-
             this
         });
 

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -39,6 +39,7 @@ pub struct RichText {
 
 /// Allows one to specify extra links to the rendered markdown, which can be used
 /// for e.g. mentions.
+#[derive(Debug)]
 pub struct Mention {
     pub range: Range<usize>,
     pub is_self_mention: bool,
@@ -138,20 +139,21 @@ pub fn render_markdown_mut(
                 if let Some(language) = &current_language {
                     render_code(text, highlights, t.as_ref(), language);
                 } else {
-                    if let Some(mention) = mentions.first() {
-                        if source_range.contains_inclusive(&mention.range) {
-                            mentions = &mentions[1..];
-                            let range = (prev_len + mention.range.start - source_range.start)
-                                ..(prev_len + mention.range.end - source_range.start);
-                            highlights.push((
-                                range.clone(),
-                                if mention.is_self_mention {
-                                    Highlight::SelfMention
-                                } else {
-                                    Highlight::Mention
-                                },
-                            ));
+                    while let Some(mention) = mentions.first() {
+                        if !source_range.contains_inclusive(&mention.range) {
+                            break;
                         }
+                        mentions = &mentions[1..];
+                        let range = (prev_len + mention.range.start - source_range.start)
+                            ..(prev_len + mention.range.end - source_range.start);
+                        highlights.push((
+                            range.clone(),
+                            if mention.is_self_mention {
+                                Highlight::SelfMention
+                            } else {
+                                Highlight::Mention
+                            },
+                        ));
                     }
 
                     text.push_str(t.as_ref());

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use project::{Fs, ProjectEntryId};
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsStore};
+use settings::Settings;
 use terminal::terminal_settings::{TerminalDockPosition, TerminalSettings};
 use ui::{h_stack, ButtonCommon, Clickable, IconButton, IconSize, Selectable, Tooltip};
 use util::{ResultExt, TryFutureExt};

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -159,15 +159,6 @@ impl TerminalPanel {
             height: None,
             _subscriptions: subscriptions,
         };
-        let mut old_dock_position = this.position(cx);
-        cx.observe_global::<SettingsStore>(move |this, cx| {
-            let new_dock_position = this.position(cx);
-            if new_dock_position != old_dock_position {
-                old_dock_position = new_dock_position;
-                cx.emit(PanelEvent::ChangePosition);
-            }
-        })
-        .detach();
         this
     }
 

--- a/crates/ui/src/components/avatar.rs
+++ b/crates/ui/src/components/avatar.rs
@@ -26,6 +26,7 @@ pub enum AvatarShape {
 #[derive(IntoElement)]
 pub struct Avatar {
     image: Img,
+    size: Option<Pixels>,
     border_color: Option<Hsla>,
     is_available: Option<bool>,
 }
@@ -36,7 +37,7 @@ impl RenderOnce for Avatar {
             self = self.shape(AvatarShape::Circle);
         }
 
-        let size = cx.rem_size();
+        let size = self.size.unwrap_or_else(|| cx.rem_size());
 
         div()
             .size(size + px(2.))
@@ -78,6 +79,7 @@ impl Avatar {
             image: img(src),
             is_available: None,
             border_color: None,
+            size: None,
         }
     }
 
@@ -122,6 +124,12 @@ impl Avatar {
 
     pub fn availability_indicator(mut self, is_available: impl Into<Option<bool>>) -> Self {
         self.is_available = is_available.into();
+        self
+    }
+
+    /// Size overrides the avatar size. By default they are 1rem.
+    pub fn size(mut self, size: impl Into<Option<Pixels>>) -> Self {
+        self.size = size.into();
         self
     }
 }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -743,8 +743,9 @@ pub mod test {
             true
         }
 
-        fn set_position(&mut self, position: DockPosition, _: &mut ViewContext<Self>) {
+        fn set_position(&mut self, position: DockPosition, cx: &mut ViewContext<Self>) {
             self.position = position;
+            cx.update_global::<SettingsStore, _>(|_, _| {});
         }
 
         fn size(&self, _: &WindowContext) -> Pixels {


### PR DESCRIPTION
- Update chat panel with current channel
- Open chat panel for guests
- Open chat when joining a channel with guests
- Some tweaks for chat panels
- Don't lose focus on default panel state
- Make chat prettier (to my eyes at least)
- Fix multiple mentions in one message
- Show a border when scrolled in chat
- Fix re-docking chat panel
- Move settings subscription to dock

[[PR Description]]

Release Notes:

- Opens chat by default when joining a public channel
- Improves chat panel UI
