### PR TITLE
Style notifications for notification panel

### DIFF
--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -713,6 +713,9 @@ impl Render for NotificationToast {
 
         h_flex()
             .id("notification_panel_toast")
+            .elevation_3(cx)
+            .p_2()
+            .gap_2()
             .children(user.map(|user| Avatar::new(user.avatar_uri.clone())))
             .child(Label::new(self.text.clone()))
             .child(


### PR DESCRIPTION
This PR styles the notifications for the notification panel.

These are the notification toasts you receive when you have a new notification (e.g., a mention in chat):

<img width="423" alt="Screenshot 2024-01-19 at 11 39 16 AM" src="https://github.com/zed-industries/zed/assets/1486634/a1fc7a67-5aad-4cb2-8dc9-35d302984fcb">

Release Notes:

- Improved the look of toasts for incoming notifications.
