### PR TITLE
collab errors

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2959,6 +2959,7 @@ impl InlineAssistant {
                     cx.prompt(
                         PromptLevel::Info,
                         prompt_text.as_str(),
+                        None,
                         &["Continue", "Cancel"],
                     )
                 })?;

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -130,7 +130,8 @@ pub fn check(_: &Check, cx: &mut WindowContext) {
     } else {
         drop(cx.prompt(
             gpui::PromptLevel::Info,
-            "Auto-updates disabled for non-bundled app.",
+            "Could not check for updates",
+            Some("Auto-updates disabled for non-bundled app."),
             &["Ok"],
         ));
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -689,12 +689,7 @@ impl Client {
                 Ok(())
             }
             Err(error) => {
-                client.respond_with_error(
-                    receipt,
-                    proto::Error {
-                        message: format!("{:?}", error),
-                    },
-                )?;
+                client.respond_with_error(receipt, error.to_proto())?;
                 Err(error)
             }
         }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -22,7 +22,10 @@ use gpui::{
 };
 use menu::{Cancel, Confirm, SecondaryConfirm, SelectNext, SelectPrev};
 use project::{Fs, Project};
-use rpc::proto::{self, PeerId};
+use rpc::{
+    proto::{self, PeerId},
+    ErrorCode, ErrorExt,
+};
 use serde_derive::{Deserialize, Serialize};
 use settings::Settings;
 use smallvec::SmallVec;
@@ -35,7 +38,7 @@ use ui::{
 use util::{maybe, ResultExt, TryFutureExt};
 use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
-    notifications::{NotifyResultExt, NotifyTaskExt},
+    notifications::{DetachAndPromptErr, NotifyResultExt, NotifyTaskExt},
     Workspace,
 };
 
@@ -879,7 +882,7 @@ impl CollabPanel {
                     .update(cx, |workspace, cx| {
                         let app_state = workspace.app_state().clone();
                         workspace::join_remote_project(project_id, host_user_id, app_state, cx)
-                            .detach_and_log_err(cx);
+                            .detach_and_prompt_err("Failed to join project", cx, |_, _| None);
                     })
                     .ok();
             }))
@@ -1017,7 +1020,12 @@ impl CollabPanel {
                                     )
                                 })
                             })
-                            .detach_and_notify_err(cx)
+                            .detach_and_prompt_err("Failed to grant write access", cx, |e, _| {
+                                match e.error_code() {
+                                    ErrorCode::NeedsCla => Some("This user has not yet signed the CLA at https://zed.dev/cla.".into()),
+                                    _ => None,
+                                }
+                            })
                     }),
                 )
             } else if role == proto::ChannelRole::Member {
@@ -1038,7 +1046,7 @@ impl CollabPanel {
                                     )
                                 })
                             })
