### PR TITLE
Adjust tab size for Markdown

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,5 +1,9 @@
 {
   "languages": {
+    "Markdown": {
+      "tab_size": 2,
+      "formatter": "prettier"
+    },
     "TOML": {
       "formatter": "prettier",
       "format_on_save": "off"


### PR DESCRIPTION
This PR sets the `tab_size` for Markdown to 2 spaces.

This should prevent Prettier from adding a bunch of leading whitespace when formatting Markdown lists.

Release Notes:

- N/A

