### PR TITLE
Add an app_menu to Storybook which enables quitting with `cmd-q`

### DIFF
--- a/assets/keymaps/storybook.json
+++ b/assets/keymaps/storybook.json
@@ -1,0 +1,23 @@
+[
+  // Standard macOS bindings
+  {
+    "bindings": {
+      "up": "menu::SelectPrev",
+      "pageup": "menu::SelectFirst",
+      "shift-pageup": "menu::SelectFirst",
+      "ctrl-p": "menu::SelectPrev",
+      "down": "menu::SelectNext",
+      "pagedown": "menu::SelectLast",
+      "shift-pagedown": "menu::SelectFirst",
+      "ctrl-n": "menu::SelectNext",
+      "cmd-up": "menu::SelectFirst",
+      "cmd-down": "menu::SelectLast",
+      "enter": "menu::Confirm",
+      "ctrl-enter": "menu::ShowContextMenu",
+      "cmd-enter": "menu::SecondaryConfirm",
+      "escape": "menu::Cancel",
+      "ctrl-c": "menu::Cancel",
+      "cmd-q": "storybook::Quit"
+    }
+  }
+]

--- a/crates/storybook/src/actions.rs
+++ b/crates/storybook/src/actions.rs
@@ -1,0 +1,2 @@
+use gpui::actions;
+actions!(storybook, [Quit]);

--- a/crates/storybook/src/app_menus.rs
+++ b/crates/storybook/src/app_menus.rs
@@ -1,0 +1,10 @@
+use gpui::{Menu, MenuItem};
+
+pub fn app_menus() -> Vec<Menu<'static>> {
+    use crate::actions::Quit;
+
+    vec![Menu {
+        name: "Storybook",
+        items: vec![MenuItem::action("Quit", Quit)],
+    }]
+}

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -1,3 +1,5 @@
+mod actions;
+mod app_menus;
 mod assets;
 mod stories;
 mod story_selector;
@@ -9,14 +11,16 @@ use gpui::{
     WindowOptions,
 };
 use log::LevelFilter;
-use settings::{default_settings, Settings, SettingsStore};
+use settings::{default_settings, KeymapFile, Settings, SettingsStore};
 use simplelog::SimpleLogger;
 use strum::IntoEnumIterator;
 use theme::{ThemeRegistry, ThemeSettings};
 use ui::prelude::*;
 
+use crate::app_menus::app_menus;
 use crate::assets::Assets;
 use crate::story_selector::{ComponentStory, StorySelector};
+use actions::Quit;
 pub use indoc::indoc;
 
 #[derive(Parser)]
@@ -37,6 +41,7 @@ fn main() {
 
     SimpleLogger::init(LevelFilter::Info, Default::default()).expect("could not initialize logger");
 
+    menu::init();
     let args = Args::parse();
 
     let story_selector = args.story.clone().unwrap_or_else(|| {
@@ -78,6 +83,9 @@ fn main() {
 
         language::init(cx);
         editor::init(cx);
+        init(cx);
+        load_storybook_keymap(cx);
+        cx.set_menus(app_menus());
 
         let _window = cx.open_window(
             WindowOptions {
@@ -132,4 +140,20 @@ fn load_embedded_fonts(cx: &AppContext) -> gpui::Result<()> {
     }
 
     cx.text_system().add_fonts(embedded_fonts)
+}
+
+fn load_storybook_keymap(cx: &mut AppContext) {
+    KeymapFile::load_asset("keymaps/storybook.json", cx).unwrap();
+}
+
+pub fn init(cx: &mut AppContext) {
+    cx.on_action(quit);
+}
+
+fn quit(_: &Quit, cx: &mut AppContext) {
+    cx.spawn(|cx| async move {
+        cx.update(|cx| cx.quit())?;
+        anyhow::Ok(())
+    })
+    .detach_and_log_err(cx);
 }


### PR DESCRIPTION

I really think storybook is a cool standalone app but there are some usability issues that are getting in the way of making this a fun tool to use.

Currently it is not easy to gracefully exit out of storybook.

In fact even trying to Ctrl-c out of storybook seems currently broken to me...

So the only real way to exit out of storybook is to kill the process after a Ctrl-z.

This PR attempts to make this much easier by adding a simple app_menu with a menu item called quit along with the ability to *Cmd-q* out of storybook as well...

Both the menu item quit and *Cmd-q* gracefully exit storybook.

There are still a bunch of issues with storybook which I plan on addressing in future PR's but this is a start and something that to me is the highest priority to make storybook more functional and easy to use moving forward.

One of my longer term goals of storybook is to have it be a nice stand alone application similar to [Loungy](https://github.com/MatthiasGrandl/Loungy) which can be used as a nice tutorial application for how to develop a real world *gpui* app.

For that reason I added a *assets/keymaps/storybook.json* file as well.
