### PR TITLE
languages: go.mod/go.work fix highlighting no longer working

### DIFF
--- a/crates/zed/src/languages/gomod/config.toml
+++ b/crates/zed/src/languages/gomod/config.toml
@@ -1,5 +1,5 @@
 name = "Go Mod"
-grammar = "go"
+grammar = "gomod"
 path_suffixes = ["mod"]
 line_comments = ["//"]
 autoclose_before = ")"

--- a/crates/zed/src/languages/gowork/config.toml
+++ b/crates/zed/src/languages/gowork/config.toml
@@ -1,5 +1,5 @@
 name = "Go Work"
-grammar = "go_work"
+grammar = "gowork"
 path_suffixes = ["work"]
 line_comments = ["//"]
 autoclose_before = ")"


### PR DESCRIPTION
At some point go.mod and go.work syntax highlighting quit working. Looks like the grammars weren't matching for some reason and I'm not sure how they were working originally.

Not sure if we could write a test to make sure the tree-sitter queries are being loaded for the grammars or not but seems like something that could be useful to avoid something like this in the future.