### PR TITLE
Correctly use the base element in `HighlightedLabel`

### DIFF
--- a/crates/ui/src/components/label/highlighted_label.rs
+++ b/crates/ui/src/components/label/highlighted_label.rs
@@ -79,8 +79,7 @@ impl RenderOnce for HighlightedLabel {
         let mut text_style = cx.text_style().clone();
         text_style.color = self.base.color.color(cx);
 
-        LabelLike::new()
-            .size(self.base.size)
+        self.base
             .child(StyledText::new(self.label).with_highlights(&text_style, highlights))
     }
 }

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -36,7 +36,7 @@ pub trait LabelCommon {
 
 #[derive(IntoElement)]
 pub struct LabelLike {
-    pub(crate) size: LabelSize,
+    size: LabelSize,
     line_height_style: LineHeightStyle,
     pub(crate) color: Color,
     strikethrough: bool,


### PR DESCRIPTION
This PR updates the `HighlightedLabel` to correctly render its base element, which is the one that receives the styling properties, instead of rendering a new `LabelLike`.

Release Notes:

- N/A
