### PR TITLE
Fix file paths in stories

### DIFF
--- a/crates/ui/src/components/stories/icon_button.rs
+++ b/crates/ui/src/components/stories/icon_button.rs
@@ -113,7 +113,7 @@ impl Render for IconButtonStory {
 
         StoryContainer::new(
             "Icon Button",
-            "crates/ui2/src/components/stories/icon_button.rs",
+            "crates/ui/src/components/stories/icon_button.rs",
         )
         .child(StorySection::new().children(buttons))
         .child(

--- a/crates/ui/src/components/stories/toggle_button.rs
+++ b/crates/ui/src/components/stories/toggle_button.rs
@@ -9,7 +9,7 @@ impl Render for ToggleButtonStory {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
         StoryContainer::new(
             "Toggle Button",
-            "crates/ui2/src/components/stories/toggle_button.rs",
+            "crates/ui/src/components/stories/toggle_button.rs",
         )
         .child(
             StorySection::new().child(


### PR DESCRIPTION
This PR fixes some file paths used in our stories that were still referencing the `ui2` crate.

Release Notes:

- N/A
