### PR TITLE
Show diagnostics on hover

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -545,6 +545,7 @@ impl DiagnosticPopover {
 
         div()
             .id("diagnostic")
+            .elevation_2(cx)
             .overflow_y_scroll()
             .px_2()
             .py_1()


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/6415

Release Notes:

- Fixed a bug that was preventing diagnostics from being shown on hover.
