### PR TITLE
Highlight escape sequences in TypeScript/JavaScript

### DIFF
--- a/crates/zed/src/languages/javascript/highlights.scm
+++ b/crates/zed/src/languages/javascript/highlights.scm
@@ -77,6 +77,8 @@
   (template_string)
 ] @string
 
+(escape_sequence) @string.escape
+
 (regex) @string.regex
 (number) @number
 

--- a/crates/zed/src/languages/tsx/highlights.scm
+++ b/crates/zed/src/languages/tsx/highlights.scm
@@ -80,6 +80,8 @@
   (template_string)
 ] @string
 
+(escape_sequence) @string.escape
+
 (regex) @string.regex
 (number) @number
 

--- a/crates/zed/src/languages/typescript/highlights.scm
+++ b/crates/zed/src/languages/typescript/highlights.scm
@@ -80,6 +80,8 @@
   (template_string)
 ] @string
 
+(escape_sequence) @string.escape
+
 (regex) @string.regex
 (number) @number
 


### PR DESCRIPTION
Ran into this while hacking on TypeScript/React/TSX...

Release Notes:


- N/A

![screenshot-2024-02-16-07 03 56@2x](https://github.com/zed-industries/zed/assets/1185253/e6725a1e-7653-4316-abd0-280ea8818d66)
