### PR TITLE
Improve perf of get_channel_descendants_including_self

### DIFF
--- a/crates/collab/migrations/20240129105000_add_gin_index_on_channels_pathname.sql
+++ b/crates/collab/migrations/20240129105000_add_gin_index_on_channels_pathname.sql
@@ -1,0 +1,1 @@
+CREATE INDEX trigram_index_channels_on_parent_path ON channels USING GIN(parent_path gin_trgm_ops);


### PR DESCRIPTION
In this morning's incident this query stood out with a max runtime of
>1s.

We run it in quite a few places, so we dug in and tried to optimize it.

Turns out that:
a) the index on `channels.parent_path` wasn't used b) query can be simplifed and sped-up when using a CTE and not a cross-join

While testing this on production with `EXPLAIN ANALYZE` the query previously took ~145ms to run for our main `zed` channel. After the changes here it took ~1ms.

Release Notes:

- N/A
