### PR TITLE
rust: Update rust-analyzer repo address

### DIFF
--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -32,7 +32,7 @@ impl LspAdapter for RustLspAdapter {
         delegate: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
         let release =
-            latest_github_release("rust-analyzer/rust-analyzer", false, delegate.http_client())
+            latest_github_release("rust-lang/rust-analyzer", false, delegate.http_client())
                 .await?;
         let asset_name = format!("rust-analyzer-{}-apple-darwin.gz", consts::ARCH);
         let asset = release

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -32,8 +32,7 @@ impl LspAdapter for RustLspAdapter {
         delegate: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
         let release =
-            latest_github_release("rust-lang/rust-analyzer", false, delegate.http_client())
-                .await?;
+            latest_github_release("rust-lang/rust-analyzer", false, delegate.http_client()).await?;
         let asset_name = format!("rust-analyzer-{}-apple-darwin.gz", consts::ARCH);
         let asset = release
             .assets


### PR DESCRIPTION
I am so sorry that I closed the https://github.com/zed-industries/zed/pull/6980 misoperationally. Here is a new pr.
