### PR TITLE
Swift syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,6 +8597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-swift"
+version = "0.4.0"
+source = "git+https://github.com/matyunya/tree-sitter-swift?rev=5967461adbd05cd85ad571381670c9edda4c7654#5967461adbd05cd85ad571381670c9edda4c7654"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-toml"
 version = "0.5.1"
 source = "git+https://github.com/tree-sitter/tree-sitter-toml?rev=342d9be207c2dba869b9967124c679b5e6fd0ebe#342d9be207c2dba869b9967124c679b5e6fd0ebe"
@@ -9734,6 +9743,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scheme",
  "tree-sitter-svelte",
+ "tree-sitter-swift",
  "tree-sitter-toml",
  "tree-sitter-typescript",
  "tree-sitter-uiua",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ tree-sitter-ruby = "0.20.0"
 tree-sitter-html = "0.19.0"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9"}
 tree-sitter-svelte = { git = "https://github.com/Himujjal/tree-sitter-svelte", rev = "697bb515471871e85ff799ea57a76298a71a9cca"}
+tree-sitter-swift = { git = "https://github.com/matyunya/tree-sitter-swift", rev = "5967461adbd05cd85ad571381670c9edda4c7654" }
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a"}
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "f545a41f57502e1b5ddf2a6668896c1b0620f930"}
 tree-sitter-lua = "0.0.14"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -135,6 +135,7 @@ tree-sitter-html.workspace = true
 tree-sitter-php.workspace = true
 tree-sitter-scheme.workspace = true
 tree-sitter-svelte.workspace = true
+tree-sitter-swift.workspace = true
 tree-sitter-racket.workspace = true
 tree-sitter-yaml.workspace = true
 tree-sitter-lua.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -242,6 +242,7 @@ pub fn init(
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ],
     );
+    language("swift", tree_sitter_swift::language(), vec![]);
     language(
         "php",
         tree_sitter_php::language(),

--- a/crates/zed/src/languages/swift/config.toml
+++ b/crates/zed/src/languages/swift/config.toml
@@ -1,0 +1,10 @@
+name = "Swift"
+path_suffixes = ["swift"]
+line_comment = "// "
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = true, newline = true },
+]

