### PR TITLE
linux/x11: disable Vulkan validation in Debug

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -244,7 +244,7 @@ impl X11WindowState {
                 gpu::Context::init_windowed(
                     &raw,
                     gpu::ContextDesc {
-                        validation: cfg!(debug_assertions),
+                        validation: false,
                         capture: false,
                     },
                 )


### PR DESCRIPTION
Turns out this validation requirement is confusing new users.

Release Notes:
- N/A
