### PR TITLE
Select the second item in the file finder by default

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -61,7 +61,7 @@ impl FileFinder {
                 let abs_path = project
                     .worktree_for_id(project_path.worktree_id, cx)
                     .map(|worktree| worktree.read(cx).abs_path().join(&project_path.path));
-                FoundPath::new(project_path, abs_path)
+                FoundPath::new_opened_file(project_path, abs_path)
             });
 
         // if exists, bubble the currently opened path to the top
@@ -139,8 +139,7 @@ pub struct FileFinderDelegate {
     latest_search_query: Option<PathLikeWithPosition<FileSearchQuery>>,
     currently_opened_path: Option<FoundPath>,
     matches: Matches,
-    selected_index: Option<usize>,
-    first_search: bool,
+    selected_index: usize,
     cancel_flag: Arc<AtomicBool>,
     history_items: Vec<FoundPath>,
 }
@@ -232,7 +231,15 @@ impl Matches {
             &mut self.history,
             history_items_to_show,
             100,
-            |(_, a), (_, b)| b.cmp(a),
+            |(ap, a), (bp, b)| {
+                if ap.opened_file {
+                    return cmp::Ordering::Less;
+                }
+                if bp.opened_file {
+                    return cmp::Ordering::Greater;
+                }
+                b.cmp(a)
+            },
         );
 
         if extend_old_matches {
@@ -306,11 +313,24 @@ fn matching_history_item_paths(
 struct FoundPath {
     project: ProjectPath,
     absolute: Option<PathBuf>,
+    opened_file: bool,
 }
 
 impl FoundPath {
     fn new(project: ProjectPath, absolute: Option<PathBuf>) -> Self {
-        Self { project, absolute }
+        Self {
+            project,
+            absolute,
+            opened_file: false,
+        }
+    }
+
+    fn new_opened_file(project: ProjectPath, absolute: Option<PathBuf>) -> Self {
+        Self {
+            project,
+            absolute,
+            opened_file: true,
+        }
     }
 }
 
@@ -363,13 +383,6 @@ impl FileFinderDelegate {
         })
         .detach();
 
-        // Select the second history item (the first one is the opened buffer if it exists)
-        let selected_index = if currently_opened_path.is_some() && history_items.len() > 1 {
-            Some(1)
-        } else {
-            None
-        };
-
         Self {
             file_finder,
             workspace,
@@ -380,8 +393,7 @@ impl FileFinderDelegate {
             latest_search_query: None,
             currently_opened_path,
             matches: Matches::default(),
-            selected_index,
-            first_search: true,
+            selected_index: 0,
             cancel_flag: Arc::new(AtomicBool::new(false)),
             history_items,
         }
@@ -436,7 +448,6 @@ impl FileFinderDelegate {
             let did_cancel = cancel_flag.load(atomic::Ordering::Relaxed);
             picker
                 .update(&mut cx, |picker, cx| {
-                    picker.delegate.selected_index.take();
                     picker
                         .delegate
                         .set_search_matches(search_id, did_cancel, query, matches, cx)
@@ -469,6 +480,7 @@ impl FileFinderDelegate {
             );
             self.latest_search_query = Some(query);
             self.latest_search_did_cancel = did_cancel;
+            self.selected_index = self.calculate_selected_index();
             cx.notify();
         }
     }
@@ -639,6 +651,20 @@ impl FileFinderDelegate {
                 .log_err();
         })
     }
+
+    /// Calculates selection index after the user performed search.
+    /// Prefers to return 1 if the top visible item corresponds to the currently opened file, otherwise returns 0.
+    fn calculate_selected_index(&self) -> usize {
+        let first = self.matches.history.get(0);
+        if let Some(first) = first {
+            if !first.0.opened_file {
+                return 0;
+            }
+        } else {
+            return 0;
+        }
+        (self.matches.len() - 1).min(1)
+    }
 }
 
 impl PickerDelegate for FileFinderDelegate {
@@ -653,11 +679,11 @@ impl PickerDelegate for FileFinderDelegate {
     }
 
     fn selected_index(&self) -> usize {
-        self.selected_index.unwrap_or(0)
+        self.selected_index
     }
 
     fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Picker<Self>>) {
-        self.selected_index = Some(ix);
+        self.selected_index = ix;
         cx.notify();
     }
 
@@ -679,11 +705,6 @@ impl PickerDelegate for FileFinderDelegate {
         if raw_query.is_empty() {
             let project = self.project.read(cx);
             self.latest_search_id = post_inc(&mut self.search_count);
-            if self.first_search {
-                self.first_search = false;
-            } else {
-                self.selected_index.take();
-            }
             self.matches = Matches {
                 history: self
                     .history_items
@@ -699,6 +720,7 @@ impl PickerDelegate for FileFinderDelegate {
                     .collect(),
                 search: Vec::new(),
             };
+            self.selected_index = self.calculate_selected_index();
             cx.notify();
             Task::ready(())
         } else {

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1087,8 +1087,8 @@ async fn test_select_first_history_file_by_default(cx: &mut gpui::TestAppContext
     open_close_queried_buffer("2", 1, "2_second", &workspace, cx).await;
     open_queried_buffer("3", 1, "3_third", &workspace, cx).await;
 
-    let pricker = open_file_picker(&workspace, cx);
-    pricker.update(cx, |finder, _| {
+    let picker = open_file_picker(&workspace, cx);
+    picker.update(cx, |finder, _| {
         assert_eq!(finder.delegate.selected_index(), 1);
     });
 


### PR DESCRIPTION
This PR completes the first task of the Tabless editing feature (#6424). It makes file finder select the previously opened file by default which allows the user to quickly switch between two last opened files by clicking `Cmd-P + Enter`.

This feature was also requested in #4663 comments.
