### PR TITLE
Fix Terminal focus handlers not being called

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -311,7 +311,7 @@ impl TerminalView {
             workspace: workspace_handle,
             has_new_content: true,
             has_bell: false,
-            focus_handle: cx.focus_handle(),
+            focus_handle,
             context_menu: None,
             blink_state: true,
             blinking_on: false,


### PR DESCRIPTION
This fixes #7401 and probably a few other things that seemed odd with the terminal.

Turns out that `TerminalView` has `focus_in` and `focus_out` callbacks, but they were never called. The `focus_handle` on which they were set was not passed in to `TerminalView`.

That meant that the `impl FocusableView for TerminalView` never returned the focus handle with the right callbacks.

This change here uses the already created focus handle and passes it in, so that `focus_in` and `focus_out` are now correctly called.

Release Notes:

- Fixed terminal not handling focus-state correctly and, for example, not restoring cursor blinking state correctly. ([#7401](https://github.com/zed-industries/zed/issues/7401)).

