### PR TITLE
Extend support for outlining in Gleam

### DIFF
--- a/crates/zed/src/languages/gleam/outline.scm
+++ b/crates/zed/src/languages/gleam/outline.scm
@@ -1,4 +1,30 @@
+(external_type
+    (visibility_modifier)? @context
+    "type" @context
+    (_) @name) @item
+
+(type_definition
+    (visibility_modifier)? @context
+    (opacity_modifier)? @context
+    "type" @context
+    (type_name) @name) @item
+
+(data_constructor
+    (constructor_name) @name) @item
+
+(data_constructor_argument
+    (label) @name) @item
+
+(type_alias
+    (visibility_modifier)? @context
+    "type" @context
+    (type_name) @name) @item
+
 (function
     (visibility_modifier)? @context
     "fn" @context
+    name: (_) @name) @item
+
+(constant
+    "const" @context
     name: (_) @name) @item

--- a/crates/zed/src/languages/gleam/outline.scm
+++ b/crates/zed/src/languages/gleam/outline.scm
@@ -1,7 +1,7 @@
 (external_type
     (visibility_modifier)? @context
     "type" @context
-    (_) @name) @item
+    (type_name) @name) @item
 
 (type_definition
     (visibility_modifier)? @context
@@ -26,5 +26,6 @@
     name: (_) @name) @item
 
 (constant
+    (visibility_modifier)? @context
     "const" @context
     name: (_) @name) @item


### PR DESCRIPTION
This PR extends support for outlines in the recently-added Gleam support.

Note that I'm leaving the release notes section blank as we haven't yet released Gleam support, so it can just roll up into that item.

Release Notes:

- N/A
