### PR TITLE
add missing character "-" for "Go back" in key_bindings.md

### DIFF
--- a/docs/src/configuring_zed__key_bindings.md
+++ b/docs/src/configuring_zed__key_bindings.md
@@ -38,7 +38,7 @@ Some people have unique and custom keyboard layouts.
 
 For example, [@TomPlanche](https://github.com/TomPlanche) having a [French keyboard](https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0810%2F3669%2Ffiles%2Ffrench-azerty-mac-keyboard-layout-2021-keyshorts.png&f=1&nofb=1&ipt=f53a06c5e60a20b621082410aa699c8cceff269a11ff90b3b5a35c6124dbf827&ipo=images), had to type `Shift-Alt-(` in order to have a simple `[` so he made a simple layout with those 'rules':
 `ù -> [`, `backtick -> ]`, `Alt-[ (where [ is the old ù) -> {`, `Alt-] -> }`.
-But, it was impossible to take into account the `{` and `}` when he was typing so now, in order to ignore a binding, he can add `null` to the binding: 
+But, it was impossible to take into account the `{` and `}` when he was typing so now, in order to ignore a binding, he can add `null` to the binding:
 ```json
 [
     {
@@ -298,7 +298,7 @@ But, it was impossible to take into account the `{` and `}` when he was typing s
 | Activate item 8        | Pane           | `Control` + `8`      |
 | Activate item 9        | Pane           | `Control` + `9`      |
 | Activate last item     | Pane           | `Control` + `0`      |
-| Go back                | Pane           | `Control` + ` `      |
+| Go back                | Pane           | `Control` + `-`      |
 | Go forward             | Pane           | `Control` + `_`      |
 | Reopen closed item     | Pane           | `⌘` + `Shift` + `T`  |
 | Split down             | Pane           | `⌘` + `K`, `Down`    |


### PR DESCRIPTION
Release Notes:
- Fixed the missing character `-` for "Go back" in `key_bindings.md`

## Screenshots
### Before
![image](https://github.com/zed-industries/zed/assets/13592559/c98bbce9-5a82-4e88-a59c-c7b667474740)

### After
![image](https://github.com/zed-industries/zed/assets/13592559/ac6865c4-ebfc-4b10-bdae-5c159e92d6b3)

