### PR TITLE
Fix for toggles on the Welcome page

### DIFF
--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -116,25 +116,17 @@ pub fn update_settings_file<T: Settings>(
             store.new_text_for_update::<T>(old_text, update)
         })?;
         let initial_path = paths::SETTINGS.as_path();
-        let file_exists = fs.is_file(initial_path).await;
-        let resolved_path = if file_exists {
-            fs.canonicalize(initial_path).await.with_context(|| {
-                format!("Failed to canonicalize settings path {:?}", initial_path)
-            })?
-        } else {
-            fs.create_file(
-                initial_path,
-                fs::CreateOptions {
-                    overwrite: false,
-                    ignore_if_exists: true,
-                },
-            )
-            .await
-            .with_context(|| format!("Failed to create settings file {:?}", initial_path))?;
-            fs.canonicalize(initial_path)
+        if !fs.is_file(initial_path).await {
+            fs.create_file(initial_path, fs::CreateOptions::default())
                 .await
-                .unwrap_or_else(|_| initial_path.to_path_buf())
-        };
+                .with_context(|| format!("Failed to create settings file {:?}", initial_path))?;
+        }
+
+        let resolved_path = fs
+            .canonicalize(initial_path)
+            .await
+            .with_context(|| format!("Failed to canonicalize settings path {:?}", initial_path))?;
+
         fs.atomic_write(resolved_path.clone(), new_text)
             .await
             .with_context(|| format!("Failed to write settings to file {:?}", resolved_path))?;


### PR DESCRIPTION
Release Notes:

The issue is that when welcome page appears settings.json file is not created yet. So the idea of this fix is to create the file in case it is not there yet. 

- Fixed the toggles on the welcome screen not working if no settings file exists yet. ([#8153](https://github.com/zed-industries/zed/issues/8153)).