### PR TITLE
Add ability to navigate to/from docks via keybindings

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -502,5 +502,18 @@
       "enter": "vim::SearchSubmit",
       "escape": "buffer_search::Dismiss"
     }
+  },
+  {
+    "context": "Dock",
+    "bindings": {
+      "ctrl-w h": ["workspace::ActivatePaneInDirection", "Left"],
+      "ctrl-w l": ["workspace::ActivatePaneInDirection", "Right"],
+      "ctrl-w k": ["workspace::ActivatePaneInDirection", "Up"],
+      "ctrl-w j": ["workspace::ActivatePaneInDirection", "Down"],
+      "ctrl-w ctrl-h": ["workspace::ActivatePaneInDirection", "Left"],
+      "ctrl-w ctrl-l": ["workspace::ActivatePaneInDirection", "Right"],
+      "ctrl-w ctrl-k": ["workspace::ActivatePaneInDirection", "Up"],
+      "ctrl-w ctrl-j": ["workspace::ActivatePaneInDirection", "Down"]
+    }
   }
 ]

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -3,8 +3,9 @@ use crate::DraggedDock;
 use crate::{status_bar::StatusItemView, Workspace};
 use gpui::{
     div, px, Action, AnchorCorner, AnyView, AppContext, Axis, ClickEvent, Entity, EntityId,
-    EventEmitter, FocusHandle, FocusableView, IntoElement, MouseButton, ParentElement, Render,
-    SharedString, Styled, Subscription, View, ViewContext, VisualContext, WeakView, WindowContext,
+    EventEmitter, FocusHandle, FocusableView, IntoElement, KeyContext, MouseButton, ParentElement,
+    Render, SharedString, Styled, Subscription, View, ViewContext, VisualContext, WeakView,
+    WindowContext,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -534,10 +535,18 @@ impl Dock {
             DockPosition::Right => crate::ToggleRightDock.boxed_clone(),
         }
     }
+
+    fn dispatch_context() -> KeyContext {
+        let mut dispatch_context = KeyContext::default();
+        dispatch_context.add("Dock");
+
+        dispatch_context
+    }
 }
 
 impl Render for Dock {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let dispatch_context = Self::dispatch_context();
         if let Some(entry) = self.visible_entry() {
             let size = entry.panel.size(cx);
 
@@ -588,6 +597,7 @@ impl Render for Dock {
             }
 
             div()
+                .key_context(dispatch_context)
                 .track_focus(&self.focus_handle)
                 .flex()
                 .bg(cx.theme().colors().panel_background)
@@ -612,7 +622,9 @@ impl Render for Dock {
                 )
                 .child(handle)
         } else {
-            div().track_focus(&self.focus_handle)
+            div()
+                .key_context(dispatch_context)
+                .track_focus(&self.focus_handle)
         }
     }
 }


### PR DESCRIPTION
This adds the ability to navigate to/from docks (Terminal, Project, Collaboration, Assistant) via keybindings.

When using the `ActivatePaneInDirection` keybinding from the left/bottom/right dock, we check whether the movement is towards the center panel. If it is, we focus the last active pane.

Fixes https://github.com/zed-industries/zed/issues/6833 and it came up in a few other tickes/discussions.

Release Notes:

- Added ability to navigate to docks and back to the editor using the `workspace::ActivatePaneInDirection` action (by default bound to `Ctrl-w [hjkl]` in Vim mode). ([#6833](https://github.com/zed-industries/zed/issues/6833)).

## Drawback

There's this weird behavior: if you start Zed and no files are opened, you focus terminal, go left (project panel), then back to right to terminal, the terminal isn't focused. Even though we focus it in the code.

Maybe this is a bug in the current focus handling code?

## Demo

https://github.com/zed-industries/zed/assets/1185253/5d56db40-36aa-4758-a3bc-7a0de20ce5d7



