### PR TITLE
theme_importer: Add `--output` flag for outputting the theme to a file

### DIFF
--- a/crates/theme_importer/README.md
+++ b/crates/theme_importer/README.md
@@ -1,5 +1,5 @@
 # Zed Theme Importer
 
-```bash
-cargo run -p theme_importer -- dark-plus-syntax-color-theme.json output.json
+```sh
+cargo run -p theme_importer -- dark-plus-syntax-color-theme.json --output output-theme.json
 ```

--- a/crates/theme_importer/README.md
+++ b/crates/theme_importer/README.md
@@ -1,1 +1,5 @@
 # Zed Theme Importer
+
+```bash
+cargo run -p theme_importer -- dark-plus-syntax-color-theme.json output.json
+```

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -5,6 +5,7 @@ mod vscode;
 
 use std::fs::File;
 use std::path::PathBuf;
+use std::io::Write;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -74,6 +75,8 @@ struct Args {
     /// Whether to warn when values are missing from the theme.
     #[arg(long)]
     warn_on_missing: bool,
+
+    output: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -146,7 +149,12 @@ fn main() -> Result<()> {
 
     let theme_json = serde_json::to_string_pretty(&theme).unwrap();
 
-    println!("{}", theme_json);
+    if let Some(output) = args.output {
+        let mut file = File::create(output)?;
+        file.write_all(theme_json.as_bytes())?;
+    } else {
+        println!("{}", theme_json);
+    }
 
     log::info!("Done!");
 

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -4,8 +4,8 @@ mod util;
 mod vscode;
 
 use std::fs::File;
-use std::path::PathBuf;
 use std::io::Write;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -76,6 +76,8 @@ struct Args {
     #[arg(long)]
     warn_on_missing: bool,
 
+    /// The path to write the output to.
+    #[arg(long, short)]
     output: Option<PathBuf>,
 
     #[command(subcommand)]


### PR DESCRIPTION
```bash
cargo run -p theme_importer -- dark-plus-syntax-color-theme.json --output output.json
```

Release Notes:

- N/A