### PR TITLE
Ignore 'DROP COLUMN enviroment' in typo checker

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -22,5 +22,6 @@ extend-ignore-re = [
     ":ba\\|z",
     # :/ crates/collab/migrations/20231009181554_add_release_channel_to_rooms.sql
     "ADD COLUMN enviroment TEXT",
+    "ALTER TABLE rooms DROP COLUMN enviroment;",
 ]
 check-filename = true


### PR DESCRIPTION
In dropping a misspelled "enviroment" column in #7742, a new "typo" was introduced breaking CI. This fixes that.

Release Notes:

- N/A
