### PR TITLE
Feature: PHP: Add `readonly` keyword to keyword list

### DIFF
--- a/crates/zed/src/languages/php/highlights.scm
+++ b/crates/zed/src/languages/php/highlights.scm
@@ -96,6 +96,7 @@
 "endwhile" @keyword
 "extends" @keyword
 "final" @keyword
+"readonly" @keyword
 "finally" @keyword
 "foreach" @keyword
 "function" @keyword


### PR DESCRIPTION

Release Notes:

- Added `readonly` to keyword list for PHP ([#6797](https://github.com/zed-industries/zed/issues/6797)).
