### PR TITLE
theme_importer: Make VS Code theme parsing more lenient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,12 +3868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json_comments"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
-
-[[package]]
 name = "jwt"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8251,7 +8245,6 @@ dependencies = [
  "gpui",
  "indexmap 1.9.3",
  "indoc",
- "json_comments",
  "log",
  "palette",
  "pathfinder_color",
@@ -8259,6 +8252,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_json_lenient",
  "simplelog",
  "strum",
  "theme",

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -13,7 +13,6 @@ convert_case = "0.6.0"
 gpui = { path = "../gpui" }
 indexmap = { version = "1.6.2", features = ["serde"] }
 indoc.workspace = true
-json_comments = "0.2.2"
 log.workspace = true
 palette = { version = "0.7.3", default-features = false, features = ["std"] }
 pathfinder_color = "0.5"
@@ -21,6 +20,7 @@ rust-embed.workspace = true
 schemars = { workspace = true, features = ["indexmap"] }
 serde.workspace = true
 serde_json.workspace = true
+serde_json_lenient.workspace = true
 simplelog = "0.9"
 strum = { version = "0.25.0", features = ["derive"] }
 theme = { path = "../theme" }

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use indexmap::IndexMap;
-use json_comments::StripComments;
 use log::LevelFilter;
 use schemars::schema_for;
 use serde::Deserialize;
@@ -132,8 +131,7 @@ fn main() -> Result<()> {
         }
     };
 
-    let theme_without_comments = StripComments::new(theme_file);
-    let vscode_theme: VsCodeTheme = serde_json::from_reader(theme_without_comments)
+    let vscode_theme: VsCodeTheme = serde_json_lenient::from_reader(theme_file)
         .context(format!("failed to parse theme {theme_file_path:?}"))?;
 
     let theme_metadata = ThemeMetadata {


### PR DESCRIPTION
This PR updates the `theme_importer` to use `serde_json_lenient` to parse VS Code themes.

This should allow us to parse themes that have trailing commas and such, in addition to the comment support that we already had.

Release Notes:

- N/A
