### PR TITLE
Improve file types list for Ruby syntax

### DIFF
--- a/crates/zed/src/languages/ruby/config.toml
+++ b/crates/zed/src/languages/ruby/config.toml
@@ -1,5 +1,24 @@
 name = "Ruby"
-path_suffixes = ["rb", "Gemfile", "rake", "Rakefile"]
+path_suffixes = [
+  "rb",
+  "Gemfile",
+  "rake",
+  "Rakefile",
+  "ru",
+  "thor",
+  "cap",
+  "capfile",
+  "Capfile",
+  "jbuilder",
+  "rabl",
+  "rxml",
+  "builder",
+  "gemspec",
+  "rdoc",
+  "thor",
+  "pryrc",
+  "simplecov"
+]
 first_line_pattern = '^#!.*\bruby\b'
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"


### PR DESCRIPTION
### Improved list of file types that require Ruby syntax highlighting

- `.ru` files: These are Rackup files and are used for configuring Rack applications.
- `.thor` files: Used for defining Thor tasks. Thor is a toolkit for building powerful command-line interfaces in Ruby.
- `.cap, .capfile, and Capfile`: These files are used for Capistrano deployment configuration.
- `.jbuilder` files: Used for creating JSON responses in a Rails application.
- `.rabl files`: RABL (Ruby API Builder Language) files are used for defining JSON templates.
- `.rxml` files: RXML files are used for creating XML responses.
- `.builder` files: Builder templates, which are used for generating XML and other formats.
- `.gemspec` files: These files define metadata for a RubyGem.
- `.rdoc` files: RDoc documentation files.
- `.thor` files: These files are used for defining Thor tasks.
- `.pryrc` files: Configuration files for the Pry REPL (Read-Eval-Print Loop).
- `.simplecov`: Configuration file for SimpleCov, a code coverage analysis tool.

#### Some examples
- <img width="393" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/4e30b03a-ae21-4bae-ab11-48aa46b4bd0b">
- <img width="501" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/07251529-bcde-42d2-8973-341679e5cbc4">
- <img width="365" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/8c9c116c-2b51-4062-b83b-83f60838d28a">
- <img width="396" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/02d591af-88df-41f0-ba52-b11fa370ba07">
- <img width="432" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/91cd760f-f56a-488a-9736-bc03a44b27cf">
- <img width="296" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/282c331e-8896-49d4-b3b6-b3edbf0c1cc5">
- <img width="316" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/a2ddfccf-43d4-4657-a764-9e8d62aa4467">
- <img width="536" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/b0fce8db-4a9e-4615-bf5d-0b6c523bcbc8">

- `path_suffixes` Also new lines the array for readability especially for diffs.

Release Notes:

- Associated `.ru`, `.thor`, `.cap`, `.capfile`, `Capfile`, `.jbuilder`, `.rabl`, `.rxml`, `.builder`, `.gemspec`, `.rdoc`, `.thor`, `.pryrc`, and `.simplecov` files with Ruby.