### PR TITLE
Deploy collab like nightly

### DIFF
--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - collab-production
       - collab-staging
-    branches:
-      - test-collab-deploy
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -95,9 +95,6 @@ jobs:
           elif [[ $GITHUB_REF_NAME = "collab-staging" ]]; then
             echo "Deploying collab:$GITHUB_SHA to staging"
             echo "KUBE_NAMESPACE=staging" >> $GITHUB_ENV
-          elif [[ $GITHUB_REF_NAME = "test-collab-deploy" ]]; then
-            echo "Deploying collab:$GITHUB_SHA to staging"
-            echo "KUBE_NAMESPACE=staging" >> $GITHUB_ENV
           else
             echo "cowardly refusing to deploy from an unknown branch"
             exit 1

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -62,7 +62,7 @@ jobs:
         run: doctl registry login
 
       - name: Prune Docker system
-        run: docker system prune
+        run: docker system prune  --filter 'until=720h' -f
 
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -110,6 +110,3 @@ jobs:
 
       - name: Wait for rollout to finish
         run: kubectl -n "$KUBE_NAMESPACE" rollout status deployment/collab
-
-      - name: Cleanup
-        run: docker system prune --filter 'until=720h' -f

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -110,3 +110,6 @@ jobs:
 
       - name: Wait for rollout to finish
         run: kubectl -n "$KUBE_NAMESPACE" rollout status deployment/collab
+
+      - name: Cleanup
+        run: docker system prune --filter 'until=720h' -f

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           clean: false
           submodules: "recursive"
+          fetch-depth: 0
 
       - name: Run tests
         uses: ./.github/actions/run_test

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run tests
-        uses: ./.github/actions/run_test
+        uses: ./.github/actions/run_tests
 
   publish:
     name: Publish collab server image

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -71,7 +71,7 @@ jobs:
           submodules: "recursive"
 
       - name: Build docker image
-        run: docker build . --tag registry.digitalocean.com/zed/collab:${GITHUB_SHA}
+        run: docker build . --build-arg GITHUB_SHA=$GITHUB_SHA --tag registry.digitalocean.com/zed/collab:$GITHUB_SHA
 
       - name: Publish docker image
         run: docker push registry.digitalocean.com/zed/collab:${GITHUB_SHA}
@@ -92,16 +92,16 @@ jobs:
         run: |
           set -eu
           if [[ $GITHUB_REF_NAME = "collab-production" ]]; then
-            echo "Deploying collab:${GITHUB_SHA} to production"
+            echo "Deploying collab:$GITHUB_SHA to production"
             echo "KUBE_NAMESPACE=production" >> $GITHUB_ENV
           elif [[ $GITHUB_REF_NAME = "collab-staging" ]]; then
-            echo "Deploying collab:${GITHUB_SHA} to staging"
+            echo "Deploying collab:$GITHUB_SHA to staging"
             echo "KUBE_NAMESPACE=staging" >> $GITHUB_ENV
           elif [[ $GITHUB_REF_NAME = "test-collab-deploy" ]]; then
-            echo "Deploying collab:${GITHUB_SHA} to staging"
+            echo "Deploying collab:$GITHUB_SHA to staging"
             echo "KUBE_NAMESPACE=staging" >> $GITHUB_ENV
           else
-            echo "release tag ${GITHUB_REF_NAME} does not match version ${version}"
+            echo "cowardly refusing to deploy from an unknown branch"
             exit 1
           fi
 

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Start rollout
-        run: echo kubectl -n "$KUBE_NAMESPACE" set image deployment/collab collab=registry.digitalocean.com/zed/collab:${GITHUB_SHA}
+        run: kubectl -n "$KUBE_NAMESPACE" set image deployment/collab collab=registry.digitalocean.com/zed/collab:${GITHUB_SHA}
 
       - name: Wait for rollout to finish
         run: kubectl -n "$KUBE_NAMESPACE" rollout status deployment/collab

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -83,6 +83,7 @@ jobs:
       - self-hosted
       - deploy
 
+    steps:
       - name: Sign into Kubernetes
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 ${{ secrets.CLUSTER_NAME }}
 

--- a/.github/workflows/publish_collab_image.yml
+++ b/.github/workflows/publish_collab_image.yml
@@ -3,15 +3,53 @@ name: Publish Collab Server Image
 on:
   push:
     tags:
