### PR TITLE
Fix notes unread status

### DIFF
--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -1131,9 +1131,10 @@ impl ChannelState {
         if let Some(latest_version) = &self.latest_notes_versions {
             if let Some(observed_version) = &self.observed_notes_versions {
                 latest_version.epoch > observed_version.epoch
-                    || latest_version
-                        .version
-                        .changed_since(&observed_version.version)
+                    || (latest_version.epoch == observed_version.epoch
+                        && latest_version
+                            .version
+                            .changed_since(&observed_version.version))
             } else {
                 true
             }

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -587,6 +587,9 @@ pub struct ChannelsForUser {
     pub channels: Vec<Channel>,
     pub channel_memberships: Vec<channel_member::Model>,
     pub channel_participants: HashMap<ChannelId, Vec<UserId>>,
+
+    pub observed_buffer_versions: Vec<proto::ChannelBufferVersion>,
+    pub observed_channel_messages: Vec<proto::ChannelMessageId>,
     pub latest_buffer_versions: Vec<proto::ChannelBufferVersion>,
     pub latest_channel_messages: Vec<proto::ChannelMessageId>,
 }

--- a/crates/collab/src/db/queries/buffers.rs
+++ b/crates/collab/src/db/queries/buffers.rs
@@ -561,7 +561,6 @@ impl Database {
         tx: &DatabaseTransaction,
     ) -> Result<()> {
         use observed_buffer_edits::Column;
-
         observed_buffer_edits::Entity::insert(observed_buffer_edits::ActiveModel {
             user_id: ActiveValue::Set(user_id),
             buffer_id: ActiveValue::Set(buffer_id),
@@ -671,7 +670,7 @@ impl Database {
                 buffer_id: row.buffer_id,
                 epoch: row.epoch,
                 lamport_timestamp: row.lamport_timestamp,
-                replica_id: row.lamport_timestamp,
+                replica_id: row.replica_id,
                 value: Default::default(),
             });
             operations.push(proto::Operation {
@@ -750,25 +749,44 @@ impl Database {
 
     pub async fn latest_channel_buffer_changes(
         &self,
-        channel_ids: &[ChannelId],
+        channel_ids_by_buffer_id: &HashMap<BufferId, ChannelId>,
         tx: &DatabaseTransaction,
     ) -> Result<Vec<proto::ChannelBufferVersion>> {
-        let mut channel_ids_by_buffer_id = HashMap::default();
-        let mut rows = buffer::Entity::find()
-            .filter(buffer::Column::ChannelId.is_in(channel_ids.iter().copied()))
-            .stream(&*tx)
-            .await?;
-        while let Some(row) = rows.next().await {
-            let row = row?;
-            channel_ids_by_buffer_id.insert(row.id, row.channel_id);
-        }
-        drop(rows);
-
         let latest_operations = self
             .get_latest_operations_for_buffers(channel_ids_by_buffer_id.keys().copied(), &*tx)
             .await?;
 
         Ok(latest_operations
+            .iter()
+            .flat_map(|op| {
+                Some(proto::ChannelBufferVersion {
+                    channel_id: channel_ids_by_buffer_id.get(&op.buffer_id)?.to_proto(),
+                    epoch: op.epoch as u64,
+                    version: vec![proto::VectorClockEntry {
+                        replica_id: op.replica_id as u32,
+                        timestamp: op.lamport_timestamp as u32,
+                    }],
+                })
+            })
+            .collect())
+    }
+
+    pub async fn observed_channel_buffer_changes(
+        &self,
+        channel_ids_by_buffer_id: &HashMap<BufferId, ChannelId>,
+        user_id: UserId,
+        tx: &DatabaseTransaction,
+    ) -> Result<Vec<proto::ChannelBufferVersion>> {
+        let observed_operations = observed_buffer_edits::Entity::find()
+            .filter(observed_buffer_edits::Column::UserId.eq(user_id))
+            .filter(
+                observed_buffer_edits::Column::BufferId
+                    .is_in(channel_ids_by_buffer_id.keys().copied()),
+            )
+            .all(&*tx)
+            .await?;
+
+        Ok(observed_operations
             .iter()
             .flat_map(|op| {
                 Some(proto::ChannelBufferVersion {

--- a/crates/collab/src/db/tests/buffer_tests.rs
+++ b/crates/collab/src/db/tests/buffer_tests.rs
@@ -337,17 +337,12 @@ async fn test_channel_buffers_last_operations(db: &Database) {
     let buffer_changes = db
         .transaction(|tx| {
             let buffers = &buffers;
-            async move {
-                db.latest_channel_buffer_changes(
-                    &[
-                        buffers[0].channel_id,
-                        buffers[1].channel_id,
-                        buffers[2].channel_id,
-                    ],
-                    &*tx,
-                )
-                .await
-            }
+            let mut hash = HashMap::default();
+            hash.insert(buffers[0].id, buffers[0].channel_id);
+            hash.insert(buffers[1].id, buffers[1].channel_id);
+            hash.insert(buffers[2].id, buffers[2].channel_id);
+
+            async move { db.latest_channel_buffer_changes(&hash, &*tx).await }
         })
         .await
         .unwrap();

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -10,6 +10,7 @@ use channel::{ChannelBuffer, ChannelStore};
 use client::{
     self, proto::PeerId, Client, Connection, Credentials, EstablishConnectionError, UserStore,
 };
+use collab_ui::channel_view::ChannelView;
 use collections::{HashMap, HashSet};
 use fs::FakeFs;
 use futures::{channel::oneshot, StreamExt as _};
@@ -764,6 +765,16 @@ impl TestClient {
 pub fn join_channel_call(cx: &mut TestAppContext) -> Task<anyhow::Result<()>> {
     let room = cx.read(|cx| ActiveCall::global(cx).read(cx).room().cloned());
     room.unwrap().update(cx, |room, cx| room.join_call(cx))
+}
+
+pub fn open_channel_notes(
+    channel_id: u64,
+    cx: &mut VisualTestContext,
+) -> Task<anyhow::Result<View<ChannelView>>> {
+    let window = cx.update(|cx| cx.active_window().unwrap().downcast::<Workspace>().unwrap());
+    let view = window.root_view(cx).unwrap();
+
+    cx.update(|cx| ChannelView::open(channel_id, None, view.clone(), cx))
 }
 
 impl Drop for TestClient {


### PR DESCRIPTION
1. The client-side comparison was wrong
2. The server never told the client about the version it remembered
3. The server generated broken timestamps in some cases

Release Notes:

- Fixed the notes/chat appearing as unread too often

**or**

- N/A
