### PR TITLE
Improve TS and JSON Syntax Highlighting

### DIFF
--- a/crates/zed/src/languages/json/highlights.scm
+++ b/crates/zed/src/languages/json/highlights.scm
@@ -3,7 +3,7 @@
 (string) @string
 
 (pair
-  key: (string) @property)
+  key: (string) @property.json_key)
 
 (number) @number
 

--- a/crates/zed/src/languages/tsx/highlights.scm
+++ b/crates/zed/src/languages/tsx/highlights.scm
@@ -78,6 +78,7 @@
 [
   (string)
   (template_string)
+  (template_literal_type)
 ] @string
 
 (regex) @string.regex
@@ -91,6 +92,7 @@
   "."
   ","
   ":"
+  "?"
 ] @punctuation.delimiter
 
 [
@@ -195,6 +197,10 @@
 ] @keyword
 
 (template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(template_type
   "${" @punctuation.special
   "}" @punctuation.special) @embedded
 

--- a/crates/zed/src/languages/typescript/highlights.scm
+++ b/crates/zed/src/languages/typescript/highlights.scm
@@ -78,6 +78,7 @@
 [
   (string)
   (template_string)
+  (template_literal_type)
 ] @string
 
 (regex) @string.regex
@@ -91,6 +92,7 @@
   "."
   ","
   ":"
+  "?"
 ] @punctuation.delimiter
 
 [
@@ -195,6 +197,10 @@
 ] @keyword
 
 (template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(template_type
   "${" @punctuation.special
   "}" @punctuation.special) @embedded
 


### PR DESCRIPTION
This PR adds support for highlighting typescript literal types and improves the highlighting of Typescript and JSON (adds a new identifier for json keys).

Before:

<img width="309" alt="SCR-20240214-kifi-2" src="https://github.com/zed-industries/zed/assets/67913738/74bbe207-69f7-4164-b1a6-05f09e1370c7">


After:

<img width="306" alt="SCR-20240214-kiro" src="https://github.com/zed-industries/zed/assets/67913738/7a9965ed-5fdb-419a-bd9a-cd9edc2846cc">

Release Notes:

- Added support for highlighting literal types
- Improved Typescript and JSON highlighting
