### PR TITLE
rust-analyzer check command is `check` and not `checkOnSave`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -540,10 +540,10 @@
   "lsp": {
     // Specify the LSP name as a key here.
     // "rust-analyzer": {
-    //     //These initialization options are merged into Zed's defaults
+    //     // These initialization options are merged into Zed's defaults
     //     "initialization_options": {
-    //         "checkOnSave": {
-    //             "command": "clippy"
+    //         "check": {
+    //             "command": "clippy" // rust-analyzer.check.command (default: "check")
     //         }
     //     }
     // }

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -245,8 +245,8 @@ To override settings for a language, add an entry for that language server's nam
 "lsp": {
   "rust-analyzer": {
     "initialization_options": {
-      "checkOnSave": {
-        "command": "clippy" // rust-analyzer.checkOnSave.command
+      "check": {
+        "command": "clippy" // rust-analyzer.check.command (default: "check")
       }
     }
   }


### PR DESCRIPTION
Just a minor configuration fix and its docs-counterpart.

[Here's the reference.](https://rust-analyzer.github.io/manual.html#configuration)