### PR TITLE
Build media and live-kit in test-mode on non-MacOS

### DIFF
--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -42,6 +42,12 @@ nanoid = { version ="0.4", optional = true}
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.3"
 
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+async-trait = { workspace = true }
+collections = { path = "../collections", features = ["test-support"] }
+gpui = { path = "../gpui", features = ["test-support"] }
+live_kit_server = { path = "../live_kit_server" }
+
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/live_kit_client/src/live_kit_client.rs
+++ b/crates/live_kit_client/src/live_kit_client.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
-#[cfg(not(any(test, feature = "test-support")))]
+#[cfg(all(target_os = "macos", not(any(test, feature = "test-support"))))]
 pub mod prod;
 
-#[cfg(not(any(test, feature = "test-support")))]
+#[cfg(all(target_os = "macos", not(any(test, feature = "test-support"))))]
 pub use prod::*;
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", not(target_os = "macos")))]
 pub mod test;
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", not(target_os = "macos")))]
 pub use test::*;
 
 pub type Sid = String;

--- a/crates/live_kit_client/src/test.rs
+++ b/crates/live_kit_client/src/test.rs
@@ -5,6 +5,7 @@ use collections::{BTreeMap, HashMap, HashSet};
 use futures::Stream;
 use gpui::BackgroundExecutor;
 use live_kit_server::{proto, token};
+#[cfg(target_os = "macos")]
 use media::core_video::CVImageBuffer;
 use parking_lot::Mutex;
 use postage::watch;
@@ -845,6 +846,7 @@ impl Frame {
         self.height
     }
 
+    #[cfg(target_os = "macos")]
     pub fn image(&self) -> CVImageBuffer {
         unimplemented!("you can't call this in test mode")
     }

--- a/crates/media/build.rs
+++ b/crates/media/build.rs
@@ -1,6 +1,7 @@
-use std::{env, path::PathBuf, process::Command};
-
+#[cfg(target_os = "macos")]
 fn main() {
+    use std::{env, path::PathBuf, process::Command};
+
     let sdk_path = String::from_utf8(
         Command::new("xcrun")
             .args(["--sdk", "macosx", "--show-sdk-path"])
@@ -37,3 +38,6 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("couldn't write dispatch bindings");
 }
+
+#[cfg(not(target_os = "macos"))]
+fn main() {}

--- a/crates/media/src/bindings.rs
+++ b/crates/media/src/bindings.rs
@@ -3,6 +3,8 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 
+#[cfg(target_os = "macos")]
 use objc::*;
 
+#[cfg(target_os = "macos")]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/media/src/media.rs
+++ b/crates/media/src/media.rs
@@ -3,12 +3,14 @@
 
 mod bindings;
 
+#[cfg(target_os = "macos")]
 use core_foundation::{
     base::{CFTypeID, TCFType},
     declare_TCFType, impl_CFTypeDescription, impl_TCFType,
 };
 use std::ffi::c_void;
 
+#[cfg(target_os = "macos")]
 pub mod io_surface {
     use super::*;
 
@@ -27,6 +29,7 @@ pub mod io_surface {
     }
 }
 
+#[cfg(target_os = "macos")]
 pub mod core_video {
     #![allow(non_snake_case)]
 
@@ -206,6 +209,7 @@ pub mod core_video {
     }
 }
 
+#[cfg(target_os = "macos")]
 pub mod core_media {
     #![allow(non_snake_case)]
 
@@ -413,6 +417,7 @@ pub mod core_media {
     }
 }
 
+#[cfg(target_os = "macos")]
 pub mod video_toolbox {
     #![allow(non_snake_case)]
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -11,3 +11,6 @@ echo "migrating database..."
 
 echo "seeding database..."
 script/seed-db
+
+echo "Linux dependencies..."
+script/linux

--- a/script/linux
+++ b/script/linux
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# if not on Linux, do nothing
+[[ $(uname) == "Linux" ]] || exit 0
+
+# if sudo is not installed, define an empty alias
+maysudo=$(command -v sudo || true)
+export maysudo
+
+# package manager
+pkgman=$(command -v apt-get || true)
+
+# install packages
+if [[ -n $pkgman ]]; then
+  $maysudo "$pkgman" install -y \
+    libasound2-dev
+else
+  echo "Could not install: libasound2-dev"
+fi

--- a/script/linux
+++ b/script/linux
@@ -7,13 +7,34 @@
 maysudo=$(command -v sudo || true)
 export maysudo
 
-# package manager
-pkgman=$(command -v apt-get || true)
-
-# install packages
-if [[ -n $pkgman ]]; then
-  $maysudo "$pkgman" install -y \
-    libasound2-dev
-else
-  echo "Could not install: libasound2-dev"
+# Ubuntu, Debian, etc.
+apt=$(command -v apt-get || true)
+deps=(
+  libasound2-dev
+)
+if [[ -n $apt ]]; then
+  $maysudo "$apt" install -y "${deps[@]}"
+  exit 0
 fi
+
+# Fedora, CentOS, RHEL, etc.
+dnf=$(command -v dnf || true)
+deps=(
+  alsa-lib-devel
+)
+if [[ -n $dnf ]]; then
+  $maysudo "$dnf" install -y "${deps[@]}"
+  exit 0
+fi
+
+# Arch, Manjaro, etc.
+pacman=$(command -v pacman || true)
+deps=(
+  alsa-lib
+)
+if [[ -n $pacman ]]; then
+  $maysudo "$pacman" -S --noconfirm "${deps[@]}"
+  exit 0
+fi
+
+echo "Unsupported Linux distribution in script/linux"


### PR DESCRIPTION
Build media and live-kit in test-mode on non-MacOS (Related to https://github.com/zed-industries/zed/issues/5391 https://github.com/zed-industries/zed/issues/5395 https://github.com/zed-industries/zed/issues/5394)

This makes it possible to build the media and live-kit crates on non-MacOS 

Release Notes:

- N/A