### PR TITLE
use EndOfLineDownward rather than EndOfLine

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -32,7 +32,7 @@
       "l": "vim::Right",
       "right": "vim::Right",
       "space": "vim::Space",
-      "$": "vim::EndOfLine",
+      "$": "vim::EndOfLineDownward",
       "^": "vim::FirstNonWhitespace",
       "_": "vim::StartOfLineDownward",
       "g _": "vim::EndOfLineDownward",


### PR DESCRIPTION

Release Notes:

-Fixed `2$` to go to the next line of end ([#8007](https://github.com/zed-industries/zed/issues/8007)).

I figure out that many commands invoke `end_of_line` function, and just found that there is a `g _`(EndOfLineDownward) which plays well.
