### PR TITLE
Tweak the description of the `gpui` crate

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -3,7 +3,7 @@ name = "gpui"
 version = "0.1.0"
 edition = "2021"
 authors = ["Nathan Sobo <nathan@zed.dev>"]
-description = "The next version of Zed's GPU-accelerated UI framework"
+description = "Zed's GPU-accelerated UI framework"
 publish = false
 
 [features]


### PR DESCRIPTION
This PR tweaks the description of the `gpui` crate, since it's now the only version.

There can only be one!

Release Notes:

- N/A
