### PR TITLE
Add blob store to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,17 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./docker-compose.sql:/docker-entrypoint-initdb.d/init.sql
 
+  blob_store:
+    image: quay.io/minio/minio
+    container_name: blob_store
+    command: server /data
+    ports:
+      - 9000:9000
+    environment:
+      MINIO_ROOT_USER: the-blob-store-access-key
+      MINIO_ROOT_PASSWORD: the-blob-store-secret-key
+    volumes:
+      - ./.blob_store:/data
+
 volumes:
   postgres_data:


### PR DESCRIPTION
This PR adds the local blob store—backed by [MinIO](https://github.com/minio/minio)—to the Docker Compose setup.

This allows running the blob store locally all within a container.

Release Notes:

- N/A
