### PR TITLE
Added bicep tree-sitter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8748,6 +8748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bicep"
+version = "1.0.1"
+source = "git+https://github.com/amaanq/tree-sitter-bicep.git?rev=48a00c254671b5e847e615442678f4f3f5aa1e43#48a00c254671b5e847e615442678f4f3f5aa1e43"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-c"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10395,6 +10404,7 @@ dependencies = [
  "toml",
  "tree-sitter",
  "tree-sitter-bash",
+ "tree-sitter-bicep",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ time = { version = "0.3", features = ["serde", "serde-well-known"] }
 toml = "0.5"
 tree-sitter = { version = "0.20", features = ["wasm"] }
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "7331995b19b8f8aba2d5e26deb51d2195c18bc94" }
+tree-sitter-bicep = {git = "https://github.com/amaanq/tree-sitter-bicep.git" ,rev = "48a00c254671b5e847e615442678f4f3f5aa1e43"}
 tree-sitter-c = "0.20.1"
 tree-sitter-c-sharp = { git = "https://github.com/tree-sitter/tree-sitter-c-sharp", rev = "dd5e59721a5f8dae34604060833902b882023aaf" }
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev="f44509141e7e483323d2ec178f2d2e6c0fc041c1" }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -107,6 +107,7 @@ thiserror.workspace = true
 tiny_http = "0.8"
 toml.workspace = true
 tree-sitter-bash.workspace = true
+tree-sitter-bicep.workspace = true
 tree-sitter-c-sharp.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -66,6 +66,8 @@ pub fn init(
     };
 
     language("bash", tree_sitter_bash::language(), vec![]);
