### PR TITLE
Fix panic when closing window on macOS

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1610,6 +1610,12 @@ extern "C" fn display_layer(this: &Object, _: Sel, _: id) {
 
 unsafe extern "C" fn step(view: *mut c_void) {
     let view = view as id;
+    let class = (*view).class();
+    if class.instance_size() == 0 {
+        // the class is nil
+        return;
+    }
+
     let window_state = unsafe { get_window_state(&*view) };
     let mut lock = window_state.lock();
 


### PR DESCRIPTION
Fixes a bug when closing window on macOS that caused a panic.

**Step to reproduce:**

- Start the application
- Close a window
- Panic with logs

```
thread 'main' panicked at /Users/i/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/runtime.rs:480:25:
Ivar windowState not found on class nil
stack backtrace:
   0: rust_begin_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:72:14
   2: objc::runtime::Object::get_ivar
             at /Users/i/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/runtime.rs:480:25
   3: gpui::platform::mac::window::get_window_state
             at /Users/i/ws/clone/zed/crates/gpui/src/platform/mac/window.rs:1081:29
   4: gpui::platform::mac::window::step
             at /Users/i/ws/clone/zed/crates/gpui/src/platform/mac/window.rs:1557:33
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <unknown>
  19: <unknown>
  20: <() as objc::message::MessageArguments>::invoke
             at /Users/i/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/mod.rs:128:17
  21: objc::message::platform::send_unverified
             at /Users/i/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/apple/mod.rs:27:9
  22: objc::message::send_message
             at /Users/i/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/mod.rs:178:5
  23: <*mut objc::runtime::Object as cocoa::appkit::NSApplication>::run
             at /Users/i/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cocoa-0.25.0/src/appkit.rs:603:9
  24: <gpui::platform::mac::platform::MacPlatform as gpui::platform::Platform>::run
             at /Users/i/ws/clone/zed/crates/gpui/src/platform/mac/platform.rs:387:13
  25: gpui::app::App::run
             at /Users/i/ws/clone/zed/crates/gpui/src/app.rs:139:9
  26: hello_gpui::main
             at ./src/main.rs:7:5
  27: core::ops::function::FnOnce::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
libc++abi: terminating due to uncaught foreign exception
```

**Release Notes:**

- Fixed panic when closing window on macOS