### PR TITLE
Play guess who's to blame

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -14,7 +14,6 @@ use foreign_types::ForeignType;
 use media::core_video::CVMetalTextureCache;
 use metal::{CommandQueue, MTLPixelFormat, MTLResourceOptions, NSRange};
 use objc::{self, msg_send, sel, sel_impl};
-use smallvec::SmallVec;
 use std::{ffi::c_void, mem, ptr, sync::Arc};
 
 const SHADERS_METALLIB: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shaders.metallib"));
@@ -538,7 +537,7 @@ impl MetalRenderer {
         );
 
         let mut prev_texture_id = None;
-        let mut sprites = SmallVec::<[_; 1]>::new();
+        let mut sprites = Vec::new();
         let mut paths_and_tiles = paths
             .iter()
             .map(|path| (path, tiles_by_path_id.get(&path.id).unwrap()))


### PR DESCRIPTION
We're occasionally seeing a crash in MetalRenderer::draw.

Looking at the backtrace, it seems almost certainly to be happening in the call to `ptr::copy_nonoverlapping` on line 604 (see `#Don't Panic!` channel notes)

As we already have added bounds checking to the destination, it seems most
likely (however improbable) that somehow we're getting an invalid Ptr and
length from the SmallVec.

To try and make progress on this, let's try a Vec for a bit lest there is a subtle issue in SmallVec (though I couldn't spot one).


Release Notes:

- (maybe) Fixes SEGFAULT in MetalRenderer::draw
