### PR TITLE
Fix Dart syntax highlighting issue

### DIFF
--- a/extensions/dart/languages/dart/config.toml
+++ b/extensions/dart/languages/dart/config.toml
@@ -7,7 +7,9 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = true, newline = false},
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "`", end = "`", close = true, newline = false, not_in = ["string", "comment"] },
 ]

--- a/extensions/dart/languages/dart/highlights.scm
+++ b/extensions/dart/languages/dart/highlights.scm
@@ -4,113 +4,102 @@
 ; --------------------
 (super) @function
 
-(function_expression_body
-  (identifier) @function)
-
+(function_expression_body (identifier) @type)
 ; ((identifier)(selector (argument_part)) @function)
-(((identifier) @function
-  (#lua-match? @function "^_?[%l]"))
-  .
-  (selector
-    .
-    (argument_part))) @function
+
+(((identifier) @function (#match? @function "^_?[a-z]"))
+ . (selector . (argument_part))) @function
 
 ; Annotations
 ; --------------------
 (annotation
-  name: (identifier) @attribute)
+ name: (identifier) @attribute)
 
 ; Operators and Tokens
 ; --------------------
 (template_substitution
-  "$" @punctuation.special
-  "{" @punctuation.special
-  "}" @punctuation.special) @none
+ "$" @punctuation.special
+ "{" @punctuation.special
+ "}" @punctuation.special) @none
 
 (template_substitution
-  "$" @punctuation.special
-  (identifier_dollar_escaped) @variable) @none
+ "$" @punctuation.special
+ (identifier_dollar_escaped) @variable) @none
 
 (escape_sequence) @string.escape
 
 [
-  "@"
-  "=>"
-  ".."
-  "??"
-  "=="
-  "?"
-  ":"
-  "&&"
-  "%"
-  "<"
-  ">"
-  "="
-  ">="
-  "<="
-  "||"
-  (multiplicative_operator)
-  (increment_operator)
-  (is_operator)
-  (prefix_operator)
-  (equality_operator)
-  (additive_operator)
-] @operator
+ "@"
+ "=>"
+ ".."
+ "??"
+ "=="
+ "?"
+ ":"
+ "&&"
+ "%"
+ "<"
+ ">"
+ "="
+ ">="
+ "<="
+ "||"
+ (multiplicative_operator)
+ (increment_operator)
+ (is_operator)
+ (prefix_operator)
+ (equality_operator)
+ (additive_operator)
+ ] @operator
 
 [
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+ ] @punctuation.bracket
 
 ; Delimiters
 ; --------------------
 [
-  ";"
-  "."
-  ","
-] @punctuation.delimiter
+ ";"
+ "."
+ ","
+ ] @punctuation.delimiter
 
 ; Types
 ; --------------------
 (class_definition
-  name: (identifier) @type)
-
+ name: (identifier) @type)
 (constructor_signature
-  name: (identifier) @type)
-
+ name: (identifier) @type)
 (scoped_identifier
-  scope: (identifier) @type)
-
+ scope: (identifier) @type)
 (function_signature
-  name: (identifier) @function.method)
+ name: (identifier) @function.method)
 
 (getter_signature
-  (identifier) @function.method)
+ (identifier) @function.method)
 
 (setter_signature
-  name: (identifier) @function.method)
-
+ name: (identifier) @function.method)
 (enum_declaration
-  name: (identifier) @type)
-
+ name: (identifier) @type)
 (enum_constant
-  name: (identifier) @type)
-
+ name: (identifier) @type)
 (void_type) @type
 
 ((scoped_identifier
   scope: (identifier) @type
   name: (identifier) @type)
-  (#lua-match? @type "^[%u%l]"))
+ (#match? @type "^[a-zA-Z]"))
 
 (type_identifier) @type
 
 (type_alias
-  (type_identifier) @type.definition)
+ (type_identifier) @type.definition)
 
 ; Variables
 ; --------------------
@@ -118,48 +107,48 @@
 (inferred_type) @keyword
 
 ((identifier) @type
-  (#lua-match? @type "^_?[%u].*[%l]"))
+ (#match? @type "^_?[A-Z].*[a-z]"))
 
-"Function" @type
+("Function" @type)
 
 ; properties
 (unconditional_assignable_selector
-  (identifier) @property)
+ (identifier) @property)
 
 (conditional_assignable_selector
-  (identifier) @property)
+ (identifier) @property)
 
 ; assignments
 (assignment_expression
-  left: (assignable_expression) @variable)
+ left: (assignable_expression) @variable)
 
 (this) @variable.builtin
 
 ; Parameters
 ; --------------------
 (formal_parameter
-  name: (identifier) @variable.parameter)
+ name: (identifier) @variable.parameter)
 
 (named_argument
-  (label
+ (label
     (identifier) @variable.parameter))
 
 ; Literals
 ; --------------------
 [
-  (hex_integer_literal)
-  (decimal_integer_literal)
-  (decimal_floating_point_literal)
-] @number
+ (hex_integer_literal)
+ (decimal_integer_literal)
+ (decimal_floating_point_literal)
+ ; TODO: inaccessbile nodes
+ ; (octal_integer_literal)
+ ; (hex_floating_point_literal)
+ ] @number
 
 (symbol_literal) @string.special.symbol
 
 (string_literal) @string
-
 (true) @boolean
-
 (false) @boolean
-
 (null_literal) @constant.builtin
 
 (comment) @comment @spell
@@ -169,30 +158,30 @@
 ; Keywords
 ; --------------------
 [
-  "import"
-  "library"
-  "export"
-  "as"
-  "show"
-  "hide"
-] @keyword.import
+ "import"
+ "library"
+ "export"
+ "as"
+ "show"
+ "hide"
+ ] @keyword.import
 
 ; Reserved words (cannot be used as identifiers)
 [
   (case_builtin)
-  "late"
-  "required"
-  "extension"
-  "on"
-  "class"
-  "enum"
-  "extends"
-  "in"
-  "is"
-  "new"
-  "super"
-  "with"
-] @keyword
+ "late"
+ "required"
+ "extension"
+ "on"
+ "class"
+ "enum"
+ "extends"
+ "in"
+ "is"
+ "new"
+ "super"
+ "with"
+ ] @keyword
 
 "return" @keyword.return
 
