### PR TITLE
Update button label and state based on extension status

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -192,7 +192,11 @@ impl ExtensionsPage {
                             this.install_extension(extension_id.clone(), version.clone(), cx);
                         }
                     }))
-                    .disabled(matches!(status, ExtensionStatus::Installing))
+                    .when(matches!(status, ExtensionStatus::Installing), |button| {
+                        button
+                            .label("Installing...")
+                            .disabled(true)
+                    })
             }
             ExtensionStatus::Installed(_)
             | ExtensionStatus::Upgrading
@@ -206,6 +210,14 @@ impl ExtensionsPage {
                             this.uninstall_extension(extension_id.clone(), cx);
                         }
                     }))
+                    .when(
+                        matches!(status, ExtensionStatus::Removing),
+                        |button| button.label("Uninstalling...")
+                    )
+                    .when(
+                        matches!(status, ExtensionStatus::Upgrading),
+                        |button| button.label("Upgrading...")
+                    )
                     .disabled(matches!(
                         status,
                         ExtensionStatus::Upgrading | ExtensionStatus::Removing

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -193,9 +193,7 @@ impl ExtensionsPage {
                         }
                     }))
                     .when(matches!(status, ExtensionStatus::Installing), |button| {
-                        button
-                            .label("Installing...")
-                            .disabled(true)
+                        button.label("Installing...").disabled(true)
                     })
             }
             ExtensionStatus::Installed(_)
@@ -210,14 +208,12 @@ impl ExtensionsPage {
                             this.uninstall_extension(extension_id.clone(), cx);
                         }
                     }))
-                    .when(
-                        matches!(status, ExtensionStatus::Removing),
-                        |button| button.label("Uninstalling...")
-                    )
-                    .when(
-                        matches!(status, ExtensionStatus::Upgrading),
-                        |button| button.label("Upgrading...")
-                    )
+                    .when(matches!(status, ExtensionStatus::Removing), |button| {
+                        button.label("Uninstalling...")
+                    })
+                    .when(matches!(status, ExtensionStatus::Upgrading), |button| {
+                        button.label("Upgrading...")
+                    })
                     .disabled(matches!(
                         status,
                         ExtensionStatus::Upgrading | ExtensionStatus::Removing

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -112,6 +112,12 @@ impl Button {
         }
     }
 
+    /// Sets the label of the button.
+    pub fn label<L: Into<SharedString>>(mut self, label: L) -> Self {
+        self.label = label.into();
+        self
+    }
+
     /// Sets the color of the button's label.
     pub fn color(mut self, label_color: impl Into<Option<Color>>) -> Self {
         self.label_color = label_color.into();


### PR DESCRIPTION
This code makes buttons like "Rename" and "Install" change their text and become unclickable based on what's happening with an extension (installing, uninstalling, etc.). This helps users know what's going on.

Release Notes:

- N/A
