### PR TITLE
unique channel names

### DIFF
--- a/crates/channel/src/channel_store/channel_index.rs
+++ b/crates/channel/src/channel_store/channel_index.rs
@@ -94,14 +94,17 @@ impl<'a> Drop for ChannelPathsInsertGuard<'a> {
 fn channel_path_sorting_key<'a>(
     id: ChannelId,
     channels_by_id: &'a BTreeMap<ChannelId, Arc<Channel>>,
-) -> impl Iterator<Item = &str> {
+) -> impl Iterator<Item = (&str, u64)> {
     let (parent_path, name) = channels_by_id
         .get(&id)
         .map_or((&[] as &[_], None), |channel| {
-            (channel.parent_path.as_slice(), Some(channel.name.as_ref()))
+            (
+                channel.parent_path.as_slice(),
+                Some((channel.name.as_ref(), channel.id)),
+            )
         });
     parent_path
         .iter()
-        .filter_map(|id| Some(channels_by_id.get(id)?.name.as_ref()))
+        .filter_map(|id| Some((channels_by_id.get(id)?.name.as_ref(), *id)))
         .chain(name)
 }

--- a/crates/collab/migrations/20240226164505_unique_channel_names.sql
+++ b/crates/collab/migrations/20240226164505_unique_channel_names.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+
+CREATE UNIQUE INDEX uix_channels_parent_path_name ON channels(parent_path, name) WHERE (parent_path IS NOT NULL);


### PR DESCRIPTION
Before this change duplicate channels were ordered arbitrarily, which put the
collab channel in an inconsistent state.

Release Notes:

- Fixed duplicate channel names appearing in the collab sidebar.

