### PR TITLE
Do not enable venv in terminal for bash-like oneshot task invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 [[package]]
 name = "alacritty_terminal"
 version = "0.22.1-dev"
-source = "git+https://github.com/alacritty/alacritty?rev=992011a4cd9a35f197acc0a0bd430d89a0d01013#992011a4cd9a35f197acc0a0bd430d89a0d01013"
+source = "git+https://github.com/alacritty/alacritty#fe88aaa0855283d689dc41d531db916404ef9c51"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.22.0",
  "bitflags 2.4.2",
  "home",
  "libc",
@@ -1327,6 +1327,12 @@ name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64-simd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,9 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.22.1-dev"
-source = "git+https://github.com/alacritty/alacritty#fe88aaa0855283d689dc41d531db916404ef9c51"
+version = "0.23.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2c16faa5425a10be102dda76f73d76049b44746e18ddeefc44d78bbe76cbce"
 dependencies = [
  "base64 0.22.0",
  "bitflags 2.4.2",

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -147,7 +147,7 @@ impl Project {
         &mut self,
         settings: &VenvSettingsContent,
         working_directory: Option<PathBuf>,
-        env: &mut std::collections::HashMap<String, String>,
+        env: &mut collections::HashMap<String, String>,
     ) {
         let working_directory = working_directory.unwrap_or_else(|| Path::new("/").to_path_buf());
         for virtual_environment_name in settings.directories {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -34,8 +34,9 @@ impl Project {
         let (completion_tx, completion_rx) = bounded(1);
         let mut env = settings.env.clone();
 
-        // if we are creating a task, activate minimal python virtual environment
-        if !is_terminal {
+        let (spawn_task, shell) = if let Some(spawn_task) = spawn_task {
+            env.extend(spawn_task.env);
+            // Activate minimal python virtual environment
             if let Some(python_settings) = &python_settings.as_option() {
                 self.set_python_venv_path_for_tasks(
                     python_settings,
@@ -43,9 +44,6 @@ impl Project {
                     &mut env,
                 );
             }
-        }
-        let (spawn_task, shell) = if let Some(spawn_task) = spawn_task {
-            env.extend(spawn_task.env);
             (
                 Some(TaskState {
                     id: spawn_task.id,

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -160,10 +160,8 @@ impl Project {
                 let path_bin = path.join("bin");
                 // We need to set the PATH to include the virtual environment's bin directory
                 if let Some(paths) = std::env::var_os("PATH") {
-                    let mut paths = std::env::split_paths(&paths)
-                        .filter(|p| p != &path_bin) // so we don't add the same path twice
-                        .collect::<Vec<_>>();
-                    paths.insert(0, path_bin);
+                    let paths = std::iter::once(path_bin)
+                        .chain(std::env::split_paths(&paths));
                     let new_path = std::env::join_paths(paths).unwrap();
                     env.insert("PATH".to_string(), new_path.to_string_lossy().to_string());
                 } else {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -160,8 +160,7 @@ impl Project {
                 let path_bin = path.join("bin");
                 // We need to set the PATH to include the virtual environment's bin directory
                 if let Some(paths) = std::env::var_os("PATH") {
-                    let paths = std::iter::once(path_bin)
-                        .chain(std::env::split_paths(&paths));
+                    let paths = std::iter::once(path_bin).chain(std::env::split_paths(&paths));
                     let new_path = std::env::join_paths(paths).unwrap();
                     env.insert("PATH".to_string(), new_path.to_string_lossy().to_string());
                 } else {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -28,7 +28,7 @@ impl Project {
             "creating terminals as a guest is not supported yet"
         );
 
-        let is_terminal = !spawn_task.is_some();
+        let is_terminal = spawn_task.is_none();
         let settings = TerminalSettings::get_global(cx);
         let python_settings = settings.detect_venv.clone();
         let (completion_tx, completion_rx) = bounded(1);

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 # TODO: when new version of this crate is released, change it
-alacritty_terminal = { git = "https://github.com/alacritty/alacritty" }
+alacritty_terminal = "0.23.0-rc1"
 anyhow.workspace = true
 collections.workspace = true
 dirs = "4.0.0"

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 # TODO: when new version of this crate is released, change it
-alacritty_terminal = { git = "https://github.com/alacritty/alacritty", rev = "992011a4cd9a35f197acc0a0bd430d89a0d01013" }
+alacritty_terminal = { git = "https://github.com/alacritty/alacritty" }
 anyhow.workspace = true
 collections.workspace = true
 dirs = "4.0.0"

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -649,7 +649,7 @@ impl Terminal {
             AlacTermEvent::ColorRequest(idx, fun_ptr) => {
                 self.events
                     .push_back(InternalEvent::ColorRequest(*idx, fun_ptr.clone()));
-            },
+            }
             AlacTermEvent::ChildExit(_) => {
                 // TODO: Handle child exit
             }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -321,8 +321,7 @@ impl TerminalBuilder {
         env.entry("LC_ALL".to_string())
             .or_insert_with(|| "en_US.UTF-8".to_string());
 
-        env.entry("ZED_TERM".to_string())
-            .or_insert_with(|| "true".to_string());
+        env.insert("ZED_TERM".to_string(), "true".to_string());
 
         let pty_options = {
             let alac_shell = match shell.clone() {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -310,13 +310,20 @@ impl TerminalBuilder {
         working_directory: Option<PathBuf>,
         task: Option<TaskState>,
         shell: Shell,
-        env: HashMap<String, String>,
+        mut env: HashMap<String, String>,
         blink_settings: Option<TerminalBlink>,
         alternate_scroll: AlternateScroll,
         max_scroll_history_lines: Option<usize>,
         window: AnyWindowHandle,
         completion_tx: Sender<()>,
     ) -> Result<TerminalBuilder> {
+        // TODO: Properly set the current locale,
+        env.entry("LC_ALL".to_string())
+            .or_insert_with(|| "en_US.UTF-8".to_string());
+
+        env.entry("ZED_TERM".to_string())
+            .or_insert_with(|| "true".to_string());
+
         let pty_options = {
             let alac_shell = match shell.clone() {
                 Shell::System => None,
@@ -332,19 +339,12 @@ impl TerminalBuilder {
                 shell: alac_shell,
                 working_directory: working_directory.clone(),
                 hold: false,
+                env: env.into_iter().collect(),
             }
         };
 
-        // First, setup Alacritty's env
+        // Setup Alacritty's env
         setup_env();
-
-        // Then setup configured environment variables
-        for (key, value) in env {
-            std::env::set_var(key, value);
-        }
-        //TODO: Properly set the current locale,
-        std::env::set_var("LC_ALL", "en_US.UTF-8");
-        std::env::set_var("ZED_TERM", "true");
 
         let scrolling_history = if task.is_some() {
             // Tasks like `cargo build --all` may produce a lot of output, ergo allow maximum scrolling.
@@ -649,6 +649,9 @@ impl Terminal {
             AlacTermEvent::ColorRequest(idx, fun_ptr) => {
                 self.events
                     .push_back(InternalEvent::ColorRequest(*idx, fun_ptr.clone()));
+            },
+            AlacTermEvent::ChildExit(_) => {
+                // TODO: Handle child exit
             }
         }
     }


### PR DESCRIPTION
Release Notes:
- Work around #8334 by only activating venv in the terminal not in tasks (see #8440 for a proper solution)
- To use venv modify your tasks in the following way:
```json
{
  "label": "Python main.py",
  "command": "sh",
  "args": ["-c", "source .venv/bin/activate && python3 main.py"]
}
```
