### PR TITLE
Add missing workspace edit capabilities

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -479,6 +479,15 @@ impl LanguageServer {
                     diagnostic: Some(DiagnosticWorkspaceClientCapabilities {
                         refresh_support: None,
                     }),
+                    workspace_edit: Some(WorkspaceEditClientCapabilities {
+                        resource_operations: Some(vec![
+                            ResourceOperationKind::Create,
+                            ResourceOperationKind::Rename,
+                            ResourceOperationKind::Delete,
+                        ]),
+                        document_changes: Some(true),
+                        ..WorkspaceEditClientCapabilities::default()
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(TextDocumentClientCapabilities {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/6916

Specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit
Adds a safe minimum of the capabilities that Zed supports already, allowing rust-analyzer to send file edits on rename.

Release Notes:

- Fixed Rust module rename from editor not renaming the FS entries ([#6916](https://github.com/zed-industries/zed/issues/6916)).