### PR TITLE
recent projects: fix list flashing/empty

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -548,32 +548,27 @@ impl Element for List {
 
                     let summary = state.items.summary();
                     let total_height = summary.height;
-                    let all_rendered = summary.unrendered_count == 0;
 
-                    if all_rendered {
-                        cx.request_measured_layout(
-                            style,
-                            move |known_dimensions, available_space, _cx| {
-                                let width = known_dimensions.width.unwrap_or(match available_space
-                                    .width
-                                {
-                                    AvailableSpace::Definite(x) => x,
-                                    AvailableSpace::MinContent | AvailableSpace::MaxContent => {
-                                        max_element_width
-                                    }
-                                });
-                                let height = match available_space.height {
-                                    AvailableSpace::Definite(height) => total_height.min(height),
-                                    AvailableSpace::MinContent | AvailableSpace::MaxContent => {
-                                        total_height
-                                    }
-                                };
-                                size(width, height)
-                            },
-                        )
-                    } else {
-                        cx.request_layout(&style, None)
-                    }
+                    cx.request_measured_layout(
+                        style,
+                        move |known_dimensions, available_space, _cx| {
+                            let width = known_dimensions.width.unwrap_or(match available_space
+                                .width
+                            {
+                                AvailableSpace::Definite(x) => x,
+                                AvailableSpace::MinContent | AvailableSpace::MaxContent => {
+                                    max_element_width
+                                }
+                            });
+                            let height = match available_space.height {
+                                AvailableSpace::Definite(height) => total_height.min(height),
+                                AvailableSpace::MinContent | AvailableSpace::MaxContent => {
+                                    total_height
+                                }
+                            };
+                            size(width, height)
+                        },
+                    )
                 })
             }
             ListSizingBehavior::Auto => {

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -552,14 +552,15 @@ impl Element for List {
                     cx.request_measured_layout(
                         style,
                         move |known_dimensions, available_space, _cx| {
-                            let width = known_dimensions.width.unwrap_or(match available_space
-                                .width
-                            {
-                                AvailableSpace::Definite(x) => x,
-                                AvailableSpace::MinContent | AvailableSpace::MaxContent => {
-                                    max_element_width
-                                }
-                            });
+                            let width =
+                                known_dimensions
+                                    .width
+                                    .unwrap_or(match available_space.width {
+                                        AvailableSpace::Definite(x) => x,
+                                        AvailableSpace::MinContent | AvailableSpace::MaxContent => {
+                                            max_element_width
+                                        }
+                                    });
                             let height = match available_space.height {
                                 AvailableSpace::Definite(height) => total_height.min(height),
                                 AvailableSpace::MinContent | AvailableSpace::MaxContent => {


### PR DESCRIPTION
If the list is large (size > overdraw + available height) the `all_rendered` check was preventing the list from returning an inferred size. Theoretically we can now report heights which are actually too small (because not all items were affected during layout), this can be manually adjusted using the overdraw parameter. In this case its fine because the picker is inside a max_height which should never be more then the overdraw we specify (1000 px), and the list will shrink down either way when the request_measured_layout callback is called again.

Release Notes:

- Fixed flashing of recent projects list when there were a lot of projects in the list ([#8346](https://github.com/zed-industries/zed/issues/8364#issuecomment-1962849393)).
