### PR TITLE
Add a newtype wrapper around the global `ThemeRegistry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7920,6 +7920,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "color",
+ "derive_more",
  "fs",
  "gpui",
  "indexmap 1.9.3",

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+derive_more.workspace = true
 fs = { path = "../fs" }
 gpui = { path = "../gpui" }
 indexmap = { version = "1.6.2", features = ["serde"] }

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -60,7 +60,7 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut AppContext) {
         LoadThemes::JustBase => (Box::new(()) as Box<dyn AssetSource>, false),
         LoadThemes::All(assets) => (assets, true),
     };
-    cx.set_global(ThemeRegistry::new(assets));
+    registry::init(assets, cx);
 
     if load_user_themes {
         ThemeRegistry::global_mut(cx).load_user_themes();


### PR DESCRIPTION
This PR adds a newtype wrapper around the global `ThemeRegistry`.

This allows us to limit where the `ThemeRegistry` can be accessed directly via `cx.global` et al., without going through the dedicated methods on the `ThemeRegistry`.

Release Notes:

- N/A