-      - collab-v*
+      - collab-production
+      - collab-staging
+    branches:
+      - test-collab-deploy
 
 env:
   DOCKER_BUILDKIT: 1
   DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
 jobs:
+  style:
+    name: Check formatting and Clippy lints
+    runs-on:
+      - self-hosted
+      - test
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: Run style checks
+        uses: ./.github/actions/check_style
+
+  tests:
+    name: Run tests
+    runs-on:
+      - self-hosted
+      - test
+    needs: style
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: "recursive"
+
+      - name: Run tests
+        uses: ./.github/actions/run_test
+
   publish:
     name: Publish collab server image
+    needs:
+      - style
+      - tests
     runs-on:
       - self-hosted
       - deploy
@@ -29,21 +67,44 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: 'recursive'
+          submodules: "recursive"
 
-      - name: Determine version
+      - name: Build docker image
+        run: docker build . --tag registry.digitalocean.com/zed/collab:${GITHUB_SHA}
+
+      - name: Publish docker image
+        run: docker push registry.digitalocean.com/zed/collab:${GITHUB_SHA}
+
+  deploy:
+    name: Deploy new server image
+    needs:
+      - publish
+    runs-on:
+      - self-hosted
+      - deploy
+
+      - name: Sign into Kubernetes
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 ${{ secrets.CLUSTER_NAME }}
+
+      - name: Determine namespace
         run: |
           set -eu
-          version=$(script/get-crate-version collab)
-          if [[ $GITHUB_REF_NAME != "collab-v${version}" ]]; then
+          if [[ $GITHUB_REF_NAME = "collab-production" ]]; then
+            echo "Deploying collab:${GITHUB_SHA} to production"
+            echo "KUBE_NAMESPACE=production" >> $GITHUB_ENV
+          elif [[ $GITHUB_REF_NAME = "collab-staging" ]]; then
+            echo "Deploying collab:${GITHUB_SHA} to staging"
+            echo "KUBE_NAMESPACE=staging" >> $GITHUB_ENV
+          elif [[ $GITHUB_REF_NAME = "test-collab-deploy" ]]; then
+            echo "Deploying collab:${GITHUB_SHA} to staging"
+            echo "KUBE_NAMESPACE=staging" >> $GITHUB_ENV
+          else
             echo "release tag ${GITHUB_REF_NAME} does not match version ${version}"
             exit 1
           fi
-          echo "Publishing collab version: ${version}"
-          echo "COLLAB_VERSION=${version}" >> $GITHUB_ENV
 
-      - name: Build docker image
-        run: docker build . --tag registry.digitalocean.com/zed/collab:v${COLLAB_VERSION}
+      - name: Start rollout
+        run: echo kubectl -n "$KUBE_NAMESPACE" set image deployment/collab collab=registry.digitalocean.com/zed/collab:${GITHUB_SHA}
 
-      - name: Publish docker image
-        run: docker push registry.digitalocean.com/zed/collab:v${COLLAB_VERSION}
+      - name: Wait for rollout to finish
+        run: kubectl -n "$KUBE_NAMESPACE" rollout status deployment/collab

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY . .
 
 # Compile collab server
 ARG CARGO_PROFILE_RELEASE_PANIC=abort
+ARG GITHUB_SHA
+
+ENV GITHUB_SHA=$GITHUB_SHA
 RUN --mount=type=cache,target=./script/node_modules \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=./target \

--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -4,6 +4,10 @@ This crate is what we run at https://collab.zed.dev.
 
 It contains our back-end logic for collaboration, to which we connect from the Zed client via a websocket after authenticating via https://zed.dev, which is a separate repo running on Vercel.
 
