### PR TITLE
Setting terminal font_size

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -443,7 +443,7 @@
     }
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
-    // "font_size": "15",
+    // "font_size": 15,
     // Set the terminal's font family. If this option is not included,
     // the terminal will default to matching the buffer's font family.
     // "font_family": "Zed Mono",


### PR DESCRIPTION

Release Notes:

Fixed : font_size should be number (https://github.com/zed-industries/zed/issues/7469).

made font size's value number in default.json.
or

N/A
