### PR TITLE
Add Make language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10337,6 +10337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-make"
+version = "0.0.1"
+source = "git+https://github.com/caius/tree-sitter-make?rev=b35c2714e73d2846b26061b06cda4fa56d61e3a5#b35c2714e73d2846b26061b06cda4fa56d61e3a5"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-markdown"
 version = "0.0.1"
 source = "git+https://github.com/MDeiml/tree-sitter-markdown?rev=330ecab87a3e3a7211ac69bbadc19eabecdb1cca#330ecab87a3e3a7211ac69bbadc19eabecdb1cca"
@@ -12066,6 +12075,7 @@ dependencies = [
  "tree-sitter-html",
  "tree-sitter-json 0.20.0",
  "tree-sitter-lua",
+ "tree-sitter-make",
  "tree-sitter-markdown",
  "tree-sitter-nix",
  "tree-sitter-nu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,6 +255,7 @@ tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex
 tree-sitter-html = "0.19.0"
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-lua = "0.0.14"
+tree-sitter-make = { git = "https://github.com/caius/tree-sitter-make", rev = "b35c2714e73d2846b26061b06cda4fa56d61e3a5" }
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
 tree-sitter-nix = { git = "https://github.com/nix-community/tree-sitter-nix", rev = "66e3e9ce9180ae08fc57372061006ef83f0abde7" }
 tree-sitter-nu = { git = "https://github.com/nushell/tree-sitter-nu", rev = "7dd29f9616822e5fc259f5b4ae6c4ded9a71a132" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -519,6 +519,10 @@
         "source.organizeImports": true
       }
     },
+    "Make": {
+      "tab_size": 4,
+      "hard_tabs": true
+    },
     "Markdown": {
       "tab_size": 2,
       "soft_wrap": "preferred_line_length"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -138,6 +138,7 @@ tree-sitter-heex.workspace = true
 tree-sitter-html.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-lua.workspace = true
+tree-sitter-make.workspace = true
 tree-sitter-markdown.workspace = true
 tree-sitter-nix.workspace = true
 tree-sitter-nu.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -95,6 +95,7 @@ pub fn init(
         ("html", tree_sitter_html::language()),
         ("json", tree_sitter_json::language()),
         ("lua", tree_sitter_lua::language()),
+        ("make", tree_sitter_make::language()),
         ("markdown", tree_sitter_markdown::language()),
         ("nix", tree_sitter_nix::language()),
         ("nu", tree_sitter_nu::language()),
@@ -202,6 +203,7 @@ pub fn init(
             languages.clone(),
         ))],
     );
