### PR TITLE
Only `impl Global` for `DebugBelow` when compiling with `debug_assertions`

### DIFF
--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -14,12 +14,13 @@ pub use taffy::style::{
     Overflow, Position,
 };
 
-#[cfg(debug_assertions)]
 /// Use this struct for interfacing with the 'debug_below' styling from your own elements.
 /// If a parent element has this style set on it, then this struct will be set as a global in
 /// GPUI.
+#[cfg(debug_assertions)]
 pub struct DebugBelow;
 
+#[cfg(debug_assertions)]
 impl Global for DebugBelow {}
 
 /// The CSS styling that can be applied to an element via the `Styled` trait


### PR DESCRIPTION
This PR fixes this error when compiling a release build:

<img width="504" alt="Screenshot 2024-01-30 at 2 30 38 PM" src="https://github.com/zed-industries/zed/assets/1486634/96470735-2b9e-4945-b4c3-c86ef0168b8c">

`DebugBelow` only exists when compiling with `debug_assertions`, so we only want to implement it using that same criterion.

Release Notes:

- N/A
