### PR TITLE
Don't panic when collaborating with older Zed versions

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2784,8 +2784,10 @@ impl Workspace {
                         item_tasks.push(task);
                         leader_view_ids.push(id);
                         break;
-                    } else {
-                        assert!(variant.is_some());
+                    } else if variant.is_none() {
+                        Err(anyhow!(
+                            "failed to construct view from leader (maybe from a different version of zed?)"
+                        ))?;
                     }
                 }
             }


### PR DESCRIPTION
Older Zed versions may send a buffer id of 0, which is no-longer
supported. (as of #6993)

This doesn't fix that, but it does ensure that we don't panic in the
workspace by maintaining the invariant that from_proto_state returns
Some(Task) if the variant matches.

It also converts the panic to an error should something similar happen
again in the future.


Release Notes:

- N/A
