### PR TITLE
Fix scrolling in collab panel

### DIFF
--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -643,7 +643,8 @@ impl<'a> VisualTestContext {
     /// Simulate an event from the platform, e.g. a SrollWheelEvent
     /// Make sure you've called [VisualTestContext::draw] first!
     pub fn simulate_event<E: InputEvent>(&mut self, event: E) {
-        self.update(|cx| cx.dispatch_event(event.to_platform_input()));
+        self.test_window(self.window)
+            .simulate_input(event.to_platform_input());
         self.background_executor.run_until_parked();
     }
 

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -3,9 +3,9 @@
 use crate::{
     div, Action, AnyView, AnyWindowHandle, AppCell, AppContext, AsyncAppContext,
     BackgroundExecutor, ClipboardItem, Context, Entity, EventEmitter, ForegroundExecutor,
-    IntoElement, Keystroke, Model, ModelContext, Pixels, Platform, Render, Result, Size, Task,
-    TestDispatcher, TestPlatform, TestWindow, TextSystem, View, ViewContext, VisualContext,
-    WindowContext, WindowHandle, WindowOptions,
+    InputEvent, IntoElement, Keystroke, Model, ModelContext, Pixels, Platform, Render, Result,
+    Size, Task, TestDispatcher, TestPlatform, TestWindow, TextSystem, View, ViewContext,
+    VisualContext, WindowContext, WindowHandle, WindowOptions,
 };
 use anyhow::{anyhow, bail};
 use futures::{Stream, StreamExt};
@@ -607,6 +607,12 @@ impl<'a> VisualTestContext {
     /// Automatically runs until parked.
     pub fn simulate_input(&mut self, input: &str) {
         self.cx.simulate_input(self.window, input)
+    }
+
+    /// Simulate an event from the platform, e.g. a SrollWheelEvent
+    pub fn simulate_event(&mut self, event: InputEvent) {
+        self.update(|cx| cx.dispatch_event(event));
+        self.background_executor.run_until_parked();
     }
 
     /// Simulates the user blurring the window.

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -568,6 +568,11 @@ pub struct VisualTestContext {
 }
 
 impl<'a> VisualTestContext {
+    /// Get the underlying window handle underlying this context.
+    pub fn handle(&self) -> AnyWindowHandle {
+        self.window
+    }
+
     /// Provides the `WindowContext` for the duration of the closure.
     pub fn update<R>(&mut self, f: impl FnOnce(&mut WindowContext) -> R) -> R {
         self.cx.update_window(self.window, |_, cx| f(cx)).unwrap()

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -115,6 +115,12 @@ pub trait Render: 'static + Sized {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement;
 }
 
+impl Render for () {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        ()
+    }
+}
+
 /// You can derive [`IntoElement`] on any type that implements this trait.
 /// It is used to allow views to be expressed in terms of abstract data.
 pub trait RenderOnce: 'static {

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -598,20 +598,30 @@ mod test {
             div().h(px(10.)).w_full().into_any()
         });
 
+        // Ensure that the list is scrolled to the top
+        state.scroll_to(gpui::ListOffset {
+            item_ix: 0,
+            offset_in_item: px(0.0),
+        });
+
+        // Paint
         cx.draw(
             point(px(0.), px(0.)),
             size(px(100.), px(20.)).into(),
             |_| list(state.clone()).w_full().h_full().z_index(10).into_any(),
         );
 
+        // Reset
         state.reset(5);
 
+        // And then recieve a scroll event _before_ the next paint
         cx.simulate_event(ScrollWheelEvent {
             position: point(px(1.), px(1.)),
             delta: ScrollDelta::Pixels(point(px(0.), px(-500.))),
             ..Default::default()
         });
 
+        // Scroll position should stay at the top of the list
         assert_eq!(state.logical_scroll_top().item_ix, 0);
         assert_eq!(state.logical_scroll_top().offset_in_item, px(0.));
 

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1,6 +1,6 @@
 use crate::{
     point, px, AnyElement, AvailableSpace, BorrowAppContext, BorrowWindow, Bounds, ContentMask,
-    DispatchPhase, Element, IntoElement, IsZero, Pixels, Point, ScrollWheelEvent, Size, Style,
+    DispatchPhase, Element, IntoElement, Pixels, Point, ScrollWheelEvent, Size, Style,
     StyleRefinement, Styled, WindowContext,
 };
 use collections::VecDeque;
