### PR TITLE
Add `"code_actions_on_format"`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -482,6 +482,7 @@
   "deno": {
     "enable": false
   },
+  "code_actions_on_format": {},
   // Different settings for specific languages.
   "languages": {
     "Plain Text": {
@@ -492,7 +493,10 @@
     },
     "Go": {
       "tab_size": 4,
-      "hard_tabs": true
+      "hard_tabs": true,
+      "code_actions_on_format": {
+        "source.organizeImports": true
+      }
     },
     "Markdown": {
       "soft_wrap": "preferred_line_length"

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -704,10 +704,12 @@ impl Item for Editor {
 
     fn save(&mut self, project: Model<Project>, cx: &mut ViewContext<Self>) -> Task<Result<()>> {
         self.report_editor_event("save", None, cx);
-        let format = self.perform_format(project.clone(), FormatTrigger::Save, cx);
         let buffers = self.buffer().clone().read(cx).all_buffers();
-        cx.spawn(|_, mut cx| async move {
-            format.await?;
+        cx.spawn(|this, mut cx| async move {
+            this.update(&mut cx, |this, cx| {
+                this.perform_format(project.clone(), FormatTrigger::Save, cx)
+            })?
+            .await?;
 
             if buffers.len() == 1 {
                 project

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -93,6 +93,8 @@ pub struct LanguageSettings {
     pub inlay_hints: InlayHintSettings,
     /// Whether to automatically close brackets.
     pub use_autoclose: bool,
+    /// Which code actions to run on save
+    pub code_actions_on_format: HashMap<String, bool>,
 }
 
 /// The settings for [GitHub Copilot](https://github.com/features/copilot).
@@ -215,6 +217,11 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub use_autoclose: Option<bool>,
+
+    /// Which code actions to run on save
+    ///
+    /// Default: {} (or {"source.organizeImports": true} for Go).
+    pub code_actions_on_format: Option<HashMap<String, bool>>,
 }
 
 /// The contents of the GitHub Copilot settings.
@@ -550,6 +557,10 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
     merge(&mut settings.use_autoclose, src.use_autoclose);
     merge(&mut settings.show_wrap_guides, src.show_wrap_guides);
     merge(&mut settings.wrap_guides, src.wrap_guides.clone());
+    merge(
+        &mut settings.code_actions_on_format,
+        src.code_actions_on_format.clone(),
+    );
 
     merge(
         &mut settings.preferred_line_length,

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -123,6 +123,7 @@ pub(crate) struct GetCompletions {
 
 pub(crate) struct GetCodeActions {
     pub range: Range<Anchor>,
+    pub kinds: Option<Vec<lsp::CodeActionKind>>,
 }
 
 pub(crate) struct OnTypeFormatting {
@@ -1603,7 +1604,10 @@ impl LspCommand for GetCodeActions {
             partial_result_params: Default::default(),
             context: lsp::CodeActionContext {
                 diagnostics: relevant_diagnostics,
-                only: language_server.code_action_kinds(),
+                only: self
+                    .kinds
+                    .clone()
+                    .or_else(|| language_server.code_action_kinds()),
                 ..lsp::CodeActionContext::default()
             },
         }
@@ -1664,7 +1668,10 @@ impl LspCommand for GetCodeActions {
             })?
             .await?;
 
-        Ok(Self { range: start..end })
+        Ok(Self {
+            range: start..end,
+            kinds: None,
+        })
     }
 
     fn response_to_proto(


### PR DESCRIPTION
This lets Go programmers configure `"code_actions_on_format": {
  "source.organizeImports": true,
}` so that they don't have to manage their imports manually

I landed on `code_actions_on_format` instead of `code_actions_on_save` (the
VSCode version of this) because I want to run these when I explicitly format
(and not if `format_on_save` is disabled).

Co-Authored-By: Thorsten <thorsten@zed.dev>

Release Notes:

- Added `"code_actions_on_format"` to control additional formatting steps on format/save ([#5232](https://github.com/zed-industries/zed/issues/5232)).
- Added a `"code_actions_on_format"` of `"source.organizeImports"` for Go ([#4886](https://github.com/zed-industries/zed/issues/4886)).
