### PR TITLE
Implement terminal text dimming

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -329,8 +329,13 @@ impl TerminalElement {
         hyperlink: Option<(HighlightStyle, &RangeInclusive<AlacPoint>)>,
     ) -> TextRun {
         let flags = indexed.cell.flags;
-        let fg = convert_color(&fg, &colors);
-        // let bg = convert_color(&bg, &colors);
+        let mut fg = convert_color(&fg, &colors);
+
+        // Ghostty uses (175/255) as the multiplier (~0.69), Alacritty uses 0.66, Kitty
+        // uses 0.75. We're using 0.7 because it's pretty well in the middle of that.
+        if flags.intersects(Flags::DIM) {
+            fg.a *= 0.7;
+        }
 
         let underline = (flags.intersects(Flags::ALL_UNDERLINES)
             || indexed.cell.hyperlink().is_some())


### PR DESCRIPTION
Dims text by a certain factor - this respects theme opacity. The amount is documented in the code. As far as I can tell, all other terminals also dim text using this same method. Dim only affects the foreground.

<img width="755" alt="SCR-20240209-mfls" src="https://github.com/zed-industries/zed/assets/52195359/c32f2aff-1142-4333-a05d-6aca425cb235">

Release Notes:

- Added terminal text dimming (fixes #7497)
