### PR TITLE
Implement `Default` for `PromptArguments`

### DIFF
--- a/crates/ai/src/prompts/base.rs
+++ b/crates/ai/src/prompts/base.rs
@@ -7,13 +7,13 @@ use util::ResultExt;
 
 use crate::models::LanguageModel;
 use crate::prompts::repository_context::PromptCodeSnippet;
+use crate::providers::open_ai::OpenAILanguageModel;
 
 pub(crate) enum PromptFileType {
     Text,
     Code,
 }
 
-// TODO: Set this up to manage for defaults well
 pub struct PromptArguments {
     pub model: Arc<dyn LanguageModel>,
     pub user_prompt: Option<String>,
@@ -23,6 +23,21 @@ pub struct PromptArguments {
     pub reserved_tokens: usize,
     pub buffer: Option<BufferSnapshot>,
     pub selected_range: Option<Range<usize>>,
+}
+
+impl Default for PromptArguments {
+    fn default() -> Self {
+        PromptArguments {
+            model: Arc::new(OpenAILanguageModel::default()),
+            user_prompt: None,
+            language_name: None,
+            project_name: None,
+            snippets: Vec::new(),
+            reserved_tokens: 0,
+            buffer: None,
+            selected_range: None,
+        }
+    }
 }
 
 impl PromptArguments {

--- a/crates/ai/src/providers/open_ai/model.rs
+++ b/crates/ai/src/providers/open_ai/model.rs
@@ -4,7 +4,7 @@ use util::ResultExt;
 
 use crate::models::{LanguageModel, TruncationDirection};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct OpenAILanguageModel {
     name: String,
     bpe: Option<CoreBPE>,


### PR DESCRIPTION
## Description

This pull request adds the `Default` trait implementation for the `PromptArguments` struct. The `Default` implementation initializes a default instance of the `PromptArguments` struct, setting sensible default values for its fields.

## Changes Made

- Implemented the `Default` trait for the `PromptArguments` struct.


