### PR TITLE
Erlang syntax highlight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8502,6 +8502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-erlang"
+version = "0.4.0"
+source = "git+https://github.com/WhatsApp/tree-sitter-erlang?rev=54b6f814f43c4eac81eeedefaa7cc8762fec6683#54b6f814f43c4eac81eeedefaa7cc8762fec6683"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-gleam"
 version = "0.34.0"
 source = "git+https://github.com/gleam-lang/tree-sitter-gleam?rev=58b7cac8fc14c92b0677c542610d8738c373fa81#58b7cac8fc14c92b0677c542610d8738c373fa81"
@@ -9818,6 +9827,7 @@ dependencies = [
  "tree-sitter-elixir",
  "tree-sitter-elm",
  "tree-sitter-embedded-template",
+ "tree-sitter-erlang",
  "tree-sitter-gleam",
  "tree-sitter-glsl",
  "tree-sitter-go",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev 
 tree-sitter-elixir = { git = "https://github.com/elixir-lang/tree-sitter-elixir", rev = "a2861e88a730287a60c11ea9299c033c7d076e30" }
 tree-sitter-elm = { git = "https://github.com/elm-tooling/tree-sitter-elm", rev = "692c50c0b961364c40299e73c1306aecb5d20f40"}
 tree-sitter-embedded-template = "0.20.0"
+tree-sitter-erlang = {git = "https://github.com/WhatsApp/tree-sitter-erlang", rev = "54b6f814f43c4eac81eeedefaa7cc8762fec6683"}
 tree-sitter-glsl = { git = "https://github.com/theHamsta/tree-sitter-glsl", rev = "2a56fb7bc8bb03a1892b4741279dd0a8758b7fb3" }
 tree-sitter-gleam = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "58b7cac8fc14c92b0677c542610d8738c373fa81" }
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }

--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -22,6 +22,7 @@
         "doc": "document",
         "docx": "document",
         "eex": "elixir",
+        "erl": "erlang",
         "eslintrc": "eslint",
         "eslintrc.js": "eslint",
         "eslintrc.json": "eslint",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -120,6 +120,7 @@ tree-sitter-css.workspace = true
 tree-sitter-elixir.workspace = true
 tree-sitter-elm.workspace = true
 tree-sitter-embedded-template.workspace = true
+tree-sitter-erlang.workspace = true
 tree-sitter-glsl.workspace = true
 tree-sitter-gleam.workspace = true
 tree-sitter-go.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -13,6 +13,7 @@ mod c;
 mod css;
 mod deno;
 mod elixir;
+mod erlang;
 mod gleam;
 mod go;
 mod haskell;
@@ -104,6 +105,8 @@ pub fn init(
             })],
         ),
     }
+
+    language("erlang", tree_sitter_erlang::language(), vec![]);
 
     language(
         "gleam",

--- a/crates/zed/src/languages/erlang.rs
+++ b/crates/zed/src/languages/erlang.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde_derive::{Serialize,Deserialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ErlangSettings;

--- a/crates/zed/src/languages/erlang.rs
+++ b/crates/zed/src/languages/erlang.rs
@@ -1,0 +1,5 @@
+use schemars::JsonSchema;
+use serde_derive::{Serialize,Deserialize};
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ErlangSettings;

--- a/crates/zed/src/languages/erlang/brackets.scm
+++ b/crates/zed/src/languages/erlang/brackets.scm
@@ -1,3 +1,1 @@
-(_ "(" @open ")" @close)
-(_ "{" @open "}" @close)
-(_ "[" @open "]" @close)
+

--- a/crates/zed/src/languages/erlang/brackets.scm
+++ b/crates/zed/src/languages/erlang/brackets.scm
@@ -1,1 +1,3 @@
-
+(_ "(" @open ")" @close)
+(_ "{" @open "}" @close)
+(_ "[" @open "]" @close)

--- a/crates/zed/src/languages/erlang/brackets.scm
+++ b/crates/zed/src/languages/erlang/brackets.scm
@@ -1,0 +1,4 @@
+; ("(" @open ")" @close)
+; ("[" @open "]" @close)
+; ("{" @open "}" @close)
+; ("\"" @open "\"" @close)

--- a/crates/zed/src/languages/erlang/brackets.scm
+++ b/crates/zed/src/languages/erlang/brackets.scm
@@ -1,4 +1,1 @@
-; ("(" @open ")" @close)
-; ("[" @open "]" @close)
-; ("{" @open "}" @close)
-; ("\"" @open "\"" @close)
+

--- a/crates/zed/src/languages/erlang/config.toml
+++ b/crates/zed/src/languages/erlang/config.toml
@@ -1,0 +1,11 @@
+
+name = "Erlang"
+path_suffixes = ["erl"]
+line_comments = ["% "]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+]

--- a/crates/zed/src/languages/erlang/config.toml
+++ b/crates/zed/src/languages/erlang/config.toml
@@ -1,6 +1,5 @@
-
 name = "Erlang"
-path_suffixes = ["erl"]
+path_suffixes = ["erl", "hrl"]
 line_comments = ["% "]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -29,12 +29,9 @@
     ">"
     "=:="
     "=/="
-] @operator
 
