### PR TITLE
Fix overlapping block headers when using custom line height

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2288,17 +2288,18 @@ impl EditorElement {
                                 .map(|p| SharedString::from(p.to_string_lossy().to_string() + "/"));
                         }
 
-                        div()
+                        v_flex()
                             .id(("path header container", block_id))
                             .size_full()
-                            .p_1p5()
+                            .justify_center()
+                            .p(gpui::px(6.))
                             .child(
                                 h_flex()
                                     .id("path header block")
-                                    .py_1p5()
-                                    .pl_3()
-                                    .pr_2()
-                                    .rounded_lg()
+                                    .size_full()
+                                    .pl(gpui::px(12.))
+                                    .pr(gpui::px(8.))
+                                    .rounded_md()
                                     .shadow_md()
                                     .border()
                                     .border_color(cx.theme().colors().border)
@@ -2861,6 +2862,7 @@ impl Element for EditorElement {
             cx.with_text_style(
                 Some(gpui::TextStyleRefinement {
                     font_size: Some(self.style.text.font_size),
+                    line_height: Some(self.style.text.line_height),
                     ..Default::default()
                 }),
                 |cx| {


### PR DESCRIPTION
This fixes block headers overlapping over text in the buffer when using a custom line height of 1.25.

It fixes the issue by making the parent container a v-flex, vertically-justifying the content and moving from relative padding to absolute padding for the header itself.

## Before/After

With setting:
```json
  "buffer_line_height": {
    "custom": 1.25
  },
```

### Before

![screenshot-2024-01-16-16 48 48@2x](https://github.com/zed-industries/zed/assets/1185253/8c3b977e-333f-403c-a4d3-0911f3fac5e0)

### After

![screenshot-2024-01-16-16 50 13@2x](https://github.com/zed-industries/zed/assets/1185253/2d854eba-c4c4-4bce-b60b-dd250856b08f)

### Release notes
Release Notes:

- Fixed headers in multi-buffers overlapping over content of the buffer
