### PR TITLE
Don't move traffic lights while fullscreen

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -359,6 +359,12 @@ struct MacWindowState {
 impl MacWindowState {
     fn move_traffic_light(&self) {
         if let Some(traffic_light_position) = self.traffic_light_position {
+            if self.is_fullscreen() {
+                // Moving traffic lights while fullscreen doesn't work,
+                // see https://github.com/zed-industries/zed/issues/4712
+                return;
+            }
+
             let titlebar_height = self.titlebar_height();
 
             unsafe {


### PR DESCRIPTION
Fixes #4712, or at least works around it. As discussed in the issue, setting the buttons frames while fullscreen can cause them to render in the wrong location. This fixes that by simply not moving them when fullscreen.

Release Notes:

- Fixed traffic lights occasionally disappearing while fullscreen ([#4712](https://github.com/zed-industries/zed/issues/4712))
