### PR TITLE
Make scripts/histogram ignore lines without frame duration

### DIFF
--- a/script/histogram
+++ b/script/histogram
@@ -28,7 +28,7 @@ def parse_log_file(file_path):
     data = {'measurement': [], 'time': [], 'unit': [], 'log_file': []}
     with open(file_path, 'r') as file:
         for line in file:
-            if 'duration:' not in line:
+            if ':' not in line:
                 continue
 
             parts = line.strip().split(': ')
@@ -41,7 +41,8 @@ def parse_log_file(file_path):
             elif 'µs' in time_with_unit:
                 time, unit = time_with_unit[:-2], 'µs'
             else:
-                raise ValueError(f"Invalid time unit in line: {line.strip()}")
+                # Print an error message if we can't parse the line and then continue with rest.
+                print(f'Error: Invalid time unit in line "{line.strip()}". Skipping.', file=sys.stderr)
                 continue
 
             data['measurement'].append(measurement)

--- a/script/histogram
+++ b/script/histogram
@@ -28,7 +28,7 @@ def parse_log_file(file_path):
     data = {'measurement': [], 'time': [], 'unit': [], 'log_file': []}
     with open(file_path, 'r') as file:
         for line in file:
-            if ':' not in line:
+            if 'duration:' not in line:
                 continue
 
             parts = line.strip().split(': ')


### PR DESCRIPTION
Previously the script would choke on lines generated, for example, by `cargo run`.

This just skips lines that don't contain `frame duration:`.

Release Notes:

- N/A