-; Arithmetic Expressions
-[
     "+"
-    "-"
+    ; "-"
     "*"
     "/"
     "bnot"
@@ -45,41 +42,32 @@
     "bxor"
     "bsl"
     "bsr"
-] @operator
 
-; Boolean Expressions
-[
     "and"
     "or"
     "not"
     "xor"
-] @operator
 
-; Short-Circuit Expressions
-[
     "andalso"
     "orelse"
-] @operator
 
-; List Operations
-[
     "++"
     "--"
+
+    "!"
+    "|"
+    "->"
 ] @operator
 
-; Send Expressions
-"!" @operator
+(unary_op_expr) @operator
+(binary_op_expr) @operator
 
-[
-    (atom)
-] @string.special.symbol
+(atom) @string.special.symbol
 (string) @string
-
 [
     (integer)
     (float)
 ] @number
-
 (var) @variable
 
 (function_clause
@@ -89,7 +77,10 @@
     (module_attribute "(" @open ")" @close)
     (pp_define "(" @open ")" @close)
     (spec)
+    (record_decl "(" @open ")" @close)
 ] @keyword
+
+(spec fun: (atom) @function)
 
 (expr_args "(" @open ")" @close)
 
@@ -100,5 +91,7 @@
 (remote
     module: (remote_module module: (atom) @type)
     fun: (atom) @function)
+
+(call expr: (atom) @function)
 
 (comment) @comment

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -93,6 +93,10 @@
 
 (expr_args "(" @open ")" @close)
 
+(external_fun
+    module: (module name: (atom) @type)
+    fun: (atom) @function)
+
 (remote
     module: (remote_module module: (atom) @type)
     fun: (atom) @function)

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -1,0 +1,49 @@
+[
+    ";"
+    ","
+    "."
+] @delimeter
+
+;; NOTE: `cond` and `let` are not covered by tree-sitter-erlang.
+[
+    "after"
+    "and"
+    "andalso"
+    "band"
+    "begin"
+    "bnot"
+    "bor"
+    "bsl"
+    "bsr"
+    "bxor"
+    "case"
+    "catch"
+    "div"
+    "end"
+    "fun"
+    "if"
+    "maybe"
+    "not"
+    "of"
+    "or"
+    "orelse"
+    "receive"
+    "rem"
+    "try"
+    "when"
+    "xor"
+] @keyword
+
+[
+    (atom)
+] @string.special.symbol
+(string) @string
+
+[
+    (integer)
+    (float)
+] @number
+
+(var) @variable
+
+(comment) @comment

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -19,7 +19,6 @@
     "when"
 ] @keyword
 
