### PR TITLE
Fix panic when typing umlauts in command palette using Vim mode

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -282,7 +282,7 @@ fn generate_positions(string: &str, query: &str) -> Vec<usize> {
         return positions;
     };
 
-    for (i, c) in string.chars().enumerate() {
+    for (i, c) in string.char_indices() {
         if c == current {
             positions.push(i);
             if let Some(c) = chars.next() {


### PR DESCRIPTION

Release Notes:

- This fixes a panic that occurs when someone was using Vim mode and typing umlauts into the command palette. E.g: `:%s/impërt`
