### PR TITLE
Upgrade GH actions to reduce CI warnings

### DIFF
--- a/.github/actions/check_style/action.yml
+++ b/.github/actions/check_style/action.yml
@@ -2,29 +2,29 @@ name: "Check formatting"
 description: "Checks code formatting use cargo fmt"
 
 runs:
-  using: "composite"
-  steps:
-    - name: cargo fmt
-      shell: bash -euxo pipefail {0}
-      run: cargo fmt --all -- --check
+    using: "composite"
+    steps:
+        - name: cargo fmt
+          shell: bash -euxo pipefail {0}
+          run: cargo fmt --all -- --check
 
-    - name: cargo clippy
-      shell: bash -euxo pipefail {0}
-      # clippy.toml is not currently supporting specifying allowed lints
-      # so specify those here, and disable the rest until Zed's workspace
-      # will have more fixes & suppression for the standard lint set
-      run: |
-        cargo clippy --release --workspace --all-features --all-targets -- -A clippy::all -D clippy::dbg_macro -D clippy::todo
-        cargo clippy -p gpui
+        - name: cargo clippy
+          shell: bash -euxo pipefail {0}
+          # clippy.toml is not currently supporting specifying allowed lints
+          # so specify those here, and disable the rest until Zed's workspace
+          # will have more fixes & suppression for the standard lint set
+          run: |
+              cargo clippy --release --workspace --all-features --all-targets -- -A clippy::all -D clippy::dbg_macro -D clippy::todo
+              cargo clippy -p gpui
 
-    - name: Find modified migrations
-      shell: bash -euxo pipefail {0}
-      run: |
-        export SQUAWK_GITHUB_TOKEN=${{ github.token }}
-        . ./script/squawk
+        - name: Find modified migrations
+          shell: bash -euxo pipefail {0}
+          run: |
+              export SQUAWK_GITHUB_TOKEN=${{ github.token }}
+              . ./script/squawk
 
-    - uses: bufbuild/buf-setup-action@v1
-    - uses: bufbuild/buf-breaking-action@v1
-      with:
-        input: "crates/rpc/proto/"
-        against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=crates/rpc/proto/"
+        - uses: bufbuild/buf-setup-action@v1
+        - uses: bufbuild/buf-breaking-action@v1
+          with:
+              input: "crates/rpc/proto/"
+              against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=crates/rpc/proto/"

--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -10,7 +10,7 @@ runs:
               cargo install cargo-nextest
 
         - name: Install Node
-          uses: actions/setup-node@v3
+          uses: actions/setup-node@v4
           with:
               node-version: "18"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,149 +1,149 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - "v[0-9]+.[0-9]+.x"
-    tags:
-      - "v*"
-  pull_request:
-    branches:
-      - "**"
+    push:
+        branches:
+            - main
+            - "v[0-9]+.[0-9]+.x"
+        tags:
+            - "v*"
+    pull_request:
+        branches:
+            - "**"
 
 concurrency:
-  # Allow only one workflow per any non-`main` branch.
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
-  cancel-in-progress: true
+    # Allow only one workflow per any non-`main` branch.
+    group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+    cancel-in-progress: true
 
 env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  RUST_BACKTRACE: 1
+    CARGO_TERM_COLOR: always
+    CARGO_INCREMENTAL: 0
+    RUST_BACKTRACE: 1
 
 jobs:
-  style:
-    name: Check formatting, Clippy lints, and spelling
-    runs-on:
-      - self-hosted
-      - test
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          clean: false
-          submodules: "recursive"
-          fetch-depth: 0
+    style:
+        name: Check formatting, Clippy lints, and spelling
+        runs-on:
+            - self-hosted
+            - test
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                  clean: false
+                  submodules: "recursive"
+                  fetch-depth: 0
 
-      - name: Set up default .cargo/config.toml
-        run: cp ./.cargo/ci-config.toml ~/.cargo/config.toml
+            - name: Set up default .cargo/config.toml
+              run: cp ./.cargo/ci-config.toml ~/.cargo/config.toml
 
-      - name: Check spelling
-        run: |
-          if ! which typos > /dev/null; then
-            cargo install typos-cli
-          fi
-          typos
+            - name: Check spelling
+              run: |
+                  if ! which typos > /dev/null; then
+                    cargo install typos-cli
+                  fi
+                  typos
 
-      - name: Run style checks
-        uses: ./.github/actions/check_style
+            - name: Run style checks
+              uses: ./.github/actions/check_style
 
-  tests:
-    name: Run tests
-    runs-on:
-      - self-hosted
-      - test
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          clean: false
-          submodules: "recursive"
+    tests:
+        name: Run tests
+        runs-on:
+            - self-hosted
+            - test
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Run tests
-        uses: ./.github/actions/run_tests
+            - name: Run tests
+              uses: ./.github/actions/run_tests
 
-      - name: Build collab
-        run: cargo build -p collab
+            - name: Build collab
+              run: cargo build -p collab
 
-      - name: Build other binaries
-        run: cargo build --workspace --bins --all-features
+            - name: Build other binaries
+              run: cargo build --workspace --bins --all-features
 
