### PR TITLE
gpui: Always recompute layout on cache miss.

### DIFF
--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -321,10 +321,7 @@ impl Element for AnyView {
                 }
             }
 
-            let mut element = state
-                .element
-                .take()
-                .unwrap_or_else(|| (self.request_layout)(self, cx).1);
+            let mut element = (self.request_layout)(self, cx).1;
             element.draw(bounds.origin, bounds.size.into(), cx);
 
             state.cache_key = Some(ViewCacheKey {


### PR DESCRIPTION
I'm not yet sure whether this is 100% correct, but it seems to alleviate the following issue:
`When opening a dock, the panel doesn't appear right away. An empty dock is briefly visible.`
Release Notes:

- Fixed panel layout being incorrect for a brief time after opening (fixes https://github.com/zed-industries/zed/issues/6409)
