### PR TITLE
Add syntax highlighting for `.htm` and `.shtml` files

### DIFF
--- a/crates/zed/src/languages/html/config.toml
+++ b/crates/zed/src/languages/html/config.toml
@@ -1,5 +1,5 @@
 name = "HTML"
-path_suffixes = ["html"]
+path_suffixes = ["html", "htm", "shtml"]
 autoclose_before = ">})"
 block_comment = ["<!-- ", " -->"]
 brackets = [


### PR DESCRIPTION
enabled syntax highlighting for **.htm** and **.shtml** files

Release Notes:
- Added support for syntax highlighting in HTML files with `.htm` and `.shtml` extensions ([#4510](https://github.com/zed-industries/zed/issues/4510)).
