### PR TITLE
Dismiss notification when viewing releases notes

### DIFF
--- a/crates/auto_update/src/update_notification.rs
+++ b/crates/auto_update/src/update_notification.rs
@@ -40,10 +40,11 @@ impl Render for UpdateNotification {
                     .id("notes")
                     .child(Label::new("View the release notes"))
                     .cursor_pointer()
-                    .on_click(|_, cx| {
+                    .on_click(cx.listener(|this, _, cx| {
                         crate::view_release_notes(&Default::default(), cx);
-                    }),
-            )
+                        this.dismiss(&menu::Cancel, cx)
+                    })),
+            );
     }
 }
 


### PR DESCRIPTION
After updating zed, a notification is shown in the bottom right with the new version number, a link to the release notes, and an 'x' to dismiss the dialog.

Before this PR, clicking the link to the release notes would not dismiss the modal. So, a user returning to the IDE after viewing the notes in the browser would still see the notification. With this change, clicking 'View release notes' also dismisses the notification.