### PR TITLE
List all font names in settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,6 +7776,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_derive",
+ "serde_json",
  "settings",
  "shellexpand",
  "smallvec",

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -192,7 +192,7 @@ pub trait PlatformDispatcher: Send + Sync {
 
 pub trait PlatformTextSystem: Send + Sync {
     fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> Result<()>;
-    fn all_font_families(&self) -> Vec<String>;
+    fn all_font_names(&self) -> Vec<String>;
     fn font_id(&self, descriptor: &Font) -> Result<FontId>;
     fn font_metrics(&self, font_id: FontId) -> FontMetrics;
     fn typographic_bounds(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Bounds<f32>>;

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -65,8 +65,8 @@ impl TextSystem {
         }
     }
 
-    pub fn all_font_families(&self) -> Vec<String> {
-        let mut families = self.platform_text_system.all_font_families();
+    pub fn all_font_names(&self) -> Vec<String> {
+        let mut families = self.platform_text_system.all_font_names();
         families.append(
             &mut self
                 .fallback_font_stack
@@ -101,7 +101,6 @@ impl TextSystem {
         if let Ok(font_id) = self.font_id(font) {
             return font_id;
         }
-
         for fallback in &self.fallback_font_stack {
             if let Ok(font_id) = self.font_id(fallback) {
                 return font_id;

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -33,6 +33,7 @@ thiserror.workspace = true
 lazy_static.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -205,7 +205,7 @@ impl settings::Settings for ThemeSettings {
 
         let available_fonts = cx
             .text_system()
-            .all_font_families()
+            .all_font_names()
             .into_iter()
             .map(Value::String)
             .collect();

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -234,6 +234,10 @@ impl settings::Settings for ThemeSettings {
                     "buffer_font_family".to_owned(),
                     Schema::new_ref("#/definitions/FontFamilies".into()),
                 ),
+                (
+                    "ui_font_family".to_owned(),
+                    Schema::new_ref("#/definitions/FontFamilies".into()),
+                ),
             ]);
 
         root_schema


### PR DESCRIPTION
This fixes an issue reported by @maxdeviant  where font name completions were a subset of valid names accepted by Zed. It also adds completions to two other font settings that I've missed initially: UI and terminal (thx Nate)

Release Notes:
- Fixed font name completions listing font families instead of font names.
- Added font name completions to `ui_font_family` and `terminal::font_family` settings.
