### PR TITLE
Remove obviated comment in `zed-licenses.toml`

### DIFF
--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -1,5 +1,3 @@
-# NOTE: This file's location is hardcoded into the theme build system in 
-# styles/src/buildLicenses.ts
 no-clearly-defined = true
 private = { ignore = true }
 accepted = [


### PR DESCRIPTION
This PR removes a comment from `zed-licenses.toml`, as it no longer applies now that we don't have `buildLicenses.ts` anymore.

Release Notes:

- N/A
