### PR TITLE
Disable extra frames for ProMotion when screen is not active.

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1530,6 +1530,7 @@ extern "C" fn display_layer(this: &Object, _: Sel, _: id) {
 extern "C" fn step(this: &Object, _: Sel, display_link: id) {
     let window_state = unsafe { get_window_state(this) };
     let mut lock = window_state.lock();
+
     if lock.display_link == display_link {
         if let Some(mut callback) = lock.request_frame_callback.take() {
             drop(lock);


### PR DESCRIPTION
This was causing an issue where windows about 1/10 of the way across the display would hang for a fully second after being deactivated.

Release Notes:

- N/A
