### PR TITLE
Use mimalloc as default allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4094,6 +4094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,6 +4430,15 @@ dependencies = [
  "foreign-types 0.3.2",
  "log",
  "objc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -10275,6 +10294,7 @@ dependencies = [
  "log",
  "lsp",
  "menu",
+ "mimalloc",
  "node_runtime",
  "notifications",
  "num_cpus",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -66,6 +66,7 @@ libc = "0.2"
 log.workspace = true
 lsp = { path = "../lsp" }
 menu = { path = "../menu" }
+mimalloc = "0.1"
 node_runtime = { path = "../node_runtime" }
 notifications = { path = "../notifications" }
 num_cpus = "1.13.0"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -18,6 +18,7 @@ use language::LanguageRegistry;
 use log::LevelFilter;
 
 use assets::Assets;
+use mimalloc::MiMalloc;
 use node_runtime::RealNodeRuntime;
 use parking_lot::Mutex;
 use release_channel::{parse_zed_link, AppCommitSha, ReleaseChannel, RELEASE_CHANNEL};
@@ -56,6 +57,9 @@ use zed::{
     handle_keymap_file_changes, initialize_workspace, languages, IsOnlyInstance, OpenListener,
     OpenRequest,
 };
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
     menu::init();


### PR DESCRIPTION
From https://github.com/microsoft/mimalloc:
> In our benchmarks (see [below](https://github.com/microsoft/mimalloc#performance)), mimalloc outperforms other leading allocators (jemalloc, tcmalloc, Hoard, etc), and often uses less memory. A nice property is that it does consistently well over a wide range of benchmarks. There is also good huge OS page support for larger server programs.


Release Notes:

- Changed default allocator to mimalloc.
