### PR TITLE
Add information to Copilot sign-in UI when disabled

### DIFF
--- a/crates/copilot_ui/src/sign_in.rs
+++ b/crates/copilot_ui/src/sign_in.rs
@@ -144,6 +144,12 @@ impl CopilotCodeVerification {
                     .on_click(|_, cx| cx.open_url(COPILOT_SIGN_UP_URL)),
             )
     }
+
+    fn render_disabled_modal() -> impl Element {
+        v_flex()
+            .child(Headline::new("Copilot is disabled").size(HeadlineSize::Large))
+            .child(Label::new("You can enable Copilot in your settings."))
+    }
 }
 
 impl Render for CopilotCodeVerification {
@@ -159,6 +165,10 @@ impl Render for CopilotCodeVerification {
             Status::Authorized => {
                 self.connect_clicked = false;
                 Self::render_enabled_modal(cx).into_any_element()
+            }
+            Status::Disabled => {
+                self.connect_clicked = false;
+                Self::render_disabled_modal().into_any_element()
             }
             _ => div().into_any_element(),
         };


### PR DESCRIPTION
I'd love to take on fixing this but:

1. I don't think this is the right solution - it would be really nice to have something actionable that I could do when presented with this message.
2. Should signing in to Copilot be independent from whether it's enabled? You can only access the sign-in modal when `features.copilot` isn't disabled, but when `show_copilot_suggestions` is `false` the server is disabled but you can't sign in. So I guess another solution might be to just not show the UI if copilot suggestions are disabled?
3. I don't know what other circumstances could trigger the empty modal. I see `Status::Error` and that seems like it might be important to surface gracefully?

Would love some thoughts on this

Release Notes:

- Improved UX for enabling Copilot when it's disabled in settings
