### PR TITLE
Never show whitespace-only Copilot suggestions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1222,7 +1222,12 @@ impl CopilotState {
         if completion_range.is_empty()
             && completion_range.start == cursor.text_anchor.to_offset(&completion_buffer)
         {
-            Some(&completion.text[prefix_len..completion.text.len() - suffix_len])
+            let completion_text = &completion.text[prefix_len..completion.text.len() - suffix_len];
+            if completion_text.trim().is_empty() {
+                None
+            } else {
+                Some(completion_text)
+            }
         } else {
             None
         }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/7582

Release Notes:

- Fixed a bug that caused Copilot to suggest leading indentation even after the user accepted/discarded a suggestion ([#7582](https://github.com/zed-industries/zed/issues/7582))