### PR TITLE
Fix missing icons: set svg_renderer when assets are updated

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -121,7 +121,11 @@ impl App {
 
     /// Assign
     pub fn with_assets(self, asset_source: impl AssetSource) -> Self {
-        self.0.borrow_mut().asset_source = Arc::new(asset_source);
+        let mut context_lock = self.0.borrow_mut();
+        let asset_source = Arc::new(asset_source);
+        context_lock.asset_source = asset_source.clone();
+        context_lock.svg_renderer = SvgRenderer::new(asset_source);
+        drop(context_lock);
         self
     }
 


### PR DESCRIPTION
This fixes the missing icons in nightly. Regression was introduced in https://github.com/zed-industries/zed/pull/4122.

Release Notes:

- N/A
