### PR TITLE
Show diagnostics in scrollbar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -127,7 +127,9 @@
     // Whether to show selections in the scrollbar.
     "selections": true,
     // Whether to show symbols selections in the scrollbar.
-    "symbols_selections": true
+    "symbols_selections": true,
+    // Whether to show diagnostic indicators in the scrollbar.
+    "diagnostics": true
   },
   "relative_line_numbers": false,
   // When to populate a new search's query based on the text under the cursor.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -123,7 +123,7 @@ pub struct ScrollbarContent {
     ///
     /// Default: true
     pub symbols_selections: Option<bool>,
-    /// Whether to show symbols diagnostic indicators in the scrollbar.
+    /// Whether to show diagnostic indicators in the scrollbar.
     ///
     /// Default: true
     pub diagnostics: Option<bool>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -34,6 +34,7 @@ pub struct Scrollbar {
     pub git_diff: bool,
     pub selections: bool,
     pub symbols_selections: bool,
+    pub diagnostics: bool,
 }
 
 /// When to show the scrollbar in the editor.
@@ -122,6 +123,10 @@ pub struct ScrollbarContent {
     ///
     /// Default: true
     pub symbols_selections: Option<bool>,
+    /// Whether to show symbols diagnostic indicators in the scrollbar.
+    ///
+    /// Default: true
+    pub diagnostics: Option<bool>,
 }
 
 impl Settings for EditorSettings {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2167,6 +2167,9 @@ impl EditorElement {
                     // Symbols Selections
                     (is_singleton && scrollbar_settings.symbols_selections && (editor.has_background_highlights::<DocumentHighlightRead>() || editor.has_background_highlights::<DocumentHighlightWrite>()))
                     ||
+                    // Diagnostics
+                    (is_singleton && scrollbar_settings.diagnostics && snapshot.buffer_snapshot.has_diagnostics())
+                    ||
                     // Scrollmanager
                     editor.scroll_manager.scrollbars_visible()
                 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2993,6 +2993,11 @@ impl BufferSnapshot {
         self.git_diff.hunks_intersecting_range_rev(range, self)
     }
 
+    /// Returns if the buffer contains any diagnostics.
+    pub fn has_diagnostics(&self) -> bool {
+        !self.diagnostics.is_empty()
+    }
+
     /// Returns all the diagnostics intersecting the given range.
     pub fn diagnostics_in_range<'a, T, O>(
         &'a self,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3052,6 +3052,15 @@ impl MultiBufferSnapshot {
         self.has_conflict
     }
 
+    pub fn has_diagnostics(&self) -> bool {
+        for excerpt in self.excerpts.iter() {
+            if excerpt.buffer.has_diagnostics() {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn diagnostic_group<'a, O>(
         &'a self,
         group_id: usize,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3053,12 +3053,9 @@ impl MultiBufferSnapshot {
     }
 
     pub fn has_diagnostics(&self) -> bool {
-        for excerpt in self.excerpts.iter() {
-            if excerpt.buffer.has_diagnostics() {
-                return true;
-            }
-        }
-        false
+        self.excerpts
+            .iter()
+            .any(|excerpt| excerpt.buffer.has_diagnostics())
     }
 
     pub fn diagnostic_group<'a, O>(


### PR DESCRIPTION
This PR implements support for displaying diagnostics in the scrollbar, similar to what is already done for search results, symbols, git diff, ...

For example, changing a field name (`text`) without changing the references looks like this in `buffer.rs` (note the red lines in the scrollbar):
![image](https://github.com/zed-industries/zed/assets/53836821/c46f0d55-32e3-4334-8ad7-66d1578d5725)

As you can see, the errors, warnings, ... are displayed in the scroll bar, which helps to identify possible problems with the current file.

Relevant issues: #4866, #6819

I'm not so sure about some things:
- What's the performance impact for calling `diagnostics_in_range` on the whole buffer when painting scrollbars? Are there some benchmarks I can run?
- How does scrollbar auto actually work? My scrollbars are always displayed, even when I set them to auto (regardless of my change). So I'm not sure if my change to `element.rs` in line 2171 is correct.
- I don't think the very thin lines that are currently rendered look very nice. Are there any plans to redesign this? At the moment I've just kept the same style as the scrollbar indicators that are already there.

Release Notes:

- Added diagnostic indicators to the scrollbar
