### PR TITLE
Improve ruby highlighting

### DIFF
--- a/crates/zed/src/languages/ruby/highlights.scm
+++ b/crates/zed/src/languages/ruby/highlights.scm
@@ -30,8 +30,6 @@
   "yield"
 ] @keyword
 
-(identifier) @variable
-
 ((identifier) @keyword
  (#match? @keyword "^(private|protected|public)$"))
 
@@ -54,11 +52,6 @@
 
 ; Identifiers
 
-[
-  (class_variable)
-  (instance_variable)
-] @property
-
 ((identifier) @constant.builtin
  (#match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))
 
@@ -73,10 +66,18 @@
 ((constant) @constant
  (#match? @constant "^[A-Z\\d_]+$"))
 
+(global_variable) @constant
+
 (constant) @type
 
 (self) @variable.special
 (super) @variable.special
+
+[
+  (class_variable)
+  (instance_variable)
+] @variable.member
+
 
 ; Literals
 


### PR DESCRIPTION

Release Notes:

- Improved syntax-highlighting of identifiers in Ruby.

Before:

![screenshot-2024-02-15-14 40 19@2x](https://github.com/zed-industries/zed/assets/1185253/29fca0eb-7c0c-4aee-9f31-a8a3c6680cb9)

After:

![screenshot-2024-02-15-14 40 56@2x](https://github.com/zed-industries/zed/assets/1185253/2ce0e0c9-8689-4ff8-9f40-2ea5f6ccc2f6)
