### PR TITLE
Add Java support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8484,6 +8484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-java"
+version = "0.20.2"
+source = "git+https://github.com/tree-sitter/tree-sitter-java?rev=2b57cd9541f9fd3a89207d054ce8fbe72657c444#2b57cd9541f9fd3a89207d054ce8fbe72657c444"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-json"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9733,6 +9742,7 @@ dependencies = [
  "tree-sitter-haskell",
  "tree-sitter-heex",
  "tree-sitter-html",
+ "tree-sitter-java",
  "tree-sitter-json 0.20.0",
  "tree-sitter-lua",
  "tree-sitter-markdown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ tree-sitter-glsl = { git = "https://github.com/theHamsta/tree-sitter-glsl", rev 
 tree-sitter-gleam = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "58b7cac8fc14c92b0677c542610d8738c373fa81" }
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
+tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java", rev = "2b57cd9541f9fd3a89207d054ce8fbe72657c444" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-rust = "0.20.3"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -124,6 +124,7 @@ tree-sitter-glsl.workspace = true
 tree-sitter-gleam.workspace = true
 tree-sitter-go.workspace = true
 tree-sitter-heex.workspace = true
+tree-sitter-java.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-markdown.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -17,6 +17,7 @@ mod gleam;
 mod go;
 mod haskell;
 mod html;
+mod java;
 mod json;
 #[cfg(feature = "plugin_runtime")]
 mod language_plugin;
@@ -126,6 +127,11 @@ pub fn init(
             Arc::new(elixir::ElixirLspAdapter),
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ],
+    );
+    language(
+        "java",
+        tree_sitter_java::language(),
+        vec![Arc::new(java::JavaLspAdapter)],
     );
     language(
         "json",

--- a/crates/zed/src/languages/java.rs
+++ b/crates/zed/src/languages/java.rs
@@ -1,0 +1,132 @@
+use anyhow::{anyhow, Context, Result};
+use async_compression::futures::bufread::GzipDecoder;
+use async_tar::Archive;
+use async_trait::async_trait;
+use futures::{io::BufReader, StreamExt};
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use smol::fs;
+use std::{any::Any, path::PathBuf};
+use util::async_maybe;
+use util::github::latest_github_release;
+use util::{
+    github::GitHubLspBinaryVersion,
+    ResultExt,
+};
+
+pub struct JavaLspAdapter;
+
+#[async_trait]
+impl LspAdapter for JavaLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("eclipse.jdt.ls".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "jdtls"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        delegate: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        let release =
+            latest_github_release("ABckh/eclipse.jdt.ls", false, delegate.http_client())
+                .await?;
+
+        let asset_name = "eclipse.jdt.ls.tar.gz";
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| anyhow!("no asset found matching {:?} \n", asset_name))?;
+        let version = GitHubLspBinaryVersion {
+            name: release.name,
+            url: asset.browser_download_url.clone(),
+        };
+
+        Ok(Box::new(version) as Box<_>)
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        container_dir: PathBuf,
+        delegate: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
+        let binary_path = container_dir.join("bin/jdtls");
+
+        if fs::metadata(&binary_path).await.is_err() {
+            let mut response = delegate
+                .http_client()
+                .get(&version.url, Default::default(), true)
+                .await
+                .context("error downloading release")?;
+            let decompressed_bytes = GzipDecoder::new(BufReader::new(response.body_mut()));
+            let archive = Archive::new(decompressed_bytes);
+            archive.unpack(container_dir).await?;
+        }
+
+        fs::set_permissions(
+            &binary_path,
+            <fs::Permissions as fs::unix::PermissionsExt>::from_mode(0o755),
+        )
+        .await?;
+        Ok(LanguageServerBinary {
+            path: binary_path,
+            arguments: vec![],
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir).await
+    }
+
+    async fn installation_test_binary(
+        &self,
+        container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir)
+            .await
+            .map(|mut binary| {
+                binary.arguments = vec!["--help".into()];
+                binary
+            })
+    }
+
+    
+}
+
+async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServerBinary> {
+    async_maybe!({
+        let mut last_binary_path = None;
+        let mut entries = fs::read_dir(&container_dir).await?;
+        while let Some(entry) = entries.next().await {
+            let entry = entry?;
+            if entry.file_type().await?.is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map_or(false, |name| name == "eclipse.jdt.ls")
+            {
+                last_binary_path = Some(entry.path());
+            }
+        }
+
+        if let Some(path) = last_binary_path {
+            Ok(LanguageServerBinary {
+                path,
+                arguments: Vec::new(),
+            })
+        } else {
+            Err(anyhow!("no cached binary"))
+        }
+    })
+    .await
+    .log_err()
+}