+    language("make", vec![]);
     language("markdown", vec![]);
     language(
         "python",

--- a/crates/zed/src/languages/make/config.toml
+++ b/crates/zed/src/languages/make/config.toml
@@ -1,0 +1,6 @@
+name = "Make"
+path_suffixes = ["Makefile", "makefile", "GNUmakefile"]
+line_comments = ["#"]
+brackets = [
+  { start = "(", end = ")", close = true, newline = true },
+]

--- a/crates/zed/src/languages/make/highlights.scm
+++ b/crates/zed/src/languages/make/highlights.scm
@@ -1,0 +1,171 @@
+[
+ "("
+ ")"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ ":"
+ "&:"
+ "::"
+ "|"
+ ";"
+ "\""
+ "'"
+ ","
+] @punctuation.delimiter
+
+[
+ "$"
+ "$$"
+] @punctuation.special
+
+(automatic_variable
+ [ "@" "%" "<" "?" "^" "+" "/" "*" "D" "F"] @punctuation.special)
+
+(automatic_variable
+ "/" @error . ["D" "F"])
+
+[
+ "="
+ ":="
+ "::="
+ "?="
+ "+="
+ "!="
+ "@"
+ "-"
+ "+"
+] @operator
+
+[
+ (text)
+ (string)
+ (raw_text)
+] @string
+
+(variable_assignment (word) @string)
+
+[
+ "ifeq"
+ "ifneq"
+ "ifdef"
+ "ifndef"
+ "else"
+ "endif"
+ "if"
+ "or"  ; boolean functions are conditional in make grammar
+ "and"
+] @conditional
+
+"foreach" @repeat
+
+[
+ "define"
+ "endef"
+ "vpath"
+ "undefine"
+ "export"
+ "unexport"
+ "override"
+ "private"
+; "load"
+] @keyword
+
+[
+ "include"
+ "sinclude"
+ "-include"
+] @include
+
+[
+ "subst"
+ "patsubst"
+ "strip"
+ "findstring"
+ "filter"
+ "filter-out"
+ "sort"
+ "word"
+ "words"
+ "wordlist"
+ "firstword"
+ "lastword"
+ "dir"
+ "notdir"
+ "suffix"
+ "basename"
+ "addsuffix"
+ "addprefix"
+ "join"
+ "wildcard"
+ "realpath"
+ "abspath"
+ "call"
+ "eval"
+ "file"
+ "value"
+ "shell"
+] @keyword.function
+
+[
+ "error"
+ "warning"
+ "info"
+] @exception
+
+;; Variable
+(variable_assignment
+  name: (word) @constant)
+
+(variable_reference
+  (word) @constant)
+
+(comment) @comment
+
+((word) @clean @string.regex
+ (#match? @clean "[%\*\?]"))
+
+(function_call
+  function: "error"
+  (arguments (text) @text.danger))
+
+(function_call
+  function: "warning"
+  (arguments (text) @text.warning))
+
+(function_call
+  function: "info"
+  (arguments (text) @text.note))
+
+;; Install Command Categories
+;; Others special variables
+;; Variables Used by Implicit Rules
+[
+ "VPATH"
+ ".RECIPEPREFIX"
+] @constant.builtin
+
+(variable_assignment
+  name: (word) @clean @constant.builtin
+        (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS)$"))
+
+(variable_reference
+  (word) @clean @constant.builtin
+  (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS\.VARIABLES|\.FEATURES|\.INCLUDE_DIRS|\.LOADED)$"))
+
+;; Standart targets
+(targets
+  (word) @constant.macro
+  (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
+
+(targets
+  (word) @constant.macro
+  (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
+
+;; Builtin targets
+(targets
+  (word) @constant.macro
+  (#match? @constant.macro "^\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX)$"))
+

--- a/crates/zed/src/languages/make/highlights.scm
+++ b/crates/zed/src/languages/make/highlights.scm
@@ -24,9 +24,6 @@
 (automatic_variable
  [ "@" "%" "<" "?" "^" "+" "/" "*" "D" "F"] @punctuation.special)
 
-(automatic_variable
- "/" @error . ["D" "F"])
-
 [
  "="
  ":="
@@ -57,9 +54,9 @@
  "if"
  "or"  ; boolean functions are conditional in make grammar
  "and"
-] @conditional
+] @keyword
 
-"foreach" @repeat
+"foreach" @keyword
 
 [
  "define"
@@ -77,7 +74,7 @@
  "include"
  "sinclude"
  "-include"
-] @include
+] @keyword
 
 [
  "subst"
@@ -107,13 +104,13 @@
  "file"
  "value"
  "shell"
-] @keyword.function
+] @function
 
 [
  "error"
  "warning"
  "info"
-] @exception
+] @label
 
 ;; Variable
 (variable_assignment
@@ -129,15 +126,15 @@
 
 (function_call
   function: "error"
-  (arguments (text) @text.danger))
+  (arguments (text) @text.literal))
 
 (function_call
   function: "warning"
-  (arguments (text) @text.warning))
+  (arguments (text) @text.literal))
 
 (function_call
   function: "info"
-  (arguments (text) @text.note))
+  (arguments (text) @text.literal))
 
 ;; Install Command Categories
 ;; Others special variables
@@ -145,27 +142,26 @@
 [
  "VPATH"
  ".RECIPEPREFIX"
-] @constant.builtin
+] @constant
 
 (variable_assignment
-  name: (word) @clean @constant.builtin
+  name: (word) @clean @constant
         (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS)$"))
 
 (variable_reference
-  (word) @clean @constant.builtin
+  (word) @clean @constant
   (#match? @clean "^(AR|AS|CC|CXX|CPP|FC|M2C|PC|CO|GET|LEX|YACC|LINT|MAKEINFO|TEX|TEXI2DVI|WEAVE|CWEAVE|TANGLE|CTANGLE|RM|ARFLAGS|ASFLAGS|CFLAGS|CXXFLAGS|COFLAGS|CPPFLAGS|FFLAGS|GFLAGS|LDFLAGS|LDLIBS|LFLAGS|YFLAGS|PFLAGS|RFLAGS|LINTFLAGS|PRE_INSTALL|POST_INSTALL|NORMAL_INSTALL|PRE_UNINSTALL|POST_UNINSTALL|NORMAL_UNINSTALL|MAKEFILE_LIST|MAKE_RESTARTS|MAKE_TERMOUT|MAKE_TERMERR|\.DEFAULT_GOAL|\.RECIPEPREFIX|\.EXTRA_PREREQS\.VARIABLES|\.FEATURES|\.INCLUDE_DIRS|\.LOADED)$"))
 
-;; Standart targets
+;; Standard targets
 (targets
-  (word) @constant.macro
-  (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
+  (word) @constant
+  (#match? @constant "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
 
 (targets
-  (word) @constant.macro
-  (#match? @constant.macro "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
+  (word) @constant
+  (#match? @constant "^(all|install|install-html|install-dvi|install-pdf|install-ps|uninstall|install-strip|clean|distclean|mostlyclean|maintainer-clean|TAGS|info|dvi|html|pdf|ps|dist|check|installcheck|installdirs)$"))
 
 ;; Builtin targets
 (targets
-  (word) @constant.macro
-  (#match? @constant.macro "^\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX)$"))
-
+  (word) @constant
+  (#match? @constant "^\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX)$"))


### PR DESCRIPTION
Adds Makefile syntax highlighting, based on [tree-sitter-make](https://github.com/alemuller/tree-sitter-make).


Release Notes:

- Added Makefile language support ([#5366](https://github.com/zed-industries/extensions/issues/135)).
