### PR TITLE
picker: Outline Editor::new

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -58,13 +58,16 @@ impl<D: PickerDelegate> FocusableView for Picker<D> {
     }
 }
 
+fn create_editor(placeholder: Arc<str>, cx: &mut WindowContext<'_>) -> View<Editor> {
+    cx.new_view(|cx| {
+        let mut editor = Editor::single_line(cx);
+        editor.set_placeholder_text(placeholder, cx);
+        editor
+    })
+}
 impl<D: PickerDelegate> Picker<D> {
     pub fn new(delegate: D, cx: &mut ViewContext<Self>) -> Self {
-        let editor = cx.new_view(|cx| {
-            let mut editor = Editor::single_line(cx);
-            editor.set_placeholder_text(delegate.placeholder_text(), cx);
-            editor
-        });
+        let editor = create_editor(delegate.placeholder_text(), cx);
         cx.subscribe(&editor, Self::on_input_editor_event).detach();
         let mut this = Self {
             delegate,


### PR DESCRIPTION
That way crates that use Picker::new do not have to codegen constructor of Editor; tl;dr, 10% of LLVM IR shaved off of crates like vcs_menu or theme_selector in release mode.

Release Notes:

- N/A
