### PR TITLE
Add LSP logs into the end of the editor, not after its caret

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4513,7 +4513,7 @@ impl Editor {
     }
 
     pub fn tab(&mut self, _: &Tab, cx: &mut ViewContext<Self>) {
-        if self.move_to_next_snippet_tabstop(cx) {
+        if self.move_to_next_snippet_tabstop(cx) || self.read_only(cx) {
             return;
         }
 

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -405,8 +405,14 @@ impl LspLogView {
                     {
                         log_view.editor.update(cx, |editor, cx| {
                             editor.set_read_only(false);
-                            editor.handle_input(entry.trim(), cx);
-                            editor.handle_input("\n", cx);
+                            let last_point = editor.buffer().read(cx).len(cx);
+                            editor.edit(
+                                vec![
+                                    (last_point..last_point, entry.trim()),
+                                    (last_point..last_point, "\n"),
+                                ],
+                                cx,
+                            );
                             editor.set_read_only(true);
                         });
                     }


### PR DESCRIPTION
Also prevent tabs from being added in readonly editors

Release Notes:

- Fixed LSP logs being inserted into the editor incorrectly
- Fixed `editor::Tab` action inserting tabs in read-only files