### PR TITLE
Add swift support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8599,6 +8599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-swift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452e6ee0a14b82a0dcd93400b8d3fe3784fdbd775191a89ef84586e5ccec6be7"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-toml"
 version = "0.5.1"
 source = "git+https://github.com/tree-sitter/tree-sitter-toml?rev=342d9be207c2dba869b9967124c679b5e6fd0ebe#342d9be207c2dba869b9967124c679b5e6fd0ebe"
@@ -9736,6 +9746,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scheme",
  "tree-sitter-svelte",
+ "tree-sitter-swift",
  "tree-sitter-toml",
  "tree-sitter-typescript",
  "tree-sitter-uiua",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typ
 tree-sitter-ruby = "0.20.0"
 tree-sitter-html = "0.19.0"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9"}
+tree-sitter-swift = "0.4.0"
 tree-sitter-svelte = { git = "https://github.com/Himujjal/tree-sitter-svelte", rev = "697bb515471871e85ff799ea57a76298a71a9cca"}
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a"}
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "f545a41f57502e1b5ddf2a6668896c1b0620f930"}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -135,6 +135,7 @@ tree-sitter-html.workspace = true
 tree-sitter-php.workspace = true
 tree-sitter-scheme.workspace = true
 tree-sitter-svelte.workspace = true
+tree-sitter-swift.workspace = true
 tree-sitter-racket.workspace = true
 tree-sitter-yaml.workspace = true
 tree-sitter-lua.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -26,6 +26,7 @@ mod python;
 mod ruby;
 mod rust;
 mod svelte;
+mod swift;
 mod tailwind;
 mod typescript;
 mod uiua;
@@ -243,6 +244,11 @@ pub fn init(
         ],
     );
     language(
+        "swift",
+        tree_sitter_swift::language(),
+        vec![Arc::new(swift::SourcekitLspAdapter)],
+    );
+    language(
         "php",
         tree_sitter_php::language(),
         vec![
@@ -250,7 +256,6 @@ pub fn init(
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ],
     );
-
     language("elm", tree_sitter_elm::language(), vec![]);
     language("glsl", tree_sitter_glsl::language(), vec![]);
     language("nix", tree_sitter_nix::language(), vec![]);

--- a/crates/zed/src/languages/swift.rs
+++ b/crates/zed/src/languages/swift.rs
@@ -1,0 +1,59 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use std::{any::Any, ffi::OsString, path::PathBuf};
+
+pub struct SourcekitLspAdapter;
+
+#[async_trait]
+impl LspAdapter for SourcekitLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("swift-sourcekit-lsp".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "sourcekit-lsp"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!(
+            "swift toolchain must be installed and available in your $PATH"
+        ))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_sourcekit_lsp_binary(vec![])
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        get_cached_sourcekit_lsp_binary(vec!["--help".into()])
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+}
+
+fn get_cached_sourcekit_lsp_binary(arguments: Vec<OsString>) -> Option<LanguageServerBinary> {
+    Some(LanguageServerBinary {
+        path: "/usr/bin/sourcekit-lsp".into(),
+        arguments,
+    })
+}

--- a/crates/zed/src/languages/swift/brackets.scm
+++ b/crates/zed/src/languages/swift/brackets.scm
@@ -1,0 +1,5 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/src/languages/swift/config.toml
+++ b/crates/zed/src/languages/swift/config.toml
@@ -1,0 +1,11 @@
+name = "Swift"
+path_suffixes = ["swift"]
+line_comments = ["// ", "/// "]
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true, not_in = ["string", "comment"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]

