### PR TITLE
Use "enter" to ask for assistance

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -197,10 +197,11 @@
   {
     "context": "ConversationEditor > Editor",
     "bindings": {
+      "enter": "assistant::Assist",
       "cmd-enter": "assistant::Assist",
       "cmd-s": "workspace::Save",
       "cmd->": "assistant::QuoteSelection",
-      "shift-enter": "assistant::Split",
+      "shift-enter": "editor::NewLine",
       "ctrl-r": "assistant::CycleMessageRole"
     }
   },


### PR DESCRIPTION
This confused me, and a few other people in feedback; as although we
present this UI as a chat, it doesn't work like a chat.

Release Notes:

- Breaking change: Use `"enter"` to send a message to the AI. `"shift-enter"` can be used to extend the prompt.
