### PR TITLE
Make language server id more explicit in unhandled message logs

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -210,7 +210,7 @@ impl LanguageServer {
             cx,
             move |notification| {
                 log::info!(
-                    "{} unhandled notification {}:\n{}",
+                    "Language server with id {} sent unhandled notification {}:\n{}",
                     server_id,
                     notification.method,
                     serde_json::to_string_pretty(


### PR DESCRIPTION
Before:
```
[2024-02-21T18:55:55+02:00 INFO  language::language_registry] starting language server "eslint", path: "/Users/someonetoignore/Downloads/eslint-configs-demo", id: 2
[2024-02-21T18:55:56+02:00 INFO  lsp] 2 unhandled notification window/logMessage:
{
  "type": 3,
  "message": "ESLint server running in node v18.15.0"
}
[2024-02-21T18:55:56+02:00 INFO  lsp] 2 unhandled notification eslint/confirmESLintExecution:
{
  "scope": "local",
  "uri": "file:///Users/someonetoignore/Downloads/eslint-configs-demo/index.js",
  "libraryPath": "/Users/someonetoignore/Downloads/eslint-configs-demo/node_modules/eslint/lib/api.js"
}
```

After:
```
[2024-02-21T18:57:31+02:00 INFO  language::language_registry] starting language server "eslint", path: "/Users/someonetoignore/Downloads/eslint-configs-demo", id: 2
[2024-02-21T18:57:32+02:00 INFO  lsp] Language server with id 2 sent unhandled notification window/logMessage:
{
  "type": 3,
  "message": "ESLint server running in node v18.15.0"
}
[2024-02-21T18:57:32+02:00 INFO  project::prettier_support] Fetching default prettier and plugins: [("prettier-plugin-tailwindcss", "0.5.11"), ("prettier", "3.2.5")]
[2024-02-21T18:57:32+02:00 INFO  lsp] Language server with id 2 sent unhandled notification eslint/confirmESLintExecution:
{
  "scope": "local",
  "uri": "file:///Users/someonetoignore/Downloads/eslint-configs-demo/index.js",
  "libraryPath": "/Users/someonetoignore/Downloads/eslint-configs-demo/node_modules/eslint/lib/api.js"
}
```

We have to pass a name there too, but the problem here is that the unhandled message callback is created very early, along with the binary, but the server name is received from the LSP initialize response, which is a totally separate piece of code.
I plan to refactor that code next, but so far, improve the logs at least slightly.

Release Notes:

- N/A
