### PR TITLE
Fix off-by-one highlighting in hover tooltip

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -394,6 +394,27 @@ async fn parse_blocks(
         }
     }
 
+    let leading_space = text.chars().take_while(|c| c.is_whitespace()).count();
+    if leading_space > 0 {
+        highlights = highlights
+            .into_iter()
+            .map(|(range, style)| {
+                (
+                    range.start.saturating_sub(leading_space)
+                        ..range.end.saturating_sub(leading_space),
+                    style,
+                )
+            })
+            .collect();
+        region_ranges = region_ranges
+            .into_iter()
+            .map(|range| {
+                    range.start.saturating_sub(leading_space)
+                        ..range.end.saturating_sub(leading_space),
+            })
+            .collect();
+    }
+
     ParsedMarkdown {
         text: text.trim().to_string(),
         highlights,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -409,8 +409,7 @@ async fn parse_blocks(
         region_ranges = region_ranges
             .into_iter()
             .map(|range| {
-                    range.start.saturating_sub(leading_space)
-                        ..range.end.saturating_sub(leading_space),
+                range.start.saturating_sub(leading_space)..range.end.saturating_sub(leading_space)
             })
             .collect();
     }


### PR DESCRIPTION
rust analyzer has a tendency to return markdown of the form:

```rust
 // <-- note the leading space
blah blah blah
```

This is clearly defectuous, so we used to .trim() the output.

Unfortunately we trim after applying syntax highlighting, so that causes
the output to look goofy.

Fix this by updating the highlighting when we trim.

[[PR Description]]

Release Notes:

- Fixed a bug where syntax highlighting was off in hover tooltips