@@ -200,17 +189,17 @@
 ; alone these are marked as keywords
 [
   "deferred"
-  "factory"
-  "get"
-  "implements"
-  "interface"
-  "library"
-  "operator"
-  "mixin"
-  "part"
-  "set"
-  "typedef"
-] @keyword
+ "factory"
+ "get"
+ "implements"
+ "interface"
+ "library"
+ "operator"
+ "mixin"
+ "part"
+ "set"
+ "typedef"
+ ] @keyword
 
 [
   "async"
@@ -221,23 +210,41 @@
 ] @keyword.coroutine
 
 [
-  (const_builtin)
-  (final_builtin)
-  "abstract"
+ (const_builtin)
+ (final_builtin)
+ "abstract"
   "covariant"
-  "dynamic"
-  "external"
-  "static"
-  "final"
+ "dynamic"
+ "external"
+ "static"
+ "final"
   "base"
   "sealed"
-] @type.qualifier
+ ] @type.qualifier
 
 ; when used as an identifier:
 ((identifier) @variable.builtin
-  (#any-of? @variable.builtin
-    "abstract" "as" "covariant" "deferred" "dynamic" "export" "external" "factory" "Function" "get"
-    "implements" "import" "interface" "library" "operator" "mixin" "part" "set" "static" "typedef"))
+ (#any-of? @variable.builtin
+           "abstract"
+           "as"
+           "covariant"
+           "deferred"
+           "dynamic"
+           "export"
+           "external"
+           "factory"
+           "Function"
+           "get"
+           "implements"
+           "import"
+           "interface"
+           "library"
+           "operator"
+           "mixin"
+           "part"
+           "set"
+           "static"
+           "typedef"))
 
 [
   "if"

--- a/extensions/dart/languages/dart/highlights.scm
+++ b/extensions/dart/languages/dart/highlights.scm
@@ -151,9 +151,9 @@
 (false) @boolean
 (null_literal) @constant.builtin
 
-(comment) @comment @spell
+(comment) @comment
 
-(documentation_comment) @comment.documentation @spell
+(documentation_comment) @comment.documentation
 
 ; Keywords
 ; --------------------

--- a/extensions/dart/languages/dart/highlights.scm
+++ b/extensions/dart/languages/dart/highlights.scm
@@ -4,14 +4,10 @@
 ; --------------------
 (super) @function
 
-; TODO: add method/call_expression to grammar and
-; distinguish method call from variable access
 (function_expression_body
   (identifier) @function)
 
 ; ((identifier)(selector (argument_part)) @function)
-; NOTE: This query is a bit of a work around for the fact that the dart grammar doesn't
-; specifically identify a node as a function call
 (((identifier) @function
   (#lua-match? @function "^_?[%l]"))
   .
@@ -122,7 +118,7 @@
 (inferred_type) @keyword
 
 ((identifier) @type
-  (#lua-match? @type "^_?[%u].*[%l]")) ; catch Classes or IClasses not CLASSES
+  (#lua-match? @type "^_?[%u].*[%l]"))
 
 "Function" @type
 
@@ -154,9 +150,6 @@
   (hex_integer_literal)
   (decimal_integer_literal)
   (decimal_floating_point_literal)
-  ; TODO: inaccessible nodes
-  ; (octal_integer_literal)
-  ; (hex_floating_point_literal)
 ] @number
 
 (symbol_literal) @string.special.symbol
@@ -186,13 +179,6 @@
 
 ; Reserved words (cannot be used as identifiers)
 [
-  ; TODO:
-  ; "rethrow" cannot be targeted at all and seems to be an invisible node
-  ; TODO:
-  ; the assert keyword cannot be specifically targeted
-  ; because the grammar selects the whole node or the content
-  ; of the assertion not just the keyword
-  ; assert
   (case_builtin)
   "late"
   "required"

--- a/extensions/dart/languages/dart/highlights.scm
+++ b/extensions/dart/languages/dart/highlights.scm
@@ -2,9 +2,22 @@
 
 ; Methods
 ; --------------------
-(function_type
-    name: (identifier) @function)
 (super) @function
+
+; TODO: add method/call_expression to grammar and
+; distinguish method call from variable access
+(function_expression_body
+  (identifier) @function)
+
+; ((identifier)(selector (argument_part)) @function)
+; NOTE: This query is a bit of a work around for the fact that the dart grammar doesn't
+; specifically identify a node as a function call
+(((identifier) @function
+  (#lua-match? @function "^_?[%l]"))
+  .
+  (selector
+    .
+    (argument_part))) @function
 
 ; Annotations
 ; --------------------
@@ -16,13 +29,11 @@
 (template_substitution
   "$" @punctuation.special
   "{" @punctuation.special
-  "}" @punctuation.special
-  ) @none
+  "}" @punctuation.special) @none
 
 (template_substitution
   "$" @punctuation.special
-  (identifier_dollar_escaped) @variable
-  ) @none
+  (identifier_dollar_escaped) @variable) @none
 
 (escape_sequence) @string.escape
 
@@ -42,12 +53,13 @@
   ">="
   "<="
   "||"
+  (multiplicative_operator)
   (increment_operator)
   (is_operator)
   (prefix_operator)
   (equality_operator)
   (additive_operator)
-  ] @operator
+] @operator
 
 [
   "("
@@ -56,9 +68,7 @@
   "]"
   "{"
   "}"
-  "<"
-  ">"
-  ]  @punctuation.bracket
+] @punctuation.bracket
 
 ; Delimiters
 ; --------------------
@@ -66,53 +76,61 @@
   ";"
   "."
   ","
-  ] @punctuation.delimiter
+] @punctuation.delimiter
 
 ; Types
 ; --------------------
 (class_definition
   name: (identifier) @type)
+
 (constructor_signature
   name: (identifier) @type)
+
 (scoped_identifier
   scope: (identifier) @type)
+
 (function_signature
-  name: (identifier) @function)
+  name: (identifier) @function.method)
+
 (getter_signature
-  (identifier) @function)
+  (identifier) @function.method)
+
 (setter_signature
-  name: (identifier) @function)
+  name: (identifier) @function.method)
+
 (enum_declaration
   name: (identifier) @type)
