### PR TITLE
Require prerelease eslint version

### DIFF
--- a/crates/zed/src/languages/typescript.rs
+++ b/crates/zed/src/languages/typescript.rs
@@ -259,7 +259,7 @@ impl LspAdapter for EsLintLspAdapter {
         let release = latest_github_release(
             "microsoft/vscode-eslint",
             false,
-            false,
+            true,
             delegate.http_client(),
         )
         .await?;


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/7650

Release Notes:

- Fixed eslint diagnostics not showing up due to old eslint version used