### PR TITLE
Show channel rename keybinding in the context menu

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -20,7 +20,7 @@ use gpui::{
     Model, MouseDownEvent, ParentElement, Pixels, Point, PromptLevel, Render, SharedString, Styled,
     Subscription, Task, TextStyle, View, ViewContext, VisualContext, WeakView, WhiteSpace,
 };
-use menu::{Cancel, Confirm, SelectNext, SelectPrev};
+use menu::{Cancel, Confirm, SecondaryConfirm, SelectNext, SelectPrev};
 use project::{Fs, Project};
 use rpc::proto::{self, PeerId};
 use serde_derive::{Deserialize, Serialize};
@@ -1124,7 +1124,7 @@ impl CollabPanel {
                     )
                     .entry(
                         "Rename",
-                        None,
+                        Some(Box::new(SecondaryConfirm)),
                         cx.handler_for(&this, move |this, cx| this.rename_channel(channel_id, cx)),
                     )
                     .entry(
@@ -1492,7 +1492,7 @@ impl CollabPanel {
         }
     }
 
-    fn rename_selected_channel(&mut self, _: &menu::SecondaryConfirm, cx: &mut ViewContext<Self>) {
+    fn rename_selected_channel(&mut self, _: &SecondaryConfirm, cx: &mut ViewContext<Self>) {
         if let Some(channel) = self.selected_channel() {
             self.rename_channel(channel.id, cx);
         }


### PR DESCRIPTION
Deals with `Can't rename channels from keyboard` #product note.
We actually already have the action binding to rename the context menu entries, but had no label entry to show that.

Release Notes:

- Added a channel rename keymap label on the collab panel context menu