### PR TITLE
Revert the commit that broke Zed display capabilities

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -652,20 +652,27 @@ impl AppContext {
                     }
                 }
             } else {
+                for window in self.windows.values() {
+                    if let Some(window) = window.as_ref() {
+                        if window.dirty {
+                            window.platform_window.invalidate();
+                        }
+                    }
+                }
+
                 #[cfg(any(test, feature = "test-support"))]
                 for window in self
                     .windows
                     .values()
                     .filter_map(|window| {
                         let window = window.as_ref()?;
-                        window.dirty.get().then_some(window.handle)
+                        (window.dirty || window.focus_invalidated).then_some(window.handle)
                     })
                     .collect::<Vec<_>>()
                 {
                     self.update_window(window, |_, cx| cx.draw()).unwrap();
                 }
 
-                #[allow(clippy::collapsible_else_if)]
                 if self.pending_effects.is_empty() {
                     break;
                 }
@@ -742,7 +749,7 @@ impl AppContext {
     fn apply_refresh_effect(&mut self) {
         for window in self.windows.values_mut() {
             if let Some(window) = window.as_mut() {
-                window.dirty.set(true);
+                window.dirty = true;
             }
         }
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -175,6 +175,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn is_topmost_for_position(&self, position: Point<Pixels>) -> bool;
+    fn invalidate(&self);
     fn draw(&self, scene: &Scene);
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -282,6 +282,8 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
+    fn invalidate(&self) {}
+
     fn draw(&self, _scene: &crate::Scene) {}
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -22,7 +22,7 @@ use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
     borrow::{Borrow, BorrowMut},
-    cell::{Cell, RefCell},
+    cell::RefCell,
     collections::hash_map::Entry,
     fmt::{Debug, Display},
     future::Future,
@@ -34,7 +34,7 @@ use std::{
         atomic::{AtomicUsize, Ordering::SeqCst},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 use util::{measure, ResultExt};
 
@@ -272,8 +272,7 @@ pub struct Window {
     appearance: WindowAppearance,
     appearance_observers: SubscriberSet<(), AnyObserver>,
     active: bool,
-    pub(crate) dirty: Rc<Cell<bool>>,
-    pub(crate) last_input_timestamp: Rc<Cell<Instant>>,
+    pub(crate) dirty: bool,
     pub(crate) refreshing: bool,
     pub(crate) drawing: bool,
     activation_observers: SubscriberSet<(), AnyObserver>,
@@ -340,28 +339,13 @@ impl Window {
         let bounds = platform_window.bounds();
         let appearance = platform_window.appearance();
         let text_system = Arc::new(WindowTextSystem::new(cx.text_system().clone()));
-        let dirty = Rc::new(Cell::new(false));
-        let last_input_timestamp = Rc::new(Cell::new(Instant::now()));
 
         platform_window.on_request_frame(Box::new({
             let mut cx = cx.to_async();
-            let dirty = dirty.clone();
-            let last_input_timestamp = last_input_timestamp.clone();
             move || {
-                if dirty.get() {
-                    measure("frame duration", || {
-                        handle
-                            .update(&mut cx, |_, cx| {
-                                cx.draw();
-                                cx.present();
-                            })
-                            .log_err();
-                    })
-                } else if last_input_timestamp.get().elapsed() < Duration::from_secs(2) {
-                    // Keep presenting the current scene for 2 extra seconds since the
-                    // last input to prevent the display from underclocking the refresh rate.
-                    handle.update(&mut cx, |_, cx| cx.present()).log_err();
-                }
+                measure("frame duration", || {
+                    handle.update(&mut cx, |_, cx| cx.draw()).log_err();
+                })
             }
         }));
         platform_window.on_resize(Box::new({
@@ -440,8 +424,7 @@ impl Window {
             appearance,
             appearance_observers: SubscriberSet::new(),
             active: false,
-            dirty,
-            last_input_timestamp,
+            dirty: false,
             refreshing: false,
             drawing: false,
             activation_observers: SubscriberSet::new(),
@@ -499,7 +482,7 @@ impl<'a> WindowContext<'a> {
     pub fn refresh(&mut self) {
         if !self.window.drawing {
             self.window.refreshing = true;
-            self.window.dirty.set(true);
+            self.window.dirty = true;
         }
     }
 
@@ -967,10 +950,9 @@ impl<'a> WindowContext<'a> {
         &self.window.next_frame.z_index_stack
     }
 
-    /// Produces a new frame and assigns it to `rendered_frame`. To actually show
-    /// the contents of the new [Scene], use [present].
+    /// Draw pixels to the display for this window based on the contents of its scene.
     pub(crate) fn draw(&mut self) {
-        self.window.dirty.set(false);
+        self.window.dirty = false;
         self.window.drawing = true;
 
         if let Some(requested_handler) = self.window.rendered_frame.requested_input_handler.as_mut()
@@ -1106,19 +1088,16 @@ impl<'a> WindowContext<'a> {
                 .clone()
                 .retain(&(), |listener| listener(&event, self));
         }
+
+        self.window
+            .platform_window
+            .draw(&self.window.rendered_frame.scene);
         self.window.refreshing = false;
         self.window.drawing = false;
     }
 
-    fn present(&self) {
-        self.window
-            .platform_window
-            .draw(&self.window.rendered_frame.scene);
-    }
-
     /// Dispatch a mouse or keyboard event on the window.
     pub fn dispatch_event(&mut self, event: PlatformInput) -> bool {
-        self.window.last_input_timestamp.set(Instant::now());
         // Handlers may set this to false by calling `stop_propagation`.
         self.app.propagate_event = true;
         // Handlers may set this to true by calling `prevent_default`.
@@ -2062,7 +2041,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
         }
 
         if !self.window.drawing {
-            self.window_cx.window.dirty.set(true);
+            self.window_cx.window.dirty = true;
             self.window_cx.app.push_effect(Effect::Notify {
                 emitter: self.view.model.entity_id,
             });


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/7318

Reverts
https://github.com/zed-industries/zed/commit/15edc46827a08f4befeaecf0a7f6be692b8391a4 to make Zed working again.


Release Notes:

- N/A
