### PR TITLE
Rename `overflow_hidden_{x,y}` to `overflow_{x,y}_hidden`

### DIFF
--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -66,18 +66,24 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets the behavior of content that overflows the container to be hidden.
+    /// [Docs](https://tailwindcss.com/docs/overflow#hiding-content-that-overflows)
     fn overflow_hidden(mut self) -> Self {
         self.style().overflow.x = Some(Overflow::Hidden);
         self.style().overflow.y = Some(Overflow::Hidden);
         self
     }
 
-    fn overflow_hidden_x(mut self) -> Self {
+    /// Sets the behavior of content that overflows the container on the X axis to be hidden.
+    /// [Docs](https://tailwindcss.com/docs/overflow#hiding-content-that-overflows)
+    fn overflow_x_hidden(mut self) -> Self {
         self.style().overflow.x = Some(Overflow::Hidden);
         self
     }
 
-    fn overflow_hidden_y(mut self) -> Self {
+    /// Sets the behavior of content that overflows the container on the Y axis to be hidden.
+    /// [Docs](https://tailwindcss.com/docs/overflow#hiding-content-that-overflows)
+    fn overflow_y_hidden(mut self) -> Self {
         self.style().overflow.y = Some(Overflow::Hidden);
         self
     }

--- a/crates/story/src/story.rs
+++ b/crates/story/src/story.rs
@@ -104,7 +104,7 @@ impl RenderOnce for StoryContainer {
                     .h_px()
                     .flex_1()
                     .id("story_body")
-                    .overflow_hidden_x()
+                    .overflow_x_hidden()
                     .overflow_y_scroll()
                     .flex()
                     .flex_col()

--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -117,7 +117,7 @@ impl RenderOnce for TabBar {
                     .relative()
                     .flex_1()
                     .h_full()
-                    .overflow_hidden_x()
+                    .overflow_x_hidden()
                     .child(
                         div()
                             .absolute()

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -51,7 +51,7 @@ impl StatusBar {
     fn render_left_tools(&self, _: &mut ViewContext<Self>) -> impl IntoElement {
         h_flex()
             .gap_2()
-            .overflow_hidden_x()
+            .overflow_x_hidden()
             .children(self.left_items.iter().map(|item| item.to_any()))
     }
 


### PR DESCRIPTION
This PR renames the `overflow_hidden_x` and `overflow_hidden_y` methods to `overflow_x_hidden` and `overflow_y_hidden`, respectively.

This provides consistency with our `overflow_x_scroll` / `overflow_y_scroll` methods, as well as better matches Tailwind's naming.

Release Notes:

- N/A