-                            .detach_and_notify_err(cx)
+                            .detach_and_prompt_err("Failed to revoke write access", cx, |_, _| None)
                     }),
                 )
             } else {
@@ -1258,7 +1266,11 @@ impl CollabPanel {
                                 app_state,
                                 cx,
                             )
-                            .detach_and_log_err(cx);
+                            .detach_and_prompt_err(
+                                "Failed to join project",
+                                cx,
+                                |_, _| None,
+                            );
                         }
                     }
                     ListEntry::ParticipantScreen { peer_id, .. } => {
@@ -1432,7 +1444,7 @@ impl CollabPanel {
     fn leave_call(cx: &mut WindowContext) {
         ActiveCall::global(cx)
             .update(cx, |call, cx| call.hang_up(cx))
-            .detach_and_log_err(cx);
+            .detach_and_prompt_err("Failed to hang up", cx, |_, _| None);
     }
 
     fn toggle_contact_finder(&mut self, cx: &mut ViewContext<Self>) {
@@ -1534,11 +1546,11 @@ impl CollabPanel {
         cx: &mut ViewContext<CollabPanel>,
     ) {
         if let Some(clipboard) = self.channel_clipboard.take() {
-            self.channel_store.update(cx, |channel_store, cx| {
-                channel_store
-                    .move_channel(clipboard.channel_id, Some(to_channel_id), cx)
-                    .detach_and_log_err(cx)
-            })
+            self.channel_store
+                .update(cx, |channel_store, cx| {
+                    channel_store.move_channel(clipboard.channel_id, Some(to_channel_id), cx)
+                })
+                .detach_and_prompt_err("Failed to move channel", cx, |_, _| None)
         }
     }
 
@@ -1610,7 +1622,12 @@ impl CollabPanel {
                 "Are you sure you want to remove the channel \"{}\"?",
                 channel.name
             );
-            let answer = cx.prompt(PromptLevel::Warning, &prompt_message, &["Remove", "Cancel"]);
+            let answer = cx.prompt(
+                PromptLevel::Warning,
+                &prompt_message,
+                None,
+                &["Remove", "Cancel"],
+            );
             cx.spawn(|this, mut cx| async move {
                 if answer.await? == 0 {
                     channel_store
@@ -1631,7 +1648,12 @@ impl CollabPanel {
             "Are you sure you want to remove \"{}\" from your contacts?",
             github_login
         );
-        let answer = cx.prompt(PromptLevel::Warning, &prompt_message, &["Remove", "Cancel"]);
+        let answer = cx.prompt(
+            PromptLevel::Warning,
+            &prompt_message,
+            None,
+            &["Remove", "Cancel"],
+        );
         cx.spawn(|_, mut cx| async move {
             if answer.await? == 0 {
                 user_store
@@ -1641,7 +1663,7 @@ impl CollabPanel {
             }
             anyhow::Ok(())
         })
-        .detach_and_log_err(cx);
+        .detach_and_prompt_err("Failed to remove contact", cx, |_, _| None);
     }
 
     fn respond_to_contact_request(
@@ -1654,7 +1676,7 @@ impl CollabPanel {
             .update(cx, |store, cx| {
                 store.respond_to_contact_request(user_id, accept, cx)
             })
-            .detach_and_log_err(cx);
+            .detach_and_prompt_err("Failed to respond to contact request", cx, |_, _| None);
     }
 
     fn respond_to_channel_invite(
@@ -1675,7 +1697,7 @@ impl CollabPanel {
             .update(cx, |call, cx| {
                 call.invite(recipient_user_id, Some(self.project.clone()), cx)
             })
-            .detach_and_log_err(cx);
+            .detach_and_prompt_err("Call failed", cx, |_, _| None);
     }
 
     fn join_channel(&self, channel_id: u64, cx: &mut ViewContext<Self>) {
@@ -1691,7 +1713,7 @@ impl CollabPanel {
             Some(handle),
             cx,
         )
-        .detach_and_log_err(cx)
+        .detach_and_prompt_err("Failed to join channel", cx, |_, _| None)
     }
 
     fn join_channel_chat(&mut self, channel_id: ChannelId, cx: &mut ViewContext<Self>) {
@@ -1704,7 +1726,7 @@ impl CollabPanel {
                     panel.update(cx, |panel, cx| {
                         panel
                             .select_channel(channel_id, None, cx)
-                            .detach_and_log_err(cx);
+                            .detach_and_notify_err(cx);
                     });
                 }
             });
@@ -1981,7 +2003,7 @@ impl CollabPanel {
                             .update(cx, |channel_store, cx| {
                                 channel_store.move_channel(dragged_channel.id, None, cx)
                             })
-                            .detach_and_log_err(cx)
+                            .detach_and_prompt_err("Failed to move channel", cx, |_, _| None)
                     }))
             })
     }
@@ -2257,7 +2279,7 @@ impl CollabPanel {
                     .update(cx, |channel_store, cx| {
                         channel_store.move_channel(dragged_channel.id, Some(channel_id), cx)
                     })
-                    .detach_and_log_err(cx)
+                    .detach_and_prompt_err("Failed to move channel", cx, |_, _| None)
             }))
             .child(
                 ListItem::new(channel_id as usize)

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -14,7 +14,7 @@ use rpc::proto::channel_member;
 use std::sync::Arc;
 use ui::{prelude::*, Avatar, Checkbox, ContextMenu, ListItem, ListItemSpacing};
 use util::TryFutureExt;
-use workspace::{notifications::NotifyTaskExt, ModalView};
+use workspace::{notifications::DetachAndPromptErr, ModalView};
 
 actions!(
     channel_modal,
@@ -498,7 +498,7 @@ impl ChannelModalDelegate {
                 cx.notify();
             })
         })
