### PR TITLE
Add inline code blocks in markdown preview

### DIFF
--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -56,49 +56,47 @@ impl RichText {
             id,
             StyledText::new(self.text.clone()).with_highlights(
                 &cx.text_style(),
-                self.highlights.iter().map(
-                    |(range, highlight)| -> (Range<usize>, HighlightStyle) {
-                        (
-                            range.clone(),
-                            match highlight {
-                                Highlight::Code => HighlightStyle {
-                                    background_color: Some(code_background),
-                                    ..Default::default()
-                                },
-                                Highlight::Id(id) => HighlightStyle {
-                                    background_color: Some(code_background),
-                                    ..id.style(theme.syntax()).unwrap_or_default()
-                                },
-                                Highlight::InlineCode(link) => {
-                                    if !*link {
-                                        HighlightStyle {
-                                            background_color: Some(code_background),
+                self.highlights.iter().map(|(range, highlight)| {
+                    (
+                        range.clone(),
+                        match highlight {
+                            Highlight::Code => HighlightStyle {
+                                background_color: Some(code_background),
+                                ..Default::default()
+                            },
+                            Highlight::Id(id) => HighlightStyle {
+                                background_color: Some(code_background),
+                                ..id.style(theme.syntax()).unwrap_or_default()
+                            },
+                            Highlight::InlineCode(link) => {
+                                if !*link {
+                                    HighlightStyle {
+                                        background_color: Some(code_background),
+                                        ..Default::default()
+                                    }
+                                } else {
+                                    HighlightStyle {
+                                        background_color: Some(code_background),
+                                        underline: Some(UnderlineStyle {
+                                            thickness: 1.0.into(),
                                             ..Default::default()
-                                        }
-                                    } else {
-                                        HighlightStyle {
-                                            background_color: Some(code_background),
-                                            underline: Some(UnderlineStyle {
-                                                thickness: 1.0.into(),
-                                                ..Default::default()
-                                            }),
-                                            ..Default::default()
-                                        }
+                                        }),
+                                        ..Default::default()
                                     }
                                 }
-                                Highlight::Highlight(highlight) => *highlight,
-                                Highlight::Mention => HighlightStyle {
-                                    font_weight: Some(FontWeight::BOLD),
-                                    ..Default::default()
-                                },
-                                Highlight::SelfMention => HighlightStyle {
-                                    font_weight: Some(FontWeight::BOLD),
-                                    ..Default::default()
-                                },
+                            }
+                            Highlight::Highlight(highlight) => *highlight,
+                            Highlight::Mention => HighlightStyle {
+                                font_weight: Some(FontWeight::BOLD),
+                                ..Default::default()
                             },
-                        )
-                    },
-                ),
+                            Highlight::SelfMention => HighlightStyle {
+                                font_weight: Some(FontWeight::BOLD),
+                                ..Default::default()
+                            },
+                        },
+                    )
+                }),
             ),
         )
         .on_click(self.link_ranges.clone(), {

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -13,6 +13,7 @@ use util::RangeExt;
 pub enum Highlight {
     Code,
     Id(HighlightId),
+    InlineCode(bool),
     Highlight(HighlightStyle),
     Mention,
     SelfMention,
@@ -55,30 +56,49 @@ impl RichText {
             id,
             StyledText::new(self.text.clone()).with_highlights(
                 &cx.text_style(),
-                self.highlights.iter().map(|(range, highlight)| {
-                    (
-                        range.clone(),
-                        match highlight {
-                            Highlight::Code => HighlightStyle {
-                                background_color: Some(code_background),
-                                ..Default::default()
+                self.highlights.iter().map(
+                    |(range, highlight)| -> (Range<usize>, HighlightStyle) {
+                        (
+                            range.clone(),
+                            match highlight {
+                                Highlight::Code => HighlightStyle {
+                                    background_color: Some(code_background),
+                                    ..Default::default()
+                                },
+                                Highlight::Id(id) => HighlightStyle {
+                                    background_color: Some(code_background),
+                                    ..id.style(theme.syntax()).unwrap_or_default()
+                                },
+                                Highlight::InlineCode(link) => {
+                                    if !*link {
+                                        HighlightStyle {
+                                            background_color: Some(code_background),
+                                            ..Default::default()
+                                        }
+                                    } else {
+                                        HighlightStyle {
+                                            background_color: Some(code_background),
+                                            underline: Some(UnderlineStyle {
+                                                thickness: 1.0.into(),
+                                                ..Default::default()
+                                            }),
+                                            ..Default::default()
+                                        }
+                                    }
+                                }
+                                Highlight::Highlight(highlight) => *highlight,
+                                Highlight::Mention => HighlightStyle {
+                                    font_weight: Some(FontWeight::BOLD),
+                                    ..Default::default()
+                                },
+                                Highlight::SelfMention => HighlightStyle {
+                                    font_weight: Some(FontWeight::BOLD),
+                                    ..Default::default()
+                                },
                             },
-                            Highlight::Id(id) => HighlightStyle {
-                                background_color: Some(code_background),
-                                ..id.style(theme.syntax()).unwrap_or_default()
-                            },
-                            Highlight::Highlight(highlight) => *highlight,
-                            Highlight::Mention => HighlightStyle {
-                                font_weight: Some(FontWeight::BOLD),
-                                ..Default::default()
-                            },
-                            Highlight::SelfMention => HighlightStyle {
-                                font_weight: Some(FontWeight::BOLD),
-                                ..Default::default()
-                            },
-                        },
-                    )
-                }),
+                        )
+                    },
+                ),
             ),
         )
         .on_click(self.link_ranges.clone(), {
@@ -184,22 +204,14 @@ pub fn render_markdown_mut(
             }
             Event::Code(t) => {
                 text.push_str(t.as_ref());
-                if link_url.is_some() {
-                    highlights.push((
-                        prev_len..text.len(),
-                        Highlight::Highlight(HighlightStyle {
-                            underline: Some(UnderlineStyle {
-                                thickness: 1.0.into(),
-                                ..Default::default()
-                            }),
-                            ..Default::default()
-                        }),
-                    ));
-                }
+                let is_link = link_url.is_some();
+
                 if let Some(link_url) = link_url.clone() {
                     link_ranges.push(prev_len..text.len());
                     link_urls.push(link_url);
                 }
+
+                highlights.push((prev_len..text.len(), Highlight::InlineCode(is_link)))
             }
             Event::Start(tag) => match tag {
                 Tag::Paragraph => new_paragraph(text, &mut list_stack),


### PR DESCRIPTION
This PR attempts to fix #7236.

The reason why the code was not dipslayed correctly is due to missing background color for the inline code block.

Previously to this PR:

<img width="1840" alt="SCR-20240202-mclv" src="https://github.com/zed-industries/zed/assets/67913738/92f63e72-db86-4de9-bb42-40549679e159" alt="Screenshot showing that inline code blocks are not highlighted in Markdown preview">

After this PR:

<img width="1796" alt="SCR-20240202-mccs" src="https://github.com/zed-industries/zed/assets/67913738/5cf039af-82d7-41b8-b461-f79dec5ddf6a" alt="Screenshot showing that inline code blocks are now highlighted in Markdown preview">



Release Notes:

- Fixed inline code block not shown in markdown preview ([#7236](https://github.com/zed-industries/zed/issues/7236)).
