### PR TITLE
Clean up `gpui` docs

### DIFF
--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -154,6 +154,7 @@ impl AsyncAppContext {
     }
 
     /// Reads the global state of the specified type, passing it to the given callback.
+    ///
     /// Panics if no global state of the specified type has been assigned.
     /// Returns an error if the `AppContext` has been dropped.
     pub fn read_global<G: 'static, R>(&self, read: impl FnOnce(&G, &AppContext) -> R) -> Result<R> {
@@ -166,7 +167,10 @@ impl AsyncAppContext {
     }
 
     /// Reads the global state of the specified type, passing it to the given callback.
-    /// Similar to [read_global], but returns an error instead of panicking if no state of the specified type has been assigned.
+    ///
+    /// Similar to [`AsyncAppContext::read_global`], but returns an error instead of panicking
+    /// if no state of the specified type has been assigned.
+    ///
     /// Returns an error if no state of the specified type has been assigned the `AppContext` has been dropped.
     pub fn try_read_global<G: 'static, R>(
         &self,
@@ -212,12 +216,12 @@ impl AsyncWindowContext {
         self.window
     }
 
-    /// A convenience method for [WindowContext::update()]
+    /// A convenience method for [`AppContext::update_window`].
     pub fn update<R>(&mut self, update: impl FnOnce(&mut WindowContext) -> R) -> Result<R> {
         self.app.update_window(self.window, |_, cx| update(cx))
     }
 