-        .detach_and_notify_err(cx);
+        .detach_and_prompt_err("Failed to update role", cx, |_, _| None);
         Some(())
     }
 
@@ -530,7 +530,7 @@ impl ChannelModalDelegate {
                 cx.notify();
             })
         })
-        .detach_and_notify_err(cx);
+        .detach_and_prompt_err("Failed to remove member", cx, |_, _| None);
         Some(())
     }
 
@@ -556,7 +556,7 @@ impl ChannelModalDelegate {
                 cx.notify();
             })
         })
-        .detach_and_notify_err(cx);
+        .detach_and_prompt_err("Failed to invite member", cx, |_, _| None);
     }
 
     fn show_context_menu(&mut self, ix: usize, cx: &mut ViewContext<Picker<Self>>) {

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -31,7 +31,8 @@ pub fn init(cx: &mut AppContext) {
 
                     let prompt = cx.prompt(
                         PromptLevel::Info,
-                        &format!("Copied into clipboard:\n\n{specs}"),
+                        "Copied into clipboard",
+                        Some(&specs),
                         &["OK"],
                     );
                     cx.spawn(|_, _cx| async move {

--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -97,7 +97,7 @@ impl ModalView for FeedbackModal {
             return true;
         }
 
-        let answer = cx.prompt(PromptLevel::Info, "Discard feedback?", &["Yes", "No"]);
+        let answer = cx.prompt(PromptLevel::Info, "Discard feedback?", None, &["Yes", "No"]);
 
         cx.spawn(move |this, mut cx| async move {
             if answer.await.ok() == Some(0) {
@@ -222,6 +222,7 @@ impl FeedbackModal {
         let answer = cx.prompt(
             PromptLevel::Info,
             "Ready to submit your feedback?",
+            None,
             &["Yes, Submit!", "No"],
         );
         let client = cx.global::<Arc<Client>>().clone();
@@ -255,6 +256,7 @@ impl FeedbackModal {
                             let prompt = cx.prompt(
                                 PromptLevel::Critical,
                                 FEEDBACK_SUBMISSION_ERROR_TEXT,
+                                None,
                                 &["OK"],
                             );
                             cx.spawn(|_, _cx| async move {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -150,7 +150,13 @@ pub(crate) trait PlatformWindow {
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn set_input_handler(&mut self, input_handler: PlatformInputHandler);
     fn take_input_handler(&mut self) -> Option<PlatformInputHandler>;
-    fn prompt(&self, level: PromptLevel, msg: &str, answers: &[&str]) -> oneshot::Receiver<usize>;
+    fn prompt(
+        &self,
+        level: PromptLevel,
+        msg: &str,
+        detail: Option<&str>,
+        answers: &[&str],
+    ) -> oneshot::Receiver<usize>;
     fn activate(&self);
     fn set_title(&mut self, title: &str);
     fn set_edited(&mut self, edited: bool);

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -772,7 +772,13 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().input_handler.take()
     }
 
-    fn prompt(&self, level: PromptLevel, msg: &str, answers: &[&str]) -> oneshot::Receiver<usize> {
+    fn prompt(
+        &self,
+        level: PromptLevel,
+        msg: &str,
+        detail: Option<&str>,
+        answers: &[&str],
+    ) -> oneshot::Receiver<usize> {
         // macOs applies overrides to modal window buttons after they are added.
         // Two most important for this logic are:
         // * Buttons with "Cancel" title will be displayed as the last buttons in the modal
@@ -808,6 +814,9 @@ impl PlatformWindow for MacWindow {
             };
             let _: () = msg_send![alert, setAlertStyle: alert_style];
             let _: () = msg_send![alert, setMessageText: ns_string(msg)];
+            if let Some(detail) = detail {
+                let _: () = msg_send![alert, setInformativeText: ns_string(detail)];
+            }
 
             for (ix, answer) in answers
                 .iter()

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -185,6 +185,7 @@ impl PlatformWindow for TestWindow {
         &self,
         _level: crate::PromptLevel,
         _msg: &str,
+        _detail: Option<&str>,
         _answers: &[&str],
     ) -> futures::channel::oneshot::Receiver<usize> {
         self.0

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1478,9 +1478,12 @@ impl<'a> WindowContext<'a> {
         &self,
         level: PromptLevel,
         message: &str,
+        detail: Option<&str>,
         answers: &[&str],
     ) -> oneshot::Receiver<usize> {
-        self.window.platform_window.prompt(level, message, answers)
+        self.window
+            .platform_window
+            .prompt(level, message, detail, answers)
     }
 
     /// Returns all available actions for the focused element.

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -778,6 +778,7 @@ impl ProjectPanel {
             let answer = cx.prompt(
                 PromptLevel::Info,
                 &format!("Delete {file_name:?}?"),
+                None,
                 &["Delete", "Cancel"],
             );
 

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -197,6 +197,18 @@ message Ack {}
 
 message Error {
     string message = 1;
+    ErrorCode code = 2;
+    repeated string tags = 3;
+}
+
+enum ErrorCode {
+    Internal = 0;
+    NoSuchChannel = 1;
+    Disconnected = 2;
+    SignedOut = 3;
+    UpgradeRequired = 4;
+    Forbidden = 5;
+    WrongReleaseChannel = 6;
 }
 
 message Test {

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -209,6 +209,7 @@ enum ErrorCode {
     UpgradeRequired = 4;
     Forbidden = 5;
     WrongReleaseChannel = 6;
+    NeedsCla = 7;
 }
 
 message Test {

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,0 +1,223 @@
+/// Some helpers for structured error handling.
+///
+/// The helpers defined here allow you to pass type-safe error codes from
+/// the collab server to the client; and provide a mechanism for additional
+/// structured data alongside the message.
+///
+/// When returning an error, it can be as simple as:
+///
+/// `return Err(Error::Forbidden.into())`
+///
+/// If you'd like to log more context, you can set a message. These messages
+/// show up in our logs, but are not shown visibly to users.
+///
+/// `return Err(Error::Forbidden.message("not an admin").into())`
+///
+/// If you'd like to provide enough context that the UI can render a good error
+/// message (or would be helpful to see in a structured format in the logs), you
+/// can use .with_tag():
+///
+/// `return Err(Error::WrongReleaseChannel.with_tag("required", "stable").into())`
+///
+/// When handling an error you can use .error_code() to match which error it was
+/// and .error_tag() to read any tags.
+///
+/// ```
+/// match err.error_code() {
+///   ErrorCode::Forbidden => alert("I'm sorry I can't do that.")
+///   ErrorCode::WrongReleaseChannel =>
+///     alert(format!("You need to be on the {} release channel.", err.error_tag("required").unwrap()))
+///   ErrorCode::Internal => alert("Sorry, something went wrong")
+/// }
+/// ```
+///
+use crate::proto;
+pub use proto::ErrorCode;
+
+/// ErrorCodeExt provides some helpers for structured error handling.
+///
+/// The primary implementation is on the proto::ErrorCode to easily convert
+/// that into an anyhow::Error, which we use pervasively.
+///
+/// The RPCError struct provides support for further metadata if needed.
+pub trait ErrorCodeExt {
+    /// Return an anyhow::Error containing this.
+    /// (useful in places where .into() doesn't have enough type information)
+    fn anyhow(self) -> anyhow::Error;
+
+    /// Add a message to the error (by default the error code is used)
+    fn message(self, msg: String) -> RPCError;
+
+    /// Add a tag to the error. Tags are key value pairs that can be used
+    /// to send semi-structured data along with the error.
+    fn with_tag(self, k: &str, v: &str) -> RPCError;
+}
+
+impl ErrorCodeExt for proto::ErrorCode {
+    fn anyhow(self) -> anyhow::Error {
+        self.into()
+    }
+
+    fn message(self, msg: String) -> RPCError {
+        let err: RPCError = self.into();
+        err.message(msg)
+    }
+
+    fn with_tag(self, k: &str, v: &str) -> RPCError {
+        let err: RPCError = self.into();
+        err.with_tag(k, v)
+    }
+}
+
+/// ErrorExt provides helpers for structured error handling.
+///
+/// The primary implementation is on the anyhow::Error, which is
+/// what we use throughout our codebase. Though under the hood this
+pub trait ErrorExt {
+    /// error_code() returns the ErrorCode (or ErrorCode::Internal if there is none)
+    fn error_code(&self) -> proto::ErrorCode;
+    /// error_tag() returns the value of the tag with the given key, if any.
+    fn error_tag(&self, k: &str) -> Option<&str>;
+    /// to_proto() convers the error into a proto::Error
+    fn to_proto(&self) -> proto::Error;
+}
+
+impl ErrorExt for anyhow::Error {
+    fn error_code(&self) -> proto::ErrorCode {
+        if let Some(rpc_error) = self.downcast_ref::<RPCError>() {
+            rpc_error.code
+        } else {
+            proto::ErrorCode::Internal
+        }
+    }
+
+    fn error_tag(&self, k: &str) -> Option<&str> {
+        if let Some(rpc_error) = self.downcast_ref::<RPCError>() {
+            rpc_error.error_tag(k)
+        } else {
+            None
+        }
+    }
+
+    fn to_proto(&self) -> proto::Error {
+        if let Some(rpc_error) = self.downcast_ref::<RPCError>() {
+            rpc_error.to_proto()
+        } else {
+            ErrorCode::Internal.message(format!("{}", self)).to_proto()
+        }
+    }
+}
+
+impl From<proto::ErrorCode> for anyhow::Error {
+    fn from(value: proto::ErrorCode) -> Self {
+        RPCError {
+            request: None,
+            code: value,
+            msg: format!("{:?}", value).to_string(),
+            tags: Default::default(),
+        }
+        .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RPCError {
+    request: Option<String>,
+    msg: String,
+    code: proto::ErrorCode,
+    tags: Vec<String>,
+}
+
+/// RPCError is a structured error type that is returned by the collab server.
+/// In addition to a message, it lets you set a specific ErrorCode, and attach
+/// small amounts of metadata to help the client handle the error appropriately.
+///
+/// This struct is not typically used directly, as we pass anyhow::Error around
+/// in the app; however it is useful for chaining .message() and .with_tag() on
+/// ErrorCode.
+impl RPCError {
+    /// from_proto converts a proto::Error into an anyhow::Error containing
+    /// an RPCError.
+    pub fn from_proto(error: &proto::Error, request: &str) -> anyhow::Error {
+        RPCError {
+            request: Some(request.to_string()),
+            code: error.code(),
+            msg: error.message.clone(),
+            tags: error.tags.clone(),
+        }
+        .into()
+    }
+}
+
+impl ErrorCodeExt for RPCError {
+    fn message(mut self, msg: String) -> RPCError {
+        self.msg = msg;
+        self
+    }
+
+    fn with_tag(mut self, k: &str, v: &str) -> RPCError {
+        self.tags.push(format!("{}={}", k, v));
+        self
+    }
+
+    fn anyhow(self) -> anyhow::Error {
+        self.into()
+    }
+}
+
+impl ErrorExt for RPCError {
+    fn error_tag(&self, k: &str) -> Option<&str> {
+        for tag in &self.tags {
+            let mut parts = tag.split('=');
+            if let Some(key) = parts.next() {
+                if key == k {
+                    return parts.next();
+                }
+            }
+        }
+        None
+    }
+
+    fn error_code(&self) -> proto::ErrorCode {
+        self.code
+    }
+
+    fn to_proto(&self) -> proto::Error {
+        proto::Error {
+            code: self.code as i32,
+            message: self.msg.clone(),
+            tags: self.tags.clone(),
+        }
+    }
+}
+
+impl std::error::Error for RPCError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl std::fmt::Display for RPCError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(request) = &self.request {
+            write!(f, "RPC request {} failed: {}", request, self.msg)?
+        } else {
+            write!(f, "{}", self.msg)?
+        }
+        for tag in &self.tags {
+            write!(f, " {}", tag)?
+        }
+        Ok(())
+    }
+}
+
+impl From<proto::ErrorCode> for RPCError {
+    fn from(code: proto::ErrorCode) -> Self {
+        RPCError {
+            request: None,
+            code,
+            msg: format!("{:?}", code).to_string(),
+            tags: Default::default(),
+        }
+    }
+}

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -1,3 +1,5 @@
+use crate::{ErrorCode, ErrorCodeExt, ErrorExt, RPCError};
+
 use super::{
     proto::{self, AnyTypedEnvelope, EnvelopedMessage, MessageStream, PeerId, RequestMessage},
     Connection,
@@ -423,11 +425,7 @@ impl Peer {
             let (response, _barrier) = rx.await.map_err(|_| anyhow!("connection was closed"))?;
 
             if let Some(proto::envelope::Payload::Error(error)) = &response.payload {
-                Err(anyhow!(
-                    "RPC request {} failed - {}",
-                    T::NAME,
-                    error.message
-                ))
+                Err(RPCError::from_proto(&error, T::NAME))
             } else {
                 Ok(TypedEnvelope {
                     message_id: response.id,
@@ -516,9 +514,12 @@ impl Peer {
         envelope: Box<dyn AnyTypedEnvelope>,
     ) -> Result<()> {
         let connection = self.connection_state(envelope.sender_id())?;
-        let response = proto::Error {
-            message: format!("message {} was not handled", envelope.payload_type_name()),
-        };
+        let response = ErrorCode::Internal
+            .message(format!(
+                "message {} was not handled",
+                envelope.payload_type_name()
+            ))
+            .to_proto();
         let message_id = connection
             .next_message_id
             .fetch_add(1, atomic::Ordering::SeqCst);
@@ -692,17 +693,17 @@ mod tests {
                 server
                     .send(
                         server_to_client_conn_id,
-                        proto::Error {
-                            message: "message 1".to_string(),
-                        },
+                        ErrorCode::Internal
+                            .message("message 1".to_string())
+                            .to_proto(),
                     )
                     .unwrap();
                 server
                     .send(
                         server_to_client_conn_id,
-                        proto::Error {
-                            message: "message 2".to_string(),
-                        },
+                        ErrorCode::Internal
+                            .message("message 2".to_string())
+                            .to_proto(),
                     )
                     .unwrap();
                 server.respond(request.receipt(), proto::Ack {}).unwrap();
@@ -797,17 +798,17 @@ mod tests {
                 server
                     .send(
                         server_to_client_conn_id,
-                        proto::Error {
-                            message: "message 1".to_string(),
-                        },
+                        ErrorCode::Internal
+                            .message("message 1".to_string())
+                            .to_proto(),
                     )
                     .unwrap();
                 server
                     .send(
                         server_to_client_conn_id,
-                        proto::Error {
-                            message: "message 2".to_string(),
-                        },
+                        ErrorCode::Internal
+                            .message("message 2".to_string())
+                            .to_proto(),
                     )
                     .unwrap();
                 server.respond(request1.receipt(), proto::Ack {}).unwrap();

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorCode, ErrorCodeExt, ErrorExt, RPCError};
+use crate::{ErrorCode, ErrorCodeExt, ErrorExt, RpcError};
 
 use super::{
     proto::{self, AnyTypedEnvelope, EnvelopedMessage, MessageStream, PeerId, RequestMessage},
@@ -425,7 +425,7 @@ impl Peer {
             let (response, _barrier) = rx.await.map_err(|_| anyhow!("connection was closed"))?;
 
             if let Some(proto::envelope::Payload::Error(error)) = &response.payload {
-                Err(RPCError::from_proto(&error, T::NAME))
+                Err(RpcError::from_proto(&error, T::NAME))
             } else {
                 Ok(TypedEnvelope {
                     message_id: response.id,

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -1,10 +1,12 @@
 pub mod auth;
 mod conn;
+mod error;
 mod notification;
 mod peer;
 pub mod proto;
 
 pub use conn::Connection;
+pub use error::*;
 pub use notification::*;
 pub use peer::*;
 mod macros;

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -746,6 +746,7 @@ impl ProjectSearchView {
                             cx.prompt(
                                 PromptLevel::Info,
                                 prompt_text.as_str(),
+                                None,
                                 &["Continue", "Cancel"],
                             )
                         })?;

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -870,7 +870,7 @@ impl Pane {
         items: &mut dyn Iterator<Item = &Box<dyn ItemHandle>>,
         all_dirty_items: usize,
         cx: &AppContext,
-    ) -> String {
+    ) -> (String, String) {
         /// Quantity of item paths displayed in prompt prior to cutoff..
         const FILE_NAMES_CUTOFF_POINT: usize = 10;
         let mut file_names: Vec<_> = items
@@ -894,10 +894,12 @@ impl Pane {
                 file_names.push(format!(".. {} files not shown", not_shown_files).into());
             }
         }
-        let file_names = file_names.join("\n");
-        format!(
-            "Do you want to save changes to the following {} files?\n{file_names}",
-            all_dirty_items
+        (
+            format!(
+                "Do you want to save changes to the following {} files?",
+                all_dirty_items
+            ),
+            file_names.join("\n"),
         )
     }
 
@@ -929,11 +931,12 @@ impl Pane {
         cx.spawn(|pane, mut cx| async move {
             if save_intent == SaveIntent::Close && dirty_items.len() > 1 {
                 let answer = pane.update(&mut cx, |_, cx| {
-                    let prompt =
+                    let (prompt, detail) =
                         Self::file_names_for_prompt(&mut dirty_items.iter(), dirty_items.len(), cx);
                     cx.prompt(
                         PromptLevel::Warning,
                         &prompt,
+                        Some(&detail),
                         &["Save all", "Discard all", "Cancel"],
                     )
                 })?;
@@ -1131,6 +1134,7 @@ impl Pane {
                 cx.prompt(
                     PromptLevel::Warning,
                     CONFLICT_MESSAGE,
+                    None,
                     &["Overwrite", "Discard", "Cancel"],
                 )
             })?;
@@ -1154,6 +1158,7 @@ impl Pane {
                         cx.prompt(
                             PromptLevel::Warning,
                             &prompt,
+                            None,
                             &["Save", "Don't Save", "Cancel"],
                         )
                     })?;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -14,8 +14,8 @@ mod workspace_settings;
 use anyhow::{anyhow, Context as _, Result};
 use call::ActiveCall;
 use client::{
-    proto::{self, PeerId},
-    Client, Status, TypedEnvelope, UserStore,
+    proto::{self, ErrorCode, PeerId},
+    Client, ErrorExt, Status, TypedEnvelope, UserStore,
 };
 use collections::{hash_map, HashMap, HashSet};
 use dock::{Dock, DockPosition, Panel, PanelButtons, PanelHandle};
@@ -3919,10 +3919,10 @@ async fn join_channel_internal(
             | Status::Reconnecting
             | Status::Reauthenticating => continue,
             Status::Connected { .. } => break 'outer,
-            Status::SignedOut => return Err(anyhow!("not signed in")),
-            Status::UpgradeRequired => return Err(anyhow!("zed is out of date")),
+            Status::SignedOut => return Err(ErrorCode::SignedOut.into()),
+            Status::UpgradeRequired => return Err(ErrorCode::UpgradeRequired.into()),
             Status::ConnectionError | Status::ConnectionLost | Status::ReconnectionError { .. } => {
-                return Err(anyhow!("zed is offline"))
+                return Err(ErrorCode::Disconnected.into())
             }
         }
     }
@@ -3995,9 +3995,23 @@ pub fn join_channel(
             if let Some(active_window) = active_window {
                 active_window
                     .update(&mut cx, |_, cx| {
+                        let message:SharedString = match err.error_code() {
+                            ErrorCode::SignedOut => {
+                                "Failed to join channel\n\nPlease sign in to continue.".into()
+                            },
+                            ErrorCode::UpgradeRequired => {
+                                "Failed to join channel\n\nPlease update to the latest version of Zed to continue.".into()
+                            },
+                            ErrorCode::NoSuchChannel => {
+                                "Failed to find channel\n\nPlease check the link and try again.".into()
+                            },
+                            ErrorCode::Disconnected => "Failed to join channel\n\nPlease check your internet connection and try again.".into(),
+                            ErrorCode::WrongReleaseChannel => format!("Failed to join channel\n\nOther people in the channel are using the {} release of Zed, please switch to that release instead.", err.error_tag("required").unwrap_or("other")).into(),
+                            _ => format!("Failed to join channel\n\n{}\n\nPlease try again.", err).into(),
+                        };
                         cx.prompt(
                             PromptLevel::Critical,
-                            &format!("Failed to join channel: {}", err),
+                            &message,
                             &["Ok"],
                         )
                     })?

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -370,16 +370,12 @@ fn initialize_pane(workspace: &mut Workspace, pane: &View<Pane>, cx: &mut ViewCo
 }
 
 fn about(_: &mut Workspace, _: &About, cx: &mut gpui::ViewContext<Workspace>) {
-    use std::fmt::Write as _;
-
     let app_name = cx.global::<ReleaseChannel>().display_name();
     let version = env!("CARGO_PKG_VERSION");
-    let mut message = format!("{app_name} {version}");
-    if let Some(sha) = cx.try_global::<AppCommitSha>() {
-        write!(&mut message, "\n\n{}", sha.0).unwrap();
-    }
+    let message = format!("{app_name} {version}");
+    let detail = cx.try_global::<AppCommitSha>().map(|sha| sha.0.as_ref());
 
-    let prompt = cx.prompt(PromptLevel::Info, &message, &["OK"]);
+    let prompt = cx.prompt(PromptLevel::Info, &message, detail, &["OK"]);
     cx.foreground_executor()
         .spawn(async {
             prompt.await.ok();
@@ -410,6 +406,7 @@ fn quit(_: &Quit, cx: &mut AppContext) {
                     cx.prompt(
                         PromptLevel::Info,
                         "Are you sure you want to quit?",
+                        None,
                         &["Quit", "Cancel"],
                     )
                 })


### PR DESCRIPTION
One of the complaints of users on our first Hack call was that the error
messages you got when channel joining failed were not great.

This aims to fix that specific case, and lay the groundwork for future improvements.

It adds two new methods to anyhow::Error

* `.error_code()` which returns a value from zed.proto (or ErrorCode::Internal if the error has no specific tag)
* `.error_tag("key")` which returns the value of the tag (or None).

To construct errors with these fields set, you can use a builder API based on the ErrorCode type:

* `Err(ErrorCode::Forbidden.anyhow())`
* `Err(ErrorCode::Forbidden.message("cannot join channel").into())` - to add any context you want in the logs
* `Err(ErrorCode::WrongReleaseChannel.tag("required", "stable").into())` - to add structured metadata to help the client handle the error better.


Release Notes:

- Improved error messaging when channel joining fails.