--- a/crates/zed/src/languages/swift/highlights.scm
+++ b/crates/zed/src/languages/swift/highlights.scm
@@ -1,0 +1,290 @@
+[
+  "."
+  ";"
+  ":"
+  ","
+] @punctuation.delimiter
+
+; TODO: "\\(" ")" in interpolations should be @punctuation.special
+[
+  "\\("
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; Identifiers
+(attribute) @variable
+
+(type_identifier) @type
+
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+  (mutation_modifier)
+] @type.qualifier
+
+(function_declaration
+  (simple_identifier) @function.method)
+
+(function_declaration
+  "init" @constructor)
+
+(throws) @keyword
+
+(where_keyword) @keyword
+
+(parameter
+  external_name: (simple_identifier) @variable.parameter)
+
+(parameter
+  name: (simple_identifier) @variable.parameter)
+
+(type_parameter
+  (type_identifier) @variable.parameter)
+
+(inheritance_constraint
+  (identifier
+    (simple_identifier) @variable.parameter))
+
+(equality_constraint
+  (identifier
+    (simple_identifier) @variable.parameter))
+
+(pattern
+  bound_identifier: (simple_identifier)) @variable
+
+[
+  "actor"
+  "associatedtype"
+  "class"
+  "convenience"
+  "enum"
+  "extension"
+  "indirect"
+  "nonisolated"
+  "override"
+  "protocol"
+  "required"
+  "some"
+  "struct"
+  "typealias"
+] @keyword
+
+[
+  "async"
+  "await"
+] @keyword.coroutine
+
+[
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
+] @keyword
+
+(class_body
+  (property_declaration
+    (pattern
+      (simple_identifier) @variable.member)))
+
+(protocol_property_declaration
+  (pattern
+    (simple_identifier) @variable.member))
+
+(navigation_expression
+  (navigation_suffix
+    (simple_identifier) @variable.member))
+
+(value_argument
+  name: (value_argument_label) @variable.member)
+
+(import_declaration
+  "import" @keyword.import)
+
+(enum_entry
+  "case" @keyword)
+
+; Function calls
+(call_expression
+  (simple_identifier) @function.call) ; foo()
+
+(call_expression
+  ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix
+      (simple_identifier) @function.call)))
+
+(call_expression
+  (prefix_expression
+    (simple_identifier) @function.call)) ; .foo()
+
+((navigation_expression
+  (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+  (#lua-match? @type "^[A-Z]"))
+
+(directive) @function.macro
+
+(diagnostic) @function.macro
+
+; Statements
+(for_statement
+  "for" @keyword.repeat)
+
+(for_statement
+  "in" @keyword.repeat)
+
+(for_statement
+  (pattern) @variable)
+
+(else) @keyword
+
+(as_operator) @keyword
+
+[
+  "while"
+  "repeat"
+  "continue"
+  "break"
+] @keyword.repeat
+
+[
+  "let"
+  "var"
+] @keyword
+
+(guard_statement
+  "guard" @keyword.conditional)
+
+(if_statement
+  "if" @keyword.conditional)
+
+(switch_statement
+  "switch" @keyword.conditional)
+
+(switch_entry
+  "case" @keyword)
+
+(switch_entry
+  "fallthrough" @keyword)
+
+(switch_entry
+  (default_keyword) @keyword)
+
+"return" @keyword.return
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional)
+
+[
+  "do"
+  (throw_keyword)
+  (catch_keyword)
+] @keyword
+
+(statement_label) @label
+
+; Comments
+[
+  (comment)
+  (multiline_comment)
+] @comment @spell
+
+((comment) @comment.documentation
+  (#lua-match? @comment.documentation "^///[^/]"))
+
+((comment) @comment.documentation
+  (#lua-match? @comment.documentation "^///$"))
+
+((multiline_comment) @comment.documentation
+  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+
+; String literals
+(line_str_text) @string
+
+(str_escaped_char) @string
+
+(multi_line_str_text) @string
+
+(raw_str_part) @string
+
+(raw_str_end_part) @string
+
+(raw_str_interpolation_start) @punctuation.special
+
+[
+  "\""
+  "\"\"\""
+] @string
+
+; Lambda literals
+(lambda_literal
+  "in" @keyword.operator)
+
+; Basic literals
+[
+  (integer_literal)
+  (hex_literal)
+  (oct_literal)
+  (bin_literal)
+] @number
+
+(real_literal) @number.float
+
+(boolean_literal) @boolean
+
+"nil" @constant.builtin
+
+; Regex literals
+(regex_literal) @string.regexp
+
+; Operators
+(custom_operator) @operator
+
+[
+  "try"
+  "try?"
+  "try!"
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "<"
+  ">"
+  "<="
+  ">="
+  "++"
+  "--"
+  "&"
+  "~"
+  "%="
+  "!="
+  "!=="
+  "=="
+  "==="
+  "??"
+  "->"
+  "..<"
+  "..."
+  (bang)
+] @operator

--- a/crates/zed/src/languages/swift/indents.scm
+++ b/crates/zed/src/languages/swift/indents.scm
@@ -1,0 +1,101 @@
+; format-ignore
+[
+  ; ... refers to the section that will get affected by this indent.begin capture
+  (protocol_body)               ; protocol Foo { ... }
+  (class_body)                  ; class Foo { ... }
+  (enum_class_body)             ; enum Foo { ... }
+  (function_declaration)        ; func Foo (...) {...}
+  (computed_property)           ; { ... }
+  (subscript_declaration)       ; subscript Foo(...) { ... }
+
+  (computed_getter)             ; get { ... }
+  (computed_setter)             ; set { ... }
+
+  (assignment)                  ; a = b
+
+  (control_transfer_statement)  ; return ...
+  (for_statement)
+  (while_statement)
+  (repeat_while_statement)
+  (do_statement)
+  (if_statement)
+  (switch_statement)
+  (guard_statement)
+
+  (type_parameters)             ; x<Foo>
+  (tuple_type)                  ; (...)
+  (array_type)                  ; [String]
+  (dictionary_type)             ; [Foo: Bar]
+
+  (call_expression)             ; callFunc(...)
+  (tuple_expression)            ; ( foo + bar )
+  (array_literal)               ; [ foo, bar ]
+  (dictionary_literal)          ; [ foo: bar, x: y ]
+  (lambda_literal)
+] @indent.begin
+
+; @something(...)
+(modifiers
+  (attribute) @indent.begin)
+
+(function_declaration
+  (modifiers
+    .
+    (attribute)
+    (_)* @indent.branch)
+  .
+  _ @indent.branch
+  (#not-has-type? @indent.branch type_parameters parameter))
+
+(ERROR
+  [
+    "<"
+    "{"
+    "("
+    "["
+  ]) @indent.begin
+
+; if-elseif
+(if_statement
+  (if_statement) @indent.dedent)
+
+; case Foo:
+; default Foo:
+; @attribute default Foo:
+(switch_entry
+  .
+  _ @indent.branch)
+
+(function_declaration
+  ")" @indent.branch)
+
+(type_parameters
+  ">" @indent.branch @indent.end .)
+
+(tuple_expression
+  ")" @indent.branch @indent.end)
+
+(value_arguments
+  ")" @indent.branch @indent.end)
+
+(tuple_type
+  ")" @indent.branch @indent.end)
+
+(modifiers
+  (attribute
+    ")" @indent.branch @indent.end))
+
+[
+  "}"
+  "]"
+] @indent.branch @indent.end
+
+[
+  ; (ERROR)
+  (comment)
+  (multiline_comment)
+  (raw_str_part)
+  (multi_line_string_literal)
+] @indent.auto
+
+(directive) @indent.ignore


### PR DESCRIPTION
This PR adds the Swift tree-sitter grammar copied from [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries/swift). It also adds the [sourcekit-lsp](https://github.com/apple/sourcekit-lsp).

This PR resolves zed-industries/extensions#139

Release Notes:
- Added Swift support (#5278).