### PR TITLE
Rename diagnostics::Deploy to diagnostics::Open

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -408,7 +408,7 @@
       "cmd-t": "project_symbols::Toggle",
       "cmd-p": "file_finder::Toggle",
       "cmd-shift-p": "command_palette::Toggle",
-      "cmd-shift-m": "diagnostics::Deploy",
+      "cmd-shift-m": "diagnostics::Open",
       "cmd-shift-e": "project_panel::ToggleFocus",
       "cmd-?": "assistant::ToggleFocus",
       "cmd-alt-s": "workspace::SaveAll",

--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -77,7 +77,7 @@
       "cmd-shift-a": "command_palette::Toggle",
       "cmd-alt-o": "project_symbols::Toggle",
       "cmd-1": "workspace::ToggleLeftDock",
-      "cmd-6": "diagnostics::Deploy"
+      "cmd-6": "diagnostics::Open"
     }
   }
 ]

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -43,7 +43,7 @@ use workspace::{
     ItemNavHistory, Pane, ToolbarItemLocation, Workspace,
 };
 
-actions!(diagnostics, [Deploy, ToggleWarnings]);
+actions!(diagnostics, [Open, ToggleWarnings]);
 
 const CONTEXT_LINE_COUNT: u32 = 1;
 
@@ -194,7 +194,7 @@ impl ProjectDiagnosticsEditor {
         this
     }
 
-    fn deploy(workspace: &mut Workspace, _: &Deploy, cx: &mut ViewContext<Workspace>) {
+    fn deploy(workspace: &mut Workspace, _: &Open, cx: &mut ViewContext<Workspace>) {
         if let Some(existing) = workspace.item_of_type::<ProjectDiagnosticsEditor>(cx) {
             workspace.activate_item(&existing, cx);
         } else {

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -9,7 +9,7 @@ use lsp::LanguageServerId;
 use ui::{h_flex, prelude::*, Button, ButtonLike, Color, Icon, IconName, Label, Tooltip};
 use workspace::{item::ItemHandle, StatusItemView, ToolbarItemEvent, Workspace};
 
-use crate::{Deploy, ProjectDiagnosticsEditor};
+use crate::{Open, ProjectDiagnosticsEditor};
 
 pub struct DiagnosticIndicator {
     summary: project::DiagnosticSummary,
@@ -97,7 +97,7 @@ impl Render for DiagnosticIndicator {
             .child(
                 ButtonLike::new("diagnostic-indicator")
                     .child(diagnostic_indicator)
-                    .tooltip(|cx| Tooltip::for_action("Project Diagnostics", &Deploy, cx))
+                    .tooltip(|cx| Tooltip::for_action("Project Diagnostics", &Open, cx))
                     .on_click(cx.listener(|this, _, cx| {
                         if let Some(workspace) = this.workspace.upgrade() {
                             workspace.update(cx, |workspace, cx| {

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -203,7 +203,7 @@ pub fn command_interceptor(mut query: &str, _: &AppContext) -> Option<CommandInt
         ),
 
         // quickfix / loclist (merged together for now)
-        "cl" | "cli" | "clis" | "clist" => ("clist", diagnostics::Deploy.boxed_clone()),
+        "cl" | "cli" | "clis" | "clist" => ("clist", diagnostics::Open.boxed_clone()),
         "cc" => ("cc", editor::actions::Hover.boxed_clone()),
         "ll" => ("ll", editor::actions::Hover.boxed_clone()),
         "cn" | "cne" | "cnex" | "cnext" => ("cnext", editor::actions::GoToDiagnostic.boxed_clone()),

--- a/crates/zed/src/app_menus.rs
+++ b/crates/zed/src/app_menus.rs
@@ -118,7 +118,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::separator(),
                 MenuItem::action("Project Panel", project_panel::ToggleFocus),
                 MenuItem::action("Command Palette", command_palette::Toggle),
-                MenuItem::action("Diagnostics", diagnostics::Deploy),
+                MenuItem::action("Diagnostics", diagnostics::Open),
                 MenuItem::separator(),
             ],
         },


### PR DESCRIPTION
I think that `diagnostics: deploy` can be confusing for new users finding it in the command palette.

Release Notes:

- Renamed `diagnostics::Deploy` to `diagnostics::Open`
