### PR TITLE
Fix code actions support for elm-language-server

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -532,35 +532,6 @@ async fn test_collaborating_with_code_actions(
             Ok(Some(vec![lsp::CodeActionOrCommand::CodeAction(
                 lsp::CodeAction {
                     title: "Inline into all callers".to_string(),
-                    edit: Some(lsp::WorkspaceEdit {
-                        changes: Some(
-                            [
-                                (
-                                    lsp::Url::from_file_path("/a/main.rs").unwrap(),
-                                    vec![lsp::TextEdit::new(
-                                        lsp::Range::new(
-                                            lsp::Position::new(1, 22),
-                                            lsp::Position::new(1, 34),
-                                        ),
-                                        "4".to_string(),
-                                    )],
-                                ),
-                                (
-                                    lsp::Url::from_file_path("/a/other.rs").unwrap(),
-                                    vec![lsp::TextEdit::new(
-                                        lsp::Range::new(
-                                            lsp::Position::new(0, 0),
-                                            lsp::Position::new(0, 27),
-                                        ),
-                                        "".to_string(),
-                                    )],
-                                ),
-                            ]
-                            .into_iter()
-                            .collect(),
-                        ),
-                        ..Default::default()
-                    }),
                     data: Some(json!({
                         "codeActionParams": {
                             "range": {


### PR DESCRIPTION
This PR makes code actions in elm-language-server work and probably fixes this for other language servers that do not populate the `edit` or `command` action property right away. This didn't work before:

![unexpose](https://github.com/zed-industries/zed/assets/43472/4879130d-b10d-49aa-9863-bf92c761f816)

After comparing actions from elm-language-server to rust-analyzer, we realized that they have different content in the `data` property.

```json
// elm-language-server:
{"jsonrpc":"2.0","id":62,"result":[{"title":"Expose Function","kind":"refactor","data":{"actionName":"expose_function","refactorName":"expose_unexpose","uri":"file:///Users/unsoundscapes/Src/Github/elm-pool/src/Game.elm","range":{"start":{"line":121,"character":2},"end":{"line":121,"character":2}}},"isPreferred":true}]}

// rust-analyzer:
{"jsonrpc":"2.0","id":52,"result":[{"title":"Generate a documentation template","kind":"","data":{"codeActionParams":{"textDocument":{"uri":"file:///Users/unsoundscapes/Src/Github/zed/crates/zed/src/languages/elm.rs"},"range":{"start":{"line":42,"character":10},"end":{"line":42,"character":10}},"context":{"diagnostics":[],"only":["","quickfix","refactor","refactor.extract","source"]}},"id":"generate_documentation_template:Generate:0"}}]}
```

The LSP spec allows any content in the `data` property, but [the current implementation in Zed](https://github.com/zed-industries/zed/blob/efe23ebfcdd653b13be79132b1e2925bcd7bde45/crates/project/src/project.rs#L5142) checks that `data.codeActionParams.range` should exist, and only then it resolves the action from the language server. This assumption is most likely coming from [the rust-analyzer implementation](https://github.com/rust-lang/rust-analyzer/blob/bb0de88f24cc3a8de10837585fbb8172f6859752/crates/rust-analyzer/src/lsp/ext.rs#L445).

What should be the right condition to check in order to resolve the action? [Zed declares](https://github.com/zed-industries/zed/blob/efe23ebfcdd653b13be79132b1e2925bcd7bde45/crates/lsp/src/lsp.rs#L523) that it supports resolve for `edit` and `command` properties. If both are none, it is safe to assume that an action needs to be resolved.

Regarding patching the `range` property, we are not exactly sure why it was necessary, but we've implemented support for elm-language-server. Maybe this custom functionality should be extracted into an LSP adapter?

Release Notes:

- Fix code actions support for elm-language-server.
