### PR TITLE
gpui: Bring back family and style names in font name suggestions

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -201,6 +201,7 @@ pub trait PlatformDispatcher: Send + Sync {
 pub(crate) trait PlatformTextSystem: Send + Sync {
     fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> Result<()>;
     fn all_font_names(&self) -> Vec<String>;
+    fn all_font_families(&self) -> Vec<String>;
     fn font_id(&self, descriptor: &Font) -> Result<FontId>;
     fn font_metrics(&self, font_id: FontId) -> FontMetrics;
     fn typographic_bounds(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Bounds<f32>>;

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -85,12 +85,22 @@ impl PlatformTextSystem for MacTextSystem {
         };
         let mut names = BTreeSet::new();
         for descriptor in descriptors.into_iter() {
-            names.insert(descriptor.display_name());
+            names.insert(descriptor.font_name());
+            names.insert(descriptor.family_name());
+            names.insert(descriptor.style_name());
         }
         if let Ok(fonts_in_memory) = self.0.read().memory_source.all_families() {
             names.extend(fonts_in_memory);
         }
         names.into_iter().collect()
+    }
+
+    fn all_font_families(&self) -> Vec<String> {
+        self.0
+            .read()
+            .system_source
+            .all_families()
+            .expect("core text should never return an error")
     }
 
     fn font_id(&self, font: &Font) -> Result<FontId> {

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -13,7 +13,7 @@ use crate::{
     SharedString, Size, UnderlineStyle,
 };
 use anyhow::anyhow;
-use collections::{FxHashMap, FxHashSet};
+use collections::{BTreeSet, FxHashMap, FxHashSet};
 use core::fmt;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
@@ -66,15 +66,18 @@ impl TextSystem {
     }
 
     pub fn all_font_names(&self) -> Vec<String> {
-        let mut families = self.platform_text_system.all_font_names();
-        families.append(
-            &mut self
-                .fallback_font_stack
+        let mut names: BTreeSet<_> = self
+            .platform_text_system
+            .all_font_names()
+            .into_iter()
+            .collect();
+        names.extend(self.platform_text_system.all_font_families().into_iter());
+        names.extend(
+            self.fallback_font_stack
                 .iter()
-                .map(|font| font.family.to_string())
-                .collect(),
+                .map(|font| font.family.to_string()),
         );
-        families
+        names.into_iter().collect()
     }
     pub fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> Result<()> {
         self.platform_text_system.add_fonts(fonts)


### PR DESCRIPTION
Release Notes:
- Fixed font name suggestions not including family and style names (fixes [#2427 ](https://github.com/zed-industries/zed/issues/6416))
