### PR TITLE
Update default VSCode bindings for ALT + up/down

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -333,8 +333,8 @@
           "advance_downwards": false
         }
       ],
-      "alt-up": "editor::SelectLargerSyntaxNode",
-      "alt-down": "editor::SelectSmallerSyntaxNode",
+      "alt-up": "editor::MoveLineUp",
+      "alt-down": "editor::MoveLineDown"
       "cmd-u": "editor::UndoSelection",
       "cmd-shift-u": "editor::RedoSelection",
       "f8": "editor::GoToDiagnostic",


### PR DESCRIPTION
The default keybindings for `alt + up` or `alt + down` in VSCode are move line up and down. 

Release Notes:

- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).
