### PR TITLE
Sort `.mailmap` alphabetically

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -11,6 +11,8 @@
 
 Antonio Scandurra <me@as-cii.com>
 Antonio Scandurra <me@as-cii.com> <antonio@zed.dev>
+Conrad Irwin <conrad@zed.dev>
+Conrad Irwin <conrad@zed.dev> <conrad.irwin@gmail.com>
 Joseph T. Lyons <JosephTLyons@gmail.com>
 Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
 Julia <floc@unpromptedtirade.com>
@@ -37,8 +39,6 @@ Nathan Sobo <nathan@zed.dev> <nathan@warp.dev>
 Nathan Sobo <nathan@zed.dev> <nathansobo@gmail.com>
 Piotr Osiewicz <piotr@zed.dev>
 Piotr Osiewicz <piotr@zed.dev> <24362066+osiewicz@users.noreply.github.com>
-Conrad Irwin <conrad@zed.dev>
-Conrad Irwin <conrad@zed.dev> <conrad.irwin@gmail.com>
 Thorsten Ball <thorsten@zed.dev>
-Thorsten Ball <thorsten@zed.dev> <mrnugget@gmail.com>
 Thorsten Ball <thorsten@zed.dev> <me@thorstenball.com>
+Thorsten Ball <thorsten@zed.dev> <mrnugget@gmail.com>


### PR DESCRIPTION
This PR sorts the entries in the `.mailmap` file to keep them in alphabetical order.

Release Notes:

- N/A
