### PR TITLE
Don't wait to dispatch commands

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -317,9 +317,7 @@ impl PickerDelegate for CommandPaletteDelegate {
         });
         let action = command.action;
         cx.focus(&self.previous_focus_handle);
-        cx.window_context()
-            .spawn(move |mut cx| async move { cx.update(|cx| cx.dispatch_action(action)) })
-            .detach_and_log_err(cx);
+        cx.dispatch_action(action);
         self.dismissed(cx);
     }
 


### PR DESCRIPTION
I added this when porting vim mode to gpui2 to work around life-cycle
problems.
Since #7647, this is no longer needed for vim mode, and causes other
problems (c.f. #7748)

Release Notes:

- Improved command to drop fewer keystrokes
