### PR TITLE
Make clicking `ListHeader` labels toggle the disclosure

### DIFF
--- a/crates/ui/src/components/disclosure.rs
+++ b/crates/ui/src/components/disclosure.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use gpui::ClickEvent;
 
 use crate::{prelude::*, Color, IconButton, IconName, IconSize};
@@ -6,7 +8,7 @@ use crate::{prelude::*, Color, IconButton, IconName, IconSize};
 pub struct Disclosure {
     id: ElementId,
     is_open: bool,
-    on_toggle: Option<Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
+    on_toggle: Option<Arc<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
 }
 
 impl Disclosure {
@@ -20,7 +22,7 @@ impl Disclosure {
 
     pub fn on_toggle(
         mut self,
-        handler: impl Into<Option<Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>>,
+        handler: impl Into<Option<Arc<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>>,
     ) -> Self {
         self.on_toggle = handler.into();
         self

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use gpui::{px, AnyElement, AnyView, ClickEvent, MouseButton, MouseDownEvent, Pixels};
 use smallvec::SmallVec;
 
@@ -29,7 +31,7 @@ pub struct ListItem {
     toggle: Option<bool>,
     inset: bool,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
-    on_toggle: Option<Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
+    on_toggle: Option<Arc<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>>,
     tooltip: Option<Box<dyn Fn(&mut WindowContext) -> AnyView + 'static>>,
     on_secondary_mouse_down: Option<Box<dyn Fn(&MouseDownEvent, &mut WindowContext) + 'static>>,
     children: SmallVec<[AnyElement; 2]>,
@@ -104,7 +106,7 @@ impl ListItem {
         mut self,
         on_toggle: impl Fn(&ClickEvent, &mut WindowContext) + 'static,
     ) -> Self {
-        self.on_toggle = Some(Box::new(on_toggle));
+        self.on_toggle = Some(Arc::new(on_toggle));
         self
     }
 


### PR DESCRIPTION
This PR makes clicking the label inside of a `ListHeader` with a disclosure also toggle the disclosure.

Release Notes:

- Added support for clicking the "Online", "Offline", and "Requests" headers in the contact list to toggle their expansion.
