### PR TITLE
gpui: Pin to font-kit with improved OTC parsing performance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "font-kit"
 version = "0.11.0"
-source = "git+https://github.com/zed-industries/font-kit?rev=b2f77d56f450338aa4f7dd2f0197d8c9acb0cf18#b2f77d56f450338aa4f7dd2f0197d8c9acb0cf18"
+source = "git+https://github.com/zed-industries/font-kit?rev=d97147f#d97147ff11a9024b9707d9c9c7e3a0bdaba048ac"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -78,7 +78,7 @@ cocoa = "0.24"
 core-foundation = { version = "0.9.3", features = ["with-uuid"] }
 core-graphics = "0.22.3"
 core-text = "19.2"
-font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "b2f77d56f450338aa4f7dd2f0197d8c9acb0cf18" }
+font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "d97147f" }
 foreign-types = "0.3"
 log.workspace = true
 metal = "0.21.0"

--- a/crates/gpui/src/platform/mac/open_type.rs
+++ b/crates/gpui/src/platform/mac/open_type.rs
@@ -378,7 +378,7 @@ fn toggle_open_type_feature(
                 new_descriptor.as_concrete_TypeRef(),
             );
             let new_font = CTFont::wrap_under_create_rule(new_font);
-            *font = Font::from_native_font(new_font);
+            *font = Font::from_native_font(&new_font);
         }
     }
 }


### PR DESCRIPTION
Details are in https://github.com/zed-industries/font-kit/pull/1; We're not doing anything too fancy, really. Still, you should mostly see font loading times drop significantly for font collections
Fixes Z-2578
Release Notes:
- Improved loading performance of large font collections (e.g. Iosevka). Fixes https://github.com/zed-industries/zed/issues/6205, https://github.com/zed-industries/zed/issues/5554

https://github.com/zed-industries/zed/assets/24362066/f70edbad-ded6-4c12-9c6d-7a487f330a1b

