### PR TITLE
Add Ruby method visibility in outline view

### DIFF
--- a/crates/zed/src/languages/ruby/outline.scm
+++ b/crates/zed/src/languages/ruby/outline.scm
@@ -2,6 +2,9 @@
     "class" @context
     name: (_) @name) @item
 
+((identifier) @context
+  (#match? @context "^(private|protected|public)$")) @item
+
 (method
     "def" @context
     name: (_) @name) @item


### PR DESCRIPTION
Release Notes:

- Improved ([#7849 ](https://github.com/zed-industries/zed/issues/7849)).

<img width="897" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/a2b0db84-1971-45c0-a5a2-68de651e342b">
