### PR TITLE
Prevent terminal being a single column wide

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -450,6 +450,13 @@ impl TerminalElement {
             let mut size = bounds.size.clone();
             size.width -= gutter;
 
+            // https://github.com/zed-industries/zed/issues/2750
+            // if the terminal is one column wide, rendering 🦀
+            // causes alacritty to misbehave.
+            if size.width < cell_width * 2.0 {
+                size.width = cell_width * 2.0;
+            }
+
             TerminalSize::new(line_height, cell_width, size)
         };
 


### PR DESCRIPTION
Fixes: #2750
Fixes: #7457



Release Notes:

- Fixed a hang/panic that could happen rendering a double-width character in a single-width terminal ([#2750](https://github.com/zed-industries/zed/issues/2750), [#7457](https://github.com/zed-industries/zed/issues/7457)).
