### PR TITLE
#4282 Fix TSX lang install error

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -152,7 +152,7 @@ impl NodeRuntime for RealNodeRuntime {
             let mut command = Command::new(node_binary);
             command.env_clear();
             command.env("PATH", env_path);
-            command.arg(npm_file).arg(subcommand);
+            command.arg(&npm_file).arg(subcommand);
             command.args(["--cache".into(), installation_path.join("cache")]);
             command.args([
                 "--userconfig".into(),


### PR DESCRIPTION
more clearly separated args



Release Notes:

- Fixed install issue with TSX language server ([#4282](https://github.com/zed-industries/zed/issues/4282)).