### PR TITLE
Prevent many call participants from overflowing the title bar

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -85,7 +85,14 @@ impl Render for CollabTitlebarItem {
                     .gap_1()
                     .children(self.render_project_host(cx))
                     .child(self.render_project_name(cx))
-                    .child(div().pr_1().children(self.render_project_branch(cx)))
+                    .children(self.render_project_branch(cx)),
+            )
+            .child(
+                h_flex()
+                    .id("collaborator-list")
+                    .w_full()
+                    .gap_1()
+                    .overflow_x_scroll()
                     .when_some(
                         current_user.clone().zip(client.peer_id()).zip(room.clone()),
                         |this, ((current_user, peer_id), room)| {


### PR DESCRIPTION
This PR fixes an issue where having a lot of participants in a call could cause the avatars/facepiles to overflow the title bar, pushing the call controls off-screen.

The participant list will now scroll when it would otherwise exceed the available space:

https://github.com/zed-industries/zed/assets/1486634/806c77e6-bd4c-4864-8567-92e0960734ee

Release Notes:

- Fixed participant list overflowing the title bar.
