### PR TITLE
Add plus and dollar sign to terminal paths

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -417,7 +417,7 @@ impl TerminalBuilder {
         let _io_thread = event_loop.spawn(); // DANGER
 
         let url_regex = RegexSearch::new(r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`]+"#).unwrap();
-        let word_regex = RegexSearch::new(r#"[\w.\[\]:/@\-~]+"#).unwrap();
+        let word_regex = RegexSearch::new(r#"[\$\+\w.\[\]:/@\-~]+"#).unwrap();
 
         let terminal = Terminal {
             task,


### PR DESCRIPTION
Release Notes:

- Fixed an issue with terminal paths not allowing links when the path included `+` or `$` symbols. ([#8256](https://github.com/zed-industries/zed/issues/#8256)).

After fix (file path is now clickable):
<img width="1019" alt="Screenshot 2024-02-23 at 8 59 45 PM" src="https://github.com/zed-industries/zed/assets/63214891/cbdcb0f5-cd58-436b-9980-f657436f2bc0">

Before fix:
<img width="936" alt="Screenshot 2024-02-23 at 9 15 25 PM" src="https://github.com/zed-industries/zed/assets/63214891/72d27155-a708-4b8d-a0b6-85d1e9031627">

