### PR TITLE
chore: fix compiler warnings by removing unused import `anyhow::Result`

### DIFF
--- a/crates/time_format/src/time_format.rs
+++ b/crates/time_format/src/time_format.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use lazy_static::lazy_static;
 use time::{OffsetDateTime, UtcOffset};
 


### PR DESCRIPTION

Release Notes:

- removed the `anyhow::Result` import from `time_format.rs` which was unused and rust emitted warnings due to this

![compile_warn_zed](https://github.com/zed-industries/zed/assets/84385565/7dae8152-4727-461f-81c9-da1cb1568e73)


