### PR TITLE
Maintain smooth frame rates when ProMotion and direct mode are enabled

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -652,21 +652,13 @@ impl AppContext {
                     }
                 }
             } else {
-                for window in self.windows.values() {
-                    if let Some(window) = window.as_ref() {
-                        if window.dirty {
-                            window.platform_window.invalidate();
-                        }
-                    }
-                }
-
                 #[cfg(any(test, feature = "test-support"))]
                 for window in self
                     .windows
                     .values()
                     .filter_map(|window| {
                         let window = window.as_ref()?;
-                        (window.dirty || window.focus_invalidated).then_some(window.handle)
+                        (window.dirty.get() || window.focus_invalidated).then_some(window.handle)
                     })
                     .collect::<Vec<_>>()
                 {
@@ -749,7 +741,7 @@ impl AppContext {
     fn apply_refresh_effect(&mut self) {
         for window in self.windows.values_mut() {
             if let Some(window) = window.as_mut() {
-                window.dirty = true;
+                window.dirty.set(true);
             }
         }
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -665,6 +665,7 @@ impl AppContext {
                     self.update_window(window, |_, cx| cx.draw()).unwrap();
                 }
 
+                #[allow(clippy::collapsible_else_if)]
                 if self.pending_effects.is_empty() {
                     break;
                 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -175,7 +175,6 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn is_topmost_for_position(&self, position: Point<Pixels>) -> bool;
-    fn invalidate(&self);
     fn draw(&self, scene: &Scene);
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -16,8 +16,8 @@ use cocoa::{
     },
     base::{id, nil},
     foundation::{
-        NSArray, NSAutoreleasePool, NSDictionary, NSFastEnumeration, NSInteger, NSPoint, NSRect,
-        NSSize, NSString, NSUInteger,
+        NSArray, NSAutoreleasePool, NSDefaultRunLoopMode, NSDictionary, NSFastEnumeration,
+        NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger,
     },
 };
 use core_graphics::display::CGRect;
@@ -321,6 +321,7 @@ struct MacWindowState {
     executor: ForegroundExecutor,
     native_window: id,
     native_view: NonNull<id>,
+    display_link: id,
     renderer: MetalRenderer,
     kind: WindowKind,
     request_frame_callback: Option<Box<dyn FnMut()>>,
@@ -522,6 +523,10 @@ impl MacWindow {
             let native_view: id = msg_send![VIEW_CLASS, alloc];
             let native_view = NSView::init(native_view);
 
+            let display_link: id = msg_send![class!(CADisplayLink), displayLinkWithTarget: native_view selector: sel!(displayLayer:)];
+            let main_run_loop: id = msg_send![class!(NSRunLoop), mainRunLoop];
+            let _: () =
+                msg_send![display_link, addToRunLoop: main_run_loop forMode: NSDefaultRunLoopMode];
             assert!(!native_view.is_null());
 
             let window = Self(Arc::new(Mutex::new(MacWindowState {
@@ -529,6 +534,7 @@ impl MacWindow {
                 executor,
                 native_window,
                 native_view: NonNull::new_unchecked(native_view as *mut _),
+                display_link,
                 renderer: MetalRenderer::new(true),
                 kind: options.kind,
                 request_frame_callback: None,
@@ -687,6 +693,9 @@ impl Drop for MacWindow {
     fn drop(&mut self) {
         let this = self.0.lock();
         let window = this.native_window;
+        unsafe {
+            let _: () = msg_send![this.display_link, invalidate];
+        }
         this.executor
             .spawn(async move {
                 unsafe {
@@ -997,13 +1006,6 @@ impl PlatformWindow for MacWindow {
                 // Someone else's window is on top
                 false
             }
-        }
-    }
-
-    fn invalidate(&self) {
-        let this = self.0.lock();
-        unsafe {
-            let _: () = msg_send![this.native_window.contentView(), setNeedsDisplay: YES];
         }
     }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -282,8 +282,6 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
-    fn invalidate(&self) {}
-
     fn draw(&self, _scene: &crate::Scene) {}
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {


### PR DESCRIPTION
This is achieved by starting a `CADisplayLink` that will invoke the `on_request_frame` callback at the refresh interval of the display.

We only actually draw frames when the window was dirty, or for 2 extra seconds after the last input event to ensure ProMotion doesn't downclock the refresh rate when the user is actively interacting with the window.

Release Notes:

- Improved performance when using a ProMotion display with fast key repeat rates.