-; Term Comparisons
 [
     "=="
     "/="

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -64,7 +64,10 @@
 (binary_op_expr) @operator
 
 (atom) @string.special.symbol
-(string) @string
+[
+    (char)
+    (string)
+] @string
 [
     (integer)
     (float)

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -4,35 +4,71 @@
     "."
 ] @delimeter
 
-;; NOTE: `cond` and `let` are not covered by tree-sitter-erlang.
 [
     "after"
-    "and"
-    "andalso"
-    "band"
     "begin"
-    "bnot"
-    "bor"
-    "bsl"
-    "bsr"
-    "bxor"
     "case"
     "catch"
-    "div"
     "end"
     "fun"
     "if"
     "maybe"
-    "not"
     "of"
-    "or"
-    "orelse"
     "receive"
-    "rem"
     "try"
     "when"
-    "xor"
 ] @keyword
+
+; Term Comparisons
+[
+    "=="
+    "/="
+    "=<"
+    "<"
+    ">="
+    ">"
+    "=:="
+    "=/="
+] @operator
+
+; Arithmetic Expressions
+[
+    "+"
+    "-"
+    "*"
+    "/"
+    "bnot"
+    "div"
+    "rem"
+    "band"
+    "bor"
+    "bxor"
+    "bsl"
+    "bsr"
+] @operator
+
+; Boolean Expressions
+[
+    "and"
+    "or"
+    "not"
+    "xor"
+] @operator
+
+; Short-Circuit Expressions
+[
+    "andalso"
+    "orelse"
+] @operator
+
+; List Operations
+[
+    "++"
+    "--"
+] @operator
+
+; Send Expressions
+"!" @operator
 
 [
     (atom)
@@ -45,5 +81,20 @@
 ] @number
 
 (var) @variable
+
+(function_clause
+    name: _ @function)
+
+[
+    (module_attribute "(" @open ")" @close)
+    (pp_define "(" @open ")" @close)
+    (spec)
+] @keyword
+
+(expr_args "(" @open ")" @close)
+
+(remote
+    module: (remote_module module: (atom) @type)
+    fun: (atom) @function)
 
 (comment) @comment

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -57,6 +57,7 @@
     "!"
     "|"
     "->"
+    "::"
 ] @operator
 
 (unary_op_expr) @operator
@@ -70,28 +71,33 @@
 ] @number
 (var) @variable
 
-(function_clause
-    name: _ @function)
-
 [
-    (module_attribute "(" @open ")" @close)
-    (pp_define "(" @open ")" @close)
+    (module_attribute)
+    (pp_define)
+    (pp_include)
     (spec)
-    (record_decl "(" @open ")" @close)
+    (record_decl)
+    (export_attribute)
+    (compile_options_attribute)
 ] @keyword
 
+(wild_attribute
+    name: (attr_name
+            "-" @keyword
+            name: (atom) @keyword))
+
+[ "(" "{" "[" ] @open
+[ ")" "}" "]" ] @close
+
+(function_clause name: _ @function)
 (spec fun: (atom) @function)
-
-(expr_args "(" @open ")" @close)
-
+(fa fun: (atom) @function)
+(call expr: (atom) @function)
 (external_fun
     module: (module name: (atom) @type)
     fun: (atom) @function)
-
 (remote
     module: (remote_module module: (atom) @type)
     fun: (atom) @function)
-
-(call expr: (atom) @function)
 
 (comment) @comment

--- a/crates/zed/src/languages/erlang/highlights.scm
+++ b/crates/zed/src/languages/erlang/highlights.scm
@@ -57,6 +57,7 @@
     "!"
     "|"
     "->"
+    ":"
     "::"
 ] @operator
 
@@ -86,8 +87,14 @@
             "-" @keyword
             name: (atom) @keyword))
 
-[ "(" "{" "[" ] @open
-[ ")" "}" "]" ] @close
+[
+    "("
+    ")"
+    "{"
+    "}"
+    "["
+    "]"
+] @punctuation.bracket
 
 (function_clause name: _ @function)
 (spec fun: (atom) @function)
@@ -99,5 +106,7 @@
 (remote
     module: (remote_module module: (atom) @type)
     fun: (atom) @function)
+
+(record_name name: (atom) @type)
 
 (comment) @comment

--- a/docs/src/languages/erlang.md
+++ b/docs/src/languages/erlang.md
@@ -1,0 +1,3 @@
+# Erlang
+
+- Tree Sitter: [tree-sitter-erlang](https://github.com/WhatsApp/tree-sitter-erlang)


### PR DESCRIPTION
This PR adds Erlang syntax highlight by using [`tree-sitter-erlang`](https://github.com/WhatsApp/tree-sitter-erlang) as a grammar. The highlights query write by hand instead of copying from the source because of I'm not sure it can copy due to LICENSE.

This PR didn't include indent, outline or LSP to scope down the PR size. But I can continue on later PR.  

Release Notes:

- Added Erlang syntax highlights ([#4939](https://github.com/zed-industries/zed/issues/4939)).
