### PR TITLE
Tweak mute indicator positioning

### DIFF
--- a/crates/ui/src/components/avatar/avatar_audio_status_indicator.rs
+++ b/crates/ui/src/components/avatar/avatar_audio_status_indicator.rs
@@ -37,8 +37,8 @@ impl RenderOnce for AvatarAudioStatusIndicator {
 
         div()
             .absolute()
-            .bottom(rems(-1. / 16.))
-            .right(rems(-4. / 16.))
+            .bottom(rems(-3. / 16.))
+            .right(rems(-6. / 16.))
             .w(width_in_px + padding_x)
             .h(icon_size.rems())
             .child(


### PR DESCRIPTION
This PR tweaks the positioning of the mute indicators so that they cover a little bit less of the avatar:

#### Before

<img width="305" alt="Screenshot 2024-01-16 at 6 32 51 PM" src="https://github.com/zed-industries/zed/assets/1486634/3f6ad2f4-2c3e-498b-97a4-8b522f3ceda9">

#### After

<img width="311" alt="Screenshot 2024-01-16 at 6 26 48 PM" src="https://github.com/zed-industries/zed/assets/1486634/37161557-084d-4b69-b61f-a0958e8e867c">

(It's a bit hard to tell in the screenshot, but there is a gap between the bottom of the indicator and the top of the color ribbon).

Release Notes:

- N/A
