### PR TITLE
Improve elm-language-server configuration

### DIFF
--- a/docs/src/languages/elm.md
+++ b/docs/src/languages/elm.md
@@ -2,3 +2,24 @@
 
 - Tree Sitter: [tree-sitter-elm](https://github.com/elm-tooling/tree-sitter-elm)
 - Language Server: [elm-language-server](https://github.com/elm-tooling/elm-language-server)
+
+### Setting up `elm-language-server`
+
+Elm language server can be configured in your `settings.json`, e.g.:
+
+```json
+{
+  "lsp": {
+    "elm-language-server": {
+      "initialization_options": {
+        "disableElmLSDiagnostics": true,
+        "onlyUpdateDiagnosticsOnSave": false,
+        "elmReviewDiagnostics": "warning"
+      }
+    }
+  }
+}
+```
+
+`elm-format`, `elm-review` and `elm` need to be installed and made available in the environment
+or configured in the settings. See the [full list of server settings here](https://github.com/elm-tooling/elm-language-server?tab=readme-ov-file#server-settings).


### PR DESCRIPTION
Hi folks! @absynce and I paired a bit to improve the `elm-language-server` configuration. We have realised that sometimes `elm-language-server` settings were being reset to default. We had been configuring `elm-language-server` like this:

```json
"lsp": {
  "elm-language-server": {
    "initialization_options": {
      "disableElmLSDiagnostics": true,
      "onlyUpdateDiagnosticsOnSave": true,
      "elmReviewDiagnostics": "warning"
    }
  }
}
```

And then we noticed that the following communication happened:

```
// Send:
{"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{}}}
// Receive:
{"jsonrpc":"2.0","id":5,"method":"workspace/configuration","params":{"items":[{"section":"elmLS"}]}}
// Send:
{"jsonrpc":"2.0","id":5,"result":[null],"error":null}
```

In `elm-language-server` the settings from `didChangeConfiguration` [replace the initial settings](https://github.com/elm-tooling/elm-language-server/blob/edd68133883f3902f8940a6e5e2834a9cd627dc1/src/common/providers/diagnostics/diagnosticsProvider.ts#L188). Setting the value to `{}` effectively resets the configuration options to defaults.

In Zed, `initialization_options` and `workspace_configuration` are two different things, but in `elm-language-server` they are coupled. Additionally, `elm-language-server` is requesting workspace configuration for the `elmLS` section that doesn't exist.

This PR: 

1. Fixes  settings reset on `didChangeConfiguration` by populating `workspace_configuration` from `initialization_options`
2. Makes workspace configuration requests work by inserting an extra copy of the settings under the `elmLS` key in `workspace_configuration` — this is a bit ugly, but we're not sure how to make both kinds of configuration messages work in the current setup.

This is how communication looks like after the proposed changes:

```
// Send:
{
  "jsonrpc": "2.0",
  "method": "workspace/didChangeConfiguration",
  "params": {
    "settings": {
      "disableElmLSDiagnostics": true,
      "onlyUpdateDiagnosticsOnSave": true,
      "elmReviewDiagnostics": "warning",
      "elmLS": {
        "disableElmLSDiagnostics": true,
        "onlyUpdateDiagnosticsOnSave": true,
        "elmReviewDiagnostics": "warning"
      }
    }
  }
}
// Receive:
{
  "jsonrpc": "2.0",
  "id": 4,
  "method": "workspace/configuration",
  "params": {
    "items": [
      {
        "section": "elmLS"
      }
    ]
  }
}
// Send:
{
  "jsonrpc": "2.0",
  "id": 4,
  "result": [
    {
      "disableElmLSDiagnostics": true,
      "onlyUpdateDiagnosticsOnSave": true,
      "elmReviewDiagnostics": "warning"
    }
  ],
  "error": null
}
```

Things we have considered:

1. Extracting  the `elm-language-server` settings into a separate section: we haven't found this being widely used in Zed, seems that all language server configuration should fall under the top level `lsp` section
2. Changing the way `elm-language-server` configuration  works: `elm-language-server` has got integrations with multiple editors, changing the configuration behaviour would mean updating all the existing integrations. Plus we are not exactly sure if it's doing anything wrong.

Release Notes:

N/A
