### PR TITLE
Display extension download counts

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -42,6 +42,7 @@ pub struct Extension {
     pub description: Option<String>,
     pub authors: Vec<String>,
     pub repository: String,
+    pub download_count: usize,
 }
 
 #[derive(Clone)]

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -236,18 +236,24 @@ impl ExtensionsPage {
                         ),
                 )
                 .child(
-                    h_flex().justify_between().child(
-                        Label::new(format!(
-                            "{}: {}",
-                            if extension.authors.len() > 1 {
-                                "Authors"
-                            } else {
-                                "Author"
-                            },
-                            extension.authors.join(", ")
-                        ))
-                        .size(LabelSize::Small),
-                    ),
+                    h_flex()
+                        .justify_between()
+                        .child(
+                            Label::new(format!(
+                                "{}: {}",
+                                if extension.authors.len() > 1 {
+                                    "Authors"
+                                } else {
+                                    "Author"
+                                },
+                                extension.authors.join(", ")
+                            ))
+                            .size(LabelSize::Small),
+                        )
+                        .child(
+                            Label::new(format!("Downloads: {}", extension.download_count))
+                                .size(LabelSize::Small),
+                        ),
                 )
                 .child(
                     h_flex()


### PR DESCRIPTION
This PR adds the download count for extensions to the extensions view.

Release Notes:

- Added download counts for extensions to the extensions view.

