### PR TITLE
Fix slow query for fetching descendants of channels

### DIFF
--- a/crates/collab/migrations/20240129193601_fix_parent_path_index.sql
+++ b/crates/collab/migrations/20240129193601_fix_parent_path_index.sql
@@ -1,0 +1,4 @@
+-- Add migration script here
+
+DROP INDEX index_channels_on_parent_path;
+CREATE INDEX index_channels_on_parent_path ON channels (parent_path text_pattern_ops);

--- a/crates/collab/src/db/tables/channel.rs
+++ b/crates/collab/src/db/tables/channel.rs
@@ -39,6 +39,10 @@ impl Model {
     pub fn path(&self) -> String {
         format!("{}{}/", self.parent_path, self.id)
     }
+
+    pub fn descendant_path_filter(&self) -> String {
+        format!("{}{}/%", self.parent_path, self.id)
+    }
 }
 
 impl ActiveModelBehavior for ActiveModel {}


### PR DESCRIPTION
Previously, the index on `channels.parent_path` was not used, for two reasons:

* The index wasn't created with the `text_pattern_ops` directive, which allows it to be used in prefix based `LIKE` expressions
* The join that we were doing prevented the query planner from using the index.

This PR fixes the problem by recreating the index with `text_pattern_ops` and also simplifying the query, removing the unnecessary join (since the root channels were often already fetched by the caller).

Release Notes:

- N/A
