### PR TITLE
Add double quote wrap in activate_python_virtual_environment

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -124,7 +124,10 @@ impl Project {
             // Paths are not strings so we need to jump through some hoops to format the command without `format!`
             let mut command = Vec::from(activate_command.as_bytes());
             command.push(b' ');
+            // Wrapping path in double quotes to catch spaces in folder name
+            command.extend_from_slice(b"\"");
             command.extend_from_slice(activate_script.as_os_str().as_encoded_bytes());
+            command.extend_from_slice(b"\"");
             command.push(b'\n');
 
             terminal_handle.update(cx, |this, _| this.input_bytes(command));


### PR DESCRIPTION
Added double quote wrap in activate_python_virtual_environment to handle spaces in path.
Would fail to find venv activate script when spaces exist.


Release Notes:

- Fixed venv_detection activation not finding directory if space is in the path
![image](https://github.com/zed-industries/zed/assets/52263845/9bf95b92-c6d4-4e2c-9158-d91a41c10216)


- With changes
![image](https://github.com/zed-industries/zed/assets/52263845/93602ae7-d991-494b-89c3-5afcce556888)

