### PR TITLE
fixed zig config on line_comments

### DIFF
--- a/crates/zed/src/languages/haskell/config.toml
+++ b/crates/zed/src/languages/haskell/config.toml
@@ -1,7 +1,7 @@
 name = "Haskell"
 path_suffixes = ["hs"]
 autoclose_before = ",=)}]"
-line_comment = ["-- "]
+line_comments = ["-- "]
 block_comment = ["{- ", " -}"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/zed/src/languages/haskell/config.toml
+++ b/crates/zed/src/languages/haskell/config.toml
@@ -1,7 +1,7 @@
 name = "Haskell"
 path_suffixes = ["hs"]
 autoclose_before = ",=)}]"
-line_comment = "-- "
+line_comment = ["-- "]
 block_comment = ["{- ", " -}"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/zed/src/languages/purescript/config.toml
+++ b/crates/zed/src/languages/purescript/config.toml
@@ -1,7 +1,7 @@
 name = "PureScript"
 path_suffixes = ["purs"]
 autoclose_before = ",=)}]"
-line_comment = "-- "
+line_comments = ["-- "]
 block_comment = ["{- ", " -}"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/zed/src/languages/zig/config.toml
+++ b/crates/zed/src/languages/zig/config.toml
@@ -1,6 +1,6 @@
 name = "Zig"
 path_suffixes = ["zig"]
-line_comment = "// "
+line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
On a .zig files , the `CMD-/` keybinding don't work,
In the language config its the only language with '//' type comment that is written in singular without array.
This fixed the problem, so i assume it was just a typo

![image](https://github.com/zed-industries/zed/assets/6186996/d7f2381a-8b21-4f50-8910-6685b81a5aec)

- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).
