### PR TITLE
Always synchronize terminal before rendering it

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -446,7 +446,7 @@ impl TerminalElement {
 
         let last_hovered_word = self.terminal.update(cx, |terminal, cx| {
             terminal.set_size(dimensions);
-            terminal.try_sync(cx);
+            terminal.sync(cx);
             if self.can_navigate_to_selected_word && terminal.can_navigate_to_selected_word() {
                 terminal.last_content.last_hovered_word.clone()
             } else {


### PR DESCRIPTION
Previously, we were trying not to synchronize the terminal too often because there could be multiple layout/paint calls prior to rendering a frame.

Now that we perform a single render pass per frame, we can just synchronize the terminal state. Not doing so could make it seem like we're dropping frames.

Release Notes:

- Improved terminal rendering performance.
