### PR TITLE
Update docs for inlay hints

### DIFF
--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -393,93 +393,14 @@ Inlay hints querying consists of two parts: editor (client) and LSP server.
 With the inlay settings above are changed to enable the hints, editor will start to query certain types of hints and react on LSP hint refresh request from the server.
 At this point, the server may or may not return hints depending on its implementation, further configuration might be needed, refer to the corresponding LSP server documentation.
 
-Use `lsp` section for the server configuration, below are some examples for well known servers:
+The following languages have inlay hints preconfigured by Zed:
 
-### Rust
+- [Go](https://docs.zed.dev/languages/go)
+- [Rust](https://docs.zed.dev/languages/rust)
+- [Svelte](https://docs.zed.dev/languages/svelte)
+- [Typescript](https://docs.zed.dev/languages/typescript)
 
-```json
-"lsp": {
-  "rust-analyzer": {
-    "initialization_options": {
-      "inlayHints": {
-        "maxLength": null,
-        "lifetimeElisionHints": {
-          "useParameterNames": true,
-          "enable": "skip_trivial"
-        },
-        "closureReturnTypeHints": {
-          "enable": "always"
-        }
-      }
-    }
-  }
-}
-```
-
-### Typescript
-
-```json
-"lsp": {
-  "typescript-language-server": {
-    "initialization_options": {
-      "preferences": {
-        "includeInlayParameterNameHints": "all",
-        "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
-        "includeInlayFunctionParameterTypeHints": true,
-        "includeInlayVariableTypeHints": true,
-        "includeInlayVariableTypeHintsWhenTypeMatchesName": false,
-        "includeInlayPropertyDeclarationTypeHints": true,
-        "includeInlayFunctionLikeReturnTypeHints": true,
-        "includeInlayEnumMemberValueHints": true
-      }
-    }
-  }
-}
-```
-
-### Go
-
-```json
-"lsp": {
-  "gopls": {
-    "initialization_options": {
-      "hints": {
-        "assignVariableTypes": true,
-        "compositeLiteralFields": true,
-        "compositeLiteralTypes": true,
-        "constantValues": true,
-        "functionTypeParameters": true,
-        "parameterNames": true,
-        "rangeVariableTypes": true
-      }
-    }
-  }
-}
-```
-
-### Svelte
-
-```json
-{
-  "lsp": {
-    "typescript-language-server": {
-      "initialization_options": {
-        "preferences": {
-          "includeInlayParameterNameHints": "all",
-          "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
-          "includeInlayFunctionParameterTypeHints": true,
-          "includeInlayVariableTypeHints": true,
-          "includeInlayVariableTypeHintsWhenTypeMatchesName": false,
-          "includeInlayPropertyDeclarationTypeHints": true,
-          "includeInlayFunctionLikeReturnTypeHints": true,
-          "includeInlayEnumMemberValueHints": true,
-          "includeInlayEnumMemberDeclarationTypes": true
-        }
-      }
-    }
-  }
-}
-```
+Use the `lsp` section for the server configuration. Examples are provided in the corresponding language documentation.
 
 ## Journal
 

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -3,7 +3,42 @@
 - Tree Sitter: [tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust)
 - Language Server: [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 
-### Target directory
+## Inlay Hints
+
+The following configuration can be used to enable inlay hints for rust:
+
+```json
+"inlayHints": {
+  "maxLength": null,
+  "lifetimeElisionHints": {
+  "useParameterNames": true,
+    "enable": "skip_trivial"
+  },
+  "closureReturnTypeHints": {
+    "enable": "always"
+  }
+}
+```
+
+to make the language server send back inlay hints when Zed has them enabled in the settings.
+
+Use
+
+```json
+"lsp": {
+  "$LANGUAGE_SERVER_NAME": {
+    "initialization_options": {
+      ....
+    }
+  }
+}
+```
+
+to override these settings.
+
+See https://rust-analyzer.github.io/manual.html#inlay-hints for more information.
+
+## Target directory
 
 The `rust-analyzer` target directory can be set in `initialization_options`:
 


### PR DESCRIPTION
Follow up of #7943. Updates the docs for inlay hints as they are incorrect (for Svelte).

Release Notes:

- N/A
