### PR TITLE
linux: fix reveal_path for files

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -294,7 +294,13 @@ impl Platform for LinuxPlatform {
     }
 
     fn reveal_path(&self, path: &Path) {
-        open::that(path);
+        if path.is_dir() {
+            open::that(path);
+            return;
+        }
+        // If `path` is a file, the system may try to open it in a text editor
+        let dir = path.parent().unwrap_or(Path::new(""));
+        open::that(dir);
     }
 
     fn on_become_active(&self, callback: Box<dyn FnMut()>) {


### PR DESCRIPTION
Fixes 'Reveal in Finder' opening files instead of showing them in the file explorer.  
Tested on Fedora KDE 39.

Release Notes:

- N/A