### PR TITLE
Load embedded fonts directly from .rdata instead of cloning

### DIFF
--- a/crates/assets/src/lib.rs
+++ b/crates/assets/src/lib.rs
@@ -16,7 +16,7 @@ use rust_embed::RustEmbed;
 pub struct Assets;
 
 impl AssetSource for Assets {
-    fn load(&self, path: &str) -> Result<std::borrow::Cow<[u8]>> {
+    fn load(&self, path: &str) -> Result<std::borrow::Cow<'static, [u8]>> {
         Self::get(path)
             .map(|f| f.data)
             .ok_or_else(|| anyhow!("could not find asset at path \"{}\"", path))

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -11,14 +11,14 @@ use std::{
 /// A source of assets for this app to use.
 pub trait AssetSource: 'static + Send + Sync {
     /// Load the given asset from the source path.
-    fn load(&self, path: &str) -> Result<Cow<[u8]>>;
+    fn load(&self, path: &str) -> Result<Cow<'static, [u8]>>;
 
     /// List the assets at the given path.
     fn list(&self, path: &str) -> Result<Vec<SharedString>>;
 }
 
 impl AssetSource for () {
-    fn load(&self, path: &str) -> Result<Cow<[u8]>> {
+    fn load(&self, path: &str) -> Result<Cow<'static, [u8]>> {
         Err(anyhow!(
             "get called on empty asset provider with \"{}\"",
             path

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -204,7 +204,7 @@ pub trait PlatformDispatcher: Send + Sync {
 }
 
 pub(crate) trait PlatformTextSystem: Send + Sync {
-    fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> Result<()>;
+    fn add_fonts(&self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()>;
     fn all_font_names(&self) -> Vec<String>;
     fn all_font_families(&self) -> Vec<String>;
     fn font_id(&self, descriptor: &Font) -> Result<FontId>;

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use smallvec::{smallvec, SmallVec};
 use std::{
+    borrow::Cow,
     cmp,
     fmt::{Debug, Display, Formatter},
     hash::{Hash, Hasher},
@@ -85,7 +86,7 @@ impl TextSystem {
     }
 
     /// Add a font's data to the text system.
-    pub fn add_fonts(&self, fonts: &[Arc<Vec<u8>>]) -> Result<()> {
+    pub fn add_fonts(&self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()> {
         self.platform_text_system.add_fonts(fonts)
     }
 

--- a/crates/storybook/src/assets.rs
+++ b/crates/storybook/src/assets.rs
@@ -15,7 +15,7 @@ use rust_embed::RustEmbed;
 pub struct Assets;
 
 impl AssetSource for Assets {
-    fn load(&self, path: &str) -> Result<Cow<[u8]>> {
+    fn load(&self, path: &str) -> Result<Cow<'static, [u8]>> {
         Self::get(path)
             .map(|f| f.data)
             .ok_or_else(|| anyhow!("could not find asset at path \"{}\"", path))

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -2,8 +2,6 @@ mod assets;
 mod stories;
 mod story_selector;
 
-use std::sync::Arc;
-
 use clap::Parser;
 use dialoguer::FuzzySelect;
 use gpui::{
@@ -128,10 +126,10 @@ fn load_embedded_fonts(cx: &AppContext) -> gpui::Result<()> {
     let mut embedded_fonts = Vec::new();
     for font_path in font_paths {
         if font_path.ends_with(".ttf") {
-            let font_bytes = cx.asset_source().load(&font_path)?.to_vec();
-            embedded_fonts.push(Arc::from(font_bytes));
+            let font_bytes = cx.asset_source().load(&font_path)?;
+            embedded_fonts.push(font_bytes);
         }
     }
 
-    cx.text_system().add_fonts(&embedded_fonts)
+    cx.text_system().add_fonts(embedded_fonts)
 }

--- a/crates/theme_importer/src/assets.rs
+++ b/crates/theme_importer/src/assets.rs
@@ -11,7 +11,7 @@ use rust_embed::RustEmbed;
 pub struct Assets;
 
 impl AssetSource for Assets {
-    fn load(&self, path: &str) -> Result<Cow<[u8]>> {
+    fn load(&self, path: &str) -> Result<Cow<'static, [u8]>> {
         Self::get(path)
             .map(|f| f.data)
             .ok_or_else(|| anyhow!("could not find asset at path \"{}\"", path))

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -815,14 +815,14 @@ fn load_embedded_fonts(cx: &AppContext) {
             }
 
             scope.spawn(async {
-                let font_bytes = asset_source.load(font_path).unwrap().to_vec();
-                embedded_fonts.lock().push(Arc::from(font_bytes));
+                let font_bytes = asset_source.load(font_path).unwrap();
+                embedded_fonts.lock().push(font_bytes);
             });
         }
     }));
 
     cx.text_system()
-        .add_fonts(&embedded_fonts.into_inner())
+        .add_fonts(embedded_fonts.into_inner())
         .unwrap();
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2676,17 +2676,9 @@ mod tests {
     #[gpui::test]
     fn test_bundled_settings_and_themes(cx: &mut AppContext) {
         cx.text_system()
-            .add_fonts(&[
-                Assets
-                    .load("fonts/zed-sans/zed-sans-extended.ttf")
-                    .unwrap()
-                    .to_vec()
-                    .into(),
-                Assets
-                    .load("fonts/zed-mono/zed-mono-extended.ttf")
-                    .unwrap()
-                    .to_vec()
-                    .into(),
+            .add_fonts(vec![
+                Assets.load("fonts/zed-sans/zed-sans-extended.ttf").unwrap(),
+                Assets.load("fonts/zed-mono/zed-mono-extended.ttf").unwrap(),
             ])
             .unwrap();
         let themes = ThemeRegistry::default();


### PR DESCRIPTION
The fonts we embed in Zed binary (Zed Sans & Zed Mono) weigh about 30Mb in total and we are cloning them several times during startup and loading of embedded assets (once explicitly in Zed and then under the hood in font-kit). Moreover, after loading we have at least 2 copies of each font in our program; one in .rdata and the other on the heap for use by font-kit.
This commit does away with that distinction (we're no longer allocating the font data) and slightly relaxes the interface of `TextSystem::add_fonts` by expecting one to pass `Cow<[u8]>` instead of `Arc<Vec<u8>>`. Additionally, `AssetSource::get` now returns `Cow<'static, [u8]>` instead of `Cow<'self, [u8]>`; all existing implementations conform with that change.

Note that this optimization takes effect only in Release builds, as the library we use for asset embedding - rust-embed - embeds the assets only in Release mode and in Dev builds it simply loads data from disk. Thus it returns `Cow<[u8]>` in it's interface. Therefore, we still copy that memory around in Dev builds, but that's not really an issue. 
This patch makes no assumptions about the build profile we're running under, that's just an intrinsic property of rust-embed.

Tl;dr: this should shave off about 30Mb of memory usage and a fair chunk (~30ms) of startup time.

Release Notes:
- Improved startup time and memory usage.
