### PR TITLE
Log if element arena allocation is >80%

### DIFF
--- a/crates/gpui/src/arena.rs
+++ b/crates/gpui/src/arena.rs
@@ -44,6 +44,14 @@ impl Arena {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.offset as usize - self.start as usize
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.end as usize - self.start as usize
+    }
+
     pub fn clear(&mut self) {
         self.valid.set(false);
         self.valid = Rc::new(Cell::new(true));

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1031,7 +1031,13 @@ impl<'a> WindowContext<'a> {
         self.window
             .next_frame
             .finish(&mut self.window.rendered_frame);
-        ELEMENT_ARENA.with_borrow_mut(|element_arena| element_arena.clear());
+        ELEMENT_ARENA.with_borrow_mut(|element_arena| {
+            let percentage = (element_arena.len() as f32 / element_arena.capacity() as f32) * 100.;
+            if percentage >= 80. {
+                log::warn!("elevated element arena occupation: {}.", percentage);
+            }
+            element_arena.clear();
+        });
 
         let previous_focus_path = self.window.rendered_frame.focus_path();
         let previous_window_active = self.window.rendered_frame.window_active;


### PR DESCRIPTION
We recently doubled the size of the `ELEMENT_ARENA` after someone ran into a panic due to the arena running out of space.

This adds some logging so that we can hopefully develop a better understanding of when the element area's allocation is elevated.

Release Notes:

- N/A
