### PR TITLE
Filter LSP github releases that have no assets

### DIFF
--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -68,7 +68,6 @@ pub async fn latest_github_release(
 
     releases
         .into_iter()
-        .filter(|release| !release.assets.is_empty())
-        .find(|release| release.pre_release == pre_release)
+        .find(|release| !release.assets.is_empty() && release.pre_release == pre_release)
         .ok_or(anyhow!("Failed to find a release"))
 }

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -68,6 +68,7 @@ pub async fn latest_github_release(
 
     releases
         .into_iter()
+        .filter(|release| release.assets.len() > 2)
         .find(|release| release.pre_release == pre_release)
         .ok_or(anyhow!("Failed to find a release"))
 }

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -68,7 +68,7 @@ pub async fn latest_github_release(
 
     releases
         .into_iter()
-        .filter(|release| release.assets.len() > 0)
+        .filter(|release| release.assets.is_empty())
         .find(|release| release.pre_release == pre_release)
         .ok_or(anyhow!("Failed to find a release"))
 }

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -68,7 +68,7 @@ pub async fn latest_github_release(
 
     releases
         .into_iter()
-        .filter(|release| release.assets.len() > 2)
+        .filter(|release| release.assets.len() > 0)
         .find(|release| release.pre_release == pre_release)
         .ok_or(anyhow!("Failed to find a release"))
 }

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -68,7 +68,7 @@ pub async fn latest_github_release(
 
     releases
         .into_iter()
-        .filter(|release| release.assets.is_empty())
+        .filter(|release| !release.assets.is_empty())
         .find(|release| release.pre_release == pre_release)
         .ok_or(anyhow!("Failed to find a release"))
 }


### PR DESCRIPTION
Release Notes:

- Filter lsp github releases that have no assets. Fixed #7183