### PR TITLE
Expose Python docstrings for syntax highlighting

### DIFF
--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -52,6 +52,15 @@
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
+; Doc strings.
+; This has to come after string literals.
+(function_definition
+  "async"?
+  "def"
+  name: (_)
+  (parameters)?
+  body: (block (expression_statement (string) @comment.doc)))
+
 [
   "-"
   "-="

--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -53,13 +53,12 @@
   "}" @punctuation.special) @embedded
 
 ; Docstrings.
-; This has to come after string literals.
 (function_definition
   "async"?
   "def"
   name: (_)
   (parameters)?
-  body: (block (expression_statement (string) @comment.doc)))
+  body: (block (expression_statement (string) @string.doc)))
 
 [
   "-"

--- a/crates/zed/src/languages/python/highlights.scm
+++ b/crates/zed/src/languages/python/highlights.scm
@@ -52,7 +52,7 @@
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
-; Doc strings.
+; Docstrings.
 ; This has to come after string literals.
 (function_definition
   "async"?


### PR DESCRIPTION
This PR extends our Tree-sitter highlights for Python to allow highlighting docstrings differently from other strings.

Docstrings in Python will now use `string.doc` instead of just `string`, which will allow for them to be styled independently of other strings. If no `string.doc` is present in the theme, then it will fall back to using the `string` styles.

<img width="272" alt="Screenshot 2024-02-08 at 1 52 21 PM" src="https://github.com/zed-industries/zed/assets/1486634/034cffa0-91c0-4924-8ccc-3a385cf31126">

This is slightly different than the approach I took in #7585 in that we are still treating docstrings as strings by default (which appears to be the more common behavior), but allowing theme authors to hook in and style them separately, if desired.

Release Notes:

- Added ability add custom styles for Python docstrings using `string.doc` ([#7346](https://github.com/zed-industries/zed/issues/7346)).
