### PR TITLE
linux/x11: prioritize input in the event loop

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -507,15 +507,15 @@ impl BladeRenderer {
     }
 
     pub fn draw(&mut self, scene: &Scene) {
+        self.command_encoder.start();
+        self.atlas.before_frame(&mut self.command_encoder);
+        self.rasterize_paths(scene.paths());
+
         let frame = {
             profiling::scope!("acquire frame");
             self.gpu.acquire_frame()
         };
-        self.command_encoder.start();
         self.command_encoder.init_texture(frame.texture());
-
-        self.atlas.before_frame(&mut self.command_encoder);
-        self.rasterize_paths(scene.paths());
 
         let globals = GlobalParams {
             viewport_size: [


### PR DESCRIPTION
With this change, interaction with Zed is actually real-time and usable :rocket: :tada: 

The gist of it is - trying to process all of the input events before rendering anything.

Release Notes:
- N/A

**Note**: this can be further improved in a follow-up.
Currently, once the input and runnables are processed, we'd try to draw + render a frame.
Presentation starts with acquiring a new frame. We currently have FIFO presentation method, so acquiring a frame is blocking on that swapchain image to become available. As the result, presentation takes around 16 ms, most of which is just busy wait.
Ideally, we'd be able to process more input in this time frame, instead.

**Note2**: it's a bit laggy in Debug for me, but that's just because of the extra-long `draw` times, which is unrelated to rendering (or platform support, for the matter). I'm curious how come on MacOS the `draw()` times in Debug are more modest.