### PR TITLE
Search bar UI enhancements

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -37,8 +37,8 @@ use workspace::{
 pub use registrar::DivRegistrar;
 use registrar::{ForDeployed, ForDismissed, SearchActionsRegistrar, WithResults};
 
-const MIN_INPUT_WIDHT_REMS: f32 = 15.;
-const MAX_INPUT_WIDHT_REMS: f32 = 25.;
+const MIN_INPUT_WIDTH_REMS: f32 = 15.;
+const MAX_INPUT_WIDTH_REMS: f32 = 25.;
 
 #[derive(PartialEq, Clone, Deserialize)]
 pub struct Deploy {
@@ -218,8 +218,8 @@ impl Render for BufferSearchBar {
                     .gap_2()
                     .border_1()
                     .border_color(editor_border)
-                    .min_w(rems(MIN_INPUT_WIDHT_REMS))
-                    .max_w(rems(MAX_INPUT_WIDHT_REMS))
+                    .min_w(rems(MIN_INPUT_WIDTH_REMS))
+                    .max_w(rems(MAX_INPUT_WIDTH_REMS))
                     .rounded_lg()
                     .child(self.render_text_input(&self.query_editor, match_color.color(cx), cx))
                     .children(supported_options.case.then(|| {
@@ -339,8 +339,8 @@ impl Render for BufferSearchBar {
                         .border_1()
                         .border_color(cx.theme().colors().border)
                         .rounded_lg()
-                        .min_w(rems(MIN_INPUT_WIDHT_REMS))
-                        .max_w(rems(MAX_INPUT_WIDHT_REMS))
+                        .min_w(rems(MIN_INPUT_WIDTH_REMS))
+                        .max_w(rems(MAX_INPUT_WIDTH_REMS))
                         .child(self.render_text_input(
                             &self.replacement_editor,
                             cx.theme().colors().text,


### PR DESCRIPTION
This PR introduces several enhancements (along with fixing a couple of bugs) in the search bar UI (copied from [this comment](https://github.com/zed-industries/zed/issues/7663#issuecomment-1937659091)):

- Moving the Replace field under the Search field makes it easier to compare texts and avoid typos. Also, less eyes movements.
- Use red (error) color to indicate that nothing matched. VSCode, IDEA do this. Again, it helps to get a quicker feedback on typos without moving your eyes.
- Much less moving parts and no place for flickering.
- Better fits to narrow panes.
- The Close button that allows to close the search bar with the mouse.
- Better keyboard handling (tab, shift+tab in the replacement mode), autofocus on the Replace field.

How it looks:

https://github.com/zed-industries/zed/assets/2101250/93b0edb4-4311-4a7f-9f43-b30c4d1aede5

Implementation details:

- Using `Self::on_query_editor_event` looked suspicious [here](https://github.com/zed-industries/zed/blob/288013503755f0d44feff6a517169a2861b43f26/crates/search/src/buffer_search.rs#L491) because it triggered searching on the replacement text changes. I've created a separate method for the replacement editor.
- These changes don't affect the project search bar. If the PR is accepted, the same changes may be implemented there.

Fixed issues:

- #7661
- #7663

Release Notes:

- Buffer search bar UI enhancements.
