### PR TITLE
Linux: Disable PureScript grammar to avoid linking error

### DIFF
--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -98,7 +98,7 @@ pub fn init(
         ),
         ("php", tree_sitter_php::language_php()),
         ("proto", tree_sitter_proto::language()),
-        ("purescript", tree_sitter_purescript::language()),
+        // ("purescript", tree_sitter_purescript::language()),
         ("python", tree_sitter_python::language()),
         ("racket", tree_sitter_racket::language()),
         ("ruby", tree_sitter_ruby::language()),

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -98,7 +98,8 @@ pub fn init(
         ),
         ("php", tree_sitter_php::language_php()),
         ("proto", tree_sitter_proto::language()),
-        // ("purescript", tree_sitter_purescript::language()),
+        #[cfg(not(target_os = "linux"))]
+        ("purescript", tree_sitter_purescript::language()),
         ("python", tree_sitter_python::language()),
         ("racket", tree_sitter_racket::language()),
         ("ruby", tree_sitter_ruby::language()),


### PR DESCRIPTION
Release Notes:

- N/A
