### PR TITLE
Wayland: avoid replacing text with empty string

### DIFF
--- a/crates/gpui/src/platform/linux/util.rs
+++ b/crates/gpui/src/platform/linux/util.rs
@@ -17,7 +17,7 @@ impl Keystroke {
 
         // Ignore control characters (and DEL) for the purposes of ime_key,
         // but if key_utf32 is 0 then assume it isn't one
-        let ime_key = (key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127)).then_some(key_utf8);
+        let ime_key = ((key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127)) && key_utf8.len() > 0).then_some(key_utf8);
 
         Keystroke {
             modifiers,

--- a/crates/gpui/src/platform/linux/util.rs
+++ b/crates/gpui/src/platform/linux/util.rs
@@ -17,7 +17,9 @@ impl Keystroke {
 
         // Ignore control characters (and DEL) for the purposes of ime_key,
         // but if key_utf32 is 0 then assume it isn't one
-        let ime_key = ((key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127)) && key_utf8.len() > 0).then_some(key_utf8);
+        let ime_key = ((key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127))
+            && key_utf8.len() > 0)
+            .then_some(key_utf8);
 
         Keystroke {
             modifiers,

--- a/crates/gpui/src/platform/linux/util.rs
+++ b/crates/gpui/src/platform/linux/util.rs
@@ -19,7 +19,7 @@ impl Keystroke {
         // but if key_utf32 is 0 then assume it isn't one
         let ime_key = ((key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127))
             && !key_utf8.is_empty())
-            .then_some(key_utf8);
+        .then_some(key_utf8);
 
         Keystroke {
             modifiers,

--- a/crates/gpui/src/platform/linux/util.rs
+++ b/crates/gpui/src/platform/linux/util.rs
@@ -18,7 +18,7 @@ impl Keystroke {
         // Ignore control characters (and DEL) for the purposes of ime_key,
         // but if key_utf32 is 0 then assume it isn't one
         let ime_key = ((key_utf32 == 0 || (key_utf32 >= 32 && key_utf32 != 127))
-            && key_utf8.len() > 0)
+            && !key_utf8.is_empty())
             .then_some(key_utf8);
 
         Keystroke {


### PR DESCRIPTION
Fix an issue where the `ime_key` is sometimes an empty string, and pressing a keystroke replaces the selected text.

E.g. select some text, press `Escape`: selected text is deleted.