### PR TITLE
chore: Move workspace dependencies to workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,90 @@ default-members = ["crates/zed"]
 resolver = "2"
 
 [workspace.dependencies]
+activity_indicator = { path = "crates/activity_indicator" }
+ai = { path = "crates/ai" }
+assets = { path = "crates/assets" }
+assistant = { path = "crates/assistant" }
+audio = { path = "crates/audio" }
+auto_update = { path = "crates/auto_update" }
+breadcrumbs = { path = "crates/breadcrumbs" }
+call = { path = "crates/call" }
+channel = { path = "crates/channel" }
+cli = { path = "crates/cli" }
+client = { path = "crates/client" }
+clock = { path = "crates/clock" }
+collab = { path = "crates/collab" }
+collab_ui = { path = "crates/collab_ui" }
+collections = { path = "crates/collections" }
+color = { path = "crates/color" }
+command_palette = { path = "crates/command_palette" }
+copilot = { path = "crates/copilot" }
+copilot_ui = { path = "crates/copilot_ui" }
+db = { path = "crates/db" }
+diagnostics = { path = "crates/diagnostics" }
+editor = { path = "crates/editor" }
+feature_flags = { path = "crates/feature_flags" }
+feedback = { path = "crates/feedback" }
+file_finder = { path = "crates/file_finder" }
+fs = { path = "crates/fs" }
+fsevent = { path = "crates/fsevent" }
+fuzzy = { path = "crates/fuzzy" }
+git = { path = "crates/git" }
+go_to_line = { path = "crates/go_to_line" }
+gpui = { path = "crates/gpui" }
+gpui_macros = { path = "crates/gpui_macros" }
+install_cli = { path = "crates/install_cli" }
+journal = { path = "crates/journal" }
+language = { path = "crates/language" }
+language_selector = { path = "crates/language_selector" }
+language_tools = { path = "crates/language_tools" }
+live_kit_client = { path = "crates/live_kit_client" }
+live_kit_server = { path = "crates/live_kit_server" }
+lsp = { path = "crates/lsp" }
+markdown_preview = { path = "crates/markdown_preview" }
+media = { path = "crates/media" }
+menu = { path = "crates/menu" }
+multi_buffer = { path = "crates/multi_buffer" }
+node_runtime = { path = "crates/node_runtime" }
+notifications = { path = "crates/notifications" }
+outline = { path = "crates/outline" }
+picker = { path = "crates/picker" }
+plugin = { path = "crates/plugin" }
+plugin_macros = { path = "crates/plugin_macros" }
+prettier = { path = "crates/prettier" }
+project = { path = "crates/project" }
+project_panel = { path = "crates/project_panel" }
+project_symbols = { path = "crates/project_symbols" }
+quick_action_bar = { path = "crates/quick_action_bar" }
+recent_projects = { path = "crates/recent_projects" }
+release_channel = { path = "crates/release_channel" }
+rich_text = { path = "crates/rich_text" }
+rope = { path = "crates/rope" }
+rpc = { path = "crates/rpc" }
+search = { path = "crates/search" }
+semantic_index = { path = "crates/semantic_index" }
+settings = { path = "crates/settings" }
+snippet = { path = "crates/snippet" }
+sqlez = { path = "crates/sqlez" }
+sqlez_macros = { path = "crates/sqlez_macros" }
+story = { path = "crates/story" }
+storybook = { path = "crates/storybook" }
+sum_tree = { path = "crates/sum_tree" }
+terminal = { path = "crates/terminal" }
+terminal_view = { path = "crates/terminal_view" }
+text = { path = "crates/text" }
+theme = { path = "crates/theme" }
+theme_importer = { path = "crates/theme_importer" }
+theme_selector = { path = "crates/theme_selector" }
+ui = { path = "crates/ui" }
+util = { path = "crates/util" }
+vcs_menu = { path = "crates/vcs_menu" }
+vim = { path = "crates/vim" }
+welcome = { path = "crates/welcome" }
+workspace = { path = "crates/workspace" }
+zed = { path = "crates/zed" }
+zed_actions = { path = "crates/zed_actions" }
+
 anyhow = "1.0.57"
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 async-trait = "0.1"
@@ -157,7 +241,7 @@ tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go", rev = 
 tree-sitter-gomod = { git = "https://github.com/camdencheek/tree-sitter-go-mod" }
 tree-sitter-gowork = { git = "https://github.com/d1y/tree-sitter-go-work" }
 tree-sitter-haskell = { git = "https://github.com/tree-sitter/tree-sitter-haskell", rev = "cf98de23e4285b8e6bcb57b050ef2326e2cc284b" }
