### PR TITLE
Fix some typos in comments

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -137,7 +137,7 @@ impl Clone for Command {
 
 /// Hit count for each command in the palette.
 /// We only account for commands triggered directly via command palette and not by e.g. keystrokes because
-/// if an user already knows a keystroke for a command, they are unlikely to use a command palette to look for it.
+/// if a user already knows a keystroke for a command, they are unlikely to use a command palette to look for it.
 #[derive(Default)]
 struct HitCounts(HashMap<String, usize>);
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2310,7 +2310,7 @@ impl Editor {
                 let mut bracket_pair = None;
                 let mut is_bracket_pair_start = false;
                 if !text.is_empty() {
-                    // `text` can be empty when an user is using IME (e.g. Chinese Wubi Simplified)
+                    // `text` can be empty when a user is using IME (e.g. Chinese Wubi Simplified)
                     //  and they are removing the character that triggered IME popup.
                     for (pair, enabled) in scope.brackets() {
                         if enabled && pair.close && pair.start.ends_with(text.as_ref()) {


### PR DESCRIPTION
This PR fixes a couple typos I found in some comments/doc comments.

Release Notes:

- N/A
