### PR TITLE
Mention Docker Compose in the collab docs

### DIFF
--- a/docs/src/developing_zed__building_zed.md
+++ b/docs/src/developing_zed__building_zed.md
@@ -44,6 +44,12 @@ If you are developing collaborative features of Zed, you'll need to install the 
   brew install livekit foreman
   ```
 
+Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
+
+```sh
+docker compose up -d
+```
+
 ## Building Zed from Source
 
 Once you have the dependencies installed, you can build Zed using [Cargo](https://doc.rust-lang.org/cargo/).


### PR DESCRIPTION
This PR adds a note about using Docker Compose to run the `collab` dependencies.

Release Notes:

- N/A

