### PR TITLE
Add ability to bind to pane::RevealInProjectPanel

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -284,7 +284,8 @@
       "ctrl-w o": "workspace::CloseInactiveTabsAndPanes",
       "ctrl-w ctrl-o": "workspace::CloseInactiveTabsAndPanes",
       "ctrl-w n": ["workspace::NewFileInDirection", "Up"],
-      "ctrl-w ctrl-n": ["workspace::NewFileInDirection", "Up"]
+      "ctrl-w ctrl-n": ["workspace::NewFileInDirection", "Up"],
+      "-": "pane::RevealInProjectPanel"
     }
   },
   {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -112,7 +112,7 @@ impl_actions!(
         MoveUpByLines,
         MoveDownByLines,
         SelectUpByLines,
-        SelectDownByLines,
+        SelectDownByLines
     ]
 );
 


### PR DESCRIPTION
Previously it wasn't possible to create a keybinding for this action because it required an argument.

Now the action takes the active item of the pane and if it's a multi-buffer the first one.

This also adds a default keybinding for Vim mode: `-` will reveal the file in the project panel.

Fixes #7485.

Release Notes:

- Added `pane::RevealInProjectPanel` as an action in the command palette. ([#7485](https://github.com/zed-industries/zed/issues/7485)).

