### PR TITLE
Jetbrains keymap - Movement between panes

### DIFF
--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -82,6 +82,13 @@
     }
   },
   {
+    "context": "Pane",
+    "bindings": {
+      "cmd-alt-left": "pane::GoBack",
+      "cmd-alt-right": "pane::GoForward"
+    }
+  },
+  {
     "context": "ProjectPanel",
     "bindings": {
       "enter": "project_panel::Open",


### PR DESCRIPTION

Release Notes:

- Improved - Jetbrains keybindings to include cmd+alt+left/right to go back and forwards between panes rather than the default previous / next pane
