### PR TITLE
Also update chat location when opening a new workspace

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -125,6 +125,23 @@ impl ChatPanel {
                 open_context_menu: None,
             };
 
+            if let Some(channel_id) = ActiveCall::global(cx)
+                .read(cx)
+                .room()
+                .and_then(|room| room.read(cx).channel_id())
+            {
+                this.select_channel(channel_id, None, cx)
+                    .detach_and_log_err(cx);
+
+                if ActiveCall::global(cx)
+                    .read(cx)
+                    .room()
+                    .is_some_and(|room| room.read(cx).contains_guests())
+                {
+                    cx.emit(PanelEvent::Activate)
+                }
+            }
+
             this.subscriptions.push(cx.subscribe(
                 &ActiveCall::global(cx),
                 move |this: &mut Self, call, event: &room::Event, cx| match event {


### PR DESCRIPTION
This happens a lot in guest workflows where they open the call with a
link and are jumped straight to a shared workspace.

Release Notes:

- Fixed opening the chat automatically in new windows
