### PR TITLE
Add "Extension" item to user menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "collections",
  "db",
  "editor",
+ "extensions_ui",
  "feature_flags",
  "feedback",
  "futures 0.3.28",

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -34,6 +34,7 @@ clock.workspace = true
 collections.workspace = true
 db.workspace = true
 editor.workspace = true
+extensions_ui.workspace = true
 feature_flags.workspace = true
 feedback.workspace = true
 futures.workspace = true

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -695,6 +695,7 @@ impl CollabTitlebarItem {
                 .menu(|cx| {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
+                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
                             .action("Theme", theme_selector::Toggle.boxed_clone())
                             .separator()
                             .action("Share Feedback", feedback::GiveFeedback.boxed_clone())
@@ -720,6 +721,7 @@ impl CollabTitlebarItem {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Theme", theme_selector::Toggle.boxed_clone())
+                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
                             .separator()
                             .action("Share Feedback", feedback::GiveFeedback.boxed_clone())
                     })


### PR DESCRIPTION
My first PR to Zed :)).

This pull request adds an "Extension" option to the user menu in the collaboration UI for easier access to the Extensions page.

Release Note:

N/A


<img width="274" alt="Screenshot 2024-02-22 at 18 12 52" src="https://github.com/zed-industries/zed/assets/56961917/9057d1be-bedb-474a-a663-c53d62366f26">
