### PR TITLE
bugfix: fix LineEnding for windows

### DIFF
--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2634,7 +2634,7 @@ impl Default for LineEnding {
         return Self::Unix;
 
         #[cfg(not(unix))]
-        return Self::CRLF;
+        return Self::Windows;
     }
 }
 


### PR DESCRIPTION
fixes a bug when compiling on windows

![image](https://github.com/zed-industries/zed/assets/715417/5a35b1b2-29f4-4987-9410-730c9b287f82)

Release Notes:

- Fixed: compilation error related to `LineEnding` on Windows
