### PR TITLE
vim: `f` and `t` multiline option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -572,7 +572,8 @@
   },
   // Vim settings
   "vim": {
-    "use_system_clipboard": "always"
+    "use_system_clipboard": "always",
+    "use_multiline_find": false
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -12,7 +12,7 @@ use std::{ops::Range, sync::Arc};
 /// Defines search strategy for items in `movement` module.
 /// `FindRange::SingeLine` only looks for a match on a single line at a time, whereas
 /// `FindRange::MultiLine` keeps going until the end of a string.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FindRange {
     SingleLine,
     MultiLine,

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -22,27 +22,57 @@ use crate::{
 pub enum Motion {
     Left,
     Backspace,
-    Down { display_lines: bool },
-    Up { display_lines: bool },
+    Down {
+        display_lines: bool,
+    },
+    Up {
+        display_lines: bool,
+    },
     Right,
     Space,
-    NextWordStart { ignore_punctuation: bool },
-    NextWordEnd { ignore_punctuation: bool },
-    PreviousWordStart { ignore_punctuation: bool },
-    PreviousWordEnd { ignore_punctuation: bool },
-    FirstNonWhitespace { display_lines: bool },
+    NextWordStart {
+        ignore_punctuation: bool,
+    },
+    NextWordEnd {
+        ignore_punctuation: bool,
+    },
+    PreviousWordStart {
+        ignore_punctuation: bool,
+    },
+    PreviousWordEnd {
+        ignore_punctuation: bool,
+    },
+    FirstNonWhitespace {
+        display_lines: bool,
+    },
     CurrentLine,
-    StartOfLine { display_lines: bool },
-    EndOfLine { display_lines: bool },
+    StartOfLine {
+        display_lines: bool,
+    },
+    EndOfLine {
+        display_lines: bool,
+    },
     StartOfParagraph,
     EndOfParagraph,
     StartOfDocument,
     EndOfDocument,
     Matching,
-    FindForward { before: bool, char: char, mode: FindRange },
-    FindBackward { after: bool, char: char, mode: FindRange },
-    RepeatFind { last_find: Box<Motion> },
-    RepeatFindReversed { last_find: Box<Motion> },
+    FindForward {
+        before: bool,
+        char: char,
+        mode: FindRange,
+    },
+    FindBackward {
+        after: bool,
+        char: char,
+        mode: FindRange,
+    },
+    RepeatFind {
+        last_find: Box<Motion>,
+    },
+    RepeatFindReversed {
+        last_find: Box<Motion>,
+    },
     NextLineStart,
     StartOfLineDownward,
     EndOfLineDownward,
@@ -1052,9 +1082,7 @@ fn find_backward(
 
     for _ in 0..times {
         let new_to =
-            find_preceding_boundary_display_point(map, to, mode, |_, right| {
-                right == target
-            });
+            find_preceding_boundary_display_point(map, to, mode, |_, right| right == target);
         if to == new_to {
             break;
         }

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1017,7 +1017,7 @@ fn find_forward(
 
     for _ in 0..times {
         found = false;
-        let new_to = find_boundary(map, to, FindRange::SingleLine, |_, right| {
+        let new_to = find_boundary(map, to, FindRange::MultiLine, |_, right| {
             found = right == target;
             found
         });
@@ -1050,7 +1050,7 @@ fn find_backward(
 
     for _ in 0..times {
         let new_to =
-            find_preceding_boundary_display_point(map, to, FindRange::SingleLine, |_, right| {
+            find_preceding_boundary_display_point(map, to, FindRange::MultiLine, |_, right| {
                 right == target
             });
         if to == new_to {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -39,8 +39,8 @@ pub enum Motion {
     StartOfDocument,
     EndOfDocument,
     Matching,
-    FindForward { before: bool, char: char },
-    FindBackward { after: bool, char: char },
+    FindForward { before: bool, char: char, mode: FindRange },
+    FindBackward { after: bool, char: char, mode: FindRange },
     RepeatFind { last_find: Box<Motion> },
     RepeatFindReversed { last_find: Box<Motion> },
     NextLineStart,
@@ -481,30 +481,30 @@ impl Motion {
             ),
             Matching => (matching(map, point), SelectionGoal::None),
             // t f
-            FindForward { before, char } => {
-                return find_forward(map, point, *before, *char, times)
+            FindForward { before, char, mode } => {
+                return find_forward(map, point, *before, *char, times, *mode)
                     .map(|new_point| (new_point, SelectionGoal::None))
             }
             // T F
-            FindBackward { after, char } => (
-                find_backward(map, point, *after, *char, times),
+            FindBackward { after, char, mode } => (
+                find_backward(map, point, *after, *char, times, *mode),
                 SelectionGoal::None,
             ),
             // ; -- repeat the last find done with t, f, T, F
             RepeatFind { last_find } => match **last_find {
-                Motion::FindForward { before, char } => {
-                    let mut new_point = find_forward(map, point, before, char, times);
+                Motion::FindForward { before, char, mode } => {
+                    let mut new_point = find_forward(map, point, before, char, times, mode);
                     if new_point == Some(point) {
-                        new_point = find_forward(map, point, before, char, times + 1);
+                        new_point = find_forward(map, point, before, char, times + 1, mode);
                     }
 
                     return new_point.map(|new_point| (new_point, SelectionGoal::None));
                 }
 
-                Motion::FindBackward { after, char } => {
-                    let mut new_point = find_backward(map, point, after, char, times);
+                Motion::FindBackward { after, char, mode } => {
+                    let mut new_point = find_backward(map, point, after, char, times, mode);
                     if new_point == point {
-                        new_point = find_backward(map, point, after, char, times + 1);
+                        new_point = find_backward(map, point, after, char, times + 1, mode);
                     }
 
                     (new_point, SelectionGoal::None)
@@ -513,19 +513,19 @@ impl Motion {
             },
             // , -- repeat the last find done with t, f, T, F, in opposite direction
             RepeatFindReversed { last_find } => match **last_find {
-                Motion::FindForward { before, char } => {
-                    let mut new_point = find_backward(map, point, before, char, times);
+                Motion::FindForward { before, char, mode } => {
+                    let mut new_point = find_backward(map, point, before, char, times, mode);
                     if new_point == point {
-                        new_point = find_backward(map, point, before, char, times + 1);
+                        new_point = find_backward(map, point, before, char, times + 1, mode);
                     }
 
                     (new_point, SelectionGoal::None)
                 }
 
-                Motion::FindBackward { after, char } => {
-                    let mut new_point = find_forward(map, point, after, char, times);
+                Motion::FindBackward { after, char, mode } => {
+                    let mut new_point = find_forward(map, point, after, char, times, mode);
                     if new_point == Some(point) {
-                        new_point = find_forward(map, point, after, char, times + 1);
+                        new_point = find_forward(map, point, after, char, times + 1, mode);
                     }
 
                     return new_point.map(|new_point| (new_point, SelectionGoal::None));
@@ -1011,13 +1011,14 @@ fn find_forward(
     before: bool,
     target: char,
     times: usize,
+    mode: FindRange,
 ) -> Option<DisplayPoint> {
     let mut to = from;
     let mut found = false;
 
     for _ in 0..times {
         found = false;
-        let new_to = find_boundary(map, to, FindRange::MultiLine, |_, right| {
+        let new_to = find_boundary(map, to, mode, |_, right| {
             found = right == target;
             found
         });
@@ -1045,12 +1046,13 @@ fn find_backward(
     after: bool,
     target: char,
     times: usize,
+    mode: FindRange,
 ) -> DisplayPoint {
     let mut to = from;
 
     for _ in 0..times {
         let new_to =
-            find_preceding_boundary_display_point(map, to, FindRange::MultiLine, |_, right| {
+            find_preceding_boundary_display_point(map, to, mode, |_, right| {
                 right == target
             });
         if to == new_to {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -917,13 +917,13 @@ mod test {
         cx.assert_binding(
             ["f", "l"],
             indoc! {"
-            ˇfunction test() {
+            ˇfunction print() {
                 console.log('ok')
             }
             "},
             Mode::Normal,
             indoc! {"
-            function test() {
+            function print() {
                 consoˇle.log('ok')
             }
             "},
@@ -933,13 +933,13 @@ mod test {
         cx.assert_binding(
             ["t", "l"],
             indoc! {"
-            ˇfunction test() {
+            ˇfunction print() {
                 console.log('ok')
             }
             "},
             Mode::Normal,
             indoc! {"
-            function test() {
+            function print() {
                 consˇole.log('ok')
             }
             "},
@@ -957,15 +957,15 @@ mod test {
         });
 
         cx.assert_binding(
-            ["F", "f"],
+            ["F", "p"],
             indoc! {"
-            function test() {
+            function print() {
                 console.ˇlog('ok')
             }
             "},
             Mode::Normal,
             indoc! {"
-            ˇfunction test() {
+            function ˇprint() {
                 console.log('ok')
             }
             "},
@@ -973,15 +973,15 @@ mod test {
         );
 
         cx.assert_binding(
-            ["T", "f"],
+            ["T", "p"],
             indoc! {"
-            function test() {
+            function print() {
                 console.ˇlog('ok')
             }
             "},
             Mode::Normal,
             indoc! {"
-            fˇunction test() {
+            function pˇrint() {
                 console.log('ok')
             }
             "},

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -907,7 +907,7 @@ mod test {
 
     #[gpui::test]
     async fn test_f_and_t_multiline(cx: &mut gpui::TestAppContext) {
-        let mut cx = VimTestContext::new(cx, false).await;
+        let mut cx = VimTestContext::new(cx, true).await;
         cx.update_global(|store: &mut SettingsStore, cx| {
             store.update_user_settings::<VimSettings>(cx, |s| {
                 s.use_multiline_find = Some(true);
@@ -949,7 +949,7 @@ mod test {
 
     #[gpui::test]
     async fn test_capital_f_and_capital_t_multiline(cx: &mut gpui::TestAppContext) {
-        let mut cx = VimTestContext::new(cx, false).await;
+        let mut cx = VimTestContext::new(cx, true).await;
         cx.update_global(|store: &mut SettingsStore, cx| {
             store.update_user_settings::<VimSettings>(cx, |s| {
                 s.use_multiline_find = Some(true);

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -957,7 +957,7 @@ mod test {
         });
 
         cx.assert_binding(
-            ["F", "p"],
+            ["F", "l", "F", "p"],
             indoc! {"
             function print() {
                 console.ˇlog('ok')

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -957,7 +957,7 @@ mod test {
         });
 
         cx.assert_binding(
-            ["F", "l", "F", "p"],
+            ["shift-f", "p"],
             indoc! {"
             function print() {
                 console.ˇlog('ok')
@@ -973,7 +973,7 @@ mod test {
         );
 
         cx.assert_binding(
-            ["T", "p"],
+            ["shift-t", "p"],
             indoc! {"
             function print() {
                 console.ˇlog('ok')

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -924,7 +924,7 @@ mod test {
             Mode::Normal,
             indoc! {"
             function test() {
-                console.ˇlog('ok')
+                consoˇle.log('ok')
             }
             "},
             Mode::Normal,
@@ -940,7 +940,7 @@ mod test {
             Mode::Normal,
             indoc! {"
             function test() {
-                consoleˇ.log('ok')
+                consˇole.log('ok')
             }
             "},
             Mode::Normal,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -17,7 +17,10 @@ mod visual;
 use anyhow::Result;
 use collections::HashMap;
 use command_palette_hooks::{CommandPaletteFilter, CommandPaletteInterceptor};
-use editor::{movement::{self, FindRange}, Editor, EditorEvent, EditorMode};
+use editor::{
+    movement::{self, FindRange},
+    Editor, EditorEvent, EditorMode,
+};
 use gpui::{
     actions, impl_actions, Action, AppContext, EntityId, Global, Subscription, View, ViewContext,
     WeakView, WindowContext,
@@ -482,7 +485,11 @@ impl Vim {
                 let find = Motion::FindForward {
                     before,
                     char: text.chars().next().unwrap(),
-                    mode: if VimSettings::get_global(cx).use_multiline_find { FindRange::MultiLine } else { FindRange::SingleLine },
+                    mode: if VimSettings::get_global(cx).use_multiline_find {
+                        FindRange::MultiLine
+                    } else {
+                        FindRange::SingleLine
+                    },
                 };
                 Vim::update(cx, |vim, _| {
                     vim.workspace_state.last_find = Some(find.clone())
@@ -493,7 +500,11 @@ impl Vim {
                 let find = Motion::FindBackward {
                     after,
                     char: text.chars().next().unwrap(),
-                    mode: if VimSettings::get_global(cx).use_multiline_find { FindRange::MultiLine } else { FindRange::SingleLine },
+                    mode: if VimSettings::get_global(cx).use_multiline_find {
+                        FindRange::MultiLine
+                    } else {
+                        FindRange::SingleLine
+                    },
                 };
                 Vim::update(cx, |vim, _| {
                     vim.workspace_state.last_find = Some(find.clone())

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -17,7 +17,7 @@ mod visual;
 use anyhow::Result;
 use collections::HashMap;
 use command_palette_hooks::{CommandPaletteFilter, CommandPaletteInterceptor};
-use editor::{movement, Editor, EditorEvent, EditorMode};
+use editor::{movement::{self, FindRange}, Editor, EditorEvent, EditorMode};
 use gpui::{
     actions, impl_actions, Action, AppContext, EntityId, Global, Subscription, View, ViewContext,
     WeakView, WindowContext,
@@ -482,6 +482,7 @@ impl Vim {
                 let find = Motion::FindForward {
                     before,
                     char: text.chars().next().unwrap(),
+                    mode: if VimSettings::get_global(cx).use_multiline_find { FindRange::MultiLine } else { FindRange::SingleLine },
                 };
                 Vim::update(cx, |vim, _| {
                     vim.workspace_state.last_find = Some(find.clone())
@@ -492,6 +493,7 @@ impl Vim {
                 let find = Motion::FindBackward {
                     after,
                     char: text.chars().next().unwrap(),
+                    mode: if VimSettings::get_global(cx).use_multiline_find { FindRange::MultiLine } else { FindRange::SingleLine },
                 };
                 Vim::update(cx, |vim, _| {
                     vim.workspace_state.last_find = Some(find.clone())
@@ -628,11 +630,13 @@ struct VimSettings {
     // vim always uses system cliupbaord
     // some magic where yy is system and dd is not.
     pub use_system_clipboard: UseSystemClipboard,
+    pub use_multiline_find: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 struct VimSettingsContent {
     pub use_system_clipboard: Option<UseSystemClipboard>,
+    pub use_multiline_find: Option<bool>,
 }
 
 impl Settings for VimSettings {

--- a/docs/src/configuring_zed__configuring_vim.md
+++ b/docs/src/configuring_zed__configuring_vim.md
@@ -144,6 +144,23 @@ Currently supported vim-specific commands (as of Zed 0.106):
     to sort the current selection (with i, case-insensitively)
 ```
 
+## Vim settings
+
+Some vim settings are available to modify the default vim behavior:
+
+```json
+{
+  "vim": {
+    // "always": use system clipboard
+    // "never": don't use system clipboard
+    // "on_yank": use system clipboard for yank operations
+    "use_system_clipboard": "always",
+    // Enable multi-line find for `f` and `t` motions
+    "use_multiline_find": false
+  }
+}
+```
+
 ## Related settings
 
 There are a few Zed settings that you may also enjoy if you use vim mode:


### PR DESCRIPTION
I'm not sure how compliant you're aiming to be with vim, but the `f` behavior is more useful when it can search on multiple lines instead of a single one, so I'd like to propose this change.

This change is quite frequent in vim/neovim as a plugin (e.g. [clever-f](https://github.com/VSCodeVim/Vim), [improved-ft](https://github.com/backdround/improved-ft.nvim), etc), and in other vim emulations (e.g. [vscode-vim](https://github.com/VSCodeVim/Vim)).


Release notes:

- vim: Add a setting for `{"vim": {"use_multiline_find":true}}` that lets `f,t,F,T` search across line boundaries.