### PR TITLE
Update keymaps for `cmd-backspace` or `delete` to delete file in project panel.

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -491,8 +491,7 @@
         "ctrl-alt-shift-c": "project_panel::CopyRelativePath",
         "f2": "project_panel::Rename",
         "enter": "project_panel::Rename",
-        "delete": "project_panel::Delete",
-        "ctrl-backspace": "project_panel::Delete",
+        "backspace": "project_panel::Delete",
         "ctrl-alt-r": "project_panel::RevealInFinder",
         "alt-shift-f": "project_panel::NewSearchInDirectory"
       }

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -491,7 +491,8 @@
         "ctrl-alt-shift-c": "project_panel::CopyRelativePath",
         "f2": "project_panel::Rename",
         "enter": "project_panel::Rename",
-        "backspace": "project_panel::Delete",
+        "delete": "project_panel::Delete",
+        "ctrl-backspace": "project_panel::Delete",
         "ctrl-alt-r": "project_panel::RevealInFinder",
         "alt-shift-f": "project_panel::NewSearchInDirectory"
       }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -531,7 +531,8 @@
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
-      "backspace": "project_panel::Delete",
+      "delete": "project_panel::Delete",
+      "cmd-backspace": "project_panel::Delete",
       "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }


### PR DESCRIPTION
Fix #7228

Release Notes:

- Improved project panel keymaps for `cmd-backspace` / `delete` to delete file.