### PR TITLE
chore: Remove rerun-if-changed clause that might cause spurious rebuilds

### DIFF
--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -100,7 +100,6 @@ fn compile_metal_shaders(header_path: &Path) {
     let air_output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("shaders.air");
     let metallib_output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("shaders.metallib");
 
-    println!("cargo:rerun-if-changed={}", header_path.display());
     println!("cargo:rerun-if-changed={}", shader_path);
 
     let output = Command::new("xcrun")


### PR DESCRIPTION
Something is stomping over the timestamp of generated scene.h right after the build script finishes:
`Dirty gpui v0.1.0 (/Users/someonetoignore/work/zed/zed/crates/gpui): the file target/debug/build/gpui-ca04eedfe8d0e13c/out/scene.h has changed (1705922004.637000680s, 1s after last build at 1705922003.507431315s)`
^ That's an output of `-v` flag added to either `cargo run` or `cargo build`.
This comes up when you do `cargo build` followed by `cargo run` or another `cargo build`; the artifact is not getting reused, even though it should be possible?
Release Notes:
- N/A
