### PR TITLE
Update GPT-4 Turbo Version

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -190,8 +190,8 @@
     //
     // 1. "gpt-3.5-turbo-0613""
     // 2. "gpt-4-0613""
-    // 3. "gpt-4-1106-preview"
-    "default_open_ai_model": "gpt-4-1106-preview"
+    // 3. "gpt-4-0125-preview"
+    "default_open_ai_model": "gpt-4-0125-preview"
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -10,7 +10,7 @@ pub enum OpenAiModel {
     ThreePointFiveTurbo,
     #[serde(rename = "gpt-4-0613")]
     Four,
-    #[serde(rename = "gpt-4-1106-preview")]
+    #[serde(rename = "gpt-4-0125-preview")]
     FourTurbo,
 }
 
@@ -19,7 +19,7 @@ impl OpenAiModel {
         match self {
             OpenAiModel::ThreePointFiveTurbo => "gpt-3.5-turbo-0613",
             OpenAiModel::Four => "gpt-4-0613",
-            OpenAiModel::FourTurbo => "gpt-4-1106-preview",
+            OpenAiModel::FourTurbo => "gpt-4-0125-preview",
         }
     }
 


### PR DESCRIPTION
Release Notes:

- Updated GPT4 model version to the latest ([#7038](https://github.com/zed-industries/zed/issues/7038)).