### PR TITLE
Do not show completion documentation if disabled

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -852,7 +852,7 @@ impl CompletionsMenu {
         let selected_item = self.selected_item;
         let style = style.clone();
 
-        let multiline_docs = {
+        let multiline_docs = if show_completion_documentation {
             let mat = &self.matches[selected_item];
             let multiline_docs = match &self.completions.read()[mat.candidate_id].documentation {
                 Some(Documentation::MultiLinePlainText(text)) => {
@@ -883,6 +883,8 @@ impl CompletionsMenu {
                     // because that would move the cursor.
                     .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
             })
+        } else {
+            None
         };
 
         let list = uniform_list(


### PR DESCRIPTION
This fixes #7348 by not rendering completions if they are disabled in the settings. Previously we only checked that setting when starting or not starting background threads to fetch documentation. But in case we already have documentation, this stops it from being rendered.

Release Notes:

- Fixed documentation in completions showing up even when disabled via `show_completion_documentation` ([#7348](https://github.com/zed-industries/zed/issues/7348))

