### PR TITLE
Add default settings to display Svelte inlay hints

### DIFF
--- a/crates/zed/src/languages/svelte.rs
+++ b/crates/zed/src/languages/svelte.rs
@@ -91,8 +91,37 @@ impl LspAdapter for SvelteLspAdapter {
     }
 
     fn initialization_options(&self) -> Option<serde_json::Value> {
+        let config = json!({
+          "inlayHints": {
+            "parameterNames": {
+              "enabled": "all",
+              "suppressWhenArgumentMatchesName": false
+            },
+            "parameterTypes": {
+              "enabled": true
+            },
+            "variableTypes": {
+              "enabled": true,
+              "suppressWhenTypeMatchesName": false
+            },
+            "propertyDeclarationTypes": {
+              "enabled": true
+            },
+            "functionLikeReturnType": {
+              "enabled": true
+            },
+            "enumMemberValues": {
+              "enabled": true
+            }
+          }
+        });
+
         Some(json!({
-            "provideFormatter": true
+            "provideFormatter": true,
+            "configuration": {
+              "typescript": config,
+              "javascript": config
+            }
         }))
     }
 

--- a/docs/src/languages/svelte.md
+++ b/docs/src/languages/svelte.md
@@ -2,3 +2,56 @@
 
 - Tree Sitter: [tree-sitter-svelte](https://github.com/Himujjal/tree-sitter-svelte)
 - Language Server: [svelte](https://github.com/sveltejs/language-tools/tree/master/packages/language-server)
+
+## Inlay Hints
+
+Zed sets the following initialization options for inlay Hints:
+
+```json
+"inlayHints": {
+  "parameterNames": {
+    "enabled": "all",
+    "suppressWhenArgumentMatchesName": false
+  },
+  "parameterTypes": {
+    "enabled": true
+  },
+  "variableTypes": {
+    "enabled": true,
+    "suppressWhenTypeMatchesName": false
+  },
+  "propertyDeclarationTypes": {
+    "enabled": true
+  },
+  "functionLikeReturnType": {
+    "enabled": true
+  },
+  "enumMemberValues": {
+    "enabled": true
+  }
+}
+```
+
+to make the language server send back inlay hints when Zed has them enabled in the settings.
+
+Use
+
+```json
+"lsp": {
+  "$LANGUAGE_SERVER_NAME": {
+    "initialization_options": {
+      "configuration": {
+        "typescript": {
+          ......
+        },
+        "javascript": {
+          ......
+        }
+      }
+    }
+  }
+}
+
+to override these settings.
+
+See https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/package.json for more information.


### PR DESCRIPTION
Fixes: #7913.

- Added default settings for Svelte language server to display inlay hints ([#7913](https://github.com/zed-industries/zed/issues/7913)).
