### PR TITLE
Hide Inline Assist button if assistant.button is disabled

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -1,5 +1,5 @@
 pub mod assistant_panel;
-mod assistant_settings;
+pub mod assistant_settings;
 mod codegen;
 mod prompts;
 mod streaming_diff;

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -1,3 +1,4 @@
+use assistant::assistant_settings::AssistantSettings;
 use assistant::{AssistantPanel, InlineAssist};
 use editor::{Editor, EditorSettings};
 
@@ -126,7 +127,9 @@ impl Render for QuickActionBar {
             .gap_2()
             .children(inlay_hints_button)
             .children(search_button)
-            .child(assistant_button)
+            .when(AssistantSettings::get_global(cx).button, |bar| {
+                bar.child(assistant_button)
+            })
     }
 }
 


### PR DESCRIPTION
This PR adds check for `assistant.button` setting in quick bar, to hide it when the setting is set to false. It seems that the setting can be a separate one, I would be happy to add it if needed.

Release Notes:

- Improved `assistant.button` setting so that `Inline Assist` button in editor quick bar is also hidden ([#4500](https://github.com/zed-industries/zed/issues/4500)).