### PR TITLE
Add LiveKit server to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,16 @@ services:
     volumes:
       - ./.blob_store:/data
 
+  livekit_server:
+    image: livekit/livekit-server
+    container_name: livekit_server
+    entrypoint: /livekit-server --config /livekit.yaml
+    ports:
+      - 7880:7880
+      - 7881:7881
+      - 7882:7882/udp
+    volumes:
+      - ./livekit.yaml:/livekit.yaml
+
 volumes:
   postgres_data:

--- a/livekit.yaml
+++ b/livekit.yaml
@@ -1,0 +1,10 @@
+development: true
+port: 7880
+rtc:
+  udp_port: 7882
+  tcp_port: 7881
+  use_external_ip: false
+keys:
+  devkey: secret
+logging:
+  level: debug


### PR DESCRIPTION
This PR adds the LiveKit server to the Docker Compose setup.

All of the dependencies needed to run the collab server are now encapsulated within Docker Compose.

Release Notes:

- N/A
