### PR TITLE
go: improve outline queries to get rid of whitespace

### DIFF
--- a/crates/zed/src/languages/go/outline.scm
+++ b/crates/zed/src/languages/go/outline.scm
@@ -7,20 +7,21 @@
     "func" @context
     name: (identifier) @name
     parameters: (parameter_list
-      "(" @context
-      ")" @context)) @item
+      "("
+      ")")) @item
 
 (method_declaration
     "func" @context
     receiver: (parameter_list
         "(" @context
         (parameter_declaration
+            name: (_) @name
             type: (_) @context)
         ")" @context)
     name: (field_identifier) @name
     parameters: (parameter_list
-      "(" @context
-      ")" @context)) @item
+      "("
+      ")")) @item
 
 (const_declaration
     "const" @context


### PR DESCRIPTION
This changes the Go `outline.scm` queries a bit so that we don't have these stray whitespaces floating around. I'm sure there's more improvements possible, but for now I think this makes it look less wrong.

Release Notes:

- Improved outline and breadcrumbs for Go code.

## Before
![before](https://github.com/zed-industries/zed/assets/1185253/d2b93c41-639b-4819-b87e-d8456960c5a7)

## After
![after](https://github.com/zed-industries/zed/assets/1185253/1ff6efb1-75a4-487b-8947-f070073887d4)