+    language("bicep", tree_sitter_bicep::language(), vec![]);
+
     language(
         "c",
         tree_sitter_c::language(),

--- a/crates/zed/src/languages/bicep/config.toml
+++ b/crates/zed/src/languages/bicep/config.toml
@@ -1,0 +1,10 @@
+name = "Bicep"
+path_suffixes = ["bicep"]
+line_comments = ["// "]
+autoclose_before = "',)]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]
+

--- a/crates/zed/src/languages/bicep/folds.scm
+++ b/crates/zed/src/languages/bicep/folds.scm
@@ -1,0 +1,25 @@
+[
+  (module_declaration)
+  (metadata_declaration)
+  (output_declaration)
+  (parameter_declaration)
+  (resource_declaration)
+  (type_declaration)
+  (variable_declaration)
+
+  (parenthesized_expression)
+
+  (decorators)
+  (array)
+  (object)
+
+  (if_statement)
+  (for_statement)
+
+  (subscript_expression)
+  (ternary_expression)
+
+  (string)
+
+  (comment)
+] @fold

--- a/crates/zed/src/languages/bicep/highlights.scm
+++ b/crates/zed/src/languages/bicep/highlights.scm
@@ -1,0 +1,230 @@
+; Includes
+
+(import_statement
+  "import" @include)
+
+(import_with_statement
+  "import" @include
+  "with" @include)
+
+; Namespaces
+
+(module_declaration
+  (identifier) @namespace)
+
+; Builtins
+
+(primitive_type) @type.builtin
+
+((member_expression
+  object: (identifier) @type.builtin)
+  (#match? @type.builtin "^sys$"))
+
+; Functions
+
+(call_expression
+  function: (identifier) @function.call)
+
+; Properties
+
+(object_property
+  (identifier) @property
+  ":" @punctuation.delimiter
+  (_))
+
+(object_property
+  (compatible_identifier) @property
+  ":" @punctuation.delimiter
+  (_))
+
+(property_identifier) @property
+
+; Attributes
+
+(decorator
+  "@" @attribute)
+
+(decorator
+  (call_expression (identifier) @attribute))
+
+(decorator
+  (call_expression
+    (member_expression
+	  object: (identifier) @attribute
+	  property: (property_identifier) @attribute)))
+
+; Types
+
+(type_declaration
+  (identifier) @type)
+
+(type_declaration
+  (identifier)
+  "="
+  (identifier) @type)
+
+(type_declaration
+  (identifier)
+  "="
+  (array_type (identifier) @type))
+
+(type
+  (identifier) @type)
+
+(resource_declaration
+  (identifier) @type)
+
+(resource_expression
+  (identifier) @type)
+
+; Parameters
+
+(parameter_declaration
+  (identifier) @parameter
+  (_))
+
+(call_expression
+  function: (_) 
+  (arguments (identifier) @parameter))
+
+(call_expression
+  function: (_) 
+  (arguments (member_expression object: (identifier) @parameter)))
+
+; Variables
+
+(variable_declaration
+  (identifier) @variable
+  (_))
+
+(metadata_declaration
+  (identifier) @variable
+  (_))
+
+(output_declaration
+  (identifier) @variable
+  (_))
+
+(object_property
+  (_)
+  ":"
+  (identifier) @variable)
+
+(for_statement
+  "for"
+  (for_loop_parameters
+    (loop_variable) @variable
+    (loop_enumerator) @variable))
+
+; Conditionals
+
+"if" @conditional
+
+(ternary_expression
+  "?" @conditional.ternary
+  ":" @conditional.ternary)
+
+; Loops
+
+(for_statement
+  "for" @repeat
+  "in"
+  ":" @punctuation.delimiter)
+
+; Keywords
+
+[
+  "module"
+  "metadata"
+  "output"
+  "param"
+  "resource"
+  "existing"
+  "targetScope"
+  "type"
+  "var"
+] @keyword
+
+; Operators
+
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "||"
+  "&&"
+  "|"
+  "=="
+  "!="
+  "=~"
+  "!~"
+  ">"
+  ">="
+  "<="
+  "<"
+  "??"
+  "="
+  "!"
+] @operator
+
+[
+  "in"
+] @keyword.operator
+
+
+; Literals
+
+(string) @string
+(import_string
+  "'" @string
+  (import_name) @namespace
+  "@" @symbol
+  (import_version) @string.special)
+
+(escape_sequence) @string.escape
+
+(number) @number
+
+(boolean) @boolean
+
+(null) @constant.builtin
+
+; Misc
+
+(compatible_identifier
+  "?" @punctuation.special)
+
+(nullable_return_type) @punctuation.special
+
+["{" "}"] @punctuation.bracket
+
+["[" "]"] @punctuation.bracket
+
+["(" ")"] @punctuation.bracket
+
+[
+  "."
+  "::"
+  "=>"
+] @punctuation.delimiter
+
+
+; Interpolation
+
+(interpolation) @none
+
+(interpolation
+  "${" @punctuation.special
+  "}" @punctuation.special)
+
+(interpolation
+  (identifier) @variable)
+
+; Comments
+
+[
+  (comment)
+  (diagnostic_comment)
+] @comment @spell

--- a/crates/zed/src/languages/bicep/indents.scm
+++ b/crates/zed/src/languages/bicep/indents.scm
@@ -1,0 +1,18 @@
+[
+  (array)
+  (object)
+] @indent
+
+"}" @indent_end
+
+[ "{" "}" ] @branch
+
+[ "[" "]" ] @branch
+
+[ "(" ")" ] @branch
+
+[
+  (ERROR)
+  (comment)
+  (diagnostic_comment)
+] @auto

--- a/crates/zed/src/languages/bicep/injections.scm
+++ b/crates/zed/src/languages/bicep/injections.scm
@@ -1,0 +1,4 @@
+[
+ (comment)
+ (diagnostic_comment)
+] @comment

--- a/crates/zed/src/languages/bicep/locals.scm
+++ b/crates/zed/src/languages/bicep/locals.scm
@@ -1,0 +1,74 @@
+; Scopes
+
+[
+  (infrastructure)
+  (call_expression)
+
+  (lambda_expression)
+  (subscript_expression)
+
+  (if_statement)
+  (for_statement)
+
+  (array)
+  (object)
+  (interpolation)
+] @scope
+
+; References
+
+(property_identifier) @reference
+
+(call_expression
+  (identifier) @reference)
+
+(object_property
+  (_)
+  ":"
+  (identifier) @reference)
+
+(resource_expression
+  (identifier) @reference)
+
+; Definitions
+
+(type) @definition.associated
+
+(object_property
+  (identifier) @definition.field
+  (_))
+
+(object_property
+  (compatible_identifier) @definition.field
+  (_))
+
+(import_name) @definition.import
+
+(module_declaration
+  (identifier) @definition.namespace)
+
+(parameter_declaration
+  (identifier) @definition.parameter
+  (_))
+
+(type_declaration
+  (identifier) @definition.type
+  (_))
+
+(variable_declaration
+  (identifier) @definition.var
+  (_))
+
+(metadata_declaration
+  (identifier) @definition.var
+  (_))
+
+(output_declaration
+  (identifier) @definition.var
+  (_))
+
+(for_statement
+  "for"
+  (for_loop_parameters
+    (loop_variable) @definition.var
+    (loop_enumerator) @definition.var))


### PR DESCRIPTION

Release Notes:

- Added Tree-Sitter syntax highlight for bicep files. 
<img width="1511" alt="Screenshot 2024-02-01 at 11 28 47 PM" src="https://github.com/zed-industries/zed/assets/70438312/ccade25c-2eb2-4965-92c3-a4e1b91e83aa">

