### PR TITLE
Add regex syntax highlighting for JS and TS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5328,6 +5328,7 @@ dependencies = [
  "tree-sitter-purescript",
  "tree-sitter-python",
  "tree-sitter-racket",
+ "tree-sitter-regex",
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scheme",
@@ -10660,6 +10661,16 @@ dependencies = [
 name = "tree-sitter-racket"
 version = "0.0.1"
 source = "git+https://github.com/zed-industries/tree-sitter-racket?rev=eb010cf2c674c6fd9a6316a84e28ef90190fe51a#eb010cf2c674c6fd9a6316a84e28ef90190fe51a"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-regex"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb5a53e9c990757895476216796b170fd81e4d173d08f8b082279c4e6ff8c5c"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,7 @@ tree-sitter-proto = { git = "https://github.com/rewinfrey/tree-sitter-proto", re
 tree-sitter-purescript = { git = "https://github.com/postsolar/tree-sitter-purescript", rev = "v0.1.0" }
 tree-sitter-python = "0.20.2"
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a" }
+tree-sitter-regex = "0.20.0"
 tree-sitter-ruby = "0.20.0"
 tree-sitter-rust = "0.20.3"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9" }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -71,6 +71,7 @@ tree-sitter-proto.workspace = true
 tree-sitter-purescript.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-racket.workspace = true
+tree-sitter-regex.workspace = true
 tree-sitter-ruby.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-scheme.workspace = true

--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -1,2 +1,5 @@
 ((comment) @content
   (#set! "language" "jsdoc"))
+  
+((regex) @content
+  (#set! "language" "regex"))

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -107,6 +107,7 @@ pub fn init(
         ("purescript", tree_sitter_purescript::language()),
         ("python", tree_sitter_python::language()),
         ("racket", tree_sitter_racket::language()),
+        ("regex", tree_sitter_regex::language()),
         ("ruby", tree_sitter_ruby::language()),
         ("rust", tree_sitter_rust::language()),
         ("scheme", tree_sitter_scheme::language()),
@@ -312,6 +313,7 @@ pub fn init(
     );
     language!("scheme");
     language!("racket");
+    language!("regex");
     language!("lua", vec![Arc::new(lua::LuaLspAdapter)]);
     language!(
         "yaml",

--- a/crates/languages/src/regex/brackets.scm
+++ b/crates/languages/src/regex/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/crates/languages/src/regex/config.toml
+++ b/crates/languages/src/regex/config.toml
@@ -1,0 +1,8 @@
+name = "Regex"
+grammar = "regex"
+autoclose_before = ")]}"
+brackets = [
+  { start = "(", end = ")", close = true, newline = false },
+  { start = "{", end = "}", close = true, newline = false },
+  { start = "[", end = "]", close = true, newline = false },
+]

--- a/crates/languages/src/regex/highlights.scm
+++ b/crates/languages/src/regex/highlights.scm
@@ -1,0 +1,50 @@
+[
+  "("
+  ")"
+  "(?"
+  "(?:"
+  "(?<"
+  ">"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(group_name) @property
+
+[
+  (identity_escape)
+  (control_letter_escape)
+  (character_class_escape)
+  (control_escape)
+  (start_assertion)
+  (end_assertion)
+  (boundary_assertion)
+  (non_boundary_assertion)
+] @escape
+
+[
+  "*"
+  "+"
+  "?"
+  "|"
+  "="
+  "!"
+] @operator
+
+(count_quantifier
+  [
+    (decimal_digits) @number
+    "," @punctuation.delimiter
+  ])
+
+(character_class
+  [
+    "^" @operator
+    (class_range "-" @operator)
+  ])
+
+(class_character) @constant.character
+
+(pattern_character) @string

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -1,2 +1,5 @@
 ((comment) @content
   (#set! "language" "jsdoc"))
+
+((regex) @content
+  (#set! "language" "regex"))

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -1,2 +1,5 @@
 ((comment) @content
   (#set! "language" "jsdoc"))
+
+((regex) @content
+  (#set! "language" "regex"))


### PR DESCRIPTION
<img width="544" alt="SCR-20240215-pvzy" src="https://github.com/zed-industries/zed/assets/67913738/e4d463a6-1795-4728-ac24-6c8e03e7ea5b">

Release Notes:

- Added support for regex syntax highlighting in `JS` and `TS`.