### PR TITLE
Fix a bug when extension loading is failed after it's folder is viewed by MacOS finder

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -651,6 +651,9 @@ impl ExtensionStore {
                 let Ok(relative_path) = language_path.strip_prefix(&extension_dir) else {
                     continue;
                 };
+                if !language_path.is_dir() {
+                    continue;
+                }
                 let config = fs.load(&language_path.join("config.toml")).await?;
                 let config = ::toml::from_str::<LanguageConfig>(&config)?;
 

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -651,7 +651,10 @@ impl ExtensionStore {
                 let Ok(relative_path) = language_path.strip_prefix(&extension_dir) else {
                     continue;
                 };
-                if !language_path.is_dir() {
+                let Ok(Some(fs_metadata)) = fs.metadata(&language_path).await else {
+                    continue;
+                };
+                if !fs_metadata.is_dir {
                     continue;
                 }
                 let config = fs.load(&language_path.join("config.toml")).await?;


### PR DESCRIPTION
Fixes #8096

# Bug description

I was experimenting with adding extensions and almost went crazy trying to make my demo extension work. It appeared that I was copying files with Finder that creates hidden `.DS_Store` files which interfered with Zed's loading logic. It assumes that `languages/` directory contains only directories and never files and so it crashes when meets `.DS_Store`. This makes any extension stop working after it has been viewed via Finder

# Change

Check if path is directory when loading extension languages (so it will skip .DS_Store files)