### PR TITLE
Support ESLint flat configs

### DIFF
--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -237,6 +237,9 @@ impl LspAdapter for EsLintLspAdapter {
                     "name": workspace_root.file_name()
                         .unwrap_or_else(|| workspace_root.as_os_str()),
                 },
+                "experimental": {
+                    "useFlatConfig": workspace_root.join("eslint.config.js").exists()
+                }
             }
         })
     }

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -237,6 +237,7 @@ impl LspAdapter for EsLintLspAdapter {
                     "name": workspace_root.file_name()
                         .unwrap_or_else(|| workspace_root.as_os_str()),
                 },
+                "problems": {},
                 "experimental": {
                     "useFlatConfig": workspace_root.join("eslint.config.js").is_file(),
                 },

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -238,8 +238,8 @@ impl LspAdapter for EsLintLspAdapter {
                         .unwrap_or_else(|| workspace_root.as_os_str()),
                 },
                 "experimental": {
-                    "useFlatConfig": workspace_root.join("eslint.config.js").exists()
-                }
+                    "useFlatConfig": workspace_root.join("eslint.config.js").exists(),
+                },
             }
         })
     }

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -238,7 +238,7 @@ impl LspAdapter for EsLintLspAdapter {
                         .unwrap_or_else(|| workspace_root.as_os_str()),
                 },
                 "experimental": {
-                    "useFlatConfig": workspace_root.join("eslint.config.js").exists(),
+                    "useFlatConfig": workspace_root.join("eslint.config.js").is_file(),
                 },
             }
         })


### PR DESCRIPTION
Hey 👋🏻!

I'm not 100% sure I've done this right and am happy to receive pointers. 

This change sets the `experimental.useFlatConfig` attribute to `true` if a `eslint.config.js` file exists in the workspace root and `false` if not.

## Further reading

- https://eslint.org/docs/latest/use/configure/configuration-files-new
- https://github.com/microsoft/vscode-eslint?tab=readme-ov-file#settings-options

Release Notes:

- Added ESLint flat config support ([#7271](https://github.com/zed-industries/zed/issues/7271)).
