### PR TITLE
Use window's screen rather than window itself to start display link

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -530,7 +530,7 @@ impl MacWindow {
             let native_view = NSView::init(native_view);
             assert!(!native_view.is_null());
 
-            let display_link = start_display_link(native_window, native_view);
+            let display_link = start_display_link(native_window.screen(), native_view);
 
             let window = Self(Arc::new(Mutex::new(MacWindowState {
                 handle,


### PR DESCRIPTION
Fixes crash that doesn't seem to be present on Sonoma but I experience on Ventura

Release Notes:

- N/A
