### PR TITLE
terminal: strikethrough text

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -4,8 +4,8 @@ use gpui::{
     ElementContext, ElementId, FocusHandle, Font, FontStyle, FontWeight, HighlightStyle, Hsla,
     InputHandler, InteractiveBounds, InteractiveElement, InteractiveElementState, Interactivity,
     IntoElement, LayoutId, Model, ModelContext, ModifiersChangedEvent, MouseButton, MouseMoveEvent,
-    Pixels, Point, ShapedLine, StatefulInteractiveElement, Styled, TextRun, TextStyle,
-    UnderlineStyle, WeakView, WhiteSpace, WindowContext, WindowTextSystem,
+    Pixels, Point, ShapedLine, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun,
+    TextStyle, UnderlineStyle, WeakView, WhiteSpace, WindowContext, WindowTextSystem,
 };
 use itertools::Itertools;
 use language::CursorShape;
@@ -340,6 +340,13 @@ impl TerminalElement {
             wavy: flags.contains(Flags::UNDERCURL),
         });
 
+        let strikethrough = flags
+            .intersects(Flags::STRIKEOUT)
+            .then(|| StrikethroughStyle {
+                color: Some(fg),
+                thickness: Pixels::from(1.0),
+            });
+
         let weight = if flags.intersects(Flags::BOLD | Flags::DIM_BOLD) {
             FontWeight::BOLD
         } else {
@@ -362,7 +369,7 @@ impl TerminalElement {
                 ..text_style.font()
             },
             underline,
-            strikethrough: None,
+            strikethrough,
         };
 
         if let Some((style, range)) = hyperlink {


### PR DESCRIPTION
#7363 added support for rendering strikethrough text, so now we can handle this case in the terminal.

Should close: #7434

Before:
![image](https://github.com/zed-industries/zed/assets/53836821/cb7a4eae-5bc9-425c-974d-07a9f089917a)

After:
![image](https://github.com/zed-industries/zed/assets/53836821/5aaacee2-95bc-4039-972d-96bd7c01ea59)

Release Notes:

- Fixed rendering strikethrough text inside the terminal #7434
