### PR TITLE
Fix bug with vim mode undo of visual selection

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -328,7 +328,7 @@
           "before": true
         }
       ],
-      "u": "editor::Undo",
+      "u": "vim::Undo",
       "ctrl-r": "editor::Redo",
       "/": "vim::Search",
       "?": [

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -392,7 +392,7 @@ mod test {
 
     use crate::{
         state::Mode::{self},
-        test::{NeovimBackedTestContext, VimTestContext},
+        test::NeovimBackedTestContext,
     };
 
     #[gpui::test]
@@ -924,12 +924,25 @@ mod test {
 
     #[gpui::test]
     async fn test_undo(cx: &mut TestAppContext) {
-        let mut cx = VimTestContext::new(cx, true).await;
+        let mut cx = NeovimBackedTestContext::new(cx).await;
 
-        cx.set_state("The quick brown ˇfox", Mode::Normal);
-        cx.simulate_keystrokes(["v", "e", "d"]);
-        cx.assert_editor_state("The quick brownˇ ");
-        cx.simulate_keystrokes(["u"]);
-        cx.assert_editor_state("The quick brownˇ fox");
+        cx.set_shared_state(indoc! {"
+                ˇThe quick
+                brown fox
+                jumps over"})
+            .await;
+
+        cx.simulate_shared_keystrokes(["shift-v", "d"]).await;
+        cx.assert_shared_state(indoc! {"
+                    ˇbrown fox
+                    jumps over"})
+            .await;
+
+        cx.simulate_shared_keystrokes(["u"]).await;
+        cx.assert_shared_state(indoc! {"
+                ˇThe quick
+                brown fox
+                jumps over"})
+            .await;
     }
 }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -331,9 +331,8 @@ fn yank_line(_: &mut Workspace, _: &YankLine, cx: &mut ViewContext<Workspace>) {
 
 fn undo(_: &mut Workspace, _: &Undo, cx: &mut ViewContext<Workspace>) {
     Vim::update(cx, |vim, cx| {
-        vim.update_active_editor(cx, |_, editor, cx| {
-            editor.buffer().update(cx, |buffer, cx| buffer.undo(cx));
-        });
+        vim.update_active_editor(cx, |_, editor, cx| editor.undo(&editor::actions::Undo, cx));
+        vim.switch_mode(Mode::Visual, false, cx);
         vim.switch_mode(Mode::Normal, false, cx);
     })
 }

--- a/crates/vim/test_data/test_undo.json
+++ b/crates/vim/test_data/test_undo.json
@@ -1,0 +1,7 @@
+{"Put":{"state":"The quick brown ˇfox"}}
+{"Key":"v"}
+{"Key":"e"}
+{"Key":"d"}
+{"Get":{"state":"The quick brownˇ ","mode":"Normal"}}
+{"Key":"u"}
+{"Get":{"state":"The quick brown ˇfox","mode":"Normal"}}

--- a/crates/vim/test_data/test_undo.json
+++ b/crates/vim/test_data/test_undo.json
@@ -1,7 +1,6 @@
-{"Put":{"state":"The quick brown ˇfox"}}
-{"Key":"v"}
-{"Key":"e"}
+{"Put":{"state":"ˇThe quick\nbrown fox\njumps over"}}
+{"Key":"shift-v"}
 {"Key":"d"}
-{"Get":{"state":"The quick brownˇ ","mode":"Normal"}}
+{"Get":{"state":"ˇbrown fox\njumps over","mode":"Normal"}}
 {"Key":"u"}
-{"Get":{"state":"The quick brown ˇfox","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\nbrown fox\njumps over","mode":"Normal"}}


### PR DESCRIPTION
This pull request fixes a bug that was introduced in zed-industries/zed#6948 where undoing an operation in vim mode would reselect the previous change in visual mode, which has a different binding for the `u` key, preventing the user from continuing to undo with the `u` key until they hit escape.

~~This is not the most robust solution as it does not keep track of the cursor position and restore it after an undo, but this is meant to be a quick way of addressing the bug in zed-industries/zed#7521.~~

Release Notes:

- Fixed undo of visual mode selections in Vim mode (https://github.com/zed-industries/zed/issues/7521).