### PR TITLE
Enable server side decorations on wayland

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -105,7 +105,7 @@ ashpd = "0.7.0"
 # todo!(linux) - Technically do not use `randr`, but it doesn't compile otherwise
 xcb = { version = "1.3", features = ["as-raw-xcb-connection", "present", "randr", "xkb"] }
 wayland-client= { version = "0.31.2" }
-wayland-protocols = { version = "0.31.2", features = ["client", "staging"] }
+wayland-protocols = { version = "0.31.2", features = ["client", "staging", "unstable"] }
 wayland-backend = { version = "0.3.3", features = ["client_system"] }
 xkbcommon = { version = "0.7", features = ["wayland", "x11"] }
 as-raw-xcb-connection = "1"


### PR DESCRIPTION

This PR enables server side decorations on Wayland if possible. This is stopgap solution, so that the window can be moved, resized and dragged on Wayland sessions at all.

![image](https://github.com/zed-industries/zed/assets/25827180/3dc9af53-76c0-4664-8746-ed6a6e5eafe7)

Since Wayland compositors can decide to force either mode (as in, forcing server or client side decorations), this requires additional handling in zed. Since zed doesn't provide any of that handling as of now, as a temporary solution server side decorations are always requested.