### PR TITLE
theme: Rework the solarized themes

### DIFF
--- a/assets/themes/solarized/solarized.json
+++ b/assets/themes/solarized/solarized.json
@@ -12,97 +12,97 @@
         "border.selected": "#1b3149ff",
         "border.transparent": "#00000000",
         "border.disabled": "#19424dff",
-        "elevated_surface.background": "#04313bff",
-        "surface.background": "#04313bff",
-        "background": "#073743ff",
-        "element.background": "#04313bff",
+        "elevated_surface.background": "#073642ff",
+        "surface.background": "#073642ff",
+        "background": "#073642ff",
+        "element.background": "#073642ff",
         "element.hover": "#053541ff",
         "element.active": "#294d58ff",
         "element.selected": "#294d58ff",
-        "element.disabled": "#04313bff",
-        "drop_target.background": "#93a1a180",
+        "element.disabled": "#073642ff",
+        "drop_target.background": "#586e7580",
         "ghost_element.background": "#00000000",
-        "ghost_element.hover": "#053541ff",
+        "ghost_element.hover": "#294d58ff",
         "ghost_element.active": "#294d58ff",
         "ghost_element.selected": "#294d58ff",
-        "ghost_element.disabled": "#04313bff",
-        "text": "#fdf6e3ff",
-        "text.muted": "#93a1a1ff",
-        "text.placeholder": "#6f8389ff",
-        "text.disabled": "#6f8389ff",
-        "text.accent": "#278ad1ff",
-        "icon": "#fdf6e3ff",
-        "icon.muted": "#93a1a1ff",
-        "icon.disabled": "#6f8389ff",
-        "icon.placeholder": "#93a1a1ff",
-        "icon.accent": "#278ad1ff",
-        "status_bar.background": "#073743ff",
-        "title_bar.background": "#073743ff",
-        "toolbar.background": "#002a35ff",
-        "tab_bar.background": "#04313bff",
-        "tab.inactive_background": "#04313bff",
-        "tab.active_background": "#002a35ff",
-        "search.match_background": "#288bd166",
-        "panel.background": "#04313bff",
+        "ghost_element.disabled": "#073642ff",
+        "text": "#93a1a1ff",
+        "text.muted": "#586e75ff",
+        "text.placeholder": "#586e75ff",
+        "text.disabled": "#586e75ff",
+        "text.accent": "#268bd2ff",
+        "icon": "#93a1a1ff",
+        "icon.muted": "#586e75ff",
+        "icon.disabled": "#586e75ff",
+        "icon.placeholder": "#586e75ff",
+        "icon.accent": "#268bd2ff",
+        "status_bar.background": "#073642ff",
+        "title_bar.background": "#073642ff",
+        "toolbar.background": "#002b36ff",
+        "tab_bar.background": "#073642ff",
+        "tab.inactive_background": "#073642ff",
+        "tab.active_background": "#002b36ff",
+        "search.match_background": "#268bd266",
+        "panel.background": "#073642ff",
         "panel.focused_border": null,
         "pane.focused_border": null,
-        "scrollbar_thumb.background": "#fdf6e34c",
+        "scrollbar_thumb.background": "#8394964c",
         "scrollbar.thumb.hover_background": "#053541ff",
         "scrollbar.thumb.border": "#053541ff",
         "scrollbar.track.background": "#00000000",
-        "scrollbar.track.border": "#022f3bff",
-        "editor.foreground": "#fdf6e3ff",
-        "editor.background": "#002a35ff",
-        "editor.gutter.background": "#002a35ff",
-        "editor.subheader.background": "#04313bff",
-        "editor.active_line.background": "#04313bbf",
-        "editor.highlighted_line.background": "#04313bff",
-        "editor.line_number": "#fdf6e359",
-        "editor.active_line_number": "#fdf6e3ff",
+        "scrollbar.track.border": "#053541ff",
+        "editor.foreground": "#839496ff",
+        "editor.background": "#002b36ff",
+        "editor.gutter.background": "#002b36ff",
+        "editor.subheader.background": "#073642ff",
+        "editor.active_line.background": "#073642bf",
+        "editor.highlighted_line.background": "#073642ff",
+        "editor.line_number": "#586e7559",
+        "editor.active_line_number": "#586e75ff",
         "editor.invisible": "#6c8287ff",
