### PR TITLE
Show keybindings instead of action names in the recent project modal

### DIFF
--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -266,7 +266,7 @@ pub struct ChannelModalDelegate {
 impl PickerDelegate for ChannelModalDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Search collaborator by username...".into()
     }
 

--- a/crates/collab_ui/src/collab_panel/contact_finder.rs
+++ b/crates/collab_ui/src/collab_panel/contact_finder.rs
@@ -84,7 +84,7 @@ impl PickerDelegate for ContactFinderDelegate {
         self.selected_index = ix;
     }
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Search collaborator by username...".into()
     }
 

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -231,7 +231,7 @@ impl CommandPaletteDelegate {
 impl PickerDelegate for CommandPaletteDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Execute a command...".into()
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1749,7 +1749,7 @@ impl Editor {
         self.completion_provider = Some(hub);
     }
 
-    pub fn placeholder_text(&self) -> Option<&str> {
+    pub fn placeholder_text(&self, _cx: &mut WindowContext) -> Option<&str> {
         self.placeholder_text.as_deref()
     }
 
@@ -9618,7 +9618,7 @@ impl EditorSnapshot {
         self.is_focused
     }
 
-    pub fn placeholder_text(&self) -> Option<&Arc<str>> {
+    pub fn placeholder_text(&self, _cx: &mut WindowContext) -> Option<&Arc<str>> {
         self.placeholder_text.as_ref()
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1904,7 +1904,7 @@ impl EditorElement {
         rows: Range<u32>,
         line_number_layouts: &[Option<ShapedLine>],
         snapshot: &EditorSnapshot,
-        cx: &ViewContext<Editor>,
+        cx: &mut ViewContext<Editor>,
     ) -> Vec<LineWithInvisibles> {
         if rows.start >= rows.end {
             return Vec::new();
@@ -1914,7 +1914,7 @@ impl EditorElement {
         if snapshot.is_empty() {
             let font_size = self.style.text.font_size.to_pixels(cx.rem_size());
             let placeholder_color = cx.theme().colors().text_placeholder;
-            let placeholder_text = snapshot.placeholder_text();
+            let placeholder_text = snapshot.placeholder_text(cx);
 
             let placeholder_lines = placeholder_text
                 .as_ref()

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -663,7 +663,7 @@ impl FileFinderDelegate {
 impl PickerDelegate for FileFinderDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Search project files...".into()
     }
 

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -120,7 +120,7 @@ impl LanguageSelectorDelegate {
 impl PickerDelegate for LanguageSelectorDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Select a language...".into()
     }
 

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -157,7 +157,7 @@ impl OutlineViewDelegate {
 impl PickerDelegate for OutlineViewDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Search buffer symbols...".into()
     }
 

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -37,7 +37,7 @@ pub trait PickerDelegate: Sized + 'static {
     }
     fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Picker<Self>>);
 
-    fn placeholder_text(&self) -> Arc<str>;
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str>;
     fn update_matches(&mut self, query: String, cx: &mut ViewContext<Picker<Self>>) -> Task<()>;
 
     // Delegates that support this method (e.g. the CommandPalette) can chose to block on any background
@@ -98,7 +98,7 @@ impl<D: PickerDelegate> Picker<D> {
     }
 
     fn new(delegate: D, cx: &mut ViewContext<Self>, is_uniform: bool) -> Self {
-        let editor = create_editor(delegate.placeholder_text(), cx);
+        let editor = create_editor(delegate.placeholder_text(cx), cx);
         cx.subscribe(&editor, Self::on_input_editor_event).detach();
         let mut this = Self {
             delegate,

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -2,7 +2,7 @@ use editor::{scroll::Autoscroll, styled_runs_for_code_label, Bias, Editor};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     actions, rems, AppContext, DismissEvent, FontWeight, Model, ParentElement, StyledText, Task,
-    View, ViewContext, WeakView,
+    View, ViewContext, WeakView, WindowContext,
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
@@ -106,7 +106,7 @@ impl ProjectSymbolsDelegate {
 
 impl PickerDelegate for ProjectSymbolsDelegate {
     type ListItem = ListItem;
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Search project symbols...".into()
     }
 

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -146,7 +146,7 @@ impl EventEmitter<DismissEvent> for RecentProjectsDelegate {}
 impl PickerDelegate for RecentProjectsDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         Arc::from(format!(
             "`{:?}` reuses the window, `{:?}` opens in new",
             menu::Confirm,

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -146,11 +146,25 @@ impl EventEmitter<DismissEvent> for RecentProjectsDelegate {}
 impl PickerDelegate for RecentProjectsDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
+    fn placeholder_text(&self, cx: &mut WindowContext) -> Arc<str> {
+        let action_binding_text = |action: &dyn gpui::Action| {
+            cx.bindings_for_action(action)
+                .into_iter()
+                .next()
+                .map(|binding| {
+                    binding
+                        .keystrokes()
+                        .into_iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_else(|| format!("{action:?}"))
+        };
         Arc::from(format!(
-            "`{:?}` reuses the window, `{:?}` opens in new",
-            menu::Confirm,
-            menu::SecondaryConfirm,
+            "{} reuses the window, {} opens a new one",
+            action_binding_text(&menu::Confirm),
+            action_binding_text(&menu::SecondaryConfirm),
         ))
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -127,7 +127,9 @@ impl Render for BufferSearchBar {
 
         let supported_options = self.supported_options();
 
-        if self.query_editor.read(cx).placeholder_text().is_none() {
+        if self.query_editor.update(cx, |query_editor, cx| {
+            query_editor.placeholder_text(cx).is_none()
+        }) {
             let query_focus_handle = self.query_editor.focus_handle(cx);
             let up_keystrokes = cx
                 .bindings_for_action_in(&PreviousHistoryQuery {}, &query_focus_handle)

--- a/crates/storybook/src/stories/picker.rs
+++ b/crates/storybook/src/stories/picker.rs
@@ -41,7 +41,7 @@ impl PickerDelegate for Delegate {
         self.candidates.len()
     }
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Test".into()
     }
 

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -9,7 +9,7 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use project::Inventory;
 use task::{oneshot_source::OneshotSource, Task};
-use ui::{v_flex, HighlightedLabel, ListItem, ListItemSpacing, Selectable};
+use ui::{v_flex, HighlightedLabel, ListItem, ListItemSpacing, Selectable, WindowContext};
 use util::ResultExt;
 use workspace::{ModalView, Workspace};
 
@@ -115,7 +115,7 @@ impl PickerDelegate for TasksModalDelegate {
         self.selected_index = ix;
     }
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         self.placeholder_text.clone()
     }
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -153,7 +153,7 @@ impl ThemeSelectorDelegate {
 impl PickerDelegate for ThemeSelectorDelegate {
     type ListItem = ui::ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Select Theme...".into()
     }
 

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -135,7 +135,7 @@ impl BranchListDelegate {
 impl PickerDelegate for BranchListDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Select branch...".into()
     }
 

--- a/crates/welcome/src/base_keymap_picker.rs
+++ b/crates/welcome/src/base_keymap_picker.rs
@@ -99,7 +99,7 @@ impl BaseKeymapSelectorDelegate {
 impl PickerDelegate for BaseKeymapSelectorDelegate {
     type ListItem = ui::ListItem;
 
-    fn placeholder_text(&self) -> Arc<str> {
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "Select a base keymap...".into()
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/8267#discussion_r1500609122

Before:
<img width="555" alt="Screenshot 2024-02-24 at 23 44 52" src="https://github.com/zed-industries/zed/assets/2690773/27be1fc0-3028-44ed-a371-e530aaad18eb">

After:
<img width="559" alt="Screenshot 2024-02-24 at 23 44 43" src="https://github.com/zed-industries/zed/assets/2690773/f725af20-acf9-4aa4-9390-5d48087a3878">


Release Notes:

- N/A

