### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -287,7 +287,7 @@ impl UserStore {
                     load_users.await?;
 
                     // Users are fetched in parallel above and cached in call to get_users
-                    // No need to paralellize here
+                    // No need to parallelize here
                     let mut updated_contacts = Vec::new();
                     let this = this
                         .upgrade()

--- a/crates/collab/migrations/20231009181554_add_release_channel_to_rooms.sql
+++ b/crates/collab/migrations/20231009181554_add_release_channel_to_rooms.sql
@@ -1,1 +1,1 @@
-ALTER TABLE rooms ADD COLUMN environment TEXT;
+ALTER TABLE rooms ADD COLUMN enviroment TEXT;

--- a/crates/collab/migrations/20231009181554_add_release_channel_to_rooms.sql
+++ b/crates/collab/migrations/20231009181554_add_release_channel_to_rooms.sql
@@ -1,1 +1,1 @@
-ALTER TABLE rooms ADD COLUMN enviroment TEXT;
+ALTER TABLE rooms ADD COLUMN environment TEXT;

--- a/crates/collab/src/db/tests/message_tests.rs
+++ b/crates/collab/src/db/tests/message_tests.rs
@@ -100,7 +100,7 @@ async fn test_channel_message_nonces(db: &Arc<Database>) {
         .await
         .unwrap();
 
-    // As user A, create messages that re-use the same nonces. The requests
+    // As user A, create messages that reuse the same nonces. The requests
     // succeed, but return the same ids.
     let id1 = db
         .create_channel_message(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3582,7 +3582,7 @@ mod tests {
         );
 
         // multi-buffer support
-        // in DisplayPoint co-ordinates, this is what we're dealing with:
+        // in DisplayPoint coordinates, this is what we're dealing with:
         //  0: [[file
         //  1:   header]]
         //  2: aaaaaa

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -1971,7 +1971,7 @@ pub mod tests {
             assert_eq!(
                 lsp_request_count.load(Ordering::Relaxed),
                 3,
-                "Should query for new hints when they got reenabled"
+                "Should query for new hints when they got re-enabled"
             );
             assert_eq!(
                 vec![
@@ -1980,7 +1980,7 @@ pub mod tests {
                     "type hint".to_string(),
                 ],
                 cached_hint_labels(editor),
-                "Should get its cached hints fully repopulated after the hints got reenabled"
+                "Should get its cached hints fully repopulated after the hints got re-enabled"
             );
             assert_eq!(
                 vec!["parameter hint".to_string()],
@@ -1990,11 +1990,11 @@ pub mod tests {
             let inlay_cache = editor.inlay_hint_cache();
             assert_eq!(
                 inlay_cache.allowed_hint_kinds, final_allowed_hint_kinds,
-                "Cache should update editor settings when hints got reenabled"
+                "Cache should update editor settings when hints got re-enabled"
             );
             assert_eq!(
                 inlay_cache.version, edits_made,
-                "Cache should update its version after hints got reenabled"
+                "Cache should update its version after hints got re-enabled"
             );
         });
 
@@ -2736,7 +2736,7 @@ pub mod tests {
                 assert_eq!(expected_hints, cached_hint_labels(editor),
                     "After multibuffer was scrolled to the end, further scrolls up should not bring more hints");
                 assert_eq!(expected_hints, visible_hint_labels(editor, cx));
-                assert_eq!(editor.inlay_hint_cache().version, last_scroll_update_version, "No updates should happen during scrolling already scolled buffer");
+                assert_eq!(editor.inlay_hint_cache().version, last_scroll_update_version, "No updates should happen during scrolling already scrolled buffer");
             });
 
         editor_edited.store(true, Ordering::Release);
@@ -2762,7 +2762,7 @@ pub mod tests {
             assert_eq!(
                 expected_hints,
                 cached_hint_labels(editor),
-                "After multibuffer edit, editor gets scolled back to the last selection; \
+                "After multibuffer edit, editor gets scrolled back to the last selection; \
     all hints should be invalidated and required for all of its visible excerpts"
             );
             assert_eq!(expected_hints, visible_hint_labels(editor, cx));

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -574,7 +574,7 @@ impl AppContext {
     }
 
     /// Displays a platform modal for selecting a new path where a file can be saved.
-    /// The provided directory will be used to set the iniital location.
+    /// The provided directory will be used to set the initial location.
     /// When a path is selected, it is relayed asynchronously via the returned oneshot channel.
     /// If cancelled, a `None` will be relayed instead.
     pub fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>> {

--- a/crates/gpui/src/elements/overlay.rs
+++ b/crates/gpui/src/elements/overlay.rs
@@ -40,7 +40,7 @@ impl Overlay {
         self
     }
 
-    /// Sets the position in window co-ordinates
+    /// Sets the position in window coordinates
     /// (otherwise the location the overlay is rendered is used)
     pub fn position(mut self, anchor: Point<Pixels>) -> Self {
         self.anchor_position = Some(anchor);

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -584,7 +584,7 @@ impl<'de> Deserialize<'de> for BracketPairConfig {
 }
 
 /// Describes a single bracket pair and how an editor should react to e.g. inserting
-/// an opening bracket or to a newline character insertion inbetween `start` and `end` characters.
+/// an opening bracket or to a newline character insertion in between `start` and `end` characters.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 pub struct BracketPair {
     /// Starting substring for a bracket.

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -911,7 +911,7 @@ impl SearchableItem for TerminalView {
     }
 }
 
-///Get's the working directory for the given workspace, respecting the user's settings.
+///Gets the working directory for the given workspace, respecting the user's settings.
 pub fn get_working_directory(
     workspace: &Workspace,
     cx: &AppContext,
@@ -932,7 +932,7 @@ pub fn get_working_directory(
     res.or_else(home_dir)
 }
 
-///Get's the first project's home directory, or the home directory
+///Gets the first project's home directory, or the home directory
 fn first_project_directory(workspace: &Workspace, cx: &AppContext) -> Option<PathBuf> {
     workspace
         .worktrees(cx)

--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -236,7 +236,7 @@ pub struct ThemeColors {
 #[derive(Refineable, Clone)]
 pub struct ThemeStyles {
     pub system: SystemColors,
-    /// An array of colors used for theme elements that iterrate through a series of colors.
+    /// An array of colors used for theme elements that iterate through a series of colors.
     ///
     /// Example: Player colors, rainbow brackets and indent guides, etc.
     pub accents: Vec<Hsla>,

--- a/crates/theme_importer/README.md
+++ b/crates/theme_importer/README.md
@@ -66,7 +66,7 @@ Copy that json file into the theme family directory and tidy up the filenames as
 
 A LICENSE file is required to import a theme family. Failing to provide a complete text license will cause it to be skipped when the import is run.
 
-If the theme only provices a license code (e.g. MIT, Apache 2.0, etc.) then put that code into the LICENSE file.
+If the theme only provides a license code (e.g. MIT, Apache 2.0, etc.) then put that code into the LICENSE file.
 
 If no license is provided, either contact the theme creator or don't add the theme.
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -143,7 +143,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
         cx.on_window_should_close(move |cx| {
             handle
                 .update(cx, |workspace, cx| {
-                    // We'll handle closing asynchoronously
+                    // We'll handle closing asynchronously
                     workspace.close_window(&Default::default(), cx);
                     false
                 })


### PR DESCRIPTION
> codespell --skip="*.json,*.rtf" \
    --ignore-words-list=crate,delet,inout,iterm,jumo,lightening,othe,ser,tabe,te,tese,thi,updat
* https://github.com/codespell-project/codespell/blob/master/README.rst

Release Notes:

- N/A
