### PR TITLE
Use async-native-tls for websockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-native-tls"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
+dependencies = [
+ "async-std",
+ "native-tls",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "async-net"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,19 +583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
-name = "async-tls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.19.1",
- "webpki",
- "webpki-roots 0.21.1",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +599,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5682ea0913e5c20780fe5785abacb85a411e7437bf52a1bedb93ddb3972cb8dd"
 dependencies = [
- "async-tls",
+ "async-native-tls",
+ "async-std",
  "futures-io",
  "futures-util",
  "log",
@@ -6733,26 +6733,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "ring",
  "rustls-webpki",
- "sct 0.7.0",
+ "sct",
 ]
 
 [[package]]
@@ -6893,16 +6880,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.9.9",
-]
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -7626,7 +7603,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rust_decimal",
- "rustls 0.21.7",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -7640,7 +7617,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid 1.4.1",
- "webpki-roots 0.24.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -9129,6 +9106,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "sha-1 0.9.8",
  "thiserror",
@@ -9834,25 +9812,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ sum_tree = { path = "../sum_tree" }
 
 anyhow.workspace = true
 async-recursion = "0.3"
-async-tungstenite = { version = "0.16", features = ["async-tls"] }
+async-tungstenite = { version = "0.16", features = ["async-std", "async-native-tls"] }
 futures.workspace = true
 image = "0.23"
 lazy_static.workspace = true

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1040,7 +1040,7 @@ impl Client {
                     rpc_url.set_scheme("wss").unwrap();
                     let request = request.uri(rpc_url.as_str()).body(())?;
                     let (stream, _) =
-                        async_tungstenite::async_tls::client_async_tls(request, stream).await?;
+                        async_tungstenite::async_std::client_async_tls(request, stream).await?;
                     Ok(Connection::new(
                         stream
                             .map_err(|error| anyhow!(error))


### PR DESCRIPTION
This change switches from using async_tungstenite::async_tls to async_tungstenite::async_std with the async-native-tls feature.

The previous feature, async_tls, used async-tls which wraps rustls. rustls bundles webpki-roots, which is a copy of Mozilla's root certificates. These certificates are used by default, and manual configuration is required to support custom certificates, such as those required by web security gateways in enterprise environments.

Instead of introducing a new configuration option to Zed, async-native-tls integrates with the platform-native certificate store to support enterprise environments out-of-the-box. For MacOS, this adds support for Security.framework TLS. This integration is provided through openssl-sys, which is also the SSL certificate provider for isahc, the library underlying Zed's HTTP client. Making websockets and HTTP communications use the same SSL provider should keep Zed consistent operations and make the project easier to maintain.



Release Notes:

- Fixed WebSocket communications using custom TLS certificates ([#4759](https://github.com/zed-industries/zed/issues/4759)).
