### PR TITLE
Add netrw bindings for vim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9950,6 +9950,7 @@ dependencies = [
  "nvim-rs",
  "parking_lot 0.11.2",
  "project",
+ "project_panel",
  "regex",
  "release_channel",
  "search",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -505,5 +505,33 @@
       "enter": "vim::SearchSubmit",
       "escape": "buffer_search::Dismiss"
     }
+  },
+  {
+    // Directory expansion
+    "context": "ProjectPanel && not_editing",
+    "bindings": {
+      "escape": "project_panel::ToggleFocus",
+      "enter": "project_panel::Open",
+      "o": "project_panel::Open",
+      "t": "project_panel::Open",
+      "v": "project_panel::Open",
+      "d": "project_panel::NewDirectory",
+      "%": "project_panel::NewFile",
+      "shift-r": "project_panel::Rename",
+      "m m": "project_panel::Cut",
+      "m c": "project_panel::Copy",
+      "m t": "project_panel::Paste",
+      "x": "project_panel::RevealInFinder",
+      "l": "project_panel::ExpandSelectedEntry",
+      "h": "project_panel::CollapseSelectedEntry",
+      // Move up and down
+      "j": "menu::SelectNext",
+      "k": "menu::SelectPrev",
+      "shift-d": "project_panel::Delete",
+      "/": "project_panel::NewSearchInDirectory",
+      // zed specific
+      "q p": "project_panel::CopyPath",
+      "q r": "project_panel::CopyRelativePath"
+    }
   }
 ]

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -20,13 +20,16 @@ collections.workspace = true
 command_palette.workspace = true
 # HACK: We're only depending on `copilot` here for `CommandPaletteFilter`.  See the attached comment on that type.
 copilot.workspace = true
+project_panel.workspace = true
 diagnostics.workspace = true
 editor.workspace = true
 gpui.workspace = true
 itertools = "0.10"
 language.workspace = true
 log.workspace = true
-nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"], optional = true }
+nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = [
+    "use_tokio",
+], optional = true }
 regex.workspace = true
 search.workspace = true
 serde.workspace = true

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -233,6 +233,23 @@ pub fn command_interceptor(mut query: &str, _: &AppContext) -> Option<CommandInt
         "sor" | "sor " | "sort" | "sort " => ("sort", SortLinesCaseSensitive.boxed_clone()),
         "sor i" | "sort i" => ("sort i", SortLinesCaseInsensitive.boxed_clone()),
 
+        // Explore, etc.
+        "E" | "Ex" | "Exp" | "Expl" | "Explo" | "Explor" | "Explore" => {
+            ("Explore", project_panel::ToggleFocus.boxed_clone())
+        }
+        "H" | "He" | "Hex" | "Hexp" | "Hexpl" | "Hexplo" | "Hexplor" | "Hexplore" => {
+            ("Hexplore", project_panel::ToggleFocus.boxed_clone())
+        }
+        "L" | "Le" | "Lex" | "Lexp" | "Lexpl" | "Lexplo" | "Lexplor" | "Lexplore" => {
+            ("Lexplore", project_panel::ToggleFocus.boxed_clone())
+        }
+        "S" | "Se" | "Sex" | "Sexp" | "Sexpl" | "Sexplo" | "Sexplor" | "Sexplore" => {
+            ("Sexplore", project_panel::ToggleFocus.boxed_clone())
+        }
+        "Ve" | "Vex" | "Vexp" | "Vexpl" | "Vexplo" | "Vexplor" | "Vexplore" => {
+            ("Vexplore", project_panel::ToggleFocus.boxed_clone())
+        }
+
         // goto (other ranges handled under _ => )
         "$" => ("$", EndOfDocument.boxed_clone()),
         "%" => ("%", EndOfDocument.boxed_clone()),


### PR DESCRIPTION
This is now possible after #7647

Release Notes:

- Added vim bindings for project panel ([#4270](https://github.com/zed-industries/zed/issues/4270)).
