### PR TITLE
Dont group chat messages after certain period of time

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -18,7 +18,7 @@ use project::Fs;
 use rich_text::RichText;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use time::{OffsetDateTime, UtcOffset};
 use ui::{
     popover_menu, prelude::*, Avatar, Button, ContextMenu, IconButton, IconName, KeyBinding, Label,
@@ -304,8 +304,11 @@ impl ChatPanel {
                 let last_message = active_chat.message(ix.saturating_sub(1));
                 let this_message = active_chat.message(ix).clone();
 
-                let is_continuation_from_previous = last_message.id != this_message.id
-                    && last_message.sender.id == this_message.sender.id;
+                let duration_since_last_message = this_message.timestamp - last_message.timestamp;
+                let is_continuation_from_previous = last_message.sender.id
+                    == this_message.sender.id
+                    && last_message.id != this_message.id
+                    && duration_since_last_message < Duration::from_secs(5 * 60);
 
                 if let ChannelMessageId::Saved(id) = this_message.id {
                     if this_message


### PR DESCRIPTION
<img width="447" alt="SCR-20240121-ofhg" src="https://github.com/zed-industries/zed/assets/19867440/7fe13a74-45c7-43ec-a5e8-5127bc285b32">

In this screenshot, the first two messages were sent back-to-back, but the third message was sent nearly two hours later. Coalescing the messages doesn't feel right after a certain period of time, as it gives misleading timestamps on messages that happen long after others.  Discord has this behavior, but I'm not sure what the value they use is. I've set the threshold to 5 minutes for now.

<img width="480" alt="SCR-20240121-oghs" src="https://github.com/zed-industries/zed/assets/19867440/ee1cfe36-7c13-4072-9f66-93e2de6542f1">

Release Notes:

- Improved the grouping of chat messages when multiple are sent from the same user in succession. Grouping now only occurs if the user sends multiple messages within a specified duration of time.
