### PR TITLE
vim: Improve tests for compatibilities with Vim's visual line mode

### DIFF
--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -281,7 +281,17 @@ impl EditorTestContext {
     }
 
     pub fn editor_state(&mut self) -> String {
-        generate_marked_text(self.buffer_text().as_str(), &self.editor_selections(), true)
+        generate_marked_text(
+            self.buffer_text().as_str(),
+            &self.editor_selections(),
+            true,
+            self.line_mode(),
+        )
+    }
+
+    fn line_mode(&mut self) -> bool {
+        self.editor
+            .update(&mut self.cx, |editor, _cx| editor.selections.line_mode)
     }
 
     #[track_caller]
@@ -317,8 +327,12 @@ impl EditorTestContext {
 
     #[track_caller]
     pub fn assert_editor_selections(&mut self, expected_selections: Vec<Range<usize>>) {
-        let expected_marked_text =
-            generate_marked_text(&self.buffer_text(), &expected_selections, true);
+        let expected_marked_text = generate_marked_text(
+            &self.buffer_text(),
+            &expected_selections,
+            true,
+            self.line_mode(),
+        );
         self.assert_selections(expected_selections, expected_marked_text)
     }
 
@@ -346,8 +360,12 @@ impl EditorTestContext {
         expected_marked_text: String,
     ) {
         let actual_selections = self.editor_selections();
-        let actual_marked_text =
-            generate_marked_text(&self.buffer_text(), &actual_selections, true);
+        let actual_marked_text = generate_marked_text(
+            &self.buffer_text(),
+            &actual_selections,
+            true,
+            self.line_mode(),
+        );
         if expected_selections != actual_selections {
             panic!(
                 indoc! {"

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -566,7 +566,7 @@ mod test {
         })
         .await;
         cx.simulate_shared_keystrokes(["shift-v"]).await;
-        cx.assert_shared_state(indoc! { "The «qˇ»uick brown
+        cx.assert_shared_state(indoc! { "«The qˇuick brown»
             fox jumps over
             the lazy dog"})
             .await;
@@ -995,6 +995,24 @@ mod test {
             k"
         })
         .await;
+    }
+
+    #[gpui::test]
+    async fn test_visual_line_mode(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        let initial_state = "The quick brown fox\njumps\nover the lazˇy dog.";
+        cx.set_shared_state(initial_state).await;
+        cx.simulate_shared_keystrokes(["shift-v", "k"]).await;
+        cx.assert_shared_state("The quick brown fox\n«jumpsˇ\nover the lazy dog.»")
+            .await;
+        assert_eq!(cx.mode(), Mode::VisualLine);
+
+        cx.set_shared_state(initial_state).await;
+        cx.simulate_shared_keystrokes(["shift-v", "2", "k"]).await;
+        cx.assert_shared_state("«The quick brˇown fox\njumps\nover the lazy dog.»")
+            .await;
+        assert_eq!(cx.mode(), Mode::VisualLine);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Currently, there are several issues in tests for compatibilities with Vim visual line mode. Due to these issues, it is hard to test paragraph objects. This PR fixes those issues (affecting only to tests).

Issues:

- The current test is done by comparing the range starting from the position of the selection operation (`'v'`') and the cursor position after the selection operation (`'.'`) (the same range as in visual mode) between vim and zed, and does not compare the line-based selection ranges. This test works correctly for selection by motion, but not for selection by paragraph objects.
- In the current selection using visual line mode + motion in zed, the selection range extends to the right side of the right-most character. As a result, the cursor position in "zed state" generated from the selection moves to the right by one character.

Examples of issues:

```
# Example 1: initial state:
The quiˇck brown fox jumps over the lazy dog.
# keystrokes:
shift-v
# currently expected:
«The quiˇck brown fox jumps over the lazy dog.»
# neovim state:
The qui«cˇ»k brown fox jumps over the lazy dog.
# zed state:
The qui«cˇ»k brown fox jumps over the lazy dog.
```

```
# Example 2: initial state:
The quiˇck brown fox
jumps
over the lazy dog.
# keystrokes:
shift-v j
# currently expected:
«The quick brown fox
jumpsˇ»
over the lazy dog.
# neovim state:
The quic«k brown fox
jumpsˇ»
over the lazy dog.
# zed state:
The qui«ck brown fox
jumps
ˇ»over the lazy dog.
```

```
# Example 3: initial state:
The quick brown fox
jumps
over the lazˇy dog.
# keystrokes:
shift-v 2 k
# currently expected:
«The quick brˇown fox
jumps
over the lazy dog.»
# neovim state:
The quick bro«ˇwn fox
jumps
over the laz»y dog.
# zed state:
The quick br«ˇown fox
jumps
over the lazy» dog.
```

```
# Example 4: initial state:
The quick brown fox
jumpˇs
over the lazy dog.
# keystrokes:
v i p
# currently expected:
«The quick brown fox
jumps
ˇover the lazy dog.»
# neovim state:
«The quick brown fox
jumps
oˇ»ver the lazy dog.
# zed state:
(currently N/A)
```

```
# Example 5: initial state:
The quiˇck brown fox
jumps
over the lazy dog.
# keystrokes:
v i p
# currently expected:
«The quick brown fox
jumps
ˇover the lazy dog.»
# neovim state:
The quic«k brown fox
jumps
ˇ»over the lazy dog.
# zed state:
(currently N/A)
```

This PR attempts to solve these issues with the following approach:

- For selections where `line_mode` is true, extend the selections between line breaks in generating the marked text data.
- Make motions in visual line mode to select ranges up to the left side of the rightmost character.


Release Notes:

- N/A