-        "editor.wrap_guide": "#fdf6e30d",
-        "editor.active_wrap_guide": "#fdf6e31a",
-        "editor.document_highlight.read_background": "#278ad11a",
+        "editor.wrap_guide": "#8394960d",
+        "editor.active_wrap_guide": "#8394961a",
+        "editor.document_highlight.read_background": "#268bd21a",
         "editor.document_highlight.write_background": "#6c828766",
-        "terminal.background": "#002a35ff",
-        "terminal.foreground": "#fdf6e3ff",
-        "terminal.bright_foreground": "#fdf6e3ff",
-        "terminal.dim_foreground": "#002a35ff",
-        "terminal.ansi.black": "#002a35ff",
+        "terminal.background": "#002b36ff",
+        "terminal.foreground": "#839496ff",
+        "terminal.bright_foreground": "#839496ff",
+        "terminal.dim_foreground": "#002b36ff",
+        "terminal.ansi.black": "#002b36ff",
         "terminal.ansi.bright_black": "#5c7279ff",
-        "terminal.ansi.dim_black": "#fdf6e3ff",
-        "terminal.ansi.red": "#dc3330ff",
+        "terminal.ansi.dim_black": "#839496ff",
+        "terminal.ansi.red": "#dc322fff",
         "terminal.ansi.bright_red": "#7d181cff",
         "terminal.ansi.dim_red": "#faa091ff",
-        "terminal.ansi.green": "#849903ff",
+        "terminal.ansi.green": "#859900ff",
         "terminal.ansi.bright_green": "#434a10ff",
         "terminal.ansi.dim_green": "#c6cb8bff",
-        "terminal.ansi.yellow": "#b58902ff",
+        "terminal.ansi.yellow": "#b58900ff",
         "terminal.ansi.bright_yellow": "#5d430fff",
         "terminal.ansi.dim_yellow": "#e0c189ff",
-        "terminal.ansi.blue": "#278ad1ff",
+        "terminal.ansi.blue": "#268bd2ff",
         "terminal.ansi.bright_blue": "#214365ff",
         "terminal.ansi.dim_blue": "#a5c3e9ff",
-        "terminal.ansi.magenta": "#d33781ff",
+        "terminal.ansi.magenta": "#d33682ff",
         "terminal.ansi.bright_magenta": "#6f1f3fff",
         "terminal.ansi.dim_magenta": "#f0a2beff",
-        "terminal.ansi.cyan": "#2ba198ff",
+        "terminal.ansi.cyan": "#2aa198ff",
         "terminal.ansi.bright_cyan": "#204e4aff",
         "terminal.ansi.dim_cyan": "#9fd0cbff",
-        "terminal.ansi.white": "#fdf6e3ff",
-        "terminal.ansi.bright_white": "#fdf6e3ff",
+        "terminal.ansi.white": "#839496ff",
+        "terminal.ansi.bright_white": "#839496ff",
         "terminal.ansi.dim_white": "#7b8e91ff",
-        "link_text.hover": "#278ad1ff",
-        "conflict": "#b58902ff",
+        "link_text.hover": "#268bd2ff",
+        "conflict": "#b58900ff",
         "conflict.background": "#2e1d0cff",
         "conflict.border": "#47300fff",
-        "created": "#849903ff",
+        "created": "#859900ff",
         "created.background": "#1e210cff",
         "created.border": "#313510ff",
-        "deleted": "#dc3330ff",
+        "deleted": "#dc322fff",
         "deleted.background": "#4a080eff",
         "deleted.border": "#641015ff",
