### PR TITLE
Fix hover popovers showing up over zoomed panels

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1218,9 +1218,11 @@ impl EditorElement {
                         popover_origin.x = popover_origin.x + x_out_of_bounds;
                     }
 
-                    cx.break_content_mask(|cx| {
-                        hover_popover.draw(popover_origin, available_space, cx)
-                    });
+                    if cx.was_top_layer(&popover_origin, cx.stacking_order()) {
+                        cx.break_content_mask(|cx| {
+                            hover_popover.draw(popover_origin, available_space, cx)
+                        });
+                    }
 
                     current_y = popover_origin.y - HOVER_POPOVER_GAP;
                 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -599,6 +599,10 @@ impl Terminal {
         }
     }
 
+    pub fn selection_started(&self) -> bool {
+        self.selection_phase == SelectionPhase::Selecting
+    }
+
     /// Updates the cached process info, returns whether the Zed-relevant info has changed
     fn update_process_info(&mut self) -> bool {
         let mut pid = unsafe { libc::tcgetpgrp(self.shell_fd as i32) };

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -621,9 +621,17 @@ impl TerminalElement {
                 }
 
                 if e.pressed_button.is_some() && !cx.has_active_drag() {
+                    let visibly_contains = interactive_bounds.visibly_contains(&e.position, cx);
                     terminal.update(cx, |terminal, cx| {
-                        terminal.mouse_drag(e, origin, bounds);
-                        cx.notify();
+                        if !terminal.selection_started() {
+                            if visibly_contains {
+                                terminal.mouse_drag(e, origin, bounds);
+                                cx.notify();
+                            }
+                        } else {
+                            terminal.mouse_drag(e, origin, bounds);
+                            cx.notify();
+                        }
                     })
                 }
 


### PR DESCRIPTION
Release Notes:

- Fixes a bug where open popovers would stay over top of zoomed panels, if already open when the panel is zoomed.
- Fixes a bug where the terminal would create a selection when clicking the status bar or title bar.