### PR TITLE
Fix markdown preview heading overflows no wrap

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -8,7 +8,10 @@ use gpui::{
     HighlightStyle, Hsla, InteractiveText, IntoElement, ParentElement, SharedString, Styled,
     StyledText, TextStyle, WeakView, WindowContext,
 };
-use std::{ops::Range, sync::Arc};
+use std::{
+    ops::{Mul, Range},
+    sync::Arc,
+};
 use theme::{ActiveTheme, SyntaxTheme};
 use ui::{h_flex, v_flex, Label};
 use workspace::Workspace;
@@ -115,7 +118,7 @@ fn render_markdown_heading(parsed: &ParsedMarkdownHeading, cx: &mut RenderContex
         _ => cx.text_color,
     };
 
-    let line_height = DefiniteLength::from(rems(1.25));
+    let line_height = DefiniteLength::from(size.mul(1.25));
 
     div()
         .line_height(line_height)
@@ -124,6 +127,7 @@ fn render_markdown_heading(parsed: &ParsedMarkdownHeading, cx: &mut RenderContex
         .pt(rems(0.15))
         .pb_1()
         .child(render_markdown_text(&parsed.contents, cx))
+        .whitespace_normal()
         .into_any()
 }
 


### PR DESCRIPTION

Release Notes:

- Fixed ([#8047](https://github.com/zed-industries/zed/issues/8047)).

![Kapture 2024-02-20 at 18 27 15](https://github.com/zed-industries/zed/assets/8416130/87d4dcea-e2f0-44ba-88a4-06829dbb0e89)
