### PR TITLE
Use regular info color for speaker borders

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -486,7 +486,7 @@ impl CollabTitlebarItem {
                 Avatar::new(user.avatar_uri.clone())
                     .grayscale(!is_present)
                     .border_color(if is_speaking {
-                        cx.theme().status().info_border
+                        cx.theme().status().info
                     } else {
                         // We draw the border in a transparent color rather to avoid
                         // the layout shift that would come with adding/removing the border.


### PR DESCRIPTION
This PR updates the speaker borders to use the regular `info` status color instead of the `info_border` color.

This should provide more contrast and make it clearer as to who is speaking.

Release Notes:

- Made the active speakers' borders more visible when in a call.
