### PR TITLE
Re-enable PureScript on Linux and Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10398,8 +10398,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-purescript"
-version = "1.0.0"
-source = "git+https://github.com/ivanmoreau/tree-sitter-purescript?rev=a37140f0c7034977b90faa73c94fcb8a5e45ed08#a37140f0c7034977b90faa73c94fcb8a5e45ed08"
+version = "0.1.0"
+source = "git+https://github.com/postsolar/tree-sitter-purescript?rev=v0.1.0#0554811a512b9cec08b5a83ce9096eb22da18213"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", 
 tree-sitter-php = "0.21.1"
 tree-sitter-prisma-io = { git = "https://github.com/victorhqc/tree-sitter-prisma" }
 tree-sitter-proto = { git = "https://github.com/rewinfrey/tree-sitter-proto", rev = "36d54f288aee112f13a67b550ad32634d0c2cb52" }
-tree-sitter-purescript = { git = "https://github.com/ivanmoreau/tree-sitter-purescript", rev = "a37140f0c7034977b90faa73c94fcb8a5e45ed08" }
+tree-sitter-purescript = { git = "https://github.com/postsolar/tree-sitter-purescript", rev = "v0.1.0" }
 tree-sitter-python = "0.20.2"
 tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-racket", rev = "eb010cf2c674c6fd9a6316a84e28ef90190fe51a" }
 tree-sitter-ruby = "0.20.0"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -144,6 +144,7 @@ tree-sitter-ocaml.workspace = true
 tree-sitter-php.workspace = true
 tree-sitter-prisma-io.workspace = true
 tree-sitter-proto.workspace = true
+tree-sitter-purescript.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-racket.workspace = true
 tree-sitter-ruby.workspace = true
@@ -165,9 +166,6 @@ vim.workspace = true
 welcome.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
-
-[target.'cfg(not(windows))'.dependencies]
-tree-sitter-purescript.workspace = true
 
 [dev-dependencies]
 call = { workspace = true, features = ["test-support"] }

--- a/crates/zed/src/languages.rs
+++ b/crates/zed/src/languages.rs
@@ -106,7 +106,6 @@ pub fn init(
         ("php", tree_sitter_php::language_php()),
         ("prisma", tree_sitter_prisma_io::language()),
         ("proto", tree_sitter_proto::language()),
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         ("purescript", tree_sitter_purescript::language()),
         ("python", tree_sitter_python::language()),
         ("racket", tree_sitter_racket::language()),
@@ -294,10 +293,6 @@ pub fn init(
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ],
     );
-
-    // Produces a link error on linux due to duplicated `state_new` symbol
-    // todo!(linux): Restore purescript
-    #[cfg(not(target_os = "linux"))]
     language(
         "purescript",
         vec![Arc::new(purescript::PurescriptLspAdapter::new(

--- a/docs/src/languages/purescript.md
+++ b/docs/src/languages/purescript.md
@@ -1,4 +1,4 @@
 # PureScript
 
-- Tree Sitter: [tree-sitter-purescript](https://github.com/ivanmoreau/tree-sitter-purescript)
+- Tree Sitter: [tree-sitter-purescript](https://github.com/postsolar/tree-sitter-purescript)
 - Language Server: [purescript](https://github.com/nwolverson/purescript-language-server)


### PR DESCRIPTION
Release Notes:

- Fixed build issues with PureScript on Windows and Linux


Relevant PRs:
- https://github.com/zed-industries/zed/pull/7543
- https://github.com/zed-industries/zed/pull/7827

I merged discussed changes into upstream grammar and switched you to that repo. I'm on NixOS so I'm unable to test it on either Windows or Linux, ~~hence the draft PR~~ but CI passed so there's that. But the Linux linking issue was solved for another program, and as for Windows I just replicated the changes that @kazatsuyu PR'd to some other grammars' repos so it could work, I think.
