### PR TITLE
Add support for custom file association settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -297,6 +297,8 @@
     // Whether to show warnings or not by default.
     "include_warnings": true
   },
+  // custom file associations
+  "associations": {},
   // Add files or globs of files that will be excluded by Zed entirely:
   // they will be skipped during FS scan(s), file tree and file search
   // will lack the corresponding file entries.

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -90,14 +90,14 @@ fn test_select_language() {
     // matching file extension
     assert_eq!(
         registry
-            .language_for_file("zed/lib.rs", None)
+            .language_for_file("zed/lib.rs", None, None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Rust".into())
     );
     assert_eq!(
         registry
-            .language_for_file("zed/lib.mk", None)
+            .language_for_file("zed/lib.mk", None, None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
@@ -106,7 +106,7 @@ fn test_select_language() {
     // matching filename
     assert_eq!(
         registry
-            .language_for_file("zed/Makefile", None)
+            .language_for_file("zed/Makefile", None, None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
@@ -115,21 +115,21 @@ fn test_select_language() {
     // matching suffix that is not the full file extension or filename
     assert_eq!(
         registry
-            .language_for_file("zed/cars", None)
+            .language_for_file("zed/cars", None, None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
         registry
-            .language_for_file("zed/a.cars", None)
+            .language_for_file("zed/a.cars", None, None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
         registry
-            .language_for_file("zed/sumk", None)
+            .language_for_file("zed/sumk", None, None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -44,6 +44,7 @@ pub struct AllLanguageSettings {
     pub copilot: CopilotSettings,
     defaults: LanguageSettings,
     languages: HashMap<Arc<str>, LanguageSettings>,
+    pub associations: HashMap<Arc<str>, Vec<Arc<str>>>
 }
 
 /// The settings for a particular language.
@@ -119,6 +120,8 @@ pub struct AllLanguageSettingsContent {
     /// The settings for individual languages.
     #[serde(default, alias = "language_overrides")]
     pub languages: HashMap<Arc<str>, LanguageSettingsContent>,
+    #[serde(default)]
+    pub associations: HashMap<Arc<str>, Vec<Arc<str>>>
 }
 
 /// The settings for a particular language.
@@ -473,6 +476,11 @@ impl settings::Settings for AllLanguageSettings {
             }
         }
 
+        let mut associations = default_value.associations.clone();
+        for map in user_settings.iter().map(|s| &s.associations) {
+            associations.extend(map.clone());
+        }
+
         Ok(Self {
             copilot: CopilotSettings {
                 feature_enabled: copilot_enabled,
@@ -483,6 +491,7 @@ impl settings::Settings for AllLanguageSettings {
             },
             defaults,
             languages,
+            associations
         })
     }
 

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -575,7 +575,7 @@ impl SemanticIndex {
                                 }
 
                                 if let Ok(language) = language_registry
-                                    .language_for_file(&absolute_path, None)
+                                    .language_for_file(&absolute_path, None, None)
                                     .await
                                 {
                                     // Test if file is valid parseable file
@@ -1137,7 +1137,7 @@ impl SemanticIndex {
 
                     for mut pending_file in pending_files {
                         if let Ok(language) = language_registry
-                            .language_for_file(&pending_file.relative_path, None)
+                            .language_for_file(&pending_file.relative_path, None, None)
                             .await
                         {
                             if !PARSEABLE_ENTIRE_FILE_TYPES.contains(&language.name().as_ref())


### PR DESCRIPTION
Release Notes:

- Added support for custom file associations.

This PR allows user to set their own file association settings.

Users can specify the association settings by configuring the `.zed/settings.json`:
```JSON
{
  "associations" : {
    "Rust": ["my_rust", "my_rs"],
    "C++": ["hh"]
  }
}
```

I modified the `language_for_file` function to receive an additional `context_info`  (a tuple of (`worktree_id, &AppContext`)) argument, and then use the `AppContext` to load user's custom association settings before using the default `path_suffixes` described in each language's config file to detect the language.

I don't know if this is a appropriate way to solve the problem, and I am encountering difficulties in obtaining `AppContext` in the following locations: 
[[1]](https://github.com/ljwljwljwljw/zed/blob/1130f24d0ebf5ba9d6b2725e95c2f20a3d1d16a4/crates/semantic_index/src/semantic_index.rs#L578), [[2]](https://github.com/ljwljwljwljw/zed/blob/1130f24d0ebf5ba9d6b2725e95c2f20a3d1d16a4/crates/semantic_index/src/semantic_index.rs#L1140), [[3]](https://github.com/ljwljwljwljw/zed/blob/1130f24d0ebf5ba9d6b2725e95c2f20a3d1d16a4/crates/project/src/project.rs#L8507)

so I left them unchanged, awaiting for your suggestions.


Related discussions:
- #5178
- #6108
- #7150
