### PR TITLE
Linux: Make `nanoid` non-optional on livekit, put version in main Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ isahc = { version = "1.7.2", default-features = false, features = [
 ] }
 lazy_static = "1.4.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde"] }
+nanoid = { version = "0.4" }
 ordered-float = "2.1.1"
 parking_lot = "0.11.1"
 postage = { version = "0.5", features = ["futures-traits"] }

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -19,7 +19,6 @@ test-support = [
     "collections/test-support",
     "gpui/test-support",
     "live_kit_server",
-    "nanoid",
 ]
 
 [dependencies]
@@ -32,9 +31,9 @@ gpui = { workspace = true, optional = true }
 live_kit_server = { workspace = true, optional = true }
 log.workspace = true
 media.workspace = true
-nanoid = { version ="0.4", optional = true}
 parking_lot.workspace = true
 postage.workspace = true
+nanoid.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.3"


### PR DESCRIPTION

Release Notes:

- Added/Fixed/Improved ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).

**or**

- N/A
