### PR TITLE
Submit bigger primitive batches when rendering

### DIFF
--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -299,8 +299,8 @@ impl<'a> Iterator for BatchIterator<'a> {
 
         let first = orders_and_kinds[0];
         let second = orders_and_kinds[1];
-        let (batch_kind, max_order) = if first.0.is_some() {
-            (first.1, second.0.unwrap_or(u32::MAX))
+        let (batch_kind, max_order_and_kind) = if first.0.is_some() {
+            (first.1, (second.0.unwrap_or(u32::MAX), second.1))
         } else {
             return None;
         };
@@ -312,7 +312,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.shadows_iter.next();
                 while self
                     .shadows_iter
-                    .next_if(|shadow| shadow.order < max_order)
+                    .next_if(|shadow| (shadow.order, batch_kind) < max_order_and_kind)
                     .is_some()
                 {
                     shadows_end += 1;
@@ -328,7 +328,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.quads_iter.next();
                 while self
                     .quads_iter
-                    .next_if(|quad| quad.order < max_order)
+                    .next_if(|quad| (quad.order, batch_kind) < max_order_and_kind)
                     .is_some()
                 {
                     quads_end += 1;
@@ -342,7 +342,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.paths_iter.next();
                 while self
                     .paths_iter
-                    .next_if(|path| path.order < max_order)
+                    .next_if(|path| (path.order, batch_kind) < max_order_and_kind)
                     .is_some()
                 {
                     paths_end += 1;
@@ -356,7 +356,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.underlines_iter.next();
                 while self
                     .underlines_iter
-                    .next_if(|underline| underline.order < max_order)
+                    .next_if(|underline| (underline.order, batch_kind) < max_order_and_kind)
                     .is_some()
                 {
                     underlines_end += 1;
@@ -374,7 +374,8 @@ impl<'a> Iterator for BatchIterator<'a> {
                 while self
                     .monochrome_sprites_iter
                     .next_if(|sprite| {
-                        sprite.order < max_order && sprite.tile.texture_id == texture_id
+                        (sprite.order, batch_kind) < max_order_and_kind
+                            && sprite.tile.texture_id == texture_id
                     })
                     .is_some()
                 {
@@ -394,7 +395,8 @@ impl<'a> Iterator for BatchIterator<'a> {
                 while self
                     .polychrome_sprites_iter
                     .next_if(|sprite| {
-                        sprite.order < max_order && sprite.tile.texture_id == texture_id
+                        (sprite.order, batch_kind) < max_order_and_kind
+                            && sprite.tile.texture_id == texture_id
                     })
                     .is_some()
                 {
@@ -412,7 +414,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.surfaces_iter.next();
                 while self
                     .surfaces_iter
-                    .next_if(|surface| surface.order < max_order)
+                    .next_if(|surface| (surface.order, batch_kind) < max_order_and_kind)
                     .is_some()
                 {
                     surfaces_end += 1;


### PR DESCRIPTION
Before this change we wouldn't submit all possible primitives of the same kind that are less-than the max order.

Result was that we would submit, say, 10 paths each in a separate batch instead of actually batching them.

This was overly strict because even if the order of two different primitives was the same, we could have still batched the 1st primitive kind, if its implicit ordering was less than 2nd kind.

Example: say we have the following primitives and these orders

  5x paths, order 3
  2x sprites, order 3

Previously, we would submit 1 path, 1 path, 1 path, 1 path, 1 path, then the sprites.

With this changes, we batch the 5 paths into one batch.

Release Notes:

- Improved performance when rendering lots of selection.
