### PR TITLE
Fix svelte injections / outline

### DIFF
--- a/crates/zed/src/languages/svelte/injections.scm
+++ b/crates/zed/src/languages/svelte/injections.scm
@@ -1,7 +1,11 @@
 ; injections.scm
 ; --------------
-(script_element
-  (raw_text) @content
+((script_element
+    (start_tag
+      (attribute
+        (quoted_attribute_value (attribute_value) @_language))?)
+     (raw_text) @content)
+  (#eq? @_language "")
   (#set! "language" "javascript"))
 
  ((script_element


### PR DESCRIPTION
This PR fixes the buffer symbol search to show `js` and `ts` buffer symbols when using svelte components with `ts`.

Does also seem to improve `ts` capabilities (probably because there has been a conflict of `js` and `ts` before).

Unfortunately when changing the script tag from no lang attribute to `ts` one needs to update the file (input anyting) to get correct buffer symbol search.

Before:
![SCR-20240222-mthf-2](https://github.com/zed-industries/zed/assets/67913738/980cf4bf-15d5-478d-a217-ed8f2b1f197d)

After:
![SCR-20240222-mvjr](https://github.com/zed-industries/zed/assets/67913738/41069e75-77ef-40fe-92d1-c19912b34770)

Release Notes:

- Fixed svelte outlines for `TS`.
