### PR TITLE
go: enable completions with placeholders by default

### DIFF
--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -6,6 +6,7 @@ pub use language::*;
 use lazy_static::lazy_static;
 use lsp::LanguageServerBinary;
 use regex::Regex;
+use serde_json::json;
 use smol::{fs, process};
 use std::{
     any::Any,
@@ -168,6 +169,12 @@ impl super::LspAdapter for GoLspAdapter {
                 binary.arguments = vec!["--help".into()];
                 binary
             })
+    }
+
+    fn initialization_options(&self) -> Option<serde_json::Value> {
+        Some(json!({
+            "usePlaceholders": true,
+        }))
     }
 
     async fn label_for_completion(


### PR DESCRIPTION
This fixes #7523 by enabling completions with placeholders by default.

This setting controls whether gopls sends back snippets with placeholders. According to the documentation (https://github.com/golang/tools/blob/master/gopls/doc/settings.md#useplaceholders-bool) this only controls whether "placeholders for function parameters or struct fields" are sent in completion responses.

In practice, though, this seems to also control whether any snippets with *any* placeholders are being sent back.

Example: for the given Go code

    err := myFunction()
    i^

With the cursor being at `^`, this setting controls whether `gopls` sends back statement snippets such as `if err != nil { return ... }` with the `...` being dynamically matched to the return value of the function.

So I think this setting controls far more than just function params and struct fields. And since we *do* support placeholders in snippets, I think this provides a better default experience.

Release Notes:

- Improved default Go experience by enabling snippets-with-placeholders when initializing `gopls`. ([#7523](https://github.com/zed-industries/zed/issues/7523)).
