### PR TITLE
Extend Ruby word characters to include valid identifier chars

### DIFF
--- a/crates/zed/src/languages/ruby/config.toml
+++ b/crates/zed/src/languages/ruby/config.toml
@@ -31,3 +31,4 @@ brackets = [
   { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 collapsed_placeholder = "# ..."
+word_characters = ["_", "$", "=", "@", "!", ":", "?"]

--- a/crates/zed/src/languages/ruby/config.toml
+++ b/crates/zed/src/languages/ruby/config.toml
@@ -1,34 +1,40 @@
 name = "Ruby"
 grammar = "ruby"
 path_suffixes = [
-  "rb",
-  "Gemfile",
-  "rake",
-  "Rakefile",
-  "ru",
-  "thor",
-  "cap",
-  "capfile",
-  "Capfile",
-  "jbuilder",
-  "rabl",
-  "rxml",
-  "builder",
-  "gemspec",
-  "rdoc",
-  "thor",
-  "pryrc",
-  "simplecov"
+    "rb",
+    "Gemfile",
+    "rake",
+    "Rakefile",
+    "ru",
+    "thor",
+    "cap",
+    "capfile",
+    "Capfile",
+    "jbuilder",
+    "rabl",
+    "rxml",
+    "builder",
+    "gemspec",
+    "rdoc",
+    "thor",
+    "pryrc",
+    "simplecov",
 ]
 first_line_pattern = '^#!.*\bruby\b'
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [
-  { start = "{", end = "}", close = true, newline = true },
-  { start = "[", end = "]", close = true, newline = true },
-  { start = "(", end = ")", close = true, newline = true },
-  { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
-  { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
 ]
 collapsed_placeholder = "# ..."
 word_characters = ["_", "$", "=", "@", "!", ":", "?"]


### PR DESCRIPTION
In Ruby `_$=@!:?` can all be part of an identifier. If we don't have them in this list, autocomplete doesn't work as expected.

See: https://gist.github.com/misfo/1072693

This fixes one part of #7819 but not the whole ticket.

Release Notes:

- Fixed completions in Ruby not working for identifiers that start or end with special characters (e.g.: `@`)