### PR TITLE
Revert "Upgrade to Taffy 0.4"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.13.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d196ffc1627db18a531359249b2bf8416178d84b729f3cebeb278f285fb9b58c"
+checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
 
 [[package]]
 name = "group"
@@ -9103,14 +9103,12 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddbee94e20bc4612dcb789953324236eebd4fc6a08c650ccbf7f615e59a0d6a"
+version = "0.3.11"
+source = "git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b#1876f72bee5e376023eaa518aa7b8a34c769bd1b"
 dependencies = [
  "arrayvec 0.7.4",
  "grid",
  "num-traits",
- "serde",
  "slotmap",
 ]
 

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -60,7 +60,7 @@ slotmap = "1.0.6"
 smallvec.workspace = true
 smol.workspace = true
 sum_tree.workspace = true
-taffy = "0.4"
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
 thiserror.workspace = true
 time.workspace = true
 tiny-skia = "0.5"

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -6,15 +6,17 @@ use collections::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::fmt::Debug;
 use taffy::{
-    AvailableSpace as TaffyAvailableSpace, NodeId, Point as TaffyPoint, Rect as TaffyRect,
-    Size as TaffySize, TaffyTree, TraversePartialTree,
+    geometry::{Point as TaffyPoint, Rect as TaffyRect, Size as TaffySize},
+    style::AvailableSpace as TaffyAvailableSpace,
+    tree::NodeId,
+    Taffy,
 };
 
 type NodeMeasureFn =
     Box<dyn FnMut(Size<Option<Pixels>>, Size<AvailableSpace>, &mut WindowContext) -> Size<Pixels>>;
 
 pub struct TaffyLayoutEngine {
-    taffy: TaffyTree<()>,
+    taffy: Taffy,
     styles: FxHashMap<LayoutId, Style>,
     children_to_parents: FxHashMap<LayoutId, LayoutId>,
     absolute_layout_bounds: FxHashMap<LayoutId, Bounds<Pixels>>,
@@ -27,7 +29,7 @@ static EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by constructi
 impl TaffyLayoutEngine {
     pub fn new() -> Self {
         TaffyLayoutEngine {
-            taffy: TaffyTree::new(),
+            taffy: Taffy::new(),
             styles: FxHashMap::default(),
             children_to_parents: FxHashMap::default(),
             absolute_layout_bounds: FxHashMap::default(),
@@ -118,7 +120,7 @@ impl TaffyLayoutEngine {
     fn max_depth(&self, depth: u32, parent: LayoutId) -> anyhow::Result<u32> {
         println!(
             "{parent:?} at depth {depth} has {} children",
-            self.taffy.child_count(parent.0)
+            self.taffy.child_count(parent.0)?
         );
 
         let mut max_child_depth = 0;


### PR DESCRIPTION
Reverts zed-industries/zed#7868

@nicoburns: this seems to break text input in the chat panel, so reverting this for now.

<img width="365" alt="image" src="https://github.com/zed-industries/zed/assets/482957/fc47eee9-6049-49c2-be2c-fb91f7d35caf">

It would be great to upgrade to Taffy 0.4 though, so we should figure out why that particular input breaks.

Release notes:

- N/A