### PR TITLE
Support "dtx" vim key combination when "x" is immediately to the right of the cursor

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -434,10 +434,13 @@ impl Motion {
                 SelectionGoal::None,
             ),
             Matching => (matching(map, point), SelectionGoal::None),
-            FindForward { before, char } => (
-                find_forward(map, point, *before, *char, times),
-                SelectionGoal::None,
-            ),
+            FindForward { before, char } => {
+                if let Some(new_point) = find_forward(map, point, *before, *char, times) {
+                    return Some((new_point, SelectionGoal::None));
+                } else {
+                    return None;
+                }
+            }
             FindBackward { after, char } => (
                 find_backward(map, point, *after, *char, times),
                 SelectionGoal::None,
@@ -882,7 +885,7 @@ fn find_forward(
     before: bool,
     target: char,
     times: usize,
-) -> DisplayPoint {
+) -> Option<DisplayPoint> {
     let mut to = from;
     let mut found = false;
 
@@ -897,12 +900,12 @@ fn find_forward(
     if found {
         if before && to.column() > 0 {
             *to.column_mut() -= 1;
-            map.clip_point(to, Bias::Left)
+            Some(map.clip_point(to, Bias::Left))
         } else {
-            to
+            Some(to)
         }
     } else {
-        from
+        None
     }
 }
 

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -472,4 +472,11 @@ mod test {
         the ˇlazy dog"})
             .await;
     }
+
+    #[gpui::test]
+    async fn test_delete_to_adjacent_character(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.assert_neovim_compatible("ˇax", ["d", "t", "x"]).await;
+        cx.assert_neovim_compatible("aˇx", ["d", "t", "x"]).await;
+    }
 }

--- a/crates/vim/test_data/test_delete_to_adjacent_character.json
+++ b/crates/vim/test_data/test_delete_to_adjacent_character.json
@@ -1,0 +1,10 @@
+{"Put":{"state":"ˇax"}}
+{"Key":"d"}
+{"Key":"t"}
+{"Key":"x"}
+{"Get":{"state":"ˇx","mode":"Normal"}}
+{"Put":{"state":"aˇx"}}
+{"Key":"d"}
+{"Key":"t"}
+{"Key":"x"}
+{"Get":{"state":"aˇx","mode":"Normal"}}


### PR DESCRIPTION
Closes #4358

The bug originates on this line: https://github.com/zed-industries/zed/blob/5db7e8f89ee4f5d9801a2eab88adc1db3fda0f46/crates/vim/src/motion.rs#L451

- When running "dtx" on "ˇabcx", the range to delete is 0 -> 2 ("abc")
- When running "dtx" on "abˇcx", the range to delete is 2 -> 2 ("c"), so `new_point == point` and the function incorrectly returns `None` and "c" is not deleted
- We need to disambiguate between the "not found" case and the "found immediately to the right" case
- This bug does not apply to the backwards case ("dTx")

Release Notes:
- Fixed "dtx" vim key combination when "x" is immediately to the right of the cursor (#4358)