### PR TITLE
file_finder: Simplify removal of file name from file path

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -584,12 +584,7 @@ impl FileFinderDelegate {
             })
             .collect();
 
-        // Trim file name from the full path
-        let full_path = if full_path.len() > file_name.len() {
-            full_path[..full_path.len() - file_name.len() - 1].to_string()
-        } else {
-            "".to_string()
-        };
+        let full_path = full_path.trim_end_matches(&file_name).to_string();
         path_positions.retain(|idx| *idx < full_path.len());
 
         (file_name, file_name_positions, full_path, path_positions)


### PR DESCRIPTION
This PR simplifies the removal of the file name from the file path when computing the file finder matches.

Release Notes:

- N/A
