### PR TITLE
Add JSDoc syntax highlighting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,6 +5314,7 @@ dependencies = [
  "tree-sitter-hcl",
  "tree-sitter-heex",
  "tree-sitter-html",
+ "tree-sitter-jsdoc",
  "tree-sitter-json 0.20.0",
  "tree-sitter-lua",
  "tree-sitter-markdown",
@@ -10527,6 +10528,15 @@ name = "tree-sitter-html"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "184e6b77953a354303dc87bf5fe36558c83569ce92606e7b382a0dc1b7443443"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-jsdoc"
+version = "0.20.0"
+source = "git+https://github.com/tree-sitter/tree-sitter-jsdoc#6a6cf9e7341af32d8e2b2e24a37fbfebefc3dc55"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ tree-sitter-hcl = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", re
 rustc-demangle = "0.1.23"
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
 tree-sitter-html = "0.19.0"
+tree-sitter-jsdoc = { git = "https://github.com/tree-sitter/tree-sitter-jsdoc", ref = "6a6cf9e7341af32d8e2b2e24a37fbfebefc3dc55" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-lua = "0.0.14"
 tree-sitter-markdown = { git = "https://github.com/MDeiml/tree-sitter-markdown", rev = "330ecab87a3e3a7211ac69bbadc19eabecdb1cca" }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -58,6 +58,7 @@ tree-sitter-haskell.workspace = true
 tree-sitter-hcl.workspace = true
 tree-sitter-heex.workspace = true
 tree-sitter-html.workspace = true
+tree-sitter-jsdoc.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-lua.workspace = true
 tree-sitter-markdown.workspace = true

--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -1,0 +1,2 @@
+((comment) @content
+  (#set! "language" "jsdoc"))

--- a/crates/languages/src/jsdoc/brackets.scm
+++ b/crates/languages/src/jsdoc/brackets.scm
@@ -1,0 +1,2 @@
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/crates/languages/src/jsdoc/config.toml
+++ b/crates/languages/src/jsdoc/config.toml
@@ -1,0 +1,7 @@
+name = "JSDoc"
+grammar = "jsdoc"
+autoclose_before = "]}"
+brackets = [
+  { start = "{", end = "}", close = true, newline = false },
+  { start = "[", end = "]", close = true, newline = false },
+]

--- a/crates/languages/src/jsdoc/highlights.scm
+++ b/crates/languages/src/jsdoc/highlights.scm
@@ -1,0 +1,2 @@
+(tag_name) @keyword
+(type) @type

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -90,6 +90,7 @@ pub fn init(
         ("hcl", tree_sitter_hcl::language()),
         ("heex", tree_sitter_heex::language()),
         ("html", tree_sitter_html::language()),
+        ("jsdoc", tree_sitter_jsdoc::language()),
         ("json", tree_sitter_json::language()),
         ("lua", tree_sitter_lua::language()),
         ("markdown", tree_sitter_markdown::language()),
@@ -258,6 +259,7 @@ pub fn init(
                     Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
                 ]
             );
+            language!("jsdoc", vec![Arc::new(deno::DenoLspAdapter::new())]);
         }
         false => {
             language!(
@@ -282,6 +284,12 @@ pub fn init(
                     Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
                     Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
                 ]
+            );
+            language!(
+                "jsdoc",
+                vec![Arc::new(typescript::TypeScriptLspAdapter::new(
+                    node_runtime.clone(),
+                ))]
             );
         }
     }

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -1,0 +1,2 @@
+((comment) @content
+  (#set! "language" "jsdoc"))

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -1,0 +1,2 @@
+((comment) @content
+  (#set! "language" "jsdoc"))


### PR DESCRIPTION
![SCR-20240215-mokn](https://github.com/zed-industries/zed/assets/67913738/17750eb5-bf48-4e23-adc5-0f7a5e15a41b)

Closes zed-industries/zed#4926

Release Notes:

- Added support for [JSDoc](https://jsdoc.app) syntax highlighting ([#7224](https://github.com/zed-industries/zed/issues/7224)).
