### PR TITLE
Remove unused dependency

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -31,7 +31,6 @@ command_palette = { path = "../command_palette" }
 # component_test = { path = "../component_test" }
 client = { path = "../client" }
 # clock = { path = "../clock" }
-color = { path = "../color" }
 copilot = { path = "../copilot" }
 copilot_ui = { path = "../copilot_ui" }
 diagnostics = { path = "../diagnostics" }


### PR DESCRIPTION
[[PR Description]]

The `color` crate is not actually used by the `zed` crate, despite being listed as a dependency. This PR removes it.
