### PR TITLE
Revert "Store a z-index id per-layer (#4128)"

### DIFF
--- a/crates/collab_ui/src/face_pile.rs
+++ b/crates/collab_ui/src/face_pile.rs
@@ -13,7 +13,7 @@ impl RenderOnce for FacePile {
             let isnt_last = ix < player_count - 1;
 
             div()
-                .z_index((player_count - ix) as u16)
+                .z_index((player_count - ix) as u8)
                 .when(isnt_last, |div| div.neg_mr_1())
                 .child(player)
         });

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -110,7 +110,7 @@ pub struct Style {
     /// The mouse cursor style shown when the mouse pointer is over an element.
     pub mouse_cursor: Option<CursorStyle>,
 
-    pub z_index: Option<u16>,
+    pub z_index: Option<u8>,
 
     #[cfg(debug_assertions)]
     pub debug: bool,
@@ -386,7 +386,7 @@ impl Style {
 
         let background_color = self.background.as_ref().and_then(Fill::color);
         if background_color.map_or(false, |color| !color.is_transparent()) {
-            cx.with_z_index(1, |cx| {
+            cx.with_z_index(0, |cx| {
                 let mut border_color = background_color.unwrap_or_default();
                 border_color.a = 0.;
                 cx.paint_quad(quad(
@@ -399,12 +399,12 @@ impl Style {
             });
         }
 
-        cx.with_z_index(2, |cx| {
+        cx.with_z_index(0, |cx| {
             continuation(cx);
         });
 
         if self.is_border_visible() {
-            cx.with_z_index(3, |cx| {
+            cx.with_z_index(0, |cx| {
                 let corner_radii = self.corner_radii.to_pixels(bounds.size, rem_size);
                 let border_widths = self.border_widths.to_pixels(rem_size);
                 let max_border_width = border_widths.max();

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -12,7 +12,7 @@ pub trait Styled: Sized {
 
     gpui_macros::style_helpers!();
 
-    fn z_index(mut self, z_index: u16) -> Self {
+    fn z_index(mut self, z_index: u8) -> Self {
         self.style().z_index = Some(z_index);
         self
     }

--- a/crates/storybook/src/stories/z_index.rs
+++ b/crates/storybook/src/stories/z_index.rs
@@ -76,7 +76,7 @@ impl Styles for Div {}
 
 #[derive(IntoElement)]
 struct ZIndexExample {
-    z_index: u16,
+    z_index: u8,
 }
 
 impl RenderOnce for ZIndexExample {
@@ -166,7 +166,7 @@ impl RenderOnce for ZIndexExample {
 }
 
 impl ZIndexExample {
-    pub fn new(z_index: u16) -> Self {
+    pub fn new(z_index: u8) -> Self {
         Self { z_index }
     }
 }

--- a/crates/ui/src/styles/elevation.rs
+++ b/crates/ui/src/styles/elevation.rs
@@ -20,7 +20,7 @@ pub enum ElevationIndex {
 }
 
 impl ElevationIndex {
-    pub fn z_index(self) -> u16 {
+    pub fn z_index(self) -> u8 {
         match self {
             ElevationIndex::Background => 0,
             ElevationIndex::Surface => 42,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4334,7 +4334,7 @@ impl Element for DisconnectedOverlay {
     }
 
     fn paint(&mut self, bounds: Bounds<Pixels>, overlay: &mut Self::State, cx: &mut WindowContext) {
-        cx.with_z_index(u16::MAX, |cx| {
+        cx.with_z_index(u8::MAX, |cx| {
             cx.add_opaque_layer(bounds);
             overlay.paint(cx);
         })


### PR DESCRIPTION
This reverts commit 28a23372185c7a30c7790085a6a010c3cad6ad09, reversing
changes made to e992f84735a2ca166a7388d4eca69a6b4e6ee212.

[[PR Description]]

Release Notes:

- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/community/issues/<public_issue_number_if_exists>)).
