### PR TITLE
Ensure sqlez build succeeds on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,6 +4139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4501,6 +4517,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
@@ -7281,6 +7303,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "smol",
  "thread_local",
+ "util",
  "uuid 1.4.1",
 ]
 
@@ -7808,6 +7831,17 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix 0.38.30",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -8989,6 +9023,7 @@ dependencies = [
  "smol",
  "take-until",
  "tempfile",
+ "tendril",
  "url",
 ]
 

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
+rust-version = "1.74"
 
 
 [dependencies]
@@ -15,4 +16,5 @@ thread_local = "1.1.4"
 lazy_static.workspace = true
 parking_lot.workspace = true
 futures.workspace = true
+util = { path = "../util" }
 uuid.workspace = true

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
-rust-version = "1.74"
 
 
 [dependencies]

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -32,6 +32,9 @@ git2 = { workspace = true, optional = true }
 dirs = "3.0"
 take-until = "0.2.0"
 
+[target.'cfg(windows)'.dependencies]
+tendril = "0.4.3"
+
 [dev-dependencies]
 tempfile.workspace = true
 git2.workspace = true


### PR DESCRIPTION
On Windows, `OsStr` must be a valid [WTF-8](https://simonsapin.github.io/wtf-8/) sequence, and there are no safety ways converting from bytes to OsStr in std. So I added `PathExt::try_from_bytes` and use it in `sqlez`.
