### PR TITLE
Wayland: Keyboard input improvements

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -379,9 +379,10 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                 let key_sym = keymap_state.key_get_one_sym(keycode);
                 let key = xkb::keysym_get_name(key_sym).to_lowercase();
 
-                // Ignore control characters for the purposes of ime_key,
-                // but if key_utf32 is 0 then assume it isn't a control character
-                let ime_key = (key_utf32 == 0 || key_utf32 >= 32).then_some(key_utf8);
+                // Ignore control characters (and DEL) for the purposes of ime_key,
+                // but if key_utf32 is 0 then assume it isn't one
+                let ime_key =
+                    (key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127)).then_some(key_utf8);
 
                 let focused_window = &state.keyboard_focused_window;
                 if let Some(focused_window) = focused_window {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -375,6 +375,15 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                 let key_utf8 = keymap_state.key_get_utf8(Keycode::from(key + MIN_KEYCODE));
                 let key_sym = keymap_state.key_get_one_sym(Keycode::from(key + MIN_KEYCODE));
 
+                state.modifiers.shift =
+                    keymap_state.mod_name_is_active(xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE);
+                state.modifiers.alt =
+                    keymap_state.mod_name_is_active(xkb::MOD_NAME_ALT, xkb::STATE_MODS_EFFECTIVE);
+                state.modifiers.control =
+                    keymap_state.mod_name_is_active(xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE);
+                state.modifiers.command =
+                    keymap_state.mod_name_is_active(xkb::MOD_NAME_LOGO, xkb::STATE_MODS_EFFECTIVE);
+
                 let key = if matches!(
                     key_sym,
                     xkb::Keysym::BackSpace
@@ -394,45 +403,23 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                 if let Some(focused_window) = focused_window {
                     match key_state {
                         wl_keyboard::KeyState::Pressed => {
-                            if key_sym == xkb::Keysym::Shift_L || key_sym == xkb::Keysym::Shift_R {
-                                state.modifiers.shift = true;
-                            } else if key_sym == xkb::Keysym::Control_L
-                                || key_sym == xkb::Keysym::Control_R
-                            {
-                                state.modifiers.control = true;
-                            } else if key_sym == xkb::Keysym::Alt_L || key_sym == xkb::Keysym::Alt_R
-                            {
-                                state.modifiers.alt = true;
-                            } else {
-                                focused_window.handle_input(KeyDown(KeyDownEvent {
-                                    keystroke: Keystroke {
-                                        modifiers: state.modifiers,
-                                        key,
-                                        ime_key: None,
-                                    },
-                                    is_held: false, // todo!(linux)
-                                }));
-                            }
+                            focused_window.handle_input(KeyDown(KeyDownEvent {
+                                keystroke: Keystroke {
+                                    modifiers: state.modifiers,
+                                    key,
+                                    ime_key: None,
+                                },
+                                is_held: false, // todo!(linux)
+                            }));
                         }
                         wl_keyboard::KeyState::Released => {
-                            if key_sym == xkb::Keysym::Shift_L || key_sym == xkb::Keysym::Shift_R {
-                                state.modifiers.shift = false;
-                            } else if key_sym == xkb::Keysym::Control_L
-                                || key_sym == xkb::Keysym::Control_R
-                            {
-                                state.modifiers.control = false;
-                            } else if key_sym == xkb::Keysym::Alt_L || key_sym == xkb::Keysym::Alt_R
-                            {
-                                state.modifiers.alt = false;
-                            } else {
-                                focused_window.handle_input(PlatformInput::KeyUp(KeyUpEvent {
-                                    keystroke: Keystroke {
-                                        modifiers: state.modifiers,
-                                        key,
-                                        ime_key: None,
-                                    },
-                                }));
-                            }
+                            focused_window.handle_input(PlatformInput::KeyUp(KeyUpEvent {
+                                keystroke: Keystroke {
+                                    modifiers: state.modifiers,
+                                    key,
+                                    ime_key: None,
+                                },
+                            }));
                         }
                         _ => {}
                     }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -384,20 +384,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                 state.modifiers.command =
                     keymap_state.mod_name_is_active(xkb::MOD_NAME_LOGO, xkb::STATE_MODS_EFFECTIVE);
 
-                let key = if matches!(
-                    key_sym,
-                    xkb::Keysym::BackSpace
-                        | xkb::Keysym::Left
-                        | xkb::Keysym::Right
-                        | xkb::Keysym::Down
-                        | xkb::Keysym::Up
-                        | xkb::Keysym::Super_L
-                        | xkb::Keysym::Super_R
-                ) {
-                    xkb::keysym_get_name(key_sym).to_lowercase()
-                } else {
-                    key_utf8.clone()
-                };
+                let key = xkb::keysym_get_name(key_sym).to_lowercase();
 
                 let focused_window = &state.keyboard_focused_window;
                 if let Some(focused_window) = focused_window {
@@ -407,7 +394,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                                 keystroke: Keystroke {
                                     modifiers: state.modifiers,
                                     key,
-                                    ime_key: None,
+                                    ime_key: Some(key_utf8),
                                 },
                                 is_held: false, // todo!(linux)
                             }));
@@ -417,7 +404,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                                 keystroke: Keystroke {
                                     modifiers: state.modifiers,
                                     key,
-                                    ime_key: None,
+                                    ime_key: Some(key_utf8),
                                 },
                             }));
                         }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -22,7 +22,6 @@ use xkbcommon::xkb::{Keycode, KEYMAP_COMPILE_NO_FLAGS};
 use crate::platform::linux::client::Client;
 use crate::platform::linux::wayland::window::WaylandWindow;
 use crate::platform::{LinuxPlatformInner, PlatformWindow};
-use crate::PlatformInput::KeyDown;
 use crate::ScrollDelta;
 use crate::{
     platform::linux::wayland::window::WaylandWindowState, AnyWindowHandle, DisplayId, KeyDownEvent,
@@ -390,7 +389,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                 if let Some(focused_window) = focused_window {
                     match key_state {
                         wl_keyboard::KeyState::Pressed => {
-                            focused_window.handle_input(KeyDown(KeyDownEvent {
+                            focused_window.handle_input(PlatformInput::KeyDown(KeyDownEvent {
                                 keystroke: Keystroke {
                                     modifiers: state.modifiers,
                                     key,

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -69,8 +69,8 @@ impl WaylandWindowInner {
         bounds: Bounds<i32>,
     ) -> Self {
         let raw = RawWindow {
-            window: wl_surf.id().as_ptr() as *mut _,
-            display: conn.backend().display_ptr() as *mut _,
+            window: wl_surf.id().as_ptr().cast::<c_void>(),
+            display: conn.backend().display_ptr().cast::<c_void>(),
         };
         let gpu = Arc::new(
             unsafe {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -188,7 +188,9 @@ impl WaylandWindowState {
         if let PlatformInput::KeyDown(event) = input {
             let mut inner = self.inner.lock();
             if let Some(ref mut input_handler) = inner.input_handler {
-                input_handler.replace_text_in_range(None, &event.keystroke.key);
+                if let Some(ime_key) = &event.keystroke.ime_key {
+                    input_handler.replace_text_in_range(None, ime_key);
+                }
             }
         }
     }


### PR DESCRIPTION

Release Notes:

- N/A

---

Right now the Wayland backend is using `xkb::State::key_get_utf8` as the `key`, when it should be used as the `ime_key`. It also manages pressing/releasing modifiers manually when this should be managed by the display server.

This allows modifier combinations to work in more cases, making it an alternative to https://github.com/zed-industries/zed/pull/7975, which interprets what is now only used as the `ime_key` value as a `key` value.
