### PR TITLE
vscode keymap ProjectPanel::Open add `space` key

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -418,6 +418,12 @@
       "escape": "workspace::Unfollow"
     }
   },
+  {
+    "context": "ProjectPanel",
+    "bindings": {
+      "space": "project_panel::Open"
+    }
+  },
   // Bindings from Sublime Text
   {
     "context": "Editor",


### PR DESCRIPTION
Once this [PR]( https://github.com/zed-industries/zed/pull/6914) is merged, then this binding is what vscode users will like

Release Notes:

- Added `space` keybind with `ProjectPane::Open`