### PR TITLE
Clean up references in doc comments in `language` crate

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -197,7 +197,7 @@ pub struct Diagnostic {
     /// Whether this diagnostic is considered to originate from an analysis of
     /// files on disk, as opposed to any unsaved buffer contents. This is a
     /// property of a given diagnostic source, and is configured for a given
-    /// language server via the [LspAdapter::disk_based_diagnostic_sources] method
+    /// language server via the [`LspAdapter::disk_based_diagnostic_sources`](crate::LspAdapter::disk_based_diagnostic_sources) method
     /// for the language server.
     pub is_disk_based: bool,
     /// Whether this diagnostic marks unnecessary code.
@@ -236,7 +236,7 @@ pub async fn prepare_completion_documentation(
     }
 }
 
-/// Documentation associated with a [Completion].
+/// Documentation associated with a [`Completion`].
 #[derive(Clone, Debug)]
 pub enum Documentation {
     /// There is no documentation for this completion.
@@ -301,7 +301,7 @@ pub enum Operation {
         lamport_timestamp: clock::Lamport,
         /// Whether the selections are in 'line mode'.
         line_mode: bool,
-        /// The [CursorShape] associated with these selections.
+        /// The [`CursorShape`] associated with these selections.
         cursor_shape: CursorShape,
     },
 
@@ -347,7 +347,7 @@ pub enum Event {
 
 /// The file associated with a buffer.
 pub trait File: Send + Sync {
-    /// Returns the [LocalFile] associated with this file, if the
+    /// Returns the [`LocalFile`] associated with this file, if the
     /// file is local.
     fn as_local(&self) -> Option<&dyn LocalFile>;
 
@@ -378,7 +378,7 @@ pub trait File: Send + Sync {
     /// Returns whether the file has been deleted.
     fn is_deleted(&self) -> bool;
 
-    /// Converts this file into an [Any] trait object.
+    /// Converts this file into an [`Any`] trait object.
     fn as_any(&self) -> &dyn Any;
 
     /// Converts this file into a protobuf message.
@@ -1538,8 +1538,6 @@ impl Buffer {
     /// Starts a transaction, providing the current time. Subsequent transactions
     /// that occur within a short period of time will be grouped together. This
     /// is controlled by the buffer's undo grouping duration.
-    ///
-    /// See [`Buffer::set_group_interval`].
     pub fn start_transaction_at(&mut self, now: Instant) -> Option<TransactionId> {
         self.transaction_depth += 1;
         if self.was_dirty_before_starting_transaction.is_none() {
@@ -1556,8 +1554,6 @@ impl Buffer {
     /// Terminates the current transaction, providing the current time. Subsequent transactions
     /// that occur within a short period of time will be grouped together. This
     /// is controlled by the buffer's undo grouping duration.
-    ///
-    /// See [`Buffer::set_group_interval`].
     pub fn end_transaction_at(
         &mut self,
         now: Instant,
@@ -2420,7 +2416,7 @@ impl BufferSnapshot {
     }
 
     /// Iterates over chunks of text in the given range of the buffer. Text is chunked
-    /// in an arbitrary way due to being stored in a [`rope::Rope`]. The text is also
+    /// in an arbitrary way due to being stored in a [`Rope`](text::Rope). The text is also
     /// returned in chunks where each chunk has a single syntax highlighting style and
     /// diagnostic status.
     pub fn chunks<T: ToOffset>(&self, range: Range<T>, language_aware: bool) -> BufferChunks {

--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -12,7 +12,7 @@ use text::{Anchor, FromAnchor, PointUtf16, ToOffset};
 /// A set of diagnostics associated with a given buffer, provided
 /// by a single language server.
 ///
-/// The diagnostics are stored in a [SumTree], which allows this struct
+/// The diagnostics are stored in a [`SumTree`], which allows this struct
 /// to be cheaply copied, and allows for efficient retrieval of the
 /// diagnostics that intersect a given range of the buffer.
 #[derive(Clone, Debug, Default)]
@@ -21,9 +21,9 @@ pub struct DiagnosticSet {
 }
 
 /// A single diagnostic in a set. Generic over its range type, because
-/// the diagnostics are stored internally as [Anchor]s, but can be
-/// resolved to different coordinates types like [usize] byte offsets or
-/// [Point]s.
+/// the diagnostics are stored internally as [`Anchor`]s, but can be
+/// resolved to different coordinates types like [`usize`] byte offsets or
+/// [`Point`](gpui::Point)s.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DiagnosticEntry<T> {
     /// The range of the buffer where the diagnostic applies.
@@ -52,7 +52,7 @@ pub struct Summary {
 }
 
 impl<T> DiagnosticEntry<T> {
-    /// Returns a raw LSP diagnostic ssed to provide diagnostic context to lsp
+    /// Returns a raw LSP diagnostic ssed to provide diagnostic context to LSP
     /// codeAction request
     pub fn to_lsp_diagnostic_stub(&self) -> lsp::Diagnostic {
         let code = self

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -298,10 +298,12 @@ pub trait LspAdapter: 'static + Send + Sync {
         delegate: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary>;
 
-    /// Returns true if a language server can be reinstalled.
-    /// If language server initialization fails, a reinstallation will be attempted unless the value returned from this method is false.
+    /// Returns `true` if a language server can be reinstalled.
+    ///
+    /// If language server initialization fails, a reinstallation will be attempted unless the value returned from this method is `false`.
+    ///
     /// Implementations that rely on software already installed on user's system
-    /// should have [`can_be_reinstalled`] return false.
+    /// should have [`can_be_reinstalled`](Self::can_be_reinstalled) return `false`.
     fn can_be_reinstalled(&self) -> bool {
         true
     }
@@ -313,7 +315,7 @@ pub trait LspAdapter: 'static + Send + Sync {
 
     fn process_diagnostics(&self, _: &mut lsp::PublishDiagnosticsParams) {}
 
-    /// A callback called for each [`lsp_types::CompletionItem`] obtained from LSP server.
+    /// A callback called for each [`lsp::CompletionItem`] obtained from LSP server.
     /// Some LspAdapter implementations might want to modify the obtained item to
     /// change how it's displayed.
     async fn process_completion(&self, _: &mut lsp::CompletionItem) {}
@@ -335,7 +337,7 @@ pub trait LspAdapter: 'static + Send + Sync {
         None
     }
 
-    /// Returns initialization options that are going to be sent to a LSP server as a part of [`lsp_types::InitializeParams`]
+    /// Returns initialization options that are going to be sent to a LSP server as a part of [`lsp::InitializeParams`]
     fn initialization_options(&self) -> Option<Value> {
         None
     }

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -103,7 +103,7 @@ pub fn serialize_operation(operation: &crate::Operation) -> proto::Operation {
     }
 }
 
-/// Serializes an [`operation::EditOperation`] to be sent over RPC.
+/// Serializes an [`EditOperation`] to be sent over RPC.
 pub fn serialize_edit_operation(operation: &EditOperation) -> proto::operation::Edit {
     proto::operation::Edit {
         replica_id: operation.timestamp.replica_id as u32,


### PR DESCRIPTION
This PR cleans up a handful of references in doc comments in the `language` crate so that `rustdoc` will link and display them correctly.

Release Notes:

- N/A