### PR TITLE
Adjust heading levels in docs

### DIFF
--- a/docs/src/CODE_OF_CONDUCT.md
+++ b/docs/src/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -2,7 +2,7 @@
 
 ## Folder-specific settings
 
-Folder-specific settings are used to override Zed's global settings for files within a specific directory in the project panel.  To get started, create a `.zed` subdirectory and add a `settings.json` within it.  It should be noted that folder-specific settings don't need to live only a project's root, but can be defined at multiple levels in the project hierarchy.  In setups like this, Zed will find the configuration nearest to the file you are working in and apply those settings to it.  In most cases, this level of flexibility won't be needed and a single configuration for all files in a project is all that is required; the `Zed > Settings > Open Local Settings` menu action is built for this case.  Running this action will look for a `.zed/settings.json` file at the root of the first top-level directory in your project panel.  If it does not exist, it will create it.
+Folder-specific settings are used to override Zed's global settings for files within a specific directory in the project panel. To get started, create a `.zed` subdirectory and add a `settings.json` within it. It should be noted that folder-specific settings don't need to live only a project's root, but can be defined at multiple levels in the project hierarchy. In setups like this, Zed will find the configuration nearest to the file you are working in and apply those settings to it. In most cases, this level of flexibility won't be needed and a single configuration for all files in a project is all that is required; the `Zed > Settings > Open Local Settings` menu action is built for this case. Running this action will look for a `.zed/settings.json` file at the root of the first top-level directory in your project panel. If it does not exist, it will create it.
 
 The following global settings can be overridden with a folder-specific configuration:
 
@@ -20,7 +20,7 @@ The following global settings can be overridden with a folder-specific configura
 - `show_copilot_suggestions`
 - `show_whitespaces`
 
-*See the Global settings section for details about these settings*
+_See the Global settings section for details about these settings_
 
 ## Global settings
 
@@ -110,7 +110,7 @@ The name of any font family installed on the user's system
 
 **Options**
 
