### PR TITLE
app version to server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
  "prometheus",
  "prost 0.8.0",
  "rand 0.8.5",
+ "release_channel",
  "reqwest",
  "rpc",
  "scrypt",

--- a/crates/channel/src/channel_store_tests.rs
+++ b/crates/channel/src/channel_store_tests.rs
@@ -329,6 +329,7 @@ async fn test_channel_messages(cx: &mut TestAppContext) {
 fn init_test(cx: &mut AppContext) -> Model<ChannelStore> {
     let settings_store = SettingsStore::test(cx);
     cx.set_global(settings_store);
+    release_channel::init("0.0.0", cx);
     client::init_settings(cx);
 
     let http = FakeHttpClient::with_404_response();

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -15,14 +15,13 @@ use futures::{
     TryFutureExt as _, TryStreamExt,
 };
 use gpui::{
-    actions, AnyModel, AnyWeakModel, AppContext, AsyncAppContext, Global, Model, SemanticVersion,
-    Task, WeakModel,
+    actions, AnyModel, AnyWeakModel, AppContext, AsyncAppContext, Global, Model, Task, WeakModel,
 };
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use postage::watch;
 use rand::prelude::*;
-use release_channel::ReleaseChannel;
+use release_channel::{AppVersion, ReleaseChannel};
 use rpc::proto::{AnyTypedEnvelope, EntityMessage, EnvelopedMessage, PeerId, RequestMessage};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -58,9 +57,6 @@ lazy_static! {
     pub static ref ADMIN_API_TOKEN: Option<String> = std::env::var("ZED_ADMIN_API_TOKEN")
         .ok()
         .and_then(|s| if s.is_empty() { None } else { Some(s) });
-    pub static ref ZED_APP_VERSION: Option<SemanticVersion> = std::env::var("ZED_APP_VERSION")
-        .ok()
-        .and_then(|v| v.parse().ok());
     pub static ref ZED_APP_PATH: Option<PathBuf> =
         std::env::var("ZED_APP_PATH").ok().map(PathBuf::from);
     pub static ref ZED_ALWAYS_ACTIVE: bool =
@@ -1011,13 +1007,22 @@ impl Client {
             .update(|cx| ReleaseChannel::try_global(cx))
             .ok()
             .flatten();
+        let app_version = cx
+            .update(|cx| AppVersion::global(cx).to_string())
+            .ok()
+            .unwrap_or_default();
 
         let request = Request::builder()
             .header(
                 "Authorization",
                 format!("{} {}", credentials.user_id, credentials.access_token),
             )
-            .header("x-zed-protocol-version", rpc::PROTOCOL_VERSION);
+            .header("x-zed-protocol-version", rpc::PROTOCOL_VERSION)
+            .header("x-zed-app-version", app_version)
+            .header(
+                "x-zed-release-channel",
+                release_channel.map(|r| r.dev_name()).unwrap_or("unknown"),
+            );
 
         let http = self.http.clone();
         cx.background_executor().spawn(async move {

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -61,6 +61,7 @@ util = { path = "../util" }
 uuid.workspace = true
 
 [dev-dependencies]
+release_channel = { path = "../release_channel" }
 async-trait.workspace = true
 audio = { path = "../audio" }
 call = { path = "../call", features = ["test-support"] }

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -153,6 +153,7 @@ impl TestServer {
             }
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
+            release_channel::init("0.0.0", cx);
             client::init_settings(cx);
         });
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -11,7 +11,7 @@ use crate::{
     Pixels, PlatformInput, Point, RenderGlyphParams, RenderImageParams, RenderSvgParams, Scene,
     SharedString, Size, Task, TaskLabel, WindowContext,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use async_task::Runnable;
 use futures::channel::oneshot;
 use parking::Unparker;
@@ -23,11 +23,10 @@ use std::hash::{Hash, Hasher};
 use std::time::Duration;
 use std::{
     any::Any,
-    fmt::{self, Debug, Display},
+    fmt::{self, Debug},
     ops::Range,
     path::{Path, PathBuf},
     rc::Rc,
-    str::FromStr,
     sync::Arc,
 };
 use uuid::Uuid;
@@ -39,6 +38,7 @@ pub(crate) use mac::*;
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) use test::*;
 use time::UtcOffset;
+pub use util::SemanticVersion;
 
 #[cfg(target_os = "macos")]
 pub(crate) fn current_platform() -> Rc<dyn Platform> {
@@ -694,45 +694,6 @@ pub enum CursorStyle {
 impl Default for CursorStyle {
     fn default() -> Self {
         Self::Arrow
-    }
-}
-
-/// A datastructure representing a semantic version number
-#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct SemanticVersion {
-    major: usize,
-    minor: usize,
-    patch: usize,
-}
-
-impl FromStr for SemanticVersion {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let mut components = s.trim().split('.');
-        let major = components
-            .next()
-            .ok_or_else(|| anyhow!("missing major version number"))?
-            .parse()?;
-        let minor = components
-            .next()
-            .ok_or_else(|| anyhow!("missing minor version number"))?
-            .parse()?;
-        let patch = components
-            .next()
-            .ok_or_else(|| anyhow!("missing patch version number"))?
-            .parse()?;
-        Ok(Self {
-            major,
-            minor,
-            patch,
-        })
-    }
-}
-
-impl Display for SemanticVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
     }
 }
 

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -1,4 +1,4 @@
-use gpui::{AppContext, AsyncAppContext, Global, SemanticVersion};
+use gpui::{AppContext, Global, SemanticVersion};
 use once_cell::sync::Lazy;
 use std::env;
 
@@ -49,15 +49,12 @@ pub struct AppVersion;
 impl AppVersion {
     pub fn init(pkg_version: &str, cx: &mut AppContext) {
         let version = if let Some(from_env) = env::var("ZED_APP_VERSION").ok() {
-            dbg!(from_env).parse().expect("invalid ZED_APP_VERSION")
+            from_env.parse().expect("invalid ZED_APP_VERSION")
         } else {
-            dbg!(cx.app_metadata().app_version).unwrap_or_else(|| {
-                dbg!(pkg_version)
-                    .parse()
-                    .expect("invalid version in Cargo.toml")
-            })
+            cx.app_metadata()
+                .app_version
+                .unwrap_or_else(|| pkg_version.parse().expect("invalid version in Cargo.toml"))
         };
-        println!("Zed version: {}", version);
         cx.set_global(GlobalAppVersion(version))
     }
 

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -76,11 +76,12 @@ struct GlobalReleaseChannel(ReleaseChannel);
 
 impl Global for GlobalReleaseChannel {}
 
-impl ReleaseChannel {
-    pub fn init(cx: &mut AppContext) {
-        cx.set_global(GlobalReleaseChannel(*RELEASE_CHANNEL))
-    }
+pub fn init(pkg_version: &str, cx: &mut AppContext) {
+    AppVersion::init(pkg_version, cx);
+    cx.set_global(GlobalReleaseChannel(*RELEASE_CHANNEL))
+}
 
+impl ReleaseChannel {
     pub fn global(cx: &AppContext) -> Self {
         cx.global::<GlobalReleaseChannel>().0
     }

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Context, Result};
 use collections::{btree_map, hash_map, BTreeMap, HashMap};
 use gpui::{AppContext, AsyncAppContext, Global};
 use lazy_static::lazy_static;
-use release_channel::ReleaseChannel;
 use schemars::{gen::SchemaGenerator, schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Deserialize as _, Serialize};
 use smallvec::SmallVec;
@@ -210,7 +209,7 @@ impl SettingsStore {
 
             if let Some(release_settings) = &self
                 .raw_user_settings
-                .get(ReleaseChannel::global(cx).dev_name())
+                .get(&*release_channel::RELEASE_CHANNEL.dev_name())
             {
                 if let Some(release_settings) = setting_value
                     .deserialize_setting(&release_settings)
@@ -543,7 +542,7 @@ impl SettingsStore {
 
             if let Some(release_settings) = &self
                 .raw_user_settings
-                .get(ReleaseChannel::global(cx).dev_name())
+                .get(&*release_channel::RELEASE_CHANNEL.dev_name())
             {
                 if let Some(release_settings) = setting_value
                     .deserialize_setting(&release_settings)

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use collections::{btree_map, hash_map, BTreeMap, HashMap};
 use gpui::{AppContext, AsyncAppContext, Global};
 use lazy_static::lazy_static;
+use release_channel::ReleaseChannel;
 use schemars::{gen::SchemaGenerator, schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Deserialize as _, Serialize};
 use smallvec::SmallVec;
@@ -209,7 +210,7 @@ impl SettingsStore {
 
             if let Some(release_settings) = &self
                 .raw_user_settings
-                .get(&*release_channel::RELEASE_CHANNEL_NAME)
+                .get(ReleaseChannel::global(cx).dev_name())
             {
                 if let Some(release_settings) = setting_value
                     .deserialize_setting(&release_settings)
@@ -542,7 +543,7 @@ impl SettingsStore {
 
             if let Some(release_settings) = &self
                 .raw_user_settings
-                .get(&*release_channel::RELEASE_CHANNEL_NAME)
+                .get(ReleaseChannel::global(cx).dev_name())
             {
                 if let Some(release_settings) = setting_value
                     .deserialize_setting(&release_settings)

--- a/crates/util/src/semantic_version.rs
+++ b/crates/util/src/semantic_version.rs
@@ -1,0 +1,46 @@
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+
+/// A datastructure representing a semantic version number
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct SemanticVersion {
+    pub major: usize,
+    pub minor: usize,
+    pub patch: usize,
+}
+
+impl FromStr for SemanticVersion {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let mut components = s.trim().split('.');
+        let major = components
+            .next()
+            .ok_or_else(|| anyhow!("missing major version number"))?
+            .parse()?;
+        let minor = components
+            .next()
+            .ok_or_else(|| anyhow!("missing minor version number"))?
+            .parse()?;
+        let patch = components
+            .next()
+            .ok_or_else(|| anyhow!("missing patch version number"))?
+            .parse()?;
+        Ok(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl Display for SemanticVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -3,6 +3,7 @@ pub mod fs;
 pub mod github;
 pub mod http;
 pub mod paths;
+mod semantic_version;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test;
 
@@ -10,6 +11,7 @@ pub use backtrace::Backtrace;
 use futures::Future;
 use lazy_static::lazy_static;
 use rand::{seq::SliceRandom, Rng};
+pub use semantic_version::SemanticVersion;
 use std::{
     borrow::Cow,
     cmp::{self, Ordering},

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -20,7 +20,7 @@ use log::LevelFilter;
 use assets::Assets;
 use node_runtime::RealNodeRuntime;
 use parking_lot::Mutex;
-use release_channel::{parse_zed_link, AppCommitSha, AppVersion, ReleaseChannel, RELEASE_CHANNEL};
+use release_channel::{parse_zed_link, AppCommitSha, ReleaseChannel, RELEASE_CHANNEL};
 use serde::{Deserialize, Serialize};
 use settings::{
     default_settings, handle_settings_file_changes, watch_config_file, Settings, SettingsStore,
@@ -115,8 +115,7 @@ fn main() {
     });
 
     app.run(move |cx| {
-        ReleaseChannel::init(cx);
-        AppVersion::init(env!("CARGO_PKG_VERSION"), cx);
+        release_channel::init(env!("CARGO_PKG_VERSION"), cx);
         if let Some(build_sha) = option_env!("ZED_COMMIT_SHA") {
             AppCommitSha::set_global(AppCommitSha(build_sha.into()), cx);
         }


### PR DESCRIPTION
- Send app version and release stage to collab on connect
- Read the new header on the server

Release Notes:

- Added the ability to collaborate with users on different releases of Zed. 
