### PR TITLE
Restrict access to global `Audio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
+ "derive_more",
  "futures 0.3.28",
  "gpui",
  "log",

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -10,14 +10,12 @@ path = "src/audio.rs"
 doctest = false
 
 [dependencies]
-gpui = { path = "../gpui" }
-collections = { path = "../collections" }
-util = { path = "../util" }
-
-
-rodio ={version = "0.17.1", default-features=false, features = ["wav"]}
-
-log.workspace = true
-futures.workspace = true
 anyhow.workspace = true
+collections = { path = "../collections" }
+derive_more.workspace = true
+futures.workspace = true
+gpui = { path = "../gpui" }
+log.workspace = true
 parking_lot.workspace = true
+rodio = { version = "0.17.1", default-features = false, features = ["wav"] }
+util = { path = "../util" }


### PR DESCRIPTION
This PR restricts access to the `Audio` global to force consumers to go through the `Audio` public interface to interact with it.

Release Notes:

- N/A
