### PR TITLE
gpui: add example sections in Cargo.toml

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -115,3 +115,15 @@ blade-macros.workspace = true
 blade-rwh.workspace = true
 bytemuck = "1"
 cosmic-text = "0.10.0"
+
+[[example]]
+name = "hello_world"
+path = "examples/hello_world.rs"
+
+[[example]]
+name = "image"
+path = "examples/image.rs"
+
+[[example]]
+name = "ownership_post"
+path = "examples/ownership_post.rs"


### PR DESCRIPTION
So that we can run the example simply by `cargo run --example hello_world`

Release Notes:
- N/A
