### PR TITLE
Center "Open Chat" button in chat panel

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -559,6 +559,7 @@ impl Render for ChatPanel {
                 } else {
                     this.child(
                         div()
+                            .full()
                             .p_4()
                             .child(
                                 Label::new("Select a channel to chat in.")


### PR DESCRIPTION
The layout of the chat panel wasn't correct but this visual glitch was being masked by caching, because it seems like Taffy was rendering things slightly differently when laying out the chat panel as a detached layout node. This wasn't an issue with caching, but rather an inconsistency with how Taffy lays things out.

Release Notes:

- N/A
