### PR TITLE
Fix terminal line background being reset on each line

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -218,7 +218,22 @@ impl TerminalElement {
                         match cur_alac_color {
                             Some(cur_color) => {
                                 if bg == cur_color {
-                                    cur_rect = cur_rect.take().map(|rect| rect.extend());
+                                    // `cur_rect` can be None if it was moved to the `rects` vec after wrapping around
+                                    // from one line to the next. The variables are all set correctly but there is no current
+                                    // rect, so we create one if necessary.
+                                    cur_rect = cur_rect.map_or_else(
+                                        || {
+                                            Some(LayoutRect::new(
+                                                AlacPoint::new(
+                                                    line_index as i32,
+                                                    cell.point.column.0 as i32,
+                                                ),
+                                                1,
+                                                convert_color(&bg, theme),
+                                            ))
+                                        },
+                                        |rect| Some(rect.extend()),
+                                    );
                                 } else {
                                     cur_alac_color = Some(bg);
                                     if cur_rect.is_some() {


### PR DESCRIPTION
Release Notes:

- Fixed #5027
- Fixed #5079

Info:

The terminal draws a rectangle for the background color of cells, but this was being reset on every line. The effect of this was that tools like Vim, Helix, and git-delta would only have one line with a background color:

<img width="979" alt="Screenshot 2024-01-30 at 2 48 13 pm" src="https://github.com/zed-industries/zed/assets/52195359/ab1873d2-0653-44c6-9406-bc2a277d9a2f">

After this change:

<img width="1011" alt="Screenshot 2024-01-30 at 2 49 45 pm" src="https://github.com/zed-industries/zed/assets/52195359/6e4d2a70-590b-48b0-a464-4c827f55622e">
