### PR TITLE
Disable copilot for feedback and lsp log editors

### DIFF
--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -186,6 +186,7 @@ impl FeedbackModal {
                 cx,
             );
             editor.set_show_gutter(false, cx);
+            editor.set_show_copilot_suggestions(false);
             editor.set_vertical_scroll_margin(5, cx);
             editor
         });

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -449,6 +449,7 @@ impl LspLogView {
             editor.set_text(log_contents, cx);
             editor.move_to_end(&MoveToEnd, cx);
             editor.set_read_only(true);
+            editor.set_show_copilot_suggestions(false);
             editor
         });
         let editor_subscription = cx.subscribe(


### PR DESCRIPTION
LSP log editor caused recursive flood of messages, and feedback editor is better with people writing their own feedback.

Release Notes:

- Fixed hanging due to excessive logs when browsing Copilot LSP logs