### PR TITLE
Add C-w and C-u keymaps in vim mode (Fix #7691)

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -485,7 +485,9 @@
       "ctrl-x ctrl-a": "assistant::InlineAssist", // zed specific
       "ctrl-x ctrl-c": "copilot::Suggest", // zed specific
       "ctrl-x ctrl-l": "editor::ToggleCodeActions", // zed specific
-      "ctrl-x ctrl-z": "editor::Cancel"
+      "ctrl-x ctrl-z": "editor::Cancel",
+      "ctrl-w": "editor::DeleteToPreviousWordStart",
+      "ctrl-u": "editor::DeleteToBeginningOfLine"
     }
   },
   {


### PR DESCRIPTION

Release Notes:
- Added C-w and C-u keymaps in vim mode ([#7691](https://github.com/zed-industries/zed/issues/7691))