### PR TITLE
Add syntax highlighting and LSP for Dockerfiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8402,6 +8402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dockerfile"
+version = "0.1.0"
+source = "git+https://github.com/camdencheek/tree-sitter-dockerfile?rev=33e22c33bcdbfc33d42806ee84cfd0b1248cc392#33e22c33bcdbfc33d42806ee84cfd0b1248cc392"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-elixir"
 version = "0.1.0"
 source = "git+https://github.com/elixir-lang/tree-sitter-elixir?rev=a2861e88a730287a60c11ea9299c033c7d076e30#a2861e88a730287a60c11ea9299c033c7d076e30"
@@ -9743,6 +9752,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-dockerfile",
  "tree-sitter-elixir",
  "tree-sitter-elm",
  "tree-sitter-embedded-template",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ tree-sitter-nu = { git = "https://github.com/nushell/tree-sitter-nu", rev = "26b
 tree-sitter-vue = { git = "https://github.com/zed-industries/tree-sitter-vue", rev = "6608d9d60c386f19d80af7d8132322fa11199c42" }
 tree-sitter-uiua = { git = "https://github.com/shnarazk/tree-sitter-uiua", rev = "9260f11be5900beda4ee6d1a24ab8ddfaf5a19b2" }
 tree-sitter-zig = { git = "https://github.com/maxxnino/tree-sitter-zig", rev = "0d08703e4c3f426ec61695d7617415fff97029bd" }
+tree-sitter-dockerfile = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = "33e22c33bcdbfc33d42806ee84cfd0b1248cc392" }
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "31c40449749c4263a91a43593831b82229049a4c" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -145,6 +145,7 @@ tree-sitter-nu.workspace = true
 tree-sitter-vue.workspace = true
 tree-sitter-uiua.workspace = true
 tree-sitter-zig.workspace = true
+tree-sitter-dockerfile.workspace = true
 
 url = "2.2"
 urlencoding = "2.1.2"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -12,6 +12,7 @@ use self::{deno::DenoSettings, elixir::ElixirSettings};
 mod c;
 mod css;
 mod deno;
+mod dockerfile;
 mod elixir;
 mod gleam;
 mod go;
@@ -79,6 +80,13 @@ pub fn init(
             Arc::new(css::CssLspAdapter::new(node_runtime.clone())),
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ],
+    );
+    language(
+        "dockerfile",
+        tree_sitter_dockerfile::language(),
+        vec![Arc::new(dockerfile::DockerfileLspAdapter::new(
+            node_runtime.clone(),
+        ))],
     );
 
     match &ElixirSettings::get(None, cx).lsp {

--- a/crates/zed/src/languages/dockerfile.rs
+++ b/crates/zed/src/languages/dockerfile.rs
@@ -1,0 +1,124 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use node_runtime::NodeRuntime;
+use smol::fs;
+use std::{
+    any::Any,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::{async_maybe, ResultExt};
+
+const SERVER_PATH: &'static str =
+    "node_modules/dockerfile-language-server-nodejs/bin/docker-langserver";
+
+fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
+    vec![server_path.into(), "--stdio".into()]
+}
+
+pub struct DockerfileLspAdapter {
+    node: Arc<dyn NodeRuntime>,
+}
+
+impl DockerfileLspAdapter {
+    pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
+        Self { node }
+    }
+}
+
+#[async_trait]
+impl LspAdapter for DockerfileLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("docker-langserver".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "dockerfile"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        Ok(Box::new(
+            self.node
+                .npm_package_latest_version("dockerfile-language-server-nodejs")
+                .await?,
+        ) as Box<_>)
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let version = version.downcast::<String>().unwrap();
+        let server_path = container_dir.join(SERVER_PATH);
+
+        if fs::metadata(&server_path).await.is_err() {
+            self.node
+                .npm_install_packages(
+                    &container_dir,
+                    &[("dockerfile-language-server-nodejs", version.as_str())],
+                )
+                .await?;
+        }
+
+        Ok(LanguageServerBinary {
+            path: self.node.binary_path().await?,
+            arguments: server_binary_arguments(&server_path),
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir, &*self.node).await
+    }
+
+    async fn installation_test_binary(
+        &self,
+        container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir, &*self.node).await
+    }
+}
+
+async fn get_cached_server_binary(
+    container_dir: PathBuf,
+    node: &dyn NodeRuntime,
+) -> Option<LanguageServerBinary> {
+    async_maybe!({
+        let mut last_version_dir = None;
+        let mut entries = fs::read_dir(&container_dir).await?;
+        while let Some(entry) = entries.next().await {
+            let entry = entry?;
+            if entry.file_type().await?.is_dir() {
+                last_version_dir = Some(entry.path());
+            }
+        }
+
+        let last_version_dir = last_version_dir.ok_or_else(|| anyhow!("no cached binary"))?;
+        let server_path = last_version_dir.join(SERVER_PATH);
+        if server_path.exists() {
+            Ok(LanguageServerBinary {
+                path: node.binary_path().await?,
+                arguments: server_binary_arguments(&server_path),
+            })
+        } else {
+            Err(anyhow!(
+                "missing executable in directory {:?}",
+                last_version_dir
+            ))
+        }
+    })
+    .await
+    .log_err()
+}

