### PR TITLE
Theme importer fix

### DIFF
--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -318,6 +318,12 @@ fn main() -> Result<()> {
             .replace(")", "")
             .to_case(Case::Snake);
 
+        let output_file_path = themes_output_path.join(format!("{theme_family_slug}.rs"));
+        if (output_file_path.exists()) {
+            log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {theme_output_path}.");
+            continue;
+        }
+
         let mut output_file =
             File::create(themes_output_path.join(format!("{theme_family_slug}.rs")))?;
         log::info!(

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -320,7 +320,7 @@ fn main() -> Result<()> {
 
         let output_file_path = themes_output_path.join(format!("{theme_family_slug}.rs"));
         if output_file_path.exists() {
-            theme_modules.push(format!("{}", theme_family_slug));
+            theme_modules.push(theme_family_slug.clone());
             log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {:?}.", themes_output_path.display());
             continue;
         }

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -320,6 +320,7 @@ fn main() -> Result<()> {
 
         let output_file_path = themes_output_path.join(format!("{theme_family_slug}.rs"));
         if output_file_path.exists() {
+            theme_modules.push(format!("{}", theme_family_slug));
             log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {:?}.", themes_output_path.display());
             continue;
         }
@@ -402,8 +403,6 @@ fn main() -> Result<()> {
 
     log::info!("Writing LICENSES file...");
 
-    // let mut licenses_file = File::create(themes_output_path.join(format!("LICENSES")))?;
-    // create LICENSES file only if it doesn't exist
     let mut licenses_file = OpenOptions::new()
         .append(true)
         .create_new(true)

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -7,7 +7,7 @@ mod zed1;
 
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
@@ -405,10 +405,18 @@ fn main() -> Result<()> {
 
     let mut licenses_file = OpenOptions::new()
         .append(true)
-        .create_new(true)
+        .read(true)
+        .create(true)
         .open(themes_output_path.join(format!("LICENSES")))?;
 
-    licenses_file.write(licenses.join("\n").as_bytes())?;
+    for license in &licenses {
+        let mut licenses_content = String::new();
+        licenses_file.read_to_string(&mut licenses_content)?;
+        if licenses_content.contains(license) {
+            continue;
+        }
+        licenses_file.write(licenses.join("\n").as_bytes())?;
+    }
 
     log::info!("Formatting themes...");
 

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -320,7 +320,7 @@ fn main() -> Result<()> {
 
         let output_file_path = themes_output_path.join(format!("{theme_family_slug}.rs"));
         if (output_file_path.exists()) {
-            log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {theme_output_path}.");
+            log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {themes_output_path}.");
             continue;
         }
 

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -287,6 +287,10 @@ fn main() -> Result<()> {
                 None => theme.name.clone(),
             };
 
+            if licenses.contains(&license_header) {
+                continue;
+            }
+
             licenses.push(formatdoc!(
                 "
                 ## {license_header}
@@ -319,7 +323,7 @@ fn main() -> Result<()> {
             .to_case(Case::Snake);
 
         let output_file_path = themes_output_path.join(format!("{theme_family_slug}.rs"));
-        if (output_file_path.exists()) {
+        if output_file_path.exists() {
             log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {:?}.", themes_output_path.display());
             continue;
         }
@@ -404,7 +408,7 @@ fn main() -> Result<()> {
 
     let mut licenses_file = File::create(themes_output_path.join(format!("LICENSES")))?;
 
-    licenses_file.write_all(licenses.join("\n").as_bytes())?;
+    licenses_file.write(licenses.join("\n").as_bytes())?;
 
     log::info!("Formatting themes...");
 

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -6,7 +6,7 @@ mod vscode;
 mod zed1;
 
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
@@ -287,10 +287,6 @@ fn main() -> Result<()> {
                 None => theme.name.clone(),
             };
 
-            if licenses.contains(&license_header) {
-                continue;
-            }
-
             licenses.push(formatdoc!(
                 "
                 ## {license_header}
@@ -406,7 +402,12 @@ fn main() -> Result<()> {
 
     log::info!("Writing LICENSES file...");
 
-    let mut licenses_file = File::create(themes_output_path.join(format!("LICENSES")))?;
+    // let mut licenses_file = File::create(themes_output_path.join(format!("LICENSES")))?;
+    // create LICENSES file only if it doesn't exist
+    let mut licenses_file = OpenOptions::new()
+        .append(true)
+        .create_new(true)
+        .open(themes_output_path.join(format!("LICENSES")))?;
 
     licenses_file.write(licenses.join("\n").as_bytes())?;
 

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -320,7 +320,7 @@ fn main() -> Result<()> {
 
         let output_file_path = themes_output_path.join(format!("{theme_family_slug}.rs"));
         if (output_file_path.exists()) {
-            log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {themes_output_path}.");
+            log::info!("Skipping file {theme_family_slug}.rs, it already exists. In order to update a theme, please delete it from the output path {:?}.", themes_output_path.display());
             continue;
         }
 


### PR DESCRIPTION
This PR addresses a few issues with the `import_themes` crate. While tinkering with importing my vscode themes I noticed that pre-existing themes were being overwritten and decided to do something about it. I'm sure it was not intended behavior for Zed1 themes to be overwritten/removed.

This PR just makes sure that pre-existing themes are skipped, and prompts the user to delete it from the `crates/theme/themes` directory if they wish to update any pre-existing theme.

BTW is how come the theme assets aren't provided for the Zed1 themes, but have their names hardcoded into the `import_themes` crate? Oh, and licenses provided by vscode themes aren't added to the `LICENSES` file... I also made sure that this isn't overwritten either.
