### PR TITLE
Replace `full` with `size_full`

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -733,7 +733,7 @@ impl Render for ChatPanel {
         v_flex()
             .key_context("ChatPanel")
             .track_focus(&self.focus_handle)
-            .full()
+            .size_full()
             .on_action(cx.listener(Self::send))
             .child(
                 h_flex().z_index(1).child(
@@ -755,11 +755,11 @@ impl Render for ChatPanel {
             )
             .child(div().flex_grow().px_2().map(|this| {
                 if self.active_chat.is_some() {
-                    this.child(list(self.message_list.clone()).full())
+                    this.child(list(self.message_list.clone()).size_full())
                 } else {
                     this.child(
                         div()
-                            .full()
+                            .size_full()
                             .p_4()
                             .child(
                                 Label::new("Select a channel to chat in.")

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2036,7 +2036,7 @@ impl CollabPanel {
     fn render_signed_in(&mut self, cx: &mut ViewContext<Self>) -> Div {
         v_flex()
             .size_full()
-            .child(list(self.list_state.clone()).full())
+            .child(list(self.list_state.clone()).size_full())
             .child(
                 v_flex()
                     .child(div().mx_2().border_primary(cx).border_t())

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -21,13 +21,6 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Sets the size of the element to sthe full width and height.
-    fn full(mut self) -> Self {
-        self.style().size.width = Some(relative(1.).into());
-        self.style().size.height = Some(relative(1.).into());
-        self
-    }
-
     /// Sets the position of the element to `relative`.
     /// [Docs](https://tailwindcss.com/docs/position)
     fn relative(mut self) -> Self {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -209,13 +209,13 @@ impl Render for MarkdownPreviewView {
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")
             .track_focus(&self.focus_handle)
-            .full()
+            .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()
             .child(
                 div()
                     .flex_grow()
-                    .map(|this| this.child(list(self.list_state.clone()).full())),
+                    .map(|this| this.child(list(self.list_state.clone()).size_full())),
             )
     }
 }

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -61,7 +61,7 @@ pub struct WelcomePage {
 impl Render for WelcomePage {
     fn render(&mut self, cx: &mut gpui::ViewContext<Self>) -> impl IntoElement {
         h_flex()
-            .full()
+            .size_full()
             .bg(cx.theme().colors().editor_background)
             .track_focus(&self.focus_handle)
             .child(


### PR DESCRIPTION
This PR removes the `full` style method and replaces it with `size_full`, as the two do the same thing.

This is the generated code for `size_full`:

```rs
#[doc = "Sets the width and height of the element.\n\n100%"]
fn size_full(mut self) -> Self {
    let style = self.style();
    style.size.width = Some((gpui::relative(1.)).into());
    style.size.height = Some((gpui::relative(1.)).into());
    self
}
```

Release Notes:

- N/A
