### PR TITLE
go: fix highlighting of brackets, variables, fields

### DIFF
--- a/crates/zed/src/languages/go/highlights.scm
+++ b/crates/zed/src/languages/go/highlights.scm
@@ -1,6 +1,10 @@
-(identifier) @variable
 (type_identifier) @type
-(field_identifier) @property
+(field_identifier) @variable.member
+
+(keyed_element
+  .
+  (literal_element
+    (identifier) @variable.member))
 
 (call_expression
   function: (identifier) @function)
@@ -14,6 +18,15 @@
 
 (method_declaration
   name: (field_identifier) @function.method)
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
 
 [
   "--"


### PR DESCRIPTION
This changes the highlighting of Go code to make it more similar to how we highlight Rust

* normal variables have the normal color, vs. being highlighted. This really stuck out.
* brackets are properly highlighted

It also brings it closer to Neovim's tree-sitter highlighting by changing how struct fields are highlighted.



Release Notes:

- Improved highlighting of Go code by tuning highlighting of variables, brackets, and struct fields.

## Before & After

![screenshot-2024-02-02-11 38 08@2x](https://github.com/zed-industries/zed/assets/1185253/a754f166-89c1-40e8-a8da-b63155180896)
