### PR TITLE
Increase capacity of element arena to 8MB

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -106,7 +106,7 @@ slotmap::new_key_type! {
 }
 
 thread_local! {
-    pub(crate) static ELEMENT_ARENA: RefCell<Arena> = RefCell::new(Arena::new(4 * 1024 * 1024));
+    pub(crate) static ELEMENT_ARENA: RefCell<Arena> = RefCell::new(Arena::new(8 * 1024 * 1024));
 }
 
 impl FocusId {


### PR DESCRIPTION
This fixes a panic we just saw on nightly. It's the first time we see this panic, so I think it's pretty safe to assume having twice as much capacity will fix it.

Release Notes:

- Fixed a crash that could sometimes occur when the window contained lots of graphical elements.