@@ -584,36 +584,33 @@ impl<'a> sum_tree::SeekTarget<'a, ListItemSummary, ListItemSummary> for Height {
 #[cfg(test)]
 mod test {
 
-    use crate::{self as gpui, Entity, TestAppContext};
+    use gpui::{ScrollDelta, ScrollWheelEvent};
+
+    use crate::{self as gpui, TestAppContext};
 
     #[gpui::test]
     fn test_reset_after_paint_before_scroll(cx: &mut TestAppContext) {
         use crate::{div, list, point, px, size, Element, ListState, Styled};
 
-        let (v, cx) = cx.add_window_view(|_| ());
+        let cx = cx.add_empty_window();
 
         let state = ListState::new(5, crate::ListAlignment::Top, px(10.), |_, _| {
             div().h(px(10.)).w_full().into_any()
         });
 
-        cx.update(|cx| {
-            cx.with_view_id(v.entity_id(), |cx| {
-                list(state.clone())
-                    .w_full()
-                    .h_full()
-                    .z_index(10)
-                    .into_any()
-                    .draw(point(px(0.0), px(0.0)), size(px(100.), px(20.)).into(), cx)
-            });
-        });
+        cx.draw(
+            point(px(0.), px(0.)),
+            size(px(100.), px(20.)).into(),
+            |_| list(state.clone()).w_full().h_full().z_index(10).into_any(),
+        );
 
         state.reset(5);
 
-        cx.simulate_event(gpui::InputEvent::ScrollWheel(gpui::ScrollWheelEvent {
+        cx.simulate_event(ScrollWheelEvent {
             position: point(px(1.), px(1.)),
-            delta: gpui::ScrollDelta::Pixels(point(px(0.), px(-500.))),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-500.))),
             ..Default::default()
-        }));
+        });
 
         assert_eq!(state.logical_scroll_top().item_ix, 0);
         assert_eq!(state.logical_scroll_top().offset_in_item, px(0.));

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -2,7 +2,7 @@ use crate::{
     div, point, Element, IntoElement, Keystroke, Modifiers, Pixels, Point, Render, ViewContext,
 };
 use smallvec::SmallVec;
