### PR TITLE
Add `command_palette_hooks` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,7 @@ dependencies = [
  "anyhow",
  "client",
  "collections",
- "copilot",
+ "command_palette_hooks",
  "ctor",
  "editor",
  "env_logger",
@@ -2235,6 +2235,14 @@ dependencies = [
  "util",
  "workspace",
  "zed_actions",
+]
+
+[[package]]
+name = "command_palette_hooks"
+version = "0.1.0"
+dependencies = [
+ "collections",
+ "gpui",
 ]
 
 [[package]]
@@ -2296,6 +2304,7 @@ dependencies = [
  "async-tar",
  "clock",
  "collections",
+ "command_palette_hooks",
  "fs",
  "futures 0.3.28",
  "gpui",
@@ -11001,8 +11010,7 @@ dependencies = [
  "async-compat",
  "async-trait",
  "collections",
- "command_palette",
- "copilot",
+ "command_palette_hooks",
  "editor",
  "futures 0.3.28",
  "gpui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11010,6 +11010,7 @@ dependencies = [
  "async-compat",
  "async-trait",
  "collections",
+ "command_palette",
  "command_palette_hooks",
  "editor",
  "futures 0.3.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/collab_ui",
     "crates/collections",
     "crates/command_palette",
+    "crates/command_palette_hooks",
     "crates/copilot",
     "crates/copilot_ui",
     "crates/db",
@@ -111,6 +112,7 @@ collab_ui = { path = "crates/collab_ui" }
 collections = { path = "crates/collections" }
 color = { path = "crates/color" }
 command_palette = { path = "crates/command_palette" }
+command_palette_hooks = { path = "crates/command_palette_hooks" }
 copilot = { path = "crates/copilot" }
 copilot_ui = { path = "crates/copilot_ui" }
 db = { path = "crates/db" }

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 anyhow.workspace = true
 client.workspace = true
 collections.workspace = true
-# HACK: We're only depending on `copilot` here for `CommandPaletteFilter`.  See the attached comment on that type.
-copilot.workspace = true
+command_palette_hooks.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 picker.workspace = true
+postage.workspace = true
 project.workspace = true
 release_channel.workspace = true
 serde.workspace = true
@@ -27,7 +27,6 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
-postage.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -6,7 +6,9 @@ use std::{
 
 use client::telemetry::Telemetry;
 use collections::HashMap;
-use copilot::CommandPaletteFilter;
+use command_palette_hooks::{
+    CommandInterceptResult, CommandPaletteFilter, CommandPaletteInterceptor,
+};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     actions, Action, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Global,
@@ -99,18 +101,6 @@ impl Render for CommandPalette {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex().w(rems(34.)).child(self.picker.clone())
     }
-}
-
-pub struct CommandPaletteInterceptor(
-    pub Box<dyn Fn(&str, &AppContext) -> Option<CommandInterceptResult>>,
-);
-
-impl Global for CommandPaletteInterceptor {}
-
-pub struct CommandInterceptResult {
-    pub action: Box<dyn Action>,
-    pub string: String,
-    pub positions: Vec<usize>,
 }
 
 pub struct CommandPaletteDelegate {

--- a/crates/command_palette_hooks/Cargo.toml
+++ b/crates/command_palette_hooks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "command_palette_hooks"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[lib]
+path = "src/command_palette_hooks.rs"
+doctest = false
+
+[dependencies]
+collections.workspace = true
+gpui.workspace = true

--- a/crates/command_palette_hooks/LICENSE-GPL
+++ b/crates/command_palette_hooks/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/command_palette_hooks/src/command_palette_hooks.rs
+++ b/crates/command_palette_hooks/src/command_palette_hooks.rs
@@ -1,0 +1,24 @@
+use std::any::TypeId;
+
+use collections::HashSet;
+use gpui::{Action, AppContext, Global};
+
+#[derive(Default)]
+pub struct CommandPaletteFilter {
+    pub hidden_namespaces: HashSet<&'static str>,
+    pub hidden_action_types: HashSet<TypeId>,
+}
+
+impl Global for CommandPaletteFilter {}
+
+pub struct CommandPaletteInterceptor(
+    pub Box<dyn Fn(&str, &AppContext) -> Option<CommandInterceptResult>>,
+);
+
+impl Global for CommandPaletteInterceptor {}
+
+pub struct CommandInterceptResult {
+    pub action: Box<dyn Action>,
+    pub string: String,
+    pub positions: Vec<usize>,
+}

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -24,6 +24,7 @@ anyhow.workspace = true
 async-compression.workspace = true
 async-tar.workspace = true
 collections.workspace = true
+command_palette_hooks.workspace = true
 futures.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Context as _, Result};
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
 use collections::{HashMap, HashSet};
+use command_palette_hooks::CommandPaletteFilter;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt, TryFutureExt};
 use gpui::{
     actions, AppContext, AsyncAppContext, Context, Entity, EntityId, EventEmitter, Global, Model,
@@ -32,17 +33,6 @@ use util::{
     ResultExt,
 };
 
-// HACK: This type is only defined in `copilot` since it is the earliest ancestor
-// of the crates that use it.
-//
-// This is not great. Let's find a better place for it to live.
-#[derive(Default)]
-pub struct CommandPaletteFilter {
-    pub hidden_namespaces: HashSet<&'static str>,
-    pub hidden_action_types: HashSet<TypeId>,
-}
-
-impl Global for CommandPaletteFilter {}
 actions!(
     copilot,
     [

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -17,9 +17,7 @@ anyhow.workspace = true
 async-compat = { version = "0.2.1", "optional" = true }
 async-trait = { workspace = true, "optional" = true }
 collections.workspace = true
-command_palette.workspace = true
-# HACK: We're only depending on `copilot` here for `CommandPaletteFilter`.  See the attached comment on that type.
-copilot.workspace = true
+command_palette_hooks.workspace = true
 editor.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -39,6 +39,7 @@ zed_actions.workspace = true
 schemars.workspace = true
 
 [dev-dependencies]
+command_palette.workspace = true
 editor = { workspace = true, features = ["test-support"] }
 futures.workspace = true
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1,4 +1,4 @@
-use command_palette::CommandInterceptResult;
+use command_palette_hooks::CommandInterceptResult;
 use editor::actions::{SortLinesCaseInsensitive, SortLinesCaseSensitive};
 use gpui::{impl_actions, Action, AppContext, ViewContext};
 use serde_derive::Deserialize;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -16,8 +16,7 @@ mod visual;
 
 use anyhow::Result;
 use collections::HashMap;
-use command_palette::CommandPaletteInterceptor;
-use copilot::CommandPaletteFilter;
+use command_palette_hooks::{CommandPaletteFilter, CommandPaletteInterceptor};
 use editor::{movement, Editor, EditorEvent, EditorMode};
 use gpui::{
     actions, impl_actions, Action, AppContext, EntityId, Global, Subscription, View, ViewContext,


### PR DESCRIPTION
This PR introduces a new `command_palette_hooks` crate that contains the types used to hook into the behavior of the command palette.

The `CommandPaletteFilter` was previously extracted to the `copilot` crate in #7095, solely because that was the earliest ancestor of the crates that depended on it.

The `CommandPaletteInterceptor` was still defined in `command_palette` itself.

Both of these types were consumed by other crates wanting to influence the behavior of the command palette, but required taking a dependency on the entire `command_palette` crate in order to gain access to these hooks.

By moving them out into their own crate, we can improve the compile order and make crates like `vim` able to begin building sooner without having to wait for `command_palette` to finish compiling.

Here's a comparison of the compilation graph before and after (ignore the timings):

#### Before

<img width="332" alt="Screenshot 2024-02-25 at 12 42 29 PM" src="https://github.com/zed-industries/zed/assets/1486634/a57c662e-fbc2-41ab-9e30-cca17afa6c73">

#### After

<img width="362" alt="Screenshot 2024-02-25 at 12 51 15 PM" src="https://github.com/zed-industries/zed/assets/1486634/c1a6d29c-b607-4604-8f1b-e5d318bf8849">

Release Notes:

- N/A
