### PR TITLE
Fix: Comment shortcut in Svelte files now respects if the line(s) are HTML vs JS/TS

### DIFF
--- a/crates/zed/src/languages/svelte/config.toml
+++ b/crates/zed/src/languages/svelte/config.toml
@@ -1,6 +1,6 @@
 name = "Svelte"
 path_suffixes = ["svelte"]
-line_comment = "// "
+block_comment = ["<!-- ", " -->"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
@@ -14,6 +14,10 @@ brackets = [
 ]
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "svelte"
+
+[overrides.comment]
+line_comment = { remove = true }
+line_comments = "// "
 
 [overrides.string]
 word_characters = ["-"]

--- a/crates/zed/src/languages/svelte/config.toml
+++ b/crates/zed/src/languages/svelte/config.toml
@@ -15,10 +15,6 @@ brackets = [
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "svelte"
 
-[overrides.comment]
-line_comment = { remove = true }
-line_comments = "// "
-
 [overrides.string]
 word_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION
Release Notes:

- Fixed: When using the comment shortcut, previously HTML or JS/TS would all prefix lines with `// `. This PR brings the comments inline with what is expected (`// ` for JS/TS, `<!-- ... -->` for HTML). Fixes [#4578](https://github.com/zed-industries/zed/issues/4578).
