### PR TITLE
Close modals and menus before dispathing actions

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -317,8 +317,8 @@ impl PickerDelegate for CommandPaletteDelegate {
         });
         let action = command.action;
         cx.focus(&self.previous_focus_handle);
-        cx.dispatch_action(action);
         self.dismissed(cx);
+        cx.dispatch_action(action);
     }
 
     fn render_match(

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -224,8 +224,8 @@ impl ContextMenu {
                     .timer(Duration::from_millis(50))
                     .await;
                 this.update(&mut cx, |this, cx| {
+                    this.cancel(&menu::Cancel, cx);
                     cx.dispatch_action(action);
-                    this.cancel(&menu::Cancel, cx)
                 })
             })
             .detach_and_log_err(cx);


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/7799 by forcing the modal to close before dispatching the action.
While not needed specifically for this case, changed the context menus to do the same, to be uniform — context menu actions seem to work properly after this change too.

Release Notes:

- Fixed markdown preview action not working ([7799](https://github.com/zed-industries/zed/issues/7799))