-  bundle:
-    name: Bundle app
-    runs-on:
-      - self-hosted
-      - bundle
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
-    needs: tests
-    env:
-      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-      APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
-      APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
-    steps:
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          clean: false
-          submodules: "recursive"
-
-      - name: Limit target directory size
-        run: script/clear-target-dir-if-larger-than 100
-
-      - name: Determine version and release channel
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          set -eu
-
-          version=$(script/get-crate-version zed)
-          channel=$(cat crates/zed/RELEASE_CHANNEL)
-          echo "Publishing version: ${version} on release channel ${channel}"
-          echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
-
-          expected_tag_name=""
-          case ${channel} in
-            stable)
-              expected_tag_name="v${version}";;
-            preview)
-              expected_tag_name="v${version}-pre";;
-            nightly)
-              expected_tag_name="v${version}-nightly";;
-            *)
-              echo "can't publish a release on channel ${channel}"
-              exit 1;;
-          esac
-          if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
-            echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
-            exit 1
-          fi
-
-      - name: Generate license file
-        run: script/generate-licenses
-
-      - name: Create app bundle
-        run: script/bundle
-
-      - name: Upload app bundle to workflow run if main branch or specific label
-        uses: actions/upload-artifact@v3
-        if: ${{ github.ref == 'refs/heads/main' }} || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
-        with:
-          name: Zed_${{ github.event.pull_request.head.sha || github.sha }}.dmg
-          path: target/release/Zed.dmg
-
-      - uses: softprops/action-gh-release@v1
-        name: Upload app bundle to release
-        if: ${{ env.RELEASE_CHANNEL == 'preview' || env.RELEASE_CHANNEL == 'stable' }}
-        with:
-          draft: true
-          prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
-          files: target/release/Zed.dmg
-          body: ""
+    bundle:
+        name: Bundle app
+        runs-on:
+            - self-hosted
+            - bundle
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
+        needs: tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+            MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+            APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
+            APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+            ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
+        steps:
+            - name: Install Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "18"
+
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                  clean: false
+                  submodules: "recursive"
+
+            - name: Limit target directory size
+              run: script/clear-target-dir-if-larger-than 100
+
+            - name: Determine version and release channel
+              if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+              run: |
+                  set -eu
+
+                  version=$(script/get-crate-version zed)
+                  channel=$(cat crates/zed/RELEASE_CHANNEL)
+                  echo "Publishing version: ${version} on release channel ${channel}"
+                  echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
+
+                  expected_tag_name=""
+                  case ${channel} in
+                    stable)
+                      expected_tag_name="v${version}";;
+                    preview)
+                      expected_tag_name="v${version}-pre";;
+                    nightly)
+                      expected_tag_name="v${version}-nightly";;
+                    *)
+                      echo "can't publish a release on channel ${channel}"
+                      exit 1;;
+                  esac
+                  if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
+                    echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
+                    exit 1
+                  fi
+
+            - name: Generate license file
+              run: script/generate-licenses
+
+            - name: Create app bundle
+              run: script/bundle
+
+            - name: Upload app bundle to workflow run if main branch or specific label
+              uses: actions/upload-artifact@v3
+              if: ${{ github.ref == 'refs/heads/main' }} || contains(github.event.pull_request.labels.*.name, 'run-build-dmg') }}
+              with:
+                  name: Zed_${{ github.event.pull_request.head.sha || github.sha }}.dmg
+                  path: target/release/Zed.dmg
+
+            - uses: softprops/action-gh-release@v1
+              name: Upload app bundle to release
+              if: ${{ env.RELEASE_CHANNEL == 'preview' || env.RELEASE_CHANNEL == 'stable' }}
+              with:
+                  draft: true
+                  prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
+                  files: target/release/Zed.dmg
+                  body: ""
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,35 +1,35 @@
 name: Danger
 
 on:
-  pull_request:
-    branches: [main]
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - edited
+    pull_request:
+        branches: [main]
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - edited
 
 jobs:
-  danger:
-    runs-on: ubuntu-latest
+    danger:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+        steps:
+            - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 8
+            - uses: pnpm/action-setup@v2.2.4
+              with:
+                  version: 8
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: "script/danger/pnpm-lock.yaml"
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: "pnpm"
+                  cache-dependency-path: "script/danger/pnpm-lock.yaml"
 
-      - run: pnpm install --dir script/danger
+            - run: pnpm install --dir script/danger
 
-      - name: Run Danger
-        run: pnpm run --dir script/danger danger ci
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+            - name: Run Danger
+              run: pnpm run --dir script/danger danger ci
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -3,35 +3,35 @@ name: Randomized Tests
 concurrency: randomized-tests
 
 on:
-  push:
-    branches:
-      - randomized-tests-runner
-  # schedule:
-  #    - cron: '0 * * * *'
+    push:
+        branches:
+            - randomized-tests-runner
+    # schedule:
+    #    - cron: '0 * * * *'
 
 env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  RUST_BACKTRACE: 1
-  ZED_SERVER_URL: https://zed.dev
+    CARGO_TERM_COLOR: always
+    CARGO_INCREMENTAL: 0
+    RUST_BACKTRACE: 1
+    ZED_SERVER_URL: https://zed.dev
 
 jobs:
-  tests:
-    name: Run randomized tests
-    runs-on:
-      - self-hosted
-      - randomized-tests
-    steps:
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
+    tests:
+        name: Run randomized tests
+        runs-on:
+            - self-hosted
+            - randomized-tests
+        steps:
+            - name: Install Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "18"
 
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          clean: false
-          submodules: "recursive"
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-      - name: Run randomized tests
-        run: script/randomized-test-ci
+            - name: Run randomized tests
+              run: script/randomized-test-ci

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -65,7 +65,7 @@ jobs:
             ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
         steps:
             - name: Install Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "18"
 


### PR DESCRIPTION
Deals with one of the warnings GH shows on our actions run:

https://github.com/zed-industries/zed/actions/runs/7790218555
<img width="1383" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/e523ec7c-bf43-4b0d-8c36-8540aef6fae9">

bufbuild/* actions seem to have no new major versions so there's nothing new to upgrade to.

Release Notes:

- N/A
