### PR TITLE
Add a line instructing users to include media screenshots

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-
-
 Release Notes:
 
 - Added/Fixed/Improved ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).
@@ -7,3 +5,5 @@ Release Notes:
 **or**
 
 - N/A
+
+Optionally, include screenshots / media that can be included in the release notes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+
+
 Release Notes:
 
 - Added/Fixed/Improved ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ Release Notes:
 
 - N/A
 
-Optionally, include screenshots / media that can be included in the release notes.
+Optionally, include screenshots / media showcasing your addition that can be included in the release notes.


### PR DESCRIPTION
Making media up for release notes / tweets is becoming very time consuming. I spoke to Max and suggested we ask users to submit media for their features, to reduce what we need to produce for tweets and such. I dont know if this is the best way to signal it; I don't like adding more to the PR template, but I'm not sure of a better way at the moment.


Release Notes:

- N/a
