### PR TITLE
Support documentation as a resolvable property

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -560,7 +560,10 @@ impl LanguageServer {
                         completion_item: Some(CompletionItemCapability {
                             snippet_support: Some(true),
                             resolve_support: Some(CompletionItemCapabilityResolveSupport {
-                                properties: vec!["additionalTextEdits".to_string()],
+                                properties: vec![
+                                    "documentation".to_string(),
+                                    "additionalTextEdits".to_string(),
+                                ],
                             }),
                             ..Default::default()
                         }),


### PR DESCRIPTION
Closes #7288 

<img width="1800" alt="Screenshot 2024-02-03 at 01 56 14" src="https://github.com/zed-industries/zed/assets/69181766/ed97ef30-c958-45c8-812c-a59bbbd02b19">

Release Notes:
- N/A