### PR TITLE
CI: Do not run cargo check --tests before running the tests

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -18,10 +18,6 @@ runs:
           shell: bash -euxo pipefail {0}
           run: script/clear-target-dir-if-larger-than 100
 
-        - name: Run check
-          shell: bash -euxo pipefail {0}
-          run: cargo check --tests --workspace
-
         - name: Run tests
           shell: bash -euxo pipefail {0}
           run: cargo nextest run --workspace --no-fail-fast


### PR DESCRIPTION
This is a bit redundant, as cargo test does not reuse results of cargo check, so we're essentially doing the cargo check unnecessarily.

Release Notes:

- N/A