### PR TITLE
Switch LSP prompts to use a non-blocking toast

### DIFF
--- a/crates/gpui_macros/src/style_helpers.rs
+++ b/crates/gpui_macros/src/style_helpers.rs
@@ -399,6 +399,8 @@ fn box_suffixes() -> Vec<(&'static str, TokenStream2, &'static str)> {
         ("72", quote! { rems(18.) }, "288px (18rem)"),
         ("80", quote! { rems(20.) }, "320px (20rem)"),
         ("96", quote! { rems(24.) }, "384px (24rem)"),
+        ("112", quote! { rems(28.) }, "448px (28rem)"),
+        ("128", quote! { rems(32.) }, "512px (32rem)"),
         ("auto", quote! { auto() }, "Auto"),
         ("px", quote! { px(1.) }, "1px"),
         ("full", quote! { relative(1.) }, "100%"),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -229,6 +229,7 @@ pub struct LanguageServerPromptRequest {
     pub level: PromptLevel,
     pub message: String,
     pub actions: Vec<MessageActionItem>,
+    pub lsp_name: String,
     response_channel: Sender<MessageActionItem>,
 }
 
@@ -3022,6 +3023,7 @@ impl Project {
             cx.update(|cx| adapter.workspace_configuration(worktree_path, cx))?;
         let language_server = pending_server.task.await?;
 
+        let name = language_server.name();
         language_server
             .on_notification::<lsp::notification::PublishDiagnostics, _>({
                 let adapter = adapter.clone();
@@ -3160,8 +3162,10 @@ impl Project {
         language_server
             .on_request::<lsp::request::ShowMessageRequest, _, _>({
                 let this = this.clone();
+                let name = name.to_string();
                 move |params, mut cx| {
                     let this = this.clone();
+                    let name = name.to_string();
                     async move {
                         if let Some(actions) = params.actions {
                             let (tx, mut rx) = smol::channel::bounded(1);
@@ -3174,6 +3178,7 @@ impl Project {
                                 message: params.message,
                                 actions,
                                 response_channel: tx,
+                                lsp_name: name.clone(),
                             };
 
                             if let Ok(_) = this.update(&mut cx, |_, cx| {
@@ -3211,6 +3216,7 @@ impl Project {
                 }
             })
             .detach();
+
         let mut initialization_options = adapter.adapter.initialization_options();
         match (&mut initialization_options, override_options) {
             (Some(initialization_options), Some(override_options)) => {

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -7,6 +7,7 @@ use crate::prelude::*;
 pub enum LabelSize {
     #[default]
     Default,
+    Large,
     Small,
     XSmall,
 }
@@ -97,6 +98,7 @@ impl RenderOnce for LabelLike {
                 )
             })
             .map(|this| match self.size {
+                LabelSize::Large => this.text_ui_lg(),
                 LabelSize::Default => this.text_ui(),
                 LabelSize::Small => this.text_ui_sm(),
                 LabelSize::XSmall => this.text_ui_xs(),

--- a/crates/ui/src/styled_ext.rs
+++ b/crates/ui/src/styled_ext.rs
@@ -35,6 +35,17 @@ pub trait StyledExt: Styled + Sized {
         self.text_size(size.rems())
     }
 
+    /// The large size for UI text.
+    ///
+    /// `1rem` or `16px` at the default scale of `1rem` = `16px`.
+    ///
+    /// Note: The absolute size of this text will change based on a user's `ui_scale` setting.
+    ///
+    /// Use `text_ui` for regular-sized text.
+    fn text_ui_lg(self) -> Self {
+        self.text_size(UiTextSize::Large.rems())
+    }
+
     /// The default size for UI text.
     ///
     /// `0.825rem` or `14px` at the default scale of `1rem` = `16px`.

--- a/crates/ui/src/styles/typography.rs
+++ b/crates/ui/src/styles/typography.rs
@@ -13,6 +13,13 @@ pub enum UiTextSize {
     /// Note: The absolute size of this text will change based on a user's `ui_scale` setting.
     #[default]
     Default,
+    /// The large size for UI text.
+    ///
+    /// `1rem` or `16px` at the default scale of `1rem` = `16px`.
+    ///
+    /// Note: The absolute size of this text will change based on a user's `ui_scale` setting.
+    Large,
+
     /// The small size for UI text.
     ///
     /// `0.75rem` or `12px` at the default scale of `1rem` = `16px`.
@@ -31,6 +38,7 @@ pub enum UiTextSize {
 impl UiTextSize {
     pub fn rems(self) -> Rems {
         match self {
+            Self::Large => rems(16. / 16.),
             Self::Default => rems(14. / 16.),
             Self::Small => rems(12. / 16.),
             Self::XSmall => rems(10. / 16.),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -59,7 +59,10 @@ use std::{
     any::TypeId,
     borrow::Cow,
     cell::RefCell,
-    cmp, env,
+    cmp,
+    collections::hash_map::DefaultHasher,
+    env,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     rc::Rc,
     sync::{atomic::AtomicUsize, Arc, Weak},
@@ -579,24 +582,13 @@ impl Workspace {
                 }),
 
                 project::Event::LanguageServerPrompt(request) => {
-                    let request = request.clone();
+                    let mut hasher = DefaultHasher::new();
+                    request.message.as_str().hash(&mut hasher);
+                    let id = hasher.finish();
 
-                    cx.spawn(|_, mut cx| async move {
-                        let messages = request
-                            .actions
-                            .iter()
-                            .map(|action| action.title.as_str())
-                            .collect::<Vec<_>>();
-                        let index = cx
-                            .update(|cx| {
-                                cx.prompt(request.level, "", Some(&request.message), &messages)
-                            })?
-                            .await?;
-                        request.respond(index).await;
-
-                        Result::<(), anyhow::Error>::Ok(())
-                    })
-                    .detach()
+                    this.show_notification(id as usize, cx, |cx| {
+                        cx.new_view(|_| notifications::LanguageServerPrompt::new(request.clone()))
+                    });
                 }
 
                 _ => {}
@@ -2766,7 +2758,7 @@ impl Workspace {
                     .z_index(100)
                     .right_3()
                     .bottom_3()
-                    .w_96()
+                    .w_112()
                     .h_full()
                     .flex()
                     .flex_col()


### PR DESCRIPTION
This fixes a major degradation in usability that some users ran into.

Fixes https://github.com/zed-industries/zed/issues/8255 
Fixes https://github.com/zed-industries/zed/issues/8229

Release Notes:

- Switch from using platform prompts to toasts for LSP prompts. ([8255](https://github.com/zed-industries/zed/issues/8255), [8229](https://github.com/zed-industries/zed/issues/8229))

<img width="583" alt="Screenshot 2024-02-23 at 2 40 05 PM" src="https://github.com/zed-industries/zed/assets/2280405/1bfc027b-b7a8-4563-88b6-020e47869668">
