### PR TITLE
Decrease the size of timestamps in the assistant conversation editor

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2311,8 +2311,7 @@ impl ConversationEditor {
                                     }
                                 });
 
-                            div()
-                                .h_flex()
+                            h_flex()
                                 .id(("message_header", message_id.0))
                                 .h_11()
                                 .relative()
@@ -2328,6 +2327,7 @@ impl ConversationEditor {
                                         .add_suffix(true)
                                         .to_string(),
                                     )
+                                    .size(LabelSize::XSmall)
                                     .color(Color::Muted),
                                 )
                                 .children(


### PR DESCRIPTION
This PR decreases the size of the timestamps in the assistant's conversation editor.

Ideally we'd want to align the baseline of the timestamp text with the text in the sender button. I spent a while trying to do this, but it seems like it may be pretty tricky.

Release Notes:

- Decreased the size of timestamps in the assistant panel conversation editor.
