### PR TITLE
Prevent GitHub from displaying comments within JSON files as errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent GitHub from displaying comments within JSON files as errors.
+*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
This PR adds a `.gitattributes` rule to prevent GitHub from displaying comments within JSON files as errors.

We have a number of JSON files (e.g., settings) that make use of comments, and having a bunch of red in a diff is annoying.

Release Notes:

- N/A
