### PR TITLE
Remove commented-out code in `auto_update`

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -96,12 +96,6 @@ pub fn init(http_client: Arc<dyn HttpClient>, server_url: String, cx: &mut AppCo
         workspace.register_action(|_, action, cx| {
             view_release_notes(action, cx);
         });
-
-        // @nate - code to trigger update notification on launch
-        // todo!("remove this when Nate is done")
-        // workspace.show_notification(0, _cx, |cx| {
-        //     cx.build_view(|_| UpdateNotification::new(SemanticVersion::from_str("1.1.1").unwrap()))
-        // });
     })
     .detach();
 


### PR DESCRIPTION
This PR removes some commented-out code in the `auto_update` crate that we no longer need.

Release Notes:

- N/A