### PR TITLE
Fix `jk` not working in Vim bindings

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -413,10 +413,7 @@ impl PlatformInputHandler {
     }
 
     pub(crate) fn flush_pending_input(&mut self, input: &str, cx: &mut WindowContext) {
-        let Some(range) = self.handler.selected_text_range(cx) else {
-            return;
-        };
-        self.handler.replace_text_in_range(Some(range), input, cx);
+        self.handler.replace_text_in_range(None, input, cx);
     }
 }
 


### PR DESCRIPTION
Fixes #8006.

Release Notes:

- Fixed two-character bindings in Vim insert mode (e.g. `j k` or `j j`) not working. ([#8006](https://github.com/zed-industries/zed/issues/8006))