-        "error": "#dc3330ff",
+        "error": "#dc322fff",
         "error.background": "#4a080eff",
         "error.border": "#641015ff",
         "hidden": "#6f8389ff",
@@ -111,40 +111,40 @@
         "hint": "#4f8297ff",
         "hint.background": "#141f2cff",
         "hint.border": "#1b3149ff",
-        "ignored": "#93a1a1ff",
+        "ignored": "#586e75ff",
         "ignored.background": "#073743ff",
         "ignored.border": "#2b4e58ff",
-        "info": "#278ad1ff",
+        "info": "#268bd2ff",
         "info.background": "#141f2cff",
         "info.border": "#1b3149ff",
-        "modified": "#b58902ff",
+        "modified": "#b58900ff",
         "modified.background": "#2e1d0cff",
         "modified.border": "#47300fff",
         "predictive": "#3f718bff",
         "predictive.background": "#1e210cff",
         "predictive.border": "#313510ff",
-        "renamed": "#278ad1ff",
+        "renamed": "#268bd2ff",
         "renamed.background": "#141f2cff",
         "renamed.border": "#1b3149ff",
-        "success": "#849903ff",
+        "success": "#859900ff",
         "success.background": "#1e210cff",
         "success.border": "#313510ff",
-        "unreachable": "#93a1a1ff",
+        "unreachable": "#586e75ff",
         "unreachable.background": "#073743ff",
         "unreachable.border": "#2b4e58ff",
-        "warning": "#b58902ff",
+        "warning": "#b58900ff",
         "warning.background": "#2e1d0cff",
         "warning.border": "#47300fff",
         "players": [
           {
-            "cursor": "#278ad1ff",
-            "background": "#278ad1ff",
-            "selection": "#278ad13d"
+            "cursor": "#268bd2ff",
+            "background": "#268bd2ff",
+            "selection": "#268bd23d"
           },
           {
-            "cursor": "#d33781ff",
-            "background": "#d33781ff",
-            "selection": "#d337813d"
+            "cursor": "#d33682ff",
+            "background": "#d33682ff",
+            "selection": "#d336823d"
           },
           {
             "cursor": "#cb4b16ff",
@@ -157,69 +157,69 @@
             "selection": "#6c71c43d"
           },
           {
-            "cursor": "#2ba198ff",
-            "background": "#2ba198ff",
-            "selection": "#2ba1983d"
+            "cursor": "#2aa198ff",
+            "background": "#2aa198ff",
+            "selection": "#2aa1983d"
           },
           {
-            "cursor": "#dc3330ff",
-            "background": "#dc3330ff",
-            "selection": "#dc33303d"
+            "cursor": "#dc322fff",
+            "background": "#dc322fff",
+            "selection": "#dc322f3d"
           },
           {
-            "cursor": "#b58902ff",
-            "background": "#b58902ff",
-            "selection": "#b589023d"
+            "cursor": "#b58900ff",
+            "background": "#b58900ff",
+            "selection": "#b589003d"
           },
           {
-            "cursor": "#849903ff",
-            "background": "#849903ff",
-            "selection": "#8499033d"
+            "cursor": "#859900ff",
+            "background": "#859900ff",
+            "selection": "#8599003d"
           }
         ],
         "syntax": {
           "attribute": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "comment": {
-            "color": "#99a5a4ff",
+            "color": "#586e75ff",
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
-            "color": "#99a5a4ff",
+            "color": "#586e75ff",
             "font_style": null,
             "font_weight": null
           },
           "constant": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "embedded": {
-            "color": "#fdf6e3ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "emphasis.strong": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": 700
           },
@@ -229,7 +229,7 @@
             "font_weight": null
           },
           "function": {
-            "color": "#b58902ff",
+            "color": "#b58900ff",
             "font_style": null,
             "font_weight": null
           },
