### PR TITLE
Use proper key for Linux rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
                   submodules: "recursive"
 
             - name: Restore from cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,14 @@ jobs:
             - name: Ensure fresh merge
               shell: bash -euxo pipefail {0}
               run: |
-                if [ -z "$GITHUB_BASE_REF" ];
-                then
-                  echo "BUF_BASE_BRANCH=$(git merge-base origin/main HEAD)" >> $GITHUB_ENV
-                else
-                  git checkout -B temp
-                  git merge -q origin/$GITHUB_BASE_REF -m "merge main into temp"
-                  echo "BUF_BASE_BRANCH=$GITHUB_BASE_REF" >> $GITHUB_ENV
-                fi
+                  if [ -z "$GITHUB_BASE_REF" ];
+                  then
+                    echo "BUF_BASE_BRANCH=$(git merge-base origin/main HEAD)" >> $GITHUB_ENV
+                  else
+                    git checkout -B temp
+                    git merge -q origin/$GITHUB_BASE_REF -m "merge main into temp"
+                    echo "BUF_BASE_BRANCH=$GITHUB_BASE_REF" >> $GITHUB_ENV
+                  fi
 
             - uses: bufbuild/buf-setup-action@v1
             - uses: bufbuild/buf-breaking-action@v1
@@ -96,34 +96,34 @@ jobs:
         name: (Linux) Run Clippy and tests
         runs-on: ubuntu-latest
         steps:
-          - name: Checkout repo
-            uses: actions/checkout@v4
-            with:
-              clean: false
-              submodules: "recursive"
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                  clean: false
+                  submodules: "recursive"
 
-          - name: Restore from cache
-            uses: actions/cache@v3
-            with:
-                path: |
-                  ~/.cargo/bin/
-                  ~/.cargo/registry/index/
-                  ~/.cargo/registry/cache/
-                  ~/.cargo/git/db/
-                  target/
-                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-                restore-keys: ${{ runner.os }}-cargo-
+            - name: Restore from cache
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                      target/
+                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain.toml') }}-
 
-          - name: configure linux
-            shell: bash -euxo pipefail {0}
-            run: script/linux
+            - name: configure linux
+              shell: bash -euxo pipefail {0}
+              run: script/linux
 
-          - name: cargo clippy
-            shell: bash -euxo pipefail {0}
-            run: script/clippy
+            - name: cargo clippy
+              shell: bash -euxo pipefail {0}
+              run: script/clippy
 
-          - name: Build Zed
-            run: cargo build -p zed
+            - name: Build Zed
+              run: cargo build -p zed
     bundle:
         name: Bundle app
         runs-on:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v2.2.4
+            - uses: pnpm/action-setup@v3
               with:
                   version: 8
 


### PR DESCRIPTION
Adds `hashFiles('**/rust-toolchain.toml')` into both cache key and the fallback key, so that on any toolchain version bump, the entire cache gets invalidated and re-populated.

Also bumps `pnpm/action-setup` and `actions/cache` to the newer versions to remove the deprecation warnings:
https://github.com/zed-industries/zed/actions/runs/7844199247
![image](https://github.com/zed-industries/zed/assets/2690773/7ff807dc-f2c9-4f71-813e-de983ce98dd2)


Release Notes:

- N/A
