### PR TITLE
Give explicit heights to items in the extension list

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -216,6 +216,7 @@ impl ExtensionsPage {
         div().w_full().child(
             v_flex()
                 .w_full()
+                .h(rems(7.))
                 .p_3()
                 .mt_4()
                 .gap_2()


### PR DESCRIPTION
This PR gives the items in the extension list an explicit height so that they work properly within the uniform list when descriptions are missing.

<img width="1235" alt="Screenshot 2024-02-14 at 10 19 14 AM" src="https://github.com/zed-industries/zed/assets/1486634/01222902-6b05-4e9a-bb5a-bada14b1fd45">

I think we may want to consider using a `list` here instead of a `uniform_list` to allow them to have variable heights.

Fixes #7756.

Release Notes:

- N/A
