### PR TITLE
Add button link to extension repository

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -200,6 +200,8 @@ impl ExtensionsPage {
         }
         .color(Color::Accent);
 
+        let repository_url = extension.repository.clone();
+
         div().w_full().child(
             v_flex()
                 .w_full()
@@ -262,7 +264,18 @@ impl ExtensionsPage {
                             Label::new(description.clone())
                                 .size(LabelSize::Small)
                                 .color(Color::Default)
-                        })),
+                        }))
+                        .child(
+                            IconButton::new(
+                                SharedString::from(format!("repository-{}", extension.id)),
+                                IconName::Github,
+                            )
+                            .icon_size(IconSize::Small)
+                            .style(ButtonStyle::Filled)
+                            .on_click(cx.listener(move |_, _, cx| {
+                                cx.open_url(&repository_url);
+                            })),
+                        ),
                 ),
         )
     }

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -270,6 +270,7 @@ impl ExtensionsPage {
                                 SharedString::from(format!("repository-{}", extension.id)),
                                 IconName::Github,
                             )
+                            .icon_color(Color::Accent)
                             .icon_size(IconSize::Small)
                             .style(ButtonStyle::Filled)
                             .on_click(cx.listener(move |_, _, cx| {


### PR DESCRIPTION
Fixes: https://github.com/zed-industries/zed/issues/7873

<img width="1165" alt="image" src="https://github.com/zed-industries/zed/assets/19867440/2338519c-bd48-4716-9f88-ed155b0dad67">

Release Notes:

- Added a button to link to an extension's repository ([#7873]( https://github.com/zed-industries/zed/issues/7873)).