### PR TITLE
Fix git_commit grammar name typo

### DIFF
--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -80,7 +80,7 @@ pub fn init(
             tree_sitter_embedded_template::language(),
         ),
         ("erlang", tree_sitter_erlang::language()),
-        ("gitcommit", tree_sitter_gitcommit::language()),
+        ("git_commit", tree_sitter_gitcommit::language()),
         ("gleam", tree_sitter_gleam::language()),
         ("glsl", tree_sitter_glsl::language()),
         ("go", tree_sitter_go::language()),


### PR DESCRIPTION
Release Notes:

- Fixed git_commit not work
