### PR TITLE
Collab UI improvements

### DIFF
--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -473,8 +473,11 @@ impl Database {
     ) -> Result<RemoveChannelMemberResult> {
         self.transaction(|tx| async move {
             let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, admin_id, &*tx)
-                .await?;
+
+            if member_id != admin_id {
+                self.check_user_is_channel_admin(&channel, admin_id, &*tx)
+                    .await?;
+            }
 
             let result = channel_member::Entity::delete_many()
                 .filter(

--- a/crates/collab/src/tests/channel_tests.rs
+++ b/crates/collab/src/tests/channel_tests.rs
@@ -1307,6 +1307,28 @@ async fn test_invite_access(
 }
 
 #[gpui::test]
+async fn test_leave_channel(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
+    let (_server, client_a, client_b, channel_id) = TestServer::start2(cx_a, cx_b).await;
+
+    client_b
+        .channel_store()
+        .update(cx_b, |channel_store, cx| {
+            channel_store.remove_member(channel_id, client_b.user_id().unwrap(), cx)
+        })
+        .await
+        .unwrap();
+
+    cx_a.run_until_parked();
+
+    assert_eq!(
+        client_b
+            .channel_store()
+            .read_with(cx_b, |store, _| store.channels().count()),
+        0
+    );
+}
+
+#[gpui::test]
 async fn test_channel_moving(
     executor: BackgroundExecutor,
     cx_a: &mut TestAppContext,

--- a/crates/collab/src/tests/channel_tests.rs
+++ b/crates/collab/src/tests/channel_tests.rs
@@ -1308,7 +1308,7 @@ async fn test_invite_access(
 
 #[gpui::test]
 async fn test_leave_channel(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
-    let (_server, client_a, client_b, channel_id) = TestServer::start2(cx_a, cx_b).await;
+    let (_server, _client_a, client_b, channel_id) = TestServer::start2(cx_a, cx_b).await;
 
     client_b
         .channel_store()

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -1575,7 +1575,7 @@ async fn test_following_across_workspaces(cx_a: &mut TestAppContext, cx_b: &mut 
 
 #[gpui::test]
 async fn test_following_stops_on_unshare(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
-    let (client_a, client_b, channel_id) = TestServer::start2(cx_a, cx_b).await;
+    let (_, client_a, client_b, channel_id) = TestServer::start2(cx_a, cx_b).await;
 
     let (workspace_a, cx_a) = client_a.build_test_workspace(cx_a).await;
     client_a

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -118,7 +118,7 @@ impl TestServer {
     pub async fn start2(
         cx_a: &mut TestAppContext,
         cx_b: &mut TestAppContext,
-    ) -> (TestClient, TestClient, u64) {
+    ) -> (TestServer, TestClient, TestClient, u64) {
         let mut server = Self::start(cx_a.executor()).await;
         let client_a = server.create_client(cx_a, "user_a").await;
         let client_b = server.create_client(cx_b, "user_b").await;
@@ -127,7 +127,7 @@ impl TestServer {
             .await;
         cx_a.run_until_parked();
 
-        (client_a, client_b, channel_id)
+        (server, client_a, client_b, channel_id)
     }
 
     pub async fn start1<'a>(cx: &'a mut TestAppContext) -> TestClient {

--- a/crates/ui/src/components/tooltip.rs
+++ b/crates/ui/src/components/tooltip.rs
@@ -85,7 +85,7 @@ impl Render for Tooltip {
     }
 }
 
-fn tooltip_container<V>(
+pub fn tooltip_container<V>(
     cx: &mut ViewContext<V>,
     f: impl FnOnce(Div, &mut ViewContext<V>) -> Div,
 ) -> impl IntoElement {


### PR DESCRIPTION
- Allow people to leave channels
- Make contacts use right click menu for call
- Add a hover menu to see who's in a channel

Release Notes:

- Fixed clicking on contacts to *not* call them immediately
- Added a hover menu on channels to see who is there
- Added a "Leave Channel" right click option
