### PR TITLE
Reload theme using `ThemeSettings::reload_current_theme`

### DIFF
--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -34,6 +34,10 @@ pub struct ThemeSettings {
 }
 
 impl ThemeSettings {
+    /// Reloads the current theme.
+    ///
+    /// Reads the [`ThemeSettings`] to know which theme should be loaded,
+    /// taking into account the current [`SystemAppearance`].
     pub fn reload_current_theme(cx: &mut AppContext) {
         let mut theme_settings = ThemeSettings::get_global(cx).clone();
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -687,15 +687,7 @@ impl Workspace {
 
                 *SystemAppearance::global_mut(cx) = SystemAppearance(window_appearance.into());
 
-                let mut theme_settings = ThemeSettings::get_global(cx).clone();
-
-                if let Some(theme_selection) = theme_settings.theme_selection.clone() {
-                    let theme_name = theme_selection.theme(window_appearance.into());
-
-                    if let Some(_theme) = theme_settings.switch_theme(&theme_name, cx) {
-                        ThemeSettings::override_global(theme_settings, cx);
-                    }
-                }
+                ThemeSettings::reload_current_theme(cx);
             }),
             cx.observe(&left_dock, |this, _, cx| {
                 this.serialize_workspace(cx);

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -918,16 +918,7 @@ fn load_user_themes_in_background(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
                     }
                 }
                 theme_registry.load_user_themes(themes_dir, fs).await?;
-                cx.update(|cx| {
-                    let mut theme_settings = ThemeSettings::get_global(cx).clone();
-                    if let Some(theme_selection) = theme_settings.theme_selection.clone() {
-                        let theme_name = theme_selection.theme(*SystemAppearance::global(cx));
-
-                        if let Some(_theme) = theme_settings.switch_theme(&theme_name, cx) {
-                            ThemeSettings::override_global(theme_settings, cx);
-                        }
-                    }
-                })?;
+                cx.update(|cx| ThemeSettings::reload_current_theme(cx))?;
             }
             anyhow::Ok(())
         }
@@ -958,23 +949,8 @@ fn watch_themes(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
                             .await
                             .log_err()
                         {
-                            cx.update(|cx| {
-                                let mut theme_settings = ThemeSettings::get_global(cx).clone();
-
-                                if let Some(theme_selection) =
-                                    theme_settings.theme_selection.clone()
-                                {
-                                    let theme_name =
-                                        theme_selection.theme(*SystemAppearance::global(cx));
-
-                                    if let Some(_theme) =
-                                        theme_settings.switch_theme(&theme_name, cx)
-                                    {
-                                        ThemeSettings::override_global(theme_settings, cx);
-                                    }
-                                }
-                            })
-                            .log_err();
+                            cx.update(|cx| ThemeSettings::reload_current_theme(cx))
+                                .log_err();
                         }
                     }
                 }


### PR DESCRIPTION
This PR updates the various spots where we reload the theme to use `ThemeSettings::reload_current_theme` instead of duplicating the code each time.

Release Notes:

- N/A
