### PR TITLE
Correct typo in `bundle` script comment

### DIFF
--- a/script/bundle
+++ b/script/bundle
@@ -12,7 +12,7 @@ bundle_name=""
 zed_crate="zed"
 binary_name="Zed"
 
-# This must match the team in the provsiioning profile.
+# This must match the team in the provisioning profile.
 APPLE_NOTORIZATION_TEAM="MQ55VZLNZQ"
 
 # Function for displaying help info


### PR DESCRIPTION
Oh boy I sure do love contributing to awesome open source projects by switching two characters and calling it a pull request!

Release Notes:

- Fixed typo in a `build` script comment.