-Zed supports a subset of OpenType features that can be enabled or disabled for a given buffer or terminal font.  The following [OpenType features](https://en.wikipedia.org/wiki/List_of_typographic_features) can be enabled or disabled too: `calt`, `case`, `cpsp`, `frac`, `liga`, `onum`, `ordn`, `pnum`, `ss01`, `ss02`, `ss03`, `ss04`, `ss05`, `ss06`, `ss07`, `ss08`, `ss09`, `ss10`, `ss11`, `ss12`, `ss13`, `ss14`, `ss15`, `ss16`, `ss17`, `ss18`, `ss19`, `ss20`, `subs`, `sups`, `swsh`, `titl`, `tnum`, `zero`.
+Zed supports a subset of OpenType features that can be enabled or disabled for a given buffer or terminal font. The following [OpenType features](https://en.wikipedia.org/wiki/List_of_typographic_features) can be enabled or disabled too: `calt`, `case`, `cpsp`, `frac`, `liga`, `onum`, `ordn`, `pnum`, `ss01`, `ss02`, `ss03`, `ss04`, `ss05`, `ss06`, `ss07`, `ss08`, `ss09`, `ss10`, `ss11`, `ss12`, `ss13`, `ss14`, `ss15`, `ss16`, `ss17`, `ss18`, `ss19`, `ss20`, `subs`, `sups`, `swsh`, `titl`, `tnum`, `zero`.
 
 For example, to disable ligatures for a given font you can add the following to your settings:
 
@@ -1005,6 +1005,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 ```
 
 ### Default Width
+
 - Description: Customise default width taken by project panel
 - Setting: `default_width`
 - Default: N/A width in pixels (eg: 420)

--- a/docs/src/configuring_zed__configuring_vim.md
+++ b/docs/src/configuring_zed__configuring_vim.md
@@ -2,12 +2,12 @@
 
 Zed includes a vim emulation layer known as “vim mode”. This document aims to describe how it works, and how to make the most out of it.
 
-### Philosophy
+## Philosophy
 Vim mode in Zed is supposed to primarily "do what you expect": it mostly tries to copy vim exactly, but will use Zed-specific functionality when available to make things smoother.
 
 This means Zed will never be 100% vim compatible, but should be 100% vim familiar! We expect that our vim mode already copes with 90% of your workflow, and we'd like to keep improving it. If you find things that you can’t yet do in vim mode, but which you rely on in your current workflow, please leave feedback in the editor itself (`:feedback`), or [file an issue](https://github.com/zed-industries/zed/issues).
 
-### Zed-specific features
+## Zed-specific features
 Zed is built on a modern foundation that (among other things) uses tree-sitter to understand the content of the file you're editing, and supports multiple cursors out of the box.
 
 Vim mode has several "core Zed" key bindings, that will help you make the most of Zed's specific feature set.
@@ -45,7 +45,7 @@ Vim mode emulates visual block mode using Zed's multiple cursor support. This ag
 
 Finally, Vim mode's search and replace functionality is backed by Zed's. This means that the pattern syntax is slightly different, see the section on [Regex differences](#regex-differences) for details.
 
-### Custom key bindings
+## Custom key bindings
 Zed does not yet have an equivalent to vim’s `map` command to convert one set of keystrokes into another, however you can bind any sequence of keys to fire any Action documented in the  [Key bindings documentation](https://docs.zed.dev/configuration/key-bindings).
 
 You can edit your personal key bindings with `:keymap`.
@@ -84,7 +84,7 @@ You can see the bindings that are enabled by default in vim mode [here](https://
 
 The details of the context are a little out of scope for this doc, but suffice to say that `menu` is true when a menu is open (e.g. the completions menu), `VimWaiting` is true after you type `f` or `t` when we’re waiting for a new key (and you probably don’t want bindings to happen). Please reach out on [GitHub](https://github.com/zed-industries/zed) if you want help making a key bindings work.
 
-### Command palette
+## Command palette
 
 Vim mode allows you to enable Zed’s command palette with `:`. This means that you can use vim's command palette to run any action that Zed supports.
 
@@ -140,7 +140,7 @@ Currently supported vim-specific commands (as of Zed 0.106):
 ```
 
 
-### Related settings
+## Related settings
 There are a few Zed settings that you may also enjoy if you use vim mode:
 ```json
 {
@@ -153,7 +153,7 @@ There are a few Zed settings that you may also enjoy if you use vim mode:
 }
 ```
 
-### Regex differences
+## Regex differences
 
 Zed uses a different regular expression engine from Vim. This means that you will have to use a different syntax for some things.
 

--- a/docs/src/configuring_zed__configuring_vim.md
+++ b/docs/src/configuring_zed__configuring_vim.md
@@ -3,14 +3,17 @@
 Zed includes a vim emulation layer known as “vim mode”. This document aims to describe how it works, and how to make the most out of it.
 
 ## Philosophy
+
 Vim mode in Zed is supposed to primarily "do what you expect": it mostly tries to copy vim exactly, but will use Zed-specific functionality when available to make things smoother.
 
 This means Zed will never be 100% vim compatible, but should be 100% vim familiar! We expect that our vim mode already copes with 90% of your workflow, and we'd like to keep improving it. If you find things that you can’t yet do in vim mode, but which you rely on in your current workflow, please leave feedback in the editor itself (`:feedback`), or [file an issue](https://github.com/zed-industries/zed/issues).
 
 ## Zed-specific features
+
 Zed is built on a modern foundation that (among other things) uses tree-sitter to understand the content of the file you're editing, and supports multiple cursors out of the box.
 
 Vim mode has several "core Zed" key bindings, that will help you make the most of Zed's specific feature set.
+
 ```
 # Normal mode
 g d   Go to definition
@@ -46,7 +49,8 @@ Vim mode emulates visual block mode using Zed's multiple cursor support. This ag
 Finally, Vim mode's search and replace functionality is backed by Zed's. This means that the pattern syntax is slightly different, see the section on [Regex differences](#regex-differences) for details.
 
 ## Custom key bindings
-Zed does not yet have an equivalent to vim’s `map` command to convert one set of keystrokes into another, however you can bind any sequence of keys to fire any Action documented in the  [Key bindings documentation](https://docs.zed.dev/configuration/key-bindings).
+
+Zed does not yet have an equivalent to vim’s `map` command to convert one set of keystrokes into another, however you can bind any sequence of keys to fire any Action documented in the [Key bindings documentation](https://docs.zed.dev/configuration/key-bindings).
 
 You can edit your personal key bindings with `:keymap`.
 For vim-specific shortcuts, you may find the following template a good place to start:
@@ -95,6 +99,7 @@ We do not (yet) emulate the full power of vim’s command line, in particular we
 As mentioned above, one thing to be aware of is that the regex engine is slightly different from vim's in `:%s/a/b`.
 
 Currently supported vim-specific commands (as of Zed 0.106):
+
 ```
 # window management
 :w[rite][!], :wq[!], :q[uit][!], :wa[ll][!], :wqa[ll][!], :qa[ll][!], :[e]x[it][!], :up[date]
@@ -139,9 +144,10 @@ Currently supported vim-specific commands (as of Zed 0.106):
     to sort the current selection (with i, case-insensitively)
 ```
 
-
 ## Related settings
+
 There are a few Zed settings that you may also enjoy if you use vim mode:
+
 ```json
 {
   // disable cursor blink
@@ -149,7 +155,7 @@ There are a few Zed settings that you may also enjoy if you use vim mode:
   // use relative line numbers
   "relative_line_numbers": true,
   // hide the scroll bar
-  "scrollbar": {"show": "never"}
+  "scrollbar": { "show": "never" }
 }
 ```
 
@@ -158,12 +164,13 @@ There are a few Zed settings that you may also enjoy if you use vim mode:
 Zed uses a different regular expression engine from Vim. This means that you will have to use a different syntax for some things.
 
 Notably:
-* Vim uses `\(` and `\)` to represent capture groups, in Zed these are `(` and `)`.
-* On the flip side, `(` and `)` represent literal parentheses, but in Zed these must be escaped to `\(` and `\)`.
-* When replacing, Vim uses `\0` to represent the entire match, in Zed this is `$0`, same for numbered capture groups `\1` -> `$1`.
-* Vim uses `\<` and `\>` to represent word boundaries, in Zed these are both handled by `\b`
-* Vim uses `/g` to indicate "all matches on one line", in Zed this is implied
-* Vim uses `/i` to indicate "case-insensitive", in Zed you can either use `(?i)` at the start of the pattern or toggle case-sensitivity with `cmd-option-c`.
+
+- Vim uses `\(` and `\)` to represent capture groups, in Zed these are `(` and `)`.
+- On the flip side, `(` and `)` represent literal parentheses, but in Zed these must be escaped to `\(` and `\)`.
+- When replacing, Vim uses `\0` to represent the entire match, in Zed this is `$0`, same for numbered capture groups `\1` -> `$1`.
+- Vim uses `\<` and `\>` to represent word boundaries, in Zed these are both handled by `\b`
+- Vim uses `/g` to indicate "all matches on one line", in Zed this is implied
+- Vim uses `/i` to indicate "case-insensitive", in Zed you can either use `(?i)` at the start of the pattern or toggle case-sensitivity with `cmd-option-c`.
 
 To help with the transition, the command palette will fix parentheses and replace groups for you when you run `:%s//`. So `%s:/\(a\)(b)/\1/` will be converted into a search for "(a)\(b\)" and a replacement of "$1".
 

--- a/docs/src/configuring_zed__key_bindings.md
+++ b/docs/src/configuring_zed__key_bindings.md
@@ -1,16 +1,16 @@
 Zed can be configured via a simple JSON file located at `~/.config/zed/keymap.json`.
 
-### Predefined keymaps
+## Predefined keymaps
 
 We have a growing collection of pre-defined keymaps in [zed repository's keymaps folder](https://github.com/zed-industries/zed/tree/main/assets/keymaps).
 
-### Custom key bindings
+## Custom key bindings
 
-#### Accessing custom key bindings
+### Accessing custom key bindings
 
 You can open `keymap.json` via `⌘` + `K`, `⌘` + `S`, the command palette, or the `Zed > Settings > Open Key Bindings` application menu item.
 
-#### Adding a custom key binding
+### Adding a custom key binding
 
 To customize key bindings, specify a context and the list of bindings to set. Re-mapping an existing binding will clobber the existing binding in favor of the custom one.
 
@@ -33,9 +33,9 @@ You can see more examples in Zed's [`default.json`](https://zed.dev/ref/default.
 
 _There are some key bindings that can't be overridden; we are working on an issue surrounding this._
 
-### All key bindings
+## All key bindings
 
-#### Global
+### Global
 
 | **Command**                      | **Target**     | **Default Shortcut**          |
 | -------------------------------- | -------------- | ----------------------------- |
@@ -97,7 +97,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Reset buffer font size           | Zed            | `⌘` + `0`                     |
 | Toggle full screen               | Zed            | `Control` + `⌘` + `F`         |
 
-#### Editor
+### Editor
 
 | **Command**                      | **Target** | **Default Shortcut**                  |
 | -------------------------------- | ---------- | ------------------------------------- |
@@ -240,7 +240,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Undo selection                   | Editor     | `⌘` + `U`                             |
 | Unfold lines                     | Editor     | `Alt` + `⌘` + `]`                     |
 
-#### Editor (Full Only)
+### Editor (Full Only)
 
 | **Command**         | **Target**    | **Default Shortcut**    |
 | ------------------- | ------------- | ----------------------- |
@@ -258,14 +258,14 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Toggle              | Go To Line    | `Control` + `G`         |
 | Toggle              | Outline       | `⌘` + `Shift` + `O`     |
 
-#### Editor (Auto Height Only)
+### Editor (Auto Height Only)
 
 | **Command**   | **Target** | **Default Shortcut**          |
 | ------------- | ---------- | ----------------------------- |
 | Newline       | Editor     | `Control` + `Enter`           |
 | Newline below | Editor     | `Control` + `Shift` + `Enter` |
 
-#### Pane
+### Pane
 
 | **Command**            | **Target**     | **Default Shortcut** |
 | ---------------------- | -------------- | -------------------- |
@@ -300,7 +300,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Toggle replace         | Search         | `⌘` + `Shift` + `H`  |
 | Toggle whole word      | Search         | `Alt` + `⌘` + `W`    |
 
-#### Buffer Search Bar
+### Buffer Search Bar
 
 | **Command**            | **Target**    | **Default Shortcut** |
 | ---------------------- | ------------- | -------------------- |
@@ -315,7 +315,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Select next match      | Search        | `Enter`              |
 | Select prev match      | Search        | `Shift` + `Enter`    |
 
-#### Workspace
+### Workspace
 
 | **Command**        | **Target**        | **Default Shortcut** |
 | ------------------ | ----------------- | -------------------- |
@@ -344,7 +344,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Toggle right dock  | Workspace         | `⌘` + `R`            |
 | Open keymap        | Zed               | `⌘` + `K`, `⌘` + `S` |
 
-#### Project Panel
+### Project Panel
 
 | **Command**             | **Target**    | **Default Shortcut**        |
 | ----------------------- | ------------- | --------------------------- |
@@ -364,7 +364,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Rename                  | Project Panel | `F2`                        |
 | Reveal in finder        | Project Panel | `Alt` + `⌘` + `R`           |
 
-#### Project Search Bar
+### Project Search Bar
 
 | **Command**            | **Target**     | **Default Shortcut** |
 | ---------------------- | -------------- | -------------------- |
@@ -380,7 +380,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Replace next           | Search         | `Enter`              |
 | Toggle replace         | Search         | `⌘` + `Shift` + `H`  |
 
-#### Terminal
+### Terminal
 
 | **Command**                 | **Target** | **Default Shortcut**      |
 | --------------------------- | ---------- | ------------------------- |
@@ -394,7 +394,7 @@ _There are some key bindings that can't be overridden; we are working on an issu
 | Paste                       | Terminal   | `⌘` + `V`                 |
 | Show character palette      | Terminal   | `Control` + `⌘` + `Space` |
 
-#### Assistant Editor
+### Assistant Editor
 
 | **Command**        | **Target** | **Default Shortcut** |
 | ------------------ | ---------- | -------------------- |

--- a/docs/src/developing_zed__adding_languages.md
+++ b/docs/src/developing_zed__adding_languages.md
@@ -18,10 +18,10 @@ We use tree-sitter queries to match certain properties to highlight.
 
 ```ts
 const font: FontFamily = {
-    weight: "normal",
-    underline: false,
-    italic: false,
-}
+  weight: "normal",
+  underline: false,
+  italic: false,
+};
 ```
 
 Match a property identifier and highlight it using the identifier `@property`. In the above example, `weight`, `underline`, and `italic` would be highlighted.
@@ -40,7 +40,7 @@ Match a property identifier and highlight it using the identifier `@property`. I
 
 ```ts
 function buildDefaultSyntax(colorScheme: Theme): Partial<Syntax> {
-    // ...
+  // ...
 }
 ```
 

--- a/docs/src/developing_zed__building_zed.md
+++ b/docs/src/developing_zed__building_zed.md
@@ -15,21 +15,21 @@ git submodule update --init --recursive
 
 - Install [Xcode command line tools](https://developer.apple.com/xcode/resources/)
 
-    ```bash
-    xcode-select --install
-    ```
+  ```bash
+  xcode-select --install
+  ```
 
 - Ensure that the Xcode command line tools are using your newly installed copy of Xcode:
 
-    ```
-    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
-    ```
+  ```
+  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+  ```
 
 * Install the Rust wasm toolchain:
 
-    ```bash
-    rustup target add wasm32-wasi
-    ```
+  ```bash
+  rustup target add wasm32-wasi
+  ```
 
 ## Backend Dependencies
 
@@ -38,9 +38,9 @@ If you are developing collaborative features of Zed, you'll need to install the 
 - Install [Postgres](https://postgresapp.com)
 - Install [Livekit](https://formulae.brew.sh/formula/livekit) and [Foreman](https://formulae.brew.sh/formula/foreman)
 
-    ```bash
-    brew install livekit foreman
-    ```
+  ```bash
+  brew install livekit foreman
+  ```
 
 ## Building Zed from Source
 

--- a/docs/src/developing_zed__local_collaboration.md
+++ b/docs/src/developing_zed__local_collaboration.md
@@ -12,7 +12,7 @@ script/bootstrap
 
 This script will set up the `zed` Postgres database, and populate it with some users. It requires internet access, because it fetches some users from the GitHub API.
 
-The script will create several *admin* users, who you'll sign in as by default when developing locally. The GitHub logins for these default admin users are specified in this file:
+The script will create several _admin_ users, who you'll sign in as by default when developing locally. The GitHub logins for these default admin users are specified in this file:
 
 ```
 cat crates/collab/.admins.default.json

--- a/docs/src/feedback.md
+++ b/docs/src/feedback.md
@@ -1,29 +1,29 @@
 # Giving feedback
 
-### Zed repository
+## Zed repository
 
 We track our issues at [`zed-industries/zed`](https://github.com/zed-industries/zed/issues).
 
-#### Feature requests
+### Feature requests
 
 Try to focus on the things that are most critical to you rather than exhaustively listing all features another editor you have used has.
 
 Command palette: `request feature`
 
-#### Bug reports
+### Bug reports
 
 Try to add as much detail as possible, if it is not obvious to reproduce. Let us know how severe the problem is for you; is the issue more of a minor inconvenience or something that would prevent you from using Zed?
 
 Command palette: `file bug report`
 
-### In-app feedback
+## In-app feedback
 
 Anonymous feedback can be submitted from within Zed via the feedback editor (command palette: `give feedback`).
 
-### Zed forum
+## Zed forum
 
 Use the [Zed forum](https://github.com/zed-industries/zed/discussions) to ask questions and learn from one another. We will be present in the forum and answering questions as well.
 
-### Email
+## Email
 
 If you prefer to write up your thoughts as an email, you can send them to [hi@zed.dev](mailto:hi@zed.dev).

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -2,14 +2,14 @@
 
 Welcome to Zed! We are excited to have you. Here is a jumping-off point to getting started.
 
-### Download Zed
+## Download Zed
 
 You can obtain the release build via the [download page](https://zed.dev/download). After the first manual installation, Zed will periodically check for and install updates automatically for you.
 
-### Configure Zed
+## Configure Zed
 
 Use `⌘` + `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See Configuring Zed for all available settings.
 
-### Set up your key bindings
+## Set up your key bindings
 
 You can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use `⌘` + `K`, `⌘` + `S` to open your custom keymap to add your own key bindings. See Key Bindings for more info.

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -20,12 +20,12 @@ brew install elixir-ls
 3. Restart Zed
 
 {% hint style="warning" %}
-If `elixir-ls` is not running in an elixir project, check the error log via the command palette action `zed: open log`.  If you find an error message mentioning: `invalid LSP message header "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\") [Yn]`, you might need to install [`Hex`](https://hex.pm). You run `elixir-ls` from the command line and accept the prompt to install `Hex`.
+If `elixir-ls` is not running in an elixir project, check the error log via the command palette action `zed: open log`. If you find an error message mentioning: `invalid LSP message header "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\") [Yn]`, you might need to install [`Hex`](https://hex.pm). You run `elixir-ls` from the command line and accept the prompt to install `Hex`.
 {% endhint %}
 
 ### Formatting with Mix
 
-If you prefer to format your code with [Mix](https://hexdocs.pm/mix/Mix.html), use the following snippet in your `settings.json` file to configure it as an external formatter.  Formatting will occur on file save.
+If you prefer to format your code with [Mix](https://hexdocs.pm/mix/Mix.html), use the following snippet in your `settings.json` file to configure it as an external formatter. Formatting will occur on file save.
 
 ```json
 {

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -17,8 +17,8 @@ By default, the Pyright language server will look for Python packages in the def
 
 To do this, create a JSON file called `pyrightconfig.json` at the root of your project. This file must include two keys:
 
-* `venvPath`: a relative path from your project directory to any directory that _contains_ one or more virtual environment directories
-* `venv`: the name of a virtual environment directory
+- `venvPath`: a relative path from your project directory to any directory that _contains_ one or more virtual environment directories
+- `venv`: the name of a virtual environment directory
 
 For example, a common approach is to create a virtual environment directory called `.venv` at the root of your project directory with the following commands:
 
@@ -40,7 +40,7 @@ Having done that, you would create a `pyrightconfig.json` with the following con
 
 ### Code formatting
 
-The Pyright language server does not provide code formatting. If you want to automatically reformat your Python code when saving, you'll need to specify an _external_code formatter in your settings. See the [configuration](../configuration/configuring-zed.md) documentation for more information.
+The Pyright language server does not provide code formatting. If you want to automatically reformat your Python code when saving, you'll need to specify an \_external_code formatter in your settings. See the [configuration](../configuration/configuring-zed.md) documentation for more information.
 
 A common tool for formatting python code is [Black](https://black.readthedocs.io/en/stable/). If you have Black installed globally, you can use it to format Python files by adding the following to your `settings.json`:
 

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -23,14 +23,14 @@ Solargraph has formatting and diagnostics disabled by default. We can tell Zed t
 
 ```json
 {
-   "lsp": {
-      "solargraph": {
-         "initialization_options": {
-            "diagnostics": true,
-            "formatting": true
-         }
+  "lsp": {
+    "solargraph": {
+      "initialization_options": {
+        "diagnostics": true,
+        "formatting": true
       }
-   }
+    }
+  }
 }
 ```
 

--- a/docs/src/languages/toml.md
+++ b/docs/src/languages/toml.md
@@ -1,5 +1,4 @@
 # TOML
 
-
 - Tree Sitter: [tree-sitter-toml](https://github.com/tree-sitter/tree-sitter-toml)
 - Language Server: [taplo](https://taplo.tamasfe.dev)

--- a/docs/src/telemetry.md
+++ b/docs/src/telemetry.md
@@ -30,14 +30,14 @@ When a panic occurs, the following data is sent:
 - `thread`: The name of the thread that panicked
 - `payload`: The panic message
 - `location_data`: The location of the panic
-    - `file`
-    - `line`
+  - `file`
+  - `line`
 - `backtrace`: The backtrace of the panic
 - `app_version`: Zed's app version
 - `release_channel`: Zed's release channel
-    - `stable`
-    - `preview`
-    - `dev`
+  - `stable`
+  - `preview`
+  - `dev`
 - `os_name`: The name of your operating system
 - `os_version`: The version of your operating system
 - `architecture`: The architecture of your CPU
@@ -62,9 +62,9 @@ The following data is sent:
 - `os_version`: The version of your operating system
 - `architecture`: The architecture of your CPU
 - `release_channel`: Zed's release channel
-    - `stable`
-    - `preview`
-    - `dev`
+  - `stable`
+  - `preview`
+  - `dev`
 - `events`: A vector of `ClickhouseEventWrapper`s
 
 #### ClickhouseEventWrapper
@@ -75,57 +75,57 @@ The following data is sent:
 #### ClickhouseEvent
 
 - `editor`
-    - `operation`: The editor operation that was performed
-        - `open`
-        - `save`
-    - `file_extension`: The extension of the file that was opened or saved
-    - `vim_mode`: A boolean that indicates whether the user is in vim mode or not
-    - `copilot_enabled`: A boolean that indicates whether the user has copilot enabled or not
-    - `copilot_enabled_for_language`: A boolean that indicates whether the user has copilot enabled for the language of the file that was opened or saved
-    - `milliseconds_since_first_event`: Duration of time between this event's timestamp and the timestamp of the first event in the current batch
+  - `operation`: The editor operation that was performed
+    - `open`
+    - `save`
+  - `file_extension`: The extension of the file that was opened or saved
+  - `vim_mode`: A boolean that indicates whether the user is in vim mode or not
+  - `copilot_enabled`: A boolean that indicates whether the user has copilot enabled or not
+  - `copilot_enabled_for_language`: A boolean that indicates whether the user has copilot enabled for the language of the file that was opened or saved
+  - `milliseconds_since_first_event`: Duration of time between this event's timestamp and the timestamp of the first event in the current batch
 - `copilot`
-    - `suggestion_id`: The ID of the suggestion
-    - `suggestion_accepted`: A boolean that indicates whether the suggestion was accepted or not
-    - `file_extension`: The file extension of the file that was opened or saved
-    - `milliseconds_since_first_event`: Same as above
+  - `suggestion_id`: The ID of the suggestion
+  - `suggestion_accepted`: A boolean that indicates whether the suggestion was accepted or not
+  - `file_extension`: The file extension of the file that was opened or saved
+  - `milliseconds_since_first_event`: Same as above
 - `call`
-    - `operation`: The call operation that was performed
-        - `accept incoming`
-        - `decline incoming`
-        - `disable microphone`
-        - `disable screen share`
-        - `enable microphone`
-        - `enable screen share`
-        - `hang up`
-        - `invite`
-        - `join channel`
-        - `open channel notes`
-        - `share project`
-        - `unshare project`
-    - `room_id`: The ID of the room
-    - `channel_id`: The ID of the channel
-    - `milliseconds_since_first_event`: Same as above
+  - `operation`: The call operation that was performed
+    - `accept incoming`
+    - `decline incoming`
+    - `disable microphone`
+    - `disable screen share`
+    - `enable microphone`
+    - `enable screen share`
+    - `hang up`
+    - `invite`
+    - `join channel`
+    - `open channel notes`
+    - `share project`
+    - `unshare project`
+  - `room_id`: The ID of the room
+  - `channel_id`: The ID of the channel
+  - `milliseconds_since_first_event`: Same as above
 - `assistant`
-    - `conversation_id`: The ID of the conversation (for panel events only)
-    - `kind`: An enum with the following variants:
-        - `panel`
-        - `inline`
-    - `model`: The model that was used
-    - `milliseconds_since_first_event`: Same as above
+  - `conversation_id`: The ID of the conversation (for panel events only)
+  - `kind`: An enum with the following variants:
+    - `panel`
+    - `inline`
+  - `model`: The model that was used
+  - `milliseconds_since_first_event`: Same as above
 - `cpu`
-    - `usage_as_percentage`: The CPU usage
-    - `core_count`: The number of cores on the CPU
-    - `milliseconds_since_first_event`: Same as above
+  - `usage_as_percentage`: The CPU usage
+  - `core_count`: The number of cores on the CPU
+  - `milliseconds_since_first_event`: Same as above
 - `memory`
-    - `memory_in_bytes`: The amount of memory used in bytes
-    - `virtual_memory_in_bytes`: The amount of virtual memory used in bytes
-    - `milliseconds_since_first_event`: Same as above
+  - `memory_in_bytes`: The amount of memory used in bytes
+  - `virtual_memory_in_bytes`: The amount of virtual memory used in bytes
+  - `milliseconds_since_first_event`: Same as above
 - `app`
-    - `operation`: The app operation that was performed
-        - `first open`
-        - `open`
-        - `close`
-    - `milliseconds_since_first_event`: Same as above
+  - `operation`: The app operation that was performed
+    - `first open`
+    - `open`
+    - `close`
+  - `milliseconds_since_first_event`: Same as above
 
 You can audit the metrics data that Zed has reported by running the command `zed: open telemetry log` from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
 


### PR DESCRIPTION
This PR adjusts the heading levels in the docs, as some of them weren't following the right hierarchy.

I also formatted all of the docs with Prettier.

Release Notes:

- N/A
