### PR TITLE
Add Git submodule initialization to repository setup steps

### DIFF
--- a/docs/src/developing_zed__building_zed.md
+++ b/docs/src/developing_zed__building_zed.md
@@ -1,5 +1,14 @@
 # Building Zed
 
+## Repository
+
+After cloning the repository, ensure all git submodules are initialized:
+
+```shell
+git submodule init
+git submodule update
+```
+
 ## Dependencies
 
 - Install [Rust](https://www.rust-lang.org/tools/install)

--- a/docs/src/developing_zed__building_zed.md
+++ b/docs/src/developing_zed__building_zed.md
@@ -5,8 +5,7 @@
 After cloning the repository, ensure all git submodules are initialized:
 
 ```shell
-git submodule init
-git submodule update
+git submodule update --init --recursive
 ```
 
 ## Dependencies


### PR DESCRIPTION
Was running into an issue building live_kit_server after a fresh clone due to missing dependencies for build.rs. The use of git submodules wasn't currently documented.

Release Notes:

- N/A