### PR TITLE
Do not run scheduled CI jobs on forks

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -16,6 +16,7 @@ env:
 jobs:
     style:
         name: Check formatting and Clippy lints
+        if: github.repository_owner == 'zed-industries'
         runs-on:
             - self-hosted
             - test
@@ -32,6 +33,7 @@ jobs:
 
     tests:
         name: Run tests
+        if: github.repository_owner == 'zed-industries'
         runs-on:
             - self-hosted
             - test
@@ -48,6 +50,7 @@ jobs:
 
     bundle:
         name: Bundle app
+        if: github.repository_owner == 'zed-industries'
         runs-on:
             - self-hosted
             - bundle

--- a/.github/workflows/update_all_top_ranking_issues.yml
+++ b/.github/workflows/update_all_top_ranking_issues.yml
@@ -6,6 +6,7 @@ on:
 jobs:
     update_top_ranking_issues:
         runs-on: ubuntu-latest
+        if: github.repository_owner == 'zed-industries'
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v4

--- a/.github/workflows/update_weekly_top_ranking_issues.yml
+++ b/.github/workflows/update_weekly_top_ranking_issues.yml
@@ -6,6 +6,7 @@ on:
 jobs:
     update_top_ranking_issues:
         runs-on: ubuntu-latest
+        if: github.repository_owner == 'zed-industries'
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v4


### PR DESCRIPTION
Runs scheduled CI jobs only on the main repository, not on forks. These jobs fail on forks and generate unnecessary noise on contributor emails. 



Release Notes:

- N/A
