### PR TITLE
Upgrade `tree-sitter-php` to v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8541,8 +8541,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-php"
-version = "0.19.1"
-source = "git+https://github.com/tree-sitter/tree-sitter-php?rev=d43130fd1525301e9826f420c5393a4d169819fc#d43130fd1525301e9826f420c5393a4d169819fc"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db3788e709a5adfb583683a4b686a084e41a0f9e5a2fcb9a8e358f11481036a"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-rust = "0.20.3"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
-tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php", rev = "d43130fd1525301e9826f420c5393a4d169819fc" }
+tree-sitter-php = "0.21.1"
 tree-sitter-python = "0.20.2"
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259" }

--- a/crates/semantic_index/src/semantic_index_tests.rs
+++ b/crates/semantic_index/src/semantic_index_tests.rs
@@ -1546,7 +1546,7 @@ fn php_lang() -> Arc<Language> {
                 collapsed_placeholder: "/* ... */".into(),
                 ..Default::default()
             },
-            Some(tree_sitter_php::language()),
+            Some(tree_sitter_php::language_php()),
         )
         .with_embedding_query(
             r#"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -251,7 +251,7 @@ pub fn init(
     );
     language(
         "php",
-        tree_sitter_php::language(),
+        tree_sitter_php::language_php(),
         vec![
             Arc::new(php::IntelephenseLspAdapter::new(node_runtime.clone())),
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),


### PR DESCRIPTION
This PR upgrades `tree-sitter-php` to v0.21.1.

Here is the diff between our current version and this version: https://github.com/tree-sitter/tree-sitter-php/compare/d43130fd1525301e9826f420c5393a4d169819fc...29a49d3a53353444ee2226e2efa140fec69dd3e0

The primary impetus for this change is to get this change that adds the `license` field to the `Cargo.toml`: https://github.com/tree-sitter/tree-sitter-php/pull/193

This will silence the warning that is shown when running `script/generate-licenses`.

Release Notes:

- Upgraded `tree-sitter-php` to v0.21.1.
