### PR TITLE
Fix Terraform syntax highlighting

### DIFF
--- a/crates/zed/src/languages/terraform/config.toml
+++ b/crates/zed/src/languages/terraform/config.toml
@@ -1,5 +1,5 @@
 name = "Terraform"
-grammar = "terraform"
+grammar = "hcl"
 path_suffixes = ["tf", "tfvars"]
 line_comments = ["# ", "// "]
 block_comment = ["/*", "*/"]


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/7467 introduced a new `grammar` field in the language configuration files.
The underlying tree-sitter grammar for Terraform should be `hcl` instead of `terraform`. This PR fixes that typo.

Release Notes:

- N/A
