### PR TITLE
Downgrade LiveKit client

### DIFF
--- a/crates/live_kit_client/LiveKitBridge/Package.resolved
+++ b/crates/live_kit_client/LiveKitBridge/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/livekit/client-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "8b9cefed8d1669ec8fce41376b56dce3036a5f50",
-          "version": "1.1.4"
+          "revision": "7331b813a5ab8a95cfb81fb2b4ed10519428b9ff",
+          "version": "1.0.12"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/webrtc-sdk/Specs.git",
         "state": {
           "branch": null,
-          "revision": "4fa8d6d647fc759cdd0265fd413d2f28ea2e0e08",
-          "version": "114.5735.8"
+          "revision": "2f6bab30c8df0fe59ab3e58bc99097f757f85f65",
+          "version": "104.5112.17"
         }
       },
       {

--- a/crates/live_kit_client/LiveKitBridge/Package.swift
+++ b/crates/live_kit_client/LiveKitBridge/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["LiveKitBridge"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/livekit/client-sdk-swift.git", .exact("1.1.4")),
+        .package(url: "https://github.com/livekit/client-sdk-swift.git", .exact("1.0.12")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
There's a deadlock that we're seeing when joining a room, which we think is a bug in the LiveKit client.

Also, we're still getting crashes when leaving calls: https://github.com/livekit/client-sdk-swift/issues/299.

At this point, we believe both problems are due to recent changes to the LiveKit swift sdk.