### PR TITLE
small refac for colors

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -4,19 +4,22 @@ use std::fmt;
 
 /// Convert an RGB hex color code number to a color type
 pub fn rgb(hex: u32) -> Rgba {
-    let r = ((hex >> 16) & 0xFF) as f32 / 255.0;
-    let g = ((hex >> 8) & 0xFF) as f32 / 255.0;
-    let b = (hex & 0xFF) as f32 / 255.0;
-    Rgba { r, g, b, a: 1.0 }
+    Rgba {
+        r: ((hex >> 16) & 0xFF) as f32 / 255.0,
+        g: ((hex >> 8) & 0xFF) as f32 / 255.0,
+        b: (hex & 0xFF) as f32 / 255.0,
+        a: 1.0,
+    }
 }
 
 /// Convert an RGBA hex color code number to [`Rgba`]
 pub fn rgba(hex: u32) -> Rgba {
-    let r = ((hex >> 24) & 0xFF) as f32 / 255.0;
-    let g = ((hex >> 16) & 0xFF) as f32 / 255.0;
-    let b = ((hex >> 8) & 0xFF) as f32 / 255.0;
-    let a = (hex & 0xFF) as f32 / 255.0;
-    Rgba { r, g, b, a }
+    Rgba {
+        r: ((hex >> 24) & 0xFF) as f32 / 255.0,
+        g: ((hex >> 16) & 0xFF) as f32 / 255.0,
+        b: ((hex >> 8) & 0xFF) as f32 / 255.0,
+        a: (hex & 0xFF) as f32 / 255.0,
+    }
 }
 
 /// An RGBA color

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -220,16 +220,6 @@ impl Ord for Hsla {
 
 impl Eq for Hsla {}
 
-/// Construct an [`Hsla`] object from plain values
-pub fn hsla(h: f32, s: f32, l: f32, a: f32) -> Hsla {
-    Hsla {
-        h: h.clamp(0., 1.),
-        s: s.clamp(0., 1.),
-        l: l.clamp(0., 1.),
-        a: a.clamp(0., 1.),
-    }
-}
-
 /// Pure black in [`Hsla`]
 pub fn black() -> Hsla {
     Hsla {
@@ -301,6 +291,16 @@ pub fn yellow() -> Hsla {
 }
 
 impl Hsla {
+    /// Construct an [`Hsla`] object from plain values
+    pub fn new(h: f32, s: f32, l: f32, a: f32) -> Self {
+        Self {
+            h: h.clamp(0., 1.),
+            s: s.clamp(0., 1.),
+            l: l.clamp(0., 1.),
+            a: a.clamp(0., 1.),
+        }
+    }
+
     /// Converts this HSLA color to an RGBA color.
     pub fn to_rgb(self) -> Rgba {
         self.into()

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,5 +1,5 @@
 use crate::{
-    self as gpui, hsla, point, px, relative, rems, AbsoluteLength, AlignItems, CursorStyle,
+    self as gpui, point, px, relative, rems, AbsoluteLength, AlignItems, CursorStyle,
     DefiniteLength, Fill, FlexDirection, FontWeight, Hsla, JustifyContent, Length, Position,
     SharedString, StyleRefinement, Visibility, WhiteSpace,
 };
@@ -436,7 +436,7 @@ pub trait Styled: Sized {
     /// [Docs](https://tailwindcss.com/docs/box-shadow)
     fn shadow_sm(mut self) -> Self {
         self.style().box_shadow = Some(smallvec::smallvec![BoxShadow {
-            color: hsla(0., 0., 0., 0.05),
+            color: Hsla::new(0., 0., 0., 0.05),
             offset: point(px(0.), px(1.)),
             blur_radius: px(2.),
             spread_radius: px(0.),
@@ -449,13 +449,13 @@ pub trait Styled: Sized {
     fn shadow_md(mut self) -> Self {
         self.style().box_shadow = Some(smallvec![
             BoxShadow {
-                color: hsla(0.5, 0., 0., 0.1),
+                color: Hsla::new(0.5, 0., 0., 0.1),
                 offset: point(px(0.), px(4.)),
                 blur_radius: px(6.),
                 spread_radius: px(-1.),
             },
             BoxShadow {
-                color: hsla(0., 0., 0., 0.1),
+                color: Hsla::new(0., 0., 0., 0.1),
                 offset: point(px(0.), px(2.)),
                 blur_radius: px(4.),
                 spread_radius: px(-2.),
@@ -469,13 +469,13 @@ pub trait Styled: Sized {
     fn shadow_lg(mut self) -> Self {
         self.style().box_shadow = Some(smallvec![
             BoxShadow {
-                color: hsla(0., 0., 0., 0.1),
+                color: Hsla::new(0., 0., 0., 0.1),
                 offset: point(px(0.), px(10.)),
                 blur_radius: px(15.),
                 spread_radius: px(-3.),
             },
             BoxShadow {
-                color: hsla(0., 0., 0., 0.1),
+                color: Hsla::new(0., 0., 0., 0.1),
                 offset: point(px(0.), px(4.)),
                 blur_radius: px(6.),
                 spread_radius: px(-4.),
@@ -489,13 +489,13 @@ pub trait Styled: Sized {
     fn shadow_xl(mut self) -> Self {
         self.style().box_shadow = Some(smallvec![
             BoxShadow {
-                color: hsla(0., 0., 0., 0.1),
+                color: Hsla::new(0., 0., 0., 0.1),
                 offset: point(px(0.), px(20.)),
                 blur_radius: px(25.),
                 spread_radius: px(-5.),
             },
             BoxShadow {
-                color: hsla(0., 0., 0., 0.1),
+                color: Hsla::new(0., 0., 0., 0.1),
                 offset: point(px(0.), px(8.)),
                 blur_radius: px(10.),
                 spread_radius: px(-6.),
@@ -508,7 +508,7 @@ pub trait Styled: Sized {
     /// [Docs](https://tailwindcss.com/docs/box-shadow)
     fn shadow_2xl(mut self) -> Self {
         self.style().box_shadow = Some(smallvec![BoxShadow {
-            color: hsla(0., 0., 0., 0.25),
+            color: Hsla::new(0., 0., 0., 0.25),
             offset: point(px(0.), px(25.)),
             blur_radius: px(50.),
             spread_radius: px(-12.),

--- a/crates/story/src/story.rs
+++ b/crates/story/src/story.rs
@@ -1,9 +1,8 @@
 use gpui::{
-    div, hsla, prelude::*, px, rems, AnyElement, Div, ElementId, Hsla, SharedString, WindowContext,
+    div, prelude::*, px, rems, AnyElement, Div, ElementId, Hsla, SharedString, WindowContext,
 };
 use itertools::Itertools;
 use smallvec::SmallVec;
-
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -34,13 +33,13 @@ pub struct StoryColor {
 impl StoryColor {
     pub fn new() -> Self {
         Self {
-            primary: hsla(216. / 360., 11. / 100., 0. / 100., 1.),
-            secondary: hsla(216. / 360., 11. / 100., 16. / 100., 1.),
-            border: hsla(216. / 360., 11. / 100., 91. / 100., 1.),
-            background: hsla(0. / 360., 0. / 100., 100. / 100., 1.),
-            card_background: hsla(0. / 360., 0. / 100., 96. / 100., 1.),
-            divider: hsla(216. / 360., 11. / 100., 86. / 100., 1.),
-            link: hsla(206. / 360., 100. / 100., 50. / 100., 1.),
+            primary: Hsla::new(216. / 360., 11. / 100., 0. / 100., 1.),
+            secondary: Hsla::new(216. / 360., 11. / 100., 16. / 100., 1.),
+            border: Hsla::new(216. / 360., 11. / 100., 91. / 100., 1.),
+            background: Hsla::new(0. / 360., 0. / 100., 100. / 100., 1.),
+            card_background: Hsla::new(0. / 360., 0. / 100., 96. / 100., 1.),
+            divider: Hsla::new(216. / 360., 11. / 100., 86. / 100., 1.),
+            link: Hsla::new(206. / 360., 100. / 100., 50. / 100., 1.),
         }
     }
 }

--- a/crates/theme/src/one_themes.rs
+++ b/crates/theme/src/one_themes.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
-use gpui::{hsla, FontStyle, FontWeight, HighlightStyle};
-
 use crate::{
     default_color_scales, Appearance, PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme,
     ThemeColors, ThemeFamily, ThemeStyles,
 };
+use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla};
+use std::sync::Arc;
 
 // Note: This theme family is not the one you see in Zed at the moment.
 // This is a from-scratch rebuild that Nate started work on. We currently
@@ -22,18 +20,18 @@ pub fn one_family() -> ThemeFamily {
 }
 
 pub(crate) fn one_dark() -> Theme {
-    let bg = hsla(215. / 360., 12. / 100., 15. / 100., 1.);
-    let editor = hsla(220. / 360., 12. / 100., 18. / 100., 1.);
-    let elevated_surface = hsla(225. / 360., 12. / 100., 17. / 100., 1.);
+    let bg = Hsla::new(215. / 360., 12. / 100., 15. / 100., 1.);
+    let editor = Hsla::new(220. / 360., 12. / 100., 18. / 100., 1.);
+    let elevated_surface = Hsla::new(225. / 360., 12. / 100., 17. / 100., 1.);
 
-    let blue = hsla(207.8 / 360., 81. / 100., 66. / 100., 1.0);
-    let gray = hsla(218.8 / 360., 10. / 100., 40. / 100., 1.0);
-    let green = hsla(95. / 360., 38. / 100., 62. / 100., 1.0);
-    let orange = hsla(29. / 360., 54. / 100., 61. / 100., 1.0);
-    let purple = hsla(286. / 360., 51. / 100., 64. / 100., 1.0);
-    let red = hsla(355. / 360., 65. / 100., 65. / 100., 1.0);
-    let teal = hsla(187. / 360., 47. / 100., 55. / 100., 1.0);
-    let yellow = hsla(39. / 360., 67. / 100., 69. / 100., 1.0);
+    let blue = Hsla::new(207.8 / 360., 81. / 100., 66. / 100., 1.0);
+    let gray = Hsla::new(218.8 / 360., 10. / 100., 40. / 100., 1.0);
+    let green = Hsla::new(95. / 360., 38. / 100., 62. / 100., 1.0);
+    let orange = Hsla::new(29. / 360., 54. / 100., 61. / 100., 1.0);
+    let purple = Hsla::new(286. / 360., 51. / 100., 64. / 100., 1.0);
+    let red = Hsla::new(355. / 360., 65. / 100., 65. / 100., 1.0);
+    let teal = Hsla::new(187. / 360., 47. / 100., 55. / 100., 1.0);
+    let yellow = Hsla::new(39. / 360., 67. / 100., 69. / 100., 1.0);
 
     Theme {
         id: "one_dark".to_string(),
@@ -43,35 +41,35 @@ pub(crate) fn one_dark() -> Theme {
         styles: ThemeStyles {
             system: SystemColors::default(),
             colors: ThemeColors {
-                border: hsla(225. / 360., 13. / 100., 12. / 100., 1.),
-                border_variant: hsla(228. / 360., 8. / 100., 25. / 100., 1.),
-                border_focused: hsla(223. / 360., 78. / 100., 65. / 100., 1.),
-                border_selected: hsla(222.6 / 360., 77.5 / 100., 65.1 / 100., 1.0),
+                border: Hsla::new(225. / 360., 13. / 100., 12. / 100., 1.),
+                border_variant: Hsla::new(228. / 360., 8. / 100., 25. / 100., 1.),
+                border_focused: Hsla::new(223. / 360., 78. / 100., 65. / 100., 1.),
+                border_selected: Hsla::new(222.6 / 360., 77.5 / 100., 65.1 / 100., 1.0),
                 border_transparent: SystemColors::default().transparent,
-                border_disabled: hsla(222.0 / 360., 11.6 / 100., 33.7 / 100., 1.0),
+                border_disabled: Hsla::new(222.0 / 360., 11.6 / 100., 33.7 / 100., 1.0),
                 elevated_surface_background: elevated_surface,
                 surface_background: bg,
                 background: bg,
-                element_background: hsla(223.0 / 360., 13. / 100., 21. / 100., 1.0),
-                element_hover: hsla(225.0 / 360., 11.8 / 100., 26.7 / 100., 1.0),
-                element_active: hsla(220.0 / 360., 11.8 / 100., 20.0 / 100., 1.0),
-                element_selected: hsla(224.0 / 360., 11.3 / 100., 26.1 / 100., 1.0),
+                element_background: Hsla::new(223.0 / 360., 13. / 100., 21. / 100., 1.0),
+                element_hover: Hsla::new(225.0 / 360., 11.8 / 100., 26.7 / 100., 1.0),
+                element_active: Hsla::new(220.0 / 360., 11.8 / 100., 20.0 / 100., 1.0),
+                element_selected: Hsla::new(224.0 / 360., 11.3 / 100., 26.1 / 100., 1.0),
                 element_disabled: SystemColors::default().transparent,
-                drop_target_background: hsla(220.0 / 360., 8.3 / 100., 21.4 / 100., 1.0),
+                drop_target_background: Hsla::new(220.0 / 360., 8.3 / 100., 21.4 / 100., 1.0),
                 ghost_element_background: SystemColors::default().transparent,
-                ghost_element_hover: hsla(225.0 / 360., 11.8 / 100., 26.7 / 100., 1.0),
-                ghost_element_active: hsla(220.0 / 360., 11.8 / 100., 20.0 / 100., 1.0),
-                ghost_element_selected: hsla(224.0 / 360., 11.3 / 100., 26.1 / 100., 1.0),
+                ghost_element_hover: Hsla::new(225.0 / 360., 11.8 / 100., 26.7 / 100., 1.0),
+                ghost_element_active: Hsla::new(220.0 / 360., 11.8 / 100., 20.0 / 100., 1.0),
+                ghost_element_selected: Hsla::new(224.0 / 360., 11.3 / 100., 26.1 / 100., 1.0),
                 ghost_element_disabled: SystemColors::default().transparent,
-                text: hsla(221. / 360., 11. / 100., 86. / 100., 1.0),
-                text_muted: hsla(218.0 / 360., 7. / 100., 46. / 100., 1.0),
-                text_placeholder: hsla(220.0 / 360., 6.6 / 100., 44.5 / 100., 1.0),
-                text_disabled: hsla(220.0 / 360., 6.6 / 100., 44.5 / 100., 1.0),
-                text_accent: hsla(222.6 / 360., 77.5 / 100., 65.1 / 100., 1.0),
-                icon: hsla(222.9 / 360., 9.9 / 100., 86.1 / 100., 1.0),
-                icon_muted: hsla(220.0 / 360., 12.1 / 100., 66.1 / 100., 1.0),
-                icon_disabled: hsla(220.0 / 360., 6.4 / 100., 45.7 / 100., 1.0),
-                icon_placeholder: hsla(220.0 / 360., 6.4 / 100., 45.7 / 100., 1.0),
+                text: Hsla::new(221. / 360., 11. / 100., 86. / 100., 1.0),
+                text_muted: Hsla::new(218.0 / 360., 7. / 100., 46. / 100., 1.0),
+                text_placeholder: Hsla::new(220.0 / 360., 6.6 / 100., 44.5 / 100., 1.0),
+                text_disabled: Hsla::new(220.0 / 360., 6.6 / 100., 44.5 / 100., 1.0),
+                text_accent: Hsla::new(222.6 / 360., 77.5 / 100., 65.1 / 100., 1.0),
+                icon: Hsla::new(222.9 / 360., 9.9 / 100., 86.1 / 100., 1.0),
+                icon_muted: Hsla::new(220.0 / 360., 12.1 / 100., 66.1 / 100., 1.0),
+                icon_disabled: Hsla::new(220.0 / 360., 6.4 / 100., 45.7 / 100., 1.0),
+                icon_placeholder: Hsla::new(220.0 / 360., 6.4 / 100., 45.7 / 100., 1.0),
                 icon_accent: blue.into(),
                 status_bar_background: bg,
                 title_bar_background: bg,
@@ -84,14 +82,24 @@ pub(crate) fn one_dark() -> Theme {
                 editor_background: editor,
                 editor_gutter_background: editor,
                 editor_subheader_background: bg,
-                editor_active_line_background: hsla(222.9 / 360., 13.5 / 100., 20.4 / 100., 1.0),
-                editor_highlighted_line_background: hsla(207.8 / 360., 81. / 100., 66. / 100., 0.1),
-                editor_line_number: hsla(222.0 / 360., 11.5 / 100., 34.1 / 100., 1.0),
-                editor_active_line_number: hsla(216.0 / 360., 5.9 / 100., 49.6 / 100., 1.0),
-                editor_invisible: hsla(222.0 / 360., 11.5 / 100., 34.1 / 100., 1.0),
-                editor_wrap_guide: hsla(228. / 360., 8. / 100., 25. / 100., 1.),
-                editor_active_wrap_guide: hsla(228. / 360., 8. / 100., 25. / 100., 1.),
-                editor_document_highlight_read_background: hsla(
+                editor_active_line_background: Hsla::new(
+                    222.9 / 360.,
+                    13.5 / 100.,
+                    20.4 / 100.,
+                    1.0,
+                ),
+                editor_highlighted_line_background: Hsla::new(
+                    207.8 / 360.,
+                    81. / 100.,
+                    66. / 100.,
+                    0.1,
+                ),
+                editor_line_number: Hsla::new(222.0 / 360., 11.5 / 100., 34.1 / 100., 1.0),
+                editor_active_line_number: Hsla::new(216.0 / 360., 5.9 / 100., 49.6 / 100., 1.0),
+                editor_invisible: Hsla::new(222.0 / 360., 11.5 / 100., 34.1 / 100., 1.0),
+                editor_wrap_guide: Hsla::new(228. / 360., 8. / 100., 25. / 100., 1.),
+                editor_active_wrap_guide: Hsla::new(228. / 360., 8. / 100., 25. / 100., 1.),
+                editor_document_highlight_read_background: Hsla::new(
                     207.8 / 360.,
                     81. / 100.,
                     66. / 100.,
@@ -132,11 +140,16 @@ pub(crate) fn one_dark() -> Theme {
                 panel_focused_border: blue,
                 pane_focused_border: blue,
                 scrollbar_thumb_background: gpui::transparent_black(),
-                scrollbar_thumb_hover_background: hsla(225.0 / 360., 11.8 / 100., 26.7 / 100., 1.0),
-                scrollbar_thumb_border: hsla(228. / 360., 8. / 100., 25. / 100., 1.),
+                scrollbar_thumb_hover_background: Hsla::new(
+                    225.0 / 360.,
+                    11.8 / 100.,
+                    26.7 / 100.,
+                    1.0,
+                ),
+                scrollbar_thumb_border: Hsla::new(228. / 360., 8. / 100., 25. / 100., 1.),
                 scrollbar_track_background: gpui::transparent_black(),
-                scrollbar_track_border: hsla(228. / 360., 8. / 100., 25. / 100., 1.),
-                editor_foreground: hsla(218. / 360., 14. / 100., 71. / 100., 1.),
+                scrollbar_track_border: Hsla::new(228. / 360., 8. / 100., 25. / 100., 1.),
+                editor_foreground: Hsla::new(218. / 360., 14. / 100., 71. / 100., 1.),
                 link_text_hover: blue,
             },
             status: StatusColors {

--- a/crates/theme/src/styles/system.rs
+++ b/crates/theme/src/styles/system.rs
@@ -1,4 +1,4 @@
-use gpui::{hsla, Hsla};
+use gpui::Hsla;
 
 #[derive(Clone)]
 pub struct SystemColors {
@@ -11,10 +11,10 @@ pub struct SystemColors {
 impl Default for SystemColors {
     fn default() -> Self {
         Self {
-            transparent: hsla(0.0, 0.0, 0.0, 0.0),
-            mac_os_traffic_light_red: hsla(0.0139, 0.79, 0.65, 1.0),
-            mac_os_traffic_light_yellow: hsla(0.114, 0.88, 0.63, 1.0),
-            mac_os_traffic_light_green: hsla(0.313, 0.49, 0.55, 1.0),
+            transparent: Hsla::new(0.0, 0.0, 0.0, 0.0),
+            mac_os_traffic_light_red: Hsla::new(0.0139, 0.79, 0.65, 1.0),
+            mac_os_traffic_light_yellow: Hsla::new(0.114, 0.88, 0.63, 1.0),
+            mac_os_traffic_light_green: Hsla::new(0.313, 0.49, 0.55, 1.0),
         }
     }
 }

--- a/crates/theme_importer/src/color.rs
+++ b/crates/theme_importer/src/color.rs
@@ -18,11 +18,15 @@ pub(crate) fn try_parse_color(color: &str) -> Result<Hsla> {
 }
 
 pub(crate) fn pack_color(color: Hsla) -> u32 {
-    let hsla = palette::Hsla::from_components((color.h * 360., color.s, color.l, color.a));
-    let rgba = palette::rgb::Srgba::from_color(hsla);
-    let rgba = rgba.into_format::<u8, u8>();
-
-    u32::from(rgba)
+    u32::from(
+        palette::rgb::Srgba::from_color(palette::Hsla::from_components((
+            color.h * 360.,
+            color.s,
+            color.l,
+            color.a,
+        )))
+        .into_format::<u8, u8>(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/theme_importer/src/color.rs
+++ b/crates/theme_importer/src/color.rs
@@ -7,7 +7,7 @@ pub(crate) fn try_parse_color(color: &str) -> Result<Hsla> {
     let rgba = palette::rgb::Srgba::from_components((rgba.r, rgba.g, rgba.b, rgba.a));
     let hsla = palette::Hsla::from_color(rgba);
 
-    let hsla = gpui::hsla(
+    let hsla = Hsla::new(
         hsla.hue.into_positive_degrees() / 360.,
         hsla.saturation,
         hsla.lightness,

--- a/crates/theme_importer/src/theme_printer.rs
+++ b/crates/theme_importer/src/theme_printer.rs
@@ -1,6 +1,5 @@
-use std::fmt::{self, Debug};
-
 use gpui::Hsla;
+use std::fmt::{self, Debug};
 use theme::{
     Appearance, PlayerColor, PlayerColors, StatusColorsRefinement, SystemColors,
     ThemeColorsRefinement, UserHighlightStyle, UserSyntaxTheme, UserTheme, UserThemeFamily,

--- a/crates/ui/src/styled_ext.rs
+++ b/crates/ui/src/styled_ext.rs
@@ -1,9 +1,8 @@
-use gpui::{hsla, px, Styled, WindowContext};
-use settings::Settings;
-use theme::ThemeSettings;
-
 use crate::prelude::*;
 use crate::{ElevationIndex, UiTextSize};
+use gpui::{px, Hsla, Styled, WindowContext};
+use settings::Settings;
+use theme::ThemeSettings;
 
 fn elevated<E: Styled>(this: E, cx: &mut WindowContext, index: ElevationIndex) -> E {
     this.bg(cx.theme().colors().elevated_surface_background)
@@ -122,32 +121,32 @@ pub trait StyledExt: Styled + Sized {
 
     /// Sets the background color to red for debugging when building UI.
     fn debug_bg_red(self) -> Self {
-        self.bg(hsla(0. / 360., 1., 0.5, 1.))
+        self.bg(Hsla::new(0. / 360., 1., 0.5, 1.))
     }
 
     /// Sets the background color to green for debugging when building UI.
     fn debug_bg_green(self) -> Self {
-        self.bg(hsla(120. / 360., 1., 0.5, 1.))
+        self.bg(Hsla::new(120. / 360., 1., 0.5, 1.))
     }
 
     /// Sets the background color to blue for debugging when building UI.
     fn debug_bg_blue(self) -> Self {
-        self.bg(hsla(240. / 360., 1., 0.5, 1.))
+        self.bg(Hsla::new(240. / 360., 1., 0.5, 1.))
     }
 
     /// Sets the background color to yellow for debugging when building UI.
     fn debug_bg_yellow(self) -> Self {
-        self.bg(hsla(60. / 360., 1., 0.5, 1.))
+        self.bg(Hsla::new(60. / 360., 1., 0.5, 1.))
     }
 
     /// Sets the background color to cyan for debugging when building UI.
     fn debug_bg_cyan(self) -> Self {
-        self.bg(hsla(160. / 360., 1., 0.5, 1.))
+        self.bg(Hsla::new(160. / 360., 1., 0.5, 1.))
     }
 
     /// Sets the background color to magenta for debugging when building UI.
     fn debug_bg_magenta(self) -> Self {
-        self.bg(hsla(300. / 360., 1., 0.5, 1.))
+        self.bg(Hsla::new(300. / 360., 1., 0.5, 1.))
     }
 }
 

--- a/crates/ui/src/styles/elevation.rs
+++ b/crates/ui/src/styles/elevation.rs
@@ -1,4 +1,4 @@
-use gpui::{hsla, point, px, BoxShadow};
+use gpui::{point, px, BoxShadow, Hsla};
 use smallvec::{smallvec, SmallVec};
 
 #[doc = include_str!("docs/elevation.md")]
@@ -36,7 +36,7 @@ impl ElevationIndex {
             ElevationIndex::Surface => smallvec![],
 
             ElevationIndex::ElevatedSurface => smallvec![BoxShadow {
-                color: hsla(0., 0., 0., 0.12),
+                color: Hsla::new(0., 0., 0., 0.12),
                 offset: point(px(0.), px(2.)),
                 blur_radius: px(3.),
                 spread_radius: px(0.),
@@ -44,19 +44,19 @@ impl ElevationIndex {
 
             ElevationIndex::ModalSurface => smallvec![
                 BoxShadow {
-                    color: hsla(0., 0., 0., 0.12),
+                    color: Hsla::new(0., 0., 0., 0.12),
                     offset: point(px(0.), px(2.)),
                     blur_radius: px(3.),
                     spread_radius: px(0.),
                 },
                 BoxShadow {
-                    color: hsla(0., 0., 0., 0.08),
+                    color: Hsla::new(0., 0., 0., 0.08),
                     offset: point(px(0.), px(3.)),
                     blur_radius: px(6.),
                     spread_radius: px(0.),
                 },
                 BoxShadow {
-                    color: hsla(0., 0., 0., 0.04),
+                    color: Hsla::new(0., 0., 0., 0.04),
                     offset: point(px(0.), px(6.)),
                     blur_radius: px(12.),
                     spread_radius: px(0.),


### PR DESCRIPTION
Small refactoring for colors.

I would also suggest to rename:
- `gpui::Rgba`
- `gpui::Hsla`

At the moment it is confusing considering the exact same `palette` crate naming, which is used as a primitive in the repo.