### PR TITLE
Do not add empty tasks to inventory

### DIFF
--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -181,8 +181,12 @@ impl PickerDelegate for TasksModalDelegate {
     fn confirm(&mut self, secondary: bool, cx: &mut ViewContext<picker::Picker<Self>>) {
         let current_match_index = self.selected_index();
 
-        let task = if secondary && !self.last_prompt.trim().is_empty() {
-            self.spawn_oneshot(cx)
+        let task = if secondary {
+            if !self.last_prompt.trim().is_empty() {
+                self.spawn_oneshot(cx)
+            } else {
+                None
+            }
         } else {
             self.matches.get(current_match_index).map(|current_match| {
                 let ix = current_match.candidate_id;

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -180,16 +180,17 @@ impl PickerDelegate for TasksModalDelegate {
 
     fn confirm(&mut self, secondary: bool, cx: &mut ViewContext<picker::Picker<Self>>) {
         let current_match_index = self.selected_index();
-        let Some(task) = secondary
-            .then(|| self.spawn_oneshot(cx))
-            .flatten()
-            .or_else(|| {
-                self.matches.get(current_match_index).map(|current_match| {
-                    let ix = current_match.candidate_id;
-                    self.candidates[ix].clone()
-                })
+
+        let task = if secondary && !self.last_prompt.trim().is_empty() {
+            self.spawn_oneshot(cx)
+        } else {
+            self.matches.get(current_match_index).map(|current_match| {
+                let ix = current_match.candidate_id;
+                self.candidates[ix].clone()
             })
-        else {
+        };
+
+        let Some(task) = task else {
             return;
         };
 


### PR DESCRIPTION
I ran into this when trying out which keybindings work and accidentally added empty tasks. They get then added to the task inventory and displayed in the picker.

Release Notes:

- Fixed empty tasks being added to the list of tasks when using `task: spawn`
