### PR TITLE
Fix bracket captures for Go, C, C++, and Zig

### DIFF
--- a/crates/zed/src/languages/cpp/brackets.scm
+++ b/crates/zed/src/languages/cpp/brackets.scm
@@ -1,3 +1,4 @@
+("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
 ("\"" @open "\"" @close)

--- a/crates/zed/src/languages/go/brackets.scm
+++ b/crates/zed/src/languages/go/brackets.scm
@@ -1,3 +1,4 @@
+("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
 ("\"" @open "\"" @close)

--- a/crates/zed/src/languages/zig/brackets.scm
+++ b/crates/zed/src/languages/zig/brackets.scm
@@ -1,4 +1,3 @@
 ("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
-("\"" @open "\"" @close)


### PR DESCRIPTION
This fixes #6702 by adding the captures for Go, C, C++, and Zig.

Witnessed-by: @dammerung2718  <dammerung2718@icloud.com>

Release Notes:

- Fixed matching-bracket navigation via `%` in Vim mode not working for `(` in Go, C, C++, and not working for any in Zig. ([#6702](https://github.com/zed-industries/zed/issues/6702))
