### PR TITLE
lsp-log: Reemit Editors search events.

### DIFF
--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -11,7 +11,7 @@ use crate::{
     ItemHandle,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum SearchEvent {
     MatchesInvalidated,
     ActiveMatchChanged,


### PR DESCRIPTION
Release Notes:

- Fixed "Go to next/previous match" actions not working in language server debug logs.
