### PR TITLE
Ensure chat opens when guests join shared projects

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -132,14 +132,6 @@ impl ChatPanel {
             {
                 this.select_channel(channel_id, None, cx)
                     .detach_and_log_err(cx);
-
-                if ActiveCall::global(cx)
-                    .read(cx)
-                    .room()
-                    .is_some_and(|room| room.read(cx).contains_guests())
-                {
-                    cx.emit(PanelEvent::Activate)
-                }
             }
 
             this.subscriptions.push(cx.subscribe(
@@ -664,6 +656,13 @@ impl Panel for ChatPanel {
 
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
         Box::new(ToggleFocus)
+    }
+
+    fn starts_open(&self, cx: &WindowContext) -> bool {
+        ActiveCall::global(cx)
+            .read(cx)
+            .room()
+            .is_some_and(|room| room.read(cx).contains_guests())
     }
 }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1939,7 +1939,6 @@ mod tests {
             .update(cx, |workspace, cx| {
                 let panel = ProjectPanel::new(workspace, cx);
                 workspace.add_panel(panel.clone(), cx);
-                workspace.toggle_dock(panel.read(cx).position(cx), cx);
                 panel
             })
             .unwrap();
@@ -2297,7 +2296,6 @@ mod tests {
             .update(cx, |workspace, cx| {
                 let panel = ProjectPanel::new(workspace, cx);
                 workspace.add_panel(panel.clone(), cx);
-                workspace.toggle_dock(panel.read(cx).position(cx), cx);
                 panel
             })
             .unwrap();
@@ -2573,7 +2571,6 @@ mod tests {
             .update(cx, |workspace, cx| {
                 let panel = ProjectPanel::new(workspace, cx);
                 workspace.add_panel(panel.clone(), cx);
-                workspace.toggle_dock(panel.read(cx).position(cx), cx);
                 panel
             })
             .unwrap();

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -58,7 +58,6 @@ pub struct ProjectPanel {
     workspace: WeakView<Workspace>,
     width: Option<Pixels>,
     pending_serialization: Task<Option<()>>,
-    was_deserialized: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -244,7 +243,6 @@ impl ProjectPanel {
                 workspace: workspace.weak_handle(),
                 width: None,
                 pending_serialization: Task::ready(None),
-                was_deserialized: false,
             };
             this.update_visible_entries(None, cx);
 
@@ -324,7 +322,6 @@ impl ProjectPanel {
             if let Some(serialized_panel) = serialized_panel {
                 panel.update(cx, |panel, cx| {
                     panel.width = serialized_panel.width;
-                    panel.was_deserialized = true;
                     cx.notify();
                 });
             }
@@ -1460,9 +1457,6 @@ impl ProjectPanel {
             cx.notify();
         }
     }
-    pub fn was_deserialized(&self) -> bool {
-        self.was_deserialized
-    }
 }
 
 impl Render for ProjectPanel {
@@ -1636,6 +1630,14 @@ impl Panel for ProjectPanel {
 
     fn persistent_name() -> &'static str {
         "Project Panel"
+    }
+
+    fn starts_open(&self, cx: &WindowContext) -> bool {
+        self.project.read(cx).visible_worktrees(cx).any(|tree| {
+            tree.read(cx)
+                .root_entry()
+                .map_or(false, |entry| entry.is_dir())
+        })
     }
 }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -38,6 +38,9 @@ pub trait Panel: FocusableView + EventEmitter<PanelEvent> {
     fn is_zoomed(&self, _cx: &WindowContext) -> bool {
         false
     }
+    fn starts_open(&self, _cx: &WindowContext) -> bool {
+        false
+    }
     fn set_zoomed(&mut self, _zoomed: bool, _cx: &mut ViewContext<Self>) {}
     fn set_active(&mut self, _active: bool, _cx: &mut ViewContext<Self>) {}
 }
@@ -414,7 +417,7 @@ impl Dock {
         let name = panel.persistent_name().to_string();
 
         self.panel_entries.push(PanelEntry {
-            panel: Arc::new(panel),
+            panel: Arc::new(panel.clone()),
             _subscriptions: subscriptions,
         });
         if let Some(serialized) = self.serialized_dock.clone() {
@@ -429,6 +432,9 @@ impl Dock {
                     };
                 }
             }
+        } else if panel.read(cx).starts_open(cx) {
+            self.activate_panel(self.panel_entries.len() - 1, cx);
+            self.set_open(true, cx);
         }
 
         cx.notify()

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1513,10 +1513,10 @@ mod tests {
             .as_fake()
             .insert_file("/root/a.txt", "changed".to_string())
             .await;
-        editor
-            .condition::<EditorEvent>(cx, |editor, cx| editor.has_conflict(cx))
-            .await;
+
+        cx.run_until_parked();
         cx.read(|cx| assert!(editor.is_dirty(cx)));
+        cx.read(|cx| assert!(editor.has_conflict(cx)));
 
         let save_task = window
             .update(cx, |workspace, cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -179,27 +179,12 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
             )?;
 
             workspace_handle.update(&mut cx, |workspace, cx| {
-                let was_deserialized = project_panel.read(cx).was_deserialized();
                 workspace.add_panel(project_panel, cx);
                 workspace.add_panel(terminal_panel, cx);
                 workspace.add_panel(assistant_panel, cx);
                 workspace.add_panel(channels_panel, cx);
                 workspace.add_panel(chat_panel, cx);
                 workspace.add_panel(notification_panel, cx);
-
-                if !was_deserialized
-                    && workspace
-                        .project()
-                        .read(cx)
-                        .visible_worktrees(cx)
-                        .any(|tree| {
-                            tree.read(cx)
-                                .root_entry()
-                                .map_or(false, |entry| entry.is_dir())
-                        })
-                {
-                    workspace.open_panel::<ProjectPanel>(cx);
-                }
                 cx.focus_self();
             })
         })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -737,7 +737,7 @@ fn open_settings_file(
 mod tests {
     use super::*;
     use assets::Assets;
-    use editor::{scroll::Autoscroll, DisplayPoint, Editor, EditorEvent};
+    use editor::{scroll::Autoscroll, DisplayPoint, Editor};
     use gpui::{
         actions, Action, AnyWindowHandle, AppContext, AssetSource, Entity, TestAppContext,
         VisualTestContext, WindowHandle,


### PR DESCRIPTION
This was broken because the panel was created before being added to a
dock. Invert the control order and add `starts_open()` to the Panel
trait (which lets us simplify how this worked for the ProjectPanel too)

Release Notes:

- Improved Chat visibility when joining a call as a guest
