### PR TITLE
Make .jsonc icon use storage icon

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -53,6 +53,7 @@
         "jpg": "image",
         "js": "code",
         "json": "storage",
+        "jsonc": "storage",
         "ldf": "storage",
         "lock": "lock",
         "log": "log",


### PR DESCRIPTION
Jsonc is a simplified json format which allows comments and unquoted values delimited by whitespace. A jsonc formatted file can be unambiguously transformed to a json file. Comments will be stripped out and quotes added.



Release Notes:

- Added icon for .jsonc files