### PR TITLE
Correctly check existence of target directory in `copy_recursive` function

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1183,7 +1183,7 @@ pub fn copy_recursive<'a>(
             .await?
             .ok_or_else(|| anyhow!("path does not exist: {}", source.display()))?;
         if metadata.is_dir {
-            if !options.overwrite && fs.metadata(target).await.is_ok() {
+            if !options.overwrite && fs.metadata(target).await.is_ok_and(|m| m.is_some()) {
                 if options.ignore_if_exists {
                     return Ok(());
                 } else {


### PR DESCRIPTION
Please see [this comment](https://github.com/zed-industries/zed/issues/6778#issuecomment-1912480339) and [the one below it](https://github.com/zed-industries/zed/issues/6778#issuecomment-1912798489) explaining the problem and my solution to it.

Release Notes:

- Fixed issue where copy-paste for folders was not working in the project panel ([#6778](https://github.com/zed-industries/zed/issues/6778)).
