### PR TITLE
Add Java language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9348,6 +9348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-java"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-json"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10911,6 +10921,7 @@ dependencies = [
  "tree-sitter-hcl",
  "tree-sitter-heex",
  "tree-sitter-html",
+ "tree-sitter-java",
  "tree-sitter-json 0.20.0",
  "tree-sitter-lua",
  "tree-sitter-markdown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4548,6 +4548,7 @@ dependencies = [
  "postage",
  "release_channel",
  "serde",
+ "serde-aux",
  "serde_derive",
  "serde_json",
  "smol",
@@ -7505,6 +7506,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-aux"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86348501c129f3ad50c2f4635a01971f76974cd8a3f335988a0f1581c082765"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ regex = "1.5"
 rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }
 rust-embed = { version = "8.0", features = ["include-exclude"] }
 schemars = "0.8"
+serde-aux = "4.4"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_derive = { version = "1.0", features = ["deserialize_in_place"] }
 serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ tree-sitter-astro = { git = "https://github.com/virchau13/tree-sitter-astro.git"
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "7331995b19b8f8aba2d5e26deb51d2195c18bc94" }
 tree-sitter-beancount = { git = "https://github.com/polarmutex/tree-sitter-beancount", rev = "da1bf8c6eb0ae7a97588affde7227630bcd678b6" }
 tree-sitter-c = "0.20.1"
-tree-sitter-clojure = { git = "https://github.com/prcastro/tree-sitter-clojure", branch = "update-ts"}
+tree-sitter-clojure = { git = "https://github.com/prcastro/tree-sitter-clojure", branch = "update-ts" }
 tree-sitter-c-sharp = { git = "https://github.com/tree-sitter/tree-sitter-c-sharp", rev = "dd5e59721a5f8dae34604060833902b882023aaf" }
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "f44509141e7e483323d2ec178f2d2e6c0fc041c1" }
 tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css", rev = "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51" }
@@ -248,6 +248,7 @@ tree-sitter-haskell = { git = "https://github.com/tree-sitter/tree-sitter-haskel
 tree-sitter-hcl = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", rev = "v1.1.0" }
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
 tree-sitter-html = "0.19.0"
+tree-sitter-java = "0.20.2"
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-lua = "0.0.14"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -22,6 +22,7 @@ log.workspace = true
 lsp-types = { git = "https://github.com/zed-industries/lsp-types", branch = "updated-completion-list-item-defaults" }
 parking_lot.workspace = true
 postage.workspace = true
+serde-aux.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -9,6 +9,9 @@ use gpui::{AppContext, AsyncAppContext, BackgroundExecutor, Task};
 use parking_lot::Mutex;
 use postage::{barrier, prelude::Stream};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_aux::field_attributes::{
+    deserialize_number_from_string, deserialize_option_number_from_string,
+};
 use serde_json::{json, value::RawValue, Value};
 use smol::{
     channel,
@@ -107,6 +110,7 @@ pub struct Request<'a, T> {
 #[derive(Serialize, Deserialize)]
 struct AnyResponse<'a> {
     jsonrpc: &'a str,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
     id: usize,
     #[serde(default)]
     error: Option<Error>,
@@ -139,7 +143,7 @@ struct Notification<'a, T> {
 /// Language server RPC notification message before it is deserialized into a concrete type.
 #[derive(Debug, Clone, Deserialize)]
 struct AnyNotification<'a> {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_number_from_string")]
     id: Option<usize>,
     #[serde(borrow)]
     method: &'a str,

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -131,6 +131,7 @@ tree-sitter-haskell.workspace = true
 tree-sitter-hcl.workspace = true
 tree-sitter-heex.workspace = true
 tree-sitter-html.workspace = true
+tree-sitter-java.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-lua.workspace = true
 tree-sitter-markdown.workspace = true

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -22,6 +22,7 @@ mod gleam;
 mod go;
 mod haskell;
 mod html;
+mod java;
 mod json;
 #[cfg(feature = "plugin_runtime")]
 mod language_plugin;
@@ -91,6 +92,7 @@ pub fn init(
         ("hcl", tree_sitter_hcl::language()),
         ("heex", tree_sitter_heex::language()),
         ("html", tree_sitter_html::language()),
+        ("java", tree_sitter_java::language()),
         ("json", tree_sitter_json::language()),
         ("lua", tree_sitter_lua::language()),
         ("markdown", tree_sitter_markdown::language()),
@@ -187,6 +189,7 @@ pub fn init(
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ],
     );
+    language("java", vec![Arc::new(java::JavaLspAdapter)]);
     language(
         "json",
         vec![Arc::new(json::JsonLspAdapter::new(

--- a/crates/zed/src/languages/java.rs
+++ b/crates/zed/src/languages/java.rs
@@ -101,7 +101,7 @@ impl LspAdapter for JavaLspAdapter {
                     return Some(CodeLabel {
                         text,
                         runs,
-                        filter_range: detail.len() + 1..detail.len() + 1 + name.rfind('(').unwrap(),
+                        filter_range: detail.len() + 1..detail.len() + 1 + name.rfind('(')?,
                     });
                 }
             }
@@ -116,6 +116,14 @@ impl LspAdapter for JavaLspAdapter {
                         filter_range: 0..name.len(),
                     });
                 }
+            }
+            Some(lsp::CompletionItemKind::KEYWORD) => {
+                let highlight_id = language.grammar()?.highlight_id_for_name("keyword")?;
+                let mut label = CodeLabel::plain(completion.label.clone(), None);
+
+                label.runs.push((0..label.text.len(), highlight_id));
+
+                return Some(label);
             }
             Some(kind) if kind != lsp::CompletionItemKind::SNIPPET => {
                 warn!("Unimplemented completion: {completion:#?}")

--- a/crates/zed/src/languages/java.rs
+++ b/crates/zed/src/languages/java.rs
@@ -1,0 +1,70 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+pub use language::*;
+use lsp::LanguageServerBinary;
+use std::{any::Any, path::PathBuf, str};
+use util::paths::HOME;
+
+pub struct JavaLspAdapter;
+
+#[async_trait]
+impl LspAdapter for JavaLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("eclipse.jdt.ls".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "jdtls"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!("eclipse.jdt.ls must be installed manually"))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "jdtls".into(),
+            arguments: vec![
+                "-configuration".into(),
+                HOME.join(".cache/jdtls").into(),
+                // Should work but... doesn't
+                // "-data".into(),
+                // ".".into(),
+            ],
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(
+        &self,
+        _container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "jdtls".into(),
+            arguments: vec!["--help".into()],
+        })
+    }
+
+    fn disk_based_diagnostic_sources(&self) -> Vec<String> {
+        vec!["java".into()]
+    }
+}

