### PR TITLE
Use user's default shell in Zed's terminal

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -284,7 +284,16 @@ impl TerminalBuilder {
     ) -> Result<TerminalBuilder> {
         let pty_options = {
             let alac_shell = match shell.clone() {
-                Shell::System => None,
+                Shell::System => {
+                    // by default alacritty does not use $SHELL as the default shell,
+                    // so we make it use it here if it's specified
+                    if std::env::var("SHELL").is_ok() {
+                        let shell = std::env::var("SHELL").unwrap();
+                        Some(alacritty_terminal::tty::Shell::new(shell, Vec::new()))
+                    } else {
+                        None
+                    }
+                }
                 Shell::Program(program) => {
                     Some(alacritty_terminal::tty::Shell::new(program, Vec::new()))
                 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -287,8 +287,7 @@ impl TerminalBuilder {
                 Shell::System => {
                     // by default alacritty does not use $SHELL as the default shell,
                     // so we make it use it here if it's specified
-                    if std::env::var("SHELL").is_ok() {
-                        let shell = std::env::var("SHELL").unwrap();
+                    if let Ok(shell) = std::env::var("SHELL") {
                         Some(alacritty_terminal::tty::Shell::new(shell, Vec::new()))
                     } else {
                         None


### PR DESCRIPTION
Context:

- I did some digging and found that Alacritty (which we forked) by default does not use the user's $SHELL, but instead uses what's specified in /etc/passwd if any. This PR starts it with $SHELL by default if $SHELL is set.

Release Notes:

- Fixed https://github.com/zed-industries/zed/issues/5320