### PR TITLE
Make avif/heif/webp icon use image icon

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -2,6 +2,7 @@
     "suffixes": {
         "aac": "audio",
         "accdb": "storage",
+        "avif": "image",
         "bak": "backup",
         "bash": "terminal",
         "bash_aliases": "terminal",
@@ -43,6 +44,7 @@
         "handlebars": "code",
         "hbs": "template",
         "heex": "elixir",
+        "heif": "image",
         "htm": "template",
         "html": "template",
         "hs": "haskell",
@@ -102,6 +104,7 @@
         "txt": "document",
         "vue": "vue",
         "wav": "audio",
+        "webp": "image",
         "webm": "video",
         "xls": "document",
         "xlsx": "document",


### PR DESCRIPTION
The Wikipedia Link:

- https://en.wikipedia.org/wiki/AVIF
- https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format
- https://en.wikipedia.org/wiki/WebP

Release Notes:

- Add avif/heif/webp format file use image icon