### PR TITLE
Debounce refresh of inlay hints on buffer edits

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -169,7 +169,9 @@
     "show_type_hints": true,
     "show_parameter_hints": true,
     // Corresponds to null/None LSP hint type value.
-    "show_other_hints": true
+    "show_other_hints": true,
+    // Time to wait after editing the buffer, before requesting the hints.
+    "default_debounce_ms": 700
   },
   "project_panel": {
     // Default width of the project panel.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -170,8 +170,12 @@
     "show_parameter_hints": true,
     // Corresponds to null/None LSP hint type value.
     "show_other_hints": true,
-    // Time to wait after editing the buffer, before requesting the hints.
-    "default_debounce_ms": 700
+    // Time to wait after editing the buffer, before requesting the hints,
+    // set to 0 to disable debouncing.
+    "edit_debounce_ms": 700,
+    // Time to wait after scrolling the buffer, before requesting the hints,
+    // set to 0 to disable debouncing.
+    "scroll_debounce_ms": 50
   },
   "project_panel": {
     // Default width of the project panel.

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -1426,6 +1426,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
+                    debounce_ms: 0,
                     show_type_hints: true,
                     show_parameter_hints: false,
                     show_other_hints: true,
@@ -1438,6 +1439,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
+                    debounce_ms: 0,
                     show_type_hints: true,
                     show_parameter_hints: false,
                     show_other_hints: true,
@@ -1695,6 +1697,7 @@ async fn test_inlay_hint_refresh_is_forwarded(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: false,
+                    debounce_ms: 0,
                     show_type_hints: false,
                     show_parameter_hints: false,
                     show_other_hints: false,
@@ -1707,6 +1710,7 @@ async fn test_inlay_hint_refresh_is_forwarded(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
+                    debounce_ms: 0,
                     show_type_hints: true,
                     show_parameter_hints: true,
                     show_other_hints: true,

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -1426,7 +1426,8 @@ async fn test_mutual_editor_inlay_hint_cache_update(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
-                    debounce_ms: 0,
+                    edit_debounce_ms: 0,
+                    scroll_debounce_ms: 0,
                     show_type_hints: true,
                     show_parameter_hints: false,
                     show_other_hints: true,
@@ -1439,7 +1440,8 @@ async fn test_mutual_editor_inlay_hint_cache_update(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
-                    debounce_ms: 0,
+                    edit_debounce_ms: 0,
+                    scroll_debounce_ms: 0,
                     show_type_hints: true,
                     show_parameter_hints: false,
                     show_other_hints: true,
@@ -1697,7 +1699,8 @@ async fn test_inlay_hint_refresh_is_forwarded(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: false,
-                    debounce_ms: 0,
+                    edit_debounce_ms: 0,
+                    scroll_debounce_ms: 0,
                     show_type_hints: false,
                     show_parameter_hints: false,
                     show_other_hints: false,
@@ -1710,7 +1713,8 @@ async fn test_inlay_hint_refresh_is_forwarded(
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
-                    debounce_ms: 0,
+                    edit_debounce_ms: 0,
+                    scroll_debounce_ms: 0,
                     show_type_hints: true,
                     show_parameter_hints: true,
                     show_other_hints: true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1360,6 +1360,7 @@ enum InlayHintRefreshReason {
     RefreshRequested,
     ExcerptsRemoved(Vec<ExcerptId>),
 }
+
 impl InlayHintRefreshReason {
     fn description(&self) -> &'static str {
         match self {
@@ -3029,6 +3030,10 @@ impl Editor {
         }
 
         let reason_description = reason.description();
+        let ignore_debounce = matches!(
+            reason,
+            InlayHintRefreshReason::SettingsChange(_) | InlayHintRefreshReason::Toggle(_)
+        );
         let (invalidate_cache, required_languages) = match reason {
             InlayHintRefreshReason::Toggle(enabled) => {
                 self.inlay_hint_cache.enabled = enabled;
@@ -3091,6 +3096,7 @@ impl Editor {
             reason_description,
             self.excerpts_for_inlay_hints_query(required_languages.as_ref(), cx),
             invalidate_cache,
+            ignore_debounce,
             cx,
         ) {
             self.splice_inlay_hints(to_remove, to_insert, cx);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3029,12 +3029,7 @@ impl Editor {
             return;
         }
 
-        let reason_description = reason.description();
-        let ignore_debounce = matches!(
-            reason,
-            InlayHintRefreshReason::SettingsChange(_) | InlayHintRefreshReason::Toggle(_)
-        );
-        let (invalidate_cache, required_languages) = match reason {
+        let (invalidate_cache, required_languages) = match reason.clone() {
             InlayHintRefreshReason::Toggle(enabled) => {
                 self.inlay_hint_cache.enabled = enabled;
                 if enabled {
@@ -3093,10 +3088,9 @@ impl Editor {
             to_remove,
             to_insert,
         }) = self.inlay_hint_cache.spawn_hint_refresh(
-            reason_description,
+            reason,
             self.excerpts_for_inlay_hints_query(required_languages.as_ref(), cx),
             invalidate_cache,
-            ignore_debounce,
             cx,
         ) {
             self.splice_inlay_hints(to_remove, to_insert, cx);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3029,7 +3029,14 @@ impl Editor {
             return;
         }
 
-        let (invalidate_cache, required_languages) = match reason.clone() {
+        let reason_description = reason.description();
+        let ignore_debounce = matches!(
+            reason,
+            InlayHintRefreshReason::SettingsChange(_)
+                | InlayHintRefreshReason::Toggle(_)
+                | InlayHintRefreshReason::ExcerptsRemoved(_)
+        );
+        let (invalidate_cache, required_languages) = match reason {
             InlayHintRefreshReason::Toggle(enabled) => {
                 self.inlay_hint_cache.enabled = enabled;
                 if enabled {
@@ -3088,9 +3095,10 @@ impl Editor {
             to_remove,
             to_insert,
         }) = self.inlay_hint_cache.spawn_hint_refresh(
-            reason,
+            reason_description,
             self.excerpts_for_inlay_hints_query(required_languages.as_ref(), cx),
             invalidate_cache,
+            ignore_debounce,
             cx,
         ) {
             self.splice_inlay_hints(to_remove, to_insert, cx);

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -984,6 +984,7 @@ mod tests {
         init_test(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettings {
                 enabled: true,
+                debounce_ms: 0,
                 show_type_hints: true,
                 show_parameter_hints: true,
                 show_other_hints: true,

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -984,7 +984,8 @@ mod tests {
         init_test(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettings {
                 enabled: true,
-                debounce_ms: 0,
+                edit_debounce_ms: 0,
+                scroll_debounce_ms: 0,
                 show_type_hints: true,
                 show_parameter_hints: true,
                 show_other_hints: true,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1066,7 +1066,8 @@ mod tests {
         init_test(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettings {
                 enabled: true,
-                debounce_ms: 0,
+                edit_debounce_ms: 0,
+                scroll_debounce_ms: 0,
                 show_type_hints: true,
                 show_parameter_hints: true,
                 show_other_hints: true,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1066,6 +1066,7 @@ mod tests {
         init_test(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettings {
                 enabled: true,
+                debounce_ms: 0,
                 show_type_hints: true,
                 show_parameter_hints: true,
                 show_other_hints: true,

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -340,6 +340,7 @@ impl InlayHintCache {
         reason: &'static str,
         excerpts_to_query: HashMap<ExcerptId, (Model<Buffer>, Global, Range<usize>)>,
         invalidate: InvalidationStrategy,
+        ignore_debounce: bool,
         cx: &mut ViewContext<Editor>,
     ) -> Option<InlaySplice> {
         if !self.enabled {
@@ -363,7 +364,7 @@ impl InlayHintCache {
         }
 
         let cache_version = self.version + 1;
-        let refresh_debounce_duration = self.refresh_debounce_duration;
+        let refresh_debounce_duration = self.refresh_debounce_duration.filter(|_| !ignore_debounce);
         self.refresh_task = Some(cx.spawn(|editor, mut cx| async move {
             if let Some(debounce_duration) = refresh_debounce_duration {
                 cx.background_executor().timer(debounce_duration).await;

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -110,10 +110,6 @@ impl InvalidationStrategy {
             InvalidationStrategy::RefreshRequested | InvalidationStrategy::BufferEdited
         )
     }
-
-    fn is_buffer_edited(&self) -> bool {
-        matches!(self, InvalidationStrategy::BufferEdited)
-    }
 }
 
 impl TasksForRanges {
@@ -369,10 +365,8 @@ impl InlayHintCache {
         let cache_version = self.version + 1;
         let refresh_debounce_duration = self.refresh_debounce_duration;
         self.refresh_task = Some(cx.spawn(|editor, mut cx| async move {
-            if invalidate.is_buffer_edited() {
-                if let Some(debounce_duration) = refresh_debounce_duration {
-                    cx.background_executor().timer(debounce_duration).await;
-                }
+            if let Some(debounce_duration) = refresh_debounce_duration {
+                cx.background_executor().timer(debounce_duration).await;
             }
 
             editor

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -2837,14 +2837,7 @@ pub mod tests {
                 assert_eq!(editor.inlay_hint_cache().version, last_scroll_update_version, "No updates should happen during scrolling already scrolled buffer");
             }).unwrap();
 
-        cx.executor().advance_clock(Duration::from_millis(
-            INVISIBLE_RANGES_HINTS_REQUEST_DELAY_MILLIS + 100,
-        ));
-        cx.executor().run_until_parked();
-        editor_edited.store(true, Ordering::SeqCst);
-        // We split these changes up in two `editor.updates` with corresponding `cx.executor().run_until_parked()`
-        // because if we do both changes in the same `editor.update` the 2 callbacks to refresh inlay hints
-        // won't both be completed: the 2nd one will cancel the first one and only 2nd one will update.
+        editor_edited.store(true, Ordering::Release);
         editor
             .update(cx, |editor, cx| {
                 editor.change_selections(None, cx, |s| {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -327,10 +327,21 @@ pub struct InlayHintSettings {
     /// Default: true
     #[serde(default = "default_true")]
     pub show_other_hints: bool,
+    /// Whether or not to debounce inlay hints updates after buffer edits.
+    ///
+    /// Set to 0 to disable debouncing.
+    ///
+    /// Default: 700
+    #[serde(default = "default_debounce_ms")]
+    pub debounce_ms: u64,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_debounce_ms() -> u64 {
+    700
 }
 
 impl InlayHintSettings {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -332,16 +332,27 @@ pub struct InlayHintSettings {
     /// Set to 0 to disable debouncing.
     ///
     /// Default: 700
-    #[serde(default = "default_debounce_ms")]
-    pub debounce_ms: u64,
+    #[serde(default = "edit_debounce_ms")]
+    pub edit_debounce_ms: u64,
+    /// Whether or not to debounce inlay hints updates after buffer scrolls.
+    ///
+    /// Set to 0 to disable debouncing.
+    ///
+    /// Default: 50
+    #[serde(default = "scroll_debounce_ms")]
+    pub scroll_debounce_ms: u64,
 }
 
 fn default_true() -> bool {
     true
 }
 
-fn default_debounce_ms() -> u64 {
+fn edit_debounce_ms() -> u64 {
     700
+}
+
+fn scroll_debounce_ms() -> u64 {
+    50
 }
 
 impl InlayHintSettings {

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -383,7 +383,9 @@ To override settings for a language, add an entry for that language server's nam
   "enabled": false,
   "show_type_hints": true,
   "show_parameter_hints": true,
-  "show_other_hints": true
+  "show_other_hints": true,
+  "edit_debounce_ms": 700,
+  "scroll_debounce_ms": 50
 }
 ```
 
@@ -401,6 +403,9 @@ The following languages have inlay hints preconfigured by Zed:
 - [Typescript](https://docs.zed.dev/languages/typescript)
 
 Use the `lsp` section for the server configuration. Examples are provided in the corresponding language documentation.
+
+Hints are not instantly queried in Zed, two kinds of debounces are used, either may be set to 0 to be disabled.
+Settings-related hint updates are not debounced.
 
 ## Journal
 


### PR DESCRIPTION
I think this makes it less chaotic to edit text when the inlay hints are on.

It's for cases where you're editing to the right side of an inlay hint. Example:

```rust
for name in names.iter().map(|item| item.len()) {
    println!("{:?}", name);
}
```

We display a `usize` inlay hint right next to `name`.

But as soon as you remove that `.` in `names.iter` your cursor jumps around because the inlay hint has been removed.

With this change we now have a 700ms debounce before we update the inlay hints.

VS Code seems to have an even longer debounce, I think somewhere around ~1s.

Release Notes:

- Added debouncing to make it easier to edit text when inlay hints are enabled and to save rendering of inlay hints when scrolling. Both debounce durations can be configured with `{"inlay_hints": {"edit_debounce_ms": 700}}` (default) and `{"inlay_hints": {"scroll_debounce_ms": 50}}`. Set a value to `0` to turn off the debouncing.


### Before

https://github.com/zed-industries/zed/assets/1185253/3afbe548-dcfb-45a3-ab9f-cce14c04a148



### After


https://github.com/zed-industries/zed/assets/1185253/7ea90e42-bca6-4f6c-995e-83324669ab43


