### PR TITLE
Fix Flashing Hover Popover

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -887,6 +887,9 @@ impl EditorElement {
         cx: &mut ElementContext,
     ) {
         let start_row = layout.visible_display_row_range.start;
+        // This additional padding added to the text bounds offsets text rendering by about half a character's width
+        // so that the cursor 'snaps' to the nearest position without `LineLayout::index_for_x`
+        // actually searching for the closest index
         let content_origin = text_bounds.origin + point(layout.gutter_margin, Pixels::ZERO);
         let line_end_overshoot = 0.15 * layout.position_map.line_height;
         let whitespace_setting = self

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -887,9 +887,7 @@ impl EditorElement {
         cx: &mut ElementContext,
     ) {
         let start_row = layout.visible_display_row_range.start;
-        // This additional padding added to the text bounds offsets text rendering by about half a character's width
-        // so that the cursor 'snaps' to the nearest position without `LineLayout::index_for_x`
-        // actually searching for the closest index
+        // Offset the content_bounds from the text_bounds by the gutter margin (which is roughly half a character wide) to make hit testing work more like how we want.
         let content_origin = text_bounds.origin + point(layout.gutter_margin, Pixels::ZERO);
         let line_end_overshoot = 0.15 * layout.position_map.line_height;
         let whitespace_setting = self

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -199,8 +199,9 @@ fn show_hover(
             if symbol_range
                 .as_text_range()
                 .map(|range| {
-                    range
-                        .to_offset(&snapshot.buffer_snapshot)
+                    let hover_range = range
+                        .to_offset(&snapshot.buffer_snapshot);
+                    (hover_range.start..=hover_range.end)
                         .contains(&multibuffer_offset)
                 })
                 .unwrap_or(false)

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -199,12 +199,10 @@ fn show_hover(
             if symbol_range
                 .as_text_range()
                 .map(|range| {
-                    let hover_range = range
-                        .to_offset(&snapshot.buffer_snapshot);
+                    let hover_range = range.to_offset(&snapshot.buffer_snapshot);
                     // LSP returns a hover result for the end index of ranges that should be hovered, so we need to
                     // use an inclusive range here to check if we should dismiss the popover
-                    (hover_range.start..=hover_range.end)
-                        .contains(&multibuffer_offset)
+                    (hover_range.start..=hover_range.end).contains(&multibuffer_offset)
                 })
                 .unwrap_or(false)
             {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -201,6 +201,8 @@ fn show_hover(
                 .map(|range| {
                     let hover_range = range
                         .to_offset(&snapshot.buffer_snapshot);
+                    // LSP returns a hover result for the end index of ranges that should be hovered, so we need to
+                    // use an inclusive range here to check if we should dismiss the popover
                     (hover_range.start..=hover_range.end)
                         .contains(&multibuffer_offset)
                 })


### PR DESCRIPTION

Release Notes:

- Use an inclusive range for local range containment check to match LSP behavior & fix popover flashing while the cursor moves over the last character of a symbol.

https://github.com/zed-industries/zed/assets/17223924/6c3ddc9c-04fb-4414-812f-025ede5ecaf7

