### PR TITLE
linux: fix getting the initial content size

### DIFF
--- a/crates/gpui/src/platform/linux/window.rs
+++ b/crates/gpui/src/platform/linux/window.rs
@@ -189,10 +189,6 @@ impl LinuxWindowState {
         xcb_connection.send_request(&x::MapWindow { window: x_window });
         xcb_connection.flush().unwrap();
 
-        //Warning: it looks like this reported size is immediately invalidated
-        // on some platforms, followed by a "ConfigureNotify" event.
-        let gpu_extent = query_render_extent(&xcb_connection, x_window);
-
         let raw = RawWindow {
             connection: as_raw_xcb_connection::AsRawXcbConnection::as_raw_xcb_connection(
                 xcb_connection,
@@ -213,6 +209,10 @@ impl LinuxWindowState {
             }
             .unwrap(),
         );
+
+        // Note: this has to be done after the GPU init, or otherwise
+        // the sizes are immediately invalidated.
+        let gpu_extent = query_render_extent(&xcb_connection, x_window);
 
         Self {
             xcb_connection: Arc::clone(xcb_connection),


### PR DESCRIPTION
Fix found by @h3mosphere (thanks!)

Solves the Vulkan validation on start on some platforms about the mismatched surface size, e.g.
```
VUID-VkSwapchainCreateInfoKHR-imageExtent-01274(ERROR / SPEC): msgNum: 2094043421 - Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 ] Object 0: handle = 0x55dff99554c0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7cd0911d | vkCreateSwapchainKHR() called with imageExtent = (1920,1080), which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (1920,1016), minImageExtent = (1920,1016), maxImageExtent = (1920,1016). The Vulkan spec states: imageExtent must be between minImageExtent and maxImageExtent, inclusive, where minImageExtent and maxImageExtent are members of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01274)
```

Release Notes:
- N/A
