### PR TITLE
Add barebones GPUI README

### DIFF
--- a/crates/gpui/README.md
+++ b/crates/gpui/README.md
@@ -1,0 +1,3 @@
+# GPUI
+
+A fast, productive UI framework from the creators of [https://zed.dev].


### PR DESCRIPTION
This PR adds a barebones README to the `gpui` crate, just so folks have somewhere to land on when we link them here from [gpui.rs](https://www.gpui.rs/).

We can flesh this out as we go.

Release Notes:

- N/A
