### PR TITLE
Add receive to Elixir keywords

### DIFF
--- a/crates/zed/src/languages/elixir/highlights.scm
+++ b/crates/zed/src/languages/elixir/highlights.scm
@@ -1,4 +1,4 @@
-["when" "and" "or" "not" "in" "not in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
+["when" "and" "or" "not" "in" "not in" "fn" "do" "end" "catch" "rescue" "after" "else" "receive"] @keyword
 
 (unary_operator
   operator: "&"


### PR DESCRIPTION
Release Notes:

- Added `receive` to Elixir keywords ([#6801](https://github.com/zed-industries/zed/issues/6801)).
