### PR TITLE
Detect and possibly use user-installed `gopls` / `zls` language servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.48",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -4348,11 +4348,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6942,6 +6942,7 @@ dependencies = [
  "toml 0.8.10",
  "unindent",
  "util",
+ "which 6.0.0",
 ]
 
 [[package]]
@@ -7051,7 +7052,7 @@ dependencies = [
  "prost-types 0.9.0",
  "regex",
  "tempfile",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -11422,6 +11423,19 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.30",
+]
+
+[[package]]
+name = "which"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.30",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,6 +279,7 @@ unindent = "0.1.7"
 url = "2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 wasmtime = "16"
+which = "6.0.0"
 sys-locale = "0.3.1"
 
 [patch.crates-io]

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -428,6 +428,8 @@ impl Copilot {
                 let binary = LanguageServerBinary {
                     path: node_path,
                     arguments,
+                    // TODO: We could set HTTP_PROXY etc here and fix the copilot issue.
+                    env: None,
                 };
 
                 let server = LanguageServer::new(

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -142,6 +142,14 @@ impl CachedLspAdapter {
         })
     }
 
+    pub fn check_if_user_installed(
+        &self,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        cx: &mut AsyncAppContext,
+    ) -> Option<Task<Option<LanguageServerBinary>>> {
+        self.adapter.check_if_user_installed(delegate, cx)
+    }
+
     pub async fn fetch_latest_server_version(
         &self,
         delegate: &dyn LspAdapterDelegate,
@@ -242,6 +250,11 @@ impl CachedLspAdapter {
 pub trait LspAdapterDelegate: Send + Sync {
     fn show_notification(&self, message: &str, cx: &mut AppContext);
     fn http_client(&self) -> Arc<dyn HttpClient>;
+    fn which_command<'a>(
+        &'a self,
+        command: &'a OsStr,
+        cx: &AppContext,
+    ) -> BoxFuture<'a, Option<PathBuf>>;
     fn build_command<'a>(
         &'a self,
         command: &'a OsStr,
@@ -254,6 +267,14 @@ pub trait LspAdapter: 'static + Send + Sync {
     fn name(&self) -> LanguageServerName;
 
     fn short_name(&self) -> &'static str;
+
+    fn check_if_user_installed(
+        &self,
+        _: &Arc<dyn LspAdapterDelegate>,
+        _: &mut AsyncAppContext,
+    ) -> Option<Task<Option<LanguageServerBinary>>> {
+        None
+    }
 
     async fn fetch_latest_server_version(
         &self,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -22,7 +22,6 @@ pub mod markdown;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use collections::{HashMap, HashSet};
-use futures::future::BoxFuture;
 use gpui::{AppContext, AsyncAppContext, Task};
 pub use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
@@ -39,7 +38,7 @@ use serde_json::Value;
 use std::{
     any::Any,
     cell::RefCell,
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     fmt::Debug,
     hash::Hash,
     mem,
@@ -250,16 +249,11 @@ impl CachedLspAdapter {
 pub trait LspAdapterDelegate: Send + Sync {
     fn show_notification(&self, message: &str, cx: &mut AppContext);
     fn http_client(&self) -> Arc<dyn HttpClient>;
-    fn which_command<'a>(
-        &'a self,
-        command: &'a OsStr,
+    fn which_command(
+        &self,
+        command: OsString,
         cx: &AppContext,
-    ) -> BoxFuture<'a, Option<(PathBuf, HashMap<String, String>)>>;
-    fn build_command<'a>(
-        &'a self,
-        command: &'a OsStr,
-        cx: &AppContext,
-    ) -> BoxFuture<'a, smol::process::Command>;
+    ) -> Task<Option<(PathBuf, HashMap<String, String>)>>;
 }
 
 #[async_trait]

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -254,7 +254,7 @@ pub trait LspAdapterDelegate: Send + Sync {
         &'a self,
         command: &'a OsStr,
         cx: &AppContext,
-    ) -> BoxFuture<'a, Option<PathBuf>>;
+    ) -> BoxFuture<'a, Option<(PathBuf, HashMap<String, String>)>>;
     fn build_command<'a>(
         &'a self,
         command: &'a OsStr,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -22,6 +22,7 @@ pub mod markdown;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use collections::{HashMap, HashSet};
+use futures::future::BoxFuture;
 use gpui::{AppContext, AsyncAppContext, Task};
 pub use highlight_map::HighlightMap;
 use lazy_static::lazy_static;
@@ -38,6 +39,7 @@ use serde_json::Value;
 use std::{
     any::Any,
     cell::RefCell,
+    ffi::OsStr,
     fmt::Debug,
     hash::Hash,
     mem,
@@ -240,6 +242,11 @@ impl CachedLspAdapter {
 pub trait LspAdapterDelegate: Send + Sync {
     fn show_notification(&self, message: &str, cx: &mut AppContext);
     fn http_client(&self) -> Arc<dyn HttpClient>;
+    fn build_command<'a>(
+        &'a self,
+        command: &'a OsStr,
+        cx: &AppContext,
+    ) -> BoxFuture<'a, smol::process::Command>;
 }
 
 #[async_trait]

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 use std::{
     any::Any,
     cell::RefCell,
-    ffi::{OsStr, OsString},
+    ffi::OsString,
     fmt::Debug,
     hash::Hash,
     mem,

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -743,12 +743,8 @@ async fn get_binary(
     }
 
     if let Some(task) = adapter.check_if_user_installed(&delegate, &mut cx) {
-        println!(
-            "checking if user has language server for {} installed",
-            language.name()
-        );
         if let Some(binary) = task.await {
-            println!(
+            log::info!(
                 "found user-installed language server for {}. path: {:?}, arguments: {:?}",
                 language.name(),
                 binary.path,

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -756,7 +756,7 @@ async fn check_user_installed_binary(
         return None;
     };
 
-    if let Some(binary) = task.await {
+    task.await.and_then(|binary| {
         log::info!(
             "found user-installed language server for {}. path: {:?}, arguments: {:?}",
             language.name(),
@@ -764,9 +764,7 @@ async fn check_user_installed_binary(
             binary.arguments
         );
         Some(binary)
-    } else {
-        None
-    }
+    })
 }
 
 async fn get_binary(

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -802,6 +802,11 @@ async fn get_binary(
             .await
         {
             statuses.send(language.clone(), LanguageServerBinaryStatus::Cached);
+            log::info!(
+                "failed to fetch newest version of language server {:?}. falling back to using {:?}",
+                adapter.name,
+                binary.path.display()
+            );
             return Ok(binary);
         } else {
             statuses.send(
@@ -838,9 +843,8 @@ async fn fetch_latest_binary(
     lsp_binary_statuses_tx.send(language.clone(), LanguageServerBinaryStatus::Downloading);
 
     log::info!(
-        "fetching version {:?} for language server {:?}",
-        version_info,
-        adapter.name
+        "checking if Zed already installed or fetching version for language server {:?}",
+        adapter.name.0
     );
     let binary = adapter
         .fetch_server_binary(version_info, container_dir.to_path_buf(), delegate)

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -31,9 +31,8 @@ pub struct LanguageRegistry {
     language_server_download_dir: Option<Arc<Path>>,
     login_shell_env_loaded: Shared<Task<()>>,
     #[allow(clippy::type_complexity)]
-    lsp_binary_paths: Mutex<
-        HashMap<LanguageServerName, Shared<Task<Result<LanguageServerBinary, Arc<anyhow::Error>>>>>,
-    >,
+    lsp_binary_paths:
+        Arc<Mutex<HashMap<LanguageServerName, Result<LanguageServerBinary, anyhow::Error>>>>,
     executor: Option<BackgroundExecutor>,
     lsp_binary_status_tx: LspBinaryStatusSender,
 }
@@ -547,47 +546,36 @@ impl LanguageRegistry {
             .clone()
             .ok_or_else(|| anyhow!("language server download directory has not been assigned before starting server"))
             .log_err()?;
-        let this = self.clone();
         let language = language.clone();
         let container_dir: Arc<Path> = Arc::from(download_dir.join(adapter.name.0.as_ref()));
         let root_path = root_path.clone();
         let adapter = adapter.clone();
         let login_shell_env_loaded = self.login_shell_env_loaded.clone();
         let lsp_binary_statuses = self.lsp_binary_status_tx.clone();
+        let lsp_binary_paths = self.lsp_binary_paths.clone();
 
         let task = {
             let container_dir = container_dir.clone();
             cx.spawn(move |mut cx| async move {
                 login_shell_env_loaded.await;
-                // TODO: This cache needs to be moved inside of `get_binary`, because we don't
-                // want to cache one binary per language server anymore. We might have
-                // worktree 1: user-installed gopls in `.bin`
-                // worktree 2: user-installed gopls in `~/bin`
-                // worktree 3: no gopls found in PATH -> fallback to Zed installation
-                let entry = this
-                    .lsp_binary_paths
-                    .lock()
-                    .entry(adapter.name.clone())
-                    .or_insert_with(|| {
-                        let adapter = adapter.clone();
-                        let language = language.clone();
-                        let delegate = delegate.clone();
-                        cx.spawn(|cx| {
-                            get_binary(
-                                adapter,
-                                language,
-                                delegate,
-                                container_dir,
-                                lsp_binary_statuses,
-                                cx,
-                            )
-                            .map_err(Arc::new)
-                        })
-                        .shared()
-                    })
-                    .clone();
 
-                let binary = match entry.await {
+                let binary = cx
+                    .spawn(|cx| {
+                        get_binary(
+                            adapter.clone(),
+                            language.clone(),
+                            delegate.clone(),
+                            container_dir,
+                            lsp_binary_statuses,
+                            lsp_binary_paths,
+                            cx,
+                        )
+                        .map_err(Arc::new)
+                    })
+                    .shared()
+                    .await;
+
+                let binary = match binary {
                     Ok(binary) => binary,
                     Err(err) => anyhow::bail!("{err}"),
                 };
@@ -734,6 +722,9 @@ async fn get_binary(
     delegate: Arc<dyn LspAdapterDelegate>,
     container_dir: Arc<Path>,
     statuses: LspBinaryStatusSender,
+    binary_paths: Arc<
+        Mutex<HashMap<LanguageServerName, Result<LanguageServerBinary, anyhow::Error>>>,
+    >,
     mut cx: AsyncAppContext,
 ) -> Result<LanguageServerBinary> {
     if !container_dir.exists() {
@@ -741,6 +732,18 @@ async fn get_binary(
             .await
             .context("failed to create container directory")?;
     }
+
+    // First we check whether the adapter can give us a user-installed binary.
+    // If so, we do *not* want to cache that, because each worktree might give us a different
+    // binary:
+    //
+    //      worktree 1: user-installed at `.bin/gopls`
+    //      worktree 2: user-installed at `~/bin/gopls`
+    //      worktree 3: no gopls found in PATH -> fallback to Zed installation
+    //
+    // We only want to cache when we fall back to the global one,
+    // because we don't want to download and overwrite our global one
+    // for each worktree we might have open.
 
     if let Some(task) = adapter.check_if_user_installed(&delegate, &mut cx) {
         if let Some(binary) = task.await {
@@ -754,11 +757,28 @@ async fn get_binary(
         }
     }
 
+    // Lock the binary_paths, so that only one project at a time can fetch a
+    // language server for a given language.
+    let mut paths = binary_paths.lock();
+
+    if let Some(binary_result) = paths.get(&adapter.name) {
+        return match binary_result {
+            Ok(binary) => Ok(binary.clone()),
+            // TODO: error.to_string here seems bad?!
+            Err(error) => return Err(anyhow!(error.to_string())),
+        };
+    }
+
+    log::info!(
+        "no cached language server for {} found. proceeding with installation.",
+        language.name(),
+    );
     if let Some(task) = adapter.will_fetch_server(&delegate, &mut cx) {
+        // TODO: this result needs to be cached too
         task.await?;
     }
 
-    let binary = fetch_latest_binary(
+    let binary_result = fetch_latest_binary(
         adapter.clone(),
         language.clone(),
         delegate.as_ref(),
@@ -767,24 +787,33 @@ async fn get_binary(
     )
     .await;
 
-    if let Err(error) = binary.as_ref() {
-        if let Some(binary) = adapter
-            .cached_server_binary(container_dir.to_path_buf(), delegate.as_ref())
-            .await
-        {
-            statuses.send(language.clone(), LanguageServerBinaryStatus::Cached);
-            return Ok(binary);
-        } else {
+    match &binary_result {
+        Ok(binary) => {
+            paths.insert(adapter.name.clone(), Ok(binary.clone()));
+        }
+        Err(error) => {
+            if let Some(cached_binary) = adapter
+                .cached_server_binary(container_dir.to_path_buf(), delegate.as_ref())
+                .await
+            {
+                statuses.send(language.clone(), LanguageServerBinaryStatus::Cached);
+                paths.insert(adapter.name.clone(), Ok(cached_binary.clone()));
+
+                return Ok(cached_binary);
+            }
+
             statuses.send(
                 language.clone(),
                 LanguageServerBinaryStatus::Failed {
-                    error: format!("{:?}", error),
+                    error: error.to_string(),
                 },
             );
+            // TODO: error.to_string here seems bad?!
+            paths.insert(adapter.name.clone(), Err(anyhow!(error.to_string())));
         }
     }
 
-    binary
+    binary_result
 }
 
 async fn fetch_latest_binary(
@@ -801,9 +830,18 @@ async fn fetch_latest_binary(
         LanguageServerBinaryStatus::CheckingForUpdate,
     );
 
+    log::info!(
+        "querying GitHub for latest version of language server {:?}",
+        adapter.name
+    );
     let version_info = adapter.fetch_latest_server_version(delegate).await?;
     lsp_binary_statuses_tx.send(language.clone(), LanguageServerBinaryStatus::Downloading);
 
+    log::info!(
+        "fetching version {:?} for language server {:?}",
+        version_info,
+        adapter.name
+    );
     let binary = adapter
         .fetch_server_binary(version_info, container_dir.to_path_buf(), delegate)
         .await?;

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -55,6 +55,7 @@ pub enum IoKind {
 pub struct LanguageServerBinary {
     pub path: PathBuf,
     pub arguments: Vec<OsString>,
+    pub env: Option<HashMap<String, String>>,
 }
 
 /// A running language server process.
@@ -189,6 +190,7 @@ impl LanguageServer {
         let mut server = process::Command::new(&binary.path)
             .current_dir(working_dir)
             .args(binary.arguments)
+            .envs(binary.env.unwrap_or_default())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -192,6 +192,7 @@ impl Prettier {
             LanguageServerBinary {
                 path: node_path,
                 arguments: vec![prettier_server.into(), prettier_dir.as_path().into()],
+                env: None,
             },
             Path::new("/"),
             None,

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -65,6 +65,7 @@ text.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 util.workspace = true
+which.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -9326,7 +9326,7 @@ impl LspAdapterDelegate for ProjectLspAdapterDelegate {
         &'a self,
         command: &'a OsStr,
         cx: &AppContext,
-    ) -> BoxFuture<'a, Option<PathBuf>> {
+    ) -> BoxFuture<'a, Option<(PathBuf, HashMap<String, String>)>> {
         let worktree_abs_path = self.worktree.read(cx).abs_path();
         async move {
             let shell_env = load_login_shell_environment(&worktree_abs_path)
@@ -9338,10 +9338,10 @@ impl LspAdapterDelegate for ProjectLspAdapterDelegate {
                 })
                 .log_err();
 
-            if let Some(shell_env) = shell_env.as_ref() {
+            if let Some(shell_env) = shell_env {
                 let shell_path = shell_env.get("PATH");
                 match which::which_in(command, shell_path, &worktree_abs_path) {
-                    Ok(command_path) => Some(command_path),
+                    Ok(command_path) => Some((command_path, shell_env)),
                     Err(error) => {
                         log::warn!(
                             "failed to determine path for command {command:?} in env {shell_env:?}: {error}"

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2833,7 +2833,6 @@ impl Project {
         let project_settings =
             ProjectSettings::get(Some((worktree_id.to_proto() as usize, Path::new(""))), cx);
         let lsp = project_settings.lsp.get(&adapter.name.0);
-        // TODO: here is where we want to get the `binary_path` override options too
         let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
 
         let server_id = pending_server.server_id;

--- a/crates/semantic_index/src/semantic_index_tests.rs
+++ b/crates/semantic_index/src/semantic_index_tests.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use ai::test::FakeEmbeddingProvider;
 
-use gpui::TestAppContext;
+use gpui::{Task, TestAppContext};
 use language::{Language, LanguageConfig, LanguageMatcher, LanguageRegistry, ToOffset};
 use parking_lot::Mutex;
 use pretty_assertions::assert_eq;
@@ -57,7 +57,7 @@ async fn test_semantic_index(cx: &mut TestAppContext) {
     )
     .await;
 
-    let languages = Arc::new(LanguageRegistry::new());
+    let languages = Arc::new(LanguageRegistry::new(Task::ready(())));
     let rust_language = rust_lang();
     let toml_language = toml_lang();
     languages.add(rust_language);

--- a/crates/semantic_index/src/semantic_index_tests.rs
+++ b/crates/semantic_index/src/semantic_index_tests.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use ai::test::FakeEmbeddingProvider;
 
-use gpui::{Task, TestAppContext};
+use gpui::TestAppContext;
 use language::{Language, LanguageConfig, LanguageMatcher, LanguageRegistry, ToOffset};
 use parking_lot::Mutex;
 use pretty_assertions::assert_eq;
@@ -57,7 +57,7 @@ async fn test_semantic_index(cx: &mut TestAppContext) {
     )
     .await;
 
-    let languages = Arc::new(LanguageRegistry::new(Task::ready(())));
+    let languages = Arc::new(LanguageRegistry::new());
     let rust_language = rust_lang();
     let toml_language = toml_lang();
     languages.add(rust_language);

--- a/crates/zed/src/languages/astro.rs
+++ b/crates/zed/src/languages/astro.rs
@@ -71,6 +71,7 @@ impl LspAdapter for AstroLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -122,6 +123,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/c.rs
+++ b/crates/zed/src/languages/c.rs
@@ -84,6 +84,7 @@ impl super::LspAdapter for CLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: vec![],
         })
     }
@@ -260,6 +261,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
         if clangd_bin.exists() {
             Ok(LanguageServerBinary {
                 path: clangd_bin,
+                env: None,
                 arguments: vec![],
             })
         } else {

--- a/crates/zed/src/languages/clojure.rs
+++ b/crates/zed/src/languages/clojure.rs
@@ -105,6 +105,7 @@ impl super::LspAdapter for ClojureLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: vec![],
         })
     }
@@ -118,6 +119,7 @@ impl super::LspAdapter for ClojureLspAdapter {
         if binary_path.exists() {
             Some(LanguageServerBinary {
                 path: binary_path,
+                env: None,
                 arguments: vec![],
             })
         } else {
@@ -133,6 +135,7 @@ impl super::LspAdapter for ClojureLspAdapter {
         if binary_path.exists() {
             Some(LanguageServerBinary {
                 path: binary_path,
+                env: None,
                 arguments: vec!["--version".into()],
             })
         } else {

--- a/crates/zed/src/languages/csharp.rs
+++ b/crates/zed/src/languages/csharp.rs
@@ -92,6 +92,7 @@ impl super::LspAdapter for OmniSharpAdapter {
         }
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: server_binary_arguments(),
         })
     }
@@ -136,6 +137,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
         if let Some(path) = last_binary_path {
             Ok(LanguageServerBinary {
                 path,
+                env: None,
                 arguments: server_binary_arguments(),
             })
         } else {

--- a/crates/zed/src/languages/css.rs
+++ b/crates/zed/src/languages/css.rs
@@ -72,6 +72,7 @@ impl LspAdapter for CssLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -116,6 +117,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/dart.rs
+++ b/crates/zed/src/languages/dart.rs
@@ -39,6 +39,7 @@ impl LspAdapter for DartLanguageServer {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "dart".into(),
+            env: None,
             arguments: vec!["language-server".into(), "--protocol=lsp".into()],
         })
     }

--- a/crates/zed/src/languages/deno.rs
+++ b/crates/zed/src/languages/deno.rs
@@ -134,6 +134,7 @@ impl LspAdapter for DenoLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: deno_server_binary_arguments(),
         })
     }
@@ -220,6 +221,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
                 if fs::metadata(&binary).await.is_ok() {
                     return Ok(LanguageServerBinary {
                         path: binary,
+                        env: None,
                         arguments: deno_server_binary_arguments(),
                     });
                 }

--- a/crates/zed/src/languages/dockerfile.rs
+++ b/crates/zed/src/languages/dockerfile.rs
@@ -71,6 +71,7 @@ impl LspAdapter for DockerfileLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -110,6 +111,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/elixir.rs
+++ b/crates/zed/src/languages/elixir.rs
@@ -174,6 +174,7 @@ impl LspAdapter for ElixirLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: vec![],
         })
     }
@@ -284,6 +285,7 @@ async fn get_cached_server_binary_elixir_ls(
     if server_path.exists() {
         Some(LanguageServerBinary {
             path: server_path,
+            env: None,
             arguments: vec![],
         })
     } else {
@@ -369,6 +371,7 @@ impl LspAdapter for NextLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: vec!["--stdio".into()],
         })
     }
@@ -435,6 +438,7 @@ async fn get_cached_server_binary_next(container_dir: PathBuf) -> Option<Languag
         if let Some(path) = last_binary_path {
             Ok(LanguageServerBinary {
                 path,
+                env: None,
                 arguments: Vec::new(),
             })
         } else {
@@ -476,6 +480,7 @@ impl LspAdapter for LocalLspAdapter {
         let path = shellexpand::full(&self.path)?;
         Ok(LanguageServerBinary {
             path: PathBuf::from(path.deref()),
+            env: None,
             arguments: self.arguments.iter().map(|arg| arg.into()).collect(),
         })
     }
@@ -488,6 +493,7 @@ impl LspAdapter for LocalLspAdapter {
         let path = shellexpand::full(&self.path).ok()?;
         Some(LanguageServerBinary {
             path: PathBuf::from(path.deref()),
+            env: None,
             arguments: self.arguments.iter().map(|arg| arg.into()).collect(),
         })
     }
@@ -496,6 +502,7 @@ impl LspAdapter for LocalLspAdapter {
         let path = shellexpand::full(&self.path).ok()?;
         Some(LanguageServerBinary {
             path: PathBuf::from(path.deref()),
+            env: None,
             arguments: self.arguments.iter().map(|arg| arg.into()).collect(),
         })
     }

--- a/crates/zed/src/languages/elm.rs
+++ b/crates/zed/src/languages/elm.rs
@@ -75,6 +75,7 @@ impl LspAdapter for ElmLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -134,6 +135,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/erlang.rs
+++ b/crates/zed/src/languages/erlang.rs
@@ -41,6 +41,7 @@ impl LspAdapter for ErlangLspAdapter {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "erlang_ls".into(),
+            env: None,
             arguments: vec![],
         })
     }
@@ -52,6 +53,7 @@ impl LspAdapter for ErlangLspAdapter {
     async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "erlang_ls".into(),
+            env: None,
             arguments: vec!["--version".into()],
         })
     }

--- a/crates/zed/src/languages/gleam.rs
+++ b/crates/zed/src/languages/gleam.rs
@@ -81,6 +81,7 @@ impl LspAdapter for GleamLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: server_binary_arguments(),
         })
     }
@@ -116,6 +117,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
 
         anyhow::Ok(LanguageServerBinary {
             path: last.ok_or_else(|| anyhow!("no cached binary"))?,
+            env: None,
             arguments: server_binary_arguments(),
         })
     })

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -64,20 +64,15 @@ impl super::LspAdapter for GoLspAdapter {
         cx: &mut AsyncAppContext,
     ) -> Option<Task<Option<LanguageServerBinary>>> {
         let delegate = delegate.clone();
+
         Some(cx.spawn(|cx| async move {
-            let command = match cx.update(|cx| delegate.which_command(OsStr::new("gopls"), cx)) {
-                Ok(task) => task.await,
-                Err(_) => {
-                    return None;
-                }
-            };
-            match command {
-                Some((path, env)) => Some(LanguageServerBinary {
+            match cx.update(|cx| delegate.which_command(OsString::from("gopls"), cx)) {
+                Ok(task) => task.await.map(|(path, env)| LanguageServerBinary {
                     path,
                     arguments: server_binary_arguments(),
                     env: Some(env),
                 }),
-                None => None,
+                Err(_) => None,
             }
         }))
     }
@@ -94,12 +89,7 @@ impl super::LspAdapter for GoLspAdapter {
 
         let delegate = delegate.clone();
         Some(cx.spawn(|cx| async move {
-            let install_output = cx
-                .update(|cx| delegate.build_command(OsStr::new("go"), cx))?
-                .await
-                .args(["version"])
-                .output()
-                .await;
+            let install_output = process::Command::new("go").args(["version"]).output().await;
             if install_output.is_err() {
                 if DID_SHOW_NOTIFICATION
                     .compare_exchange(false, true, SeqCst, SeqCst)

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -70,7 +70,12 @@ impl super::LspAdapter for GoLspAdapter {
 
         let delegate = delegate.clone();
         Some(cx.spawn(|cx| async move {
-            let install_output = process::Command::new("go").args(["version"]).output().await;
+            let install_output = cx
+                .update(|cx| delegate.build_command(OsStr::new("go"), cx))?
+                .await
+                .args(["version"])
+                .output()
+                .await;
             if install_output.is_err() {
                 if DID_SHOW_NOTIFICATION
                     .compare_exchange(false, true, SeqCst, SeqCst)

--- a/crates/zed/src/languages/go.rs
+++ b/crates/zed/src/languages/go.rs
@@ -72,9 +72,10 @@ impl super::LspAdapter for GoLspAdapter {
                 }
             };
             match command {
-                Some(path) => Some(LanguageServerBinary {
+                Some((path, env)) => Some(LanguageServerBinary {
                     path,
                     arguments: server_binary_arguments(),
+                    env: Some(env),
                 }),
                 None => None,
             }
@@ -135,6 +136,7 @@ impl super::LspAdapter for GoLspAdapter {
                     return Ok(LanguageServerBinary {
                         path: binary_path.to_path_buf(),
                         arguments: server_binary_arguments(),
+                        env: None,
                     });
                 }
             }
@@ -182,6 +184,7 @@ impl super::LspAdapter for GoLspAdapter {
         Ok(LanguageServerBinary {
             path: binary_path.to_path_buf(),
             arguments: server_binary_arguments(),
+            env: None,
         })
     }
 
@@ -400,6 +403,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
             Ok(LanguageServerBinary {
                 path,
                 arguments: server_binary_arguments(),
+                env: None,
             })
         } else {
             Err(anyhow!("no cached binary"))

--- a/crates/zed/src/languages/haskell.rs
+++ b/crates/zed/src/languages/haskell.rs
@@ -41,6 +41,7 @@ impl LspAdapter for HaskellLanguageServer {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "haskell-language-server-wrapper".into(),
+            env: None,
             arguments: vec!["lsp".into()],
         })
     }

--- a/crates/zed/src/languages/html.rs
+++ b/crates/zed/src/languages/html.rs
@@ -72,6 +72,7 @@ impl LspAdapter for HtmlLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -116,6 +117,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/json.rs
+++ b/crates/zed/src/languages/json.rs
@@ -122,6 +122,7 @@ impl LspAdapter for JsonLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -177,6 +178,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/lua.rs
+++ b/crates/zed/src/languages/lua.rs
@@ -94,6 +94,7 @@ impl super::LspAdapter for LuaLspAdapter {
         }
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: Vec::new(),
         })
     }
@@ -138,6 +139,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
         if let Some(path) = last_binary_path {
             Ok(LanguageServerBinary {
                 path,
+                env: None,
                 arguments: Vec::new(),
             })
         } else {

--- a/crates/zed/src/languages/nu.rs
+++ b/crates/zed/src/languages/nu.rs
@@ -41,6 +41,7 @@ impl LspAdapter for NuLanguageServer {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "nu".into(),
+            env: None,
             arguments: vec!["--lsp".into()],
         })
     }

--- a/crates/zed/src/languages/ocaml.rs
+++ b/crates/zed/src/languages/ocaml.rs
@@ -47,6 +47,7 @@ impl LspAdapter for OCamlLspAdapter {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "ocamllsp".into(),
+            env: None,
             arguments: vec![],
         })
     }

--- a/crates/zed/src/languages/php.rs
+++ b/crates/zed/src/languages/php.rs
@@ -69,6 +69,7 @@ impl LspAdapter for IntelephenseLspAdapter {
         }
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: intelephense_server_binary_arguments(&server_path),
         })
     }
@@ -126,6 +127,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: intelephense_server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/prisma.rs
+++ b/crates/zed/src/languages/prisma.rs
@@ -70,6 +70,7 @@ impl LspAdapter for PrismaLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -112,6 +113,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/purescript.rs
+++ b/crates/zed/src/languages/purescript.rs
@@ -74,6 +74,7 @@ impl LspAdapter for PurescriptLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -127,6 +128,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/python.rs
+++ b/crates/zed/src/languages/python.rs
@@ -62,6 +62,7 @@ impl LspAdapter for PythonLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -167,6 +168,7 @@ async fn get_cached_server_binary(
     if server_path.exists() {
         Some(LanguageServerBinary {
             path: node.binary_path().await.log_err()?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     } else {

--- a/crates/zed/src/languages/ruby.rs
+++ b/crates/zed/src/languages/ruby.rs
@@ -39,6 +39,7 @@ impl LspAdapter for RubyLanguageServer {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "solargraph".into(),
+            env: None,
             arguments: vec!["stdio".into()],
         })
     }

--- a/crates/zed/src/languages/rust.rs
+++ b/crates/zed/src/languages/rust.rs
@@ -89,6 +89,7 @@ impl LspAdapter for RustLspAdapter {
 
         Ok(LanguageServerBinary {
             path: destination_path,
+            env: None,
             arguments: Default::default(),
         })
     }
@@ -296,6 +297,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
 
         anyhow::Ok(LanguageServerBinary {
             path: last.ok_or_else(|| anyhow!("no cached binary"))?,
+            env: None,
             arguments: Default::default(),
         })
     })

--- a/crates/zed/src/languages/svelte.rs
+++ b/crates/zed/src/languages/svelte.rs
@@ -71,6 +71,7 @@ impl LspAdapter for SvelteLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -148,6 +149,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/tailwind.rs
+++ b/crates/zed/src/languages/tailwind.rs
@@ -73,6 +73,7 @@ impl LspAdapter for TailwindLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -150,6 +151,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/toml.rs
+++ b/crates/zed/src/languages/toml.rs
@@ -85,6 +85,7 @@ impl LspAdapter for TaploLspAdapter {
 
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: vec!["lsp".into(), "stdio".into()],
         })
     }
@@ -120,6 +121,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
 
         anyhow::Ok(LanguageServerBinary {
             path: last.context("no cached binary")?,
+            env: None,
             arguments: Default::default(),
         })
     })

--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -97,6 +97,7 @@ impl LspAdapter for TypeScriptLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: typescript_server_binary_arguments(&server_path),
         })
     }
@@ -192,11 +193,13 @@ async fn get_cached_ts_server_binary(
         if new_server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: typescript_server_binary_arguments(&new_server_path),
             })
         } else if old_server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: typescript_server_binary_arguments(&old_server_path),
             })
         } else {
@@ -311,6 +314,7 @@ impl LspAdapter for EsLintLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: eslint_server_binary_arguments(&server_path),
         })
     }
@@ -358,6 +362,7 @@ async fn get_cached_eslint_server_binary(
 
         Ok(LanguageServerBinary {
             path: node.binary_path().await?,
+            env: None,
             arguments: eslint_server_binary_arguments(&server_path),
         })
     })

