### PR TITLE
Show better errors when failing to start golps

### DIFF
--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
 use gpui::{AsyncAppContext, Task};
@@ -124,21 +124,22 @@ impl super::LspAdapter for GoLspAdapter {
             .args(["install", "golang.org/x/tools/gopls@latest"])
             .output()
             .await?;
-        if !install_output.status.success() {
-            Err(anyhow!("failed to install gopls. Is go installed?"))?;
-        }
+        anyhow::ensure!(
+            install_output.status.success(),
+            "failed to install gopls. Is `go` installed and in the PATH?"
+        );
 
         let installed_binary_path = gobin_dir.join("gopls");
         let version_output = process::Command::new(&installed_binary_path)
             .arg("version")
             .output()
             .await
-            .map_err(|e| anyhow!("failed to run installed gopls binary {:?}", e))?;
+            .context("failed to run installed gopls binary")?;
         let version_stdout = str::from_utf8(&version_output.stdout)
-            .map_err(|_| anyhow!("gopls version produced invalid utf8"))?;
+            .context("gopls version produced invalid utf8 output")?;
         let version = GOPLS_VERSION_REGEX
             .find(version_stdout)
-            .ok_or_else(|| anyhow!("failed to parse gopls version output"))?
+            .with_context(|| format!("failed to parse golps version output '{version_stdout}'"))?
             .as_str();
         let binary_path = container_dir.join(&format!("gopls_{version}"));
         fs::rename(&installed_binary_path, &binary_path).await?;


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/4471#issuecomment-1936008584

Improves gopls error logging to actually see what is wrong with the output we failed to match against the version regex.

Release Notes:

- N/A
