### PR TITLE
Prevent breadcrumbs from overflowing the toolbar

### DIFF
--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -112,18 +112,22 @@ impl Render for Toolbar {
             .child(
                 h_flex()
                     .justify_between()
+                    .gap_2()
                     .when(has_left_items, |this| {
                         this.child(
                             h_flex()
-                                .flex_1()
+                                .flex_auto()
                                 .justify_start()
+                                .overflow_x_hidden()
                                 .children(self.left_items().map(|item| item.to_any())),
                         )
                     })
                     .when(has_right_items, |this| {
                         this.child(
                             h_flex()
-                                .flex_1()
+                                // We're using `flex_none` here to prevent some flickering that can occur when the
+                                // size of the left items container changes.
+                                .flex_none()
                                 .justify_end()
                                 .children(self.right_items().map(|item| item.to_any())),
                         )


### PR DESCRIPTION
This PR prevents the breadcrumbs from overflowing the toolbar when its contents are long:

<img width="1270" alt="Screenshot 2024-01-19 at 6 15 58 PM" src="https://github.com/zed-industries/zed/assets/1486634/ecee7a42-51ef-43d4-99a1-9c3da784dede">

Release Notes:

- Fixed an issue where long breadcrumbs would overflow the toolbar.
