### PR TITLE
Invoke pane's focus_in handler when pane is focused directly

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -239,6 +239,7 @@ impl Pane {
         let focus_handle = cx.focus_handle();
 
         let subscriptions = vec![
+            cx.on_focus(&focus_handle, Pane::focus_in),
             cx.on_focus_in(&focus_handle, Pane::focus_in),
             cx.on_focus_out(&focus_handle, Pane::focus_out),
         ];


### PR DESCRIPTION
Fixes a bug where, when focusing a pane directly, it failed to transfer focus to the active item.