### PR TITLE
Remove placeholder description from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-[[PR Description]]
+
 
 Release Notes:
 


### PR DESCRIPTION
This PR removes the placeholder description from the PR template, opting to just leave empty space instead.

I've seen lots of instances where authors will not delete the placeholder, and it ends up in Git history, which is not desirable.

Release Notes:

- N/A
