### PR TITLE
Fix hovering over elements nested inside their parents

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2495,6 +2495,7 @@ impl CollabPanel {
                 h_flex()
                     .absolute()
                     .right(rems(0.))
+                    .z_index(1)
                     .h_full()
                     .child(
                         h_flex()

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2496,8 +2496,6 @@ impl CollabPanel {
                     .absolute()
                     .right(rems(0.))
                     .h_full()
-                    // HACK: Without this the channel name clips on top of the icons, but I'm not sure why.
-                    .z_index(10)
                     .child(
                         h_flex()
                             .h_full()

--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -328,7 +328,13 @@ impl Element for AnyView {
                 element.draw(bounds.origin, bounds.size.into(), cx);
             }
 
-            state.next_stacking_order_id = cx.window.next_frame.next_stacking_order_id;
+            state.next_stacking_order_id = cx
+                .window
+                .next_frame
+                .next_stacking_order_ids
+                .last()
+                .copied()
+                .unwrap();
             state.cache_key = Some(ViewCacheKey {
                 bounds,
                 stacking_order: cx.stacking_order().clone(),

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -859,15 +859,14 @@ impl<'a> WindowContext<'a> {
 
             // At this point, we've established that this opaque layer is on top of the queried layer
             // and contains the position:
-            // - If the opaque layer is an extension of the queried layer, we don't want
-            // to consider the opaque layer to be on top and so we ignore it.
-            // - Else, we will bail early and say that the queried layer wasn't the top one.
-            let opaque_layer_is_extension_of_queried_layer = opaque_layer.len() >= layer.len()
-                && opaque_layer
-                    .iter()
-                    .zip(layer.iter())
-                    .all(|(a, b)| a.z_index == b.z_index);
-            if !opaque_layer_is_extension_of_queried_layer {
+            // If neither the opaque layer or the queried layer is an extension of the other then
+            // we know they are on different stacking orders, and return false.
+            let is_on_same_layer = opaque_layer
+                .iter()
+                .zip(layer.iter())
+                .all(|(a, b)| a.z_index == b.z_index);
+
+            if !is_on_same_layer {
                 return false;
             }
         }
@@ -908,15 +907,14 @@ impl<'a> WindowContext<'a> {
 
             // At this point, we've established that this opaque layer is on top of the queried layer
             // and contains the position:
-            // - If the opaque layer is an extension of the queried layer, we don't want
-            // to consider the opaque layer to be on top and so we ignore it.
-            // - Else, we will bail early and say that the queried layer wasn't the top one.
-            let opaque_layer_is_extension_of_queried_layer = opaque_layer.len() >= layer.len()
-                && opaque_layer
-                    .iter()
-                    .zip(layer.iter())
-                    .all(|(a, b)| a.z_index == b.z_index);
-            if !opaque_layer_is_extension_of_queried_layer {
+            // If neither the opaque layer or the queried layer is an extension of the other then
+            // we know they are on different stacking orders, and return false.
+            let is_on_same_layer = opaque_layer
+                .iter()
+                .zip(layer.iter())
+                .all(|(a, b)| a.z_index == b.z_index);
+
+            if !is_on_same_layer {
                 return false;
             }
         }


### PR DESCRIPTION
This fixes some flickering in the sidebar when hovering over channel buttons.

There is still one issue remaining which is that the hover state of the list
item is incorrect in this case.
The only fixes we found for that cause the flickering to resume, but only if view caching is enabled.

@as-cii if you have some time tomorrow morning MT, it'd be nice to pair/triple on this.

NOTE: We couldn't reproduce this synthetically, to reproduce:

* ./script/zed-local -2
* create a call and unmute yourself
* hover over the "chat" button in a channel item in the collab panel
* talk into the microphone


[[PR Description]]

Release Notes:

- Fixed hovered buttons flickering when someone in a call speaks.
