### PR TITLE
Add support for specifying both light and dark themes in `settings.json`

### DIFF
--- a/crates/collab_ui/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui/src/notifications/incoming_call_notification.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use gpui::{prelude::*, AppContext, WindowHandle};
 use settings::Settings;
 use std::sync::{Arc, Weak};
-use theme::ThemeSettings;
+use theme::{SystemAppearance, ThemeSettings};
 use ui::{prelude::*, Button, Label};
 use util::ResultExt;
 use workspace::AppState;
@@ -35,6 +35,8 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
                     let options = notification_window_options(screen, window_size);
                     let window = cx
                         .open_window(options, |cx| {
+                            SystemAppearance::init_for_window(cx);
+
                             cx.new_view(|_| {
                                 IncomingCallNotification::new(
                                     incoming_call.clone(),

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -6,7 +6,7 @@ use collections::HashMap;
 use gpui::{AppContext, Size};
 use settings::Settings;
 use std::sync::{Arc, Weak};
-use theme::ThemeSettings;
+use theme::{SystemAppearance, ThemeSettings};
 use ui::{prelude::*, Button, Label};
 use workspace::AppState;
 
@@ -28,6 +28,8 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
             for screen in cx.displays() {
                 let options = notification_window_options(screen, window_size);
                 let window = cx.open_window(options, |cx| {
+                    SystemAppearance::init_for_window(cx);
+
                     cx.new_view(|_| {
                         ProjectSharedNotification::new(
                             owner.clone(),

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -28,7 +28,7 @@ pub struct ThemeSettings {
     pub buffer_font: Font,
     pub buffer_font_size: Pixels,
     pub buffer_line_height: BufferLineHeight,
-    pub requested_theme: Option<String>,
+    pub theme_selection: Option<ThemeSelection>,
     pub active_theme: Arc<Theme>,
     pub theme_overrides: Option<ThemeStyleContent>,
 }
@@ -260,10 +260,7 @@ impl settings::Settings for ThemeSettings {
             },
             buffer_font_size: defaults.buffer_font_size.unwrap().into(),
             buffer_line_height: defaults.buffer_line_height.unwrap(),
-            requested_theme: defaults
-                .theme
-                .as_ref()
-                .map(|selection| selection.theme(*system_appearance).to_string()),
+            theme_selection: defaults.theme.clone(),
             active_theme: themes
                 .get(defaults.theme.as_ref().unwrap().theme(*system_appearance))
                 .or(themes.get(&one_dark().name))
@@ -287,9 +284,9 @@ impl settings::Settings for ThemeSettings {
             }
 
             if let Some(value) = &value.theme {
-                let theme_name = value.theme(*system_appearance);
+                this.theme_selection = Some(value.clone());
 
-                this.requested_theme = Some(theme_name.to_string());
+                let theme_name = value.theme(*system_appearance);
 
                 if let Some(theme) = themes.get(theme_name).log_err() {
                     this.active_theme = theme;

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -72,11 +72,52 @@ pub(crate) struct AdjustedBufferFontSize(Pixels);
 
 impl Global for AdjustedBufferFontSize {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ThemeSelection {
     Theme(String),
     System { light: String, dark: String },
+}
+
+impl JsonSchema for ThemeSelection {
+    fn schema_name() -> String {
+        "ThemeSelection".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        let theme_name_ref = Schema::new_ref("#/definitions/ThemeName".into());
+
+        Schema::Object(SchemaObject {
+            subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
+                any_of: Some(vec![theme_name_ref.clone(), {
+                    let mut schema_object = schemars::schema::SchemaObject {
+                        instance_type: Some(schemars::schema::InstanceType::Object.into()),
+                        ..Default::default()
+                    };
+                    let object_validation = schema_object.object();
+                    {
+                        object_validation
+                            .properties
+                            .insert("light".to_owned(), theme_name_ref.clone());
+                        if !<String as schemars::JsonSchema>::_schemars_private_is_option() {
+                            object_validation.required.insert("light".to_owned());
+                        }
+                    }
+                    {
+                        object_validation
+                            .properties
+                            .insert("dark".to_owned(), theme_name_ref);
+                        if !<String as schemars::JsonSchema>::_schemars_private_is_option() {
+                            object_validation.required.insert("dark".to_owned());
+                        }
+                    }
+                    schemars::schema::Schema::Object(schema_object)
+                }]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
 }
 
 impl ThemeSelection {
@@ -348,10 +389,6 @@ impl settings::Settings for ThemeSettings {
             .unwrap()
             .properties
             .extend([
-                (
-                    "theme".to_owned(),
-                    Schema::new_ref("#/definitions/ThemeName".into()),
-                ),
                 (
                     "buffer_font_family".to_owned(),
                     Schema::new_ref("#/definitions/FontFamilies".into()),

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -27,7 +27,7 @@ pub use schema::*;
 pub use settings::*;
 pub use styles::*;
 
-use gpui::{AppContext, AssetSource, Hsla, SharedString};
+use gpui::{AppContext, AssetSource, Hsla, SharedString, WindowAppearance};
 use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize)]
@@ -41,6 +41,15 @@ impl Appearance {
         match self {
             Self::Light => true,
             Self::Dark => false,
+        }
+    }
+}
+
+impl From<WindowAppearance> for Appearance {
+    fn from(value: WindowAppearance) -> Self {
+        match value {
+            WindowAppearance::Dark | WindowAppearance::VibrantDark => Self::Dark,
+            WindowAppearance::Light | WindowAppearance::VibrantLight => Self::Light,
         }
     }
 }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -9,7 +9,9 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use settings::{update_settings_file, SettingsStore};
 use std::sync::Arc;
-use theme::{Appearance, Theme, ThemeMeta, ThemeRegistry, ThemeSelection, ThemeSettings};
+use theme::{
+    Appearance, Theme, ThemeMeta, ThemeMode, ThemeRegistry, ThemeSelection, ThemeSettings,
+};
 use ui::{prelude::*, v_flex, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::{ui::HighlightedLabel, ModalView, Workspace};
@@ -172,16 +174,20 @@ impl PickerDelegate for ThemeSelectorDelegate {
         update_settings_file::<ThemeSettings>(self.fs.clone(), cx, move |settings| {
             if let Some(selection) = settings.theme.as_mut() {
                 let theme_to_update = match selection {
-                    theme::ThemeSelection::Theme(theme) => theme,
-                    theme::ThemeSelection::System { light, dark } => match appearance {
-                        Appearance::Light => light,
-                        Appearance::Dark => dark,
+                    ThemeSelection::Static(theme) => theme,
+                    ThemeSelection::Dynamic { mode, light, dark } => match mode {
+                        ThemeMode::Light => light,
+                        ThemeMode::Dark => dark,
+                        ThemeMode::System => match appearance {
+                            Appearance::Light => light,
+                            Appearance::Dark => dark,
+                        },
                     },
                 };
 
                 *theme_to_update = theme_name.to_string();
             } else {
-                settings.theme = Some(ThemeSelection::Theme(theme_name.to_string()));
+                settings.theme = Some(ThemeSelection::Static(theme_name.to_string()));
             }
         });
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -64,7 +64,7 @@ use std::{
     sync::{atomic::AtomicUsize, Arc},
     time::Duration,
 };
-use theme::{ActiveTheme, ThemeSettings};
+use theme::{ActiveTheme, SystemAppearance, ThemeSettings};
 pub use toolbar::{Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
 pub use ui;
 use ui::Label;
@@ -681,6 +681,21 @@ impl Workspace {
                     }
                 }
                 cx.notify();
+            }),
+            cx.observe_window_appearance(|_, cx| {
+                *SystemAppearance::global_mut(cx) = SystemAppearance(cx.appearance().into());
+
+                let mut theme_settings = ThemeSettings::get_global(cx).clone();
+
+                if let Some(requested_theme) =
+                    theme_settings.requested_theme.clone()
+                {
+                    if let Some(_theme) =
+                        theme_settings.switch_theme(&requested_theme, cx)
+                    {
+                        ThemeSettings::override_global(theme_settings, cx);
+                    }
+                }
             }),
             cx.observe(&left_dock, |this, _, cx| {
                 this.serialize_workspace(cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -683,16 +683,16 @@ impl Workspace {
                 cx.notify();
             }),
             cx.observe_window_appearance(|_, cx| {
-                *SystemAppearance::global_mut(cx) = SystemAppearance(cx.appearance().into());
+                let window_appearance = cx.appearance();
+
+                *SystemAppearance::global_mut(cx) = SystemAppearance(window_appearance.into());
 
                 let mut theme_settings = ThemeSettings::get_global(cx).clone();
 
-                if let Some(requested_theme) =
-                    theme_settings.requested_theme.clone()
-                {
-                    if let Some(_theme) =
-                        theme_settings.switch_theme(&requested_theme, cx)
-                    {
+                if let Some(theme_selection) = theme_settings.theme_selection.clone() {
+                    let theme_name = theme_selection.theme(window_appearance.into());
+
+                    if let Some(_theme) = theme_settings.switch_theme(&theme_name, cx) {
                         ThemeSettings::override_global(theme_settings, cx);
                     }
                 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -855,6 +855,8 @@ impl Workspace {
                     let workspace_id = workspace_id.clone();
                     let project_handle = project_handle.clone();
                     move |cx| {
+                        SystemAppearance::init_for_window(cx);
+
                         cx.new_view(|cx| {
                             Workspace::new(workspace_id, project_handle, app_state, cx)
                         })

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -43,7 +43,7 @@ use std::{
     thread,
     time::Duration,
 };
-use theme::{ActiveTheme, ThemeRegistry, ThemeSettings};
+use theme::{ActiveTheme, SystemAppearance, ThemeRegistry, ThemeSettings};
 use util::{
     async_maybe,
     http::{self, HttpClient, ZedHttpClient},
@@ -912,8 +912,10 @@ fn load_user_themes_in_background(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
                 theme_registry.load_user_themes(themes_dir, fs).await?;
                 cx.update(|cx| {
                     let mut theme_settings = ThemeSettings::get_global(cx).clone();
-                    if let Some(requested_theme) = theme_settings.requested_theme.clone() {
-                        if let Some(_theme) = theme_settings.switch_theme(&requested_theme, cx) {
+                    if let Some(theme_selection) = theme_settings.theme_selection.clone() {
+                        let theme_name = theme_selection.theme(*SystemAppearance::global(cx));
+
+                        if let Some(_theme) = theme_settings.switch_theme(&theme_name, cx) {
                             ThemeSettings::override_global(theme_settings, cx);
                         }
                     }
@@ -949,11 +951,14 @@ fn watch_themes(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
                             cx.update(|cx| {
                                 let mut theme_settings = ThemeSettings::get_global(cx).clone();
 
-                                if let Some(requested_theme) =
-                                    theme_settings.requested_theme.clone()
+                                if let Some(theme_selection) =
+                                    theme_settings.theme_selection.clone()
                                 {
+                                    let theme_name =
+                                        theme_selection.theme(*SystemAppearance::global(cx));
+
                                     if let Some(_theme) =
-                                        theme_settings.switch_theme(&requested_theme, cx)
+                                        theme_settings.switch_theme(&theme_name, cx)
                                     {
                                         ThemeSettings::override_global(theme_settings, cx);
                                     }


### PR DESCRIPTION
This PR adds support for configuring both a light and dark theme in `settings.json`.

In addition to accepting just a theme name, the `theme` field now also accepts an object in the following form:

```jsonc
{
  "theme": {
    "mode": "system",
    "light": "One Light",
    "dark": "One Dark"
  }
}
```

Both `light` and `dark` are required, and indicate which theme should be used when the system is in light mode and dark mode, respectively.

The `mode` field is optional and indicates which theme should be used:
- `"system"` - Use the theme that corresponds to the system's appearance.
- `"light"` - Use the theme indicated by the `light` field.
- `"dark"` - Use the theme indicated by the `dark` field.

Thank you to @Yesterday17 for taking a first stab at this in #6881!

Release Notes:

- Added support for configuring both a light and dark theme and switching between them based on system preference.
