### PR TITLE
vim: implement <space> in normal mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -31,6 +31,7 @@
       "up": "vim::Up",
       "l": "vim::Right",
       "right": "vim::Right",
+      "space": "vim::Space",
       "$": "vim::EndOfLine",
       "^": "vim::FirstNonWhitespace",
       "_": "vim::StartOfLineDownward",

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -46,16 +46,10 @@ pub fn saturating_left(map: &DisplaySnapshot, mut point: DisplayPoint) -> Displa
     map.clip_point(point, Bias::Left)
 }
 
-/// Returns a column to the right of the current point, wrapping
-/// to the next line if that point is at the end of line.
+/// Returns a column to the right of the current point, doing nothing
+// if that point is at the end of the line.
 pub fn right(map: &DisplaySnapshot, mut point: DisplayPoint) -> DisplayPoint {
-    let line_len = map.line_len(point.row());
-    let max_column = if line_len == 0 {
-        line_len
-    } else {
-        line_len - 1
-    };
-    if point.column() < max_column {
+    if point.column() < map.line_len(point.row()) {
         *point.column_mut() += 1;
     } else if point.row() < map.max_point().row() {
         *point.row_mut() += 1;

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -49,7 +49,12 @@ pub fn saturating_left(map: &DisplaySnapshot, mut point: DisplayPoint) -> Displa
 /// Returns a column to the right of the current point, wrapping
 /// to the next line if that point is at the end of line.
 pub fn right(map: &DisplaySnapshot, mut point: DisplayPoint) -> DisplayPoint {
-    let max_column = map.line_len(point.row());
+    let line_len = map.line_len(point.row());
+    let max_column = if line_len == 0 {
+        line_len
+    } else {
+        line_len - 1
+    };
     if point.column() < max_column {
         *point.column_mut() += 1;
     } else if point.row() < map.max_point().row() {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -563,7 +563,18 @@ fn backspace(map: &DisplaySnapshot, mut point: DisplayPoint, times: usize) -> Di
 
 fn space(map: &DisplaySnapshot, mut point: DisplayPoint, times: usize) -> DisplayPoint {
     for _ in 0..times {
-        point = movement::right(map, point);
+        point = wrapping_right(map, point);
+    }
+    point
+}
+
+fn wrapping_right(map: &DisplaySnapshot, mut point: DisplayPoint) -> DisplayPoint {
+    let max_column = map.line_len(point.row()).saturating_sub(1);
+    if point.column() < max_column {
+        *point.column_mut() += 1;
+    } else if point.row() < map.max_point().row() {
+        *point.row_mut() += 1;
+        *point.column_mut() = 0;
     }
     point
 }

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -23,6 +23,7 @@ pub enum Motion {
     Down { display_lines: bool },
     Up { display_lines: bool },
     Right,
+    Space,
     NextWordStart { ignore_punctuation: bool },
     NextWordEnd { ignore_punctuation: bool },
     PreviousWordStart { ignore_punctuation: bool },
@@ -126,6 +127,7 @@ actions!(
         Left,
         Backspace,
         Right,
+        Space,
         CurrentLine,
         StartOfParagraph,
         EndOfParagraph,
@@ -160,6 +162,7 @@ pub fn register(workspace: &mut Workspace, _: &mut ViewContext<Workspace>) {
         )
     });
     workspace.register_action(|_: &mut Workspace, _: &Right, cx: _| motion(Motion::Right, cx));
+    workspace.register_action(|_: &mut Workspace, _: &Space, cx: _| motion(Motion::Space, cx));
     workspace.register_action(|_: &mut Workspace, action: &FirstNonWhitespace, cx: _| {
         motion(
             Motion::FirstNonWhitespace {
@@ -303,6 +306,7 @@ impl Motion {
             | Left
             | Backspace
             | Right
+            | Space
             | StartOfLine { .. }
             | EndOfLineDownward
             | GoToColumn
@@ -326,6 +330,7 @@ impl Motion {
             | Left
             | Backspace
             | Right
+            | Space
             | StartOfLine { .. }
             | StartOfParagraph
             | EndOfParagraph
@@ -357,6 +362,7 @@ impl Motion {
             Left
             | Backspace
             | Right
+            | Space
             | StartOfLine { .. }
             | StartOfLineDownward
             | StartOfParagraph
@@ -396,6 +402,7 @@ impl Motion {
                 display_lines: true,
             } => up_display(map, point, goal, times, &text_layout_details),
             Right => (right(map, point, times), SelectionGoal::None),
+            Space => (space(map, point, times), SelectionGoal::None),
             NextWordStart { ignore_punctuation } => (
                 next_word_start(map, point, *ignore_punctuation, times),
                 SelectionGoal::None,
@@ -550,6 +557,13 @@ fn left(map: &DisplaySnapshot, mut point: DisplayPoint, times: usize) -> Display
 fn backspace(map: &DisplaySnapshot, mut point: DisplayPoint, times: usize) -> DisplayPoint {
     for _ in 0..times {
         point = movement::left(map, point);
+    }
+    point
+}
+
+fn space(map: &DisplaySnapshot, mut point: DisplayPoint, times: usize) -> DisplayPoint {
+    for _ in 0..times {
+        point = movement::right(map, point);
     }
     point
 }


### PR DESCRIPTION
This fixes #6815 by implementing `<space>` in normal mode in Vim. Turns out that `<space>` behaves like a reverse `<backspace>` (which we already had): it goes to the right and, if at end of line, to the next line.

That means I had to touch `movement::right`, which is used in a few places, but it's documentation said that it would go to the next line, which it did *not*. So I changed the behaviour.

But I would love another pair of eyes on this, because I don't want to break non-Vim behaviour.

Release Notes:

- Added support for `<space>` in Vim normal mode: `<space>` goes to the right and to next line if at end of line. ([#6815](https://github.com/zed-industries/zed/issues/6815)).
