### PR TITLE
Add Prettier support for Vue, Markdown and PHP

### DIFF
--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -245,6 +245,8 @@ impl Prettier {
                                 prettier_plugin_dir.join("index.mjs"),
                                 prettier_plugin_dir.join("index.js"),
                                 prettier_plugin_dir.join("plugin.js"),
+                                // this one is for @prettier/plugin-php
+                                prettier_plugin_dir.join("standalone.js"),
                                 prettier_plugin_dir,
                             ] {
                                 if possible_plugin_path.is_file() {

--- a/crates/zed/src/languages/markdown/config.toml
+++ b/crates/zed/src/languages/markdown/config.toml
@@ -11,3 +11,4 @@ brackets = [
     { start = "'", end = "'", close = false, newline = false },
     { start = "`", end = "`", close = false, newline = false },
 ]
+prettier_parser_name = "markdown"

--- a/crates/zed/src/languages/php.rs
+++ b/crates/zed/src/languages/php.rs
@@ -102,6 +102,10 @@ impl LspAdapter for IntelephenseLspAdapter {
     fn language_ids(&self) -> HashMap<String, String> {
         HashMap::from_iter([("PHP".into(), "php".into())])
     }
+
+    fn prettier_plugins(&self) -> &[&'static str] {
+        &["@prettier/plugin-php"]
+    }
 }
 
 async fn get_cached_server_binary(

--- a/crates/zed/src/languages/php/config.toml
+++ b/crates/zed/src/languages/php/config.toml
@@ -14,3 +14,4 @@ brackets = [
 collapsed_placeholder = "/* ... */"
 word_characters = ["$"]
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
+prettier_parser_name = "php"

--- a/crates/zed/src/languages/vue/config.toml
+++ b/crates/zed/src/languages/vue/config.toml
@@ -13,3 +13,4 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false, not_in = ["string"] },
 ]
 word_characters = ["-"]
+prettier_parser_name = "vue"


### PR DESCRIPTION
Current prettier support w/i Zed leaves out a few languages that are officially supported by prettier. In particular, Vue and Markdown are supported by the core prettier project, and PHP is supported via an official plugin. I didn't see any open issues for this, but I have been wondering for months why `"formatter": "prettier"` wasn't working on my PHP files. Now that Zed is open source, I was able to find out why, and fix it. :smile:

I have been using this with PHP files daily for a week+ now, and I have also used it successfully with Vue and Markdown files, though not as extensively. I looked around and did not see any tests for specific prettier language integrations, but if I missed them please let me know and I'll add some tests.

**Notes**
-  I did not add support for Ruby (which has an official prettier plugin) because it seems to require some external dependencies (notably, Rudy and some Gems). When those are present on the system and `$PATH`, prettier will will work just fine on Ruby files if the plugin is set up similar to how the PHP plugin is set up (I tried it), and I can add that in here, if desired. The PHP plugin is pure JS (as I recall) and doesn't have this issue.
- I did *not* add support for languages that have "community" plugins, though I do note that Zed already ships with prettier support for svelte enabled, which – if I understand correctly – is powered by a community plugin. If desired, I could look at adding support/configuration to enable prettier support for things like elm, erb, glsl, bash, toml. Bash, in particular, *I* would find useful. :smile:

Release Notes:

- Added prettier support for Vue, Markdown and PHP
