### PR TITLE
Fix shell environment not loading for Nushell

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -811,7 +811,7 @@ async fn load_login_shell_environment() -> Result<()> {
         "SHELL environment variable is not assigned so we can't source login environment variables",
     )?;
     let output = Command::new(&shell)
-        .args(["-lic", &format!("echo {marker} && /usr/bin/env -0")])
+        .args(["-l", "-i", "-c", &format!("echo {marker}; /usr/bin/env -0")])
         .output()
         .await
         .context("failed to spawn login shell to source login environment variables")?;


### PR DESCRIPTION
Turns out that Nushell doesn't like `-lic` and `&&`, but works perfectly fine with `-l -i -c` and `;`, which the other shells do too.

These all work:

    bash -l -i -c 'echo lol; /usr/bin/env -0'
    nu -l -i -c 'echo lol; /usr/bin/env -0'
    zsh -l -i -c 'echo lol; /usr/bin/env -0'
    fish -l -i -c 'echo lol; /usr/bin/env -0'

Release Notes:

- Fixed shell environment not being loaded if Nushell was set as `$SHELL`.
