### PR TITLE
Secondarily sort by extension name instead of ID

### DIFF
--- a/crates/collab/src/db/queries/extensions.rs
+++ b/crates/collab/src/db/queries/extensions.rs
@@ -16,7 +16,7 @@ impl Database {
             let extensions = extension::Entity::find()
                 .filter(condition)
                 .order_by_desc(extension::Column::TotalDownloadCount)
-                .order_by_asc(extension::Column::Id)
+                .order_by_asc(extension::Column::Name)
                 .limit(Some(limit as u64))
                 .filter(
                     extension::Column::LatestVersion


### PR DESCRIPTION
This PR makes it so extensions are secondarily sorted by their name (instead of by ID) after we sort them by their download count.

Release Notes:

- N/A
