### PR TITLE
Disable vim in the feedback modal

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -399,6 +399,7 @@ pub struct Editor {
     workspace: Option<(WeakView<Workspace>, i64)>,
     keymap_context_layers: BTreeMap<TypeId, KeyContext>,
     input_enabled: bool,
+    use_modal_editing: bool,
     read_only: bool,
     leader_peer_id: Option<PeerId>,
     remote_id: Option<ViewId>,
@@ -1482,6 +1483,7 @@ impl Editor {
             workspace: None,
             keymap_context_layers: Default::default(),
             input_enabled: true,
+            use_modal_editing: mode == EditorMode::Full,
             read_only: false,
             use_autoclose: true,
             leader_peer_id: None,
@@ -1780,6 +1782,14 @@ impl Editor {
 
     pub fn set_show_copilot_suggestions(&mut self, show_copilot_suggestions: bool) {
         self.show_copilot_suggestions = show_copilot_suggestions;
+    }
+
+    pub fn set_use_modal_editing(&mut self, to: bool) {
+        self.use_modal_editing = to;
+    }
+
+    pub fn use_modal_editing(&self) -> bool {
+        self.use_modal_editing
     }
 
     fn selections_did_change(

--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -187,6 +187,7 @@ impl FeedbackModal {
             editor.set_show_gutter(false, cx);
             editor.set_show_copilot_suggestions(false);
             editor.set_vertical_scroll_margin(5, cx);
+            editor.set_use_modal_editing(false);
             editor
         });
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -198,7 +198,7 @@ impl Vim {
     }
 
     fn activate_editor(&mut self, editor: View<Editor>, cx: &mut WindowContext) {
-        if editor.read(cx).mode() != EditorMode::Full {
+        if !editor.read(cx).use_modal_editing() {
             return;
         }
 


### PR DESCRIPTION
Fixes #7000 by disabling vim in this context

Release Notes:

- Fixed feedback modal in vim mode ([#7000](https://github.com/zed-industries/zed/issues/7000)).

**or**

- N/A
