### PR TITLE
Introduce file_id on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,7 @@ dependencies = [
  "text",
  "time",
  "util",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -32,10 +32,16 @@ log.workspace = true
 libc = "0.2"
 time.workspace = true
 
-gpui = { workspace = true, optional = true}
+gpui = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 notify = "6.1.1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+] }
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1336,6 +1336,9 @@ pub fn copy_recursive<'a>(
     .boxed()
 }
 
+// todo!(windows)
+// can we get file id not open the file twice?
+// https://github.com/rust-lang/rust/issues/63010
 #[cfg(target_os = "windows")]
 async fn file_id(path: impl AsRef<Path>) -> u64 {
     use std::os::windows::io::AsRawHandle;

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -245,7 +245,6 @@ impl Fs for RealFs {
         #[cfg(unix)]
         let inode = metadata.ino();
 
-        // todo!("windows")
         #[cfg(windows)]
         let inode = file_id(path);
 


### PR DESCRIPTION
Added a function `file_id` to get the file id on windows, which is similar to inode on unix. 

Release Notes:

- N/A