### PR TITLE
titlebar: show placeholder when no project is selected

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -421,14 +421,20 @@ impl CollabTitlebarItem {
                 worktree.root_name()
             });
 
-            names.next().unwrap_or("")
+            names.next()
+        };
+        let is_project_selected = name.is_some();
+        let name = if let Some(name) = name {
+            util::truncate_and_trailoff(name, MAX_PROJECT_NAME_LENGTH)
+        } else {
+            "Open recent project".to_string()
         };
 
-        let name = util::truncate_and_trailoff(name, MAX_PROJECT_NAME_LENGTH);
         let workspace = self.workspace.clone();
         popover_menu("project_name_trigger")
             .trigger(
                 Button::new("project_name_trigger", name)
+                    .when(!is_project_selected, |b| b.color(Color::Muted))
                     .style(ButtonStyle::Subtle)
                     .label_size(LabelSize::Small)
                     .tooltip(move |cx| Tooltip::text("Recent Projects", cx)),


### PR DESCRIPTION
When no project is selected, the recent project dropdown is displaying an empty string, making the button basically impossible to click. This PR adds a placeholder value for that case.

Here is what it looks like now:
![image](https://github.com/zed-industries/zed/assets/53836821/c831a1eb-722e-4189-8f8b-8b3039daf8f8)



Release Notes:

- Added placeholder to titlebar when no project is selected
