### PR TITLE
Store the impersonator id on access tokens created via ZED_IMPERSONATE

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -19,11 +19,10 @@ CREATE INDEX "index_users_on_github_user_id" ON "users" ("github_user_id");
 CREATE TABLE "access_tokens" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "user_id" INTEGER REFERENCES users (id),
-    "impersonator_id" INTEGER REFERENCES users (id),
+    "impersonated_user_id" INTEGER REFERENCES users (id),
     "hash" VARCHAR(128)
 );
 CREATE INDEX "index_access_tokens_user_id" ON "access_tokens" ("user_id");
-CREATE INDEX "index_access_tokens_impersonator_id" ON "access_tokens" ("impersonator_id");
 
 CREATE TABLE "contacts" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -19,9 +19,11 @@ CREATE INDEX "index_users_on_github_user_id" ON "users" ("github_user_id");
 CREATE TABLE "access_tokens" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "user_id" INTEGER REFERENCES users (id),
+    "impersonator_id" INTEGER REFERENCES users (id),
     "hash" VARCHAR(128)
 );
 CREATE INDEX "index_access_tokens_user_id" ON "access_tokens" ("user_id");
+CREATE INDEX "index_access_tokens_impersonator_id" ON "access_tokens" ("impersonator_id");
 
 CREATE TABLE "contacts" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/crates/collab/migrations/20240117150300_add_impersonator_to_access_tokens.sql
+++ b/crates/collab/migrations/20240117150300_add_impersonator_to_access_tokens.sql
@@ -1,3 +1,1 @@
-ALTER TABLE access_tokens ADD COLUMN impersonator_id integer;
-
-CREATE INDEX "index_access_tokens_impersonator_id" ON "access_tokens" ("impersonator_id");
+ALTER TABLE access_tokens ADD COLUMN impersonated_user_id integer;

--- a/crates/collab/migrations/20240117150300_add_impersonator_to_access_tokens.sql
+++ b/crates/collab/migrations/20240117150300_add_impersonator_to_access_tokens.sql
@@ -1,0 +1,3 @@
+ALTER TABLE access_tokens ADD COLUMN impersonator_id integer;
+
+CREATE INDEX "index_access_tokens_impersonator_id" ON "access_tokens" ("impersonator_id");

--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -176,7 +176,7 @@ pub struct VerifyAccessTokenResult {
     pub impersonator_id: Option<UserId>,
 }
 
-/// verify access token returns true if the given token is valid for the given user.
+/// Checks that the given access token is valid for the given user.
 pub async fn verify_access_token(
     token: &str,
     user_id: UserId,

--- a/crates/collab/src/db/queries/access_tokens.rs
+++ b/crates/collab/src/db/queries/access_tokens.rs
@@ -6,6 +6,7 @@ impl Database {
     pub async fn create_access_token(
         &self,
         user_id: UserId,
+        impersonator_id: Option<UserId>,
         access_token_hash: &str,
         max_access_token_count: usize,
     ) -> Result<AccessTokenId> {
@@ -14,11 +15,20 @@ impl Database {
 
             let token = access_token::ActiveModel {
                 user_id: ActiveValue::set(user_id),
+                impersonator_id: ActiveValue::set(impersonator_id),
                 hash: ActiveValue::set(access_token_hash.into()),
                 ..Default::default()
             }
             .insert(&*tx)
             .await?;
+
+            let existing_token_filter = if let Some(impersonator_id) = impersonator_id {
+                access_token::Column::ImpersonatorId.eq(impersonator_id)
+            } else {
+                access_token::Column::UserId
+                    .eq(user_id)
+                    .and(access_token::Column::ImpersonatorId.is_null())
+            };
 
             access_token::Entity::delete_many()
                 .filter(
@@ -26,7 +36,7 @@ impl Database {
                         Query::select()
                             .column(access_token::Column::Id)
                             .from(access_token::Entity)
-                            .and_where(access_token::Column::UserId.eq(user_id))
+                            .cond_where(existing_token_filter)
                             .order_by(access_token::Column::Id, sea_orm::Order::Desc)
                             .limit(10000)
                             .offset(max_access_token_count as u64)

--- a/crates/collab/src/db/tables/access_token.rs
+++ b/crates/collab/src/db/tables/access_token.rs
@@ -7,7 +7,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: AccessTokenId,
     pub user_id: UserId,
-    pub impersonator_id: Option<UserId>,
+    pub impersonated_user_id: Option<UserId>,
     pub hash: String,
 }
 

--- a/crates/collab/src/db/tables/access_token.rs
+++ b/crates/collab/src/db/tables/access_token.rs
@@ -7,6 +7,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: AccessTokenId,
     pub user_id: UserId,
+    pub impersonator_id: Option<UserId>,
     pub hash: String,
 }
 

--- a/crates/collab/src/db/tests/db_tests.rs
+++ b/crates/collab/src/db/tests/db_tests.rs
@@ -178,7 +178,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_1,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h1".into(),
         }
     );
@@ -187,7 +187,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_2,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h2".into()
         }
     );
