### PR TITLE
Introduce a fast path for drawing quads with no borders / corner radii

### DIFF
--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -61,6 +61,16 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                               constant Quad *quads
                               [[buffer(QuadInputIndex_Quads)]]) {
   Quad quad = quads[input.quad_id];
+
+  // Fast path when the quad is not rounded and doesn't have any border.
+  if (quad.corner_radii.top_left == 0. && quad.corner_radii.bottom_left == 0. &&
+      quad.corner_radii.top_right == 0. &&
+      quad.corner_radii.bottom_right == 0. && quad.border_widths.top == 0. &&
+      quad.border_widths.left == 0. && quad.border_widths.right == 0. &&
+      quad.border_widths.bottom == 0.) {
+    return input.background_color;
+  }
+
   float2 half_size =
       float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
   float2 center =


### PR DESCRIPTION
This will introduce an extra conditional but saves us from doing a bunch of math in the simple case of drawing simple rectangles that aren't rounded or don't have borders.

![Figure_1](https://github.com/zed-industries/zed/assets/482957/cba95ce2-2d9a-46ab-a142-35368334eb75)

Release Notes:

- Improved rendering performance.
