### PR TITLE
Improve sorting of completion results

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3441,8 +3441,9 @@ impl Completion {
     /// them to the user.
     pub fn sort_key(&self) -> (usize, &str) {
         let kind_key = match self.lsp_completion.kind {
-            Some(lsp::CompletionItemKind::VARIABLE) => 0,
-            _ => 1,
+            Some(lsp::CompletionItemKind::KEYWORD) => 0,
+            Some(lsp::CompletionItemKind::VARIABLE) => 1,
+            _ => 2,
         };
         (kind_key, &self.label.text[self.label.filter_range.clone()])
     }


### PR DESCRIPTION
This is an attempt to fix #5013 by doing two things:

1. Rank "obvious" matches in completions higher (see the code comment)
2. When tied: rank keywords higher than variables

Release Notes:

- Improved sorting of completion results to prefer literal matches. ([#5013](https://github.com/zed-industries/zed/issues/5013)).

### Before

![screenshot-2024-02-13-13 08 13@2x](https://github.com/zed-industries/zed/assets/1185253/77decb0b-5b47-45de-ab69-f7b333072b45)
![screenshot-2024-02-13-13 10 42@2x](https://github.com/zed-industries/zed/assets/1185253/ae33d0fe-06f5-4fc1-84f8-ddf6dbe80ba5)


### After

![screenshot-2024-02-13-13 06 22@2x](https://github.com/zed-industries/zed/assets/1185253/3c526bab-6392-4eeb-a2f2-dd73ccf228e8)
![screenshot-2024-02-13-13 06 50@2x](https://github.com/zed-industries/zed/assets/1185253/b5b9d513-766d-4a53-94de-b46271f5978c)

