### PR TITLE
Improve `TS` buffer symbols

### DIFF
--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -377,8 +377,15 @@ mod tests {
         .await;
 
         let text = r#"
+            interface A {
+              b?: string
+              // Nested objects are included
+              c: {
+                d: Array<string>
+              }
+            }
             function a() {
-              // local variables are omitted
+              // local variables are included
               let a1 = 1;
               // all functions are included
               async function a2() {}
@@ -403,7 +410,12 @@ mod tests {
                 .map(|item| (item.text.as_str(), item.depth))
                 .collect::<Vec<_>>(),
             &[
+                ("interface A", 0),
+                ("b?: string", 1),
+                ("c:", 1),
+                ("d: Array<string>", 2),
                 ("function a()", 0),
+                ("let a1", 1),
                 ("async function a2()", 1),
                 ("let b", 0),
                 ("function getB()", 0),

--- a/crates/zed/src/languages/typescript/outline.scm
+++ b/crates/zed/src/languages/typescript/outline.scm
@@ -10,6 +10,32 @@
     "type" @context
     name: (_) @name) @item
 
+(property_signature
+  name: (_) @name
+  "?"? @context
+  type: (type_annotation
+    ":" @context
+    [
+      (_)
+      (predefined_type) @context
+      (type_identifier) @context
+      (generic_type) @context
+      (function_type
+        parameters: (formal_parameters
+          "(" @context
+          ")" @context)
+        "=>" @context
+        return_type: (_) @context)
+    ]) @type) @item
+
+(method_signature
+  "get"? @context
+  name: (_) @name
+  parameters: (formal_parameters
+    "(" @context
+    ")" @context)
+  return_type: (_) @context) @item
+
 (function_declaration
     "async"? @context
     "function" @context
@@ -27,6 +53,12 @@
         ["let" "const"] @context
         (variable_declarator
             name: (_) @name) @item))
+
+(statement_block
+  (lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+      name: (_) @name) @item))
 
 (program
     (lexical_declaration


### PR DESCRIPTION
This PR adds support for a more detailed buffer symbol search. 
Feedback is very much appreciated.

The following screenshots are based on https://github.com/learn-anything/learn-anything.xyz/blob/main/shared/ui/Search.tsx

After:
![SCR-20240221-mcvs](https://github.com/zed-industries/zed/assets/67913738/07eb365b-c80e-4c52-b7e7-6edc80c98a13)

Before:
![SCR-20240221-mdcr](https://github.com/zed-industries/zed/assets/67913738/0b62727e-c452-4ce9-b183-71c4de152a3e)


Release Notes:

- Improved buffer symbol search for `ts` / `tsx` ([#4483](https://github.com/zed-industries/zed/issues/4483)).
