### PR TITLE
Disable GPUI test support outside of actual tests

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 license = "Apache-2.0"
 
 [features]
+test-support-outside-test = ["test-support"]
 test-support = [
     "backtrace",
     "dhat",

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -150,6 +150,10 @@ pub use window::*;
 use std::{any::Any, borrow::BorrowMut};
 use taffy::TaffyLayoutEngine;
 
+#[cfg(all(feature = "test-support", not(test), not(feature = "test-support-outside-test")))]
+compile_error!("GPUI Test support enabled in a non-test build");
+
+
 /// The context trait, allows the different contexts in GPUI to be used
 /// interchangeably for certain operations.
 pub trait Context {

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -150,9 +150,12 @@ pub use window::*;
 use std::{any::Any, borrow::BorrowMut};
 use taffy::TaffyLayoutEngine;
 
-#[cfg(all(feature = "test-support", not(test), not(feature = "test-support-outside-test")))]
+#[cfg(all(
+    feature = "test-support",
+    not(test),
+    not(feature = "test-support-outside-test")
+))]
 compile_error!("GPUI Test support enabled in a non-test build");
-
 
 /// The context trait, allows the different contexts in GPUI to be used
 /// interchangeably for certain operations.


### PR DESCRIPTION
The linux port work was held up for a few days due to a misconfiguration in `live_kit_client`, causing the flush_effects `draw` to be called without a corresponding `present`. This would, in turn, break the presentation step as the dirty bit would always be false, meaning that nothing would be rendered. 

To fix this issue, this PR adds a `compile_error!()` if the `test-support` feature is enabled in a non-test build. To override this behavior, you can add the `test-support-outside-test` feature to GPUI.

Release Notes:

- N/A