### PR TITLE
Fix casing of `OpenZedUrl` action

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -18,7 +18,7 @@ use util::{
     ResultExt,
 };
 use workspace::{ModalView, Workspace};
-use zed_actions::OpenZedURL;
+use zed_actions::OpenZedUrl;
 
 actions!(command_palette, [Toggle]);
 
@@ -236,7 +236,7 @@ impl PickerDelegate for CommandPaletteDelegate {
             if *RELEASE_CHANNEL == ReleaseChannel::Dev {
                 if parse_zed_link(&query).is_some() {
                     intercept_result = Some(CommandInterceptResult {
-                        action: OpenZedURL { url: query.clone() }.boxed_clone(),
+                        action: OpenZedUrl { url: query.clone() }.boxed_clone(),
                         string: query.clone(),
                         positions: vec![],
                     })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -38,7 +38,7 @@ use workspace::{
     create_and_open_local_file, notifications::simple_message_notification::MessageNotification,
     open_new, AppState, NewFile, NewWindow, Workspace, WorkspaceSettings,
 };
-use zed_actions::{OpenBrowser, OpenSettings, OpenZedURL, Quit};
+use zed_actions::{OpenBrowser, OpenSettings, OpenZedUrl, Quit};
 
 actions!(
     zed,
@@ -201,7 +201,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
             .register_action(|_, _: &ToggleFullScreen, cx| {
                 cx.toggle_full_screen();
             })
-            .register_action(|_, action: &OpenZedURL, cx| {
+            .register_action(|_, action: &OpenZedUrl, cx| {
                 cx.global::<Arc<OpenListener>>()
                     .open_urls(&[action.url.clone()])
             })

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -16,10 +16,10 @@ pub struct OpenBrowser {
 }
 
 #[derive(Clone, PartialEq, Deserialize)]
-pub struct OpenZedURL {
+pub struct OpenZedUrl {
     pub url: String,
 }
 
-impl_actions!(zed, [OpenBrowser, OpenZedURL]);
+impl_actions!(zed, [OpenBrowser, OpenZedUrl]);
 
 actions!(zed, [OpenSettings, Quit]);


### PR DESCRIPTION
This PR updates the casing of the `OpenZedUrl` action to match the [Rust naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html).

Release Notes:

- N/A