### PR TITLE
languages: add highlighting for go.mod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8791,6 +8791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-gomod"
+version = "1.0.2"
+source = "git+https://github.com/camdencheek/tree-sitter-go-mod#bbe2fe3be4b87e06a613e685250f473d2267f430"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-haskell"
 version = "0.14.0"
 source = "git+https://github.com/tree-sitter/tree-sitter-haskell?rev=cf98de23e4285b8e6bcb57b050ef2326e2cc284b#cf98de23e4285b8e6bcb57b050ef2326e2cc284b"
@@ -10316,6 +10325,7 @@ dependencies = [
  "tree-sitter-gleam",
  "tree-sitter-glsl",
  "tree-sitter-go",
+ "tree-sitter-gomod",
  "tree-sitter-haskell",
  "tree-sitter-heex",
  "tree-sitter-html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ tree-sitter-embedded-template = "0.20.0"
 tree-sitter-gleam = { git = "https://github.com/gleam-lang/tree-sitter-gleam", rev = "58b7cac8fc14c92b0677c542610d8738c373fa81" }
 tree-sitter-glsl = { git = "https://github.com/theHamsta/tree-sitter-glsl", rev = "2a56fb7bc8bb03a1892b4741279dd0a8758b7fb3" }
 tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = "aeb2f33b366fd78d5789ff104956ce23508b85db" }
+tree-sitter-gomod = { git = "https://github.com/camdencheek/tree-sitter-go-mod" }
 tree-sitter-haskell = { git = "https://github.com/tree-sitter/tree-sitter-haskell", rev = "cf98de23e4285b8e6bcb57b050ef2326e2cc284b" }
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
 tree-sitter-html = "0.19.0"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -115,6 +115,7 @@ tree-sitter-embedded-template.workspace = true
 tree-sitter-gleam.workspace = true
 tree-sitter-glsl.workspace = true
 tree-sitter-go.workspace = true
+tree-sitter-gomod.workspace = true
 tree-sitter-haskell.workspace = true
 tree-sitter-heex.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -122,6 +122,7 @@ pub fn init(
         tree_sitter_go::language(),
         vec![Arc::new(go::GoLspAdapter)],
     );
+    language("gomod", tree_sitter_gomod::language(), vec![]);
     language(
         "zig",
         tree_sitter_zig::language(),

--- a/crates/zed/src/languages/gomod/config.toml
+++ b/crates/zed/src/languages/gomod/config.toml
@@ -1,0 +1,7 @@
+name = "Go Mod"
+path_suffixes = ["mod"]
+line_comments = ["//"]
+autoclose_before = ")"
+brackets = [
+    { start = "(", end = ")", close = true, newline = true}
+]

--- a/crates/zed/src/languages/gomod/highlights.scm
+++ b/crates/zed/src/languages/gomod/highlights.scm
@@ -1,0 +1,18 @@
+[
+  "require"
+  "replace"
+  "go"
+  "toolchain"
+  "exclude"
+  "retract"
+  "module"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string

--- a/crates/zed/src/languages/gomod/structure.scm
+++ b/crates/zed/src/languages/gomod/structure.scm
@@ -1,0 +1,29 @@
+(require_directive
+  "require" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(exclude_directive
+  "exclude" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(module_directive
+  "module" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(replace_directive
+  "replace" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(retract_directive
+  "retract" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)


### PR DESCRIPTION

Release Notes:

- Added syntax highlighting for go.mod files. Fixes #7133 

<img width="863" alt="image" src="https://github.com/zed-industries/zed/assets/8725798/dc521a02-c53a-44aa-b0c1-eebf31835679">
