### PR TITLE
log: Use local timezone in log timestamps

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -9,6 +9,7 @@ use client::{Client, UserStore};
 use collab_ui::channel_view::ChannelView;
 use db::kvp::KEY_VALUE_STORE;
 use editor::Editor;
+use env_logger::Builder;
 use fs::RealFs;
 use futures::StreamExt;
 use gpui::{App, AppContext, AsyncAppContext, Context, SemanticVersion, Task};
@@ -469,7 +470,26 @@ fn init_paths() {
 
 fn init_logger() {
     if stdout_is_a_pty() {
-        env_logger::init();
+        Builder::new()
+            .filter(None, LevelFilter::Info)
+            .format(|buf, record| {
+                use env_logger::fmt::Color;
+
+                let subtle = buf
+                    .style()
+                    .set_color(Color::Black)
+                    .set_intense(true)
+                    .clone();
+                write!(buf, "{}", subtle.value("["))?;
+                write!(buf, "{} ", chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"))?;
+                write!(buf, "{:<5}", buf.default_styled_level(record.level()))?;
+                if let Some(path) = record.module_path() {
+                    write!(buf, " {}", path)?;
+                }
+                write!(buf, "{}", subtle.value("]"))?;
+                writeln!(buf, " {}", record.args())
+            })
+            .init();
     } else {
         let level = LevelFilter::Info;
 
@@ -489,7 +509,8 @@ fn init_logger() {
             .expect("could not open logfile");
 
         let config = ConfigBuilder::new()
-            .set_time_format_str("%Y-%m-%dT%T") //All timestamps are UTC
+            .set_time_format_str("%Y-%m-%dT%T")
+            .set_time_to_local(true)
             .build();
 
         simplelog::WriteLogger::init(level, config, log_file).expect("could not initialize logger");

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -481,7 +481,11 @@ fn init_logger() {
                     .set_intense(true)
                     .clone();
                 write!(buf, "{}", subtle.value("["))?;
-                write!(buf, "{} ", chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"))?;
+                write!(
+                    buf,
+                    "{} ",
+                    chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%:z")
+                )?;
                 write!(buf, "{:<5}", buf.default_styled_level(record.level()))?;
                 if let Some(path) = record.module_path() {
                     write!(buf, " {}", path)?;
@@ -509,7 +513,7 @@ fn init_logger() {
             .expect("could not open logfile");
 
         let config = ConfigBuilder::new()
-            .set_time_format_str("%Y-%m-%dT%T")
+            .set_time_format_str("%Y-%m-%dT%T%:z")
             .set_time_to_local(true)
             .build();
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -471,7 +471,6 @@ fn init_paths() {
 fn init_logger() {
     if stdout_is_a_pty() {
         Builder::new()
-            .filter(None, LevelFilter::Info)
             .format(|buf, record| {
                 use env_logger::fmt::Color;
 


### PR DESCRIPTION
I'm gonna let it sit for a day in case anybody has any objections to that change.

Release Notes:

- Logs now use local timestamps instead of UTC-based timestamps
