### PR TITLE
Fix horizontal scroll going too far to the left

### DIFF
--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -202,7 +202,7 @@ impl ScrollManager {
                 ScrollAnchor {
                     anchor: top_anchor,
                     offset: point(
-                        scroll_position.x,
+                        scroll_position.x.max(0.),
                         scroll_position.y - top_anchor.to_display_point(&map).row() as f32,
                     ),
                 },


### PR DESCRIPTION
Previously one could scroll infinitely to the left. This clams it to 0.

Release Notes:

- Fixed horizontal scroll possibly going too far to the left.