--- a/crates/zed/src/languages/dockerfile/config.toml
+++ b/crates/zed/src/languages/dockerfile/config.toml
@@ -1,0 +1,8 @@
+name = "Dockerfile"
+path_suffixes = ["Dockerfile"]
+line_comments = ["# "]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]

--- a/crates/zed/src/languages/dockerfile/highlights.scm
+++ b/crates/zed/src/languages/dockerfile/highlights.scm
@@ -1,0 +1,62 @@
+; Dockerfile instructions set taken from:
+; https://docs.docker.com/engine/reference/builder/#overview
+[
+	"ADD"
+	"ARG"
+	"CMD"
+	"COPY"
+	"ENTRYPOINT"
+	"ENV"
+	"EXPOSE"
+	"FROM"
+	"HEALTHCHECK"
+	"LABEL"
+	"MAINTAINER"
+	"ONBUILD"
+	"RUN"
+	"SHELL"
+	"STOPSIGNAL"
+	"USER"
+	"VOLUME"
+	"WORKDIR"
+
+	; "as" for multi-stage builds
+	"AS"
+] @keyword
+
+[
+	":"
+	"@"
+] @operator
+
+(comment) @comment
+
+(image_spec
+	(image_tag
+		":" @punctuation.special)
+	(image_digest
+		"@" @punctuation.special))
+
+[
+  (double_quoted_string)
+  (single_quoted_string)
+  (json_string)
+] @string
+
+[
+  (env_pair)
+  (label_pair)
+] @constant
+
+[
+  (param)
+  (mount_param)
+] @function
+
+(expansion
+    [
+        "$"
+        "{"
+        "}"
+    ] @punctuation.special
+) @constant

--- a/docs/src/languages/dockerfile.md
+++ b/docs/src/languages/dockerfile.md
@@ -1,0 +1,4 @@
+# Dockerfile
+
+- Tree Sitter: [tree-sitter-dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile/tree/main)
+- Language Server: [dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server/tree/master)


### PR DESCRIPTION
Looks like it could resolve zed-industries/extensions#504 ? I haven't messed with any docker-compose stuff but seeing as that is YAML based and there is already YAML support this should address the Dockerfile syntax highlighting and LSP support.

I'm also a Rust newbie so if there is anything that looks off please do let me know!

A screenshot showing syntax highlighting when running via `cargo run`:
<img width="1226" alt="Screenshot 2024-01-27 at 8 28 25 PM" src="https://github.com/zed-industries/zed/assets/20310709/ebfd4c24-001f-4a8f-b085-e01f814cd1d9">


Release Notes:

- Added syntax highlighting and LSP for Dockerfiles
