### PR TITLE
Don't reinstall dependencies on arch linux

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -38,7 +38,7 @@ if [[ -n $pacman ]]; then
     fontconfig
     vulkan-validation-layers
   )
-  $maysudo "$pacman" -S --noconfirm "${deps[@]}"
+  $maysudo "$pacman" -S --needed --noconfirm "${deps[@]}"
   exit 0
 fi
 


### PR DESCRIPTION
Very minor quality of life update, passing the --needed flag to pacman to skip reinstalling up to date dependencies.

Release Notes:

- N/A
