### PR TITLE
linux/x11: send XCB requests asynchronously

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -208,25 +208,21 @@ impl X11WindowState {
                 });
             }
         }
-        xcb_connection
-            .send_and_check_request(&x::ChangeProperty {
-                mode: x::PropMode::Replace,
-                window: x_window,
-                property: atoms.wm_protocols,
-                r#type: x::ATOM_ATOM,
-                data: &[atoms.wm_del_window],
-            })
-            .unwrap();
+        xcb_connection.send_request(&x::ChangeProperty {
+            mode: x::PropMode::Replace,
+            window: x_window,
+            property: atoms.wm_protocols,
+            r#type: x::ATOM_ATOM,
+            data: &[atoms.wm_del_window],
+        });
 
         let fake_id = xcb_connection.generate_id();
-        xcb_connection
-            .send_and_check_request(&xcb::present::SelectInput {
-                eid: fake_id,
-                window: x_window,
-                //Note: also consider `IDLE_NOTIFY`
-                event_mask: xcb::present::EventMask::COMPLETE_NOTIFY,
-            })
-            .unwrap();
+        xcb_connection.send_request(&xcb::present::SelectInput {
+            eid: fake_id,
+            window: x_window,
+            //Note: also consider `IDLE_NOTIFY`
+            event_mask: xcb::present::EventMask::COMPLETE_NOTIFY,
+        });
 
         xcb_connection.send_request(&x::MapWindow { window: x_window });
         xcb_connection.flush().unwrap();
@@ -324,15 +320,13 @@ impl X11WindowState {
     }
 
     pub fn request_refresh(&self) {
-        self.xcb_connection
-            .send_and_check_request(&xcb::present::NotifyMsc {
-                window: self.x_window,
-                serial: 0,
-                target_msc: 0,
-                divisor: 1,
-                remainder: 0,
-            })
-            .unwrap();
+        self.xcb_connection.send_request(&xcb::present::NotifyMsc {
+            window: self.x_window,
+            serial: 0,
+            target_msc: 0,
+            divisor: 1,
+            remainder: 0,
+        });
     }
 
     pub fn handle_input(&self, input: PlatformInput) {


### PR DESCRIPTION
With `send_and_check_request` we'd be blocking both the main loop and the caller. `send_request` is only going to be blocking on the main loop when processing the request.

Release Notes:
- N/A

Based on a flamegraph from `perf`/`hotspot`, we are spending 40% of time redrawing, another 40% of time downloading stuff (i.e. rust toolchain), and the rest on text rendering, layout and such. This is with Vulkan Validation (see https://github.com/zed-industries/zed/pull/8044).

I'm also wondering if it would be better with #7758, but regardless we should have no problem rendering at 60-120 fps and processing user input. More follow-ups are expected here.