### PR TITLE
Add filter for "Command Palette: Toggle"

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -58,6 +58,7 @@ impl CommandPalette {
         let commands = cx
             .available_actions()
             .into_iter()
+            .filter(|action| action.name() != "command_palette::Toggle")
             .filter_map(|action| {
                 let name = action.name();
                 let namespace = name.split("::").next().unwrap_or("malformed action name");
@@ -218,6 +219,7 @@ impl CommandPaletteDelegate {
                 },
             )
         }
+
         self.commands = commands;
         self.matches = matches;
         if self.matches.is_empty() {
@@ -232,7 +234,7 @@ impl PickerDelegate for CommandPaletteDelegate {
     type ListItem = ListItem;
 
     fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
-        "Execute a command...".into()
+        "Start typing a command...".into()
     }
 
     fn match_count(&self) -> usize {


### PR DESCRIPTION
This PR focuses on command palette. 

Changes:
- Updated the placeholder text to 'Start typing a command...'
   - "Start typing a command..." aims to directly prompt user interaction, enhancing usability by clearly guiding users on what action to take next.

<img width="637" alt="image" src="https://github.com/zed-industries/zed/assets/25414681/b082c3de-b4b6-4d61-84e3-a83a0a5d818c">


- Removed this command since it's redundant and doesn't do anything upon selecting
<img width="582" alt="image" src="https://github.com/zed-industries/zed/assets/25414681/0e8f2535-af24-45b4-8a9b-9ada72e4d957">