--- a/crates/zed/src/languages/java.rs
+++ b/crates/zed/src/languages/java.rs
@@ -105,16 +105,18 @@ impl LspAdapter for JavaLspAdapter {
                     });
                 }
             }
-            Some(lsp::CompletionItemKind::CLASS) => {
-                if let Some((name, _detail)) = completion.label.split_once(" - ") {
-                    let source = Rope::from(format!("class {} {{}}", name).as_str());
-                    let runs = language.highlight_text(&source, 6..6 + name.len());
+            Some(
+                lsp::CompletionItemKind::CLASS
+                | lsp::CompletionItemKind::INTERFACE
+                | lsp::CompletionItemKind::ENUM,
+            ) => {
+                if let Some((name, detail)) = completion.label.split_once(" - ") {
+                    let highlight_id = language.grammar()?.highlight_id_for_name("type")?;
+                    let mut label = CodeLabel::plain(format!("{name} (import {detail})"), None);
 
-                    return Some(CodeLabel {
-                        text: name.into(),
-                        runs,
-                        filter_range: 0..name.len(),
-                    });
+                    label.runs.push((0..name.len(), highlight_id));
+
+                    return Some(label);
                 }
             }
             Some(lsp::CompletionItemKind::KEYWORD) => {

--- a/crates/zed/src/languages/java/brackets.scm
+++ b/crates/zed/src/languages/java/brackets.scm
@@ -1,0 +1,5 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)

--- a/crates/zed/src/languages/java/config.toml
+++ b/crates/zed/src/languages/java/config.toml
@@ -1,0 +1,22 @@
+name = "Java"
+grammar = "java"
+path_suffixes = ["java"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true, not_in = [
+        "string",
+        "comment",
+    ] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "string",
+    ] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = [
+        "string",
+        "comment",
+    ] },
+]
+collapsed_placeholder = " /* ... */ "

