### PR TITLE
Add rename to JetBrains keymaps

### DIFF
--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -42,6 +42,7 @@
       "shift-alt-up": "editor::MoveLineUp",
       "shift-alt-down": "editor::MoveLineDown",
       "cmd-alt-l": "editor::Format",
+      "shift-f6": "editor::Rename",
       "cmd-[": "pane::GoBack",
       "cmd-]": "pane::GoForward",
       "alt-f7": "editor::FindAllReferences",
@@ -83,7 +84,8 @@
   {
     "context": "ProjectPanel",
     "bindings": {
-      "enter": "project_panel::Open"
+      "enter": "project_panel::Open",
+      "shift-f6": "project_panel::Rename"
     }
   }
 ]


### PR DESCRIPTION
Add rename to JetBrains keymaps.

Closes #7261.

Release Notes:

- Fixed ([#7261](https://github.com/zed-industries/zed/issues/7261)).
