### PR TITLE
Upgrade `toml` to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
  "tempfile",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2065,7 +2065,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
- "toml",
+ "toml 0.8.10",
  "tonic",
  "tower",
  "tracing",
@@ -3283,7 +3283,7 @@ dependencies = [
  "serde_json",
  "settings",
  "theme",
- "toml",
+ "toml 0.8.10",
  "util",
 ]
 
@@ -4921,7 +4921,7 @@ dependencies = [
  "sum_tree",
  "text",
  "theme",
- "toml",
+ "toml 0.8.10",
  "tree-sitter",
  "tree-sitter-elixir",
  "tree-sitter-embedded-template",
@@ -6822,7 +6822,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -6832,7 +6832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -6930,7 +6930,7 @@ dependencies = [
  "terminal",
  "text",
  "thiserror",
- "toml",
+ "toml 0.8.10",
  "unindent",
  "util",
 ]
@@ -8402,6 +8402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8435,7 +8444,7 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "smallvec",
- "toml",
+ "toml 0.8.10",
  "tree-sitter",
  "tree-sitter-json 0.19.0",
  "unindent",
@@ -9490,7 +9499,7 @@ dependencies = [
  "serde_repr",
  "settings",
  "story",
- "toml",
+ "toml 0.8.10",
  "util",
  "uuid 1.4.1",
 ]
@@ -9808,10 +9817,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.3"
+name = "toml"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.6",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -9821,7 +9845,20 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.1",
 ]
 
 [[package]]
@@ -11599,6 +11636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11923,7 +11969,7 @@ dependencies = [
  "theme_selector",
  "thiserror",
  "tiny_http",
- "toml",
+ "toml 0.8.10",
  "tree-sitter",
  "tree-sitter-astro",
  "tree-sitter-bash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ tempfile = "3.9.0"
 thiserror = "1.0.29"
 tiktoken-rs = "0.5.7"
 time = { version = "0.3", features = ["serde", "serde-well-known", "formatting"] }
-toml = "0.5"
+toml = "0.8"
 tree-sitter = { version = "0.20", features = ["wasm"] }
 tree-sitter-astro = { git = "https://github.com/virchau13/tree-sitter-astro.git", rev = "e924787e12e8a03194f36a113290ac11d6dc10f3" }
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "7331995b19b8f8aba2d5e26deb51d2195c18bc94" }

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -415,8 +415,8 @@ impl ExtensionStore {
                 language.matcher.clone(),
                 vec![],
                 move || {
-                    let config = std::fs::read(language_path.join("config.toml"))?;
-                    let config: LanguageConfig = ::toml::from_slice(&config)?;
+                    let config = std::fs::read_to_string(language_path.join("config.toml"))?;
+                    let config: LanguageConfig = ::toml::from_str(&config)?;
                     let queries = load_plugin_queries(&language_path);
                     Ok((config, queries))
                 },

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -337,13 +337,17 @@ pub async fn language(
 }
 
 fn load_config(name: &str) -> LanguageConfig {
-    ::toml::from_slice(
-        &LanguageDir::get(&format!("{}/config.toml", name))
+    let config_toml = String::from_utf8(
+        LanguageDir::get(&format!("{}/config.toml", name))
             .unwrap()
-            .data,
+            .data
+            .to_vec(),
     )
-    .with_context(|| format!("failed to load config.toml for language {name:?}"))
-    .unwrap()
+    .unwrap();
+
+    ::toml::from_str(&config_toml)
+        .with_context(|| format!("failed to load config.toml for language {name:?}"))
+        .unwrap()
 }
 
 fn load_queries(name: &str) -> LanguageQueries {


### PR DESCRIPTION
This PR upgrades our `toml` dependency to v0.8.

I noticed that our current version of `toml` wasn't able to parse certain kinds of documents involving enums, whereas the newer version can.

Release Notes:

- N/A
