### PR TITLE
add smithy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,6 +5109,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scheme",
+ "tree-sitter-smithy",
  "tree-sitter-svelte",
  "tree-sitter-toml",
  "tree-sitter-typescript",
@@ -10589,6 +10590,15 @@ dependencies = [
 name = "tree-sitter-scheme"
 version = "0.2.0"
 source = "git+https://github.com/6cdh/tree-sitter-scheme?rev=af0fd1fa452cb2562dc7b5c8a8c55551c39273b9#af0fd1fa452cb2562dc7b5c8a8c55551c39273b9"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-smithy"
+version = "1.0.0"
+source = "git+https://github.com/indoorvivants/tree-sitter-smithy?rev=8327eb84d55639ffbe08c9dc82da7fff72a1ad07#8327eb84d55639ffbe08c9dc82da7fff72a1ad07"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,6 +277,7 @@ tree-sitter-racket = { git = "https://github.com/zed-industries/tree-sitter-rack
 tree-sitter-ruby = "0.20.0"
 tree-sitter-rust = "0.20.3"
 tree-sitter-scheme = { git = "https://github.com/6cdh/tree-sitter-scheme", rev = "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9" }
+tree-sitter-smithy = { git = "https://github.com/indoorvivants/tree-sitter-smithy", rev = "8327eb84d55639ffbe08c9dc82da7fff72a1ad07" }
 tree-sitter-svelte = { git = "https://github.com/Himujjal/tree-sitter-svelte", rev = "bd60db7d3d06f89b6ec3b287c9a6e9190b5564bd" }
 tree-sitter-toml = { git = "https://github.com/tree-sitter/tree-sitter-toml", rev = "342d9be207c2dba869b9967124c679b5e6fd0ebe" }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev = "5d20856f34315b068c41edaee2ac8a100081d259" }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -51,6 +51,7 @@ tree-sitter-racket.workspace = true
 tree-sitter-ruby.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-scheme.workspace = true
+tree-sitter-smithy.workspace = true
 tree-sitter-svelte.workspace = true
 tree-sitter-toml.workspace = true
 tree-sitter-typescript.workspace = true

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -34,6 +34,7 @@ mod purescript;
 mod python;
 mod ruby;
 mod rust;
+mod smithy;
 mod svelte;
 mod tailwind;
 mod toml;
@@ -110,6 +111,7 @@ pub fn init(
         ("ruby", tree_sitter_ruby::language()),
         ("rust", tree_sitter_rust::language()),
         ("scheme", tree_sitter_scheme::language()),
+        ("smithy", tree_sitter_smithy::language()),
         ("svelte", tree_sitter_svelte::language()),
         ("toml", tree_sitter_toml::language()),
         ("tsx", tree_sitter_typescript::language_tsx()),
@@ -207,6 +209,7 @@ pub fn init(
             node_runtime.clone(),
         ))],
     );
+    language("smithy", vec![Arc::new(smithy::SmithyLspAdapter)]);
     language("rust", vec![Arc::new(rust::RustLspAdapter)]);
     language("toml", vec![Arc::new(toml::TaploLspAdapter)]);
     match &DenoSettings::get(None, cx).enable {

--- a/crates/languages/src/smithy.rs
+++ b/crates/languages/src/smithy.rs
@@ -1,0 +1,165 @@
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use lsp::LanguageServerBinary;
+use smol::fs::{self, File};
+use std::{
+    any::Any, 
+    path::PathBuf
+};
+use std::ffi::OsString;
+use std::sync::Arc;
+use util::async_maybe;
+use gpui::{AsyncAppContext, Task};
+use util::github::latest_github_release;
+use util::{github::GitHubLspBinaryVersion, ResultExt};
+
+pub struct SmithyLspAdapter;
+
+fn server_binary_arguments() -> Vec<OsString> {
+    vec!["0".into()] // "0" to use STDIN and STDOUT.
+}
+
+#[async_trait]
+impl LspAdapter for SmithyLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("smithy-language-server".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "smithy-language-server"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        delegate: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        let release =
+            latest_github_release("smithy-lang/smithy-language-server", true, false, delegate.http_client()).await?;
+        let asset_name = format!("smithy-language-server-{}.zip",release.tag_name);
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| anyhow!("no asset found matching {:?}", asset_name))?;
+        let version = GitHubLspBinaryVersion {
+            name: release.tag_name,
+            url: asset.browser_download_url.clone(),
+        };
+
+        Ok(Box::new(version) as Box<_>)
+    }
+
+    fn check_if_user_installed(
+        &self,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        cx: &mut AsyncAppContext,
+    ) -> Option<Task<Option<LanguageServerBinary>>> {
+        let delegate = delegate.clone();
+
+        Some(cx.spawn(|cx| async move {
+            match cx.update(|cx| delegate.which_command(OsString::from("smithy-language-server"), cx)) {
+                Ok(task) => task.await.map(|(path, env)| LanguageServerBinary {
+                    path,
+                    arguments: server_binary_arguments(),
+                    env: Some(env),
+                }),
+                Err(_) => None,
+            }
+        }))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: Box<dyn 'static + Send + Any>,
+        container_dir: PathBuf,
+        delegate: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
+        let zip_path = container_dir.join(format!("smithy-language-server-{}.zip", version.name));
+        let version_dir = container_dir.join(format!("smithy-language-server-{}", version.name));
+        let binary_path: PathBuf = version_dir.join("bin/smithy-language-server");
+
+        
+        if fs::metadata(&binary_path).await.is_err() {
+            let mut response = delegate
+                .http_client()
+                .get(&version.url, Default::default(), true)
+                .await
+                .context("error downloading smithy-language-server release")?;
+            let mut file = File::create(&zip_path).await?;
+            if !response.status().is_success() {
+                Err(anyhow!(
+                    "smithy-language-server download failed with status {}",
+                    response.status().to_string()
+                ))?;
+            }
+            futures::io::copy(response.body_mut(), &mut file).await?;
+
+            let unzip_status = smol::process::Command::new("unzip")
+                .current_dir(&container_dir)
+                .arg(&zip_path)
+                .output()
+                .await?
+                .status;
+            if !unzip_status.success() {
+                Err(anyhow!("failed to unzip smithy-language-server archive"))?;
+            }
+        }
+        Ok(LanguageServerBinary {
+            path: binary_path.clone(),
+            env: None,
+            arguments: server_binary_arguments(),
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir).await
+    }
+
+    async fn installation_test_binary(
+        &self,
+        container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_server_binary(container_dir)
+            .await
+            .map(|mut binary| {
+                binary.arguments = vec!["--help".into()];
+                binary
+            })
+    }
+}
+
+async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServerBinary> {
+    async_maybe!({
+        let mut last_smithy_dir = None;
+        let mut entries = fs::read_dir(&container_dir).await?;
+        while let Some(entry) = entries.next().await {
+            let entry = entry?;
+            if entry.file_type().await?.is_dir() {
+                last_smithy_dir = Some(entry.path());
+            }
+        }
+        let smithy_dir = last_smithy_dir.ok_or_else(|| anyhow!("no cached binary"))?;
+        let smithy_bin = smithy_dir.join("bin/smithy-language-server");
+        if smithy_bin.exists() {
+            Ok(LanguageServerBinary {
+                path: smithy_bin.clone(),
+                env: None,
+                arguments: server_binary_arguments(), 
+            })
+        } else {
+            Err(anyhow!(
+                "missing smithy-language-server binary in directory {:?}",
+                smithy_dir
+            ))
+        }
+    })
+    .await
+    .log_err()
+}

