### PR TITLE
Style crate names in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,14 +43,14 @@ We plan to set aside time each week to pair program with contributors on promisi
 
 Zed is made up of several smaller crates - let's go over those you're most likely to interact with:
 
-- [gpui](/crates/gpui) is a GPU-accelerated UI framework which provides all of the building blocks for Zed. **We recommend familiarizing yourself with the root level GPUI documentation**
-- [editor](/crates/editor) contains the core `Editor` type that drives both the code editor and all various input fields within Zed. It also handles a display layer for LSP features such as Inlay Hints or code completions.
-- [project](/crates/project) manages files and navigation within the filetree. It is also Zed's side of communication with LSP.
-- [workspace](/crates/workspace) handles local state serialization and groups projects together.
-- [vim](/crates/vim) is a thin implementation of Vim workflow over `editor`.
-- [lsp](/crates/lsp) handles communication with external LSP server.
-- [language](/crates/language) drives `editor`'s understanding of language - from providing a list of symbols to the syntax map.
-- [collab](/crates/collab) is the collaboration server itself, driving the collaboration features such as project sharing.
-- [rpc](/crates/rpc) defines messages to be exchanged with collaboration server.
-- [theme](/crates/theme) defines the theme system and provides a default theme.
-- [ui](/crates/ui) is a collection of UI components and common patterns used throughout Zed.
+- [`gpui`](/crates/gpui) is a GPU-accelerated UI framework which provides all of the building blocks for Zed. **We recommend familiarizing yourself with the root level GPUI documentation**
+- [`editor`](/crates/editor) contains the core `Editor` type that drives both the code editor and all various input fields within Zed. It also handles a display layer for LSP features such as Inlay Hints or code completions.
+- [`project`](/crates/project) manages files and navigation within the filetree. It is also Zed's side of communication with LSP.
+- [`workspace`](/crates/workspace) handles local state serialization and groups projects together.
+- [`vim`](/crates/vim) is a thin implementation of Vim workflow over `editor`.
+- [`lsp`](/crates/lsp) handles communication with external LSP server.
+- [`language`](/crates/language) drives `editor`'s understanding of language - from providing a list of symbols to the syntax map.
+- [`collab`](/crates/collab) is the collaboration server itself, driving the collaboration features such as project sharing.
+- [`rpc`](/crates/rpc) defines messages to be exchanged with collaboration server.
+- [`theme`](/crates/theme) defines the theme system and provides a default theme.
+- [`ui`](/crates/ui) is a collection of UI components and common patterns used throughout Zed.


### PR DESCRIPTION
This PR styles the crate names in `CONTRIBUTING.md` using inline code.

Release Notes:

- N/A
