### PR TITLE
Change default Markdown tab size

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -502,6 +502,7 @@
       }
     },
     "Markdown": {
+      "tab_size": 2,
       "soft_wrap": "preferred_line_length"
     },
     "JavaScript": {


### PR DESCRIPTION
Following up to #8079, this PR changes the default Markdown tab size to 2 spaces.

This should produce less surprising formatting for lists when using Prettier.

Release Notes:

- Changed default Markdown tab size to 2 spaces.

