### PR TITLE
Retrieve credentials for saved conversations

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1097,13 +1097,6 @@ impl AssistantPanel {
                 Conversation::deserialize(saved_conversation, path.clone(), languages, &mut cx)
                     .await?;
 
-            // The saved conversation will be initialized without any credentials,
-            // so we need to retrieve the credentials again.
-            let completion_provider =
-                cx.update(|cx| conversation.read(cx).completion_provider.clone())?;
-            cx.update(|cx| completion_provider.retrieve_credentials(cx))?
-                .await;
-
             this.update(&mut cx, |this, cx| {
                 // If, by the time we've loaded the conversation, the user has already opened
                 // the same conversation, we don't want to open it again.
@@ -1515,7 +1508,9 @@ impl Conversation {
             )
             .await,
         );
-        cx.update(|cx| completion_provider.retrieve_credentials(cx))?;
+        cx.update(|cx| completion_provider.retrieve_credentials(cx))?
+            .await;
+
         let markdown = language_registry.language_for_name("Markdown");
         let mut message_anchors = Vec::new();
         let mut next_message_id = MessageId(0);


### PR DESCRIPTION
This PR fixes an issue where credentials for saved conversations weren't being fully retrieved, which was preventing continuing a conversation with the assistant in a saved conversation.

Release Notes:

- Fixed continuing a saved conversation with the Zed assistant.
