### PR TITLE
blade: Fix initialization of atlas textures used for path rasterization

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -450,9 +450,11 @@ impl BladeRenderer {
 
         for path in paths {
             let clipped_bounds = path.bounds.intersect(&path.content_mask.bounds);
-            let tile = self
-                .atlas
-                .allocate(clipped_bounds.size.map(Into::into), AtlasTextureKind::Path);
+            let tile = self.atlas.allocate_for_rendering(
+                clipped_bounds.size.map(Into::into),
+                AtlasTextureKind::Path,
+                &mut self.command_encoder,
+            );
             vertices_by_texture_id
                 .entry(tile.texture_id)
                 .or_insert(Vec::new())


### PR DESCRIPTION
Generally the BladeAtlas logic has been deferring all the texture initializations and updates till `begin_frame`. This doesn't work for path rasterization, since a texture needs to be allocated after `begin_frame` and used immediately.

Fixed validation error:
> UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout(ERROR / SPEC): msgNum: 1303270965 - Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x60ce301b9010, name = main, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x51820000000007b, name = atlas, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x4dae5635 | vkQueueSubmit(): pSubmits[0].pCommandBuffers[0] command buffer VkCommandBuffer 0x60ce301b9010[main] expects VkImage 0x51820000000007b[atlas] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_GENERAL--instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED.
    Objects: 2
        [0] 0x60ce301b9010, type: 6, name: main
        [1] 0x51820000000007b, type: 10, name: atlas

Release Notes:
- N/A