--- a/crates/zed/src/languages/swift/highlights.scm
+++ b/crates/zed/src/languages/swift/highlights.scm
@@ -1,0 +1,168 @@
+[ "." ";" ":" "," ] @punctuation.delimiter
+[ "\\(" "(" ")" "[" "]" "{" "}"] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
+
+; Identifiers
+(attribute) @variable
+(type_identifier) @type
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+] @keyword
+
+(function_declaration (simple_identifier) @method)
+(function_declaration ["init" @constructor])
+(throws) @keyword
+"async" @keyword
+"await" @keyword
+(where_keyword) @keyword
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+(pattern bound_identifier: (simple_identifier)) @variable
+
+[
+  "typealias"
+  "struct"
+  "class"
+  "actor"
+  "enum"
+  "protocol"
+  "extension"
+  "indirect"
+  "nonisolated"
+  "override"
+  "convenience"
+  "required"
+  "some"
+] @keyword
+
+[
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
+] @keyword
+
+(class_body (property_declaration (pattern (simple_identifier) @property)))
+(protocol_property_declaration (pattern (simple_identifier) @property))
+
+(import_declaration ["import" @include])
+
+(enum_entry ["case" @keyword])
+
+; Function calls
+(call_expression (simple_identifier) @function.call) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix (simple_identifier) @function.call)))
+((navigation_expression
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#match? @type "^[A-Z]"))
+
+(directive) @function.macro
+(diagnostic) @function.macro
+
+; Statements
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement (pattern) @variable)
+(else) @keyword
+(as_operator) @keyword
+
+["while" "repeat" "continue" "break"] @repeat
+
+["let" "var"] @keyword
+
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
+"return" @keyword.return
+(ternary_expression
+  ["?" ":"] @conditional)
+
+["do" (throw_keyword) (catch_keyword)] @keyword
+
+(statement_label) @label
+
+; Comments
+[
+ (comment)
+ (multiline_comment)
+] @comment @spell
+
+; String literals
+(line_str_text) @string
+(str_escaped_char) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(raw_str_interpolation_start) @punctuation.special
+["\"" "\"\"\""] @string
+
+; Lambda literals
+(lambda_literal ["in" @keyword.operator])
+
+; Basic literals
+[
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
+] @number
+(real_literal) @float
+(boolean_literal) @boolean
+"nil" @variable.builtin
+
+; Regex literals
+(regex_literal) @string.regex
+
+; Operators
+(custom_operator) @operator
+[
+ "try"
+ "try?"
+ "try!"
+ "!"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "=="
+ "==="
+ "??"
+
+ "->"
+
+ "..<"
+ "..."
+] @operator
+

--- a/crates/zed/src/languages/swift/indents.scm
+++ b/crates/zed/src/languages/swift/indents.scm
@@ -1,0 +1,92 @@
+[
+  ; ... refers to the section that will get affected by this indent.begin capture
+  (protocol_body)               ; protocol Foo { ... }
+  (class_body)                  ; class Foo { ... }
+  (enum_class_body)             ; enum Foo { ... }
+  (function_declaration)        ; func Foo (...) {...}
+  (computed_property)           ; { ... }
+  (subscript_declaration)       ; subscript Foo(...) { ... }
+
+  (computed_getter)             ; get { ... }
+  (computed_setter)             ; set { ... }
+
+  (assignment)                  ; a = b
+
+  (control_transfer_statement)  ; return ...
+  (for_statement)
+  (while_statement)
+  (repeat_while_statement)
+  (do_statement)
+  (if_statement)
+  (switch_statement)
+  (guard_statement)
+
+  (type_parameters)             ; x<Foo>
+  (tuple_type)                  ; (...)
+  (array_type)                  ; [String]
+  (dictionary_type)             ; [Foo: Bar]
+
+  (call_expression)             ; callFunc(...)
+  (tuple_expression)            ; ( foo + bar )
+  (array_literal)               ; [ foo, bar ]
+  (dictionary_literal)          ; [ foo: bar, x: y ]
+  (lambda_literal) 
+] @indent.begin
+
+; @something(...)
+((modifiers
+  (attribute) @indent.begin))
+
+(function_declaration
+  (modifiers
+    .
+    (attribute)
+    (_)* @indent.branch)
+  .
+  _ @indent.branch
+  (#not-has-type? @indent.branch type_parameters parameter))
+
+
+(ERROR
+  [
+    "<" 
+    "{" 
+    "(" 
+    "["
+  ]
+) @indent.begin
+
+
+; if-elseif
+(if_statement
+  (if_statement) @indent.dedent)
+
+; case Foo:
+; default Foo:
+; @attribute default Foo:
+(switch_entry . _ @indent.branch)
+
+(function_declaration ")" @indent.branch)
+
+(type_parameters ">" @indent.branch @indent.end .)
+(tuple_expression ")" @indent.branch @indent.end)
+(value_arguments ")" @indent.branch @indent.end)
+(tuple_type ")" @indent.branch @indent.end)
+(modifiers
+  (attribute ")" @indent.branch @indent.end))
+
+[
+  "}"
+  "]"
+] @indent.branch @indent.end
+
+
+[
+  ; (ERROR)
+  (comment)
+  (multiline_comment)
+  (raw_str_part)
+  (multi_line_string_literal)
+] @indent.auto
+
+(directive) @indent.ignore

--- a/crates/zed/src/languages/swift/locals.scm
+++ b/crates/zed/src/languages/swift/locals.scm
@@ -1,0 +1,18 @@
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
+
+; Scopes
+[
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
+] @local.scope

--- a/crates/zed/src/languages/swift/tags.scm
+++ b/crates/zed/src/languages/swift/tags.scm
@@ -1,0 +1,51 @@
+(class_declaration
+  name: (type_identifier) @name) @definition.class
+
+(protocol_declaration
+  name: (type_identifier) @name) @definition.interface
+
+(class_declaration
+    (class_body
+        [
+            (function_declaration
+                name: (simple_identifier) @name
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name)
+            )
+            (function_declaration "init" @name)
+            (deinit_declaration "deinit" @name)
+        ]
+    )
+) @definition.method
+
+(protocol_declaration
+    (protocol_body
+        [
+            (protocol_function_declaration
+                name: (simple_identifier) @name
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name)
+            )
+            (protocol_function_declaration "init" @name)
+        ]
+    )
+) @definition.method
+
+(class_declaration
+    (class_body
+        [
+            (property_declaration
+                (pattern (simple_identifier) @name)
+            )
+        ]
+    )
+) @definition.property
+
+(property_declaration
+    (pattern (simple_identifier) @name)
+) @definition.property
+
+(function_declaration
+    name: (simple_identifier) @name) @definition.function

--- a/crates/zed/src/languages/swift/textobjects.scm
+++ b/crates/zed/src/languages/swift/textobjects.scm
@@ -1,0 +1,19 @@
+
+
+; MARK: Structure
+
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+; TODO: Classes/structs/enums
+
+
+; MARK: Tests
+
+; Only matches prefix test. Other conventions
+; might be nice to add!
+(function_declaration
+	name: (simple_identifier) @_name
+	(#match? @_name "^test")
+)
+


### PR DESCRIPTION
This PR adds Swift tree-sitter grammar built from https://github.com/alex-pinkus/tree-sitter-swift.

Here's example of syntax highlighting:

<img width="1308" alt="Screenshot 2024-01-27 at 10 35 34" src="https://github.com/zed-industries/zed/assets/2044570/d16cf496-ec6c-4b6e-92e8-e060e75b3726">

Attempted to attach SourceKit LSP but it only returns empty responses.