@@ -239,12 +239,12 @@
             "font_weight": 700
           },
           "keyword": {
-            "color": "#278ad1ff",
+            "color": "#dc322fff",
             "font_style": null,
             "font_weight": null
           },
           "label": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -254,12 +254,12 @@
             "font_weight": null
           },
           "link_uri": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "number": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
@@ -274,42 +274,42 @@
             "font_weight": null
           },
           "preproc": {
-            "color": "#fdf6e3ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "primary": {
-            "color": "#fdf6e3ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "property": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
-            "color": "#efe9d6ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "#efe9d6ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
-            "color": "#efe9d6ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#efe9d6ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#efe9d6ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": null
           },
@@ -319,7 +319,7 @@
             "font_weight": null
           },
           "string.escape": {
-            "color": "#99a5a4ff",
+            "color": "#586e75ff",
             "font_style": null,
             "font_weight": null
           },
@@ -339,7 +339,7 @@
             "font_weight": null
           },
           "tag": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -349,28 +349,33 @@
             "font_weight": null
           },
           "title": {
-            "color": "#fdf6e3ff",
+            "color": "#839496ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#2ba198ff",
+            "color": "#2aa198ff",
             "font_style": null,
             "font_weight": null
           },
           "variable": {
-            "color": "#fdf6e3ff",
+            "color": "#d33682ff",
             "font_style": null,
             "font_weight": null
           },
           "variant": {
-            "color": "#278ad1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           }
         }
       }
     },
