### PR TITLE
blade: fix path rasterization

### DIFF
--- a/crates/gpui/src/platform/linux/blade_renderer.rs
+++ b/crates/gpui/src/platform/linux/blade_renderer.rs
@@ -145,14 +145,14 @@ impl BladePipelines {
                 data_layouts: &[&ShaderPathRasterizationData::layout()],
                 vertex: shader.at("vs_path_rasterization"),
                 primitive: gpu::PrimitiveState {
-                    topology: gpu::PrimitiveTopology::TriangleStrip,
+                    topology: gpu::PrimitiveTopology::TriangleList,
                     ..Default::default()
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_path_rasterization"),
                 color_targets: &[gpu::ColorTargetState {
                     format: PATH_TEXTURE_FORMAT,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(gpu::BlendState::ADDITIVE),
                     write_mask: gpu::ColorWrites::default(),
                 }],
             }),

--- a/crates/gpui/src/platform/linux/shaders.wgsl
+++ b/crates/gpui/src/platform/linux/shaders.wgsl
@@ -365,7 +365,7 @@ fn fs_path_rasterization(input: PathRasterizationVarying) -> @location(0) f32 {
         return 0.0;
     }
 
-    let gradient = 2.0 * input.st_position * vec2<f32>(dx.x, dy.x) - vec2<f32>(dx.y, dy.y);
+    let gradient = 2.0 * input.st_position.xx * vec2<f32>(dx.x, dy.x) - vec2<f32>(dx.y, dy.y);
     let f = input.st_position.x * input.st_position.x - input.st_position.y;
     let distance = f / length(gradient);
     return saturate(0.5 - distance);


### PR DESCRIPTION
There were mistakes in the blending mode, primitive topology, and the equation.
![gpui-text-selection](https://github.com/zed-industries/zed/assets/107301/13f1285e-1338-4c87-b1bb-7e426606f939)



Release Notes:
- N/A
