### PR TITLE
Scroll project search results to the top

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -3414,7 +3414,7 @@ pub mod tests {
         search_view
             .update(cx, |search_view, cx| {
                 search_view.results_editor.update(cx, |results_editor, cx| {
-                    // Results are correct and scrolled to top
+                    // Results are correct and scrolled to the top
                     assert_eq!(
                         results_editor.display_text(cx).match_indices(" A ").count(),
                         10
@@ -3437,7 +3437,7 @@ pub mod tests {
                         results_editor.display_text(cx).match_indices(" B ").count(),
                         10
                     );
-                    // ...and scrolled back to top
+                    // ...and scrolled back to the top
                     assert_eq!(results_editor.scroll_position(cx), Point::default());
                 });
             })

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use collections::HashMap;
+use editor::scroll::Axis;
 use editor::{
     actions::SelectAll, items::active_match_index, scroll::Autoscroll, Anchor, Editor, EditorEvent,
     MultiBuffer, MAX_TAB_TITLE_LEN,
@@ -14,9 +15,9 @@ use editor::{EditorElement, EditorStyle};
 use gpui::{
     actions, div, Action, AnyElement, AnyView, AppContext, Context as _, Element, EntityId,
     EventEmitter, FocusHandle, FocusableView, FontStyle, FontWeight, Global, Hsla,
-    InteractiveElement, IntoElement, KeyContext, Model, ModelContext, ParentElement, PromptLevel,
-    Render, SharedString, Styled, Subscription, Task, TextStyle, View, ViewContext, VisualContext,
-    WeakModel, WeakView, WhiteSpace, WindowContext,
+    InteractiveElement, IntoElement, KeyContext, Model, ModelContext, ParentElement, Point,
+    PromptLevel, Render, SharedString, Styled, Subscription, Task, TextStyle, View, ViewContext,
+    VisualContext, WeakModel, WeakView, WhiteSpace, WindowContext,
 };
 use menu::Confirm;
 use project::{
@@ -1302,6 +1303,7 @@ impl ProjectSearchView {
                     editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                         s.select_ranges(range_to_select)
                     });
+                    editor.scroll(Point::default(), Some(Axis::Vertical), cx);
                 }
                 editor.highlight_background::<Self>(
                     match_ranges,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -6,10 +6,11 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use collections::HashMap;
-use editor::scroll::Axis;
 use editor::{
-    actions::SelectAll, items::active_match_index, scroll::Autoscroll, Anchor, Editor, EditorEvent,
-    MultiBuffer, MAX_TAB_TITLE_LEN,
+    actions::SelectAll,
+    items::active_match_index,
+    scroll::{Autoscroll, Axis},
+    Anchor, Editor, EditorEvent, MultiBuffer, MAX_TAB_TITLE_LEN,
 };
 use editor::{EditorElement, EditorStyle};
 use gpui::{


### PR DESCRIPTION
Scroll project search results to the top after every new search.

Related issues:

- Fixes #8237

Release Notes:

- Fixed autoscrolling of the project search results.