### PR TITLE
Factor out URLs in `feedback` crate

### DIFF
--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -19,6 +19,21 @@ actions!(
     ]
 );
 
+const fn zed_repo_url() -> &'static str {
+    "https://github.com/zed-industries/zed"
+}
+
+const fn request_feature_url() -> &'static str {
+    "https://github.com/zed-industries/zed/issues/new?assignees=&labels=enhancement%2Ctriage&template=0_feature_request.yml"
+}
+
+fn file_bug_report_url(specs: &SystemSpecs) -> String {
+    format!(
+        "https://github.com/zed-industries/zed/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}",
+        urlencoding::encode(&specs.to_string())
+    )
+}
+
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, cx| {
         feedback_modal::FeedbackModal::register(workspace, cx);
@@ -39,20 +54,14 @@ pub fn init(cx: &mut AppContext) {
                 cx.write_to_clipboard(ClipboardItem::new(specs.clone()));
             })
             .register_action(|_, _: &RequestFeature, cx| {
-                let url = "https://github.com/zed-industries/zed/issues/new?assignees=&labels=enhancement%2Ctriage&template=0_feature_request.yml";
-                cx.open_url(url);
+                cx.open_url(request_feature_url());
             })
             .register_action(move |_, _: &FileBugReport, cx| {
-                let url = format!(
-                    "https://github.com/zed-industries/zed/issues/new?assignees=&labels=defect%2Ctriage&template=2_bug_report.yml&environment={}",
-                    urlencoding::encode(&SystemSpecs::new(&cx).to_string())
-                );
-                cx.open_url(&url);
+                cx.open_url(&file_bug_report_url(&SystemSpecs::new(&cx)));
             })
             .register_action(move |_, _: &OpenZedRepo, cx| {
-                let url = "https://github.com/zed-industries/zed";
-                cx.open_url(&url);
+                cx.open_url(zed_repo_url());
             });
-        })
+    })
     .detach();
 }


### PR DESCRIPTION
This PR factors out the inlined URLs in the `feedback` crate so that they don't mess with `rustfmt`.

Release Notes:

- N/A
