### PR TITLE
Fix #4628: npm install to a wrong location

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -166,6 +166,7 @@ impl NodeRuntime for RealNodeRuntime {
 
             if let Some(directory) = directory {
                 command.current_dir(directory);
+                command.args(["--prefix".into(), directory.to_path_buf()]);
             }
 
             command.output().await.map_err(|e| anyhow!("{e}"))


### PR DESCRIPTION
By default `npm install` will walk up the folder tree checking for a folder that contains either a package.json file, or a node_modules folder. If such a thing is found, then that is treated as the effective "current directory" for the purpose of running npm commands.
This caused npm dependencies for language servers sometimes to be installed in the wrong folder, described in #4628.
Adding `--prefix ./` to `npm install` forces node_runtime.npm_install_packages to install packages in provided path even if node_modules dir exists somewhere up the filesystem tree from installation path.

Release Notes:
 - Fixed an issue where Node based language servers could install in the wrong directory on some systems.

