### PR TITLE
Remove unnecessary `focus_invalidated` field

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -658,7 +658,7 @@ impl AppContext {
                     .values()
                     .filter_map(|window| {
                         let window = window.as_ref()?;
-                        (window.dirty.get() || window.focus_invalidated).then_some(window.handle)
+                        window.dirty.get().then_some(window.handle)
                     })
                     .collect::<Vec<_>>()
                 {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -280,9 +280,6 @@ pub struct Window {
     pub(crate) focus: Option<FocusId>,
     focus_enabled: bool,
     pending_input: Option<PendingInput>,
-
-    #[cfg(any(test, feature = "test-support"))]
-    pub(crate) focus_invalidated: bool,
 }
 
 #[derive(Default, Debug)]
@@ -451,9 +448,6 @@ impl Window {
             focus: None,
             focus_enabled: true,
             pending_input: None,
-
-            #[cfg(any(test, feature = "test-support"))]
-            focus_invalidated: false,
         }
     }
 }
@@ -538,12 +532,6 @@ impl<'a> WindowContext<'a> {
             .rendered_frame
             .dispatch_tree
             .clear_pending_keystrokes();
-
-        #[cfg(any(test, feature = "test-support"))]
-        {
-            self.window.focus_invalidated = true;
-        }
-
         self.refresh();
     }
 
@@ -984,11 +972,6 @@ impl<'a> WindowContext<'a> {
     pub(crate) fn draw(&mut self) {
         self.window.dirty.set(false);
         self.window.drawing = true;
-
-        #[cfg(any(test, feature = "test-support"))]
-        {
-            self.window.focus_invalidated = false;
-        }
 
         if let Some(requested_handler) = self.window.rendered_frame.requested_input_handler.as_mut()
         {


### PR DESCRIPTION
I believe at some point this was used for tests but it doesn't seem necessary anymore.

Release Notes:

- N/A