--- a/crates/zed/src/languages/java/brackets.scm
+++ b/crates/zed/src/languages/java/brackets.scm
@@ -1,0 +1,5 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/src/languages/java/config.toml
+++ b/crates/zed/src/languages/java/config.toml
@@ -1,0 +1,14 @@
+name = "Java"
+path_suffixes = ["java", "class"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false },
+    { start = "'", end = "'", close = true, newline = false },
+    { start = "`", end = "`", close = true, newline = false },
+    { start = "/*", end = " */", close = true, newline = false },
+]

--- a/crates/zed/src/languages/java/highlights.scm
+++ b/crates/zed/src/languages/java/highlights.scm
@@ -1,0 +1,321 @@
+; CREDITS @maxbrunsfeld (maxbrunsfeld@gmail.com)
+; Variables
+(identifier) @variable
+
+; Methods
+(method_declaration
+  name: (identifier) @function.method)
+
+(method_invocation
+  name: (identifier) @function.method.call)
+
+(super) @function.builtin
+
+; Parameters
+(formal_parameter
+  name: (identifier) @variable.parameter)
+
+(catch_formal_parameter
+  name: (identifier) @variable.parameter)
+
+(spread_parameter
+  (variable_declarator
+    name: (identifier) @variable.parameter)) ; int... foo
+
+; Lambda parameter
+(inferred_parameters
+  (identifier) @variable.parameter) ; (x,y) -> ...
+
+(lambda_expression
+  parameters: (identifier) @variable.parameter) ; x -> ...
+
+; Operators
+[
+  "+"
+  ":"
+  "++"
+  "-"
+  "--"
+  "&"
+  "&&"
+  "|"
+  "||"
+  "!"
+  "!="
+  "=="
+  "*"
+  "/"
+  "%"
+  "<"
+  "<="
+  ">"
+  ">="
+  "="
+  "-="
+  "+="
+  "*="
+  "/="
+  "%="
+  "->"
+  "^"
+  "^="
+  "&="
+  "|="
+  "~"
+  ">>"
+  ">>>"
+  "<<"
+  "::"
+] @operator
+
+; Types
+(interface_declaration
+  name: (identifier) @type)
+
+(annotation_type_declaration
+  name: (identifier) @type)
+
+(class_declaration
+  name: (identifier) @type)
+
+(record_declaration
+  name: (identifier) @type)
+
+(enum_declaration
+  name: (identifier) @type)
+
+(constructor_declaration
+  name: (identifier) @type)
+
+(type_identifier) @type
+
+((type_identifier) @type.builtin
+  (#eq? @type.builtin "var"))
+
+((method_invocation
+  object: (identifier) @type)
+  (#lua-match? @type "^[A-Z]"))
+
+((method_reference
+  .
+  (identifier) @type)
+  (#lua-match? @type "^[A-Z]"))
+
+((field_access
+  object: (identifier) @type)
+  (#lua-match? @type "^[A-Z]"))
+
+(scoped_identifier
+  (identifier) @type
+  (#lua-match? @type "^[A-Z]"))
+
+; Fields
+(field_declaration
+  declarator:
+    (variable_declarator
+      name: (identifier) @variable.member))
+
+(field_access
+  field: (identifier) @variable.member)
+
+[
+  (boolean_type)
+  (integral_type)
+  (floating_point_type)
+  (void_type)
+] @type.builtin
+
+; Variables
+((identifier) @constant
+  (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
+
+(this) @variable.builtin
+
+; Annotations
+(annotation
+  "@" @attribute
+  name: (identifier) @attribute)
+
+(marker_annotation
+  "@" @attribute
+  name: (identifier) @attribute)
+
+; Literals
+(string_literal) @string
+
+(escape_sequence) @string.escape
+
+(character_literal) @character
+
+[
+  (hex_integer_literal)
+  (decimal_integer_literal)
+  (octal_integer_literal)
+  (binary_integer_literal)
+] @number
+
+[
+  (decimal_floating_point_literal)
+  (hex_floating_point_literal)
+] @number.float
+
+[
+  (true)
+  (false)
+] @boolean
+
+(null_literal) @constant.builtin
+
+; Keywords
+[
+  "assert"
+  "class"
+  "record"
+  "default"
+  "enum"
+  "extends"
+  "implements"
+  "instanceof"
+  "interface"
+  "@interface"
+  "permits"
+  "to"
+  "with"
+] @keyword
+
+(synchronized_statement
+  "synchronized" @keyword)
+
+[
+  "abstract"
+  "final"
+  "native"
+  "non-sealed"
+  "open"
+  "private"
+  "protected"
+  "public"
+  "sealed"
+  "static"
+  "strictfp"
+  "transitive"
+] @type.qualifier
+
+(modifiers
+  "synchronized" @type.qualifier)
+
+[
+  "transient"
+  "volatile"
+] @keyword.storage
+
+[
+  "return"
+  "yield"
+] @keyword.return
+
+"new" @keyword.operator
+
+; Conditionals
+[
+  "if"
+  "else"
+  "switch"
+  "case"
+] @keyword.conditional
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
+
+; Loops
+[
+  "for"
+  "while"
+  "do"
+  "continue"
+  "break"
+] @keyword.repeat
+
+; Includes
+[
+  "exports"
+  "import"
+  "module"
+  "opens"
+  "package"
+  "provides"
+  "requires"
+  "uses"
+] @keyword.import
+
+; Punctuation
+[
+  ";"
+  "."
+  "..."
+  ","
+] @punctuation.delimiter
+
+[
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  "("
+  ")"
+] @punctuation.bracket
+
+(type_arguments
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(type_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(string_interpolation
+  [
+    "\\{"
+    "}"
+  ] @punctuation.special)
+
+; Exceptions
+[
+  "throw"
+  "throws"
+  "finally"
+  "try"
+  "catch"
+] @keyword.exception
+
+; Labels
+(labeled_statement
+  (identifier) @label)
+
+; Comments
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell
+
+((block_comment) @comment.documentation
+  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+
+((line_comment) @comment.documentation
+  (#lua-match? @comment.documentation "^///[^/]"))
+
+((line_comment) @comment.documentation
+  (#lua-match? @comment.documentation "^///$"))

--- a/crates/zed/src/languages/java/indents.scm
+++ b/crates/zed/src/languages/java/indents.scm
@@ -1,0 +1,40 @@
+; format-ignore
+[
+  ; ... refers to the portion that this indent query will have effects on
+  (class_body)                        ; { ... } of `class X`
+  (enum_body)                         ; { ... } of `enum X`
+  (interface_body)                    ; { ... } of `interface X`
+  (constructor_body)                  ; { `modifier` X() {...} } inside `class X`
+  (annotation_type_body)              ; { ... } of `@interface X`
+  (block)                             ; { ... } that's not mentioned in this scope
+  (switch_block)                      ; { ... } in `switch X`
+  (array_initializer)                 ; [1, 2]
+  (argument_list)                     ; foo(...)
+  (formal_parameters)                 ; method foo(...)
+  (annotation_argument_list)          ; @Annotation(...)
+  (element_value_array_initializer)   ; { a, b } inside @Annotation()
+] @indent.begin
+
+(expression_statement
+  (method_invocation) @indent.begin)
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @indent.branch
+
+(annotation_argument_list
+  ")" @indent.end) ; This should be a special cased as `()` here doesn't have ending `;`
+
+(_ "{" "}" @end) @indent
+
+(line_comment) @indent.ignore
+
+[
+  (ERROR)
+  (block_comment)
+] @indent.auto

--- a/crates/zed/src/languages/java/injections.scm
+++ b/crates/zed/src/languages/java/injections.scm
@@ -1,0 +1,20 @@
+([
+  (block_comment)
+  (line_comment)
+] @injection.content
+  (#set! injection.language "comment"))
+
+((block_comment) @injection.content
+  (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
+  (#set! injection.language "doxygen"))
+
+((method_invocation
+  name: (identifier) @_method
+  arguments:
+    (argument_list
+      .
+      (string_literal
+        .
+        (_) @injection.content)))
+  (#any-of? @_method "format" "printf")
+  (#set! injection.language "printf"))

--- a/crates/zed/src/languages/java/outline.scm
+++ b/crates/zed/src/languages/java/outline.scm
@@ -1,0 +1,102 @@
+; SCOPES
+; declarations
+(program) @local.scope
+
+(class_declaration
+  body: (_) @local.scope)
+
+(record_declaration
+  body: (_) @local.scope)
+
+(enum_declaration
+  body: (_) @local.scope)
+
+(lambda_expression) @local.scope
+
+(enhanced_for_statement) @local.scope
+
+; block
+(block) @local.scope
+
+; if/else
+(if_statement) @local.scope ; if+else
+
+(if_statement
+  consequence: (_) @local.scope) ; if body in case there are no braces
+
+(if_statement
+  alternative: (_) @local.scope) ; else body in case there are no braces
+
+; try/catch
+(try_statement) @local.scope ; covers try+catch, individual try and catch are covered by (block)
+
+(catch_clause) @local.scope ; needed because `Exception` variable
+
+; loops
+(for_statement) @local.scope ; whole for_statement because loop iterator variable
+
+(for_statement
+  ; "for" body in case there are no braces
+  body: (_) @local.scope)
+
+(do_statement
+  body: (_) @local.scope)
+
+(while_statement
+  body: (_) @local.scope)
+
+; Functions
+(constructor_declaration) @local.scope
+
+(method_declaration) @local.scope
+
+; DEFINITIONS
+(package_declaration
+  (identifier) @local.definition.namespace)
+
+(class_declaration
+  name: (identifier) @local.definition.type)
+
+(record_declaration
+  name: (identifier) @local.definition.type)
+
+(enum_declaration
+  name: (identifier) @local.definition.enum)
+
+(method_declaration
+  name: (identifier) @local.definition.method)
+
+(local_variable_declaration
+  declarator:
+    (variable_declarator
+      name: (identifier) @local.definition.var))
+
+(enhanced_for_statement
+  ; for (var item : items) {
+  name: (identifier) @local.definition.var)
+
+(formal_parameter
+  name: (identifier) @local.definition.parameter)
+
+(catch_formal_parameter
+  name: (identifier) @local.definition.parameter)
+
+(inferred_parameters
+  (identifier) @local.definition.parameter) ; (x,y) -> ...
+
+(lambda_expression
+  parameters: (identifier) @local.definition.parameter) ; x -> ...
+
+((scoped_identifier
+  (identifier) @local.definition.import)
+  (#has-ancestor? @local.definition.import import_declaration))
+
+(field_declaration
+  declarator:
+    (variable_declarator
+      name: (identifier) @local.definition.field))
+
+; REFERENCES
+(identifier) @local.reference
+
+(type_identifier) @local.reference

--- a/crates/zed/src/languages/java/overrides.scm
+++ b/crates/zed/src/languages/java/overrides.scm
@@ -1,0 +1,7 @@
+[
+  (line_comment)
+  (block_comment)
+] @comment 
+(string_literal) @string
+
+(annotation) @annotation


### PR DESCRIPTION
This pr is created to add java syntax highlighting and lsp (eclipse.jdt.ls)

<img width="1378" alt="Screenshot 2024-01-28 at 12 20 44 AM" src="https://github.com/zed-industries/zed/assets/88387714/c88d12cd-e6d7-4461-81ce-3df0643b5958">
<img width="967" alt="Screenshot 2024-01-28 at 12 26 04 AM" src="https://github.com/zed-industries/zed/assets/88387714/de4e1ec4-0242-41be-907e-2ee59158af10">


The PR is not ready to be merged yet because I am encountering some strange issues and would like to hear some suggestions as I am running out of ideas. The problem I am facing is that when Zed is launched and I press "Go to definition" several times, the LSP gets stuck, and I receive a timeout error (no response is received within 2 minutes). Important to mention that bin of the server is not attached to release in eclipse.jdt.ls repo, so I made ci which creates it: https://github.com/ABckh/eclipse.jdt.ls
Also, I am experiencing an issue where completion throws an error, but it still functions.

[zed_java_support.log](https://github.com/zed-industries/zed/files/14076512/zed_java_support.log)

Release Notes:

- Added java support ([#5301 ](https://github.com/zed-industries/extensions/issues/500)).
