### PR TITLE
Disable Discord URL embed

### DIFF
--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -20,7 +20,7 @@ jobs:
         id: get-content
         with:
           stringToTruncate: |
-            📣 Zed [${{ github.event.release.tag_name }}](${{ steps.get-release-url.outputs.URL }}) was just released!
+            📣 Zed [${{ github.event.release.tag_name }}](<${{ steps.get-release-url.outputs.URL }}>) was just released!
 
             ${{ github.event.release.body }}
           maxLength: 2000


### PR DESCRIPTION
Wrapping links in `<` and `>` disables auto-embeds in Discord, even if it's a markdown-style link.

Closes #6884

Release Notes:

- N/A