+
+
+
+
+
     {
       "name": "Solarized Light",
       "appearance": "light",
@@ -381,97 +386,97 @@
         "border.selected": "#bfd3efff",
         "border.transparent": "#00000000",
         "border.disabled": "#b6bcb5ff",
-        "elevated_surface.background": "#f3eddaff",
-        "surface.background": "#f3eddaff",
-        "background": "#cfd0c4ff",
-        "element.background": "#f3eddaff",
+        "elevated_surface.background": "#eee8d5ff",
+        "surface.background": "#eee8d5ff",
+        "background": "#eee8d5ff",
+        "element.background": "#eee8d5ff",
         "element.hover": "#dcdacbff",
         "element.active": "#a2aca9ff",
         "element.selected": "#a2aca9ff",
-        "element.disabled": "#f3eddaff",
-        "drop_target.background": "#34555e80",
+        "element.disabled": "#eee8d5ff",
+        "drop_target.background": "#93a1a180",
         "ghost_element.background": "#00000000",
-        "ghost_element.hover": "#dcdacbff",
+        "ghost_element.hover": "#a2aca9ff",
         "ghost_element.active": "#a2aca9ff",
         "ghost_element.selected": "#a2aca9ff",
-        "ghost_element.disabled": "#f3eddaff",
-        "text": "#002a35ff",
-        "text.muted": "#34555eff",
-        "text.placeholder": "#6a7f86ff",
-        "text.disabled": "#6a7f86ff",
-        "text.accent": "#288bd1ff",
-        "icon": "#002a35ff",
-        "icon.muted": "#34555eff",
-        "icon.disabled": "#6a7f86ff",
-        "icon.placeholder": "#34555eff",
-        "icon.accent": "#288bd1ff",
-        "status_bar.background": "#cfd0c4ff",
-        "title_bar.background": "#cfd0c4ff",
+        "ghost_element.disabled": "#eee8d5ff",
+        "text": "#586e75ff",
+        "text.muted": "#93a1a1ff",
+        "text.placeholder": "#93a1a1ff",
+        "text.disabled": "#93a1a1ff",
+        "text.accent": "#268bd2ff",
+        "icon": "#586e75ff",
+        "icon.muted": "#93a1a1ff",
+        "icon.disabled": "#93a1a1ff",
+        "icon.placeholder": "#93a1a1ff",
+        "icon.accent": "#268bd2ff",
+        "status_bar.background": "#eee8d5ff",
+        "title_bar.background": "#eee8d5ff",
         "toolbar.background": "#fdf6e3ff",
-        "tab_bar.background": "#f3eddaff",
-        "tab.inactive_background": "#f3eddaff",
+        "tab_bar.background": "#eee8d5ff",
+        "tab.inactive_background": "#eee8d5ff",
         "tab.active_background": "#fdf6e3ff",
         "search.match_background": "#298bd166",
-        "panel.background": "#f3eddaff",
+        "panel.background": "#eee8d5ff",
         "panel.focused_border": null,
         "pane.focused_border": null,
-        "scrollbar_thumb.background": "#002a354c",
+        "scrollbar_thumb.background": "#657b834c",
         "scrollbar.thumb.hover_background": "#dcdacbff",
         "scrollbar.thumb.border": "#dcdacbff",
         "scrollbar.track.background": "#00000000",
-        "scrollbar.track.border": "#f5eedbff",
-        "editor.foreground": "#002a35ff",
+        "scrollbar.track.border": "#dcdacbff",
+        "editor.foreground": "#657b83ff",
         "editor.background": "#fdf6e3ff",
         "editor.gutter.background": "#fdf6e3ff",
-        "editor.subheader.background": "#f3eddaff",
-        "editor.active_line.background": "#f3eddabf",
-        "editor.highlighted_line.background": "#f3eddaff",
-        "editor.line_number": "#002a3559",
-        "editor.active_line_number": "#002a35ff",
+        "editor.subheader.background": "#eee8d5ff",
+        "editor.active_line.background": "#eee8d5bf",
+        "editor.highlighted_line.background": "#eee8d5ff",
+        "editor.line_number": "#93a1a159",
+        "editor.active_line_number": "#93a1a1ff",
         "editor.invisible": "#6c8287ff",
-        "editor.wrap_guide": "#002a350d",
-        "editor.active_wrap_guide": "#002a351a",
-        "editor.document_highlight.read_background": "#288bd11a",
+        "editor.wrap_guide": "#657b830d",
+        "editor.active_wrap_guide": "#657b831a",
+        "editor.document_highlight.read_background": "#268bd21a",
         "editor.document_highlight.write_background": "#6c828766",
         "terminal.background": "#fdf6e3ff",
-        "terminal.foreground": "#002a35ff",
-        "terminal.bright_foreground": "#002a35ff",
+        "terminal.foreground": "#657b83ff",
+        "terminal.bright_foreground": "#657b83ff",
         "terminal.dim_foreground": "#fdf6e3ff",
         "terminal.ansi.black": "#fdf6e3ff",
         "terminal.ansi.bright_black": "#7b8e91ff",
-        "terminal.ansi.dim_black": "#002a35ff",
-        "terminal.ansi.red": "#dc3330ff",
+        "terminal.ansi.dim_black": "#657b83ff",
+        "terminal.ansi.red": "#dc322fff",
         "terminal.ansi.bright_red": "#faa091ff",
         "terminal.ansi.dim_red": "#7d181cff",
-        "terminal.ansi.green": "#849903ff",
+        "terminal.ansi.green": "#859900ff",
         "terminal.ansi.bright_green": "#c6cb8bff",
         "terminal.ansi.dim_green": "#434a10ff",
-        "terminal.ansi.yellow": "#b58903ff",
+        "terminal.ansi.yellow": "#b58900ff",
         "terminal.ansi.bright_yellow": "#e0c189ff",
         "terminal.ansi.dim_yellow": "#5d430fff",
-        "terminal.ansi.blue": "#288bd1ff",
+        "terminal.ansi.blue": "#268bd2ff",
         "terminal.ansi.bright_blue": "#a5c3e9ff",
         "terminal.ansi.dim_blue": "#214365ff",
-        "terminal.ansi.magenta": "#d33781ff",
+        "terminal.ansi.magenta": "#d33682ff",
         "terminal.ansi.bright_magenta": "#f0a2beff",
         "terminal.ansi.dim_magenta": "#6f1f3fff",
-        "terminal.ansi.cyan": "#2ba198ff",
+        "terminal.ansi.cyan": "#2aa198ff",
         "terminal.ansi.bright_cyan": "#9fd0cbff",
         "terminal.ansi.dim_cyan": "#204e4aff",
-        "terminal.ansi.white": "#002a35ff",
-        "terminal.ansi.bright_white": "#002a35ff",
+        "terminal.ansi.white": "#657b83ff",
+        "terminal.ansi.bright_white": "#657b83ff",
         "terminal.ansi.dim_white": "#5c7279ff",
-        "link_text.hover": "#288bd1ff",
-        "conflict": "#b58903ff",
+        "link_text.hover": "#268bd2ff",
+        "conflict": "#b58900ff",
         "conflict.background": "#f5e6d0ff",
         "conflict.border": "#ebd3aaff",
-        "created": "#849903ff",
+        "created": "#859900ff",
         "created.background": "#e9ead0ff",
         "created.border": "#d6d9abff",
-        "deleted": "#dc3330ff",
+        "deleted": "#dc322fff",
         "deleted.background": "#ffd9d2ff",
         "deleted.border": "#ffbbafff",
-        "error": "#dc3330ff",
+        "error": "#dc322fff",
         "error.background": "#ffd9d2ff",
         "error.border": "#ffbbafff",
         "hidden": "#6a7f86ff",
@@ -480,125 +485,125 @@
         "hint": "#5789a3ff",
         "hint.background": "#dbe6f6ff",
         "hint.border": "#bfd3efff",
-        "ignored": "#34555eff",
+        "ignored": "#93a1a1ff",
         "ignored.background": "#cfd0c4ff",
         "ignored.border": "#9faaa8ff",
-        "info": "#288bd1ff",
+        "info": "#268bd2ff",
         "info.background": "#dbe6f6ff",
         "info.border": "#bfd3efff",
-        "modified": "#b58903ff",
+        "modified": "#b58900ff",
         "modified.background": "#f5e6d0ff",
         "modified.border": "#ebd3aaff",
         "predictive": "#679aafff",
         "predictive.background": "#e9ead0ff",
         "predictive.border": "#d6d9abff",
-        "renamed": "#288bd1ff",
+        "renamed": "#268bd2ff",
         "renamed.background": "#dbe6f6ff",
         "renamed.border": "#bfd3efff",
-        "success": "#849903ff",
+        "success": "#859900ff",
         "success.background": "#e9ead0ff",
         "success.border": "#d6d9abff",
-        "unreachable": "#34555eff",
+        "unreachable": "#93a1a1ff",
         "unreachable.background": "#cfd0c4ff",
         "unreachable.border": "#9faaa8ff",
-        "warning": "#b58903ff",
+        "warning": "#b58900ff",
         "warning.background": "#f5e6d0ff",
         "warning.border": "#ebd3aaff",
         "players": [
           {
-            "cursor": "#288bd1ff",
-            "background": "#288bd1ff",
-            "selection": "#288bd13d"
+            "cursor": "#268bd2ff",
+            "background": "#268bd2ff",
+            "selection": "#268bd23d"
           },
           {
-            "cursor": "#d33781ff",
-            "background": "#d33781ff",
-            "selection": "#d337813d"
+            "cursor": "#d33682ff",
+            "background": "#d33682ff",
+            "selection": "#d336823d"
           },
           {
-            "cursor": "#cb4b17ff",
-            "background": "#cb4b17ff",
-            "selection": "#cb4b173d"
+            "cursor": "#cb4b16ff",
+            "background": "#cb4b16ff",
+            "selection": "#cb4b163d"
           },
           {
-            "cursor": "#6c71c3ff",
-            "background": "#6c71c3ff",
-            "selection": "#6c71c33d"
+            "cursor": "#6c71c4ff",
+            "background": "#6c71c4ff",
+            "selection": "#6c71c43d"
           },
           {
-            "cursor": "#2ba198ff",
-            "background": "#2ba198ff",
-            "selection": "#2ba1983d"
+            "cursor": "#2aa198ff",
+            "background": "#2aa198ff",
+            "selection": "#2aa1983d"
           },
           {
-            "cursor": "#dc3330ff",
-            "background": "#dc3330ff",
-            "selection": "#dc33303d"
+            "cursor": "#dc322fff",
+            "background": "#dc322fff",
+            "selection": "#dc322f3d"
           },
           {
-            "cursor": "#b58903ff",
-            "background": "#b58903ff",
-            "selection": "#b589033d"
+            "cursor": "#b58900ff",
+            "background": "#b58900ff",
+            "selection": "#b589003d"
           },
           {
-            "cursor": "#849903ff",
-            "background": "#849903ff",
-            "selection": "#8499033d"
+            "cursor": "#859900ff",
+            "background": "#859900ff",
+            "selection": "#8599003d"
           }
         ],
         "syntax": {
           "attribute": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "comment": {
-            "color": "#30525bff",
+            "color": "#93a1a1ff",
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
-            "color": "#30525bff",
+            "color": "#93a1a1ff",
             "font_style": null,
             "font_weight": null
           },
           "constant": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "embedded": {
-            "color": "#002a35ff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "emphasis.strong": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": 700
           },
           "enum": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
           "function": {
-            "color": "#b58903ff",
+            "color": "#b58900ff",
             "font_style": null,
             "font_weight": null
           },
@@ -608,32 +613,32 @@
             "font_weight": 700
           },
           "keyword": {
-            "color": "#288bd1ff",
+            "color": "#dc322fff",
             "font_style": null,
             "font_weight": null
           },
           "label": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": "italic",
             "font_weight": null
           },
           "link_uri": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "number": {
-            "color": "#849903ff",
+            "color": "#859900ff",
             "font_style": null,
             "font_weight": null
           },
           "operator": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
