### PR TITLE
Highlight Python docstrings as `comment.doc`

### DIFF
--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -52,6 +52,15 @@
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
+; Doc strings.
+; This has to come after string literals.
+(function_definition
+  "async"?
+  "def"
+  name: (_)
+  (parameters)?
+  body: (block (expression_statement (string) @comment.doc)))
+
 [
   "-"
   "-="

--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -52,7 +52,7 @@
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
-; Doc strings.
+; Docstrings.
 ; This has to come after string literals.
 (function_definition
   "async"?


### PR DESCRIPTION
**Not for merge.**

This PR demonstrates how to highlight Python docstrings as doc comments (`comment.doc`), as requested in #7346.

It looks like in VS Code's case they accepted a similar PR in https://github.com/microsoft/vscode/pull/182162

Then this was summarily reverted in https://github.com/microsoft/vscode/pull/184938 after folks were upset with the change.

It seems that there are arguments for treating docstrings as both comments and strings from a syntax highlighting perspective, but it seems that treating them as strings is the more common approach (both GitHub and VS Code do this).

Therefore, I don't think we should make this change in Zed.

It should be possible to do this via an extension in the near future. I'm opening this PR to serve as a reference for anyone who would like to apply this behavior for themselves, as well as to document the rationale for _not_ making this change.

Release Notes:

- Changed Python docstrings to highlight using `comment.doc` ([#7346](https://github.com/zed-industries/zed/issues/7346)).