@@ -198,7 +198,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_3,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h3".into()
         }
     );
@@ -207,7 +207,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_2,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h2".into()
         }
     );
@@ -219,7 +219,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_4,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h4".into()
         }
     );
@@ -228,7 +228,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_3,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h3".into()
         }
     );
@@ -238,15 +238,15 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
     // An access token for user 2 impersonating user 1 does not
     // count against user 1's access token limit (of 2).
     let token_5 = db
-        .create_access_token(user_1, Some(user_2), "h5", 2)
+        .create_access_token(user_2, Some(user_1), "h5", 2)
         .await
         .unwrap();
     assert_eq!(
         db.get_access_token(token_5).await.unwrap(),
         access_token::Model {
             id: token_5,
-            user_id: user_1,
-            impersonator_id: Some(user_2),
+            user_id: user_2,
+            impersonated_user_id: Some(user_1),
             hash: "h5".into()
         }
     );
@@ -255,7 +255,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_3,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h3".into()
         }
     );
@@ -263,19 +263,19 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
     // Only a limited number (2) of access tokens are stored for user 2
     // impersonating other users.
     let token_6 = db
-        .create_access_token(user_1, Some(user_2), "h6", 2)
+        .create_access_token(user_2, Some(user_1), "h6", 2)
         .await
         .unwrap();
     let token_7 = db
-        .create_access_token(user_1, Some(user_2), "h7", 2)
+        .create_access_token(user_2, Some(user_1), "h7", 2)
         .await
         .unwrap();
     assert_eq!(
         db.get_access_token(token_6).await.unwrap(),
         access_token::Model {
             id: token_6,
-            user_id: user_1,
-            impersonator_id: Some(user_2),
+            user_id: user_2,
+            impersonated_user_id: Some(user_1),
             hash: "h6".into()
         }
     );
@@ -283,8 +283,8 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         db.get_access_token(token_7).await.unwrap(),
         access_token::Model {
             id: token_7,
-            user_id: user_1,
-            impersonator_id: Some(user_2),
+            user_id: user_2,
+            impersonated_user_id: Some(user_1),
             hash: "h7".into()
         }
     );
@@ -294,7 +294,7 @@ async fn test_create_access_tokens(db: &Arc<Database>) {
         access_token::Model {
             id: token_3,
             user_id: user_1,
-            impersonator_id: None,
+            impersonated_user_id: None,
             hash: "h3".into()
         }
     );

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -213,6 +213,7 @@ impl TestServer {
                                 server_conn,
                                 client_name,
                                 user,
+                                None,
                                 Some(connection_id_tx),
                                 Executor::Deterministic(cx.background_executor().clone()),
                             ))

--- a/docs/src/developing_zed__building_zed.md
+++ b/docs/src/developing_zed__building_zed.md
@@ -14,7 +14,7 @@
 - Ensure that the Xcode command line tools are using your newly installed copy of Xcode:
 
     ```
-    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer.
+    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
     ```
 
 * Install the Rust wasm toolchain:

--- a/script/lib/squawk.toml
+++ b/script/lib/squawk.toml
@@ -1,0 +1,4 @@
+excluded_rules = [
+    "prefer-big-int",
+    "prefer-bigint-over-int",
+]

--- a/script/squawk
+++ b/script/squawk
@@ -8,13 +8,12 @@ set -e
 
 if [ -z "$GITHUB_BASE_REF" ]; then
   echo 'Not a pull request, skipping squawk modified migrations linting'
-  return 0
+  exit
 fi
 
 SQUAWK_VERSION=0.26.0
 SQUAWK_BIN="./target/squawk-$SQUAWK_VERSION"
-SQUAWK_ARGS="--assume-in-transaction"
-
+SQUAWK_ARGS="--assume-in-transaction --config script/lib/squawk.toml"
 
 if  [ ! -f "$SQUAWK_BIN" ]; then
   curl -L -o "$SQUAWK_BIN" "https://github.com/sbdchd/squawk/releases/download/v$SQUAWK_VERSION/squawk-darwin-x86_64"


### PR DESCRIPTION
* Use the impersonator id to prevent these tokens from counting against the impersonated user when limiting the users' total of access tokens.
* When connecting using an access token with an impersonator add the impersonator as a field to the tracing span that wraps the task for that connection.
* Disallow impersonating users via the admin API token in production, because when using the admin API token, we aren't able to identify the impersonator.
