### PR TITLE
Add `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+The Code of Conduct for this repository can be found online at [zed.dev/docs/code-of-conduct](https://zed.dev/docs/code-of-conduct).


### PR DESCRIPTION
This PR adds a `CODE_OF_CONDUCT.md` that links out to the existing code of conduct on the Zed site.

The link in the file is currently a dead link, but will work once the new site goes live tomorrow.

Release Notes:

- N/A