### PR TITLE
Improve file finder by ignoring spaces in query

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -666,7 +666,8 @@ impl PickerDelegate for FileFinderDelegate {
         raw_query: String,
         cx: &mut ViewContext<Picker<Self>>,
     ) -> Task<()> {
-        let raw_query = raw_query.trim();
+        let binding = raw_query.replace(" ", "");
+        let raw_query = binding.as_str();
         if raw_query.is_empty() {
             let project = self.project.read(cx);
             self.latest_search_id = post_inc(&mut self.search_count);

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -667,7 +667,7 @@ impl PickerDelegate for FileFinderDelegate {
         cx: &mut ViewContext<Picker<Self>>,
     ) -> Task<()> {
         let raw_query = raw_query.replace(" ", "");
-        let raw_query = raw_query.as_str();
+        let raw_query = raw_query.trim();
         if raw_query.is_empty() {
             let project = self.project.read(cx);
             self.latest_search_id = post_inc(&mut self.search_count);

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -666,8 +666,8 @@ impl PickerDelegate for FileFinderDelegate {
         raw_query: String,
         cx: &mut ViewContext<Picker<Self>>,
     ) -> Task<()> {
-        let binding = raw_query.replace(" ", "");
-        let raw_query = binding.as_str();
+        let raw_query = raw_query.replace(" ", "");
+        let raw_query = raw_query.as_str();
         if raw_query.is_empty() {
             let project = self.project.read(cx);
             self.latest_search_id = post_inc(&mut self.search_count);

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -53,7 +53,7 @@ async fn test_matching_paths(cx: &mut TestAppContext) {
         " bandana ",
         " ndan ",
         " band ",
-        "a bandana"
+        "a bandana",
     ] {
         picker
             .update(cx, |picker, cx| {

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -53,6 +53,7 @@ async fn test_matching_paths(cx: &mut TestAppContext) {
         " bandana ",
         " ndan ",
         " band ",
+        "a bandana"
     ] {
         picker
             .update(cx, |picker, cx| {


### PR DESCRIPTION
Release Notes:

- Changed file finder to ignore spaces in queries ([#5324 ](https://github.com/zed-industries/zed/issues/5324)).

![image](https://github.com/zed-industries/zed/assets/7274458/14f3d511-129d-4e73-b9d3-12ce1aaa892f)
