### PR TITLE
Fix moving focus to docks when navigating via keybinds

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -522,6 +522,17 @@ pub enum SplitDirection {
     Right,
 }
 
+impl std::fmt::Display for SplitDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SplitDirection::Up => write!(f, "up"),
+            SplitDirection::Down => write!(f, "down"),
+            SplitDirection::Left => write!(f, "left"),
+            SplitDirection::Right => write!(f, "right"),
+        }
+    }
+}
+
 impl SplitDirection {
     pub fn all() -> [Self; 4] {
         [Self::Up, Self::Down, Self::Left, Self::Right]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2152,7 +2152,13 @@ impl Workspace {
 
         match target {
             Some(ActivateInDirectionTarget::Pane(pane)) => cx.focus_view(&pane),
-            Some(ActivateInDirectionTarget::Dock(dock)) => cx.focus_view(&dock),
+            Some(ActivateInDirectionTarget::Dock(dock)) => {
+                if let Some(panel) = dock.read(cx).active_panel() {
+                    panel.focus_handle(cx).focus(cx);
+                } else {
+                    log::error!("Could not find a focus target when in switching focus in {direction} direction for a {:?} dock", dock.read(cx).position());
+                }
+            }
             None => {}
         }
     }


### PR DESCRIPTION
This is a follow-up to #7141 and fixes the focus-switching to docks in case they haven't been focused before.

We ran into issues when trying to focus a dock, that hasn't been focused in the app's lifecycle: focus would only flip after the next re-render (which could be triggered by moving the mouse, for example)

This changes the approach and uses the one we have for `toggle focus` actions.

Release Notes:

- N/A