### PR TITLE
Fix certain hovers being cut off

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -23,11 +23,12 @@
 //!
 
 use crate::{
-    point, px, Action, AnyDrag, AnyElement, AnyTooltip, AnyView, AppContext, Bounds, ClickEvent,
-    DispatchPhase, Element, ElementContext, ElementId, FocusHandle, IntoElement, IsZero,
-    KeyContext, KeyDownEvent, KeyUpEvent, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, ParentElement, Pixels, Point, Render, ScrollWheelEvent, SharedString, Size,
-    StackingOrder, Style, StyleRefinement, Styled, Task, View, Visibility, WindowContext,
+    point, px, size, Action, AnyDrag, AnyElement, AnyTooltip, AnyView, AppContext, Bounds,
+    ClickEvent, DispatchPhase, Element, ElementContext, ElementId, FocusHandle, IntoElement,
+    IsZero, KeyContext, KeyDownEvent, KeyUpEvent, LayoutId, MouseButton, MouseDownEvent,
+    MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Point, Render, ScrollWheelEvent,
+    SharedString, Size, StackingOrder, Style, StyleRefinement, Styled, Task, View, Visibility,
+    WindowContext,
 };
 
 use collections::HashMap;
@@ -1802,7 +1803,27 @@ impl Interactivity {
                                 .get_or_insert_with(Rc::default)
                                 .clone();
                             let line_height = cx.line_height();
-                            let scroll_max = (content_size - bounds.size).max(&Size::default());
+                            let rem_size = cx.rem_size();
+                            let padding_size = size(
+                                style
+                                    .padding
+                                    .left
+                                    .to_pixels(bounds.size.width.into(), rem_size)
+                                    + style
+                                        .padding
+                                        .right
+                                        .to_pixels(bounds.size.width.into(), rem_size),
+                                style
+                                    .padding
+                                    .top
+                                    .to_pixels(bounds.size.height.into(), rem_size)
+                                    + style
+                                        .padding
+                                        .bottom
+                                        .to_pixels(bounds.size.height.into(), rem_size),
+                            );
+                            let scroll_max =
+                                (content_size + padding_size - bounds.size).max(&Size::default());
                             // Clamp scroll offset in case scroll max is smaller now (e.g., if children
                             // were removed or the bounds became larger).
                             {

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -497,6 +497,20 @@ where
     }
 }
 
+impl<T> Add for Size<T>
+where
+    T: Add<Output = T> + Clone + Default + Debug,
+{
+    type Output = Size<T>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Size {
+            width: self.width + rhs.width,
+            height: self.height + rhs.height,
+        }
+    }
+}
+
 impl<T, Rhs> Mul<Rhs> for Size<T>
 where
     T: Mul<Rhs, Output = Rhs> + Clone + Default + Debug,


### PR DESCRIPTION
Release Notes:

- Fixes a bug where the bottom of hover popovers would be cut off ([#2434](https://github.com/zed-industries/zed/issues/6420)).
