### PR TITLE
settings: Suggest fonts bundled in Zed

### DIFF
--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -87,6 +87,9 @@ impl PlatformTextSystem for MacTextSystem {
         for descriptor in descriptors.into_iter() {
             names.insert(descriptor.display_name());
         }
+        if let Ok(fonts_in_memory) = self.0.read().memory_source.all_families() {
+            names.extend(fonts_in_memory);
+        }
         names.into_iter().collect()
     }
 


### PR DESCRIPTION
Fixes an issue where Zed Sans is not being suggested as a font.

Release Notes:
- N/A
