### PR TITLE
Try to flesh out our panic stacks more

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -543,7 +543,12 @@ fn init_panic_hook(app: &App, installation_id: Option<String>, session_id: Strin
         let mut backtrace = backtrace
             .frames()
             .iter()
-            .filter_map(|frame| Some(format!("{:#}", frame.symbols().first()?.name()?)))
+            .flat_map(|frame| {
+                frame
+                    .symbols()
+                    .iter()
+                    .filter_map(|frame| Some(format!("{:#}", frame.name()?)))
+            })
             .collect::<Vec<_>>();
 
         // Strip out leading stack frames for rust panic-handling.


### PR DESCRIPTION
Although we now usually get the .ips file alongside a panic, when we
don't it's much harder to track down where panics happen because we're
not showing inlined frames.

Try iterating over all symbols in a frame to see if that improves panic
reporting.

Release Notes:

- N/A
