### PR TITLE
Support rendering strikethrough text in markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7289,11 +7289,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "memchr",
  "unicase",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ profiling = "1"
 postage = { version = "0.5", features = ["futures-traits"] }
 pretty_assertions = "1.3.0"
 prost = "0.8"
-pulldown-cmark = { version = "0.9.2", default-features = false }
+pulldown-cmark = { version = "0.10.0", default-features = false }
 rand = "0.8.5"
 refineable = { path = "./crates/refineable" }
 regex = "1.5"

--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::{ops::Range, path::PathBuf};
 
 use crate::{HighlightId, Language, LanguageRegistry};
-use gpui::{px, FontStyle, FontWeight, HighlightStyle, UnderlineStyle};
+use gpui::{px, FontStyle, FontWeight, HighlightStyle, UnderlineStyle, StrikethroughStyle};
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 
 /// Parsed Markdown content.
@@ -42,6 +42,13 @@ impl MarkdownHighlight {
 
                 if style.underline {
                     highlight.underline = Some(UnderlineStyle {
+                        thickness: px(1.),
+                        ..Default::default()
+                    });
+                }
+
+                if style.strikethrough {
+                    highlight.strikethrough = Some(StrikethroughStyle {
                         thickness: px(1.),
                         ..Default::default()
                     });

--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -5,7 +5,7 @@ use std::{ops::Range, path::PathBuf};
 
 use crate::{HighlightId, Language, LanguageRegistry};
 use gpui::{px, FontStyle, FontWeight, HighlightStyle, StrikethroughStyle, UnderlineStyle};
-use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 
 /// Parsed Markdown content.
 #[derive(Debug, Clone)]
@@ -235,7 +235,12 @@ pub async fn parse_markdown_block(
             Event::Start(tag) => match tag {
                 Tag::Paragraph => new_paragraph(text, &mut list_stack),
 
-                Tag::Heading(_, _, _) => {
+                Tag::Heading {
+                    level: _,
+                    id: _,
+                    classes: _,
+                    attrs: _,
+                } => {
                     new_paragraph(text, &mut list_stack);
                     bold_depth += 1;
                 }
@@ -258,7 +263,12 @@ pub async fn parse_markdown_block(
 
                 Tag::Strikethrough => strikethrough_depth += 1,
 
-                Tag::Link(_, url, _) => link_url = Some(url.to_string()),
+                Tag::Link {
+                    link_type: _,
+                    dest_url,
+                    title: _,
+                    id: _,
+                } => link_url = Some(dest_url.to_string()),
 
                 Tag::List(number) => {
                     list_stack.push((number, false));
@@ -288,13 +298,13 @@ pub async fn parse_markdown_block(
             },
 
             Event::End(tag) => match tag {
-                Tag::Heading(_, _, _) => bold_depth -= 1,
-                Tag::CodeBlock(_) => current_language = None,
-                Tag::Emphasis => italic_depth -= 1,
-                Tag::Strong => bold_depth -= 1,
-                Tag::Strikethrough => strikethrough_depth -= 1,
-                Tag::Link(_, _, _) => link_url = None,
-                Tag::List(_) => drop(list_stack.pop()),
+                TagEnd::Heading(_) => bold_depth -= 1,
+                TagEnd::CodeBlock => current_language = None,
+                TagEnd::Emphasis => italic_depth -= 1,
+                TagEnd::Strong => bold_depth -= 1,
+                TagEnd::Strikethrough => strikethrough_depth -= 1,
+                TagEnd::Link => link_url = None,
+                TagEnd::List(_) => drop(list_stack.pop()),
                 _ => {}
             },
 

--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::{ops::Range, path::PathBuf};
 
 use crate::{HighlightId, Language, LanguageRegistry};
-use gpui::{px, FontStyle, FontWeight, HighlightStyle, UnderlineStyle, StrikethroughStyle};
+use gpui::{px, FontStyle, FontWeight, HighlightStyle, StrikethroughStyle, UnderlineStyle};
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 
 /// Parsed Markdown content.

--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -66,6 +66,8 @@ pub struct MarkdownHighlightStyle {
     pub italic: bool,
     /// Whether the text should be underlined.
     pub underline: bool,
+    /// Whether the text should be struck through.
+    pub strikethrough: bool,
     /// The weight of the text.
     pub weight: FontWeight,
 }
@@ -151,6 +153,7 @@ pub async fn parse_markdown_block(
 ) {
     let mut bold_depth = 0;
     let mut italic_depth = 0;
+    let mut strikethrough_depth = 0;
     let mut link_url = None;
     let mut current_language = None;
     let mut list_stack = Vec::new();
@@ -172,6 +175,10 @@ pub async fn parse_markdown_block(
 
                     if italic_depth > 0 {
                         style.italic = true;
+                    }
+
+                    if strikethrough_depth > 0 {
+                        style.strikethrough = true;
                     }
 
                     if let Some(link) = link_url.clone().and_then(|u| Link::identify(u)) {
@@ -242,6 +249,8 @@ pub async fn parse_markdown_block(
 
                 Tag::Strong => bold_depth += 1,
 
+                Tag::Strikethrough => strikethrough_depth += 1,
+
                 Tag::Link(_, url, _) => link_url = Some(url.to_string()),
 
                 Tag::List(number) => {
@@ -276,6 +285,7 @@ pub async fn parse_markdown_block(
                 Tag::CodeBlock(_) => current_language = None,
                 Tag::Emphasis => italic_depth -= 1,
                 Tag::Strong => bold_depth -= 1,
+                Tag::Strikethrough => strikethrough_depth -= 1,
                 Tag::Link(_, _, _) => link_url = None,
                 Tag::List(_) => drop(list_stack.pop()),
                 _ => {}

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -1,4 +1,6 @@
-use gpui::{px, FontStyle, FontWeight, HighlightStyle, SharedString, UnderlineStyle};
+use gpui::{
+    px, FontStyle, FontWeight, HighlightStyle, SharedString, StrikethroughStyle, UnderlineStyle,
+};
 use language::HighlightId;
 use std::{ops::Range, path::PathBuf};
 
@@ -170,6 +172,13 @@ impl MarkdownHighlight {
                     });
                 }
 
+                if style.strikethrough {
+                    highlight.strikethrough = Some(StrikethroughStyle {
+                        thickness: px(1.),
+                        ..Default::default()
+                    });
+                }
+
                 if style.weight != FontWeight::default() {
                     highlight.font_weight = Some(style.weight);
                 }
@@ -189,6 +198,8 @@ pub struct MarkdownHighlightStyle {
     pub italic: bool,
     /// Whether the text should be underlined.
     pub underline: bool,
+    /// Whether the text should be struck through.
+    pub strikethrough: bool,
     /// The weight of the text.
     pub weight: FontWeight,
 }

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -654,6 +654,56 @@ mod tests {
     }
 
     #[test]
+    fn test_nested_bold_strikethrough_text() {
+        let parsed = parse("Some **bo~~strikethrough~~ld** text");
+
+        assert_eq!(parsed.children.len(), 1);
+        assert_eq!(
+            parsed.children[0],
+            ParsedMarkdownElement::Paragraph(ParsedMarkdownText {
+                source_range: 0..35,
+                contents: "Some bostrikethroughld text".to_string(),
+                highlights: Vec::new(),
+                region_ranges: Vec::new(),
+                regions: Vec::new(),
+            })
+        );
+
+        let paragraph = if let ParsedMarkdownElement::Paragraph(text) = &parsed.children[0] {
+            text
+        } else {
+            panic!("Expected a paragraph");
+        };
+        assert_eq!(
+            paragraph.highlights,
+            vec![
+                (
+                    5..7,
+                    MarkdownHighlight::Style(MarkdownHighlightStyle {
+                        weight: FontWeight::BOLD,
+                        ..Default::default()
+                    }),
+                ),
+                (
+                    7..20,
+                    MarkdownHighlight::Style(MarkdownHighlightStyle {
+                        weight: FontWeight::BOLD,
+                        strikethrough: true,
+                        ..Default::default()
+                    }),
+                ),
+                (
+                    20..22,
+                    MarkdownHighlight::Style(MarkdownHighlightStyle {
+                        weight: FontWeight::BOLD,
+                        ..Default::default()
+                    }),
+                ),
+            ]
+        );
+    }
+
+    #[test]
     fn test_header_only_table() {
         let markdown = "\
 | Header 1 | Header 2 |

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -134,7 +134,7 @@ pub fn render_markdown_mut(
     link_ranges: &mut Vec<Range<usize>>,
     link_urls: &mut Vec<String>,
 ) {
-    use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
+    use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 
     let mut bold_depth = 0;
     let mut italic_depth = 0;
@@ -256,7 +256,12 @@ pub fn render_markdown_mut(
             }
             Event::Start(tag) => match tag {
                 Tag::Paragraph => new_paragraph(text, &mut list_stack),
-                Tag::Heading(_, _, _) => {
+                Tag::Heading {
+                    level: _,
+                    id: _,
+                    classes: _,
+                    attrs: _,
+                } => {
                     new_paragraph(text, &mut list_stack);
                     bold_depth += 1;
                 }
@@ -274,7 +279,12 @@ pub fn render_markdown_mut(
                 Tag::Emphasis => italic_depth += 1,
                 Tag::Strong => bold_depth += 1,
                 Tag::Strikethrough => strikethrough_depth += 1,
-                Tag::Link(_, url, _) => link_url = Some(url.to_string()),
+                Tag::Link {
+                    link_type: _,
+                    dest_url,
+                    title: _,
+                    id: _,
+                } => link_url = Some(dest_url.to_string()),
                 Tag::List(number) => {
                     list_stack.push((number, false));
                 }
@@ -300,13 +310,13 @@ pub fn render_markdown_mut(
                 _ => {}
             },
             Event::End(tag) => match tag {
-                Tag::Heading(_, _, _) => bold_depth -= 1,
-                Tag::CodeBlock(_) => current_language = None,
-                Tag::Emphasis => italic_depth -= 1,
-                Tag::Strong => bold_depth -= 1,
-                Tag::Strikethrough => strikethrough_depth -= 1,
-                Tag::Link(_, _, _) => link_url = None,
-                Tag::List(_) => drop(list_stack.pop()),
+                TagEnd::Heading(_) => bold_depth -= 1,
+                TagEnd::CodeBlock => current_language = None,
+                TagEnd::Emphasis => italic_depth -= 1,
+                TagEnd::Strong => bold_depth -= 1,
+                TagEnd::Strikethrough => strikethrough_depth -= 1,
+                TagEnd::Link => link_url = None,
+                TagEnd::List(_) => drop(list_stack.pop()),
                 _ => {}
             },
             Event::HardBreak => text.push('\n'),

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -1,7 +1,7 @@
 use futures::FutureExt;
 use gpui::{
     AnyElement, ElementId, FontStyle, FontWeight, HighlightStyle, InteractiveText, IntoElement,
-    SharedString, StyledText, UnderlineStyle, WindowContext,
+    SharedString, StrikethroughStyle, StyledText, UnderlineStyle, WindowContext,
 };
 use language::{HighlightId, Language, LanguageRegistry};
 use std::{ops::Range, sync::Arc};
@@ -138,6 +138,7 @@ pub fn render_markdown_mut(
 
     let mut bold_depth = 0;
     let mut italic_depth = 0;
+    let mut strikethrough_depth = 0;
     let mut link_url = None;
     let mut current_language = None;
     let mut list_stack = Vec::new();
@@ -174,6 +175,12 @@ pub fn render_markdown_mut(
                     }
                     if italic_depth > 0 {
                         style.font_style = Some(FontStyle::Italic);
+                    }
+                    if strikethrough_depth > 0 {
+                        style.strikethrough = Some(StrikethroughStyle {
+                            thickness: 1.0.into(),
+                            ..Default::default()
+                        });
                     }
                     let last_run_len = if let Some(link_url) = link_url.clone() {
                         link_ranges.push(prev_len..text.len());
@@ -266,6 +273,7 @@ pub fn render_markdown_mut(
                 }
                 Tag::Emphasis => italic_depth += 1,
                 Tag::Strong => bold_depth += 1,
+                Tag::Strikethrough => strikethrough_depth += 1,
                 Tag::Link(_, url, _) => link_url = Some(url.to_string()),
                 Tag::List(number) => {
                     list_stack.push((number, false));
@@ -296,6 +304,7 @@ pub fn render_markdown_mut(
                 Tag::CodeBlock(_) => current_language = None,
                 Tag::Emphasis => italic_depth -= 1,
                 Tag::Strong => bold_depth -= 1,
+                Tag::Strikethrough => strikethrough_depth -= 1,
                 Tag::Link(_, _, _) => link_url = None,
                 Tag::List(_) => drop(list_stack.pop()),
                 _ => {}


### PR DESCRIPTION
Just noticed strikethrough text handling was not implemented for the following:

Chat
![image](https://github.com/zed-industries/zed/assets/53836821/ddd98272-d4d4-4a94-bd79-77e967f3ca15)

Markdown Preview
![image](https://github.com/zed-industries/zed/assets/53836821/9087635c-5b89-40e6-8e4d-2785a43ef318)

Code Documentation
![image](https://github.com/zed-industries/zed/assets/53836821/5ed55c60-3e5e-4fc2-86c2-a81fac7de038)

It looks like there are three different markdown parsing/rendering implementations, might be worth to investigate if any of these can be combined into a single crate (looks like a lot of work though).

Release Notes:

- Added support for rendering strikethrough text in markdown elements