### PR TITLE
Load worktree settings when loading options for language servers

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2787,7 +2787,8 @@ impl Project {
             None => return,
         };
 
-        let project_settings = ProjectSettings::get_global(cx);
+        let project_settings =
+            ProjectSettings::get(Some((worktree_id.to_proto() as usize, Path::new(""))), cx);
         let lsp = project_settings.lsp.get(&adapter.name.0);
         let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
 


### PR DESCRIPTION
Previously we only looked at the global settings, this changes that to start looking in local settings first and then fall back to global ones.

Fixes #4279.

Release Notes:

- Fixed language server configurations not being picked up from local, worktree-specific settings. ([#4279](https://github.com/zed-industries/zed/issues/4279)).
