### PR TITLE
Editor toolbar configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
  "editor",
  "gpui",
  "search",
+ "settings",
  "ui",
  "workspace",
 ]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -111,8 +111,6 @@
   },
   // Toolbar related settings
   "toolbar": {
-    // Whether to show toolbar.
-    "show": true,
     // Whether to show breadcrumbs.
     "breadcrumbs": true,
     // Whether to show quick action buttons.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -109,6 +109,15 @@
     // Share your project when you are the first to join a channel
     "share_on_join": true
   },
+  // Toolbar related settings
+  "toolbar": {
+    // Whether to show toolbar.
+    "show": true,
+    // Whether to show breadcrumbs.
+    "breadcrumbs": true,
+    // Whether to show quick action buttons.
+    "quick_actions": true
+  },
   // Scrollbar related settings
   "scrollbar": {
     // When to show the scrollbar in the editor.

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -1,9 +1,9 @@
-use editor::{Editor, EditorSettings};
+use editor::Editor;
 use gpui::{
-    AppContext, Element, EventEmitter, ParentElement, Render, StyledText, Subscription, ViewContext,
+    Element, EventEmitter, IntoElement, ParentElement, Render, StyledText, Subscription,
+    ViewContext,
 };
 use itertools::Itertools;
-use settings::{Settings, SettingsStore};
 use theme::ActiveTheme;
 use ui::{prelude::*, ButtonLike, ButtonStyle, Label, Tooltip};
 use workspace::{
@@ -15,25 +15,15 @@ pub struct Breadcrumbs {
     pane_focused: bool,
     active_item: Option<Box<dyn ItemHandle>>,
     subscription: Option<Subscription>,
-    visible: bool,
 }
 
 impl Breadcrumbs {
-    pub fn new(cx: &mut ViewContext<Self>) -> Self {
-        let mut this = Self {
+    pub fn new() -> Self {
+        Self {
             pane_focused: false,
             active_item: Default::default(),
             subscription: Default::default(),
-            visible: true,
-        };
-        this.apply_settings(cx);
-        cx.observe_global::<SettingsStore>(|this, cx| this.apply_settings(cx))
-            .detach();
-        this
-    }
-
-    fn apply_settings(&mut self, cx: &mut AppContext) {
-        self.visible = EditorSettings::get_global(cx).toolbar.breadcrumbs;
+        }
     }
 }
 
@@ -41,9 +31,6 @@ impl EventEmitter<ToolbarItemEvent> for Breadcrumbs {}
 
 impl Render for Breadcrumbs {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        if !self.visible {
-            return div();
-        }
         let element = h_flex().text_ui();
         let Some(active_item) = self.active_item.as_ref() else {
             return element;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -374,6 +374,7 @@ pub struct Editor {
     hovered_cursors: HashMap<HoveredCursor, Task<()>>,
     pub show_local_selections: bool,
     mode: EditorMode,
+    show_breadcrumbs: bool,
     show_gutter: bool,
     show_wrap_guides: Option<bool>,
     placeholder_text: Option<Arc<str>>,
@@ -1448,6 +1449,7 @@ impl Editor {
             blink_manager: blink_manager.clone(),
             show_local_selections: true,
             mode,
+            show_breadcrumbs: EditorSettings::get_global(cx).toolbar.breadcrumbs,
             show_gutter: mode == EditorMode::Full,
             show_wrap_guides: None,
             placeholder_text: None,
@@ -8762,8 +8764,9 @@ impl Editor {
             )),
             cx,
         );
-        self.scroll_manager.vertical_scroll_margin =
-            EditorSettings::get_global(cx).vertical_scroll_margin;
+        let editor_settings = EditorSettings::get_global(cx);
+        self.scroll_manager.vertical_scroll_margin = editor_settings.vertical_scroll_margin;
+        self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
         cx.notify();
     }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -10,6 +10,7 @@ pub struct EditorSettings {
     pub show_completion_documentation: bool,
     pub completion_documentation_secondary_query_debounce: u64,
     pub use_on_type_format: bool,
+    pub toolbar: Toolbar,
     pub scrollbar: Scrollbar,
     pub vertical_scroll_margin: f32,
     pub relative_line_numbers: bool,
@@ -27,6 +28,13 @@ pub enum SeedQuerySetting {
     Selection,
     /// Never populate the search query
     Never,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct Toolbar {
+    pub show: bool,
+    pub breadcrumbs: bool,
+    pub quick_actions: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -86,6 +94,8 @@ pub struct EditorSettingsContent {
     ///
     /// Default: true
     pub use_on_type_format: Option<bool>,
+    /// Toolbar related settings
+    pub toolbar: Option<ToolbarContent>,
     /// Scrollbar related settings
     pub scrollbar: Option<ScrollbarContent>,
 
@@ -108,6 +118,23 @@ pub struct EditorSettingsContent {
     ///
     /// Default: false
     pub redact_private_values: Option<bool>,
+}
+
+// Toolbar related settings
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ToolbarContent {
+    /// Whether to display the toolbar in the editor.
+    ///
+    /// Default: true
+    pub show: Option<bool>,
+    /// Whether to display breadcrumbs in the editor toolbar.
+    ///
+    /// Default: true
+    pub breadcrumbs: Option<bool>,
+    /// Whether to display quik action buttons in the editor toolbar.
+    ///
+    /// Default: true
+    pub quick_actions: Option<bool>,
 }
 
 /// Scrollbar related settings

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -32,7 +32,6 @@ pub enum SeedQuerySetting {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Toolbar {
-    pub show: bool,
     pub breadcrumbs: bool,
     pub quick_actions: bool,
 }
@@ -123,10 +122,6 @@ pub struct EditorSettingsContent {
 // Toolbar related settings
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ToolbarContent {
-    /// Whether to display the toolbar in the editor.
-    ///
-    /// Default: true
-    pub show: Option<bool>,
     /// Whether to display breadcrumbs in the editor toolbar.
     ///
     /// Default: true

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -800,7 +800,11 @@ impl Item for Editor {
     }
 
     fn breadcrumb_location(&self) -> ToolbarItemLocation {
-        ToolbarItemLocation::PrimaryLeft
+        if self.show_breadcrumbs {
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
     }
 
     fn breadcrumbs(&self, variant: &Theme, cx: &AppContext) -> Option<Vec<BreadcrumbText>> {

--- a/crates/quick_action_bar/Cargo.toml
+++ b/crates/quick_action_bar/Cargo.toml
@@ -14,6 +14,7 @@ assistant = { path = "../assistant" }
 editor = { path = "../editor" }
 gpui = { path = "../gpui" }
 search = { path = "../search" }
+settings = { path = "../settings" }
 ui = { path = "../ui" }
 workspace = { path = "../workspace" }
 

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -46,10 +46,13 @@ impl QuickActionBar {
     }
 
     fn apply_settings(&mut self, cx: &mut ViewContext<Self>) {
-        self.show = EditorSettings::get_global(cx).toolbar.quick_actions;
-        cx.emit(ToolbarItemEvent::ChangeLocation(
-            self.get_toolbar_item_location(),
-        ));
+        let new_show = EditorSettings::get_global(cx).toolbar.quick_actions;
+        if new_show != self.show {
+            self.show = new_show;
+            cx.emit(ToolbarItemEvent::ChangeLocation(
+                self.get_toolbar_item_location(),
+            ));
+        }
     }
 
     fn get_toolbar_item_location(&self) -> ToolbarItemLocation {

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -127,7 +127,7 @@ impl Render for Toolbar {
                             h_flex()
                                 // We're using `flex_none` here to prevent some flickering that can occur when the
                                 // size of the left items container changes.
-                                .flex_none()
+                                .when_else(has_left_items, Div::flex_none, Div::flex_auto)
                                 .justify_end()
                                 .children(self.right_items().map(|item| item.to_any())),
                         )

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -347,13 +347,13 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
 fn initialize_pane(workspace: &mut Workspace, pane: &View<Pane>, cx: &mut ViewContext<Workspace>) {
     pane.update(cx, |pane, cx| {
         pane.toolbar().update(cx, |toolbar, cx| {
-            let breadcrumbs = cx.new_view(|_| Breadcrumbs::new());
+            let breadcrumbs = cx.new_view(|cx| Breadcrumbs::new(cx));
             toolbar.add_item(breadcrumbs, cx);
             let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
             toolbar.add_item(buffer_search_bar.clone(), cx);
 
             let quick_action_bar =
-                cx.new_view(|_| QuickActionBar::new(buffer_search_bar, workspace));
+                cx.new_view(|cx| QuickActionBar::new(buffer_search_bar, workspace, cx));
             toolbar.add_item(quick_action_bar, cx);
             let diagnostic_editor_controls = cx.new_view(|_| diagnostics::ToolbarControls::new());
             toolbar.add_item(diagnostic_editor_controls, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -347,7 +347,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
 fn initialize_pane(workspace: &mut Workspace, pane: &View<Pane>, cx: &mut ViewContext<Workspace>) {
     pane.update(cx, |pane, cx| {
         pane.toolbar().update(cx, |toolbar, cx| {
-            let breadcrumbs = cx.new_view(|cx| Breadcrumbs::new(cx));
+            let breadcrumbs = cx.new_view(|_| Breadcrumbs::new());
             toolbar.add_item(breadcrumbs, cx);
             let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
             toolbar.add_item(buffer_search_bar.clone(), cx);

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -190,6 +190,23 @@ List of `string` values
 2. Position the dock to the right of the workspace like a side panel: `right`
 3. Position the dock full screen over the entire workspace: `expanded`
 
+## Editor Toolbar
+
+- Description: Whether or not to show various elements in the editor toolbar.
+- Setting: `toolbar`
+- Default:
+
+```json
+"toolbar": {
+  "breadcrumbs": true,
+  "quick_actions": true
+},
+```
+
+**Options**
+
+Each option controls displaying of a particular toolbar element. If all elements are hidden, the editor toolbar is not displayed.
+
 ## Enable Language Server
 
 - Description: Whether or not to use language servers to provide code intelligence.


### PR DESCRIPTION
This PR adds settings for hiding breadcrumbs and quick action bar from the editor toolbar. If both elements are hidden, the toolbar disappears completely.

Example:

```json
"toolbar": {
  "breadcrumbs": true,
  "quick_actions": false
}
```

- It intentionally doesn't hide breadcrumbs in other views (for instance, in the search result window) because their usage there differ from the main editor.
- The editor controls how breadcrumbs are displayed in the toolbar, so implementation differs a bit for breadcrumbs and quick actions bar.

Release Notes:

- Added support for configuring the editor toolbar

Resolves #4756