### PR TITLE
Revert "Avoid excessive blocking of main thread when rendering in direct mode (#7253)"

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -314,7 +314,7 @@ impl MetalRenderer {
         command_buffer.commit();
         self.sprite_atlas.clear_textures(AtlasTextureKind::Path);
 
-        command_buffer.wait_until_scheduled();
+        command_buffer.wait_until_completed();
         drawable.present();
     }
 


### PR DESCRIPTION
This reverts commit 020c38a8916c063cba36c2c88a69b5e287269d5a because it leads to glitches when selecting text.


https://github.com/zed-industries/zed/assets/1185253/78c2c184-bc15-4b04-8c80-a23ca5c96afa



Release Notes:

- N/A
