### PR TITLE
Don't use stale layout when view cache is invalidated in GPUI

### DIFF
--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -282,12 +282,13 @@ impl Element for AnyView {
         cx: &mut ElementContext,
     ) -> (LayoutId, Self::State) {
         cx.with_view_id(self.entity_id(), |cx| {
-            if self.cache {
-                if !cx.window.dirty_views.contains(&self.entity_id()) && !cx.window.refreshing {
-                    if let Some(state) = state {
-                        let layout_id = cx.request_layout(&state.root_style, None);
-                        return (layout_id, state);
-                    }
+            if self.cache
+                && !cx.window.dirty_views.contains(&self.entity_id())
+                && !cx.window.refreshing
+            {
+                if let Some(state) = state {
+                    let layout_id = cx.request_layout(&state.root_style, None);
+                    return (layout_id, state);
                 }
             }
 

--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -283,9 +283,11 @@ impl Element for AnyView {
     ) -> (LayoutId, Self::State) {
         cx.with_view_id(self.entity_id(), |cx| {
             if self.cache {
-                if let Some(state) = state {
-                    let layout_id = cx.request_layout(&state.root_style, None);
-                    return (layout_id, state);
+                if !cx.window.dirty_views.contains(&self.entity_id()) && !cx.window.refreshing {
+                    if let Some(state) = state {
+                        let layout_id = cx.request_layout(&state.root_style, None);
+                        return (layout_id, state);
+                    }
                 }
             }
 
@@ -313,8 +315,6 @@ impl Element for AnyView {
                     && cache_key.content_mask == cx.content_mask()
                     && cache_key.stacking_order == *cx.stacking_order()
                     && cache_key.text_style == cx.text_style()
-                    && !cx.window.dirty_views.contains(&self.entity_id())
-                    && !cx.window.refreshing
                 {
                     cx.reuse_view(state.next_stacking_order_id);
                     return;


### PR DESCRIPTION
When a view is invalidated, we want to participate in Taffy layout with an accurate style rather than the dummy style we use when a view is cached. Previously, we only detected invalidation during paint. This adds logic to layout as well to avoid using the dummy style when dirty.

Release Notes:

- N/A
