### PR TITLE
Documentation: Clarify shortcuts and fix grammar

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -12,4 +12,4 @@ Use `⌘` + `,` to open your custom settings to set things like fonts, formattin
 
 ### Set up your key bindings
 
-You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `⌘` + `K` + `S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.
+You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `⌘` + `K`, `⌘` + `S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -8,8 +8,8 @@ You can obtain the release build via the [download page](https://zed.dev/downloa
 
 ### Configure Zed
 
-Use `CMD + ,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See Configuring Zed for all available settings.
+Use `⌘` `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See Configuring Zed for all available settings.
 
 ### Set up your key bindings
 
-You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `CMD + K`,`CMD + S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.,
+You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `⌘` `K` `S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -8,8 +8,8 @@ You can obtain the release build via the [download page](https://zed.dev/downloa
 
 ### Configure Zed
 
-Use `⌘` `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See Configuring Zed for all available settings.
+Use `⌘` + `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See Configuring Zed for all available settings.
 
 ### Set up your key bindings
 
-You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `⌘` `K` `S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.
+You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `⌘` + `K` + `S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.


### PR DESCRIPTION
I got stuck on the "Getting started" page because I was trying to use the shortcut `⌘+,` and not `⌘,`. This PR removes the `+`'s to make the shortcuts clearer to the reader.

Release Notes:

- Improved getting started instructions.
