### PR TITLE
chat: closing reply preview with action

### DIFF
--- a/assets/keymaps/default.json
+++ b/assets/keymaps/default.json
@@ -566,6 +566,12 @@
     }
   },
   {
+    "context": "ChatPanel > MessageEditor",
+    "bindings": {
+      "escape": "chat_panel::CloseReplyPreview"
+    }
+  },
+  {
     "context": "Terminal",
     "bindings": {
       "ctrl-cmd-space": "terminal::ShowCharacterPalette",


### PR DESCRIPTION
This is a follow up to #7170. Closing the reply to preview overlay is now configurable with an action (keybinding set to `escape` in the default keymap).

https://github.com/zed-industries/zed/assets/53836821/d679e734-f90b-4490-8e79-7dfe5407988a


Release Notes:
- N/A

