### PR TITLE
Feature: PHP allow single quote autocompletion

### DIFF
--- a/crates/zed/src/languages/php/config.toml
+++ b/crates/zed/src/languages/php/config.toml
@@ -8,6 +8,7 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
 ]
 collapsed_placeholder = "/* ... */"
 word_characters = ["$"]

--- a/crates/zed/src/languages/php/config.toml
+++ b/crates/zed/src/languages/php/config.toml
@@ -1,7 +1,7 @@
 name = "PHP"
 path_suffixes = ["php"]
 first_line_pattern = '^#!.*php'
-line_comments = ["// "]
+line_comments = ["// ", "# "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION

Release Notes:

- Added support for single quote autocompletion in PHP ([#6794](https://github.com/zed-industries/zed/issues/6794)).
- Added `#` to supported line comments for PHP ([#6794](https://github.com/zed-industries/zed/issues/6794)).
