### PR TITLE
chore: Fix warning from 1.77 rustc

### DIFF
--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -78,7 +78,7 @@ struct AvailableLanguage {
 
 enum AvailableGrammar {
     Native(tree_sitter::Language),
-    Loaded(PathBuf, tree_sitter::Language),
+    Loaded(#[allow(dead_code)] PathBuf, tree_sitter::Language),
     Loading(PathBuf, Vec<oneshot::Sender<Result<tree_sitter::Language>>>),
     Unloaded(PathBuf),
 }


### PR DESCRIPTION
/cc @maxbrunsfeld , I didn't remove the field outright since I'm not sure if the intent is to use it eventually in extensions work. 
This is the warning we're getting on 1.77 (release date: 03.21.2024) :
```
warning: field `0` is never read
  --> crates/language/src/language_registry.rs:81:12
   |
81 |     Loaded(PathBuf, tree_sitter::Language),
   |     ------ ^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
81 |     Loaded((), tree_sitter::Language),
   |            ~~

warning: field `0` is never read
  --> crates/language/src/language_registry.rs:82:13
   |
82 |     Loading(PathBuf, Vec<oneshot::Sender<Result<tree_sitter::Language>>>),
   |     ------- ^^^^^^^
   |     |
   |     field in this variant
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
82 |     Loading((), Vec<oneshot::Sender<Result<tree_sitter::Language>>>),
   |             ~~
```
Release Notes:

- N/A