### PR TITLE
Add settings to configure terminal scroll limit

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -451,7 +451,10 @@
     // Set the terminal's font family. If this option is not included,
     // the terminal will default to matching the buffer's font family.
     // "font_family": "Zed Mono",
-    // ---
+    // Sets the maximum number of lines in the terminal's scrollback buffer.
+    // Default: 10_000, maximum: 100_000 (all bigger values set will be treated as 100_000), 0 disables the scrolling.
+    // Existing terminals will not pick up this change until they are recreated.
+    // "max_scroll_history_lines": 10000,
   },
   // Difference settings for semantic_index
   "semantic_index": {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -57,6 +57,7 @@ impl Project {
             env,
             Some(settings.blinking.clone()),
             settings.alternate_scroll,
+            settings.max_scroll_history_lines,
             window,
             completion_tx,
         )

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -35,6 +35,7 @@ pub struct TerminalSettings {
     pub default_width: Pixels,
     pub default_height: Pixels,
     pub detect_venv: VenvSettings,
+    pub max_scroll_history_lines: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -146,6 +147,14 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: on
     pub detect_venv: Option<VenvSettings>,
+    /// The maximum number of lines to keep in the scrollback history.
+    /// Maximum allowed value is 100_000, all values above that will be treated as 100_000.
+    /// 0 disables the scrolling.
+    /// Existing terminals will not pick up this change until they are recreated.
+    /// See <a href="https://github.com/alacritty/alacritty/blob/cb3a79dbf6472740daca8440d5166c1d4af5029e/extra/man/alacritty.5.scd?plain=1#L207-L213">Alacritty documentation</a> for more information.
+    ///
+    /// Default: 10_000
+    pub max_scroll_history_lines: Option<usize>,
 }
 
 impl settings::Settings for TerminalSettings {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/7550
Also set maximum allowed to runnables' terminals.


Release Notes:

- Added settings to configure terminal scroll limit ([7550](https://github.com/zed-industries/zed/issues/7550))