### PR TITLE
Revert "Improve completion, action and shared project popovers' layout"

### DIFF
--- a/crates/collab_ui/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui/src/notifications/incoming_call_notification.rs
@@ -125,7 +125,7 @@ impl Render for IncomingCallNotification {
 
         cx.set_rem_size(ui_font_size);
 
-        h_flex().flex_grow().size_full().font(ui_font).child(
+        div().size_full().font(ui_font).child(
             CollabNotification::new(
                 self.state.call.calling_user.avatar_uri.clone(),
                 Button::new("accept", "Accept").on_click({

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -129,7 +129,7 @@ impl Render for ProjectSharedNotification {
 
         cx.set_rem_size(ui_font_size);
 
-        h_flex().flex_grow().size_full().font(ui_font).child(
+        div().size_full().font(ui_font).child(
             CollabNotification::new(
                 self.owner.avatar_uri.clone(),
                 Button::new("open", "Open").on_click(cx.listener(move |this, _event, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -848,7 +848,7 @@ impl CompletionsMenu {
                     .flex_1()
                     .px_1p5()
                     .py_1()
-                    .min_w(px(160.))
+                    .min_w(px(260.))
                     .max_w(px(640.))
                     .w(px(500.))
                     .overflow_y_scroll()
@@ -910,7 +910,7 @@ impl CompletionsMenu {
                                 None
                             };
 
-                        h_flex().flex_grow().w_full().min_w(px(120.)).child(
+                        div().min_w(px(220.)).max_w(px(540.)).child(
                             ListItem::new(mat.candidate_id)
                                 .inset(true)
                                 .selected(item_ix == selected_item)
@@ -925,7 +925,7 @@ impl CompletionsMenu {
                                         )
                                         .map(|task| task.detach_and_log_err(cx));
                                 }))
-                                .child(h_flex().flex_grow().child(completion_label))
+                                .child(h_flex().overflow_hidden().child(completion_label))
                                 .end_slot::<Div>(documentation_label),
                         )
                     })
@@ -934,9 +934,7 @@ impl CompletionsMenu {
         )
         .max_h(max_height)
         .track_scroll(self.scroll_handle.clone())
-        .with_width_from_item(widest_completion_ix)
-        .use_max_height()
-        .use_max_width();
+        .with_width_from_item(widest_completion_ix);
 
         Popover::new()
             .child(list)
@@ -1078,11 +1076,8 @@ impl CodeActionsMenu {
                         let item_ix = range.start + ix;
                         let selected = selected_item == item_ix;
                         let colors = cx.theme().colors();
-                        h_flex()
-                            .flex_grow()
-                            .w_full()
+                        div()
                             .px_2()
-                            .min_w(px(120.))
                             .text_color(colors.text)
                             .when(selected, |style| {
                                 style
@@ -1126,8 +1121,6 @@ impl CodeActionsMenu {
                 .max_by_key(|(_, action)| action.lsp_action.title.chars().count())
                 .map(|(ix, _)| ix),
         )
-        .use_max_width()
-        .use_max_height()
         .into_any_element();
 
         if self.deployed_from_indicator {

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -56,8 +56,6 @@ where
             ..Default::default()
         },
         scroll_handle: None,
-        use_max_width: false,
-        use_max_height: false,
     }
 }
 
@@ -66,8 +64,6 @@ pub struct UniformList {
     id: ElementId,
     item_count: usize,
     item_to_measure_index: usize,
-    use_max_width: bool,
-    use_max_height: bool,
     render_items:
         Box<dyn for<'a> Fn(Range<usize>, &'a mut WindowContext) -> SmallVec<[AnyElement; 64]>>,
     interactivity: Interactivity,
@@ -284,40 +280,19 @@ impl UniformList {
         self
     }
 
-    /// Forces the list to use the `AvailableSpace::MaxContent` for its items width during laying out.
-    pub fn use_max_width(mut self) -> Self {
-        self.use_max_width = true;
-        self
-    }
-
-    /// Forces the list to use the `AvailableSpace::MaxContent` for its items' height during laying out.
-    pub fn use_max_height(mut self) -> Self {
-        self.use_max_height = true;
-        self
-    }
-
     fn measure_item(&self, list_width: Option<Pixels>, cx: &mut ElementContext) -> Size<Pixels> {
         if self.item_count == 0 {
             return Size::default();
         }
 
-        let width_default = if self.use_max_width {
-            AvailableSpace::MaxContent
-        } else {
-            AvailableSpace::MinContent
-        };
-        let height_default = if self.use_max_height {
-            AvailableSpace::MaxContent
-        } else {
-            AvailableSpace::MinContent
-        };
-
         let item_ix = cmp::min(self.item_to_measure_index, self.item_count - 1);
         let mut items = (self.render_items)(item_ix..item_ix + 1, cx);
         let mut item_to_measure = items.pop().unwrap();
         let available_space = size(
-            list_width.map_or(width_default, AvailableSpace::Definite),
-            height_default,
+            list_width.map_or(AvailableSpace::MinContent, |width| {
+                AvailableSpace::Definite(width)
+            }),
+            AvailableSpace::MinContent,
         );
         item_to_measure.measure(available_space, cx)
     }

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -149,7 +149,6 @@ impl ParentElement for ListItem {
 impl RenderOnce for ListItem {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         h_flex()
-            .flex_grow()
             .id(self.id)
             .w_full()
             .relative()


### PR DESCRIPTION
Reverts zed-industries/zed#4226

Unfortunately there where some worse states possible after this PR. Reverting until after the launch, as the problems it addresses are still bad.

![Screenshot 2024-01-23 at 3 20 59 PM](https://github.com/zed-industries/zed/assets/2280405/d25ab0d5-db49-44cb-b865-e320a97616ce)
