### PR TITLE
Use a different color for ignored files in the project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1352,6 +1352,8 @@ impl ProjectPanel {
             })
             .unwrap_or(if is_selected {
                 Color::Default
+            } else if details.is_ignored {
+                Color::Disabled
             } else {
                 Color::Muted
             });


### PR DESCRIPTION

![Screenshot 2024-01-23 at 1 03 01 PM](https://github.com/zed-industries/zed/assets/326587/28b4e7e1-8847-40ff-aed6-0f4ede6b9007)


Release Notes:

- Fixed an issue where ignored files were not visually distinguished in the project panel.
