### PR TITLE
Permalink add Gitee host support

### DIFF
--- a/crates/editor/src/git/permalink.rs
+++ b/crates/editor/src/git/permalink.rs
@@ -7,6 +7,7 @@ use url::Url;
 enum GitHostingProvider {
     Github,
     Gitlab,
+    Gitee,
 }
 
 impl GitHostingProvider {
@@ -14,6 +15,7 @@ impl GitHostingProvider {
         let base_url = match self {
             Self::Github => "https://github.com",
             Self::Gitlab => "https://gitlab.com",
+            Self::Gitee => "https://gitee.com",
         };
 
         Url::parse(&base_url).unwrap()
@@ -26,7 +28,7 @@ impl GitHostingProvider {
             let line = selection.start.row + 1;
 
             match self {
-                Self::Github | Self::Gitlab => format!("L{}", line),
+                Self::Github | Self::Gitlab | Self::Gitee => format!("L{}", line),
             }
         } else {
             let start_line = selection.start.row + 1;
@@ -35,6 +37,7 @@ impl GitHostingProvider {
             match self {
                 Self::Github => format!("L{}-L{}", start_line, end_line),
                 Self::Gitlab => format!("L{}-{}", start_line, end_line),
+                Self::Gitee => format!("L{}-{}", start_line, end_line),
             }
         }
     }
@@ -65,6 +68,7 @@ pub fn build_permalink(params: BuildPermalinkParams) -> Result<Url> {
     let path = match provider {
         GitHostingProvider::Github => format!("{owner}/{repo}/blob/{sha}/{path}"),
         GitHostingProvider::Gitlab => format!("{owner}/{repo}/-/blob/{sha}/{path}"),
+        GitHostingProvider::Gitee => format!("{owner}/{repo}/blob/{sha}/{path}"),
     };
     let line_fragment = selection.map(|selection| provider.line_fragment(&selection));
 
@@ -106,6 +110,21 @@ fn parse_git_remote_url(url: &str) -> Option<ParsedGitRemote> {
 
         return Some(ParsedGitRemote {
             provider: GitHostingProvider::Gitlab,
+            owner,
+            repo,
+        });
+    }
+
+    if url.starts_with("git@gitee.com:") || url.starts_with("https://gitee.com/") {
+        let repo_with_owner = url
+            .trim_start_matches("git@gitee.com:")
+            .trim_start_matches("https://gitee.com/")
+            .trim_end_matches(".git");
+
+        let (owner, repo) = repo_with_owner.split_once("/")?;
+
+        return Some(ParsedGitRemote {
+            provider: GitHostingProvider::Gitee,
             owner,
             repo,
         });
@@ -283,6 +302,89 @@ mod tests {
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L24-48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_gitee_permalink_from_ssh_url() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitee.com:libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_gitee_permalink_from_ssh_url_single_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitee.com:libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_gitee_permalink_from_ssh_url_multi_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitee.com:libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L24-48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_gitee_permalink_from_https_url() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitee.com/libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/zed/src/main.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_gitee_permalink_from_https_url_single_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitee.com/libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_gitee_permalink_from_https_url_multi_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitee.com/libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
+        .unwrap();
+        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs#L24-48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }


### PR DESCRIPTION
China's largest git code hosting platform
About Gitee: https://gitee.com/about_us

Release Notes:

- Added Gitee host support   with Git-Permalink
