### PR TITLE
Invalidate Linux build caches more agressively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain.toml') }}-
 
       - name: configure linux
         shell: bash -euxo pipefail {0}


### PR DESCRIPTION
We run Linux CI on regular GitHub Action runners, which have ~30GB of disk space. This is nothing for Rust builds and, due to Cargo.lock perturbations, we tend to accumulate enough artifacts to fill the disk entirely since `restore-keys` allowed to keep the cache for different lockfiles.

Instead, try to invalidate the cache more aggressively (which will cost us more frequent ~30min Linux CI runs) to see how this will work in comparison.

Release Notes:

- N/A
