### PR TITLE
Allow cursors to be shown via a command

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -349,7 +349,8 @@
       "alt-cmd-]": "editor::UnfoldLines",
       "ctrl-space": "editor::ShowCompletions",
       "cmd-.": "editor::ToggleCodeActions",
-      "alt-cmd-r": "editor::RevealInFinder"
+      "alt-cmd-r": "editor::RevealInFinder",
+      "ctrl-cmd-c": "editor::ShowCursors"
     }
   },
   {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -214,5 +214,6 @@ gpui::actions!(
         Undo,
         UndoSelection,
         UnfoldLines,
+        ShowCursors
     ]
 );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -367,7 +367,7 @@ pub struct Editor {
     project: Option<Model<Project>>,
     collaboration_hub: Option<Box<dyn CollaborationHub>>,
     blink_manager: Model<BlinkManager>,
-    recently_focused: bool,
+    display_cursors: bool,
     hovered_cursor: Option<HoveredCursor>,
     pub show_local_selections: bool,
     mode: EditorMode,
@@ -1613,7 +1613,7 @@ impl Editor {
             pixel_position_of_newest_cursor: None,
             gutter_width: Default::default(),
             style: None,
-            recently_focused: false,
+            display_cursors: false,
             hovered_cursor: Default::default(),
             editor_actions: Default::default(),
             show_copilot_suggestions: mode == EditorMode::Full,
@@ -3904,12 +3904,12 @@ impl Editor {
     }
 
     fn display_cursors(&mut self, cx: &mut ViewContext<Self>) {
-        self.recently_focused = true;
+        self.display_cursors = true;
         cx.notify();
         cx.spawn(|this, mut cx| async move {
             cx.background_executor().timer(Duration::from_secs(2)).await;
             this.update(&mut cx, |this, cx| {
-                this.recently_focused = false;
+                this.display_cursors = false;
                 cx.notify()
             })
             .ok()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1999,7 +1999,7 @@ impl EditorElement {
                     if Some(selection.peer_id) == editor.leader_peer_id {
                         continue;
                     }
-                    let is_shown = editor.recently_focused || editor.hovered_cursor.as_ref().is_some_and(|c| c.replica_id == selection.replica_id && c.selection_id == selection.selection.id);
+                    let is_shown = editor.display_cursors || editor.hovered_cursor.as_ref().is_some_and(|c| c.replica_id == selection.replica_id && c.selection_id == selection.selection.id);
 
                     remote_selections
                         .entry(selection.replica_id)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -327,6 +327,7 @@ impl EditorElement {
         register_action(view, cx, Editor::context_menu_prev);
         register_action(view, cx, Editor::context_menu_next);
         register_action(view, cx, Editor::context_menu_last);
+        register_action(view, cx, Editor::show_cursors);
     }
 
     fn register_key_listeners(&self, cx: &mut WindowContext) {


### PR DESCRIPTION
I assigned a key binding to trigger the displaying of cursors - it could be anything, but I chose something with a `c` in it (`ctrl-cmd-c`). Feel free to modify, I just really want to be able to trigger this from the keyboard.  If its not wanted by the team, we can close this out.

Release Notes:

- N/A