### PR TITLE
Make diagnostics with empty messages take up one line

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7906,7 +7906,7 @@ impl Editor {
                 .insert_blocks(
                     diagnostic_group.iter().map(|entry| {
                         let diagnostic = entry.diagnostic.clone();
-                        let message_height = diagnostic.message.lines().count() as u8;
+                        let message_height = diagnostic.message.matches('\n').count() as u8 + 1;
                         BlockProperties {
                             style: BlockStyle::Fixed,
                             position: buffer.anchor_after(entry.range.start),


### PR DESCRIPTION
When a supporting diagnostic had an empty message, we were accidentally giving the corresponding block a height of zero lines.

Release Notes:

- Fixed an issue where an editors' lines were not laid out correctly when showing certain diagnostics.