### PR TITLE
completions: do not render empty multi-line documentation

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -857,9 +857,15 @@ impl CompletionsMenu {
                 Some(Documentation::MultiLinePlainText(text)) => {
                     Some(div().child(SharedString::from(text.clone())))
                 }
-                Some(Documentation::MultiLineMarkdown(parsed)) => Some(div().child(
-                    render_parsed_markdown("completions_markdown", parsed, &style, workspace, cx),
-                )),
+                Some(Documentation::MultiLineMarkdown(parsed)) if !parsed.text.is_empty() => {
+                    Some(div().child(render_parsed_markdown(
+                        "completions_markdown",
+                        parsed,
+                        &style,
+                        workspace,
+                        cx,
+                    )))
+                }
                 _ => None,
             };
             multiline_docs.map(|div| {


### PR DESCRIPTION
I ran into this a lot with Go code: the documentation would be empty so we'd display a big box with nothing in it.

I think it's better if we only display the box if we have documentation.

Release Notes:

- Fixed documentation box in showing up when using auto-complete even if documentation was empty.

## Before

![screenshot-2024-02-02-14 00 18@2x](https://github.com/zed-industries/zed/assets/1185253/e4915d51-a573-41f4-aa5d-21de6d1b0ff1)

## After

![screenshot-2024-02-02-14 01 58@2x](https://github.com/zed-industries/zed/assets/1185253/74b244af-3fc7-45e9-8cb3-7264e34b7ab7)