+
 (enum_constant
   name: (identifier) @type)
-(type_identifier) @type
+
 (void_type) @type
 
 ((scoped_identifier
-   scope: (identifier) @type
-   name: (identifier) @type)
-  (#match? @type "^[a-zA-Z]"))
+  scope: (identifier) @type
+  name: (identifier) @type)
+  (#lua-match? @type "^[%u%l]"))
 
 (type_identifier) @type
+
+(type_alias
+  (type_identifier) @type.definition)
 
 ; Variables
 ; --------------------
 ; var keyword
 (inferred_type) @keyword
 
-(const_builtin) @constant.builtin
-(final_builtin) @constant.builtin
-
 ((identifier) @type
-  (#match? @type "^_?[A-Z]"))
+  (#lua-match? @type "^_?[%u].*[%l]")) ; catch Classes or IClasses not CLASSES
 
-("Function" @type)
+"Function" @type
 
 ; properties
-; TODO: add method/call_expression to grammar and
-; distinguish method call from variable access
 (unconditional_assignable_selector
+  (identifier) @property)
+
+(conditional_assignable_selector
   (identifier) @property)
 
 ; assignments
@@ -120,6 +138,15 @@
   left: (assignable_expression) @variable)
 
 (this) @variable.builtin
+
+; Parameters
+; --------------------
+(formal_parameter
+  name: (identifier) @variable.parameter)
+
+(named_argument
+  (label
+    (identifier) @variable.parameter))
 
 ; Literals
 ; --------------------
@@ -130,26 +157,45 @@
   ; TODO: inaccessible nodes
   ; (octal_integer_literal)
   ; (hex_floating_point_literal)
-  ] @number
+] @number
 
-(symbol_literal) @symbol
+(symbol_literal) @string.special.symbol
+
 (string_literal) @string
+
 (true) @boolean
+
 (false) @boolean
+
 (null_literal) @constant.builtin
 
-(documentation_comment) @comment
-(comment) @comment
+(comment) @comment @spell
+
+(documentation_comment) @comment.documentation @spell
 
 ; Keywords
 ; --------------------
-["import" "library" "export"] @keyword.include
+[
+  "import"
+  "library"
+  "export"
+  "as"
+  "show"
+  "hide"
+] @keyword.import
 
 ; Reserved words (cannot be used as identifiers)
-; TODO: "rethrow" @keyword
 [
-  ; "assert"
+  ; TODO:
+  ; "rethrow" cannot be targeted at all and seems to be an invisible node
+  ; TODO:
+  ; the assert keyword cannot be specifically targeted
+  ; because the grammar selects the whole node or the content
+  ; of the assertion not just the keyword
+  ; assert
   (case_builtin)
+  "late"
+  "required"
   "extension"
   "on"
   "class"
@@ -158,26 +204,16 @@
   "in"
   "is"
   "new"
-  "return"
   "super"
   "with"
-  ] @keyword
+] @keyword
 
+"return" @keyword.return
 
 ; Built in identifiers:
 ; alone these are marked as keywords
 [
-  "abstract"
-  "as"
-  "async"
-  "async*"
-  "yield"
-  "sync*"
-  "await"
-  "covariant"
   "deferred"
-  "dynamic"
-  "external"
   "factory"
   "get"
   "implements"
@@ -187,16 +223,42 @@
   "mixin"
   "part"
   "set"
-  "show"
-  "static"
   "typedef"
-  ] @keyword
+] @keyword
+
+[
+  "async"
+  "async*"
+  "sync*"
+  "await"
+  "yield"
+] @keyword.coroutine
+
+[
+  (const_builtin)
+  (final_builtin)
+  "abstract"
+  "covariant"
+  "dynamic"
+  "external"
+  "static"
+  "final"
+  "base"
+  "sealed"
+] @type.qualifier
 
 ; when used as an identifier:
 ((identifier) @variable.builtin
-  (#vim-match? @variable.builtin "^(abstract|as|covariant|deferred|dynamic|export|external|factory|Function|get|implements|import|interface|library|operator|mixin|part|set|static|typedef)$"))
+  (#any-of? @variable.builtin
+    "abstract" "as" "covariant" "deferred" "dynamic" "export" "external" "factory" "Function" "get"
+    "implements" "import" "interface" "library" "operator" "mixin" "part" "set" "static" "typedef"))
 
-["if" "else" "switch" "default"] @keyword
+[
+  "if"
+  "else"
+  "switch"
+  "default"
+] @keyword.conditional
 
 [
   "try"
@@ -204,6 +266,11 @@
   "catch"
   "finally"
   (break_statement)
-  ] @keyword
+] @keyword.exception
 
