### PR TITLE
Avoid retrieving layout bounds inside of right click menu event handler

### DIFF
--- a/crates/ui/src/components/right_click_menu.rs
+++ b/crates/ui/src/components/right_click_menu.rs
@@ -134,6 +134,7 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
         let position = element_state.position.clone();
         let attach = self.attach.clone();
         let child_layout_id = element_state.child_layout_id.clone();
+        let child_bounds = cx.layout_bounds(child_layout_id.unwrap());
 
         cx.on_mouse_event(move |event: &MouseDownEvent, phase, cx| {
             if phase == DispatchPhase::Bubble
@@ -161,9 +162,7 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
                 *menu.borrow_mut() = Some(new_menu);
 
                 *position.borrow_mut() = if attach.is_some() && child_layout_id.is_some() {
-                    attach
-                        .unwrap()
-                        .corner(cx.layout_bounds(child_layout_id.unwrap()))
+                    attach.unwrap().corner(child_bounds)
                 } else {
                     cx.mouse_position()
                 };


### PR DESCRIPTION
By the time the event handler is invoked, all information about the rendered layout tree is gone.

Release Notes:

- N/A
