### PR TITLE
Don't divide by zero if the theme defines no player colors

### DIFF
--- a/crates/theme/src/styles/players.rs
+++ b/crates/theme/src/styles/players.rs
@@ -140,7 +140,7 @@ impl PlayerColors {
     }
 
     pub fn color_for_participant(&self, participant_index: u32) -> PlayerColor {
-        let len = cmp::max(self.0.len() - 1, 0);
+        let len = cmp::max(self.0.len() - 1, 1);
         self.0[(participant_index as usize % len) + 1]
     }
 }

--- a/crates/theme/src/styles/players.rs
+++ b/crates/theme/src/styles/players.rs
@@ -1,6 +1,5 @@
 use gpui::Hsla;
 use serde_derive::Deserialize;
-use std::cmp;
 
 use crate::{amber, blue, jade, lime, orange, pink, purple, red};
 
@@ -140,7 +139,7 @@ impl PlayerColors {
     }
 
     pub fn color_for_participant(&self, participant_index: u32) -> PlayerColor {
-        let len = cmp::max(self.0.len() - 1, 1);
-        self.0[(participant_index as usize % len) + 1]
+        let len = self.0.len();
+        self.0[(participant_index as usize + len - 1) % len]
     }
 }

--- a/crates/theme/src/styles/players.rs
+++ b/crates/theme/src/styles/players.rs
@@ -1,5 +1,6 @@
 use gpui::Hsla;
 use serde_derive::Deserialize;
+use std::cmp;
 
 use crate::{amber, blue, jade, lime, orange, pink, purple, red};
 
@@ -139,7 +140,7 @@ impl PlayerColors {
     }
 
     pub fn color_for_participant(&self, participant_index: u32) -> PlayerColor {
-        let len = self.0.len() - 1;
+        let len = cmp::max(self.0.len() - 1, 0);
         self.0[(participant_index as usize % len) + 1]
     }
 }


### PR DESCRIPTION

Release Notes:

- Fixed division by zero in theme player color selection ([#7733](https://github.com/zed-industries/zed/issues/7733)).
