### PR TITLE
Fix previous theme not being applied on startup

### DIFF
--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -62,6 +62,10 @@ pub enum LoadThemes {
 
 pub fn init(themes_to_load: LoadThemes, cx: &mut AppContext) {
     cx.set_global(ThemeRegistry::default());
+    match themes_to_load {
+        LoadThemes::JustBase => (),
+        LoadThemes::All => cx.global_mut::<ThemeRegistry>().load_user_themes(),
+    }
     ThemeSettings::register(cx);
 
     let mut prev_buffer_font_size = ThemeSettings::get_global(cx).buffer_font_size;
@@ -73,11 +77,6 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut AppContext) {
         }
     })
     .detach();
-
-    match themes_to_load {
-        LoadThemes::JustBase => (),
-        LoadThemes::All => cx.global_mut::<ThemeRegistry>().load_user_themes(),
-    }
 }
 
 pub trait ActiveTheme {


### PR DESCRIPTION
Fixes `[2024-01-16T09:21:54Z ERROR util] crates/theme/src/settings.rs:172: theme not found: One Light` error from the log after https://github.com/zed-industries/zed/commit/d84785f7e8519b30e474385e5a72f5726cf4783e

Release Notes:

- N/A