### PR TITLE
Moved close button to inside search_line div

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -321,6 +321,12 @@ impl Render for BufferSearchBar {
                         "Select next match",
                         &SelectNextMatch,
                     )),
+            )
+            // Moved Close button into the search_line Div from flex end to make position more intuitive
+            .child(
+                IconButton::new(SharedString::from("Close"), IconName::Close)
+                    .tooltip(move |cx| Tooltip::for_action("Close search bar", &Dismiss, cx))
+                    .on_click(cx.listener(|this, _: &ClickEvent, cx| this.dismiss(&Dismiss, cx))),
             );
 
         let replace_line = should_show_replace_input.then(|| {
@@ -399,15 +405,7 @@ impl Render for BufferSearchBar {
                 this.on_action(cx.listener(Self::toggle_whole_word))
             })
             .gap_2()
-            .child(
-                h_flex().child(search_line.w_full()).child(
-                    IconButton::new(SharedString::from("Close"), IconName::Close)
-                        .tooltip(move |cx| Tooltip::for_action("Close search bar", &Dismiss, cx))
-                        .on_click(
-                            cx.listener(|this, _: &ClickEvent, cx| this.dismiss(&Dismiss, cx)),
-                        ),
-                ),
-            )
+            .child(h_flex().child(search_line.w_full()))
             .children(replace_line)
     }
 }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -405,7 +405,7 @@ impl Render for BufferSearchBar {
                 this.on_action(cx.listener(Self::toggle_whole_word))
             })
             .gap_2()
-            .child(h_flex().child(search_line.w_full()))
+            .child(search_line)
             .children(replace_line)
     }
 }


### PR DESCRIPTION
- Very minor change to search buffer close button location from far right of display to end of other search functions to make location more intuitive.

<img width="608" alt="Screenshot 2024-02-15 at 00 32 29" src="https://github.com/zed-industries/zed/assets/52263845/83acb3ab-f84b-4f86-a0be-d966c209704a">


Previously was at right end of screen .

<img width="1265" alt="Screenshot 2024-02-15 at 00 45 56" src="https://github.com/zed-industries/zed/assets/52263845/425af877-6527-4e40-8a5f-1e149ba79bf6">


Release Notes:
N/A


 