--- a/crates/zed/src/languages/uiua.rs
+++ b/crates/zed/src/languages/uiua.rs
@@ -41,6 +41,7 @@ impl LspAdapter for UiuaLanguageServer {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "uiua".into(),
+            env: None,
             arguments: vec!["lsp".into()],
         })
     }

--- a/crates/zed/src/languages/vue.rs
+++ b/crates/zed/src/languages/vue.rs
@@ -118,6 +118,7 @@ impl super::LspAdapter for VueLspAdapter {
         *self.typescript_install_path.lock() = Some(ts_path);
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: vue_server_binary_arguments(&server_path),
         })
     }
@@ -204,6 +205,7 @@ async fn get_cached_server_binary(
             Ok((
                 LanguageServerBinary {
                     path: node.binary_path().await?,
+                    env: None,
                     arguments: vue_server_binary_arguments(&server_path),
                 },
                 typescript_path,

--- a/crates/zed/src/languages/yaml.rs
+++ b/crates/zed/src/languages/yaml.rs
@@ -74,6 +74,7 @@ impl LspAdapter for YamlLspAdapter {
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
+            env: None,
             arguments: server_binary_arguments(&server_path),
         })
     }
@@ -124,6 +125,7 @@ async fn get_cached_server_binary(
         if server_path.exists() {
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
+                env: None,
                 arguments: server_binary_arguments(&server_path),
             })
         } else {

--- a/crates/zed/src/languages/zig.rs
+++ b/crates/zed/src/languages/zig.rs
@@ -75,6 +75,7 @@ impl LspAdapter for ZlsAdapter {
         }
         Ok(LanguageServerBinary {
             path: binary_path,
+            env: None,
             arguments: vec![],
         })
     }
