### PR TITLE
Prevent channel from vertically growing when containing facepile

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2240,6 +2240,7 @@ impl CollabPanel {
         let width = self.width.unwrap_or(px(240.));
 
         div()
+            .h_6()
             .id(channel_id as usize)
             .group("")
             .flex()


### PR DESCRIPTION
Previously at UI font size of 20
 - User-less channel: 28 px tall
 - Occupied channel: 30 px tall
 
Now, still at UI font size 20:
 - User-less channel: 30 px tall
 - Occupied channel: 30 px tall

Release Notes:

- Fixed an issue where a channel would grow in height while showing participant avatars.