### PR TITLE
Fix mis-description in default settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -560,7 +560,7 @@
   "stable": {
     // "theme": "Andromeda"
   },
-  // Settings overrides to use when using Zed Stable.
+  // Settings overrides to use when using Zed Dev.
   // Mostly useful for developers who are managing multiple instances of Zed.
   "dev": {
     // "theme": "Andromeda"


### PR DESCRIPTION
Change word from "Stable" to "Dev" of option `dev`



Release Notes:

- N/A
