### PR TITLE
Adjust labels of buttons in extension list based on status

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -52,6 +52,20 @@ pub enum ExtensionStatus {
     Removing,
 }
 
+impl ExtensionStatus {
+    pub fn is_installing(&self) -> bool {
+        matches!(self, Self::Installing)
+    }
+
+    pub fn is_upgrading(&self) -> bool {
+        matches!(self, Self::Upgrading)
+    }
+
+    pub fn is_removing(&self) -> bool {
+        matches!(self, Self::Removing)
+    }
+}
+
 pub struct ExtensionStore {
     manifest: Arc<RwLock<Manifest>>,
     fs: Arc<dyn Fs>,


### PR DESCRIPTION
This PR makes the labels of the buttons in the extension list adapt to reflect the current status.

Release Notes:

- Changed the button labels in the extension list to reflect the current status.
