### PR TITLE
Add git_rebase highlighting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8993,6 +8993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-rebase"
+version = "0.0.1"
+source = "git+https://github.com/the-mikedavis/tree-sitter-git-rebase#d8a4207ebbc47bd78bacdf48f883db58283f9fd8"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-ruby"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10405,6 +10414,7 @@ dependencies = [
  "tree-sitter-purescript",
  "tree-sitter-python",
  "tree-sitter-racket",
+ "tree-sitter-rebase",
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scheme",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ tree-sitter-proto = {git = "https://github.com/rewinfrey/tree-sitter-proto", rev
 tree-sitter-purescript = { git = "https://github.com/ivanmoreau/tree-sitter-purescript", rev = "a37140f0c7034977b90faa73c94fcb8a5e45ed08" }
 tree-sitter-python = "0.20.2"
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a" }
+tree-sitter-rebase = { git = "https://github.com/the-mikedavis/tree-sitter-git-rebase" }
 tree-sitter-ruby = "0.20.0"
 tree-sitter-rust = "0.20.3"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -133,6 +133,7 @@ tree-sitter-proto.workspace = true
 tree-sitter-purescript.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-racket.workspace = true
+tree-sitter-rebase.workspace = true
 tree-sitter-ruby.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-scheme.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -113,6 +113,7 @@ pub fn init(
         ),
     }
     language("gitcommit", tree_sitter_gitcommit::language(), vec![]);
+    language("gitrebase", tree_sitter_rebase::language(), vec![]);
     language(
         "gleam",
         tree_sitter_gleam::language(),

--- a/crates/zed/src/languages/gitrebase/config.toml
+++ b/crates/zed/src/languages/gitrebase/config.toml
@@ -1,0 +1,7 @@
+name = "Git Rebase"
+path_suffixes = [
+  # Refer to https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua#L1296
+  "git-rebase-todo"
+]
+line_comments = ["#"]
+brackets = []

--- a/crates/zed/src/languages/gitrebase/highlights.scm
+++ b/crates/zed/src/languages/gitrebase/highlights.scm
@@ -1,0 +1,36 @@
+; a rough translation:
+; * constant.builtin - git hash
+; * constant - a git label
+; * keyword - command that acts on commits commits
+; * function - command that acts only on labels
+; * comment - discarded commentary on a command, has no effect on the rebase
+; * string - text used in the rebase operation
+; * operator - a 'switch' (used in fixup and merge), either -c or -C at time of writing
+
+(((command) @keyword
+  (label) @constant.builtin
+  (message)? @comment)
+ (#match? @keyword "^(p|pick|r|reword|e|edit|s|squash|d|drop)$"))
+
+(((command) @function
+  (label) @constant
+  (message)? @comment)
+ (#match? @function "^(l|label|t|reset)$"))
+
+((command) @keyword
+ (#match? @keyword "^(x|exec|b|break)$"))
+
+(((command) @attribute
+  (label) @constant.builtin
+  (message)? @comment)
+ (#match? @attribute "^(f|fixup)$"))
+
+(((command) @keyword
+  (label) @constant.builtin
+  (label) @constant
+  (message) @string)
+ (#match? @keyword "^(m|merge)$"))
+
+(option) @operator
+
+(comment) @comment

--- a/crates/zed/src/languages/gitrebase/injections.scm
+++ b/crates/zed/src/languages/gitrebase/injections.scm
@@ -1,0 +1,5 @@
+(((command) @attribute
+  (message)? @injection.content)
+ (#match? @attribute "^(x|exec)$")
+ (#set! injection.language "bash")
+)

--- a/docs/src/languages/git.md
+++ b/docs/src/languages/git.md
@@ -1,0 +1,9 @@
+# Git Commit
+
+- Tree Sitter: [tree-sitter-gitcommit](https://github.com/gbprod/tree-sitter-gitcommit)
+- Language Server: N/A
+
+# Git Rebase
+
+- Tree Sitter: [tree-sitter-git-rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase)
+- Language Server: N/A

--- a/docs/src/languages/gitcommit.md
+++ b/docs/src/languages/gitcommit.md
@@ -1,4 +1,0 @@
-# Git Commit
-
-- Tree Sitter: [tree-sitter-gitcommit](https://github.com/gbprod/tree-sitter-gitcommit)
-- Language Server: N/A


### PR DESCRIPTION
Let’s use zed as rebase editor :+1:

```bash
EDITOR="zed --wait" git rebase -i HEAD~4 # test

```

<img width="794" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/1161f005-0152-4373-8efe-9275e53847b2">



Release Notes:

- Added git_rebase highlighting