### PR TITLE
Remove comment

### DIFF
--- a/crates/gpui/src/platform/linux/blade_atlas.rs
+++ b/crates/gpui/src/platform/linux/blade_atlas.rs
@@ -200,7 +200,7 @@ impl BladeAtlasState {
     }
 
     fn upload_texture(&mut self, id: AtlasTextureId, bounds: Bounds<DevicePixels>, bytes: &[u8]) {
-        let data = self.upload_belt.alloc_data(bytes, &self.gpu);
+        let data = unsafe { self.upload_belt.alloc_data(bytes, &self.gpu) };
         self.uploads.push(PendingUpload { id, bounds, data });
     }
 

--- a/crates/gpui/src/platform/linux/blade_belt.rs
+++ b/crates/gpui/src/platform/linux/blade_belt.rs
@@ -75,7 +75,6 @@ impl BladeBelt {
         chunk.into()
     }
 
-    //todo!(linux): enforce T: bytemuck::Zeroable
     pub fn alloc_data<T>(&mut self, data: &[T], gpu: &gpu::Context) -> gpu::BufferPiece {
         assert!(!data.is_empty());
         let type_alignment = mem::align_of::<T>() as u64;

--- a/crates/gpui/src/platform/linux/blade_belt.rs
+++ b/crates/gpui/src/platform/linux/blade_belt.rs
@@ -75,6 +75,7 @@ impl BladeBelt {
         chunk.into()
     }
 
+    // SAFETY: T should be zeroable and ordinary data, no references, pointers, cells or other complicated data type.
     pub fn alloc_data<T>(&mut self, data: &[T], gpu: &gpu::Context) -> gpu::BufferPiece {
         assert!(!data.is_empty());
         let type_alignment = mem::align_of::<T>() as u64;

--- a/crates/gpui/src/platform/linux/blade_belt.rs
+++ b/crates/gpui/src/platform/linux/blade_belt.rs
@@ -76,7 +76,7 @@ impl BladeBelt {
     }
 
     // SAFETY: T should be zeroable and ordinary data, no references, pointers, cells or other complicated data type.
-    pub fn alloc_data<T>(&mut self, data: &[T], gpu: &gpu::Context) -> gpu::BufferPiece {
+    pub unsafe fn alloc_data<T>(&mut self, data: &[T], gpu: &gpu::Context) -> gpu::BufferPiece {
         assert!(!data.is_empty());
         let type_alignment = mem::align_of::<T>() as u64;
         debug_assert_eq!(

--- a/crates/gpui/src/platform/linux/blade_renderer.rs
+++ b/crates/gpui/src/platform/linux/blade_renderer.rs
@@ -340,7 +340,7 @@ impl BladeRenderer {
                 pad: [0; 2],
             };
 
-            let vertex_buf = self.instance_belt.alloc_data(&vertices, &self.gpu);
+            let vertex_buf = unsafe { self.instance_belt.alloc_data(&vertices, &self.gpu) };
             let mut pass = self.command_encoder.render(gpu::RenderTargetSet {
                 colors: &[gpu::RenderTarget {
                     view: tex_info.raw_view,
@@ -389,7 +389,8 @@ impl BladeRenderer {
             for batch in scene.batches() {
                 match batch {
                     PrimitiveBatch::Quads(quads) => {
-                        let instance_buf = self.instance_belt.alloc_data(quads, &self.gpu);
+                        let instance_buf =
+                            unsafe { self.instance_belt.alloc_data(quads, &self.gpu) };
                         let mut encoder = pass.with(&self.pipelines.quads);
                         encoder.bind(
                             0,
@@ -401,7 +402,8 @@ impl BladeRenderer {
                         encoder.draw(0, 4, 0, quads.len() as u32);
                     }
                     PrimitiveBatch::Shadows(shadows) => {
-                        let instance_buf = self.instance_belt.alloc_data(shadows, &self.gpu);
+                        let instance_buf =
+                            unsafe { self.instance_belt.alloc_data(shadows, &self.gpu) };
                         let mut encoder = pass.with(&self.pipelines.shadows);
                         encoder.bind(
                             0,
@@ -428,7 +430,8 @@ impl BladeRenderer {
                                 tile: (*tile).clone(),
                             }];
 
-                            let instance_buf = self.instance_belt.alloc_data(&sprites, &self.gpu);
+                            let instance_buf =
+                                unsafe { self.instance_belt.alloc_data(&sprites, &self.gpu) };
                             encoder.bind(
                                 0,
                                 &ShaderPathsData {
@@ -442,7 +445,8 @@ impl BladeRenderer {
                         }
                     }
                     PrimitiveBatch::Underlines(underlines) => {
-                        let instance_buf = self.instance_belt.alloc_data(underlines, &self.gpu);
+                        let instance_buf =
+                            unsafe { self.instance_belt.alloc_data(underlines, &self.gpu) };
                         let mut encoder = pass.with(&self.pipelines.underlines);
                         encoder.bind(
                             0,
@@ -458,7 +462,8 @@ impl BladeRenderer {
                         sprites,
                     } => {
                         let tex_info = self.atlas.get_texture_info(texture_id);
-                        let instance_buf = self.instance_belt.alloc_data(sprites, &self.gpu);
+                        let instance_buf =
+                            unsafe { self.instance_belt.alloc_data(sprites, &self.gpu) };
                         let mut encoder = pass.with(&self.pipelines.mono_sprites);
                         encoder.bind(
                             0,
@@ -476,7 +481,8 @@ impl BladeRenderer {
                         sprites,
                     } => {
                         let tex_info = self.atlas.get_texture_info(texture_id);
-                        let instance_buf = self.instance_belt.alloc_data(sprites, &self.gpu);
+                        let instance_buf =
+                            unsafe { self.instance_belt.alloc_data(sprites, &self.gpu) };
                         let mut encoder = pass.with(&self.pipelines.poly_sprites);
                         encoder.bind(
                             0,


### PR DESCRIPTION
Per https://github.com/zed-industries/zed/pull/7814, this is more trouble than it's worth. As these functions are never exposed to the user of GPUI, we can just manually audit and enforce the relevant rules.

Release Notes:

- N/A