### PR TITLE
linux: add prompt dialog box using gtk3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251e0b7d90e33e0ba930891a505a9a35ece37b2dd37a14f3ffc306c13b980009"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1651,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "call"
 version = "0.1.0"
 dependencies = [
@@ -1713,6 +1735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -3893,6 +3925,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,6 +4010,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "git"
 version = "0.1.0"
 dependencies = [
@@ -3978,6 +4053,26 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630f097773d7c7a0bb3258df4e8157b47dc98bbfa0e60ad9ab56174813feced4"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -4041,6 +4136,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys 0.18.1",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e2b1080b9418dd0c58b498da3a5c826030343e0ef07bde6a955d28de54979"
+dependencies = [
+ "glib-sys 0.19.0",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4101,7 +4218,10 @@ dependencies = [
  "font-kit",
  "foreign-types 0.5.0",
  "futures 0.3.28",
+ "glib-sys 0.19.0",
+ "gobject-sys 0.19.0",
  "gpui_macros",
+ "gtk-sys",
  "image",
  "itertools 0.10.5",
  "lazy_static",
@@ -4172,6 +4292,24 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771437bf1de2c1c0b496c11505bdf748e26066bbe942dfc8f614c9460f6d7722"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "pango-sys",
+ "system-deps",
 ]
 
 [[package]]
@@ -6315,6 +6453,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -9300,6 +9450,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
+dependencies = [
+ "cfg-expr",
+ "heck 0.4.1",
+ "pkg-config",
+ "toml 0.8.10",
+ "version-compare",
+]
+
+[[package]]
 name = "taffy"
 version = "0.3.11"
 source = "git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b#1876f72bee5e376023eaa518aa7b8a34c769bd1b"
@@ -10870,6 +11033,12 @@ dependencies = [
  "util",
  "workspace",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -115,3 +115,6 @@ blade-macros.workspace = true
 blade-rwh.workspace = true
 bytemuck = "1"
 cosmic-text = "0.10.0"
+gtk-sys = "0.18.0"
+gobject-sys = "0.19.0"
+glib-sys = "0.19.0"

--- a/crates/gpui/src/platform/linux.rs
+++ b/crates/gpui/src/platform/linux.rs
@@ -6,6 +6,7 @@ mod text_system;
 mod util;
 mod wayland;
 mod x11;
+mod gtk_utils;
 
 pub(crate) use dispatcher::*;
 pub(crate) use platform::*;

--- a/crates/gpui/src/platform/linux/client.rs
+++ b/crates/gpui/src/platform/linux/client.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use crate::platform::PlatformWindow;
-use crate::{AnyWindowHandle, DisplayId, PlatformDisplay, WindowOptions};
+use crate::{AnyWindowHandle, DisplayId, ForegroundExecutor, PlatformDisplay, WindowOptions};
 
 pub trait Client {
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>);
@@ -11,5 +11,6 @@ pub trait Client {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
+        executor: ForegroundExecutor,
     ) -> Box<dyn PlatformWindow>;
 }

--- a/crates/gpui/src/platform/linux/gtk_utils.rs
+++ b/crates/gpui/src/platform/linux/gtk_utils.rs
@@ -1,0 +1,276 @@
+/// Based on rfd crate's gtk backend. Useful to show GTK Widgets asynchronously and by blocking.
+
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::spawn;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+use gobject_sys::GCallback;
+use gtk_sys::{GtkDialog, GtkResponseType};
+use std::ffi::c_void;
+use std::os::raw::c_char;
+
+
+pub(crate) trait AsGtkDialog {
+    fn gtk_dialog_ptr(&self) -> *mut gtk_sys::GtkDialog;
+    unsafe fn show(&self);
+}
+
+impl AsGtkDialog for *mut gtk_sys::GtkDialog {
+    fn gtk_dialog_ptr(&self) -> *mut gtk_sys::GtkDialog {
+        self.cast()
+    }
+    unsafe fn show(&self) {
+        gtk_sys::gtk_widget_show_all(self.cast());
+    }
+}
+
+static GTK_THREAD: OnceLock<GtkGlobalThread> = OnceLock::new();
+
+/// GTK functions are not thread-safe, and must all be called from the thread that initialized GTK. To ensure this, we
+/// spawn one thread the first time a GTK dialog is opened and keep it open for the entire lifetime of the application,
+/// as GTK cannot be de-initialized or re-initialized on another thread. You're stuck on the thread on which you first
+/// initialize GTK.
+
+pub struct GtkGlobalThread {
+    running: Arc<AtomicBool>,
+}
+
+impl GtkGlobalThread {
+    /// Return the global, lazily-initialized instance of the global GTK thread.
+    pub(super) fn instance() -> &'static Self {
+        GTK_THREAD.get_or_init(|| Self::new())
+    }
+
+    fn new() -> Self {
+        // When the GtkGlobalThread is eventually dropped, we will set `running` to false and wake up the loop so
+        // gtk_main_iteration unblocks and we exit the thread on the next iteration.
+        let running = Arc::new(AtomicBool::new(true));
+        let thread_running = Arc::clone(&running);
+
+        spawn(move || {
+            let initialized =
+                unsafe { gtk_sys::gtk_init_check(ptr::null_mut(), ptr::null_mut()) == 1 };
+            if !initialized {
+                return;
+            }
+
+            loop {
+                if !thread_running.load(Ordering::Acquire) {
+                    break;
+                }
+
+                unsafe {
+                    gtk_sys::gtk_main_iteration();
+                }
+            }
+        });
+
+        Self {
+            running: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Run a function on the GTK thread, blocking on the result which is then passed back.
+    pub(super) fn run_blocking<
+        T: Send + Clone + std::fmt::Debug + 'static,
+        F: FnOnce() -> T + Send + 'static,
+    >(
+        &self,
+        cb: F,
+    ) -> T {
+        let data: Arc<(Mutex<Option<T>>, _)> = Arc::new((Mutex::new(None), Condvar::new()));
+        let thread_data = Arc::clone(&data);
+        let mut cb = Some(cb);
+        unsafe {
+            connect_idle(move || {
+                // connect_idle takes a FnMut; convert our FnOnce into that by ensuring we only call it once
+                let res = cb.take().expect("Callback should only be called once")();
+
+                // pass the result back to the main thread
+                let (lock, cvar) = &*thread_data;
+                *lock.lock().unwrap() = Some(res);
+                cvar.notify_all();
+
+                glib_sys::GFALSE
+            });
+        };
+
+        // wait for GTK thread to execute the callback and place the result into `data`
+        let lock_res = data
+            .1
+            .wait_while(data.0.lock().unwrap(), |res| res.is_none())
+            .unwrap();
+        lock_res.as_ref().unwrap().clone()
+    }
+
+    /// Launch a function on the GTK thread without blocking.
+    pub(super) fn run<F: FnOnce() + Send + 'static>(&self, cb: F) {
+        let mut cb = Some(cb);
+        unsafe {
+            connect_idle(move || {
+                cb.take().expect("Callback should only be called once")();
+                glib_sys::GFALSE
+            });
+        };
+    }
+}
+
+impl Drop for GtkGlobalThread {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+        unsafe { glib_sys::g_main_context_wakeup(std::ptr::null_mut()) };
+    }
+}
+
+struct FutureState<R, D> {
+    waker: Option<Waker>,
+    data: Option<R>,
+    dialog: Option<D>,
+}
+
+unsafe impl<R, D> Send for FutureState<R, D> {}
+
+pub(super) struct GtkDialogFuture<R, D> {
+    state: Arc<Mutex<FutureState<R, D>>>,
+}
+
+unsafe impl<R, D> Send for GtkDialogFuture<R, D> {}
+
+impl<R: Default + 'static, D: AsGtkDialog + 'static> GtkDialogFuture<R, D> {
+    pub fn new<B, F>(build: B, cb: F) -> Self
+        where
+            B: FnOnce() -> D + Send + 'static,
+            F: Fn(&mut D, i32) -> R + Send + 'static,
+    {
+        let state = Arc::new(Mutex::new(FutureState {
+            waker: None,
+            data: None,
+            dialog: None,
+        }));
+
+        {
+            let state = state.clone();
+            let callback = {
+                let state = state.clone();
+
+                move |res_id| {
+                    let mut state = state.lock().unwrap();
+
+                    if let Some(mut dialog) = state.dialog.take() {
+                        state.data = Some(cb(&mut dialog, res_id));
+                    }
+
+                    if let Some(waker) = state.waker.take() {
+                        waker.wake();
+                    }
+                }
+            };
+
+            GtkGlobalThread::instance().run(move || {
+                let mut state = state.lock().unwrap();
+                state.dialog = Some(build());
+
+                unsafe {
+                    let dialog = state.dialog.as_ref().unwrap();
+                    dialog.show();
+
+                    let ptr = dialog.gtk_dialog_ptr();
+                    connect_response(ptr as *mut _, callback);
+                }
+            });
+        }
+
+        Self { state }
+    }
+}
+
+impl<R, D> std::future::Future for GtkDialogFuture<R, D> {
+    type Output = R;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.lock().unwrap();
+
+        if state.data.is_some() {
+            Poll::Ready(state.data.take().unwrap())
+        } else {
+            state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+unsafe fn connect_idle<F: FnMut() -> glib_sys::gboolean + Send + 'static>(f: F) {
+    unsafe extern "C" fn response_trampoline<F: FnMut() -> glib_sys::gboolean + Send + 'static>(
+        f: glib_sys::gpointer,
+    ) -> glib_sys::gboolean {
+        let f: &mut F = &mut *(f as *mut F);
+
+        f()
+    }
+    let f_box: Box<F> = Box::new(f);
+
+    unsafe extern "C" fn destroy_closure<F>(ptr: *mut std::ffi::c_void) {
+        // destroy
+        let _ = Box::<F>::from_raw(ptr as *mut _);
+    }
+
+    glib_sys::g_idle_add_full(
+        glib_sys::G_PRIORITY_DEFAULT_IDLE,
+        Some(response_trampoline::<F>),
+        Box::into_raw(f_box) as glib_sys::gpointer,
+        Some(destroy_closure::<F>),
+    );
+}
+
+unsafe fn connect_raw<F>(
+    receiver: *mut gobject_sys::GObject,
+    signal_name: *const c_char,
+    trampoline: GCallback,
+    closure: *mut F,
+) {
+    use std::mem;
+
+    use glib_sys::gpointer;
+
+    unsafe extern "C" fn destroy_closure<F>(ptr: *mut c_void, _: *mut gobject_sys::GClosure) {
+        // destroy
+        let _ = Box::<F>::from_raw(ptr as *mut _);
+    }
+    assert_eq!(mem::size_of::<*mut F>(), mem::size_of::<gpointer>());
+    assert!(trampoline.is_some());
+    let handle = gobject_sys::g_signal_connect_data(
+        receiver,
+        signal_name,
+        trampoline,
+        closure as *mut _,
+        Some(destroy_closure::<F>),
+        0,
+    );
+    assert!(handle > 0);
+}
+
+unsafe fn connect_response<F: Fn(GtkResponseType) + 'static>(dialog: *mut GtkDialog, f: F) {
+    use std::mem::transmute;
+
+    unsafe extern "C" fn response_trampoline<F: Fn(GtkResponseType) + 'static>(
+        _this: *mut gtk_sys::GtkDialog,
+        res: GtkResponseType,
+        f: glib_sys::gpointer,
+    ) {
+        let f: &F = &*(f as *const F);
+
+        f(res);
+    }
+    let f: Box<F> = Box::new(f);
+    connect_raw(
+        dialog as *mut _,
+        b"response\0".as_ptr() as *const _,
+        Some(transmute::<_, unsafe extern "C" fn()>(
+            response_trampoline::<F> as *const (),
+        )),
+        Box::into_raw(f),
+    );
+}

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -211,7 +211,7 @@ impl Platform for LinuxPlatform {
         handle: AnyWindowHandle,
         options: WindowOptions,
     ) -> Box<dyn PlatformWindow> {
-        self.client.open_window(handle, options)
+        self.client.open_window(handle, options, self.foreground_executor())
     }
 
     fn open_url(&self, url: &str) {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -30,7 +30,7 @@ use crate::platform::linux::client::Client;
 use crate::platform::linux::wayland::window::{WaylandDecorationState, WaylandWindow};
 use crate::platform::{LinuxPlatformInner, PlatformWindow};
 use crate::{
-    platform::linux::wayland::window::WaylandWindowState, AnyWindowHandle, DisplayId, KeyDownEvent,
+    platform::linux::wayland::window::WaylandWindowState, AnyWindowHandle, DisplayId, ForegroundExecutor, KeyDownEvent,
     KeyUpEvent, Keystroke, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
     NavigationDirection, Pixels, PlatformDisplay, PlatformInput, Point, ScrollDelta,
     ScrollWheelEvent, TouchPhase, WindowOptions,
@@ -137,6 +137,7 @@ impl Client for WaylandClient {
         &self,
         handle: AnyWindowHandle,
         options: WindowOptions,
+        executor: ForegroundExecutor,
     ) -> Box<dyn PlatformWindow> {
         let mut state = self.state.lock();
 
@@ -182,6 +183,7 @@ impl Client for WaylandClient {
 
         let window_state = Rc::new(WaylandWindowState::new(
             &self.conn,
+            executor,
             wl_surface.clone(),
             viewport,
             Arc::new(toplevel),

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -11,8 +11,8 @@ use crate::platform::{
     LinuxPlatformInner, PlatformWindow, X11Display, X11Window, X11WindowState, XcbAtoms,
 };
 use crate::{
-    AnyWindowHandle, Bounds, DisplayId, PlatformDisplay, PlatformInput, Point, ScrollDelta, Size,
-    TouchPhase, WindowOptions,
+    AnyWindowHandle, Bounds, DisplayId, ForegroundExecutor, PlatformDisplay, PlatformInput, Point,
+    ScrollDelta, Size, TouchPhase, WindowOptions
 };
 
 pub(crate) struct X11ClientState {
@@ -238,6 +238,7 @@ impl Client for X11Client {
         &self,
         _handle: AnyWindowHandle,
         options: WindowOptions,
+        executor: ForegroundExecutor,
     ) -> Box<dyn PlatformWindow> {
         let x_window = self.xcb_connection.generate_id();
 
@@ -247,6 +248,7 @@ impl Client for X11Client {
             self.x_root_index,
             x_window,
             &self.atoms,
+            executor,
         ));
         window_ptr.request_refresh();
 


### PR DESCRIPTION

Release Notes:

- Implemented prompt (dialog box) for linux using gtk3. 

This is my first coding in Rust, so help me out a bit if I m wrong/stuck. :smile: Code for the most part is inspired from rfd crate. I couldn't directly use rfd crate because it doesn't support adding custom number of buttons. I will not be able to implement such functionality for all platforms in rfd. So, instead, I took inspiration (and code) from rfd's gtk backend and created a gtk3 based message dialog box with custom buttons support.

**To Consider**
The popup dialog doesn't freeze/block the zed editor. Once the popup is displayed, user will still be able to interact with the UI and may even start another popup dialog :disappointed:. But I see the same behavior in `ashpd`'s `SaveFileRequest` in `prompt_for_new_path` current implementation in zed. We need to figure a way to do this. There is a way to run by blocking the entire zed application. But in that case, if the user doesn't respond within like 5 seconds, GNOME complains that the app is not responding... So, I m not really sure what could be done here. I think if we somehow wrap the entire zed app in a GTK window and then add the dialog as part of the GTK window, then we can have it working as expected. But I don't know if that is the way it should be done. Maybe we can figure it out later and fix it in case of both `prompt` and `prompt_for_new_path`  implementation. Currently, it opens a nice popup asking me to save my unsaved files and the buttons work as expected. 
