### PR TITLE
chore: remove unused deps in `color` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,22 +1587,9 @@ dependencies = [
 name = "color"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "fs",
- "indexmap 1.9.3",
  "itertools 0.11.0",
  "palette",
- "parking_lot 0.11.2",
- "refineable",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
- "settings",
  "story",
- "toml 0.5.11",
- "util",
- "uuid 1.4.1",
 ]
 
 [[package]]

--- a/crates/color/Cargo.toml
+++ b/crates/color/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-only"
 
-
 [features]
 default = []
 stories = ["dep:itertools", "dep:story"]
@@ -15,20 +14,6 @@ path = "src/color.rs"
 doctest = true
 
 [dependencies]
-# TODO: Clean up dependencies
-anyhow.workspace = true
-fs = { path = "../fs" }
-indexmap = "1.6.2"
-parking_lot.workspace = true
-refineable.workspace = true
-schemars.workspace = true
-serde.workspace = true
-serde_derive.workspace = true
-serde_json.workspace = true
-settings = { path = "../settings" }
 story = { path = "../story", optional = true }
-toml.workspace = true
-uuid.workspace = true
-util = { path = "../util" }
 itertools = { version = "0.11.0", optional = true }
 palette = "0.7.3"


### PR DESCRIPTION
Removes all unused deps in the `color` crate.
