### PR TITLE
Add default language server settings to display inlay hints for Go and TypeScript

### DIFF
--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -174,6 +174,15 @@ impl super::LspAdapter for GoLspAdapter {
     fn initialization_options(&self) -> Option<serde_json::Value> {
         Some(json!({
             "usePlaceholders": true,
+            "hints": {
+                "assignVariableTypes": true,
+                "compositeLiteralFields": true,
+                "compositeLiteralTypes": true,
+                "constantValues": true,
+                "functionTypeParameters": true,
+                "parameterNames": true,
+                "rangeVariableTypes": true
+            }
         }))
     }
 

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -160,6 +160,16 @@ impl LspAdapter for TypeScriptLspAdapter {
             "tsserver": {
                 "path": "node_modules/typescript/lib",
             },
+            "preferences": {
+                "includeInlayParameterNameHints": "all",
+                "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
+                "includeInlayFunctionParameterTypeHints": true,
+                "includeInlayVariableTypeHints": true,
+                "includeInlayVariableTypeHintsWhenTypeMatchesName": true,
+                "includeInlayPropertyDeclarationTypeHints": true,
+                "includeInlayFunctionLikeReturnTypeHints": true,
+                "includeInlayEnumMemberValueHints": true,
+            }
         }))
     }
 

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -3,6 +3,40 @@
 - Tree Sitter: [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go)
 - Language Server: [gopls](https://github.com/golang/tools/tree/master/gopls)
 
+## Inlay Hints
+
+Zed sets the following initialization options for inlay hints:
+
+```json
+"hints": {
+    "assignVariableTypes": true,
+    "compositeLiteralFields": true,
+    "compositeLiteralTypes": true,
+    "constantValues": true,
+    "functionTypeParameters": true,
+    "parameterNames": true,
+    "rangeVariableTypes": true
+}
+```
+
+to make the language server send back inlay hints when Zed has them enabled in the settings.
+
+Use
+```json
+"lsp": {
+    "$LANGUAGE_SERVER_NAME": {
+        "initialization_options": {
+            "hints": {
+                ....
+            }
+        }
+    }
+}
+```
+to override these settings.
+
+See https://github.com/golang/tools/blob/master/gopls/doc/inlayHints.md for more information.
+
 # Go Mod
 
 - Tree Sitter: [tree-sitter-gomod](https://github.com/camdencheek/tree-sitter-go-mod)

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -2,3 +2,38 @@
 
 - Tree Sitter: [tree-sitter-typescript](https://github.com/tree-sitter/tree-sitter-typescript)
 - Language Server: [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
+
+## Inlay Hints
+
+Zed sets the following initialization options for inlay hints:
+
+```json
+"preferences": {
+    "includeInlayParameterNameHints": "all",
+    "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
+    "includeInlayFunctionParameterTypeHints": true,
+    "includeInlayVariableTypeHints": true,
+    "includeInlayVariableTypeHintsWhenTypeMatchesName": true,
+    "includeInlayPropertyDeclarationTypeHints": true,
+    "includeInlayFunctionLikeReturnTypeHints": true,
+    "includeInlayEnumMemberValueHints": true,
+}
+```
+
+to make the language server send back inlay hints when Zed has them enabled in the settings.
+
+Use
+```json
+"lsp": {
+    "$LANGUAGE_SERVER_NAME": {
+        "initialization_options": {
+            "preferences": {
+                ....
+            }
+        }
+    }
+}
+```
+to override these settings.
+
+See https://github.com/typescript-language-server/typescript-language-server?tab=readme-ov-file#inlay-hints-textdocumentinlayhint for more information.


### PR DESCRIPTION
Hints are still disabled by default in Zed, but when those get enabled, the language server settings allow to display those instantly without further server configuration, which might be not obvious. Also add the documentation enties for those settings and their defaults in Zed.

Closes https://github.com/zed-industries/zed/issues/7821

Release Notes:

- Added default settings for TypeScript and Go LSP servers to enable inlay hints when those are turned on in Zed ([7821](https://github.com/zed-industries/zed/issues/7821))