### PR TITLE
Add `font_style` and `font_weight` to serialized theme representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7864,6 +7864,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_repr",
  "settings",
  "story",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ schemars = { version = "0.8" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_derive = { version = "1.0", features = ["deserialize_in_place"] }
 serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
+serde_repr = "0.1"
 smallvec = { version = "1.6", features = ["union"] }
 smol = { version = "1.2" }
 strum = { version = "0.25.0", features = ["derive"] }

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -32,6 +32,7 @@ schemars = { workspace = true, features = ["indexmap"] }
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
+serde_repr.workspace = true
 settings = { path = "../settings" }
 story = { path = "../story", optional = true }
 toml.workspace = true


### PR DESCRIPTION
This PR adds `font_style` and `font_weight` as fields on the `HighlightStyleContent` used in the serialized theme representation.

Release Notes:

- N/A