-    /// A convenience method for [WindowContext::update()]
+    /// A convenience method for [`AppContext::update_window`].
     pub fn update_root<R>(
         &mut self,
         update: impl FnOnce(AnyView, &mut WindowContext) -> R,
@@ -225,12 +229,12 @@ impl AsyncWindowContext {
         self.app.update_window(self.window, update)
     }
 
-    /// A convenience method for [WindowContext::on_next_frame()]
+    /// A convenience method for [`WindowContext::on_next_frame`].
     pub fn on_next_frame(&mut self, f: impl FnOnce(&mut WindowContext) + 'static) {
         self.window.update(self, |_, cx| cx.on_next_frame(f)).ok();
     }
 
-    /// A convenience method for [AppContext::global()]
+    /// A convenience method for [`AppContext::global`].
     pub fn read_global<G: 'static, R>(
         &mut self,
         read: impl FnOnce(&G, &WindowContext) -> R,
@@ -238,7 +242,7 @@ impl AsyncWindowContext {
         self.window.update(self, |_, cx| read(cx.global(), cx))
     }
 
-    /// A convenience method for [AppContext::update_global()]
+    /// A convenience method for [`AppContext::update_global`].
     /// for updating the global state of the specified type.
     pub fn update_global<G, R>(
         &mut self,

--- a/crates/gpui/src/app/model_context.rs
+++ b/crates/gpui/src/app/model_context.rs
@@ -42,7 +42,8 @@ impl<'a, T: 'static> ModelContext<'a, T> {
         self.model_state.clone()
     }
 
-    /// Arranges for the given function to be called whenever [ModelContext::notify] or [ViewContext::notify] is called with the given model or view.
+    /// Arranges for the given function to be called whenever [`ModelContext::notify`] or
+    /// [`ViewContext::notify`](crate::ViewContext::notify) is called with the given model or view.
     pub fn observe<W, E>(
         &mut self,
         entity: &E,
@@ -150,7 +151,7 @@ impl<'a, T: 'static> ModelContext<'a, T> {
     }
 
     /// Arrange for the given function to be invoked whenever the application is quit.
-    /// The future returned from this callback will be polled for up to [gpui::SHUTDOWN_TIMEOUT] until the app fully quits.
+    /// The future returned from this callback will be polled for up to [crate::SHUTDOWN_TIMEOUT] until the app fully quits.
     pub fn on_app_quit<Fut>(
         &mut self,
         mut on_quit: impl FnMut(&mut T, &mut ModelContext<T>) -> Fut + 'static,

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1,7 +1,7 @@
 //! Div is the central, reusable element that most GPUI trees will be built from.
 //! It functions as a container for other elements, and provides a number of
 //! useful features for laying out and styling its children as well as binding
-//! mouse events and action handlers. It is meant to be similar to the HTML <div>
+//! mouse events and action handlers. It is meant to be similar to the HTML `<div>`
 //! element, but for GPUI.
 //!
 //! # Build your own div
@@ -85,7 +85,7 @@ impl Interactivity {
     /// Bind the given callback to the mouse down event for the given mouse button, during the bubble phase
     /// The imperative API equivalent of [`InteractiveElement::on_mouse_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to the view state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to the view state from this callback.
     pub fn on_mouse_down(
         &mut self,
         button: MouseButton,
@@ -105,7 +105,7 @@ impl Interactivity {
     /// Bind the given callback to the mouse down event for any button, during the capture phase
     /// The imperative API equivalent of [`InteractiveElement::capture_any_mouse_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn capture_any_mouse_down(
         &mut self,
         listener: impl Fn(&MouseDownEvent, &mut WindowContext) + 'static,
@@ -119,9 +119,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to the mouse down event for any button, during the bubble phase
-    /// the imperative API equivalent to [`InteractiveElement::on_any_mouse_down()`]
+    /// the imperative API equivalent to [`InteractiveElement::on_any_mouse_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_any_mouse_down(
         &mut self,
         listener: impl Fn(&MouseDownEvent, &mut WindowContext) + 'static,
@@ -135,9 +135,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to the mouse up event for the given button, during the bubble phase
-    /// the imperative API equivalent to [`InteractiveElement::on_mouse_up()`]
+    /// the imperative API equivalent to [`InteractiveElement::on_mouse_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_mouse_up(
         &mut self,
         button: MouseButton,
@@ -155,9 +155,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to the mouse up event for any button, during the capture phase
-    /// the imperative API equivalent to [`InteractiveElement::capture_any_mouse_up()`]
+    /// the imperative API equivalent to [`InteractiveElement::capture_any_mouse_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn capture_any_mouse_up(
         &mut self,
         listener: impl Fn(&MouseUpEvent, &mut WindowContext) + 'static,
@@ -171,9 +171,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to the mouse up event for any button, during the bubble phase
-    /// the imperative API equivalent to [`InteractiveElement::on_any_mouse_up()`]
+    /// the imperative API equivalent to [`Interactivity::on_any_mouse_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_any_mouse_up(
         &mut self,
         listener: impl Fn(&MouseUpEvent, &mut WindowContext) + 'static,
@@ -188,9 +188,9 @@ impl Interactivity {
 
     /// Bind the given callback to the mouse down event, on any button, during the capture phase,
     /// when the mouse is outside of the bounds of this element.
-    /// The imperative API equivalent to [`InteractiveElement::on_mouse_down_out()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_mouse_down_out`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_mouse_down_out(
         &mut self,
         listener: impl Fn(&MouseDownEvent, &mut WindowContext) + 'static,
@@ -206,9 +206,9 @@ impl Interactivity {
 
     /// Bind the given callback to the mouse up event, for the given button, during the capture phase,
     /// when the mouse is outside of the bounds of this element.
-    /// The imperative API equivalent to [`InteractiveElement::on_mouse_up_out()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_mouse_up_out`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_mouse_up_out(
         &mut self,
         button: MouseButton,
@@ -226,9 +226,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to the mouse move event, during the bubble phase
-    /// The imperative API equivalent to [`InteractiveElement::on_mouse_move()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_mouse_move`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_mouse_move(
         &mut self,
         listener: impl Fn(&MouseMoveEvent, &mut WindowContext) + 'static,
@@ -245,9 +245,9 @@ impl Interactivity {
     /// will be called for all move events, inside or outside of this element, as long as the
     /// drag was started with this element under the mouse. Useful for implementing draggable
     /// UIs that don't conform to a drag and drop style interaction, like resizing.
-    /// The imperative API equivalent to [`InteractiveElement::on_drag_move()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_drag_move`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_drag_move<T>(
         &mut self,
         listener: impl Fn(&DragMoveEvent<T>, &mut WindowContext) + 'static,
@@ -275,9 +275,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to scroll wheel events during the bubble phase
-    /// The imperative API equivalent to [`InteractiveElement::on_scroll_wheel()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_scroll_wheel`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_scroll_wheel(
         &mut self,
         listener: impl Fn(&ScrollWheelEvent, &mut WindowContext) + 'static,
@@ -291,9 +291,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to an action dispatch during the capture phase
-    /// The imperative API equivalent to [`InteractiveElement::capture_action()`]
+    /// The imperative API equivalent to [`InteractiveElement::capture_action`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn capture_action<A: Action>(
         &mut self,
         listener: impl Fn(&A, &mut WindowContext) + 'static,
@@ -310,9 +310,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to an action dispatch during the bubble phase
-    /// The imperative API equivalent to [`InteractiveElement::on_action()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_action`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_action<A: Action>(&mut self, listener: impl Fn(&A, &mut WindowContext) + 'static) {
         self.action_listeners.push((
             TypeId::of::<A>(),
@@ -328,9 +328,9 @@ impl Interactivity {
     /// Bind the given callback to an action dispatch, based on a dynamic action parameter
     /// instead of a type parameter. Useful for component libraries that want to expose
     /// action bindings to their users.
-    /// The imperative API equivalent to [`InteractiveElement::on_boxed_action()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_boxed_action`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_boxed_action(
         &mut self,
         action: &dyn Action,
@@ -348,9 +348,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to key down events during the bubble phase
-    /// The imperative API equivalent to [`InteractiveElement::on_key_down()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_key_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_key_down(&mut self, listener: impl Fn(&KeyDownEvent, &mut WindowContext) + 'static) {
         self.key_down_listeners
             .push(Box::new(move |event, phase, cx| {
@@ -361,9 +361,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to key down events during the capture phase
-    /// The imperative API equivalent to [`InteractiveElement::capture_key_down()`]
+    /// The imperative API equivalent to [`InteractiveElement::capture_key_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn capture_key_down(
         &mut self,
         listener: impl Fn(&KeyDownEvent, &mut WindowContext) + 'static,
@@ -377,9 +377,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to key up events during the bubble phase
-    /// The imperative API equivalent to [`InteractiveElement::on_key_up()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_key_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_key_up(&mut self, listener: impl Fn(&KeyUpEvent, &mut WindowContext) + 'static) {
         self.key_up_listeners
             .push(Box::new(move |event, phase, cx| {
@@ -390,9 +390,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to key up events during the capture phase
-    /// The imperative API equivalent to [`InteractiveElement::on_key_up()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_key_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn capture_key_up(&mut self, listener: impl Fn(&KeyUpEvent, &mut WindowContext) + 'static) {
         self.key_up_listeners
             .push(Box::new(move |event, phase, cx| {
@@ -403,9 +403,9 @@ impl Interactivity {
     }
 
     /// Bind the given callback to drop events of the given type, whether or not the drag started on this element
-    /// The imperative API equivalent to [`InteractiveElement::on_drop()`]
+    /// The imperative API equivalent to [`InteractiveElement::on_drop`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_drop<T: 'static>(&mut self, listener: impl Fn(&T, &mut WindowContext) + 'static) {
         self.drop_listeners.push((
             TypeId::of::<T>(),
@@ -416,15 +416,15 @@ impl Interactivity {
     }
 
     /// Use the given predicate to determine whether or not a drop event should be dispatched to this element
-    /// The imperative API equivalent to [`InteractiveElement::can_drop()`]
+    /// The imperative API equivalent to [`InteractiveElement::can_drop`]
     pub fn can_drop(&mut self, predicate: impl Fn(&dyn Any, &mut WindowContext) -> bool + 'static) {
         self.can_drop_predicate = Some(Box::new(predicate));
     }
 
     /// Bind the given callback to click events of this element
-    /// The imperative API equivalent to [`InteractiveElement::on_click()`]
+    /// The imperative API equivalent to [`StatefulInteractiveElement::on_click`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_click(&mut self, listener: impl Fn(&ClickEvent, &mut WindowContext) + 'static)
     where
         Self: Sized,
@@ -435,10 +435,10 @@ impl Interactivity {
 
     /// On drag initiation, this callback will be used to create a new view to render the dragged value for a
     /// drag and drop operation. This API should also be used as the equivalent of 'on drag start' with
-    /// the [`Self::on_drag_move()`] API
-    /// The imperative API equivalent to [`InteractiveElement::on_drag()`]
+    /// the [`Self::on_drag_move`] API
+    /// The imperative API equivalent to [`StatefulInteractiveElement::on_drag`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_drag<T, W>(
         &mut self,
         value: T,
@@ -460,9 +460,9 @@ impl Interactivity {
 
     /// Bind the given callback on the hover start and end events of this element. Note that the boolean
     /// passed to the callback is true when the hover starts and false when it ends.
-    /// The imperative API equivalent to [`InteractiveElement::on_drag()`]
+    /// The imperative API equivalent to [`StatefulInteractiveElement::on_drag`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     pub fn on_hover(&mut self, listener: impl Fn(&bool, &mut WindowContext) + 'static)
     where
         Self: Sized,
@@ -475,7 +475,7 @@ impl Interactivity {
     }
 
     /// Use the given callback to construct a new tooltip view when the mouse hovers over this element.
-    /// The imperative API equivalent to [`InteractiveElement::tooltip()`]
+    /// The imperative API equivalent to [`InteractiveElement::tooltip`]
     pub fn tooltip(&mut self, build_tooltip: impl Fn(&mut WindowContext) -> AnyView + 'static)
     where
         Self: Sized,
@@ -488,7 +488,7 @@ impl Interactivity {
     }
 
     /// Block the mouse from interacting with this element or any of it's children
-    /// The imperative API equivalent to [`InteractiveElement::block_mouse()`]
+    /// The imperative API equivalent to [`InteractiveElement::block_mouse`]
     pub fn block_mouse(&mut self) {
         self.block_mouse = true;
     }
@@ -559,9 +559,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to the mouse down event for the given mouse button,
-    /// the fluent API equivalent to [`Interactivity::on_mouse_down()`]
+    /// the fluent API equivalent to [`Interactivity::on_mouse_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to the view state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to the view state from this callback.
     fn on_mouse_down(
         mut self,
         button: MouseButton,
@@ -573,7 +573,7 @@ pub trait InteractiveElement: Sized {
 
     #[cfg(any(test, feature = "test-support"))]
     /// Set a key that can be used to look up this element's bounds
-    /// in the [`VisualTestContext::debug_bounds()`] map
+    /// in the [`VisualTestContext::debug_bounds`] map
     /// This is a noop in release builds
     fn debug_selector(mut self, f: impl FnOnce() -> String) -> Self {
         self.interactivity().debug_selector = Some(f());
@@ -582,7 +582,7 @@ pub trait InteractiveElement: Sized {
 
     #[cfg(not(any(test, feature = "test-support")))]
     /// Set a key that can be used to look up this element's bounds
-    /// in the [`VisualTestContext::debug_bounds()`] map
+    /// in the [`VisualTestContext::debug_bounds`] map
     /// This is a noop in release builds
     #[inline]
     fn debug_selector(self, _: impl FnOnce() -> String) -> Self {
@@ -590,9 +590,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to the mouse down event for any button, during the capture phase
-    /// the fluent API equivalent to [`Interactivity::capture_any_mouse_down()`]
+    /// the fluent API equivalent to [`Interactivity::capture_any_mouse_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn capture_any_mouse_down(
         mut self,
         listener: impl Fn(&MouseDownEvent, &mut WindowContext) + 'static,
@@ -602,9 +602,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to the mouse down event for any button, during the capture phase
-    /// the fluent API equivalent to [`Interactivity::on_any_mouse_down()`]
+    /// the fluent API equivalent to [`Interactivity::on_any_mouse_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_any_mouse_down(
         mut self,
         listener: impl Fn(&MouseDownEvent, &mut WindowContext) + 'static,
@@ -614,9 +614,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to the mouse up event for the given button, during the bubble phase
-    /// the fluent API equivalent to [`Interactivity::on_mouse_up()`]
+    /// the fluent API equivalent to [`Interactivity::on_mouse_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_mouse_up(
         mut self,
         button: MouseButton,
@@ -627,9 +627,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to the mouse up event for any button, during the capture phase
-    /// the fluent API equivalent to [`Interactivity::capture_any_mouse_up()`]
+    /// the fluent API equivalent to [`Interactivity::capture_any_mouse_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn capture_any_mouse_up(
         mut self,
         listener: impl Fn(&MouseUpEvent, &mut WindowContext) + 'static,
@@ -640,9 +640,9 @@ pub trait InteractiveElement: Sized {
 
     /// Bind the given callback to the mouse down event, on any button, during the capture phase,
     /// when the mouse is outside of the bounds of this element.
-    /// The fluent API equivalent to [`Interactivity::on_mouse_down_out()`]
+    /// The fluent API equivalent to [`Interactivity::on_mouse_down_out`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_mouse_down_out(
         mut self,
         listener: impl Fn(&MouseDownEvent, &mut WindowContext) + 'static,
@@ -653,9 +653,9 @@ pub trait InteractiveElement: Sized {
 
     /// Bind the given callback to the mouse up event, for the given button, during the capture phase,
     /// when the mouse is outside of the bounds of this element.
-    /// The fluent API equivalent to [`Interactivity::on_mouse_up_out()`]
+    /// The fluent API equivalent to [`Interactivity::on_mouse_up_out`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_mouse_up_out(
         mut self,
         button: MouseButton,
@@ -666,9 +666,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to the mouse move event, during the bubble phase
-    /// The fluent API equivalent to [`Interactivity::on_mouse_move()`]
+    /// The fluent API equivalent to [`Interactivity::on_mouse_move`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_mouse_move(
         mut self,
         listener: impl Fn(&MouseMoveEvent, &mut WindowContext) + 'static,
@@ -681,9 +681,9 @@ pub trait InteractiveElement: Sized {
     /// will be called for all move events, inside or outside of this element, as long as the
     /// drag was started with this element under the mouse. Useful for implementing draggable
     /// UIs that don't conform to a drag and drop style interaction, like resizing.
-    /// The fluent API equivalent to [`Interactivity::on_drag_move()`]
+    /// The fluent API equivalent to [`Interactivity::on_drag_move`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_drag_move<T: 'static>(
         mut self,
         listener: impl Fn(&DragMoveEvent<T>, &mut WindowContext) + 'static,
@@ -696,9 +696,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to scroll wheel events during the bubble phase
-    /// The fluent API equivalent to [`Interactivity::on_scroll_wheel()`]
+    /// The fluent API equivalent to [`Interactivity::on_scroll_wheel`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_scroll_wheel(
         mut self,
         listener: impl Fn(&ScrollWheelEvent, &mut WindowContext) + 'static,
@@ -708,9 +708,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Capture the given action, before normal action dispatch can fire
-    /// The fluent API equivalent to [`Interactivity::on_scroll_wheel()`]
+    /// The fluent API equivalent to [`Interactivity::on_scroll_wheel`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn capture_action<A: Action>(
         mut self,
         listener: impl Fn(&A, &mut WindowContext) + 'static,
@@ -720,9 +720,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to an action dispatch during the bubble phase
-    /// The fluent API equivalent to [`Interactivity::on_action()`]
+    /// The fluent API equivalent to [`Interactivity::on_action`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_action<A: Action>(mut self, listener: impl Fn(&A, &mut WindowContext) + 'static) -> Self {
         self.interactivity().on_action(listener);
         self
@@ -731,9 +731,9 @@ pub trait InteractiveElement: Sized {
     /// Bind the given callback to an action dispatch, based on a dynamic action parameter
     /// instead of a type parameter. Useful for component libraries that want to expose
     /// action bindings to their users.
-    /// The fluent API equivalent to [`Interactivity::on_boxed_action()`]
+    /// The fluent API equivalent to [`Interactivity::on_boxed_action`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_boxed_action(
         mut self,
         action: &dyn Action,
@@ -744,9 +744,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to key down events during the bubble phase
-    /// The fluent API equivalent to [`Interactivity::on_key_down()`]
+    /// The fluent API equivalent to [`Interactivity::on_key_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_key_down(
         mut self,
         listener: impl Fn(&KeyDownEvent, &mut WindowContext) + 'static,
@@ -756,9 +756,9 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to key down events during the capture phase
-    /// The fluent API equivalent to [`Interactivity::capture_key_down()`]
+    /// The fluent API equivalent to [`Interactivity::capture_key_down`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn capture_key_down(
         mut self,
         listener: impl Fn(&KeyDownEvent, &mut WindowContext) + 'static,
@@ -768,18 +768,18 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to key up events during the bubble phase
-    /// The fluent API equivalent to [`Interactivity::on_key_up()`]
+    /// The fluent API equivalent to [`Interactivity::on_key_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_key_up(mut self, listener: impl Fn(&KeyUpEvent, &mut WindowContext) + 'static) -> Self {
         self.interactivity().on_key_up(listener);
         self
     }
 
     /// Bind the given callback to key up events during the capture phase
-    /// The fluent API equivalent to [`Interactivity::capture_key_up()`]
+    /// The fluent API equivalent to [`Interactivity::capture_key_up`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn capture_key_up(
         mut self,
         listener: impl Fn(&KeyUpEvent, &mut WindowContext) + 'static,
@@ -813,16 +813,16 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to drop events of the given type, whether or not the drag started on this element
-    /// The fluent API equivalent to [`Interactivity::on_drop()`]
+    /// The fluent API equivalent to [`Interactivity::on_drop`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_drop<T: 'static>(mut self, listener: impl Fn(&T, &mut WindowContext) + 'static) -> Self {
         self.interactivity().on_drop(listener);
         self
     }
 
     /// Use the given predicate to determine whether or not a drop event should be dispatched to this element
-    /// The fluent API equivalent to [`Interactivity::can_drop()`]
+    /// The fluent API equivalent to [`Interactivity::can_drop`]
     fn can_drop(
         mut self,
         predicate: impl Fn(&dyn Any, &mut WindowContext) -> bool + 'static,
@@ -832,7 +832,7 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Block the mouse from interacting with this element or any of it's children
-    /// The fluent API equivalent to [`Interactivity::block_mouse()`]
+    /// The fluent API equivalent to [`Interactivity::block_mouse`]
     fn block_mouse(mut self) -> Self {
         self.interactivity().block_mouse();
         self
@@ -899,9 +899,9 @@ pub trait StatefulInteractiveElement: InteractiveElement {
     }
 
     /// Bind the given callback to click events of this element
-    /// The fluent API equivalent to [`Interactivity::on_click()`]
+    /// The fluent API equivalent to [`Interactivity::on_click`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_click(mut self, listener: impl Fn(&ClickEvent, &mut WindowContext) + 'static) -> Self
     where
         Self: Sized,
@@ -912,10 +912,10 @@ pub trait StatefulInteractiveElement: InteractiveElement {
 
     /// On drag initiation, this callback will be used to create a new view to render the dragged value for a
     /// drag and drop operation. This API should also be used as the equivalent of 'on drag start' with
-    /// the [`Self::on_drag_move()`] API
-    /// The fluent API equivalent to [`Interactivity::on_drag()`]
+    /// the [`Self::on_drag_move`] API
+    /// The fluent API equivalent to [`Interactivity::on_drag`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_drag<T, W>(
         mut self,
         value: T,
@@ -932,9 +932,9 @@ pub trait StatefulInteractiveElement: InteractiveElement {
 
     /// Bind the given callback on the hover start and end events of this element. Note that the boolean
     /// passed to the callback is true when the hover starts and false when it ends.
-    /// The fluent API equivalent to [`Interactivity::on_hover()`]
+    /// The fluent API equivalent to [`Interactivity::on_hover`]
     ///
-    /// See [`ViewContext::listener()`] to get access to a view's state from this callback
+    /// See [`ViewContext::listener`](crate::ViewContext::listener) to get access to a view's state from this callback.
     fn on_hover(mut self, listener: impl Fn(&bool, &mut WindowContext) + 'static) -> Self
     where
         Self: Sized,
@@ -944,7 +944,7 @@ pub trait StatefulInteractiveElement: InteractiveElement {
     }
 
     /// Use the given callback to construct a new tooltip view when the mouse hovers over this element.
-    /// The fluent API equivalent to [`Interactivity::tooltip()`]
+    /// The fluent API equivalent to [`Interactivity::tooltip`]
     fn tooltip(mut self, build_tooltip: impl Fn(&mut WindowContext) -> AnyView + 'static) -> Self
     where
         Self: Sized,

--- a/crates/gpui/src/shared_string.rs
+++ b/crates/gpui/src/shared_string.rs
@@ -4,7 +4,7 @@ use std::{borrow::Borrow, sync::Arc};
 use util::arc_cow::ArcCow;
 
 /// A shared string is an immutable string that can be cheaply cloned in GPUI
-/// tasks. Essentially an abstraction over an Arc<str> and &'static str,
+/// tasks. Essentially an abstraction over an `Arc<str>` and `&'static str`,
 #[derive(Deref, DerefMut, Eq, PartialEq, Hash, Clone)]
 pub struct SharedString(ArcCow<'static, str>);
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2669,7 +2669,7 @@ impl From<(&'static str, u64)> for ElementId {
 }
 
 /// A rectangle to be rendered in the window at the given position and size.
-/// Passed as an argument [`WindowContext::paint_quad`].
+/// Passed as an argument [`ElementContext::paint_quad`].
 #[derive(Clone)]
 pub struct PaintQuad {
     bounds: Bounds<Pixels>,

--- a/crates/gpui/src/window/element_cx.rs
+++ b/crates/gpui/src/window/element_cx.rs
@@ -656,7 +656,7 @@ impl<'a> ElementContext<'a> {
 
     /// Paint one or more quads into the scene for the next frame at the current stacking context.
     /// Quads are colored rectangular regions with an optional background, border, and corner radius.
-    /// see [`fill`], [`outline`], and [`quad`] to construct this type.
+    /// see [`fill`](crate::fill), [`outline`](crate::outline), and [`quad`](crate::quad) to construct this type.
     pub fn paint_quad(&mut self, quad: PaintQuad) {
         let scale_factor = self.scale_factor();
         let content_mask = self.content_mask();
@@ -731,9 +731,11 @@ impl<'a> ElementContext<'a> {
         );
     }
 
-    /// Paint a monochrome (non-emoji) glyph into the scene for the next frame at the current z-index.
+    /// Paints a monochrome (non-emoji) glyph into the scene for the next frame at the current z-index.
+    ///
     /// The y component of the origin is the baseline of the glyph.
-    /// You should generally prefer to use the [`ShapedLine::paint`] or [`WrappedLine::paint`] methods in the [`text_system`].
+    /// You should generally prefer to use the [`ShapedLine::paint`](crate::ShapedLine::paint) or
+    /// [`WrappedLine::paint`](crate::WrappedLine::paint) methods in the [`TextSystem`](crate::TextSystem).
     /// This method is only useful if you need to paint a single glyph that has already been shaped.
     pub fn paint_glyph(
         &mut self,
@@ -790,9 +792,11 @@ impl<'a> ElementContext<'a> {
         Ok(())
     }
 
-    /// Paint an emoji glyph into the scene for the next frame at the current z-index.
+    /// Paints an emoji glyph into the scene for the next frame at the current z-index.
+    ///
     /// The y component of the origin is the baseline of the glyph.
-    /// You should generally prefer to use the [`ShapedLine::paint`] or [`WrappedLine::paint`] methods in the [`text_system`].
+    /// You should generally prefer to use the [`ShapedLine::paint`](crate::ShapedLine::paint) or
+    /// [`WrappedLine::paint`](crate::WrappedLine::paint) methods in the [`TextSystem`](crate::TextSystem).
     /// This method is only useful if you need to paint a single emoji that has already been shaped.
     pub fn paint_emoji(
         &mut self,


### PR DESCRIPTION
This PR does some cleanup of the `gpui` docs, making sure we're linking things appropriately and following good Rust documentation style.

Release Notes:

- N/A