### PR TITLE
Fix missing Ctrl-[ bindings in Vim mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -99,7 +99,7 @@
       "ctrl-i": "pane::GoForward",
       "ctrl-]": "editor::GoToDefinition",
       "escape": ["vim::SwitchMode", "Normal"],
-      "ctrl+[": ["vim::SwitchMode", "Normal"],
+      "ctrl-[": ["vim::SwitchMode", "Normal"],
       "v": "vim::ToggleVisual",
       "shift-v": "vim::ToggleVisualLine",
       "ctrl-v": "vim::ToggleVisualBlock",
@@ -288,7 +288,7 @@
     "context": "Editor && vim_mode == normal && vim_operator == none && !VimWaiting",
     "bindings": {
       "escape": "editor::Cancel",
-      "ctrl+[": "editor::Cancel"
+      "ctrl-[": "editor::Cancel"
     }
   },
   {
@@ -441,7 +441,7 @@
       "r": ["vim::PushOperator", "Replace"],
       "ctrl-c": ["vim::SwitchMode", "Normal"],
       "escape": ["vim::SwitchMode", "Normal"],
-      "ctrl+[": ["vim::SwitchMode", "Normal"],
+      "ctrl-[": ["vim::SwitchMode", "Normal"],
       ">": "editor::Indent",
       "<": "editor::Outdent",
       "i": [
@@ -481,7 +481,7 @@
       "tab": "vim::Tab",
       "enter": "vim::Enter",
       "escape": ["vim::SwitchMode", "Normal"],
-      "ctrl+[": ["vim::SwitchMode", "Normal"]
+      "ctrl-[": ["vim::SwitchMode", "Normal"]
     }
   },
   {

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -72,6 +72,30 @@ async fn test_toggle_through_settings(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_cancel_selection(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+
+    cx.set_state(
+        indoc! {"The quick brown fox juˇmps over the lazy dog"},
+        Mode::Normal,
+    );
+    // jumps
+    cx.simulate_keystrokes(["v", "l", "l"]);
+    cx.assert_editor_state("The quick brown fox ju«mpsˇ» over the lazy dog");
+
+    cx.simulate_keystrokes(["escape"]);
+    cx.assert_editor_state("The quick brown fox jumpˇs over the lazy dog");
+
+    // go back to the same selection state
+    cx.simulate_keystrokes(["v", "h", "h"]);
+    cx.assert_editor_state("The quick brown fox ju«ˇmps» over the lazy dog");
+
+    // Ctrl-[ should behave like Esc
+    cx.simulate_keystrokes(["ctrl-["]);
+    cx.assert_editor_state("The quick brown fox juˇmps over the lazy dog");
+}
+
+#[gpui::test]
 async fn test_buffer_search(cx: &mut gpui::TestAppContext) {
     let mut cx = VimTestContext::new(cx, true).await;
 


### PR DESCRIPTION
This "adds" the keybindings I was missing in Vim mode (e.g. `Ctrl-[` to cancel a selection) by fixing the definitions in the keymap from `Ctrl+[` to `Ctrl-[`.

Release Notes:

- Fixed missing `Ctrl-[` keybindings in Vim mode where `Ctrl-[` should act like `Esc` but didn't.
