### PR TITLE
Handle autoclose when composing text

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2490,7 +2490,12 @@ impl Editor {
             let had_active_copilot_suggestion = this.has_active_copilot_suggestion(cx);
             this.change_selections(Some(Autoscroll::fit()), cx, |s| s.select(new_selections));
 
-            if !brace_inserted && EditorSettings::get_global(cx).use_on_type_format {
+            if brace_inserted {
+                // If we inserted a brace while composing text (i.e. typing `"` on a
+                // Brazilian keyboard), exit the composing state because most likely
+                // the user wanted to surround the selection.
+                this.unmark_text(cx);
+            } else if EditorSettings::get_global(cx).use_on_type_format {
                 if let Some(on_type_format_task) =
                     this.trigger_on_type_formatting(text.to_string(), cx)
                 {
@@ -9695,6 +9700,7 @@ impl ViewInputHandler for Editor {
                 this.change_selections(None, cx, |selections| {
                     selections.select_ranges(new_selected_ranges)
                 });
+                this.backspace(&Default::default(), cx);
             }
 
             this.handle_input(text, cx);
@@ -9797,7 +9803,11 @@ impl ViewInputHandler for Editor {
                 );
             }
 
+            // Disable auto-closing when composing text (i.e. typing a `"` on a Brazilian keyboard)
+            let use_autoclose = this.use_autoclose;
+            this.set_use_autoclose(false);
             this.handle_input(text, cx);
+            this.set_use_autoclose(use_autoclose);
 
             if let Some(new_selected_range) = new_selected_range_utf16 {
                 let snapshot = this.buffer.read(cx).read(cx);


### PR DESCRIPTION
This fixes two annoyances when composing text and autoclose is enabled.

Example: use a Brazilian keyboard and type `"`, which triggers a dead-key state.

Previously when a user would type `"<space>` to get a quote, we'd end up with 4 quotes.

When text was selected and a user then typed `"<space>` the selected text would be deleted.

This commit fixes both of these issues.

Fixes https://github.com/zed-industries/zed/issues/4298

Release Notes:

- Fixed autoclose behavior not working when composing text via IME (e.g. using quotes on a Brazilian keyboard) ([#4298](https://github.com/zed-industries/zed/issues/4298)).