### PR TITLE
Fix docs references in `ui`

### DIFF
--- a/crates/ui/src/components/avatar/avatar.rs
+++ b/crates/ui/src/components/avatar/avatar.rs
@@ -44,7 +44,7 @@ impl Avatar {
 
     /// Sets the shape of the avatar image.
     ///
-    /// This method allows the shape of the avatar to be specified using a [`Shape`].
+    /// This method allows the shape of the avatar to be specified using an [`AvatarShape`].
     /// It modifies the corner radius of the image to match the specified shape.
     ///
     /// # Examples

--- a/crates/ui/src/components/avatar/avatar_availability_indicator.rs
+++ b/crates/ui/src/components/avatar/avatar_availability_indicator.rs
@@ -20,7 +20,7 @@ impl AvatarAvailabilityIndicator {
         }
     }
 
-    /// Sets the size of the [`Avatar`] this indicator appears on.
+    /// Sets the size of the [`Avatar`](crate::Avatar) this indicator appears on.
     pub fn avatar_size(mut self, size: impl Into<Option<Pixels>>) -> Self {
         self.avatar_size = size.into();
         self

--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 ///
 /// Related elements:
 ///
-/// `ContextMenu`:
+/// [`ContextMenu`](crate::ContextMenu):
 ///
 /// Used to display a popover menu that only contains a list of items. Context menus are always
 /// launched by secondary clicking on an element. The menu is positioned relative to the user's cursor.


### PR DESCRIPTION
This PR fixes some more references in the docs in the `ui` crate.

Release Notes:

- N/A
