### PR TITLE
Fix editor stealing click events from copy-error button

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -388,7 +388,9 @@ impl EditorElement {
         let mut click_count = event.click_count;
         let modifiers = event.modifiers;
 
-        if gutter_bounds.contains(&event.position) {
+        if cx.default_prevented() {
+            return;
+        } else if gutter_bounds.contains(&event.position) {
             click_count = 3; // Simulate triple-click when clicking the gutter to select lines
         } else if !text_bounds.contains(&event.position) {
             return;


### PR DESCRIPTION
This fixes the click event on the "copy error message" button by changing the `editor` element to ignore mouse-down events when the default was prevented. That's similar to how `div` does it.

Release Notes:

- Fixed a bug that prevented "copy error message" button from being clicked.
