### PR TITLE
Fix dealloc of MacWindow

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -40,7 +40,7 @@ use raw_window_handle::{
 use smallvec::SmallVec;
 use std::{
     any::Any,
-    cell::{Cell, RefCell},
+    cell::Cell,
     ffi::{c_void, CStr},
     mem,
     ops::Range,
@@ -1086,7 +1086,7 @@ unsafe fn get_window_state(object: &Object) -> Arc<Mutex<MacWindowState>> {
 
 unsafe fn drop_window_state(object: &Object) {
     let raw: *mut c_void = *object.get_ivar(WINDOW_STATE_IVAR);
-    Rc::from_raw(raw as *mut RefCell<MacWindowState>);
+    Arc::from_raw(raw as *mut Mutex<MacWindowState>);
 }
 
 extern "C" fn yes(_: &Object, _: Sel) -> BOOL {


### PR DESCRIPTION
We see some panics in the Drop handler for MacWindow

Looking into this, I noticed that our drop implementation was not correctly
cleaning up the window state.

Release Notes:

- N/A
