### PR TITLE
Remove default keybinds for navigating between docks/editors

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -502,18 +502,5 @@
       "enter": "vim::SearchSubmit",
       "escape": "buffer_search::Dismiss"
     }
-  },
-  {
-    "context": "Dock",
-    "bindings": {
-      "ctrl-w h": ["workspace::ActivatePaneInDirection", "Left"],
-      "ctrl-w l": ["workspace::ActivatePaneInDirection", "Right"],
-      "ctrl-w k": ["workspace::ActivatePaneInDirection", "Up"],
-      "ctrl-w j": ["workspace::ActivatePaneInDirection", "Down"],
-      "ctrl-w ctrl-h": ["workspace::ActivatePaneInDirection", "Left"],
-      "ctrl-w ctrl-l": ["workspace::ActivatePaneInDirection", "Right"],
-      "ctrl-w ctrl-k": ["workspace::ActivatePaneInDirection", "Up"],
-      "ctrl-w ctrl-j": ["workspace::ActivatePaneInDirection", "Down"]
-    }
   }
 ]


### PR DESCRIPTION
Turns out that these keybindings are active in Vim *and* in non-Vim mode and they shadow `Ctrl-w` in terminals.

We should fix `Ctrl-w` being shadowed, but until then let's remove the default keybindings.

Release Notes:

- N/A