@@ -643,97 +648,97 @@
             "font_weight": null
           },
           "preproc": {
-            "color": "#002a35ff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "primary": {
-            "color": "#002a35ff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "property": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
-            "color": "#04333eff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "#04333eff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
-            "color": "#04333eff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#04333eff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#04333eff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": null
           },
           "string": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
-            "color": "#30525bff",
+            "color": "#93a1a1ff",
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
           "tag": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
-            "color": "#cb4b17ff",
+            "color": "#cb4b16ff",
             "font_style": null,
             "font_weight": null
           },
           "title": {
-            "color": "#002a35ff",
+            "color": "#657b83ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#2ba198ff",
+            "color": "#2aa198ff",
             "font_style": null,
             "font_weight": null
           },
           "variable": {
-            "color": "#002a35ff",
+            "color": "#d33682ff",
             "font_style": null,
             "font_weight": null
           },
           "variant": {
-            "color": "#288bd1ff",
+            "color": "#268bd2ff",
             "font_style": null,
             "font_weight": null
           }


### PR DESCRIPTION
The solarized themes are not following the standard as specified in [0] and especially the regular text is wrongly mapped and too bright to be confortable when reading.

Rework both (dark and light) themes using the correct values.

[0] https://ethanschoonover.com/solarized/

Fixes: #7594 

Before:
<img width="2032" alt="Screenshot 2024-02-09 at 15 32 39" src="https://github.com/zed-industries/zed/assets/357758/744afc2e-4abc-434c-a36d-3c834628f764">
<img width="2032" alt="Screenshot 2024-02-09 at 15 33 50" src="https://github.com/zed-industries/zed/assets/357758/8b8b5c0a-655f-49ab-924a-40d294335863">

After:
<img width="2032" alt="Screenshot 2024-02-09 at 15 32 54" src="https://github.com/zed-industries/zed/assets/357758/20fcd952-019c-497c-a9e5-f52bbc0a302f">
<img width="2032" alt="Screenshot 2024-02-09 at 15 34 01" src="https://github.com/zed-industries/zed/assets/357758/bfb9a2cf-4069-4b08-aa2c-c65bcd62a5f1">
