### PR TITLE
Rename `ZedHttpClient` for clarity

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -29,7 +29,7 @@ use std::{
 };
 use update_notification::UpdateNotification;
 use util::{
-    http::{HttpClient, ZedHttpClient},
+    http::{HttpClient, HttpClientWithUrl},
     ResultExt,
 };
 use workspace::Workspace;
@@ -67,7 +67,7 @@ pub enum AutoUpdateStatus {
 pub struct AutoUpdater {
     status: AutoUpdateStatus,
     current_version: SemanticVersion,
-    http_client: Arc<ZedHttpClient>,
+    http_client: Arc<HttpClientWithUrl>,
     pending_poll: Option<Task<Option<()>>>,
 }
 
@@ -115,7 +115,7 @@ struct ReleaseNotesBody {
     release_notes: String,
 }
 
-pub fn init(http_client: Arc<ZedHttpClient>, cx: &mut AppContext) {
+pub fn init(http_client: Arc<HttpClientWithUrl>, cx: &mut AppContext) {
     AutoUpdateSetting::register(cx);
 
     cx.observe_new_views(|workspace: &mut Workspace, _cx| {
@@ -181,7 +181,7 @@ pub fn view_release_notes(_: &ViewReleaseNotes, cx: &mut AppContext) -> Option<(
         let current_version = auto_updater.current_version;
         let url = &auto_updater
             .http_client
-            .zed_url(&format!("/releases/{release_channel}/{current_version}"));
+            .build_url(&format!("/releases/{release_channel}/{current_version}"));
         cx.open_url(&url);
     }
 
@@ -193,7 +193,7 @@ fn view_release_notes_locally(workspace: &mut Workspace, cx: &mut ViewContext<Wo
     let version = env!("CARGO_PKG_VERSION");
 
     let client = client::Client::global(cx).http_client();
-    let url = client.zed_url(&format!(
+    let url = client.build_url(&format!(
         "/api/release_notes/{}/{}",
         release_channel.dev_name(),
         version
@@ -283,7 +283,7 @@ impl AutoUpdater {
         cx.default_global::<GlobalAutoUpdate>().0.clone()
     }
 
-    fn new(current_version: SemanticVersion, http_client: Arc<ZedHttpClient>) -> Self {
+    fn new(current_version: SemanticVersion, http_client: Arc<HttpClientWithUrl>) -> Self {
         Self {
             status: AutoUpdateStatus::Idle,
             current_version,
@@ -337,7 +337,7 @@ impl AutoUpdater {
             (this.http_client.clone(), this.current_version)
         })?;
 
-        let mut url_string = client.zed_url(&format!(
+        let mut url_string = client.build_url(&format!(
             "/api/releases/latest?asset=Zed.dmg&os={}&arch={}",
             OS, ARCH
         ));

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -20,7 +20,7 @@ use telemetry_events::{
     EditEvent, EditorEvent, Event, EventRequestBody, EventWrapper, MemoryEvent, SettingEvent,
 };
 use tempfile::NamedTempFile;
-use util::http::{self, HttpClient, Method, ZedHttpClient};
+use util::http::{self, HttpClient, HttpClientWithUrl, Method};
 #[cfg(not(debug_assertions))]
 use util::ResultExt;
 use util::TryFutureExt;
@@ -29,7 +29,7 @@ use self::event_coalescer::EventCoalescer;
 
 pub struct Telemetry {
     clock: Arc<dyn SystemClock>,
-    http_client: Arc<ZedHttpClient>,
+    http_client: Arc<HttpClientWithUrl>,
     executor: BackgroundExecutor,
     state: Arc<Mutex<TelemetryState>>,
 }
@@ -75,7 +75,7 @@ static ZED_CLIENT_CHECKSUM_SEED: Lazy<Option<Vec<u8>>> = Lazy::new(|| {
 impl Telemetry {
     pub fn new(
         clock: Arc<dyn SystemClock>,
-        client: Arc<ZedHttpClient>,
+        client: Arc<HttpClientWithUrl>,
         cx: &mut AppContext,
     ) -> Arc<Self> {
         let release_channel =
@@ -474,7 +474,7 @@ impl Telemetry {
 
                     let request = http::Request::builder()
                         .method(Method::POST)
-                        .uri(this.http_client.zed_api_url("/telemetry/events"))
+                        .uri(this.http_client.build_zed_api_url("/telemetry/events"))
                         .header("Content-Type", "text/plain")
                         .header("x-zed-checksum", checksum)
                         .body(json_bytes.into());

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -20,7 +20,7 @@ use std::{
     time::Duration,
 };
 use theme::{ThemeRegistry, ThemeSettings};
-use util::http::{AsyncBody, ZedHttpClient};
+use util::http::{AsyncBody, HttpClientWithUrl};
 use util::TryFutureExt;
 use util::{http::HttpClient, paths::EXTENSIONS_DIR, ResultExt};
 
@@ -69,7 +69,7 @@ impl ExtensionStatus {
 pub struct ExtensionStore {
     manifest: Arc<RwLock<Manifest>>,
     fs: Arc<dyn Fs>,
-    http_client: Arc<ZedHttpClient>,
+    http_client: Arc<HttpClientWithUrl>,
     extensions_dir: PathBuf,
     extensions_being_installed: HashSet<Arc<str>>,
     extensions_being_uninstalled: HashSet<Arc<str>>,
@@ -125,7 +125,7 @@ actions!(zed, [ReloadExtensions]);
 
 pub fn init(
     fs: Arc<fs::RealFs>,
-    http_client: Arc<ZedHttpClient>,
+    http_client: Arc<HttpClientWithUrl>,
     language_registry: Arc<LanguageRegistry>,
     theme_registry: Arc<ThemeRegistry>,
     cx: &mut AppContext,
@@ -157,7 +157,7 @@ impl ExtensionStore {
     pub fn new(
         extensions_dir: PathBuf,
         fs: Arc<dyn Fs>,
-        http_client: Arc<ZedHttpClient>,
+        http_client: Arc<HttpClientWithUrl>,
         language_registry: Arc<LanguageRegistry>,
         theme_registry: Arc<ThemeRegistry>,
         cx: &mut ModelContext<Self>,
@@ -236,7 +236,7 @@ impl ExtensionStore {
         search: Option<&str>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Vec<Extension>>> {
-        let url = self.http_client.zed_api_url(&format!(
+        let url = self.http_client.build_zed_api_url(&format!(
             "/extensions{query}",
             query = search
                 .map(|search| format!("?filter={search}"))
@@ -276,7 +276,7 @@ impl ExtensionStore {
         log::info!("installing extension {extension_id} {version}");
         let url = self
             .http_client
-            .zed_api_url(&format!("/extensions/{extension_id}/{version}/download"));
+            .build_zed_api_url(&format!("/extensions/{extension_id}/{version}/download"));
 
         let extensions_dir = self.extensions_dir();
         let http_client = self.http_client.clone();

--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -299,7 +299,7 @@ impl FeedbackModal {
         let installation_id = telemetry.installation_id();
         let is_staff = telemetry.is_staff();
         let http_client = zed_client.http_client();
-        let feedback_endpoint = http_client.zed_url("/api/feedback");
+        let feedback_endpoint = http_client.build_url("/api/feedback");
         let request = FeedbackRequestBody {
             feedback_text: &feedback_text,
             email,

--- a/crates/util/src/http.rs
+++ b/crates/util/src/http.rs
@@ -14,23 +14,39 @@ use std::fmt;
 use std::{sync::Arc, time::Duration};
 pub use url::Url;
 
-pub struct ZedUrl(Mutex<String>);
+/// An [`HttpClient`] that has a base URL.
+pub struct HttpClientWithUrl {
+    base_url: Mutex<String>,
+    client: Arc<dyn HttpClient>,
+}
 
-impl ZedUrl {
+impl HttpClientWithUrl {
+    /// Returns a new [`HttpClientWithUrl`] with the given base URL.
     pub fn new(base_url: impl Into<String>) -> Self {
-        Self(Mutex::new(base_url.into()))
+        Self {
+            base_url: Mutex::new(base_url.into()),
+            client: client(),
+        }
     }
 
+    /// Returns the base URL.
+    pub fn base_url(&self) -> String {
+        self.base_url.lock().clone()
+    }
+
+    /// Sets the base URL.
     pub fn set_base_url(&self, base_url: impl Into<String>) {
-        *self.0.lock() = base_url.into();
+        *self.base_url.lock() = base_url.into();
     }
 
+    /// Builds a URL using the given path.
     pub fn build_url(&self, path: &str) -> String {
-        format!("{}{}", self.0.lock(), path)
+        format!("{}{}", self.base_url.lock(), path)
     }
 
-    pub fn build_api_url(&self, path: &str) -> String {
-        let base_url = self.0.lock().clone();
+    /// Builds a Zed API URL using the given path.
+    pub fn build_zed_api_url(&self, path: &str) -> String {
+        let base_url = self.base_url.lock().clone();
         let base_api_url = match base_url.as_ref() {
             "https://zed.dev" => "https://api.zed.dev",
             "https://staging.zed.dev" => "https://api-staging.zed.dev",
@@ -42,54 +58,16 @@ impl ZedUrl {
     }
 }
 
-pub struct ZedHttpClient {
-    pub zed_host: Mutex<String>,
-    client: Box<dyn HttpClient>,
-}
-
-impl ZedHttpClient {
-    pub fn zed_url(&self, path: &str) -> String {
-        format!("{}{}", self.zed_host.lock(), path)
-    }
-
-    pub fn zed_api_url(&self, path: &str) -> String {
-        let zed_host = self.zed_host.lock().clone();
-
-        let host = match zed_host.as_ref() {
-            "https://zed.dev" => "https://api.zed.dev",
-            "https://staging.zed.dev" => "https://api-staging.zed.dev",
-            "http://localhost:3000" => "http://localhost:8080",
-            other => other,
-        };
-
-        format!("{}{}", host, path)
-    }
-}
-
-impl HttpClient for Arc<ZedHttpClient> {
+impl HttpClient for Arc<HttpClientWithUrl> {
     fn send(&self, req: Request<AsyncBody>) -> BoxFuture<Result<Response<AsyncBody>, Error>> {
         self.client.send(req)
     }
 }
 
-impl HttpClient for ZedHttpClient {
+impl HttpClient for HttpClientWithUrl {
     fn send(&self, req: Request<AsyncBody>) -> BoxFuture<Result<Response<AsyncBody>, Error>> {
         self.client.send(req)
     }
-}
-
-pub fn zed_client(zed_host: &str) -> Arc<ZedHttpClient> {
-    Arc::new(ZedHttpClient {
-        zed_host: Mutex::new(zed_host.to_string()),
-        client: Box::new(
-            isahc::HttpClient::builder()
-                .connect_timeout(Duration::from_secs(5))
-                .low_speed_timeout(100, Duration::from_secs(5))
-                .proxy(http_proxy_from_env())
-                .build()
-                .unwrap(),
-        ),
-    })
 }
 
 pub trait HttpClient: Send + Sync {
@@ -162,20 +140,20 @@ pub struct FakeHttpClient {
 
 #[cfg(feature = "test-support")]
 impl FakeHttpClient {
-    pub fn create<Fut, F>(handler: F) -> Arc<ZedHttpClient>
+    pub fn create<Fut, F>(handler: F) -> Arc<HttpClientWithUrl>
     where
         Fut: 'static + Send + futures::Future<Output = Result<Response<AsyncBody>, Error>>,
         F: 'static + Send + Sync + Fn(Request<AsyncBody>) -> Fut,
     {
-        Arc::new(ZedHttpClient {
-            zed_host: Mutex::new("http://test.example".into()),
-            client: Box::new(Self {
+        Arc::new(HttpClientWithUrl {
+            base_url: Mutex::new("http://test.example".into()),
+            client: Arc::new(Self {
                 handler: Box::new(move |req| Box::pin(handler(req))),
             }),
         })
     }
 
-    pub fn with_404_response() -> Arc<ZedHttpClient> {
+    pub fn with_404_response() -> Arc<HttpClientWithUrl> {
         Self::create(|_| async move {
             Ok(Response::builder()
                 .status(404)
@@ -184,7 +162,7 @@ impl FakeHttpClient {
         })
     }
 
-    pub fn with_200_response() -> Arc<ZedHttpClient> {
+    pub fn with_200_response() -> Arc<HttpClientWithUrl> {
         Self::create(|_| async move {
             Ok(Response::builder()
                 .status(200)

--- a/crates/util/src/http.rs
+++ b/crates/util/src/http.rs
@@ -14,6 +14,34 @@ use std::fmt;
 use std::{sync::Arc, time::Duration};
 pub use url::Url;
 
+pub struct ZedUrl(Mutex<String>);
+
+impl ZedUrl {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self(Mutex::new(base_url.into()))
+    }
+
+    pub fn set_base_url(&self, base_url: impl Into<String>) {
+        *self.0.lock() = base_url.into();
+    }
+
+    pub fn build_url(&self, path: &str) -> String {
+        format!("{}{}", self.0.lock(), path)
+    }
+
+    pub fn build_api_url(&self, path: &str) -> String {
+        let base_url = self.0.lock().clone();
+        let base_api_url = match base_url.as_ref() {
+            "https://zed.dev" => "https://api.zed.dev",
+            "https://staging.zed.dev" => "https://api-staging.zed.dev",
+            "http://localhost:3000" => "http://localhost:8080",
+            other => other,
+        };
+
+        format!("{}{}", base_api_url, path)
+    }
+}
+
 pub struct ZedHttpClient {
     pub zed_host: Mutex<String>,
     client: Box<dyn HttpClient>,


### PR DESCRIPTION
This PR renames the `ZedHttpClient` to `HttpClientWithUrl` to make it slightly clearer that it still is holding a `dyn HttpClient` as opposed to being a concrete implementation.

Release Notes:

- N/A
