### PR TITLE
Fix removal of brackets inserted by auto-close when using snippets

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4121,8 +4121,12 @@ impl Editor {
                     };
 
                     let mut bracket_pair = None;
-                    let next_chars = snapshot.chars_at(selection_head).collect::<String>();
-                    let prev_chars = snapshot.reversed_chars_at(selection_head).collect::<String>();
+                    let next_chars = snapshot
+                        .chars_at(selection_head)
+                        .collect::<String>();
+                    let prev_chars = snapshot
+                        .reversed_chars_at(selection_head)
+                        .collect::<String>();
                     for (pair, enabled) in scope.brackets() {
                         if enabled
                             && pair.close

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4115,7 +4115,9 @@ impl Editor {
             let snapshot = self.buffer.read(cx).snapshot(cx);
             let selection = self.selections.first::<Point>(cx);
             let start_column = snapshot.indent_size_for_line(selection.start.row).len;
-            let scope = snapshot.language_scope_at(Point::new(selection.start.row, start_column)).unwrap();
+            let scope = snapshot
+                .language_scope_at(Point::new(selection.start.row, start_column))
+                .unwrap();
             let mut bracket_pair = None;
             for (pair, enabled) in scope.brackets() {
                 if enabled && pair.close && snippet.text.ends_with(pair.end.as_str()) {
@@ -4127,8 +4129,10 @@ impl Editor {
             // If it ends with an available surround, insert the auto close region
             if self.autoclose_regions.is_empty() {
                 if let Some(pair) = bracket_pair {
-                    let start = snapshot.anchor_after(Point::new(selection.start.row, selection.start.column));
-                    let end = snapshot.anchor_after(Point::new(selection.end.row, selection.end.column));
+                    let start = snapshot
+                        .anchor_after(Point::new(selection.start.row, selection.start.column));
+                    let end =
+                        snapshot.anchor_after(Point::new(selection.end.row, selection.end.column));
                     self.autoclose_regions.insert(
                         0,
                         AutocloseRegion {
@@ -4140,7 +4144,6 @@ impl Editor {
                 }
             }
         }
-
 
         Ok(())
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4121,9 +4121,7 @@ impl Editor {
                     };
 
                     let mut bracket_pair = None;
-                    let next_chars = snapshot
-                        .chars_at(selection_head)
-                        .collect::<String>();
+                    let next_chars = snapshot.chars_at(selection_head).collect::<String>();
                     let prev_chars = snapshot
                         .reversed_chars_at(selection_head)
                         .collect::<String>();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4116,7 +4116,10 @@ impl Editor {
                 let snapshot = self.buffer.read(cx).snapshot(cx);
                 for selection in &mut self.selections.all::<Point>(cx) {
                     let selection_head = selection.head();
-                    let scope = snapshot.language_scope_at(selection_head).unwrap();
+                    let Some(scope) = snapshot.language_scope_at(selection_head) else {
+                        continue;
+                    };
+
                     let mut bracket_pair = None;
                     for (pair, enabled) in scope.brackets() {
                         let text = snapshot

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4111,8 +4111,7 @@ impl Editor {
                 ranges: tabstops,
             });
 
-
-            // Gets whether the currently entered snipper ends with a surround
+            // Check whether the just-entered snippet ends with an auto-closable bracket.
             if self.autoclose_regions.is_empty() {
                 let snapshot = self.buffer.read(cx).snapshot(cx);
                 for selection in &mut self.selections.all::<Point>(cx) {
@@ -4139,10 +4138,7 @@ impl Editor {
                     }
                 }
             }
-
         }
-
-
         Ok(())
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4119,22 +4119,29 @@ impl Editor {
                     let scope = snapshot.language_scope_at(selection_head).unwrap();
                     let mut bracket_pair = None;
                     for (pair, enabled) in scope.brackets() {
-                        let text = snapshot.text_for_range(Point::new(selection_head.row, selection_head.column-1)..Point::new(selection_head.row, selection_head.column+1)).collect::<String>();
-                        if enabled && pair.close && text.starts_with(pair.start.as_str()) && text.ends_with(pair.end.as_str()) {
+                        let text = snapshot
+                            .text_for_range(
+                                Point::new(selection_head.row, selection_head.column - 1)
+                                    ..Point::new(selection_head.row, selection_head.column + 1),
+                            )
+                            .collect::<String>();
+                        if enabled
+                            && pair.close
+                            && text.starts_with(pair.start.as_str())
+                            && text.ends_with(pair.end.as_str())
+                        {
                             bracket_pair = Some(pair.clone());
                             break;
                         }
                     }
                     if let Some(pair) = bracket_pair {
-                        let start = snapshot.anchor_after(selection_head));
-                        let end = snapshot.anchor_after(selection_head));
-                        self.autoclose_regions.push(
-                            AutocloseRegion {
-                                selection_id: selection.id,
-                                range: start..end,
-                                pair: pair,
-                            },
-                        );
+                        let start = snapshot.anchor_after(selection_head);
+                        let end = snapshot.anchor_after(selection_head);
+                        self.autoclose_regions.push(AutocloseRegion {
+                            selection_id: selection.id,
+                            range: start..end,
+                            pair,
+                        });
                     }
                 }
             }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4121,17 +4121,13 @@ impl Editor {
                     };
 
                     let mut bracket_pair = None;
+                    let next_chars = snapshot.chars_at(selection_head).collect::<String>();
+                    let prev_chars = snapshot.reversed_chars_at(selection_head).collect::<String>();
                     for (pair, enabled) in scope.brackets() {
-                        let text = snapshot
-                            .text_for_range(
-                                Point::new(selection_head.row, selection_head.column - 1)
-                                    ..Point::new(selection_head.row, selection_head.column + 1),
-                            )
-                            .collect::<String>();
                         if enabled
                             && pair.close
-                            && text.starts_with(pair.start.as_str())
-                            && text.ends_with(pair.end.as_str())
+                            && prev_chars.starts_with(pair.start.as_str())
+                            && next_chars.starts_with(pair.end.as_str())
                         {
                             bracket_pair = Some(pair.clone());
                             break;


### PR DESCRIPTION
Release Notes:

- Fixed auto-inserted brackets (or quotes) not being removed when they were inserted as part of a snippet. ([#4605](https://github.com/zed-industries/issues/4605))