### PR TITLE
Open a new file on double-clicking the tab bar

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -9,9 +9,9 @@ use collections::{HashMap, HashSet, VecDeque};
 use futures::{stream::FuturesUnordered, StreamExt};
 use gpui::{
     actions, impl_actions, overlay, prelude::*, Action, AnchorCorner, AnyElement, AppContext,
-    AsyncWindowContext, DismissEvent, Div, DragMoveEvent, EntityId, EventEmitter, ExternalPaths,
-    FocusHandle, FocusableView, Model, MouseButton, NavigationDirection, Pixels, Point,
-    PromptLevel, Render, ScrollHandle, Subscription, Task, View, ViewContext, VisualContext,
+    AsyncWindowContext, ClickEvent, DismissEvent, Div, DragMoveEvent, EntityId, EventEmitter,
+    ExternalPaths, FocusHandle, FocusableView, Model, MouseButton, NavigationDirection, Pixels,
+    Point, PromptLevel, Render, ScrollHandle, Subscription, Task, View, ViewContext, VisualContext,
     WeakView, WindowContext,
 };
 use parking_lot::Mutex;
@@ -1505,6 +1505,7 @@ impl Pane {
             )
             .child(
                 div()
+                    .id("tab_bar_drop_target")
                     .min_w_6()
                     // HACK: This empty child is currently necessary to force the drop target to appear
                     // despite us setting a min width above.
@@ -1528,6 +1529,11 @@ impl Pane {
                     .on_drop(cx.listener(move |this, paths, cx| {
                         this.drag_split_direction = None;
                         this.handle_external_paths_drop(paths, cx)
+                    }))
+                    .on_click(cx.listener(move |_, event: &ClickEvent, cx| {
+                        if event.up.click_count == 2 {
+                            cx.dispatch_action(NewFile.boxed_clone());
+                        }
                     })),
             )
     }


### PR DESCRIPTION
Fixes #6818

This is a convenience feature that exists in other editors, allowing quick creation a new tab by double-clicking the empty space on the tab bar:
![2024-02-26 14 26 16](https://github.com/zed-industries/zed/assets/601206/55d99a84-2e61-494d-b06c-6e5f15071655)

Release Notes:

- Added the ability to open a new buffer when double-clicking on the tab bar ([#6818](https://github.com/zed-industries/zed/issues/6818)).