### PR TITLE
pane: stop propagation of drag/click events in resizing handle

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -698,6 +698,7 @@ mod element {
             workspace
                 .update(cx, |this, cx| this.schedule_serialize(cx))
                 .log_err();
+            cx.stop_propagation();
             cx.refresh();
         }
 
@@ -754,8 +755,10 @@ mod element {
                                 workspace
                                     .update(cx, |this, cx| this.schedule_serialize(cx))
                                     .log_err();
+
                                 cx.refresh();
                             }
+                            cx.stop_propagation();
                         }
                     }
                 });


### PR DESCRIPTION
This prevents focused editor from being scrolled while a pane is getting resized.

Fixes: Mouse down to start an editor resize causes a scroll

Release Notes:

- Fixed a bug where editor was getting scrolled during a pane resize.
