### PR TITLE
Fix buffer search invalid regexp indicator

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -687,7 +687,6 @@ impl BufferSearchBar {
                 });
             });
             self.search_options = options;
-            self.query_contains_error = false;
             self.clear_matches(cx);
             cx.notify();
         }
@@ -804,7 +803,6 @@ impl BufferSearchBar {
             editor::EditorEvent::Focused => self.query_editor_focused = true,
             editor::EditorEvent::Blurred => self.query_editor_focused = false,
             editor::EditorEvent::Edited => {
-                self.query_contains_error = false;
                 self.clear_matches(cx);
                 let search = self.update_matches(cx);
                 cx.spawn(|this, mut cx| async move {
@@ -869,6 +867,7 @@ impl BufferSearchBar {
         self.pending_search.take();
 
         if let Some(active_searchable_item) = self.active_searchable_item.as_ref() {
+            self.query_contains_error = false;
             if query.is_empty() {
                 self.active_match_index.take();
                 active_searchable_item.clear_matches(cx);


### PR DESCRIPTION
This PR fixes the issue with invalid regexp highlighting (red border) when switching to the simple text searching mode (#7658).

Implementation details:

- `update_matches()` always relied on the caller to reset the `query_contains_error` flag, which wasn't always the case. Now, it resets the flag itself.

Release Notes:

- Fix issue with switching between invalid regexp and simple text buffer search (#7658).

How it works now:

https://github.com/zed-industries/zed/assets/2101250/ac868a5d-5e2f-49a0-90fc-00e62a1d5ee8
