### PR TITLE
 Add LSP support for Elm

### DIFF
--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -13,6 +13,7 @@ mod c;
 mod css;
 mod deno;
 mod elixir;
+mod elm;
 mod gleam;
 mod go;
 mod haskell;
@@ -271,7 +272,11 @@ pub fn init(
             node_runtime.clone(),
         ))],
     );
-    language("elm", tree_sitter_elm::language(), vec![]);
+    language(
+        "elm",
+        tree_sitter_elm::language(),
+        vec![Arc::new(elm::ElmLspAdapter::new(node_runtime.clone()))],
+    );
     language("glsl", tree_sitter_glsl::language(), vec![]);
     language("nix", tree_sitter_nix::language(), vec![]);
     language(

--- a/crates/zed/src/languages/elm.rs
+++ b/crates/zed/src/languages/elm.rs
@@ -1,0 +1,122 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use node_runtime::NodeRuntime;
+use smol::fs;
+use std::{
+    any::Any,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::ResultExt;
+
+const SERVER_PATH: &'static str = "node_modules/@elm-tooling/elm-language-server/out/node/index.js";
+
+fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
+    vec![server_path.into(), "--stdio".into()]
+}
+
+pub struct ElmLspAdapter {
+    node: Arc<dyn NodeRuntime>,
+}
+
+impl ElmLspAdapter {
+    pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
+        ElmLspAdapter { node }
+    }
+}
+
+#[async_trait]
+impl LspAdapter for ElmLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("elm-language-server".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "elmLS"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(
+            self.node
+                .npm_package_latest_version("@elm-tooling/elm-language-server")
+                .await?,
+        ) as Box<_>)
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let version = version.downcast::<String>().unwrap();
+        let server_path = container_dir.join(SERVER_PATH);
+
+        if fs::metadata(&server_path).await.is_err() {
+            self.node
+                .npm_install_packages(
+                    &container_dir,
+                    &[("@elm-tooling/elm-language-server", version.as_str())],
+                )
+                .await?;
+        }
+
+        Ok(LanguageServerBinary {
+            path: self.node.binary_path().await?,
+            arguments: server_binary_arguments(&server_path),
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir, &*self.node).await
+    }
+
+    async fn installation_test_binary(
+        &self,
+        container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir, &*self.node).await
+    }
+}
+
+async fn get_cached_server_binary(
+    container_dir: PathBuf,
+    node: &dyn NodeRuntime,
+) -> Option<LanguageServerBinary> {
+    (|| async move {
+        let mut last_version_dir = None;
+        let mut entries = fs::read_dir(&container_dir).await?;
+        while let Some(entry) = entries.next().await {
+            let entry = entry?;
+            if entry.file_type().await?.is_dir() {
+                last_version_dir = Some(entry.path());
+            }
+        }
+        let last_version_dir = last_version_dir.ok_or_else(|| anyhow!("no cached binary"))?;
+        let server_path = last_version_dir.join(SERVER_PATH);
+        if server_path.exists() {
+            Ok(LanguageServerBinary {
+                path: node.binary_path().await?,
+                arguments: server_binary_arguments(&server_path),
+            })
+        } else {
+            Err(anyhow!(
+                "missing executable in directory {:?}",
+                last_version_dir
+            ))
+        }
+    })()
+    .await
+    .log_err()
+}

--- a/docs/src/languages/elm.md
+++ b/docs/src/languages/elm.md
@@ -1,4 +1,4 @@
 # Elm
 
 - Tree Sitter: [tree-sitter-elm](https://github.com/elm-tooling/tree-sitter-elm)
-- Language Server: N/A
+- Language Server: [elm-language-server](https://github.com/elm-tooling/elm-language-server)


### PR DESCRIPTION
Hi folks! This is a promised PR from @absynce and me to add LSP support for Elm (closes #4595).

There are a couple things that need to be improved in [elm-language-server](https://github.com/elm-tooling/elm-language-server), but this is already looking good.

One interesting bit that we've discovered: the progress percentage is not rounded in the [vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node/issues/1412) package according to the LSP spec. Other language servers based on this package may be suffering from this too. 

Release Notes:

- Added LSP support for Elm ([#4595](https://github.com/zed-industries/zed/issues/4595)).
