### PR TITLE
Log when starting language servers

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -178,6 +178,13 @@ impl LanguageServer {
             root_path.parent().unwrap_or_else(|| Path::new("/"))
         };
 
+        log::info!(
+            "starting language server. binary path: {:?}, working directory: {:?}, args: {:?}",
+            binary.path,
+            working_dir,
+            &binary.arguments
+        );
+
         let mut server = process::Command::new(&binary.path)
             .current_dir(working_dir)
             .args(binary.arguments)


### PR DESCRIPTION
This should help us debug more failures because we can now see what exactly was started.

Release Notes:

- N/A
