### PR TITLE
Remove Default impl for ConnectionId

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -692,7 +692,7 @@ impl ProjectCollaborator {
 pub struct LeftProject {
     pub id: ProjectId,
     pub host_user_id: UserId,
-    pub host_connection_id: ConnectionId,
+    pub host_connection_id: Option<ConnectionId>,
     pub connection_ids: Vec<ConnectionId>,
 }
 

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -778,7 +778,7 @@ impl Database {
             let left_project = LeftProject {
                 id: project_id,
                 host_user_id: project.host_user_id,
-                host_connection_id: project.host_connection()?,
+                host_connection_id: Some(project.host_connection()?),
                 connection_ids,
             };
             Ok((room, left_project))

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -862,7 +862,7 @@ impl Database {
                                 id: collaborator.project_id,
                                 host_user_id: Default::default(),
                                 connection_ids: Default::default(),
-                                host_connection_id: Default::default(),
+                                host_connection_id: None,
                             });
 
                     let collaborator_connection_id = collaborator.connection();
@@ -872,7 +872,7 @@ impl Database {
 
                     if collaborator.is_host {
                         left_project.host_user_id = collaborator.user_id;
-                        left_project.host_connection_id = collaborator_connection_id;
+                        left_project.host_connection_id = Some(collaborator_connection_id);
                     }
                 }
                 drop(collaborators);

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1691,7 +1691,7 @@ async fn leave_project(request: proto::LeaveProject, session: Session) -> Result
     tracing::info!(
         %project_id,
         host_user_id = %project.host_user_id,
-        host_connection_id = %project.host_connection_id,
+        host_connection_id = ?project.host_connection_id,
         "leave project"
     );
 

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tracing::instrument;
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 pub struct ConnectionId {
     pub owner_id: u32,
     pub id: u32,


### PR DESCRIPTION
We noticed the following message in my logs when trying to debug some lag when collaborating:

```
2024-02-06T09:42:09-08:00 [ERROR] error handling message. client_id:3, sender_id:Some(PeerId { owner_id: 327, id: 1123430 }), type:GetCompletions, error:no such connection: 0/0
```

That `0/0` looks like a bogus connection id, constructed via a derived `Default`. We didn't ever find a code path that would *use* a default `ConnectionId` and lead to this error, but it did seem like an improvement to not have a `Default` for that type.

Release Notes:

- N/A