### PR TITLE
chat: fix autocompletion for usernames with dash

### DIFF
--- a/crates/zed/src/languages/markdown/config.toml
+++ b/crates/zed/src/languages/markdown/config.toml
@@ -1,5 +1,6 @@
 name = "Markdown"
 path_suffixes = ["md", "mdx"]
+word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
Github usernames are allowed to contain `-`, but the autocompletion was not working correctly.
We added `-` as an allowed character for markdown files. We are not aware of any completions for markdown files, so this should be fine to add.


Before:
![image](https://github.com/zed-industries/zed/assets/53836821/5b456ed6-3098-48e8-90db-f5f42b4aa535)

After:
![image](https://github.com/zed-industries/zed/assets/53836821/a544f465-0b68-46f5-9a15-83b4c755c3c0)


Release Notes:

- Fixed autocompletion for usernames with dash character in the chat message editor

