### PR TITLE
Use Git status color for icons in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1380,7 +1380,7 @@ impl ProjectPanel {
                     .indent_step_size(px(settings.indent_size))
                     .selected(is_selected)
                     .child(if let Some(icon) = &icon {
-                        div().child(Icon::from_path(icon.to_string()).color(Color::Muted))
+                        div().child(Icon::from_path(icon.to_string()).color(filename_text_color))
                     } else {
                         div().size(IconSize::default().rems()).invisible()
                     })


### PR DESCRIPTION
This PR updates the icons in the file tree in the project panel to also use the Git status color:

<img width="267" alt="Screenshot 2024-01-29 at 10 21 41 AM" src="https://github.com/zed-industries/zed/assets/1486634/2f4f6e9e-8050-4f5b-851a-e407aec823a0">

Release Notes:

- Updated icons in project panel to reflect Git status ([#6991](https://github.com/zed-industries/zed/issues/6991)).
