### PR TITLE
chore: Bump Rust version to 1.76

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM rust:1.75-bullseye as builder
+FROM rust:1.76-bullseye as builder
 WORKDIR app
 COPY . .
 

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -304,7 +304,7 @@ impl DispatchTree {
     pub fn bindings_for_action(
         &self,
         action: &dyn Action,
-        context_stack: &Vec<KeyContext>,
+        context_stack: &[KeyContext],
     ) -> Vec<KeyBinding> {
         let keymap = self.keymap.borrow();
         keymap

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -71,7 +71,7 @@ impl Keymap {
     }
 
     /// Iterate over all bindings, in the order they were added.
-    pub fn bindings(&self) -> impl Iterator<Item = &KeyBinding> + DoubleEndedIterator {
+    pub fn bindings(&self) -> impl DoubleEndedIterator<Item = &KeyBinding> {
         self.bindings.iter()
     }
 
@@ -79,7 +79,7 @@ impl Keymap {
     pub fn bindings_for_action<'a>(
         &'a self,
         action: &'a dyn Action,
-    ) -> impl 'a + Iterator<Item = &'a KeyBinding> + DoubleEndedIterator {
+    ) -> impl 'a + DoubleEndedIterator<Item = &'a KeyBinding> {
         let action_id = action.type_id();
         self.binding_indices_by_action_id
             .get(&action_id)

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1547,7 +1547,7 @@ impl<'a> WindowContext<'a> {
         let Some(node_id) = dispatch_tree.focusable_node_id(focus_handle.id) else {
             return vec![];
         };
-        let context_stack = dispatch_tree
+        let context_stack: Vec<_> = dispatch_tree
             .dispatch_path(node_id)
             .into_iter()
             .filter_map(|node_id| dispatch_tree.node(node_id).context.clone())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.75"
+channel = "1.76"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi" ]


### PR DESCRIPTION
Release Notes:

- N/A
