### PR TITLE
Remove unneeded type annotations where inference will do

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4698,8 +4698,8 @@ impl Editor {
         let mut selections = selections.iter().peekable();
         let mut contiguous_row_selections = Vec::new();
         let mut new_selections = Vec::new();
-        let mut added_lines: usize = 0;
-        let mut removed_lines: usize = 0;
+        let mut added_lines = 0;
+        let mut removed_lines = 0;
 
         while let Some(selection) = selections.next() {
             let (start_row, end_row) = consume_contiguous_rows(


### PR DESCRIPTION
This PR removes some unneeded type annotations where we're able to infer the type accurately.

Release Notes:

- N/A
