### PR TITLE
Make .gitkeep icon use VCS icon

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -37,6 +37,7 @@
         "gitattributes": "vcs",
         "gitignore": "vcs",
         "gitmodules": "vcs",
+        "gitkeep": "vcs",
         "go": "code",
         "h": "code",
         "handlebars": "code",


### PR DESCRIPTION
This should be a standard recognized by everyone

```bash
mkdir todo
touch todo/.gitkeep # just placeholder
git add todo
git commit
```

Release Notes:

- Added icon for `.gitkeep` files.
