### PR TITLE
[WIP; Help Needed] Add Angular LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8713,6 +8713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-angular"
+version = "0.0.1"
+source = "git+https://github.com/nathansbradshaw/tree-sitter-angular?rev=f22409d87a05d3094766d9f51551d8d7f41f9a21#f22409d87a05d3094766d9f51551d8d7f41f9a21"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-html",
+]
+
+[[package]]
 name = "tree-sitter-bash"
 version = "0.20.4"
 source = "git+https://github.com/tree-sitter/tree-sitter-bash?rev=7331995b19b8f8aba2d5e26deb51d2195c18bc94#7331995b19b8f8aba2d5e26deb51d2195c18bc94"
@@ -10356,6 +10366,7 @@ dependencies = [
  "tiny_http",
  "toml",
  "tree-sitter",
+ "tree-sitter-angular",
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ tree-sitter-uiua = { git = "https://github.com/shnarazk/tree-sitter-uiua", rev =
 tree-sitter-vue = { git = "https://github.com/zed-industries/tree-sitter-vue", rev = "6608d9d60c386f19d80af7d8132322fa11199c42" }
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "f545a41f57502e1b5ddf2a6668896c1b0620f930" }
 tree-sitter-zig = { git = "https://github.com/maxxnino/tree-sitter-zig", rev = "0d08703e4c3f426ec61695d7617415fff97029bd" }
+tree-sitter-angular = { git = "https://github.com/nathansbradshaw/tree-sitter-angular", rev = "f22409d87a05d3094766d9f51551d8d7f41f9a21"}
 unindent = "0.1.7"
 url = "2.2"
 uuid = { version = "1.1.2", features = ["v4"] }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -142,6 +142,7 @@ tree-sitter-uiua.workspace = true
 tree-sitter-vue.workspace = true
 tree-sitter-yaml.workspace = true
 tree-sitter-zig.workspace = true
+tree-sitter-angular.workspace = true
 tree-sitter.workspace = true
 url.workspace = true
 urlencoding = "2.1.2"

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -9,6 +9,7 @@ use util::{asset_str, paths::PLUGINS_DIR, ResultExt};
 
 use self::{deno::DenoSettings, elixir::ElixirSettings};
 
+mod angular;
 mod c;
 mod csharp;
 mod css;
@@ -295,7 +296,15 @@ pub fn init(
     language(
         "vue",
         tree_sitter_vue::language(),
-        vec![Arc::new(vue::VueLspAdapter::new(node_runtime))],
+        vec![Arc::new(vue::VueLspAdapter::new(node_runtime.clone()))],
+    );
+    language(
+        "angular",
+        tree_sitter_angular::language(),
+        vec![
+            Arc::new(angular::AngularLspAdapter::new(node_runtime.clone())),
+            Arc::new(html::HtmlLspAdapter::new(node_runtime.clone())),
+        ],
     );
     language(
         "uiua",

--- a/crates/zed/src/languages/angular.rs
+++ b/crates/zed/src/languages/angular.rs
@@ -1,0 +1,215 @@
+use anyhow::{anyhow, ensure, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+pub use language::*;
+use lsp::LanguageServerBinary;
+use node_runtime::NodeRuntime;
+use parking_lot::Mutex;
+use serde_json::Value;
+use smol::fs::{self};
+use std::{
+    any::Any,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::ResultExt;
+
+pub struct AngularLspVersion {
+    angular_version: String,
+    ts_version: String,
+}
+
+pub struct AngularLspAdapter {
+    node: Arc<dyn NodeRuntime>,
+    typescript_install_path: Mutex<Option<PathBuf>>,
+}
+
+impl AngularLspAdapter {
+    const SERVER_PATH: &'static str = "node_modules/@angular/language-server/index.js";
+    // TODO: this can't be hardcoded, yet we have to figure out how to pass it in initialization_options.
+    const TYPESCRIPT_PATH: &'static str = "node_modules/typescript/lib";
+    pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
+        let typescript_install_path = Mutex::new(None);
+        Self {
+            node,
+            typescript_install_path,
+        }
+    }
+}
+
+#[async_trait]
+impl super::LspAdapter for AngularLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("angular-language-server".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "angular"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        Ok(Box::new(AngularLspVersion {
+            angular_version: self
+                .node
+                .npm_package_latest_version("@angular/language-server")
+                .await?,
+            ts_version: self.node.npm_package_latest_version("typescript").await?,
+        }) as Box<_>)
+    }
+    fn initialization_options(&self) -> Option<Value> {
+        let typescript_sdk_path = self.typescript_install_path.lock();
+        let typescript_sdk_path = typescript_sdk_path
+            .as_ref()
+            .expect("initialization_options called without a container_dir for typescript");
+
+        let mut service_path = typescript_sdk_path.clone();
+        service_path.pop();
+        service_path.pop();
+        service_path.push("@angular/language-service");
+
+        Some(serde_json::json!({
+            "typescript": {
+                "tsdk": typescript_sdk_path,
+            },
+            "tsProbeLocations": typescript_sdk_path,
+            "ngProbeLocations":service_path,
+
+        }))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let version = version.downcast::<AngularLspVersion>().unwrap();
+        let server_path = container_dir.join(Self::SERVER_PATH);
+        let ts_path = container_dir.join(Self::TYPESCRIPT_PATH);
+
+        if fs::metadata(&server_path).await.is_err() {
+            self.node
+                .npm_install_packages(
+                    &container_dir,
+                    &[("@angular/language-server", version.angular_version.as_str())],
+                )
+                .await?;
+        }
+
+        ensure!(
+            fs::metadata(&server_path).await.is_ok(),
+            "@angular/language-server package installation failed"
+        );
+
+        if fs::metadata(&ts_path).await.is_err() {
+            self.node
+                .npm_install_packages(
+                    &container_dir,
+                    &[("typescript", version.ts_version.as_str())],
+                )
+                .await?;
+        }
+
+        ensure!(
+            fs::metadata(&ts_path).await.is_ok(),
+            "typescript for Angular package installation failed"
+        );
+        *self.typescript_install_path.lock() = Some(ts_path.clone());
+
+        Ok(LanguageServerBinary {
+            path: self.node.binary_path().await?,
+            arguments: angular_server_binary_arguments(&server_path, &ts_path),
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        let (server, ts_path) = get_cached_server_binary(container_dir, self.node.clone()).await?;
+        *self.typescript_install_path.lock() = Some(ts_path);
+        Some(server)
+    }
+
+    async fn installation_test_binary(
+        &self,
+        container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        let (server, ts_path) = get_cached_server_binary(container_dir, self.node.clone())
+            .await
+            .map(|(mut binary, ts_path)| {
+                let mut service_path = ts_path.clone();
+                service_path.pop();
+                service_path.pop();
+                service_path.push("@angular/language-service");
+
+                binary.arguments = vec![
+                    "--stdio".into(),
+                    "--tsProbeLocations".into(),
+                    ts_path.clone().into(),
+                    "--ngProbeLocations".into(),
+                    service_path.into(),
+                ];
+                (binary, ts_path)
+            })?;
+        *self.typescript_install_path.lock() = Some(ts_path);
+        Some(server)
+    }
+}
+
+fn angular_server_binary_arguments(server_path: &Path, ts_path: &Path) -> Vec<OsString> {
+    //TODO this is very hacky way to get the servie directory
+    let mut service_path = ts_path.to_path_buf();
+    service_path.pop();
+    service_path.pop();
+    service_path.push("@angular/language-service");
+    vec![
+        server_path.into(),
+        "--stdio".into(),
+        "--tsProbeLocations".into(),
+        ts_path.into(),
+        "--ngProbeLocations".into(),
+        service_path.into(),
+    ]
+}
+
+type TypescriptPath = PathBuf;
+async fn get_cached_server_binary(
+    container_dir: PathBuf,
+    node: Arc<dyn NodeRuntime>,
+) -> Option<(LanguageServerBinary, TypescriptPath)> {
+    (|| async move {
+        let mut last_version_dir = None;
+        let mut entries = fs::read_dir(&container_dir).await?;
+        while let Some(entry) = entries.next().await {
+            let entry = entry?;
+            if entry.file_type().await?.is_dir() {
+                last_version_dir = Some(entry.path());
+            }
+        }
+        let last_version_dir = last_version_dir.ok_or_else(|| anyhow!("no cached binary"))?;
+        let server_path = last_version_dir.join(AngularLspAdapter::SERVER_PATH);
+        let typescript_path = last_version_dir.join(AngularLspAdapter::TYPESCRIPT_PATH);
+        if server_path.exists() && typescript_path.exists() {
+            Ok((
+                LanguageServerBinary {
+                    path: node.binary_path().await?,
+                    arguments: angular_server_binary_arguments(&server_path, &typescript_path),
+                },
+                typescript_path,
+            ))
+        } else {
+            Err(anyhow!(
+                "missing executable in directory {:?}",
+                last_version_dir
+            ))
+        }
+    })()
+    .await
+    .log_err()
+}

--- a/crates/zed/src/languages/angular/config.toml
+++ b/crates/zed/src/languages/angular/config.toml
@@ -1,0 +1,31 @@
+name = "Angular"
+path_suffixes = ["ts", "html", "css", "scss"]
+
+# TypeScript comments
+line_comments = ["// ", "/// "]
+block_comments = ["/*", "*/"]
+
+autoclose_before = ";:.,=}])>\"'"
+
+# Define brackets for TypeScript, HTML, CSS
+brackets = [
+    # TypeScript brackets
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = false },
+    { start = "<", end = ">", close = false, newline = true, not_in = ["string", "comment"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
+
+    # HTML brackets
+    { start = "<", end = ">", close = true, newline = true, in = ["html"] },
+    { start = "\"", end = "\"", close = true, newline = false, in = ["html"] },
+    { start = "'", end = "'", close = true, newline = false, in = ["html"] },
+
+    # CSS brackets
+    { start = "{", end = "}", close = true, newline = true, in = ["css", "scss"] },
+    { start = "(", end = ")", close = true, newline = false, in = ["css", "scss"] },
+    { start = "[", end = "]", close = true, newline = false, in = ["css", "scss"] },
+    { start = "\"", end = "\"", close = true, newline = false, in = ["css", "scss"] },
+    { start = "'", end = "'", close = true, newline = false, in = ["css", "scss"] },
+]

--- a/crates/zed/src/languages/angular/fold.scm
+++ b/crates/zed/src/languages/angular/fold.scm
@@ -1,0 +1,1 @@
+; inherits: html

--- a/crates/zed/src/languages/angular/highlights.scm
+++ b/crates/zed/src/languages/angular/highlights.scm
@@ -1,0 +1,136 @@
+; inherits: html_tags
+(identifier) @variable
+
+(pipe_operator) @operator
+
+(string) @string
+
+(number) @number
+
+(pipe_call
+  name: (identifier) @function)
+
+(pipe_call
+  arguments:
+    (pipe_arguments
+      (identifier) @variable.parameter))
+
+(structural_directive
+  "*" @keyword
+  (identifier) @keyword)
+
+(attribute
+  (attribute_name) @variable.member
+  (#lua-match? @variable.member "#.*"))
+
+(binding_name
+  (identifier) @keyword)
+
+(event_binding
+  (binding_name
+    (identifier) @keyword))
+
+(event_binding
+  "\"" @punctuation.delimiter)
+
+(property_binding
+  "\"" @punctuation.delimiter)
+
+(structural_assignment
+  operator: (identifier) @keyword)
+
+(member_expression
+  property: (identifier) @property)
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function:
+    ((identifier) @function.builtin
+      (#eq? @function.builtin "$any")))
+
+(pair
+  key:
+    ((identifier) @variable.builtin
+      (#eq? @variable.builtin "$implicit")))
+
+((control_keyword) @keyword.repeat
+  (#any-of? @keyword.repeat "for" "empty"))
+
+((control_keyword) @keyword.conditional
+  (#any-of? @keyword.conditional "if" "else" "switch" "case" "default"))
+
+((control_keyword) @keyword.coroutine
+  (#any-of? @keyword.coroutine "defer" "placeholder" "loading"))
+
+((control_keyword) @keyword.exception
+  (#eq? @keyword.exception "error"))
+
+(special_keyword) @keyword
+
+((identifier) @boolean
+  (#any-of? @boolean "true" "false"))
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "this" "$event"))
+
+((identifier) @constant.builtin
+  (#eq? @constant.builtin "null"))
+
+[
+  (ternary_operator)
+  (conditional_operator)
+] @keyword.conditional.ternary
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "@"
+  "} @"
+  (if_end_expression)
+  (for_end_expression)
+  (switch_end_expression)
+  (case_end_expression)
+  (default_end_expression)
+  (defer_end_expression)
+] @punctuation.bracket
+
+[
+  "{{"
+  "}}"
+] @punctuation.special
+
+[
+  ";"
+  "."
+  ","
+  "?."
+] @punctuation.delimiter
+
+(concatination_expression
+  "+" @operator)
+
+(binary_expression
+  [
+    "-"
+    "&&"
+    "+"
+    "<"
+    "<="
+    "="
+    "=="
+    "==="
+    "!="
+    "!=="
+    ">"
+    ">="
+    "*"
+    "/"
+    "||"
+    "%"
+  ] @operator)

--- a/crates/zed/src/languages/angular/indents.scm
+++ b/crates/zed/src/languages/angular/indents.scm
@@ -1,0 +1,1 @@
+; inherits: html_tags

--- a/crates/zed/src/languages/angular/injections.scm
+++ b/crates/zed/src/languages/angular/injections.scm
@@ -1,0 +1,1 @@
+; inherits: html_tags

--- a/crates/zed/src/languages/angular/locals.scm
+++ b/crates/zed/src/languages/angular/locals.scm
@@ -1,0 +1,1 @@
+; inherits: html


### PR DESCRIPTION
This PR adds an Angular LSP in response to resolve https://github.com/zed-industries/extensions/issues/169.

Using this tree sitter: https://github.com/nathansbradshaw/tree-sitter-angular
Using the official language server from angular: https://github.com/angular/vscode-ng-language-service
With the vim configs: https://github.com/dlvandenberg/nvim-treesitter/tree/feature-angular/queries/angular

This LSP is build much like the Vue LSP since it relies on a Typescript package. It also needs a reference to the language-service that gets installed in along side the angular lsp.

NOTE: This is very much still a WIP, I am new to the whole LSP thing and will gladly take any pointers or advice for how to get this thing off the ground. It works in it's current form but still needs a bit of work till it's ready to be merged.


Release Notes:

- Add syntax highlighting and LSP for Angular
