### PR TITLE
Do not display inlay hints as bold

### DIFF
--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -482,7 +482,7 @@
         "hidden": "#998b78ff",
         "hidden.background": "#4c4642ff",
         "hidden.border": "#544c48ff",
-        "hint": "#8c957dff",
+        "hint": "#6a695bff",
         "hint.background": "#1e2321ff",
         "hint.border": "#303a36ff",
         "ignored": "#c5b597ff",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9784,7 +9784,6 @@ impl Render for Editor {
                 status: cx.theme().status().clone(),
                 inlays_style: HighlightStyle {
                     color: Some(cx.theme().status().hint),
-                    font_weight: Some(FontWeight::BOLD),
                     ..HighlightStyle::default()
                 },
                 suggestions_style: HighlightStyle {


### PR DESCRIPTION
I think bold is the least fitting font weight for inlay hints, which should be subtle hints and not, well, bold.

If someone feels strongly about this, I can revert, but only if we add the ability to change this per theme.

Until then: beautiful, thin, subtle inlay hints!

Release Notes:

- Improved styling of inlay hints by not making them bold in the editor.


![screenshot-2024-02-23-17 30 29@2x](https://github.com/zed-industries/zed/assets/1185253/89c2a162-76bb-45cd-8b45-2a5bdf8ca87b)
