### PR TITLE
Don't send follower events from other panes

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -448,11 +448,13 @@ impl<T: Item> ItemHandle for View<T> {
                             workspace.unfollow(&pane, cx);
                         }
 
-                        if item.add_event_to_update_proto(
-                            event,
-                            &mut *pending_update.borrow_mut(),
-                            cx,
-                        ) && !pending_update_scheduled.load(Ordering::SeqCst)
+                        if item.focus_handle(cx).contains_focused(cx)
+                            && item.add_event_to_update_proto(
+                                event,
+                                &mut *pending_update.borrow_mut(),
+                                cx,
+                            )
+                            && !pending_update_scheduled.load(Ordering::SeqCst)
                         {
                             pending_update_scheduled.store(true, Ordering::SeqCst);
                             cx.defer({


### PR DESCRIPTION
Co-Authored-By: Mikayla <mikayla@zed.dev>

[[PR Description]]

Release Notes:

- Fixed a bug where following could scroll incorrectly
