### PR TITLE
Fix scroll jitter by ignoring autoscroll events if following

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -277,7 +277,7 @@ impl FollowableItem for Editor {
                         .extend(ids.iter().map(ExcerptId::to_proto));
                     true
                 }
-                EditorEvent::ScrollPositionChanged { .. } => {
+                EditorEvent::ScrollPositionChanged { autoscroll, .. } if !autoscroll => {
                     let scroll_anchor = self.scroll_manager.anchor();
                     update.scroll_top_anchor = Some(serialize_anchor(&scroll_anchor.anchor));
                     update.scroll_x = scroll_anchor.offset.x;


### PR DESCRIPTION
When following someone else we saw jitter because `ScrollPositionChanged` events were battling `SelectionsChanged` events, both of which were scrolling the viewport.

This ignores the ScrollPositionChanged if autoscrolling is on.

Release Notes:

- Fixed jittery scrolling when following someone else that had a bigger viewport.
