### PR TITLE
Fix tab bar button's focus handling lagging behind

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -342,12 +342,10 @@ impl Pane {
     }
 
     pub fn has_focus(&self, cx: &WindowContext) -> bool {
-        // In addition to checking our own focus handle,
-        // we need to account for a brief moment (when active item is being switched)
-        // where we don't have focus.
         // We not only check whether our focus handle contains focus, but also
         // whether the active_item might have focus, because we might have just activated an item
-        // but that hasn't rendered yet. So before the next render, we might have transfered focus
+        // but that hasn't rendered yet.
+        // So before the next render, we might have transfered focus
         // to the item and `focus_handle.contains_focus` returns false because the `active_item`
         // is not hooked up to us in the dispatch tree.
         self.focus_handle.contains_focused(cx)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -342,7 +342,18 @@ impl Pane {
     }
 
     pub fn has_focus(&self, cx: &WindowContext) -> bool {
+        // In addition to checking our own focus handle,
+        // we need to account for a brief moment (when active item is being switched)
+        // where we don't have focus.
+        // We not only check whether our focus handle contains focus, but also
+        // whether the active_item might have focus, because we might have just activated an item
+        // but that hasn't rendered yet. So before the next render, we might have transfered focus
+        // to the item and `focus_handle.contains_focus` returns false because the `active_item`
+        // is not hooked up to us in the dispatch tree.
         self.focus_handle.contains_focused(cx)
+            || self
+                .active_item()
+                .map_or(false, |item| item.focus_handle(cx).contains_focused(cx))
     }
 
     fn focus_in(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -345,7 +345,7 @@ impl Pane {
         // We not only check whether our focus handle contains focus, but also
         // whether the active_item might have focus, because we might have just activated an item
         // but that hasn't rendered yet.
-        // So before the next render, we might have transfered focus
+        // So before the next render, we might have transferred focus
         // to the item and `focus_handle.contains_focus` returns false because the `active_item`
         // is not hooked up to us in the dispatch tree.
         self.focus_handle.contains_focused(cx)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1470,7 +1470,7 @@ impl Pane {
                         ),
                 )
             })
-            .when(self.was_focused || self.has_focus(cx), |tab_bar| {
+            .when(self.has_focus(cx), |tab_bar| {
                 tab_bar.end_child({
                     let render_tab_buttons = self.render_tab_bar_buttons.clone();
                     render_tab_buttons(self, cx)


### PR DESCRIPTION
This fixes https://github.com/zed-industries/zed/issues/6421 for me.

Previously, the tab bar buttons would stay when the chat panel was opened (and received focus) until something else was drawn (or caused a render?)

With this change, the tab bar buttons are only shown if the pane was focus.

I'm not sure about the side-effects of this, but the toolbar still seems to work fine.

### Before

https://github.com/zed-industries/zed/assets/1185253/24b56e51-467b-4a09-909f-72ee6f76f32c

### After


https://github.com/zed-industries/zed/assets/1185253/18865f49-d00e-453a-8a38-aee15f06beb8



### Release Notes:

- Fixed the tool bar of the pane being slow to disappear when focus changes.