-tree-sitter-hcl = {git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "v1.1.0"}
+tree-sitter-hcl = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "v1.1.0" }
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
 tree-sitter-html = "0.19.0"
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -11,18 +11,18 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-auto_update = { path = "../auto_update" }
-editor = { path = "../editor" }
+auto_update.workspace = true
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
-project = { path = "../project" }
-settings = { path = "../settings" }
+gpui.workspace = true
+language.workspace = true
+project.workspace = true
+settings.workspace = true
 smallvec.workspace = true
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace", package = "workspace" }
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -25,4 +25,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -17,9 +17,9 @@ anyhow.workspace = true
 async-trait.workspace = true
 bincode = "1.3.3"
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 isahc.workspace = true
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 matrixmultiply = "0.3.7"
@@ -33,7 +33,7 @@ rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }
 serde.workspace = true
 serde_json.workspace = true
 tiktoken-rs.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -36,4 +36,4 @@ tiktoken-rs.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -7,5 +7,5 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 anyhow.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 rust-embed.workspace = true

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -44,10 +44,10 @@ uuid.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-ai = { path = "../ai", features = ["test-support"] }
+ai = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 log.workspace = true
-project = { path = "../project", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 rand.workspace = true

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -10,38 +10,38 @@ path = "src/assistant.rs"
 doctest = false
 
 [dependencies]
-ai = { path = "../ai" }
+ai.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
-client = { path = "../client" }
-collections = { path = "../collections" }
-editor = { path = "../editor" }
-fs = { path = "../fs" }
+client.workspace = true
+collections.workspace = true
+editor.workspace = true
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 indoc.workspace = true
 isahc.workspace = true
-language = { path = "../language" }
+language.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
-multi_buffer = { path = "../multi_buffer" }
+menu.workspace = true
+multi_buffer.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true
-project = { path = "../project" }
+project.workspace = true
 regex.workspace = true
 schemars.workspace = true
-search = { path = "../search" }
-semantic_index = { path = "../semantic_index" }
+search.workspace = true
+semantic_index.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
-theme = { path = "../theme" }
+theme.workspace = true
 tiktoken-rs.workspace = true
-ui = { path = "../ui" }
-util = { path = "../util" }
+ui.workspace = true
+util.workspace = true
 uuid.workspace = true
-workspace = { path = "../workspace" }
+workspace.workspace = true
 
 [dev-dependencies]
 ai = { path = "../ai", features = ["test-support"] }

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -11,11 +11,11 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
+collections.workspace = true
 derive_more.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 rodio = { version = "0.17.1", default-features = false, features = ["wav"] }
-util = { path = "../util" }
+util.workspace = true

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -11,22 +11,22 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-client = { path = "../client" }
-db = { path = "../db" }
-gpui = { path = "../gpui" }
+client.workspace = true
+db.workspace = true
+gpui.workspace = true
 isahc.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
-project = { path = "../project" }
-release_channel = { path = "../release_channel" }
+menu.workspace = true
+project.workspace = true
+release_channel.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
 tempfile.workspace = true
-theme = { path = "../theme" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+theme.workspace = true
+util.workspace = true
+workspace.workspace = true

--- a/crates/breadcrumbs/Cargo.toml
+++ b/crates/breadcrumbs/Cargo.toml
@@ -24,6 +24,6 @@ ui.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/breadcrumbs/Cargo.toml
+++ b/crates/breadcrumbs/Cargo.toml
@@ -10,18 +10,18 @@ path = "src/breadcrumbs.rs"
 doctest = false
 
 [dependencies]
-collections = { path = "../collections" }
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
+collections.workspace = true
+editor.workspace = true
+gpui.workspace = true
 itertools = "0.10"
-language = { path = "../language" }
-outline = { path = "../outline" }
-project = { path = "../project" }
-search = { path = "../search" }
-settings = { path = "../settings" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-workspace = { path = "../workspace" }
+language.workspace = true
+outline.workspace = true
+project.workspace = true
+search.workspace = true
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -22,26 +22,26 @@ test-support = [
 [dependencies]
 anyhow.workspace = true
 async-broadcast = "0.4"
-audio = { path = "../audio" }
-client = { path = "../client" }
-collections = { path = "../collections" }
-fs = { path = "../fs" }
+audio.workspace = true
+client.workspace = true
+collections.workspace = true
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 image = "0.23"
-language = { path = "../language" }
-live_kit_client = { path = "../live_kit_client" }
+language.workspace = true
+live_kit_client.workspace = true
 log.workspace = true
-media = { path = "../media" }
+media.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -44,11 +44,11 @@ smallvec.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-collections = { path = "../collections", features = ["test-support"] }
-fs = { path = "../fs", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-live_kit_client = { path = "../live_kit_client", features = ["test-support"] }
-project = { path = "../project", features = ["test-support"] }
-util = { path = "../util", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+live_kit_client = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -14,36 +14,36 @@ test-support = ["collections/test-support", "gpui/test-support", "rpc/test-suppo
 
 [dependencies]
 anyhow.workspace = true
-client = { path = "../client" }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
-db = { path = "../db" }
-feature_flags = { path = "../feature_flags" }
+client.workspace = true
+clock.workspace = true
+collections.workspace = true
+db.workspace = true
+feature_flags.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 image = "0.23"
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 rand.workspace = true
-release_channel = { path = "../release_channel" }
-rpc = { path = "../rpc" }
+release_channel.workspace = true
+rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
+sum_tree.workspace = true
 tempfile.workspace = true
-text = { path = "../text" }
+text.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tiny_http = "0.8"
 url.workspace = true
-util = { path = "../util" }
+util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -47,9 +47,9 @@ util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-collections = { path = "../collections", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-rpc = { path = "../rpc", features = ["test-support"] }
-client = { path = "../client", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
-util = { path = "../util", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,7 +20,7 @@ dirs = "3.0"
 ipc-channel = "0.16"
 serde.workspace = true
 serde_derive.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -14,16 +14,16 @@ test-support = ["collections/test-support", "gpui/test-support", "rpc/test-suppo
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-collections = { path = "../collections" }
-db = { path = "../db" }
-gpui = { path = "../gpui" }
-util = { path = "../util" }
-release_channel = { path = "../release_channel" }
-rpc = { path = "../rpc" }
-text = { path = "../text" }
-settings = { path = "../settings" }
-feature_flags = { path = "../feature_flags" }
-sum_tree = { path = "../sum_tree" }
+collections.workspace = true
+db.workspace = true
+gpui.workspace = true
+util.workspace = true
+release_channel.workspace = true
+rpc.workspace = true
+text.workspace = true
+settings.workspace = true
+feature_flags.workspace = true
+sum_tree.workspace = true
 
 anyhow.workspace = true
 async-recursion = "0.3"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -51,8 +51,8 @@ uuid.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-collections = { path = "../collections", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-rpc = { path = "../rpc", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
-util = { path = "../util", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -22,15 +22,15 @@ axum-extra = { version = "0.3", features = ["erased-json"] }
 base64 = "0.13"
 chrono.workspace = true
 clap = { version = "3.1", features = ["derive"], optional = true }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+clock.workspace = true
+collections.workspace = true
 dashmap = "5.4"
 envy = "0.4.2"
 futures.workspace = true
 hyper = "0.14"
 lazy_static.workspace = true
 lipsum = { version = "0.8", optional = true }
-live_kit_server = { path = "../live_kit_server" }
+live_kit_server.workspace = true
 log.workspace = true
 nanoid = "0.4"
 parking_lot.workspace = true
@@ -38,7 +38,7 @@ prometheus = "0.13"
 prost.workspace = true
 rand.workspace = true
 reqwest = { version = "0.11", features = ["json"], optional = true }
-rpc = { path = "../rpc" }
+rpc.workspace = true
 scrypt = "0.7"
 sea-orm = { version = "0.12.x", features = ["sqlx-postgres", "postgres-array", "runtime-tokio-rustls", "with-uuid"] }
 serde.workspace = true
@@ -47,7 +47,7 @@ serde_json.workspace = true
 sha-1 = "0.9"
 smallvec.workspace = true
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "any"] }
-text = { path = "../text" }
+text.workspace = true
 time.workspace = true
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.17"
@@ -57,22 +57,22 @@ tower = "0.4"
 tracing = "0.1.34"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
-util = { path = "../util" }
+util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 async-trait.workspace = true
-audio = { path = "../audio" }
+audio.workspace = true
 call = { path = "../call", features = ["test-support"] }
-channel = { path = "../channel" }
+channel.workspace = true
 client = { path = "../client", features = ["test-support"] }
 collab_ui = { path = "../collab_ui", features = ["test-support"] }
 collections = { path = "../collections", features = ["test-support"] }
 ctor.workspace = true
 editor = { path = "../editor", features = ["test-support"] }
 env_logger.workspace = true
-file_finder = { path = "../file_finder" }
+file_finder.workspace = true
 fs = { path = "../fs", features = ["test-support"] }
 git = { path = "../git", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
@@ -81,8 +81,8 @@ language = { path = "../language", features = ["test-support"] }
 lazy_static.workspace = true
 live_kit_client = { path = "../live_kit_client", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
-menu = { path = "../menu" }
-node_runtime = { path = "../node_runtime" }
+menu.workspace = true
+node_runtime.workspace = true
 notifications = { path = "../notifications", features = ["test-support"] }
 pretty_assertions.workspace = true
 project = { path = "../project", features = ["test-support"] }
@@ -91,9 +91,9 @@ sea-orm = { version = "0.12.x", features = ["sqlx-sqlite"] }
 serde_json.workspace = true
 settings = { path = "../settings", features = ["test-support"] }
 sqlx = { version = "0.7", features = ["sqlite"] }
-theme = { path = "../theme" }
+theme.workspace = true
 unindent.workspace = true
-util = { path = "../util" }
+util.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }
 
 [features]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -64,37 +64,37 @@ uuid.workspace = true
 release_channel.workspace = true
 async-trait.workspace = true
 audio.workspace = true
-call = { path = "../call", features = ["test-support"] }
+call = { workspace = true, features = ["test-support"] }
 channel.workspace = true
-client = { path = "../client", features = ["test-support"] }
-collab_ui = { path = "../collab_ui", features = ["test-support"] }
-collections = { path = "../collections", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+collab_ui = { workspace = true, features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 file_finder.workspace = true
-fs = { path = "../fs", features = ["test-support"] }
-git = { path = "../git", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
+git = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
-language = { path = "../language", features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 lazy_static.workspace = true
-live_kit_client = { path = "../live_kit_client", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
+live_kit_client = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 menu.workspace = true
 node_runtime.workspace = true
-notifications = { path = "../notifications", features = ["test-support"] }
+notifications = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
-project = { path = "../project", features = ["test-support"] }
-rpc = { path = "../rpc", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
 sea-orm = { version = "0.12.x", features = ["sqlx-sqlite"] }
 serde_json.workspace = true
-settings = { path = "../settings", features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
 sqlx = { version = "0.7", features = ["sqlite"] }
 theme.workspace = true
 unindent.workspace = true
 util.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
 
 [features]
 seed-support = ["clap", "lipsum", "reqwest"]

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -26,46 +26,46 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
-auto_update = { path = "../auto_update" }
-call = { path = "../call" }
-channel = { path = "../channel" }
-client = { path = "../client" }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
-db = { path = "../db" }
-editor = { path = "../editor" }
-feature_flags = { path = "../feature_flags" }
-feedback = { path = "../feedback" }
+auto_update.workspace = true
+call.workspace = true
+channel.workspace = true
+client.workspace = true
+clock.workspace = true
+collections.workspace = true
+db.workspace = true
+editor.workspace = true
+feature_flags.workspace = true
+feedback.workspace = true
 futures.workspace = true
-fuzzy = { path = "../fuzzy" }
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
-notifications = { path = "../notifications" }
+menu.workspace = true
+notifications.workspace = true
 parking_lot.workspace = true
-picker = { path = "../picker" }
+picker.workspace = true
 postage.workspace = true
-project = { path = "../project" }
-recent_projects = { path = "../recent_projects" }
-rich_text = { path = "../rich_text" }
-rpc = { path = "../rpc" }
+project.workspace = true
+recent_projects.workspace = true
+rich_text.workspace = true
+rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 story = { path = "../story", optional = true }
-theme = { path = "../theme" }
-theme_selector = { path = "../theme_selector" }
+theme.workspace = true
+theme_selector.workspace = true
 time.workspace = true
-ui = { path = "../ui" }
-util = { path = "../util" }
-vcs_menu = { path = "../vcs_menu" }
-workspace = { path = "../workspace" }
-zed_actions = { path = "../zed_actions" }
+ui.workspace = true
+util.workspace = true
+vcs_menu.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -57,7 +57,7 @@ serde_derive.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smallvec.workspace = true
-story = { path = "../story", optional = true }
+story = { workspace = true, optional = true }
 theme.workspace = true
 theme_selector.workspace = true
 time.workspace = true
@@ -68,16 +68,16 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [dev-dependencies]
-call = { path = "../call", features = ["test-support"] }
-client = { path = "../client", features = ["test-support"] }
-collections = { path = "../collections", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-notifications = { path = "../notifications", features = ["test-support"] }
+call = { workspace = true, features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+notifications = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
-project = { path = "../project", features = ["test-support"] }
-rpc = { path = "../rpc", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
 tree-sitter-markdown.workspace = true
-util = { path = "../util", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/color/Cargo.toml
+++ b/crates/color/Cargo.toml
@@ -16,4 +16,4 @@ doctest = true
 [dependencies]
 itertools = { version = "0.11.0", optional = true }
 palette = "0.7.3"
-story = { path = "../story", optional = true }
+story = { workspace = true, optional = true }

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -11,32 +11,32 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-client = { path = "../client" }
-collections = { path = "../collections" }
+client.workspace = true
+collections.workspace = true
 # HACK: We're only depending on `copilot` here for `CommandPaletteFilter`.  See the attached comment on that type.
-copilot = { path = "../copilot" }
-editor = { path = "../editor" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
-picker = { path = "../picker" }
-project = { path = "../project" }
-release_channel = { path = "../release_channel" }
+copilot.workspace = true
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+picker.workspace = true
+project.workspace = true
+release_channel.workspace = true
 serde.workspace = true
-settings = { path = "../settings" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
-zed_actions = { path = "../zed_actions" }
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
 editor = { path = "../editor", features = ["test-support"] }
 env_logger.workspace = true
-go_to_line = { path = "../go_to_line" }
+go_to_line.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
-menu = { path = "../menu" }
+menu.workspace = true
 project = { path = "../project", features = ["test-support"] }
 serde_json.workspace = true
 workspace = { path = "../workspace", features = ["test-support"] }

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -31,12 +31,12 @@ zed_actions.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 go_to_line.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 menu.workspace = true
-project = { path = "../project", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -40,11 +40,11 @@ util.workspace = true
 
 [dev-dependencies]
 clock.workspace = true
-collections = { path = "../collections", features = ["test-support"] }
-fs = { path = "../fs", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
-rpc = { path = "../rpc", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
-util = { path = "../util", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -23,23 +23,23 @@ test-support = [
 anyhow.workspace = true
 async-compression.workspace = true
 async-tar = "0.4.2"
-collections = { path = "../collections" }
+collections.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+gpui.workspace = true
+language.workspace = true
 log.workspace = true
-lsp = { path = "../lsp" }
-node_runtime = { path = "../node_runtime" }
+lsp.workspace = true
+node_runtime.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
-theme = { path = "../theme" }
-util = { path = "../util" }
+theme.workspace = true
+util.workspace = true
 
 [dev-dependencies]
-clock = { path = "../clock" }
+clock.workspace = true
 collections = { path = "../collections", features = ["test-support"] }
 fs = { path = "../fs", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/copilot_ui/Cargo.toml
+++ b/crates/copilot_ui/Cargo.toml
@@ -26,4 +26,4 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/copilot_ui/Cargo.toml
+++ b/crates/copilot_ui/Cargo.toml
@@ -11,19 +11,19 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-copilot = { path = "../copilot" }
-editor = { path = "../editor" }
-fs = { path = "../fs" }
+copilot.workspace = true
+editor.workspace = true
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
-settings = { path = "../settings" }
+gpui.workspace = true
+language.workspace = true
+settings.workspace = true
 smol.workspace = true
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
-zed_actions = { path = "../zed_actions" }
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -31,5 +31,5 @@ util.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -15,19 +15,19 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-collections = { path = "../collections" }
-gpui = { path = "../gpui" }
+collections.workspace = true
+gpui.workspace = true
 indoc.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 parking_lot.workspace = true
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 smol.workspace = true
-sqlez = { path = "../sqlez" }
-sqlez_macros = { path = "../sqlez_macros" }
-util = { path = "../util" }
+sqlez.workspace = true
+sqlez_macros.workspace = true
+util.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -31,12 +31,12 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
-theme = { path = "../theme", features = ["test-support"] }
+theme = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -11,24 +11,24 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
-editor = { path = "../editor" }
+collections.workspace = true
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+gpui.workspace = true
+language.workspace = true
 log.workspace = true
-lsp = { path = "../lsp" }
+lsp.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -72,22 +72,22 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-copilot = { path = "../copilot", features = ["test-support"] }
+copilot = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
-multi_buffer = { path = "../multi_buffer", features = ["test-support"] }
-project = { path = "../project", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
+multi_buffer = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
 rand.workspace = true
-settings = { path = "../settings", features = ["test-support"] }
-text = { path = "../text", features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+text = { workspace = true, features = ["test-support"] }
 tree-sitter-html.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 tree-sitter.workspace = true
 unindent.workspace = true
-util = { path = "../util", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -26,50 +26,50 @@ test-support = [
 [dependencies]
 aho-corasick = "1.1"
 anyhow.workspace = true
-client = { path = "../client" }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+client.workspace = true
+clock.workspace = true
+collections.workspace = true
 convert_case = "0.6.0"
-copilot = { path = "../copilot" }
-db = { path = "../db" }
+copilot.workspace = true
+db.workspace = true
 futures.workspace = true
-fuzzy = { path = "../fuzzy" }
-git = { path = "../git" }
-gpui = { path = "../gpui" }
+fuzzy.workspace = true
+git.workspace = true
+gpui.workspace = true
 indoc = "1.0.4"
 itertools = "0.10"
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 linkify = "0.10.0"
 log.workspace = true
-lsp = { path = "../lsp" }
-multi_buffer = { path = "../multi_buffer" }
+lsp.workspace = true
+multi_buffer.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 rand.workspace = true
-rich_text = { path = "../rich_text" }
-rpc = { path = "../rpc" }
+rich_text.workspace = true
+rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-snippet = { path = "../snippet" }
-sqlez = { path = "../sqlez" }
-sum_tree = { path = "../sum_tree" }
-text = { path = "../text" }
-theme = { path = "../theme" }
+snippet.workspace = true
+sqlez.workspace = true
+sum_tree.workspace = true
+text.workspace = true
+theme.workspace = true
 tree-sitter-html = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
-ui = { path = "../ui" }
+ui.workspace = true
 url.workspace = true
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 copilot = { path = "../copilot", features = ["test-support"] }
@@ -80,7 +80,7 @@ language = { path = "../language", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
 multi_buffer = { path = "../multi_buffer", features = ["test-support"] }
 project = { path = "../project", features = ["test-support"] }
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 rand.workspace = true
 settings = { path = "../settings", features = ["test-support"] }
 text = { path = "../text", features = ["test-support"] }

--- a/crates/feature_flags/Cargo.toml
+++ b/crates/feature_flags/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/feature_flags.rs"
 
 [dependencies]
 anyhow.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -44,4 +44,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -14,34 +14,34 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 bitflags = "2.4.1"
-client = { path = "../client" }
-db = { path = "../db" }
-editor = { path = "../editor" }
+client.workspace = true
+db.workspace = true
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 human_bytes = "0.4.1"
 isahc.workspace = true
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
+menu.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 regex.workspace = true
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 smol.workspace = true
 sysinfo.workspace = true
-theme = { path = "../theme" }
+theme.workspace = true
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }
-ui = { path = "../ui" }
+ui.workspace = true
 urlencoding = "2.1.2"
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -30,10 +30,10 @@ workspace.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
-theme = { path = "../theme", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+theme = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -11,22 +11,22 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
-editor = { path = "../editor" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
+collections.workspace = true
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
 itertools = "0.11"
-menu = { path = "../menu" }
-picker = { path = "../picker" }
+menu.workspace = true
+picker.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 serde.workspace = true
-settings = { path = "../settings" }
-text = { path = "../text" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+settings.workspace = true
+text.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -31,7 +31,7 @@ log.workspace = true
 libc = "0.2"
 time.workspace = true
 
-gpui = { path = "../gpui", optional = true}
+gpui = { workspace = true, optional = true}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 fsevent.workspace = true
@@ -40,7 +40,7 @@ fsevent.workspace = true
 notify = "6.1.1"
 
 [dev-dependencies]
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 
 [features]
 test-support = ["gpui/test-support"]

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -9,11 +9,11 @@ license = "GPL-3.0-or-later"
 path = "src/fs.rs"
 
 [dependencies]
-collections = { path = "../collections" }
-rope = { path = "../rope" }
-text = { path = "../text" }
-util = { path = "../util" }
-sum_tree = { path = "../sum_tree" }
+collections.workspace = true
+rope.workspace = true
+text.workspace = true
+util.workspace = true
+sum_tree.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
@@ -34,7 +34,7 @@ time.workspace = true
 gpui = { path = "../gpui", optional = true}
 
 [target.'cfg(target_os = "macos")'.dependencies]
-fsevent = { path = "../fsevent" }
+fsevent.workspace = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 notify = "6.1.1"

--- a/crates/fuzzy/Cargo.toml
+++ b/crates/fuzzy/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/fuzzy.rs"
 doctest = false
 
 [dependencies]
-gpui = { path = "../gpui" }
-util = { path = "../util" }
+gpui.workspace = true
+util.workspace = true

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -11,17 +11,17 @@ path = "src/git.rs"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+clock.workspace = true
+collections.workspace = true
 futures.workspace = true
 git2.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
-text = { path = "../text" }
-util = { path = "../util" }
+sum_tree.workspace = true
+text.workspace = true
+util.workspace = true
 
 [dev-dependencies]
 unindent.workspace = true

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -10,17 +10,17 @@ path = "src/go_to_line.rs"
 doctest = false
 
 [dependencies]
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
-menu = { path = "../menu" }
+editor.workspace = true
+gpui.workspace = true
+menu.workspace = true
 postage.workspace = true
 serde.workspace = true
-settings = { path = "../settings" }
-text = { path = "../text" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+settings.workspace = true
+text.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -23,4 +23,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -69,12 +69,12 @@ waker-fn = "1.1.0"
 
 [dev-dependencies]
 backtrace = "0.3"
-collections = { path = "../collections", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 dhat = "0.3"
 env_logger.workspace = true
 png = "0.16"
 simplelog = "0.9"
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }
 
 [build-dependencies]
 bindgen = "0.65.1"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -26,14 +26,14 @@ anyhow.workspace = true
 async-task = "4.7"
 backtrace = { version = "0.3", optional = true }
 bitflags = "2.4.0"
-collections = { path = "../collections" }
+collections.workspace = true
 ctor.workspace = true
 derive_more.workspace = true
 dhat = { version = "0.3", optional = true }
 env_logger = { version = "0.9", optional = true }
 etagere = "0.2"
 futures.workspace = true
-gpui_macros = { path = "../gpui_macros" }
+gpui_macros.workspace = true
 image = "0.23"
 itertools = "0.10"
 lazy_static.workspace = true
@@ -57,13 +57,13 @@ serde_json.workspace = true
 slotmap = "1.0.6"
 smallvec.workspace = true
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
+sum_tree.workspace = true
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
 thiserror.workspace = true
 time.workspace = true
 tiny-skia = "0.5"
 usvg = { version = "0.14", features = [] }
-util = { path = "../util" }
+util.workspace = true
 uuid = { version = "1.1.2", features = ["v4"] }
 waker-fn = "1.1.0"
 
@@ -89,6 +89,6 @@ core-text = "19.2"
 font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "d97147f" }
 foreign-types = "0.3"
 log.workspace = true
-media = { path = "../media" }
+media.workspace = true
 metal = "0.21.0"
 objc = "0.2"

--- a/crates/install_cli/Cargo.toml
+++ b/crates/install_cli/Cargo.toml
@@ -13,7 +13,7 @@ test-support = []
 
 [dependencies]
 anyhow.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 log.workspace = true
 smol.workspace = true
-util = { path = "../util" }
+util.workspace = true

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -13,15 +13,15 @@ doctest = false
 anyhow.workspace = true
 chrono = "0.4"
 dirs = "4.0"
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
+editor.workspace = true
+gpui.workspace = true
 log.workspace = true
 schemars.workspace = true
 serde.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 shellexpand = "2.1.0"
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -24,4 +24,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -60,16 +60,16 @@ unicase = "2.6"
 util.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-collections = { path = "../collections", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
-lsp = { path = "../lsp", features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 rand.workspace = true
-settings = { path = "../settings", features = ["test-support"] }
-text = { path = "../text", features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+text = { workspace = true, features = ["test-support"] }
 tree-sitter-elixir.workspace = true
 tree-sitter-embedded-template.workspace = true
 tree-sitter-heex.workspace = true
@@ -81,4 +81,4 @@ tree-sitter-ruby.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 unindent.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -26,38 +26,38 @@ test-support = [
 anyhow.workspace = true
 async-broadcast = "0.4"
 async-trait.workspace = true
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+clock.workspace = true
+collections.workspace = true
 futures.workspace = true
-fuzzy = { path = "../fuzzy" }
-git = { path = "../git" }
+fuzzy.workspace = true
+git.workspace = true
 globset.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-lsp = { path = "../lsp" }
+lsp.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 rand = { workspace = true, optional = true }
 regex.workspace = true
-rpc = { path = "../rpc" }
+rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 similar = "1.3"
 smallvec.workspace = true
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
-text = { path = "../text" }
-theme = { path = "../theme" }
+sum_tree.workspace = true
+text.workspace = true
+theme.workspace = true
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
 pulldown-cmark.workspace = true
 tree-sitter.workspace = true
 unicase = "2.6"
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -24,4 +24,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -11,17 +11,17 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-editor = { path = "../editor" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
-language = { path = "../language" }
-picker = { path = "../picker" }
-project = { path = "../project" }
-settings = { path = "../settings" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
+picker.workspace = true
+project.workspace = true
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -11,26 +11,26 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
-editor = { path = "../editor" }
+collections.workspace = true
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
-lsp = { path = "../lsp" }
-project = { path = "../project" }
+gpui.workspace = true
+language.workspace = true
+lsp.workspace = true
+project.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
-theme = { path = "../theme" }
+settings.workspace = true
+theme.workspace = true
 tree-sitter.workspace = true
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }
 editor = { path = "../editor", features = ["test-support"] }
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 env_logger.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
 unindent.workspace = true

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -28,10 +28,10 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -26,10 +26,10 @@ test-support = [
 anyhow.workspace = true
 async-broadcast = "0.4"
 async-trait = { workspace = true, optional = true }
-collections = { path = "../collections", optional = true }
+collections = { workspace = true, optional = true }
 futures.workspace = true
-gpui = { path = "../gpui", optional = true }
-live_kit_server = { path = "../live_kit_server", optional = true }
+gpui = { workspace = true, optional = true }
+live_kit_server = { workspace = true, optional = true }
 log.workspace = true
 media.workspace = true
 nanoid = { version ="0.4", optional = true}
@@ -41,8 +41,8 @@ core-foundation = "0.9.3"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 async-trait = { workspace = true }
-collections = { path = "../collections", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 live_kit_server.workspace = true
 
 [dev-dependencies]
@@ -51,10 +51,10 @@ async-trait.workspace = true
 block = "0.1"
 byteorder = "1.4"
 bytes = "1.2"
-collections = { path = "../collections", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 foreign-types = "0.3"
 futures.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 hmac = "0.12"
 jwt = "0.16"
 live_kit_server.workspace = true

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -31,7 +31,7 @@ futures.workspace = true
 gpui = { path = "../gpui", optional = true }
 live_kit_server = { path = "../live_kit_server", optional = true }
 log.workspace = true
-media = { path = "../media" }
+media.workspace = true
 nanoid = { version ="0.4", optional = true}
 parking_lot.workspace = true
 postage.workspace = true
@@ -43,7 +43,7 @@ core-foundation = "0.9.3"
 async-trait = { workspace = true }
 collections = { path = "../collections", features = ["test-support"] }
 gpui = { path = "../gpui", features = ["test-support"] }
-live_kit_server = { path = "../live_kit_server" }
+live_kit_server.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
@@ -57,8 +57,8 @@ futures.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
 hmac = "0.12"
 jwt = "0.16"
-live_kit_server = { path = "../live_kit_server" }
-media = { path = "../media" }
+live_kit_server.workspace = true
+media.workspace = true
 nanoid = "0.4"
 parking_lot.workspace = true
 serde.workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -33,6 +33,6 @@ release_channel.workspace = true
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -15,9 +15,9 @@ test-support = ["async-pipe"]
 [dependencies]
 anyhow.workspace = true
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553", optional = true }
-collections = { path = "../collections" }
+collections.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 log.workspace = true
 lsp-types = { git = "https://github.com/zed-industries/lsp-types", branch = "updated-completion-list-item-defaults" }
 parking_lot.workspace = true
@@ -26,8 +26,8 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 smol.workspace = true
-util = { path = "../util" }
-release_channel = { path = "../release_channel" }
+util.workspace = true
+release_channel.workspace = true
 
 [dev-dependencies]
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -13,19 +13,19 @@ test-support = []
 
 [dependencies]
 anyhow.workspace = true
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+editor.workspace = true
+gpui.workspace = true
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
-project = { path = "../project" }
+menu.workspace = true
+project.workspace = true
 pulldown-cmark.workspace = true
-rich_text = { path = "../rich_text" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+rich_text.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -28,4 +28,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/menu/Cargo.toml
+++ b/crates/menu/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/menu.rs"
 doctest = false
 
 [dependencies]
-gpui = { path = "../gpui" }
+gpui.workspace = true
 serde = { workspace = true }

--- a/crates/multi_buffer/Cargo.toml
+++ b/crates/multi_buffer/Cargo.toml
@@ -58,19 +58,19 @@ tree-sitter-typescript = { workspace = true, optional = true }
 util.workspace = true
 
 [dev-dependencies]
-copilot = { path = "../copilot", features = ["test-support"] }
+copilot = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
-project = { path = "../project", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 rand.workspace = true
-settings = { path = "../settings", features = ["test-support"] }
-text = { path = "../text", features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+text = { workspace = true, features = ["test-support"] }
 tree-sitter-html.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 tree-sitter.workspace = true
 unindent.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/multi_buffer/Cargo.toml
+++ b/crates/multi_buffer/Cargo.toml
@@ -23,39 +23,39 @@ test-support = [
 [dependencies]
 aho-corasick = "1.1"
 anyhow.workspace = true
-client = { path = "../client" }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+client.workspace = true
+clock.workspace = true
+collections.workspace = true
 convert_case = "0.6.0"
 futures.workspace = true
-git = { path = "../git" }
-gpui = { path = "../gpui" }
+git.workspace = true
+gpui.workspace = true
 indoc = "1.0.4"
 itertools = "0.10"
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-lsp = { path = "../lsp" }
+lsp.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 pulldown-cmark.workspace = true
 rand.workspace = true
-rich_text = { path = "../rich_text" }
+rich_text.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-snippet = { path = "../snippet" }
-sum_tree = { path = "../sum_tree" }
-text = { path = "../text" }
-theme = { path = "../theme" }
+snippet.workspace = true
+sum_tree.workspace = true
+text.workspace = true
+theme.workspace = true
 tree-sitter-html = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 copilot = { path = "../copilot", features = ["test-support"] }

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -21,4 +21,4 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 smol.workspace = true
-util = { path = "../util" }
+util.workspace = true

--- a/crates/notifications/Cargo.toml
+++ b/crates/notifications/Cargo.toml
@@ -19,19 +19,19 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
-channel = { path = "../channel" }
-client = { path = "../client" }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
-db = { path = "../db" }
-feature_flags = { path = "../feature_flags" }
-gpui = { path = "../gpui" }
-rpc = { path = "../rpc" }
-settings = { path = "../settings" }
-sum_tree = { path = "../sum_tree" }
-text = { path = "../text" }
+channel.workspace = true
+client.workspace = true
+clock.workspace = true
+collections.workspace = true
+db.workspace = true
+feature_flags.workspace = true
+gpui.workspace = true
+rpc.workspace = true
+settings.workspace = true
+sum_tree.workspace = true
+text.workspace = true
 time.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/notifications/Cargo.toml
+++ b/crates/notifications/Cargo.toml
@@ -34,9 +34,9 @@ time.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-collections = { path = "../collections", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-rpc = { path = "../rpc", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
-util = { path = "../util", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -10,20 +10,20 @@ path = "src/outline.rs"
 doctest = false
 
 [dependencies]
-editor = { path = "../editor" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
 ordered-float.workspace = true
-picker = { path = "../picker" }
+picker.workspace = true
 postage.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
-text = { path = "../text" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+text.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -26,4 +26,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -22,7 +22,7 @@ workspace.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -10,15 +10,15 @@ path = "src/picker.rs"
 doctest = false
 
 [dependencies]
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
-menu = { path = "../menu" }
+editor.workspace = true
+gpui.workspace = true
+menu.workspace = true
 parking_lot.workspace = true
-settings = { path = "../settings" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -7,6 +7,6 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 bincode = "1.3"
-plugin_macros = { path = "../plugin_macros" }
+plugin_macros.workspace = true
 serde.workspace = true
 serde_derive.workspace = true

--- a/crates/prettier/Cargo.toml
+++ b/crates/prettier/Cargo.toml
@@ -30,6 +30,6 @@ serde_json.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-fs = { path = "../fs",  features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
+fs = { workspace = true,  features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }

--- a/crates/prettier/Cargo.toml
+++ b/crates/prettier/Cargo.toml
@@ -14,20 +14,20 @@ test-support = []
 
 [dependencies]
 anyhow.workspace = true
-client = { path = "../client" }
-collections = { path = "../collections" }
-fs = { path = "../fs" }
+client.workspace = true
+collections.workspace = true
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+gpui.workspace = true
+language.workspace = true
 log.workspace = true
-lsp = { path = "../lsp" }
-node_runtime = { path = "../node_runtime" }
+lsp.workspace = true
+node_runtime.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 fs = { path = "../fs",  features = ["test-support"] }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -25,45 +25,45 @@ aho-corasick = "1.1"
 anyhow.workspace = true
 async-trait.workspace = true
 backtrace = "0.3"
-client = { path = "../client" }
-clock = { path = "../clock" }
-collections = { path = "../collections" }
-copilot = { path = "../copilot" }
-db = { path = "../db" }
-fs = { path = "../fs" }
-fsevent = { path = "../fsevent" }
+client.workspace = true
+clock.workspace = true
+collections.workspace = true
+copilot.workspace = true
+db.workspace = true
+fs.workspace = true
+fsevent.workspace = true
 futures.workspace = true
-fuzzy = {  path = "../fuzzy" }
-git = { path = "../git" }
+fuzzy.workspace = true
+git.workspace = true
 globset.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 ignore = "0.4"
 itertools = "0.10"
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-lsp = { path = "../lsp" }
-node_runtime = { path = "../node_runtime" }
+lsp.workspace = true
+node_runtime.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
-prettier = { path = "../prettier" }
+prettier.workspace = true
 rand.workspace = true
 regex.workspace = true
-rpc = { path = "../rpc" }
+rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 sha2 = "0.10"
 similar = "1.3"
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
-terminal = { path = "../terminal" }
-text = { path = "../text" }
+sum_tree.workspace = true
+terminal.workspace = true
+text.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }
@@ -75,7 +75,7 @@ fs = { path = "../fs",  features = ["test-support"] }
 git2.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 lsp = { path = "../lsp", features = ["test-support"] }
 prettier = { path = "../prettier", features = ["test-support"] }
 pretty_assertions.workspace = true

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -66,21 +66,21 @@ toml.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-collections = { path = "../collections", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-db = { path = "../db", features = ["test-support"] }
+db = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
-fs = { path = "../fs",  features = ["test-support"] }
+fs = { workspace = true,  features = ["test-support"] }
 git2.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
-lsp = { path = "../lsp", features = ["test-support"] }
-prettier = { path = "../prettier", features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
+prettier = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
-rpc = { path = "../rpc", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true
 unindent.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -11,28 +11,28 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
-db = { path = "../db" }
-editor = { path = "../editor" }
+collections.workspace = true
+db.workspace = true
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-menu = {  path = "../menu" }
+gpui.workspace = true
+menu.workspace = true
 postage.workspace = true
 pretty_assertions.workspace = true
-project = { path = "../project" }
+project.workspace = true
 schemars.workspace = true
-search = { path = "../search" }
+search.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
-theme = { path = "../theme" }
-ui = { path = "../ui" }
+theme.workspace = true
+ui.workspace = true
 unicase = "2.6"
-util = { path = "../util" }
-client = { path = "../client" }
-workspace = { path = "../workspace", package = "workspace" }
+util.workspace = true
+client.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -35,9 +35,9 @@ client.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -27,13 +27,13 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 futures.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
-project = { path = "../project", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
-settings = { path = "../settings", features = ["test-support"] }
-theme = { path = "../theme", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+theme = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -11,20 +11,20 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-editor = { path = "../editor" }
-fuzzy = {   path = "../fuzzy" }
-gpui = { path = "../gpui" }
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
 ordered-float.workspace = true
-picker = { path = "../picker" }
+picker.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
-text = { path = "../text" }
-theme = { path = "../theme" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+text.workspace = true
+theme.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }
@@ -33,7 +33,7 @@ gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
 project = { path = "../project", features = ["test-support"] }
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 settings = { path = "../settings", features = ["test-support"] }
 theme = { path = "../theme", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }

--- a/crates/quick_action_bar/Cargo.toml
+++ b/crates/quick_action_bar/Cargo.toml
@@ -19,6 +19,6 @@ ui.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/quick_action_bar/Cargo.toml
+++ b/crates/quick_action_bar/Cargo.toml
@@ -10,13 +10,13 @@ path = "src/quick_action_bar.rs"
 doctest = false
 
 [dependencies]
-assistant = { path = "../assistant" }
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
-search = { path = "../search" }
-settings = { path = "../settings" }
-ui = { path = "../ui" }
-workspace = { path = "../workspace" }
+assistant.workspace = true
+editor.workspace = true
+gpui.workspace = true
+search.workspace = true
+settings.workspace = true
+ui.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -10,21 +10,21 @@ path = "src/recent_projects.rs"
 doctest = false
 
 [dependencies]
-editor = { path = "../editor" }
+editor.workspace = true
 futures.workspace = true
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
 ordered-float.workspace = true
-picker = { path = "../picker" }
+picker.workspace = true
 postage.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
-text = { path = "../text" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+text.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -27,4 +27,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/release_channel/Cargo.toml
+++ b/crates/release_channel/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 license = "GPL-3.0-or-later"
 
 [dependencies]
-gpui = { path = "../gpui" }
+gpui.workspace = true
 once_cell = "1.19.0"

--- a/crates/rich_text/Cargo.toml
+++ b/crates/rich_text/Cargo.toml
@@ -17,15 +17,15 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
+collections.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+gpui.workspace = true
+language.workspace = true
 lazy_static.workspace = true
 pulldown-cmark.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
+sum_tree.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -13,8 +13,8 @@ arrayvec = "0.7.1"
 bromberg_sl2 = { git = "https://github.com/zed-industries/bromberg_sl2", rev = "950bc5482c216c395049ae33ae4501e08975f17f" }
 log.workspace = true
 smallvec.workspace = true
-sum_tree = { path = "../sum_tree" }
-util = { path = "../util" }
+sum_tree.workspace = true
+util.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -17,6 +17,6 @@ sum_tree.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 rand.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -18,8 +18,8 @@ anyhow.workspace = true
 async-lock = "2.4"
 async-tungstenite = "0.16"
 base64 = "0.13"
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+clock.workspace = true
+collections.workspace = true
 futures.workspace = true
 gpui = { path = "../gpui", optional = true }
 parking_lot.workspace = true
@@ -32,7 +32,7 @@ serde_json.workspace = true
 smol-timeout = "0.6"
 strum.workspace = true
 tracing = { version = "0.1.34", features = ["log"] }
-util = { path = "../util" }
+util.workspace = true
 zstd = "0.11"
 
 [build-dependencies]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.13"
 clock.workspace = true
 collections.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui", optional = true }
+gpui = { workspace = true, optional = true }
 parking_lot.workspace = true
 prost.workspace = true
 rand.workspace = true
@@ -39,9 +39,9 @@ zstd = "0.11"
 prost-build = "0.9"
 
 [dev-dependencies]
-collections = { path = "../collections", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 smol.workspace = true
 tempfile.workspace = true

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -12,26 +12,26 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 bitflags = "1"
-collections = { path = "../collections" }
-editor = { path = "../editor" }
+collections.workspace = true
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+gpui.workspace = true
+language.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
+menu.workspace = true
 postage.workspace = true
-project = { path = "../project" }
-semantic_index = { path = "../semantic_index" }
+project.workspace = true
+semantic_index.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 smol.workspace = true
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -34,8 +34,8 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/semantic_index/Cargo.toml
+++ b/crates/semantic_index/Cargo.toml
@@ -10,45 +10,45 @@ path = "src/semantic_index.rs"
 doctest = false
 
 [dependencies]
-ai = { path = "../ai" }
+ai.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
-collections = { path = "../collections" }
+collections.workspace = true
 futures.workspace = true
 globset.workspace = true
-gpui = { path = "../gpui" }
-language = { path = "../language" }
+gpui.workspace = true
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 ndarray = { version = "0.15.0" }
 ordered-float.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 rand.workspace = true
-release_channel = { path = "../release_channel" }
-rpc = { path = "../rpc" }
+release_channel.workspace = true
+rpc.workspace = true
 rusqlite.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 sha1 = "0.10.5"
 smol.workspace = true
 tiktoken-rs.workspace = true
 tree-sitter.workspace = true
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 ai = { path = "../ai", features = ["test-support"] }
-client = { path = "../client" }
+client.workspace = true
 collections = { path = "../collections", features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
 language = { path = "../language", features = ["test-support"] }
-node_runtime = { path = "../node_runtime" }
+node_runtime.workspace = true
 pretty_assertions.workspace = true
 project = { path = "../project", features = ["test-support"] }
 rand.workspace = true

--- a/crates/semantic_index/Cargo.toml
+++ b/crates/semantic_index/Cargo.toml
@@ -41,20 +41,20 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-ai = { path = "../ai", features = ["test-support"] }
+ai = { workspace = true, features = ["test-support"] }
 client.workspace = true
-collections = { path = "../collections", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 node_runtime.workspace = true
 pretty_assertions.workspace = true
-project = { path = "../project", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 rand.workspace = true
-rpc = { path = "../rpc", features = ["test-support"] }
+rpc = { workspace = true, features = ["test-support"] }
 rust-embed.workspace = true
-settings = { path = "../settings", features = ["test-support"]}
+settings = { workspace = true, features = ["test-support"]}
 tempfile.workspace = true
 tree-sitter-cpp.workspace = true
 tree-sitter-elixir.workspace = true
@@ -66,4 +66,4 @@ tree-sitter-rust.workspace = true
 tree-sitter-toml.workspace = true
 tree-sitter-typescript.workspace = true
 unindent.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -35,8 +35,8 @@ tree-sitter.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-fs = { path = "../fs", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
 pretty_assertions.workspace = true
 unindent.workspace = true

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -14,14 +14,14 @@ test-support = ["gpui/test-support", "fs/test-support"]
 
 [dependencies]
 anyhow.workspace = true
-collections = { path = "../collections" }
-feature_flags = { path = "../feature_flags" }
-fs = { path = "../fs" }
+collections.workspace = true
+feature_flags.workspace = true
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 lazy_static.workspace = true
 postage.workspace = true
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 rust-embed.workspace = true
 schemars.workspace = true
 serde.workspace = true
@@ -32,7 +32,7 @@ smallvec.workspace = true
 toml.workspace = true
 tree-sitter-json = "*"
 tree-sitter.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 fs = { path = "../fs", features = ["test-support"] }

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -14,5 +14,5 @@ libsqlite3-sys = { version = "0.26", features = ["bundled"] }
 parking_lot.workspace = true
 smol.workspace = true
 thread_local = "1.1.4"
-util = { path = "../util" }
+util.workspace = true
 uuid.workspace = true

--- a/crates/sqlez_macros/Cargo.toml
+++ b/crates/sqlez_macros/Cargo.toml
@@ -14,6 +14,6 @@ doctest = false
 lazy_static.workspace = true
 proc-macro2 = "1.0"
 quote = "1.0"
-sqlez = { path = "../sqlez" }
+sqlez.workspace = true
 sqlformat = "0.2"
 syn = "1.0"

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 license = "GPL-3.0-or-later"
 
 [dependencies]
-gpui = { path = "../gpui" }
+gpui.workspace = true
 itertools = { package = "itertools", version = "0.10" }
 smallvec.workspace = true

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -15,7 +15,7 @@ anyhow.workspace = true
 backtrace-on-stack-overflow = "0.3.0"
 chrono = "0.4"
 clap = { version = "4.4", features = ["derive", "string"] }
-collab_ui = { path = "../collab_ui", features = ["stories"] }
+collab_ui = { workspace = true, features = ["stories"] }
 ctrlc = "3.4"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 editor.workspace = true
@@ -35,8 +35,8 @@ smallvec.workspace = true
 story.workspace = true
 strum = { version = "0.25.0", features = ["derive"] }
 theme.workspace = true
-ui = { path = "../ui", features = ["stories"] }
+ui = { workspace = true, features = ["stories"] }
 util.workspace = true
 
 [dev-dependencies]
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -18,25 +18,25 @@ clap = { version = "4.4", features = ["derive", "string"] }
 collab_ui = { path = "../collab_ui", features = ["stories"] }
 ctrlc = "3.4"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
-editor = { path = "../editor" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
 indoc.workspace = true
 itertools = "0.11.0"
-language = { path = "../language" }
+language.workspace = true
 log.workspace = true
-menu = { path = "../menu" }
-picker = { path = "../picker" }
+menu.workspace = true
+picker.workspace = true
 rust-embed.workspace = true
 serde.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 simplelog = "0.9"
 smallvec.workspace = true
-story = { path = "../story" }
+story.workspace = true
 strum = { version = "0.25.0", features = ["derive"] }
-theme = { path = "../theme" }
+theme.workspace = true
 ui = { path = "../ui", features = ["stories"] }
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 gpui = { path = "../gpui", features = ["test-support"] }

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -14,10 +14,10 @@ doctest = false
 # needed for "a few weeks" until alacritty 0.13.2 is out
 alacritty_terminal = { git = "https://github.com/alacritty/alacritty", rev = "2d2b894c3b869fadc78fce9d72cb5c8d2b764cac" }
 anyhow.workspace = true
-db = { path = "../db" }
+db.workspace = true
 dirs = "4.0.0"
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 itertools = "0.10"
 lazy_static.workspace = true
 libc = "0.2"
@@ -28,13 +28,13 @@ schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 shellexpand = "2.1.0"
 smallvec.workspace = true
 smol.workspace = true
-theme = { path = "../theme" }
+theme.workspace = true
 thiserror.workspace = true
-util = { path = "../util" }
+util.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -11,34 +11,34 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-db = { path = "../db" }
-collections = { path = "../collections" }
+db.workspace = true
+collections.workspace = true
 dirs = "4.0.0"
-editor = { path = "../editor" }
+editor.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 itertools = "0.10"
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 libc = "0.2"
 mio-extras = "2.0.6"
 ordered-float.workspace = true
 procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
-project = { path = "../project" }
-search = { path = "../search" }
+project.workspace = true
+search.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 shellexpand = "2.1.0"
 smallvec.workspace = true
 smol.workspace = true
-terminal = { path = "../terminal" }
-theme = { path = "../theme" }
+terminal.workspace = true
+theme.workspace = true
 thiserror.workspace = true
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 client = { path = "../client", features = ["test-support"] }

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -41,9 +41,9 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-client = { path = "../client", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-project = { path = "../project", features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 rand.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -14,8 +14,8 @@ test-support = ["rand"]
 
 [dependencies]
 anyhow.workspace = true
-clock = { path = "../clock" }
-collections = { path = "../collections" }
+clock.workspace = true
+collections.workspace = true
 digest = { version = "0.9", features = ["std"] }
 lazy_static.workspace = true
 log.workspace = true
@@ -23,10 +23,10 @@ parking_lot.workspace = true
 postage.workspace = true
 rand = { workspace = true, optional = true }
 regex.workspace = true
-rope = { path = "../rope" }
+rope.workspace = true
 smallvec.workspace = true
-sum_tree = { path = "../sum_tree" }
-util = { path = "../util" }
+sum_tree.workspace = true
+util.workspace = true
 
 [dev-dependencies]
 collections = { path = "../collections", features = ["test-support"] }

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -29,9 +29,9 @@ sum_tree.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-collections = { path = "../collections", features = ["test-support"] }
+collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 env_logger.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 rand.workspace = true
-util = { path = "../util", features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -20,11 +20,11 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-color = { path = "../color" }
+color.workspace = true
 derive_more.workspace = true
-fs = { path = "../fs" }
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
+gpui.workspace = true
 indexmap = { version = "1.6.2", features = ["serde"] }
 itertools = { version = "0.11.0", optional = true }
 palette = { version = "0.7.3", default-features = false, features = ["std"] }
@@ -36,10 +36,10 @@ serde_derive.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
 serde_repr.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 story = { path = "../story", optional = true }
 toml.workspace = true
-util = { path = "../util" }
+util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -37,12 +37,12 @@ serde_json.workspace = true
 serde_json_lenient.workspace = true
 serde_repr.workspace = true
 settings.workspace = true
-story = { path = "../story", optional = true }
+story = { workspace = true, optional = true }
 toml.workspace = true
 util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-fs = { path = "../fs", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -10,7 +10,7 @@ any_ascii = "0.3.2"
 anyhow.workspace = true
 clap = { version = "4.4", features = ["derive"] }
 convert_case = "0.6.0"
-gpui = { path = "../gpui" }
+gpui.workspace = true
 indexmap = { version = "1.6.2", features = ["serde"] }
 indoc.workspace = true
 log.workspace = true
@@ -23,6 +23,6 @@ serde_json.workspace = true
 serde_json_lenient.workspace = true
 simplelog = "0.9"
 strum = { version = "0.25.0", features = ["derive"] }
-theme = { path = "../theme" }
+theme.workspace = true
 uuid.workspace = true
 vscode_theme = "0.2.0"

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -10,22 +10,22 @@ path = "src/theme_selector.rs"
 doctest = false
 
 [dependencies]
-client = { path = "../client" }
-editor = { path = "../editor" }
-feature_flags = { path = "../feature_flags" }
-fs = { path = "../fs" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
+client.workspace = true
+editor.workspace = true
+feature_flags.workspace = true
+fs.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
 log.workspace = true
 parking_lot.workspace = true
-picker = { path = "../picker" }
+picker.workspace = true
 postage.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smol.workspace = true
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -28,4 +28,4 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8"
 serde.workspace = true
 settings.workspace = true
 smallvec.workspace = true
-story = { path = "../story", optional = true }
+story = { workspace = true, optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 theme.workspace = true
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -12,16 +12,16 @@ path = "src/ui.rs"
 [dependencies]
 anyhow.workspace = true
 chrono = "0.4"
-gpui = { path = "../gpui" }
+gpui.workspace = true
 itertools = { version = "0.11.0", optional = true }
-menu = { path = "../menu" }
+menu.workspace = true
 rand = "0.8"
 serde.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
 story = { path = "../story", optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
-theme = { path = "../theme" }
+theme.workspace = true
 
 [features]
 default = []

--- a/crates/vcs_menu/Cargo.toml
+++ b/crates/vcs_menu/Cargo.toml
@@ -7,10 +7,10 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 anyhow.workspace = true
-fs = { path = "../fs" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
-picker = { path = "../picker" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-workspace = { path = "../workspace" }
+fs.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+picker.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -40,16 +40,16 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
 futures.workspace = true
-gpui = { path = "../gpui", features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
 indoc.workspace = true
-language = { path = "../language", features = ["test-support"] }
-lsp = { path = "../lsp", features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 parking_lot.workspace = true
-project = { path = "../project", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 settings.workspace = true
-theme = { path = "../theme", features = ["test-support"] }
-util = { path = "../util", features = ["test-support"] }
-workspace = { path = "../workspace", features = ["test-support"] }
+theme = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -16,40 +16,40 @@ neovim = ["nvim-rs", "async-compat", "async-trait", "tokio"]
 anyhow.workspace = true
 async-compat = { version = "0.2.1", "optional" = true }
 async-trait = { workspace = true, "optional" = true }
-collections = { path = "../collections" }
-command_palette = { path = "../command_palette" }
+collections.workspace = true
+command_palette.workspace = true
 # HACK: We're only depending on `copilot` here for `CommandPaletteFilter`.  See the attached comment on that type.
-copilot = { path = "../copilot" }
-diagnostics = { path = "../diagnostics" }
-editor = { path = "../editor" }
-gpui = { path = "../gpui" }
+copilot.workspace = true
+diagnostics.workspace = true
+editor.workspace = true
+gpui.workspace = true
 itertools = "0.10"
-language = { path = "../language" }
+language.workspace = true
 log.workspace = true
 nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"], optional = true }
 regex.workspace = true
-search = { path = "../search" }
+search.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
-theme = { path = "../theme" }
+settings.workspace = true
+theme.workspace = true
 tokio = { version = "1.15", "optional" = true }
-ui = { path = "../ui" }
-workspace = { path = "../workspace" }
-zed_actions = { path = "../zed_actions" }
+ui.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }
 futures.workspace = true
 gpui = { path = "../gpui", features = ["test-support"] }
-release_channel = { path = "../release_channel" }
+release_channel.workspace = true
 indoc.workspace = true
 language = { path = "../language", features = ["test-support"] }
 lsp = { path = "../lsp", features = ["test-support"] }
 parking_lot.workspace = true
 project = { path = "../project", features = ["test-support"] }
-settings = { path = "../settings" }
+settings.workspace = true
 theme = { path = "../theme", features = ["test-support"] }
 util = { path = "../util", features = ["test-support"] }
 workspace = { path = "../workspace", features = ["test-support"] }

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -34,4 +34,4 @@ vim.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-editor = { path = "../editor", features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -13,25 +13,25 @@ test-support = []
 
 [dependencies]
 anyhow.workspace = true
-client = { path = "../client" }
-db = { path = "../db" }
-editor = { path = "../editor" }
-fs = { path = "../fs" }
-fuzzy = {  path = "../fuzzy" }
-gpui = { path = "../gpui" }
-install_cli = { path = "../install_cli" }
+client.workspace = true
+db.workspace = true
+editor.workspace = true
+fs.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+install_cli.workspace = true
 log.workspace = true
-picker = { path = "../picker" }
-project = { path = "../project" }
+picker.workspace = true
+project.workspace = true
 schemars.workspace = true
 serde.workspace = true
-settings = { path = "../settings" }
-theme = { path = "../theme" }
-theme_selector = { path = "../theme_selector" }
-ui = { path = "../ui" }
-util = { path = "../util" }
-vim = { path = "../vim" }
-workspace = { path = "../workspace" }
+settings.workspace = true
+theme.workspace = true
+theme_selector.workspace = true
+ui.workspace = true
+util.workspace = true
+vim.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { path = "../editor", features = ["test-support"] }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -54,12 +54,12 @@ util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-call = { path = "../call", features = ["test-support"] }
-client = { path = "../client", features = ["test-support"] }
-db = { path = "../db", features = ["test-support"] }
+call = { workspace = true, features = ["test-support"] }
+client = { workspace = true, features = ["test-support"] }
+db = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
-fs = { path = "../fs", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
-project = { path = "../project", features = ["test-support"] }
-settings = { path = "../settings", features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -23,34 +23,34 @@ test-support = [
 anyhow.workspace = true
 async-recursion = "1.0.0"
 bincode = "1.2.1"
-call = { path = "../call" }
-client = { path = "../client" }
-collections = { path = "../collections" }
-db = { path = "../db" }
+call.workspace = true
+client.workspace = true
+collections.workspace = true
+db.workspace = true
 derive_more.workspace = true
-fs = { path = "../fs" }
+fs.workspace = true
 futures.workspace = true
-gpui = { path = "../gpui" }
-install_cli = { path = "../install_cli" }
+gpui.workspace = true
+install_cli.workspace = true
 itertools = "0.10"
-language = { path = "../language" }
+language.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-node_runtime = { path = "../node_runtime" }
+node_runtime.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
-project = { path = "../project" }
+project.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 smallvec.workspace = true
-sqlez = { path = "../sqlez" }
-terminal = { path = "../terminal" }
-theme = { path = "../theme" }
-ui = { path = "../ui" }
-util = { path = "../util" }
+sqlez.workspace = true
+terminal.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -159,14 +159,14 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [dev-dependencies]
-call = { path = "../call", features = ["test-support"] }
-editor = { path = "../editor", features = ["test-support"] }
-gpui = { path = "../gpui", features = ["test-support"] }
-language = { path = "../language", features = ["test-support"] }
-project = { path = "../project", features = ["test-support"] }
-text = { path = "../text", features = ["test-support"] }
+call = { workspace = true, features = ["test-support"] }
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+text = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
-workspace = { path = "../workspace", features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
 
 [package.metadata.bundle-dev]
 icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -16,94 +16,94 @@ name = "Zed"
 path = "src/main.rs"
 
 [dependencies]
-activity_indicator = { path = "../activity_indicator" }
-ai = { path = "../ai" }
+activity_indicator.workspace = true
+ai.workspace = true
 anyhow.workspace = true
-assets = { path = "../assets" }
-assistant = { path = "../assistant" }
+assets.workspace = true
+assistant.workspace = true
 async-compression.workspace = true
 async-recursion = "0.3"
 async-tar = "0.4.2"
 async-trait.workspace = true
-audio = { path = "../audio" }
-auto_update = { path = "../auto_update" }
+audio.workspace = true
+auto_update.workspace = true
 backtrace = "0.3"
-breadcrumbs = { path = "../breadcrumbs" }
-call = { path = "../call" }
-channel = { path = "../channel" }
+breadcrumbs.workspace = true
+call.workspace = true
+channel.workspace = true
 chrono = "0.4"
-cli = { path = "../cli" }
-client = { path = "../client" }
-collab_ui = { path = "../collab_ui" }
-collections = { path = "../collections" }
-command_palette = { path = "../command_palette" }
-copilot = { path = "../copilot" }
-copilot_ui = { path = "../copilot_ui" }
+cli.workspace = true
+client.workspace = true
+collab_ui.workspace = true
+collections.workspace = true
+command_palette.workspace = true
+copilot.workspace = true
+copilot_ui.workspace = true
 ctor.workspace = true
-db = { path = "../db" }
-diagnostics = { path = "../diagnostics" }
-editor = { path = "../editor" }
+db.workspace = true
+diagnostics.workspace = true
+editor.workspace = true
 env_logger.workspace = true
-feature_flags = { path = "../feature_flags" }
-feedback = { path = "../feedback" }
-file_finder = { path = "../file_finder" }
-fs = { path = "../fs" }
-fsevent = { path = "../fsevent" }
+feature_flags.workspace = true
+feedback.workspace = true
+file_finder.workspace = true
+fs.workspace = true
+fsevent.workspace = true
 futures.workspace = true
-go_to_line = { path = "../go_to_line" }
-gpui = { path = "../gpui" }
+go_to_line.workspace = true
+gpui.workspace = true
 ignore = "0.4"
 image = "0.23"
 indexmap = "1.6.2"
-install_cli = { path = "../install_cli" }
+install_cli.workspace = true
 isahc.workspace = true
 itertools = "0.11"
-journal = { path = "../journal" }
-language = { path = "../language" }
-language_selector = { path = "../language_selector" }
-language_tools = { path = "../language_tools" }
+journal.workspace = true
+language.workspace = true
+language_selector.workspace = true
+language_tools.workspace = true
 lazy_static.workspace = true
 libc = "0.2"
 log.workspace = true
-lsp = { path = "../lsp" }
-markdown_preview = { path = "../markdown_preview" }
-menu = { path = "../menu" }
+lsp.workspace = true
+markdown_preview.workspace = true
+menu.workspace = true
 mimalloc = "0.1"
-node_runtime = { path = "../node_runtime" }
-notifications = { path = "../notifications" }
+node_runtime.workspace = true
+notifications.workspace = true
 num_cpus = "1.13.0"
-outline = { path = "../outline" }
+outline.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
-project = { path = "../project" }
-project_panel = { path = "../project_panel" }
-project_symbols = { path = "../project_symbols" }
-quick_action_bar = { path = "../quick_action_bar" }
+project.workspace = true
+project_panel.workspace = true
+project_symbols.workspace = true
+quick_action_bar.workspace = true
 rand.workspace = true
-recent_projects = { path = "../recent_projects" }
+recent_projects.workspace = true
 regex.workspace = true
-release_channel = { path = "../release_channel" }
-rope = { path = "../rope" }
-rpc = { path = "../rpc" }
+release_channel.workspace = true
+rope.workspace = true
+rpc.workspace = true
 rsa = "0.4"
 rust-embed.workspace = true
 schemars.workspace = true
-search = { path = "../search" }
-semantic_index = { path = "../semantic_index" }
+search.workspace = true
+semantic_index.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-settings = { path = "../settings" }
+settings.workspace = true
 shellexpand = "2.1.0"
 simplelog = "0.9"
 smallvec.workspace = true
 smol.workspace = true
-sum_tree = { path = "../sum_tree" }
+sum_tree.workspace = true
 tempfile.workspace = true
-terminal_view = { path = "../terminal_view" }
-text = { path = "../text" }
-theme = { path = "../theme" }
-theme_selector = { path = "../theme_selector" }
+terminal_view.workspace = true
+text.workspace = true
+theme.workspace = true
+theme_selector.workspace = true
 thiserror.workspace = true
 tiny_http = "0.8"
 toml.workspace = true
@@ -151,12 +151,12 @@ tree-sitter-zig.workspace = true
 tree-sitter.workspace = true
 url.workspace = true
 urlencoding = "2.1.2"
-util = { path = "../util" }
+util.workspace = true
 uuid.workspace = true
-vim = { path = "../vim" }
-welcome = { path = "../welcome" }
-workspace = { path = "../workspace" }
-zed_actions = { path = "../zed_actions" }
+vim.workspace = true
+welcome.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 call = { path = "../call", features = ["test-support"] }

--- a/crates/zed_actions/Cargo.toml
+++ b/crates/zed_actions/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 license = "GPL-3.0-or-later"
 
 [dependencies]
-gpui = { path = "../gpui" }
+gpui.workspace = true
 serde.workspace = true


### PR DESCRIPTION
We should prefer referring to local deps via `.workspace = true` from now on.

Release Notes:

- N/A