--- a/crates/languages/src/smithy/config.toml
+++ b/crates/languages/src/smithy/config.toml
@@ -1,0 +1,10 @@
+name = "Smithy"
+grammar = "smithy"
+path_suffixes = ["smithy"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>` \n\t\""
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]

--- a/crates/languages/src/smithy/highlights.scm
+++ b/crates/languages/src/smithy/highlights.scm
@@ -1,0 +1,114 @@
+; Preproc
+(control_key) @keyword.directive
+
+; Namespace
+(namespace) @module
+
+; Includes
+"use" @keyword.import
+
+; Builtins
+(primitive) @type.builtin
+
+[
+  "enum"
+  "intEnum"
+  "list"
+  "map"
+  "set"
+] @type.builtin
+
+; Fields (Members)
+; (field) @variable.member
+(key_identifier) @variable.member
+
+(shape_member
+  (field) @variable.member)
+
+(operation_field) @variable.member
+
+(operation_error_field) @variable.member
+
+; Constants
+(enum_member
+  (enum_field) @constant)
+
+; Types
+(identifier) @type
+
+(structure_resource
+  (shape_id) @type)
+
+; Attributes
+(mixins
+  (shape_id) @attribute)
+
+(trait_statement
+  (shape_id
+    (#set! "priority" 105)) @attribute)
+
+; Operators
+[
+  "@"
+  "-"
+  "="
+  ":="
+] @operator
+
+; Keywords
+[
+  "namespace"
+  "service"
+  "structure"
+  "operation"
+  "union"
+  "resource"
+  "metadata"
+  "apply"
+  "for"
+  "with"
+] @keyword
+
+; Literals
+(string) @string
+
+(escape_sequence) @string.escape
+
+(number) @number
+
+(float) @number.float
+
+(boolean) @boolean
+
+(null) @constant.builtin
+
+; Misc
+[
+  "$"
+  "#"
+] @punctuation.special
+
+[
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "("
+  ")"
+] @punctuation.bracket
+
+[
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ":"
+  "."
+] @punctuation.delimiter
+
+; Comments
+(comment) @comment @spell
+
+(documentation_comment) @comment.documentation @spell

--- a/docs/src/languages/smithy.md
+++ b/docs/src/languages/smithy.md
@@ -1,0 +1,4 @@
+# Smithy
+
+- Tree Sitter: [tree-sitter-smithy](https://github.com/indoorvivants/tree-sitter-smithy)
+- Language Server: [smithy-language-server](https://github.com/smithy-lang/smithy-language-server)


### PR DESCRIPTION
This PR adds support for [Smithy IDL](https://smithy.io/) with the official LSP ([smithy-language-server](https://github.com/smithy-lang/smithy-language-server)) and tree-sitter. I tested against various Smithy files and projects.

### Testing:

```
cargo run --release
```

### Release Notes:

- Added SmithyLspAdapter
- Added tree-sitter-smithy
- Added Smithy lang docs


### Screenshots

Zed:
![Screenshot 2024-02-25 at 6 53 13 AM](https://github.com/zed-industries/zed/assets/54906829/cb6758dd-1fb6-40a1-a2af-4ad94cdfa29c)

VSCode:
![Screenshot 2024-02-25 at 6 47 47 AM](https://github.com/zed-industries/zed/assets/54906829/a34d8c7f-4d55-44e4-b1c1-b0b7931e9fcc)
