### PR TITLE
Remove empty message editor placeholder

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -596,19 +596,7 @@ impl Render for ChatPanel {
                             el.border_t_1().border_color(cx.theme().colors().border)
                         })
                         .p_2()
-                        .map(|el| {
-                            if self.active_chat.is_some() {
-                                el.child(self.message_editor.clone())
-                            } else {
-                                el.child(
-                                    div()
-                                        .rounded_md()
-                                        .h_6()
-                                        .w_full()
-                                        .bg(cx.theme().colors().editor_background),
-                                )
-                            }
-                        }),
+                        .child(self.message_editor.clone()),
                 )
                 .filter(|_| self.active_chat.is_some()),
             )


### PR DESCRIPTION
This PR removes the placeholder that we previously displayed for the chat message editor.

With the changes in #7441 we can no longer hit this codepath.

Release Notes:

- N/A