@@ -119,6 +120,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
         if let Some(path) = last_binary_path {
             Ok(LanguageServerBinary {
                 path,
+                env: None,
                 arguments: Vec::new(),
             })
         } else {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -848,7 +848,7 @@ async fn load_login_shell_environment() -> Result<()> {
             // and only trigger after `cd`s been used.
             // Since `cd $HOME` is safe (POSIX dicates that $HOME has to be set), we do that
             // before getting the `env`.
-            &format!("cd $HOME; echo {marker}; /usr/bin/env -0"),
+            &format!("cd $HOME; echo {marker}; /usr/bin/env -0; exit 0"),
         ])
         .output()
         .await

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -840,16 +840,7 @@ async fn load_login_shell_environment() -> Result<()> {
         "SHELL environment variable is not assigned so we can't source login environment variables",
     )?;
     let output = Command::new(&shell)
-        .args([
-            "-l",
-            "-i",
-            "-c",
-            // We `cd $HOME` because some tools (asdf, mise, direnv, ...) hook into $SHELL's `cd`
-            // and only trigger after `cd`s been used.
-            // Since `cd $HOME` is safe (POSIX dicates that $HOME has to be set), we do that
-            // before getting the `env`.
-            &format!("cd $HOME; echo {marker}; /usr/bin/env -0; exit 0"),
-        ])
+        .args(["-l", "-i", "-c", &format!("echo {marker}; /usr/bin/env -0")])
         .output()
         .await
         .context("failed to spawn login shell to source login environment variables")?;

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
         let clock = Arc::new(clock::RealSystemClock);
         let http = http::zed_client(&client::ClientSettings::get_global(cx).server_url);
 
