### PR TITLE
ocaml: Small query improvements and fix autoclose brackets

### DIFF
--- a/crates/languages/src/ocaml-interface/brackets.scm
+++ b/crates/languages/src/ocaml-interface/brackets.scm
@@ -1,6 +1,3 @@
 ("(" @open ")" @close)
 ("{" @open "}" @close)
 ("<" @open ">" @close)
-
-("sig" @open "end" @close)
-("object" @open "end" @close)

--- a/crates/languages/src/ocaml-interface/config.toml
+++ b/crates/languages/src/ocaml-interface/config.toml
@@ -7,8 +7,5 @@ brackets = [
   { start = "{", end = "}", close = true, newline = true },
   { start = "<", end = ">", close = true, newline = true },
   { start = "[", end = "]", close = true, newline = true },
-  { start = "(", end = ")", close = true, newline = true },
-  { start = "sig", end = " end", close = true, newline = true },
-  # HACK: For some reason `object` alone does not work
-  { start = "object ", end = "end", close = true, newline = true },
+  { start = "(", end = ")", close = true, newline = true }
 ]

--- a/crates/languages/src/ocaml/brackets.scm
+++ b/crates/languages/src/ocaml/brackets.scm
@@ -5,8 +5,3 @@
 ("<" @open ">" @close)
 ("\"" @open "\"" @close)
 
-("begin" @open "end" @close)
-("struct" @open "end" @close)
-("sig" @open "end" @close)
-("object" @open "end" @close)
-("do" @open "done" @close)

--- a/crates/languages/src/ocaml/config.toml
+++ b/crates/languages/src/ocaml/config.toml
@@ -9,11 +9,5 @@ brackets = [
   { start = "[", end = "]", close = true, newline = true },
   { start = "[|", end = "|", close = true, newline = true, not_in = ["string"] },
   { start = "(", end = ")", close = true, newline = true },
-  { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
-  { start = "begin", end = " end", close = true, newline = true },
-  { start = "struct", end = " end", close = true, newline = true },
-  { start = "sig", end = " end", close = true, newline = true },
-  # HACK: For some reason `object` alone does not work
-  { start = "object ", end = "end", close = true, newline = true },
-  { start = "do", end = " done", close = true, newline = true }
+  { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] }
 ]

--- a/crates/languages/src/ocaml/highlights.scm
+++ b/crates/languages/src/ocaml/highlights.scm
@@ -8,7 +8,8 @@
 
 [(class_name) (class_type_name) (type_constructor)] @type
 
-[(constructor_name) (tag)] @constructor
+(tag) @variant ;; Polymorphic Variants
+(constructor_name) @constructor ;; Exceptions, variants and the like
 
 ; Functions
 ;----------

--- a/crates/languages/src/ocaml/indents.scm
+++ b/crates/languages/src/ocaml/indents.scm
@@ -14,6 +14,8 @@
 
   (field_declaration)
   (field_expression)
+
+  (application_expression)
 ] @indent
 
 (_ "[" "]" @end) @indent


### PR DESCRIPTION
Turns out auto-closing words was a bad idea. win**do**w, **struct**ure, **sig**n and so on

They don't serve any purpose in `config.toml`  nor `brackets.scm` at this point, so I removed them>

Release Notes:
- N/A
