### PR TITLE
Add .cljc, .edn, & .bb to Clojure filename extensions

### DIFF
--- a/crates/languages/src/clojure/config.toml
+++ b/crates/languages/src/clojure/config.toml
@@ -1,6 +1,6 @@
 name = "Clojure"
 grammar = "clojure"
-path_suffixes = ["clj", "cljs"]
+path_suffixes = ["clj", "cljs", "cljc", "edn", "bb"]
 line_comments = [";; "]
 autoclose_before = "}])"
 brackets = [

--- a/typos.toml
+++ b/typos.toml
@@ -14,6 +14,8 @@ extend-exclude = [
     # Editor and file finder rely on partial typing and custom in-string syntax
     "crates/file_finder/src/file_finder_tests.rs",
     "crates/editor/src/editor_tests.rs",
+    # Clojure uses .edn filename extension, which is not a misspelling of "end"
+    "crates/languages/src/clojure/config.toml",
 ]
 
 [default]


### PR DESCRIPTION

Release Notes:

- Added .cljc, .edn, & .bb to Clojure filename extensions ([#7845](https://github.com/zed-industries/zed/issues/7845)).