### PR TITLE
Revert "Improve panic logging"

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -544,22 +544,7 @@ fn init_panic_hook(app: &App, installation_id: Option<String>, session_id: Strin
         let mut backtrace = backtrace
             .frames()
             .iter()
-            .flat_map(|frame| {
-                frame.symbols().iter().filter_map(|symbol| {
-                    let name = symbol.name()?;
-                    let addr = symbol.addr()? as usize;
-                    let position = if let (Some(path), Some(lineno)) = (
-                        symbol.filename().and_then(|path| path.file_name()),
-                        symbol.lineno(),
-                    ) {
-                        format!("{}:{}", path.to_string_lossy(), lineno)
-                    } else {
-                        "?".to_string()
-                    };
-
-                    Some(format!("{:} ({:#x}) at {}", name, addr, position))
-                })
-            })
+            .filter_map(|frame| Some(format!("{:#}", frame.symbols().first()?.name()?)))
             .collect::<Vec<_>>();
 
         // Strip out leading stack frames for rust panic-handling.


### PR DESCRIPTION
This reverts commit 345b983c8edd18acc346845dcdd1266e144a05a9.

This seems to have caused only the first line of panics to be reported in production builds.

Release Notes:

- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/community/issues/<public_issue_number_if_exists>)).