-["do" "while" "continue" "for"] @keyword
+[
+  "do"
+  "while"
+  "continue"
+  "for"
+] @keyword.repeat

--- a/extensions/dart/languages/dart/highlights.scm
+++ b/extensions/dart/languages/dart/highlights.scm
@@ -139,7 +139,7 @@
  (hex_integer_literal)
  (decimal_integer_literal)
  (decimal_floating_point_literal)
- ; TODO: inaccessbile nodes
+ ; TODO: inaccessible nodes
  ; (octal_integer_literal)
  ; (hex_floating_point_literal)
  ] @number

--- a/extensions/dart/languages/dart/indents.scm
+++ b/extensions/dart/languages/dart/indents.scm
@@ -1,7 +1,45 @@
 [
-  (if_statement)
-  (for_statement)
-] @indent
+  (class_body)
+  (function_body)
+  (function_expression_body)
+  (declaration
+    (initializers))
+  (switch_block)
+  (formal_parameter_list)
+  (formal_parameter)
+  (list_literal)
+  (return_statement)
+  (arguments)
+  (try_statement)
+] @indent.begin
 
-(_ "{" "}" @end) @indent
-(_ "(" ")" @end) @indent
+(switch_block
+  (_) @indent.begin
+  (#set! indent.immediate 1)
+  (#set! indent.start_at_same_line 1))
+
+[
+  (switch_statement_case)
+  (switch_statement_default)
+] @indent.branch
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @indent.branch
+
+"}" @indent.end
+
+(return_statement
+  ";" @indent.end)
+
+(break_statement
+  ";" @indent.end)
+
+(comment) @indent.ignore
+
+(if_statement) @indent.auto

--- a/extensions/dart/languages/dart/indents.scm
+++ b/extensions/dart/languages/dart/indents.scm
@@ -1,45 +1,18 @@
-[
-  (class_body)
-  (function_body)
-  (function_expression_body)
-  (declaration
-    (initializers))
-  (switch_block)
-  (formal_parameter_list)
-  (formal_parameter)
-  (list_literal)
-  (return_statement)
-  (arguments)
-  (try_statement)
-] @indent.begin
+(class_definition
+    "class" @context
+    name: (_) @name) @item
 
-(switch_block
-  (_) @indent.begin
-  (#set! indent.immediate 1)
-  (#set! indent.start_at_same_line 1))
+(function_signature
+    name: (_) @name) @item
 
-[
-  (switch_statement_case)
-  (switch_statement_default)
-] @indent.branch
+(getter_signature
+    "get" @context
+    name: (_) @name) @item
 
-[
-  "("
-  ")"
-  "{"
-  "}"
-  "["
-  "]"
-] @indent.branch
+(setter_signature
+    "set" @context
+    name: (_) @name) @item
 
-"}" @indent.end
-
-(return_statement
-  ";" @indent.end)
-
-(break_statement
-  ";" @indent.end)
-
-(comment) @indent.ignore
-
-(if_statement) @indent.auto
+(enum_declaration
+    "enum" @context
+    name: (_) @name) @item


### PR DESCRIPTION
Release Notes:
* Improved Dart syntax highlighting ([#8151](https://github.com/zed-industries/zed/pull/8347#8151))

Before:
<img width="1246" alt="Before" src="https://github.com/zed-industries/zed/assets/25414681/d9143fe8-c474-40bb-afbd-56fef16edab3">

After:
<img width="1249" alt="After" src="https://github.com/zed-industries/zed/assets/25414681/4b103c35-fb24-4693-8b9e-3dd494036c9f">


(Shameless plug, since I build the theme)
Theme: The Dark Side