-        let client = client::Client::new(http.clone(), cx);
+        let client = client::Client::new(clock, http.clone(), cx);
         let mut languages = LanguageRegistry::new(login_shell_env_loaded);
         let copilot_language_server_id = languages.next_language_server_id();
         languages.set_executor(cx.background_executor().clone());

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1,7 +1,7 @@
 // Allow binary to be called Zed for a nice application menu when running executable directly
 #![allow(non_snake_case)]
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{Context as _, Result};
 use backtrace::Backtrace;
 use chrono::Utc;
 use cli::FORCE_CLI_MODE_ENV_VAR_NAME;
@@ -14,7 +14,7 @@ use fs::RealFs;
 #[cfg(target_os = "macos")]
 use fsevent::StreamFlags;
 use futures::StreamExt;
-use gpui::{App, AppContext, AsyncAppContext, Context, SemanticVersion, Task};
+use gpui::{App, AppContext, AsyncAppContext, Context, SemanticVersion};
 use isahc::{prelude::Configurable, Request};
 use language::LanguageRegistry;
 use log::LevelFilter;
@@ -29,7 +29,6 @@ use settings::{
     default_settings, handle_settings_file_changes, watch_config_file, Settings, SettingsStore,
 };
 use simplelog::ConfigBuilder;
-use smol::process::Command;
 use std::{
     env,
     ffi::OsStr,
@@ -96,14 +95,6 @@ fn main() {
         paths::KEYMAP.clone(),
     );
 
-    let login_shell_env_loaded = if stdout_is_a_pty() {
-        Task::ready(())
-    } else {
-        app.background_executor().spawn(async {
-            load_login_shell_environment().await.log_err();
-        })
-    };
-
     let (listener, mut open_rx) = OpenListener::new();
     let listener = Arc::new(listener);
     let open_listener = listener.clone();
@@ -143,8 +134,8 @@ fn main() {
         let clock = Arc::new(clock::RealSystemClock);
         let http = http::zed_client(&client::ClientSettings::get_global(cx).server_url);
 
-        let client = client::Client::new(clock, http.clone(), cx);
-        let mut languages = LanguageRegistry::new(login_shell_env_loaded);
+        let client = client::Client::new(http.clone(), cx);
+        let mut languages = LanguageRegistry::new();
         let copilot_language_server_id = languages.next_language_server_id();
         languages.set_executor(cx.background_executor().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());
@@ -829,41 +820,6 @@ async fn upload_previous_crashes(
                     .await?;
             }
         }
-    }
-
-    Ok(())
-}
-
-async fn load_login_shell_environment() -> Result<()> {
-    let marker = "ZED_LOGIN_SHELL_START";
-    let shell = env::var("SHELL").context(
-        "SHELL environment variable is not assigned so we can't source login environment variables",
-    )?;
-    let output = Command::new(&shell)
-        .args(["-l", "-i", "-c", &format!("echo {marker}; /usr/bin/env -0")])
-        .output()
-        .await
-        .context("failed to spawn login shell to source login environment variables")?;
-    if !output.status.success() {
-        Err(anyhow!("login shell exited with error"))?;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    if let Some(env_output_start) = stdout.find(marker) {
-        let env_output = &stdout[env_output_start + marker.len()..];
-        for line in env_output.split_terminator('\0') {
-            if let Some(separator_index) = line.find('=') {
-                let key = &line[..separator_index];
-                let value = &line[separator_index + 1..];
-                env::set_var(key, value);
-            }
-        }
-        log::info!(
-            "set environment variables from shell:{}, path:{}",
-            shell,
-            env::var("PATH").unwrap_or_default(),
-        );
     }
 
     Ok(())


### PR DESCRIPTION
After a lot of back-and-forth, this is a small attempt to implement solutions (1) and (3) in https://github.com/zed-industries/zed/issues/7902. The goal is to have a minimal change that helps users get started with Zed, until we have extensions ready.

Release Notes:

- Added detection of user-installed `gopls` to Go language server adapter. If a user has `gopls` in `$PATH` when opening a worktree, it will be used.
- Added detection of user-installed `zls` to Zig language server adapter. If a user has `zls` in `$PATH` when opening a worktree, it will be used.

Example:

I don't have `go` installed globally, but I do have `gopls`:

```
~ $ which go
go not found
~ $ which gopls
/Users/thorstenball/code/go/bin/gopls
```

But I do have `go` in a project's directory:

```
~/tmp/go-testing φ which go
/Users/thorstenball/.local/share/mise/installs/go/1.21.5/go/bin/go
~/tmp/go-testing φ which gopls
/Users/thorstenball/code/go/bin/gopls
```

With current Zed when I run `zed ~/tmp/go-testing`, I'd get the dreaded error:

![screenshot-2024-02-23-11 14 08@2x](https://github.com/zed-industries/zed/assets/1185253/822ea59b-c63e-4102-a50e-75501cc4e0e3)

But with the changes in this PR, it works:

```
[2024-02-23T11:14:42+01:00 INFO  language::language_registry] starting language server "gopls", path: "/Users/thorstenball/tmp/go-testing", id: 1
[2024-02-23T11:14:42+01:00 INFO  language::language_registry] found user-installed language server for Go. path: "/Users/thorstenball/code/go/bin/gopls", arguments: ["-mode=stdio"]
[2024-02-23T11:14:42+01:00 INFO  lsp] starting language server. binary path: "/Users/thorstenball/code/go/bin/gopls", working directory: "/Users/thorstenball/tmp/go-testing", args: ["-mode=stdio"]
```