+# Local Development
+
+ Detailed instructions on getting started are [here](https://zed.dev/docs/local-collaboration).
+
 # Deployment
 
 We run two instances of collab:
@@ -19,3 +23,15 @@ Deployment is triggered by pushing to the `collab-staging` (or `collab-productio
 * `./script/deploy-collab production`
 
 You can tell what is currrently deployed with `./script/what-is-deployed`.
+
+# Database Migrations
+
+To create a new migration:
+
+```
+./script/sqlx migrate add <name>
+```
+
+Migrations are run automatically on service start, so run `foreman start` again. The service will crash if the migrations fail.
+
+When you create a new migration, you also need to update the [SQLite schema](./migrations.sqlite/20221109000000_test_schema.sql) that is used for testing.

--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -22,7 +22,7 @@ Deployment is triggered by pushing to the `collab-staging` (or `collab-productio
 * `./script/deploy-collab staging`
 * `./script/deploy-collab production`
 
-You can tell what is currrently deployed with `./script/what-is-deployed`.
+You can tell what is currently deployed with `./script/what-is-deployed`.
 
 # Database Migrations
 

--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -3,3 +3,19 @@
 This crate is what we run at https://collab.zed.dev.
 
 It contains our back-end logic for collaboration, to which we connect from the Zed client via a websocket after authenticating via https://zed.dev, which is a separate repo running on Vercel.
+
+# Deployment
+
+We run two instances of collab:
+
+* Staging (https://staging-collab.zed.dev)
+* Production (https://collab.zed.dev)
+
+Both of these run on the Kubernetes cluster hosted in Digital Ocean.
+
+Deployment is triggered by pushing to the `collab-staging` (or `collab-production`) tag in Github. The best way to do this is:
+
+* `./script/deploy-collab staging`
+* `./script/deploy-collab production`
+
+You can tell what is currrently deployed with `./script/what-is-deployed`.

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{filter::EnvFilter, fmt::format::JsonFields, Layer};
 use util::ResultExt;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-const REVISION: &'static str = env!("GITHUB_SHA");
+const REVISION: Option<&'static str> = option_env!("GITHUB_SHA");
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
 
     match args().skip(1).next().as_deref() {
         Some("version") => {
-            println!("collab v{VERSION} ({REVISION})");
+            println!("collab v{} ({})", VERSION, REVISION.unwrap_or("unknown"));
         }
         Some("migrate") => {
             run_migrations().await?;
@@ -106,7 +106,7 @@ async fn run_migrations() -> Result<()> {
 }
 
 async fn handle_root() -> String {
-    format!("collab v{VERSION} ({REVISION})")
+    format!("collab v{} ({})", VERSION, REVISION.unwrap_or("unknown"))
 }
 
 async fn handle_liveness_probe(Extension(state): Extension<Arc<AppState>>) -> Result<String> {

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -106,7 +106,7 @@ async fn run_migrations() -> Result<()> {
 }
 
 async fn handle_root() -> String {
-    format!("collab v{VERSION}")
+    format!("collab v{VERSION} ({REVISION})")
 }
 
 async fn handle_liveness_probe(Extension(state): Extension<Arc<AppState>>) -> Result<String> {

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -14,6 +14,7 @@ use tracing_subscriber::{filter::EnvFilter, fmt::format::JsonFields, Layer};
 use util::ResultExt;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const REVISION: &'static str = env!("GITHUB_SHA");
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -26,7 +27,7 @@ async fn main() -> Result<()> {
 
     match args().skip(1).next().as_deref() {
         Some("version") => {
-            println!("collab v{VERSION}");
+            println!("collab v{VERSION} ({REVISION})");
         }
         Some("migrate") => {
             run_migrations().await?;

--- a/script/bump-collab-version
+++ b/script/bump-collab-version
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [[ $# < 1 ]]; then
-  echo "Missing version increment (major, minor, or patch)" >&2
-  exit 1
-fi
-
-exec script/lib/bump-version.sh collab collab-v '' $1

--- a/script/deploy-collab
+++ b/script/deploy-collab
@@ -3,22 +3,19 @@
 set -eu
 source script/lib/deploy-helpers.sh
 
-if [[ $# < 2 ]]; then
-  echo "Usage: $0 <production|staging> <tag-name>"
+if [[ $# != 1 ]]; then
+  echo "Usage: $0 <production|staging>"
   exit 1
 fi
 environment=$1
-version=$2
+tag="$(tag_for_environment $environment)"
 
-export_vars_for_environment ${environment}
-image_id=$(image_id_for_version ${version})
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+  echo "You must be on main to run this script"
+  exit 1
+fi
 
-export ZED_DO_CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header)
-export ZED_KUBE_NAMESPACE=${environment}
-export ZED_IMAGE_ID=${image_id}
-
-target_zed_kube_cluster
-envsubst < crates/collab/k8s/collab.template.yml | kubectl apply -f -
-kubectl -n "$environment" rollout status deployment/collab --watch
-
-echo "deployed collab v${version} to ${environment}"
+echo git pull --ff-only origin main
+echo git tag -f $tag
+echo git push -f origin $tag

--- a/script/lib/deploy-helpers.sh
+++ b/script/lib/deploy-helpers.sh
@@ -8,33 +8,30 @@ function export_vars_for_environment {
   export $(cat $env_file)
 }
 
-function image_id_for_version {
-  local version=$1
-
-  # Check that version is valid
-  if [[ ! ${version} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Invalid version number '${version}'" >&2
-    exit 1
-  fi
-
-  # Check that image exists for version
-  tag_names=$(doctl registry repository list-tags collab --no-header --format Tag)
-  if ! $(echo "${tag_names}" | grep -Fqx v${version}); then
-    echo "No docker image tagged for version '${version}'" >&2
-    echo "Found images with these tags:" ${tag_names} >&2
-    exit 1
-  fi
-  
-  echo "registry.digitalocean.com/zed/collab:v${version}"
-}
-
-function version_for_image_id {
-  local image_id=$1
-  echo $image_id | cut -d: -f2
-}
-
 function target_zed_kube_cluster {
   if [[ $(kubectl config current-context 2> /dev/null) != do-nyc1-zed-1 ]]; then
     doctl kubernetes cluster kubeconfig save zed-1
+  fi
+}
+
+function tag_for_environment {
+  if [[ "$1" == "production" ]]; then
+    echo "collab-production"
+  elif [[ "$1" == "staging" ]]; then
+    echo "collab-staging"
+  else
+    echo "Invalid environment name '${environment}'" >&2
+    exit 1
+  fi
+}
+
+function url_for_environment {
+  if [[ "$1" == "production" ]]; then
+    echo "https://collab.zed.dev"
+  elif [[ "$1" == "staging" ]]; then
+    echo "https://collab-staging.zed.dev"
+  else
+    echo "Invalid environment name '${environment}'" >&2
+    exit 1
   fi
 }

--- a/script/what-is-deployed
+++ b/script/what-is-deployed
@@ -3,13 +3,15 @@
 set -eu
 source script/lib/deploy-helpers.sh
 
-if [[ $# < 1 ]]; then
+if [[ $# != 1 ]]; then
   echo "Usage: $0 <production|staging>"
   exit 1
 fi
-environment=$1
 
-export_vars_for_environment ${environment}
+environment=$1
+url="$(url_for_environment $environment)"
+tag="$(tag_for_environment $environment)"
+
 target_zed_kube_cluster
 
 deployed_image_id=$(
@@ -19,19 +21,8 @@ deployed_image_id=$(
     -o 'jsonpath={.spec.template.spec.containers[0].image}' \
     | cut -d: -f2
 )
+git fetch >/dev/null
 
-job_image_ids=$(
-  kubectl \
-    --namespace=${environment} \
-    get jobs \
-    -o 'jsonpath={range .items[0:5]}{.spec.template.spec.containers[0].image}{"\n"}{end}' \
-    2> /dev/null \
-    || true
-)
-
-echo "Deployed image version:"
-echo "$deployed_image_id"
-echo
-echo "Migration job image versions:"
-echo "$job_image_ids"
-echo
+echo "Deployed image version: $deployed_image_id"
+echo "Version from the web: $(curl -sS $url)"
+echo "Currently tagged version: $(git rev-parse tags/$tag)"

--- a/script/what-is-deployed
+++ b/script/what-is-deployed
@@ -21,8 +21,10 @@ deployed_image_id=$(
     -o 'jsonpath={.spec.template.spec.containers[0].image}' \
     | cut -d: -f2
 )
-git fetch >/dev/null
 
 echo "Deployed image version: $deployed_image_id"
-echo "Version from the web: $(curl -sS $url)"
-echo "Currently tagged version: $(git rev-parse tags/$tag)"
+
+git fetch >/dev/null
+if [[ "$(git rev-parse tags/$tag)" != $deployed_image_id ]]; then
+    echo "NOTE: tags/$tag $(git rev-parse tags/$tag) is not yet deployed"
+fi;


### PR DESCRIPTION
After this change we'll be able to push a tag to github to deploy to
collab.

The advantages of this are that there's no longer a separate step to first
build the image, and then deploy it.

In the future I'd like to make this happen more automatically (maybe as part of
bump nightly).

Release Notes:

- N/A