-use std::{any::Any, fmt::Debug, marker::PhantomData, ops::Deref, path::PathBuf};
+use std::{any::Any, default, fmt::Debug, marker::PhantomData, ops::Deref, path::PathBuf};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeyDownEvent {
@@ -30,9 +30,10 @@ impl Deref for ModifiersChangedEvent {
 
 /// The phase of a touch motion event.
 /// Based on the winit enum of the same name.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum TouchPhase {
     Started,
+    #[default]
     Moved,
     Ended,
 }
@@ -136,7 +137,7 @@ impl MouseMoveEvent {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ScrollWheelEvent {
     pub position: Point<Pixels>,
     pub delta: ScrollDelta,

--- a/crates/gpui/src/keymap/matcher.rs
+++ b/crates/gpui/src/keymap/matcher.rs
@@ -209,7 +209,6 @@ mod tests {
         );
         assert!(!matcher.has_pending_keystrokes());
 
-        eprintln!("PROBLEM AREA");
         // If a is prefixed, C will not be dispatched because there
         // was a pending binding for it
         assert_eq!(

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -7,7 +7,7 @@ mod test;
 
 use crate::{
     Action, AnyWindowHandle, BackgroundExecutor, Bounds, DevicePixels, Font, FontId, FontMetrics,
-    FontRun, ForegroundExecutor, GlobalPixels, GlyphId, InputEvent, Keymap, LineLayout, Pixels,
+    FontRun, ForegroundExecutor, GlobalPixels, GlyphId, Keymap, LineLayout, Pixels, PlatformInput,
     Point, RenderGlyphParams, RenderImageParams, RenderSvgParams, Result, Scene, SharedString,
     Size, TaskLabel,
 };
@@ -88,7 +88,7 @@ pub(crate) trait Platform: 'static {
     fn on_resign_active(&self, callback: Box<dyn FnMut()>);
     fn on_quit(&self, callback: Box<dyn FnMut()>);
     fn on_reopen(&self, callback: Box<dyn FnMut()>);
-    fn on_event(&self, callback: Box<dyn FnMut(InputEvent) -> bool>);
+    fn on_event(&self, callback: Box<dyn FnMut(PlatformInput) -> bool>);
 
     fn set_menus(&self, menus: Vec<Menu>, keymap: &Keymap);
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>);
@@ -155,7 +155,7 @@ pub trait PlatformWindow {
     fn zoom(&self);
     fn toggle_full_screen(&self);
     fn on_request_frame(&self, callback: Box<dyn FnMut()>);
-    fn on_input(&self, callback: Box<dyn FnMut(InputEvent) -> bool>);
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> bool>);
     fn on_active_status_change(&self, callback: Box<dyn FnMut(bool)>);
     fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>);
     fn on_fullscreen(&self, callback: Box<dyn FnMut(bool)>);

--- a/crates/gpui/src/platform/mac/events.rs
+++ b/crates/gpui/src/platform/mac/events.rs
@@ -1,7 +1,7 @@
 use crate::{
-    point, px, InputEvent, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent, MouseUpEvent, NavigationDirection,
-    Pixels, ScrollDelta, ScrollWheelEvent, TouchPhase,
+    point, px, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton,
+    MouseDownEvent, MouseExitEvent, MouseMoveEvent, MouseUpEvent, NavigationDirection, Pixels,
+    PlatformInput, ScrollDelta, ScrollWheelEvent, TouchPhase,
 };
 use cocoa::{
     appkit::{NSEvent, NSEventModifierFlags, NSEventPhase, NSEventType},
@@ -82,7 +82,7 @@ unsafe fn read_modifiers(native_event: id) -> Modifiers {
     }
 }
 
-impl InputEvent {
+impl PlatformInput {
     pub unsafe fn from_native(native_event: id, window_height: Option<Pixels>) -> Option<Self> {
         let event_type = native_event.eventType();
 

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -239,7 +239,7 @@ impl Platform for TestPlatform {
         unimplemented!()
     }
 
-    fn on_event(&self, _callback: Box<dyn FnMut(crate::InputEvent) -> bool>) {
+    fn on_event(&self, _callback: Box<dyn FnMut(crate::PlatformInput) -> bool>) {
         unimplemented!()
     }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -1,7 +1,7 @@
 use crate::{
-    px, AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, InputEvent, KeyDownEvent,
-    Keystroke, Pixels, PlatformAtlas, PlatformDisplay, PlatformInputHandler, PlatformWindow, Point,
-    Size, TestPlatform, TileId, WindowAppearance, WindowBounds, WindowOptions,
+    px, AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, KeyDownEvent, Keystroke,
+    Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow,
+    Point, Size, TestPlatform, TileId, WindowAppearance, WindowBounds, WindowOptions,
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -19,7 +19,7 @@ pub struct TestWindowState {
     platform: Weak<TestPlatform>,
     sprite_atlas: Arc<dyn PlatformAtlas>,
     pub(crate) should_close_handler: Option<Box<dyn FnMut() -> bool>>,
-    input_callback: Option<Box<dyn FnMut(InputEvent) -> bool>>,
+    input_callback: Option<Box<dyn FnMut(PlatformInput) -> bool>>,
     active_status_change_callback: Option<Box<dyn FnMut(bool)>>,
     resize_callback: Option<Box<dyn FnMut(Size<Pixels>, f32)>>,
     moved_callback: Option<Box<dyn FnMut()>>,
@@ -85,7 +85,7 @@ impl TestWindow {
         self.0.lock().active_status_change_callback = Some(callback);
     }
 
-    pub fn simulate_input(&mut self, event: InputEvent) -> bool {
+    pub fn simulate_input(&mut self, event: PlatformInput) -> bool {
         let mut lock = self.0.lock();
         let Some(mut callback) = lock.input_callback.take() else {
             return false;
@@ -97,7 +97,7 @@ impl TestWindow {
     }
 
     pub fn simulate_keystroke(&mut self, keystroke: Keystroke, is_held: bool) {
-        if self.simulate_input(InputEvent::KeyDown(KeyDownEvent {
+        if self.simulate_input(PlatformInput::KeyDown(KeyDownEvent {
             keystroke: keystroke.clone(),
             is_held,
         })) {
@@ -220,7 +220,7 @@ impl PlatformWindow for TestWindow {
 
     fn on_request_frame(&self, _callback: Box<dyn FnMut()>) {}
 
-    fn on_input(&self, callback: Box<dyn FnMut(crate::InputEvent) -> bool>) {
+    fn on_input(&self, callback: Box<dyn FnMut(crate::PlatformInput) -> bool>) {
         self.0.lock().input_callback = Some(callback)
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1716,6 +1716,7 @@ impl<'a> WindowContext<'a> {
             .mouse_listeners
             .remove(&event.type_id())
         {
+            dbg!(handlers.len());
             // Because handlers may add other handlers, we sort every time.
             handlers.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1717,7 +1717,6 @@ impl<'a> WindowContext<'a> {
             .mouse_listeners
             .remove(&event.type_id())
         {
-            dbg!(handlers.len());
             // Because handlers may add other handlers, we sort every time.
             handlers.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1081,7 +1081,7 @@ mod tests {
 
     use super::*;
     use editor::{DisplayPoint, Editor};
-    use gpui::{Context, EmptyView, Hsla, TestAppContext, VisualTestContext};
+    use gpui::{Context, Hsla, TestAppContext, VisualTestContext};
     use language::Buffer;
     use smol::stream::StreamExt as _;
     use unindent::Unindent as _;
@@ -1114,7 +1114,7 @@ mod tests {
                 .unindent(),
             )
         });
-        let (_, cx) = cx.add_window_view(|_| EmptyView {});
+        let cx = cx.add_empty_window();
         let editor = cx.new_view(|cx| Editor::for_buffer(buffer.clone(), None, cx));
 
         let search_bar = cx.new_view(|cx| {
@@ -1461,7 +1461,7 @@ mod tests {
             "Should pick a query with multiple results"
         );
         let buffer = cx.new_model(|cx| Buffer::new(0, cx.entity_id().as_u64(), buffer_text));
-        let window = cx.add_window(|_| EmptyView {});
+        let window = cx.add_window(|_| ());
 
         let editor = window.build_view(cx, |cx| Editor::for_buffer(buffer.clone(), None, cx));
 
@@ -1657,7 +1657,7 @@ mod tests {
         "#
         .unindent();
         let buffer = cx.new_model(|cx| Buffer::new(0, cx.entity_id().as_u64(), buffer_text));
-        let (_, cx) = cx.add_window_view(|_| EmptyView {});
+        let cx = cx.add_empty_window();
 
         let editor = cx.new_view(|cx| Editor::for_buffer(buffer.clone(), None, cx));
 


### PR DESCRIPTION
When the `List` element's state is `ListState::reset()`, it eagerly trashes it's cached element heights in anticipation of a prompt render. But, due to the recent `display_layer` changes, that re-render is not always forthcoming. This is a problem for `ListState::scroll()`, which depends on these cached elements to correctly calculate the new logical scroll offset. 

Solutions we attempted:

- Cache the element heights and continue the scroll calculation 
    - This was conceptually incorrect, reset should only be called when the underlying data has been changed, making any calculation with the old results meaningless.
- Lazily re-compute the element heights in scroll 
    - Beyond being a non-trivial refactor, this would probably also cause us to double-render the list in a single frame, which is bad.
- Cache the scroll offset and only calculate it in paint 
    - This solution felt awkward to implement and meant we can't supply synchronous list scroll events.
- Delay resetting until paint 
    - This means that all of the other APIs that `ListState` supplies would give temporarily incorrect results, worsening the problem

Given these issues, we settled on the solution with the least compromises: drop scroll events if the state has been `reset()` between `paint()` and `scroll()`. This shifts the responsibility for the problem out of the List element and into consumers of `List`, if you want perfectly smooth scrolling then you need to use `reset()` judiciously and prefer `splice()`.

That said, I tested this by aggressively scrolling the Collab panel, and it seems to work as well as it did before.

This PR also includes some initial testing infrastructure for working with input from the platform and rendered elements.

Release Notes:

- N/A
