### PR TITLE
Refactor LanguageSever::fake into FakeLanguageServer::new

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -369,10 +369,11 @@ impl Copilot {
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn fake(cx: &mut gpui::TestAppContext) -> (Model<Self>, lsp::FakeLanguageServer) {
+        use lsp::FakeLanguageServer;
         use node_runtime::FakeNodeRuntime;
 
         let (server, fake_server) =
-            LanguageServer::fake("copilot".into(), Default::default(), cx.to_async());
+            FakeLanguageServer::new("copilot".into(), Default::default(), cx.to_async());
         let http = util::http::FakeHttpClient::create(|_| async { unreachable!() });
         let node_runtime = FakeNodeRuntime::new();
         let this = cx.new_model(|cx| Self {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -951,7 +951,7 @@ impl LanguageRegistry {
         if language.fake_adapter.is_some() {
             let task = cx.spawn(|cx| async move {
                 let (servers_tx, fake_adapter) = language.fake_adapter.as_ref().unwrap();
-                let (server, mut fake_server) = lsp::LanguageServer::fake(
+                let (server, mut fake_server) = lsp::FakeLanguageServer::new(
                     fake_adapter.name.to_string(),
                     fake_adapter.capabilities.clone(),
                     cx.clone(),


### PR DESCRIPTION
This is just moving code around and doesn't change behaviour, but it's something Julia and I bumped into yesterday while writing docs.

Release Notes:

- N/A
