### PR TITLE
When searching in visual mode switch to normal mode

### DIFF
--- a/crates/gpui/src/keymap/matcher.rs
+++ b/crates/gpui/src/keymap/matcher.rs
@@ -73,9 +73,7 @@ impl KeystrokeMatcher {
         if !found_actions.is_empty() {
             self.pending_keystrokes.clear();
             return KeyMatch::Some(found_actions);
-        }
-
-        if let Some(pending_key) = pending_key {
+        } else if let Some(pending_key) = pending_key {
             self.pending_keystrokes.push(pending_key);
             KeyMatch::Pending
         } else {

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -277,6 +277,24 @@ impl NeovimBackedTestContext {
         self.neovim.mode().await.unwrap()
     }
 
+    pub async fn assert_shared_mode(&mut self, mode: Mode) {
+        let neovim = self.neovim_mode().await;
+        let editor = self.cx.mode();
+
+        if neovim != mode || editor != mode {
+            panic!(
+                indoc! {"Test failed (zed does not match nvim behaviour)
+                    # desired mode:
+                    {:?}
+                    # neovim mode:
+                    {:?}
+                    # zed mode:
+                    {:?}"},
+                mode, neovim, editor,
+            )
+        }
+    }
+
     pub async fn assert_state_matches(&mut self) {
         self.is_dirty = false;
         let neovim = self.neovim_state().await;


### PR DESCRIPTION
This matches Neovim behaviour by setting the mode to `Normal` when using search while in visual mode.

Release Notes:

- Fixed Vim mode not switching to normal mode from visual mode when using search (`/`) while in visual mode.
