### PR TITLE
Update docs for building Zed

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,8 @@
 
 - [How to Contribute]()
 - [Building from Source](./developing_zed__building_zed.md)
+  - [macOS](./developing_zed__building_zed_macos.md)
+  - [Linux](./developing_zed__building_zed_linux.md)
 - [Local Collaboration](./developing_zed__local_collaboration.md)
 - [Adding Languages](./developing_zed__adding_languages.md)
 - [Adding UI]()

--- a/docs/src/developing_zed__building_zed.md
+++ b/docs/src/developing_zed__building_zed.md
@@ -1,0 +1,6 @@
+# Building from Source
+
+See the platform-specific instructions for building Zed from source:
+
+- [macOS](./developing_zed__building_zed_macos.md)
+- [Linux](./developing_zed__building_zed_linux.md)

--- a/docs/src/developing_zed__building_zed_linux.md
+++ b/docs/src/developing_zed__building_zed_linux.md
@@ -1,4 +1,4 @@
-# Building Zed
+# Building Zed for Linux
 
 ## Repository
 

--- a/docs/src/developing_zed__building_zed_macos.md
+++ b/docs/src/developing_zed__building_zed_macos.md
@@ -1,4 +1,4 @@
-# Building Zed
+# Building Zed for macOS
 
 ## Repository
 


### PR DESCRIPTION
This PR updates the docs for building Zed to fix the links in the sidebar after the addition of the Linux-specific docs in #8083.

Release Notes:

- N/A
