### PR TITLE
Attempt to fix a panic in worktree scanning

### DIFF
--- a/crates/project/src/worktree.rs
+++ b/crates/project/src/worktree.rs
@@ -3867,7 +3867,7 @@ impl BackgroundScanner {
                     fs_entry.is_ignored = ignore_stack.is_abs_path_ignored(&abs_path, is_dir);
                     fs_entry.is_external = !canonical_path.starts_with(&root_canonical_path);
 
-                    if !is_dir && !fs_entry.is_ignored {
+                    if !is_dir && !fs_entry.is_ignored && !fs_entry.is_external {
                         if let Some((work_dir, repo)) = state.snapshot.local_repo_for_path(path) {
                             if let Ok(repo_path) = path.strip_prefix(work_dir.0) {
                                 let repo_path = RepoPath(repo_path.into());


### PR DESCRIPTION
Somehow (and this should be investigated separately) we're ending up
with paths that look like: /path/to/project/../../path/to/dependency,
these pass the Ok(repo_path) = path.strip_prefix(), but then fail.

Release Notes:

- Fixed (hopefully) a panic that could occur due to path confusing in git status
