### PR TITLE
Add CSS file type icon

### DIFF
--- a/assets/icons/file_icons/css.svg
+++ b/assets/icons/file_icons/css.svg
@@ -1,0 +1,4 @@
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" width="800px" height="800px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M24.235 6.519l-16.47-0.004 0.266 3.277 12.653 0.002-0.319 3.394h-8.298l0.3 3.215h7.725l-0.457 4.403-3.636 1.005-3.694-1.012-0.235-2.637h-3.262l0.362 4.817 6.829 2.128 6.714-1.912 1.521-16.675zM2.879 1.004h26.242l-2.387 26.946-10.763 3.045-10.703-3.047z"></path>
+</svg>

--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -13,7 +13,7 @@
         "cc": "code",
         "conf": "settings",
         "cpp": "code",
-        "css": "code",
+        "css": "css",
         "csv": "storage",
         "dat": "storage",
         "db": "storage",
@@ -128,6 +128,9 @@
         },
         "collapsed_folder": {
             "icon": "icons/file_icons/folder.svg"
+        },
+        "css": {
+          "icon": "icons/file_icons/css.svg"
         },
         "default": {
             "icon": "icons/file_icons/file.svg"


### PR DESCRIPTION
The SVG icon RAW link: https://www.svgrepo.com/svg/473577/css3
The Licensing https://www.svgrepo.com/page/licensing/#CC0

<img width="309" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/4b1fa935-144f-4c02-a378-b0974e4d0b39">


Release Notes:

- Added CSS file type icon
