### PR TITLE
Improve performance of select-all-matches

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -14,12 +14,6 @@ pub struct SelectPrevious {
 }
 
 #[derive(PartialEq, Clone, Deserialize, Default)]
-pub struct SelectAllMatches {
-    #[serde(default)]
-    pub replace_newest: bool,
-}
-
-#[derive(PartialEq, Clone, Deserialize, Default)]
 pub struct SelectToBeginningOfLine {
     #[serde(default)]
     pub(super) stop_at_soft_wraps: bool,
@@ -81,7 +75,6 @@ impl_actions!(
     [
         SelectNext,
         SelectPrevious,
-        SelectAllMatches,
         SelectToBeginningOfLine,
         MovePageUp,
         MovePageDown,
@@ -128,6 +121,7 @@ gpui::actions!(
         DeleteToNextWordEnd,
         DeleteToPreviousSubwordStart,
         DeleteToPreviousWordStart,
+        DisplayCursorNames,
         DuplicateLine,
         ExpandMacroRecursively,
         FindAllReferences,
@@ -185,6 +179,7 @@ gpui::actions!(
         ScrollCursorCenter,
         ScrollCursorTop,
         SelectAll,
+        SelectAllMatches,
         SelectDown,
         SelectLargerSyntaxNode,
         SelectLeft,
@@ -214,6 +209,5 @@ gpui::actions!(
         Undo,
         UndoSelection,
         UnfoldLines,
-        DisplayCursorNames
     ]
 );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3821,6 +3821,18 @@ async fn test_select_next(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_select_all_matches(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("abc\nˇabc abc\ndefabc\nabc");
+
+    cx.update_editor(|e, cx| e.select_all_matches(&SelectAllMatches::default(), cx))
+        .unwrap();
+    cx.assert_editor_state("«abcˇ»\n«abcˇ» «abcˇ»\ndefabc\n«abcˇ»");
+}
+
+#[gpui::test]
 async fn test_select_next_with_multiple_carets(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
This fixes #6440.

The previous approach was calling select-next-match in a loop, which leaves optimizations on the table when you already know that you want to select all of the matches.

So what we did here is to optimize the code for the "give me all matches" case:

1. Find all results in the current buffer
2. Build up *all* selections
3. Sort selections & throw away overlapping ones (keep oldest)
4. Unfold if necessary
5. Render selections

On my M3 Max searching for `<span` in the test file [1] from the ticket, it

previously took: ~1.07s
now takes: ~4ms

[1]: https://github.com/standardebooks/edgar-allan-poe_poetry/blob/master/src/epub/text/poetry.xhtml

![screenshot-2024-01-25-12 49 32@2x](https://github.com/zed-industries/zed/assets/1185253/9f8ef0fa-a3a7-461c-9ed6-263e48835806)

### Release Notes:

- Improved performance of select-all-matches by factor of ~250 ([#6440](https://github.com/zed-industries/zed/issues/6440)).
