### PR TITLE
theme_importer: Add ability to print theme JSON schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8207,6 +8207,7 @@ dependencies = [
  "palette",
  "pathfinder_color",
  "rust-embed",
+ "schemars",
  "serde",
  "serde_json",
  "simplelog",

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -18,6 +18,7 @@ log.workspace = true
 palette = { version = "0.7.3", default-features = false, features = ["std"] }
 pathfinder_color = "0.5"
 rust-embed.workspace = true
+schemars = { workspace = true, features = ["indexmap"] }
 serde.workspace = true
 serde_json.workspace = true
 simplelog = "0.9"


### PR DESCRIPTION
This PR adds a quick subcommand to the `theme_importer` to facilitate printing out the JSON schema for a theme.

Note that you do need to pass a `<PATH>` to the subcommand still, even though it will be ignored. I'll rework the CLI to this at some point.

The JSON schema for the current version of the theme can also be found at [`https://zed.dev/schema/themes/v0.1.0.json`](https://zed.dev/schema/themes/v0.1.0.json).

Release Notes:

- N/A
