### PR TITLE
Fix right click handler for tabs

### DIFF
--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Action, AnyElement, AnyView, AnyWindowHandle, AppCell, AppContext, AsyncAppContext,
-    AvailableSpace, BackgroundExecutor, ClipboardItem, Context, Entity, EventEmitter,
+    AvailableSpace, BackgroundExecutor, Bounds, ClipboardItem, Context, Entity, EventEmitter,
     ForegroundExecutor, InputEvent, Keystroke, Model, ModelContext, Pixels, Platform, Point,
     Render, Result, Size, Task, TestDispatcher, TestPlatform, TestWindow, TextSystem, View,
     ViewContext, VisualContext, WindowContext, WindowHandle, WindowOptions,
@@ -616,6 +616,16 @@ impl<'a> VisualTestContext {
     /// Automatically runs until parked.
     pub fn simulate_input(&mut self, input: &str) {
         self.cx.simulate_input(self.window, input)
+    }
+
+    /// Simulates the user resizing the window to the new size.
+    pub fn simulate_resize(&self, size: Size<Pixels>) {
+        self.simulate_window_resize(self.window, size)
+    }
+
+    /// debug_bounds returns the bounds of the element with the given selector.
+    pub fn debug_bounds(&mut self, selector: &'static str) -> Option<Bounds<Pixels>> {
+        self.update(|cx| cx.window.rendered_frame.debug_bounds.get(selector).copied())
     }
 
     /// Draw an element to the window. Useful for simulating events or actions

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -30,7 +30,7 @@ use std::{
     borrow::{Borrow, BorrowMut, Cow},
     cell::RefCell,
     collections::hash_map::Entry,
-    fmt::Debug,
+    fmt::{Debug, Display},
     future::Future,
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -325,6 +325,9 @@ pub(crate) struct Frame {
     requested_cursor_style: Option<CursorStyle>,
     pub(crate) view_stack: Vec<EntityId>,
     pub(crate) reused_views: FxHashSet<EntityId>,
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) debug_bounds: collections::FxHashMap<String, Bounds<Pixels>>,
 }
 
 impl Frame {
@@ -348,6 +351,9 @@ impl Frame {
             requested_cursor_style: None,
             view_stack: Vec::new(),
             reused_views: FxHashSet::default(),
+
+            #[cfg(any(test, feature = "test-support"))]
+            debug_bounds: FxHashMap::default(),
         }
     }
 
@@ -3377,6 +3383,20 @@ pub enum ElementId {
     FocusHandle(FocusId),
     /// A combination of a name and an integer.
     NamedInteger(SharedString, usize),
+}
+
+impl Display for ElementId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ElementId::View(entity_id) => write!(f, "view-{}", entity_id)?,
+            ElementId::Integer(ix) => write!(f, "{}", ix)?,
+            ElementId::Name(name) => write!(f, "{}", name)?,
+            ElementId::FocusHandle(__) => write!(f, "FocusHandle")?,
+            ElementId::NamedInteger(s, i) => write!(f, "{}-{}", s, i)?,
+        }
+
+        Ok(())
+    }
 }
 
 impl ElementId {

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -293,7 +293,7 @@ impl ButtonSize {
 /// This is also used to build the prebuilt buttons.
 #[derive(IntoElement)]
 pub struct ButtonLike {
-    base: Div,
+    pub base: Div,
     id: ElementId,
     pub(super) style: ButtonStyle,
     pub(super) disabled: bool,

--- a/crates/ui/src/components/button/icon_button.rs
+++ b/crates/ui/src/components/button/icon_button.rs
@@ -24,14 +24,16 @@ pub struct IconButton {
 
 impl IconButton {
     pub fn new(id: impl Into<ElementId>, icon: IconName) -> Self {
-        Self {
+        let mut this = Self {
             base: ButtonLike::new(id),
             shape: IconButtonShape::Wide,
             icon,
             icon_size: IconSize::default(),
             icon_color: Color::Default,
             selected_icon: None,
-        }
+        };
+        this.base.base = this.base.base.debug_selector(|| format!("ICON-{:?}", icon));
+        this
     }
 
     pub fn shape(mut self, shape: IconButtonShape) -> Self {

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -303,6 +303,7 @@ impl Render for ContextMenu {
                                         .w_full()
                                         .justify_between()
                                         .child(label_element)
+                                        .debug_selector(|| format!("MENU_ITEM-{}", label))
                                         .children(action.as_ref().and_then(|action| {
                                             KeyBinding::for_action(&**action, cx)
                                                 .map(|binding| div().ml_1().child(binding))

--- a/crates/ui/src/components/right_click_menu.rs
+++ b/crates/ui/src/components/right_click_menu.rs
@@ -1,9 +1,9 @@
 use std::{cell::RefCell, rc::Rc};
 
 use gpui::{
-    overlay, AnchorCorner, AnyElement, Bounds, DismissEvent, DispatchPhase, Element, ElementId,
-    IntoElement, LayoutId, ManagedView, MouseButton, MouseDownEvent, ParentElement, Pixels, Point,
-    View, VisualContext, WindowContext,
+    overlay, AnchorCorner, AnyElement, BorrowWindow, Bounds, DismissEvent, DispatchPhase, Element,
+    ElementId, InteractiveBounds, IntoElement, LayoutId, ManagedView, MouseButton, MouseDownEvent,
+    ParentElement, Pixels, Point, View, VisualContext, WindowContext,
 };
 
 pub struct RightClickMenu<M: ManagedView> {
@@ -136,10 +136,14 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
         let child_layout_id = element_state.child_layout_id.clone();
         let child_bounds = cx.layout_bounds(child_layout_id.unwrap());
 
+        let interactive_bounds = InteractiveBounds {
+            bounds: bounds.intersect(&cx.content_mask().bounds),
+            stacking_order: cx.stacking_order().clone(),
+        };
         cx.on_mouse_event(move |event: &MouseDownEvent, phase, cx| {
             if phase == DispatchPhase::Bubble
                 && event.button == MouseButton::Right
-                && bounds.contains(&event.position)
+                && interactive_bounds.visibly_contains(&event.position, cx)
             {
                 cx.stop_propagation();
                 cx.prevent_default();

--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -37,8 +37,11 @@ pub struct Tab {
 
 impl Tab {
     pub fn new(id: impl Into<ElementId>) -> Self {
+        let id = id.into();
         Self {
-            div: div().id(id),
+            div: div()
+                .id(id.clone())
+                .debug_selector(|| format!("TAB-{}", id)),
             selected: false,
             position: TabPosition::First,
             close_side: TabCloseSide::End,


### PR DESCRIPTION
Also, some fun test helpers

Co-Authored-By: Mikayla <mikayla@zed.dev>

You can now use .debug_selector() to make it possible for tests to find a given element,
and .debug_bounds() to find the coordinates of where it was painted.


Release Notes:

- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/community/issues/<public_issue_number_if_exists>)).
