### PR TITLE
Remove themes from the registry when the extension is uninstalled

### DIFF
--- a/crates/extension/src/extension_store_test.rs
+++ b/crates/extension/src/extension_store_test.rs
@@ -5,12 +5,19 @@ use fs::FakeFs;
 use gpui::{Context, TestAppContext};
 use language::{LanguageMatcher, LanguageRegistry};
 use serde_json::json;
+use settings::SettingsStore;
 use std::{path::PathBuf, sync::Arc};
 use theme::ThemeRegistry;
 use util::http::FakeHttpClient;
 
 #[gpui::test]
 async fn test_extension_store(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+        theme::init(theme::LoadThemes::JustBase, cx);
+    });
+
     let fs = FakeFs::new(cx.executor());
     let http_client = FakeHttpClient::with_200_response();
 

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -189,6 +189,14 @@ impl ThemeRegistry {
         }));
     }
 
+    /// Removes the themes with the given names from the registry.
+    pub fn remove_user_themes(&self, themes_to_remove: &[SharedString]) {
+        self.state
+            .write()
+            .themes
+            .retain(|name, _| !themes_to_remove.contains(name))
+    }
+
     pub fn clear(&mut self) {
         self.state.write().themes.clear();
     }


### PR DESCRIPTION
This PR makes it so uninstalling an extension will remove any themes provided by that extension from the theme registry.

Release Notes:

- N/A
