### PR TITLE
Add terminal icon for Nu file

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -95,6 +95,7 @@
         "mts": "typescript",
         "myd": "storage",
         "myi": "storage",
+        "nu": "terminal",
         "odp": "document",
         "ods": "document",
         "odt": "document",


### PR DESCRIPTION
Nu is a shell language so it should has the `terminal` icon.

Release Notes:

- N/A

<img width="241" alt="Capture d’écran 2024-02-25 à 18 49 43" src="https://github.com/zed-industries/zed/assets/24520681/0adcd8fd-f5b0-4688-b301-5c49c376c7a0">