--- a/crates/zed/src/languages/java/highlights.scm
+++ b/crates/zed/src/languages/java/highlights.scm
@@ -1,0 +1,142 @@
+; Methods
+
+(method_declaration
+  name: (identifier) @function.method)
+(method_invocation
+  name: (identifier) @function.method)
+(super) @function.builtin
+
+; Annotations
+
+(annotation
+  name: (identifier) @attribute)
+(marker_annotation
+  name: (identifier) @attribute)
+
+"@" @operator
+
+; Types
+
+(type_identifier) @type
+
+(interface_declaration
+  name: (identifier) @type)
+(class_declaration
+  name: (identifier) @type)
+(enum_declaration
+  name: (identifier) @type)
+
+((field_access
+  object: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((scoped_identifier
+  scope: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((method_invocation
+  object: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((method_reference
+  . (identifier) @type)
+ (#match? @type "^[A-Z]"))
+
+(constructor_declaration
+  name: (identifier) @type)
+
+[
+  (boolean_type)
+  (integral_type)
+  (floating_point_type)
+  (floating_point_type)
+  (void_type)
+] @type.builtin
+
+; Variables
+
+((identifier) @constant
+ (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
+
+(identifier) @variable
+
+(this) @variable.builtin
+
+; Literals
+
+[
+  (hex_integer_literal)
+  (decimal_integer_literal)
+  (octal_integer_literal)
+  (decimal_floating_point_literal)
+  (hex_floating_point_literal)
+] @number
+
+[
+  (character_literal)
+  (string_literal)
+] @string
+(escape_sequence) @string.escape
+
+[
+  (true)
+  (false)
+  (null_literal)
+] @constant.builtin
+
+[
+  (line_comment)
+  (block_comment)
+] @comment
+
+; Keywords
+
+[
+  "abstract"
+  "assert"
+  "break"
+  "case"
+  "catch"
+  "class"
+  "continue"
+  "default"
+  "do"
+  "else"
+  "enum"
+  "exports"
+  "extends"
+  "final"
+  "finally"
+  "for"
+  "if"
+  "implements"
+  "import"
+  "instanceof"
+  "interface"
+  "module"
+  "native"
+  "new"
+  "non-sealed"
+  "open"
+  "opens"
+  "package"
+  "private"
+  "protected"
+  "provides"
+  "public"
+  "requires"
+  "record"
+  "return"
+  "sealed"
+  "static"
+  "strictfp"
+  "switch"
+  "synchronized"
+  "throw"
+  "throws"
+  "to"
+  "transient"
+  "transitive"
+  "try"
+  "uses"
+  "volatile"
+  "while"
+  "with"
+] @keyword

--- a/crates/zed/src/languages/java/highlights.scm
+++ b/crates/zed/src/languages/java/highlights.scm
@@ -55,9 +55,10 @@
 ((identifier) @constant
  (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
 
-(identifier) @variable
+(field_access
+  field: (identifier) @property)
 
-(this) @variable.builtin
+(this) @variable.special
 
 ; Literals
 

--- a/crates/zed/src/languages/java/indents.scm
+++ b/crates/zed/src/languages/java/indents.scm
@@ -1,0 +1,17 @@
+[
+    (assignment_expression)
+    (binary_expression)
+    (instanceof_expression)
+    (lambda_expression)
+    (ternary_expression)
+    (update_expression)
+    (primary_expression)
+    (unary_expression)
+    (cast_expression)
+    (switch_expression)
+] @indent
+
+(_ "[" "]" @end) @indent
+(_ "<" ">" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent

--- a/crates/zed/src/languages/java/outline.scm
+++ b/crates/zed/src/languages/java/outline.scm
@@ -1,0 +1,40 @@
+(module_declaration
+    "open"? @context
+    "module" @context
+    name: (_) @name) @item
+
+(package_declaration
+    "package" @context
+    (_) @name) @item
+
+(class_declaration
+    (modifiers)? @context
+    "class" @context
+    name: (_) @name
+    superclass: (_)? @name
+    interfaces: (_)? @name
+    permits: (_)? @name) @item
+
+(record_declaration
+    (modifiers)? @context
+    "record" @context
+    name: (_) @name
+    interfaces: (_)? @name) @item
+
+(interface_declaration
+    (modifiers)? @context
+    "interface" @context
+    name: (_) @name
+    (extends_interfaces)? @context
+    permits: (_)? @name) @item
+
+(annotation_type_declaration
+    (modifiers)? @context
+    "@interface" @context
+    name: (_) @name) @item
+
+(enum_declaration
+    (modifiers)? @context
+    "enum" @context
+    name: (_) @name
+    interfaces: (_)? @name) @item


### PR DESCRIPTION
This pull request aims to add complete Java language support. Currently, this is being achieved in this pull request with [tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java) and [eclipse.jdt.ls](https://github.com/eclipse-jdtls/eclipse.jdt.ls).

It has been [expressed](https://github.com/zed-industries/zed/pull/6935#issuecomment-1913640078) that Java support cannot come until "collapsed directories" are implemented, so this pull request will remain in draft form until that happens. zed-industries/zed#7674 should resolve this.

Release Notes:

- Added Java language support ([#5301](https://github.com/zed-industries/extensions/issues/500)).