### PR TITLE
markdown_preview: improve two-way scrolling

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -6,8 +6,7 @@ use editor::{
 };
 use gpui::{
     list, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
-    IntoElement, ListState, ParentElement, Render, ScrollHandle, Styled, View, ViewContext,
-    WeakView,
+    IntoElement, ListState, ParentElement, Render, Styled, View, ViewContext, WeakView,
 };
 use ui::prelude::*;
 use workspace::item::{Item, ItemHandle};
@@ -192,7 +191,7 @@ impl MarkdownPreviewView {
         if let Some(state) = &self.active_editor {
             state.editor.update(cx, |editor, cx| {
                 editor.change_selections(
-                    Some(Autoscroll::Strategy(AutoscrollStrategy::Fit)),
+                    Some(Autoscroll::Strategy(AutoscrollStrategy::Center)),
                     cx,
                     |selections| selections.select_ranges(vec![selection]),
                 );


### PR DESCRIPTION
Implements @SomeoneToIgnore's request in [this comment](https://github.com/zed-industries/zed/pull/7345#pullrequestreview-1869629847).

> - scroll the *.md file as the renderer scrolls
> - do not create new splits if there's already one
> - change the rendered contents if other *.md tab gets active*

*This implementation does not yet discriminate on file type. 

Open active preview:

https://github.com/zed-industries/zed/assets/18583882/3d1b0375-a6f5-4096-a279-df32f9d83bc1

Two-way scrolling:

https://github.com/zed-industries/zed/assets/18583882/71468233-958a-47ef-8a2b-0efa401b322d


Release Notes:

- N/A

Other:

> - fix the scroll jump after editing

I'm still having trouble with this issue. I believe the issue is that list state drops `scroll_to_reveal_item` requests if `.reset` is called. The only way for list state to respect `scroll_to_reveal_item` requests is if it has a chance to [paint](https://github.com/zed-industries/zed/blob/91c699aeaa3a268a84f11a21f24c7f21a095f10f/crates/gpui/src/elements/list.rs#L380).

I tried this... 



```
EditorEvent::Edited => {
    this.on_editor_edited(cx); // calls `.reset`

    cx.on_next_frame(|_this, cx| {
        cx.on_next_frame(|this, cx| { // Unsure why this nested `on_next_frame` is needed, but it is.
            this.list_state.scroll_to_reveal_item(this.selected_block);
            cx.notify();
        })
    })
}
```


but it led to flickering:

https://github.com/zed-industries/zed/assets/18583882/ff41d4f5-df85-41bb-9668-6bc3c8951a34


