### PR TITLE
Fix display of links in lists (markdown_preview)

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -154,7 +154,7 @@ fn render_markdown_list(parsed: &ParsedMarkdownList, cx: &mut RenderContext) -> 
         let item = h_flex()
             .pl(DefiniteLength::Absolute(AbsoluteLength::Rems(padding)))
             .items_start()
-            .children(vec![bullet, div().children(contents).pr_2().w_full()]);
+            .children(vec![bullet, div().children(contents).pr_4().w_full()]);
 
         items.push(item);
     }


### PR DESCRIPTION
![markdown_preview](https://github.com/zed-industries/zed/assets/67913738/d8e4800f-d549-42e7-90b4-001d98aa39d2)

Release Notes:

- Fixed display of long links in lists not fully visible in markdown preview.
