### PR TITLE
chore: Fix up warnings from cargo +beta check.

### DIFF
--- a/crates/gpui/src/platform/mac/dispatcher.rs
+++ b/crates/gpui/src/platform/mac/dispatcher.rs
@@ -11,7 +11,12 @@ use objc::{
 };
 use parking::{Parker, Unparker};
 use parking_lot::Mutex;
-use std::{ffi::c_void, ptr::NonNull, sync::Arc, time::Duration};
+use std::{
+    ffi::c_void,
+    ptr::{addr_of, NonNull},
+    sync::Arc,
+    time::Duration,
+};
 
 /// All items in the generated file are marked as pub, so we're gonna wrap it in a separate mod to prevent
 /// these pub items from leaking into public API.
@@ -21,7 +26,7 @@ pub(crate) mod dispatch_sys {
 
 use dispatch_sys::*;
 pub(crate) fn dispatch_get_main_queue() -> dispatch_queue_t {
-    unsafe { &_dispatch_main_q as *const _ as dispatch_queue_t }
+    unsafe { addr_of!(_dispatch_main_q) as *const _ as dispatch_queue_t }
 }
 
 pub(crate) struct MacDispatcher {

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -863,6 +863,3 @@ impl PathVertex<Pixels> {
         }
     }
 }
-
-#[derive(Copy, Clone, Debug)]
-pub(crate) struct AtlasId(pub(crate) usize);


### PR DESCRIPTION
With upcoming release of 1.76 I did a check of current +beta (which seems to already be at 1.77). These would cause CI pipeline failures once 1.77 is out.

Release Notes:

- N/A
