### PR TITLE
channel projects

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -5,7 +5,7 @@ pub mod room;
 use anyhow::{anyhow, Result};
 use audio::Audio;
 use call_settings::CallSettings;
-use client::{proto, Client, TypedEnvelope, User, UserStore, ZED_ALWAYS_ACTIVE};
+use client::{proto, ChannelId, Client, TypedEnvelope, User, UserStore, ZED_ALWAYS_ACTIVE};
 use collections::HashSet;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt};
 use gpui::{
@@ -107,7 +107,7 @@ impl ActiveCall {
         }
     }
 
-    pub fn channel_id(&self, cx: &AppContext) -> Option<u64> {
+    pub fn channel_id(&self, cx: &AppContext) -> Option<ChannelId> {
         self.room()?.read(cx).channel_id()
     }
 
@@ -336,7 +336,7 @@ impl ActiveCall {
 
     pub fn join_channel(
         &mut self,
-        channel_id: u64,
+        channel_id: ChannelId,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Option<Model<Room>>>> {
         if let Some(room) = self.room().cloned() {
@@ -487,7 +487,7 @@ impl ActiveCall {
 pub fn report_call_event_for_room(
     operation: &'static str,
     room_id: u64,
-    channel_id: Option<u64>,
+    channel_id: Option<ChannelId>,
     client: &Arc<Client>,
 ) {
     let telemetry = client.telemetry();
@@ -497,7 +497,7 @@ pub fn report_call_event_for_room(
 
 pub fn report_call_event_for_channel(
     operation: &'static str,
-    channel_id: u64,
+    channel_id: ChannelId,
     client: &Arc<Client>,
     cx: &AppContext,
 ) {

--- a/crates/channel/src/channel.rs
+++ b/crates/channel/src/channel.rs
@@ -11,7 +11,9 @@ pub use channel_chat::{
     mentions_to_proto, ChannelChat, ChannelChatEvent, ChannelMessage, ChannelMessageId,
     MessageParams,
 };
-pub use channel_store::{Channel, ChannelEvent, ChannelId, ChannelMembership, ChannelStore};
+pub use channel_store::{
+    Channel, ChannelEvent, ChannelId, ChannelMembership, HostedProjectId, ChannelStore,
+};
 
 #[cfg(test)]
 mod channel_store_tests;

--- a/crates/channel/src/channel.rs
+++ b/crates/channel/src/channel.rs
@@ -11,9 +11,7 @@ pub use channel_chat::{
     mentions_to_proto, ChannelChat, ChannelChatEvent, ChannelMessage, ChannelMessageId,
     MessageParams,
 };
-pub use channel_store::{
-    Channel, ChannelEvent, ChannelId, ChannelMembership, HostedProjectId, ChannelStore,
-};
+pub use channel_store::{Channel, ChannelEvent, ChannelMembership, ChannelStore, HostedProjectId};
 
 #[cfg(test)]
 mod channel_store_tests;

--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -1,6 +1,6 @@
-use crate::{Channel, ChannelId, ChannelStore};
+use crate::{Channel, ChannelStore};
 use anyhow::Result;
-use client::{Client, Collaborator, UserStore, ZED_ALWAYS_ACTIVE};
+use client::{ChannelId, Client, Collaborator, UserStore, ZED_ALWAYS_ACTIVE};
 use collections::HashMap;
 use gpui::{AppContext, AsyncAppContext, Context, EventEmitter, Model, ModelContext, Task};
 use language::proto::serialize_version;
@@ -51,7 +51,7 @@ impl ChannelBuffer {
     ) -> Result<Model<Self>> {
         let response = client
             .request(proto::JoinChannelBuffer {
-                channel_id: channel.id,
+                channel_id: channel.id.0,
             })
             .await?;
         let buffer_id = BufferId::new(response.buffer_id)?;
@@ -68,7 +68,7 @@ impl ChannelBuffer {
         })?;
         buffer.update(&mut cx, |buffer, cx| buffer.apply_ops(operations, cx))??;
 
-        let subscription = client.subscribe_to_entity(channel.id)?;
+        let subscription = client.subscribe_to_entity(channel.id.0)?;
 
         anyhow::Ok(cx.new_model(|cx| {
             cx.subscribe(&buffer, Self::on_buffer_update).detach();
@@ -97,7 +97,7 @@ impl ChannelBuffer {
             }
             self.client
                 .send(proto::LeaveChannelBuffer {
-                    channel_id: self.channel_id,
+                    channel_id: self.channel_id.0,
                 })
                 .log_err();
         }
@@ -191,7 +191,7 @@ impl ChannelBuffer {
                 let operation = language::proto::serialize_operation(operation);
                 self.client
                     .send(proto::UpdateChannelBuffer {
-                        channel_id: self.channel_id,
+                        channel_id: self.channel_id.0,
                         operations: vec![operation],
                     })
                     .log_err();

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -1,9 +1,9 @@
-use crate::{Channel, ChannelId, ChannelStore};
+use crate::{Channel, ChannelStore};
 use anyhow::{anyhow, Result};
 use client::{
     proto,
     user::{User, UserStore},
-    Client, Subscription, TypedEnvelope, UserId,
+    ChannelId, Client, Subscription, TypedEnvelope, UserId,
 };
 use collections::HashSet;
 use futures::lock::Mutex;
@@ -104,10 +104,12 @@ impl ChannelChat {
         mut cx: AsyncAppContext,
     ) -> Result<Model<Self>> {
         let channel_id = channel.id;
-        let subscription = client.subscribe_to_entity(channel_id).unwrap();
+        let subscription = client.subscribe_to_entity(channel_id.0).unwrap();
 
         let response = client
-            .request(proto::JoinChannelChat { channel_id })
+            .request(proto::JoinChannelChat {
+                channel_id: channel_id.0,
+            })
             .await?;
 
         let handle = cx.new_model(|cx| {
@@ -143,7 +145,7 @@ impl ChannelChat {
     fn release(&mut self, _: &mut AppContext) {
         self.rpc
             .send(proto::LeaveChannelChat {
-                channel_id: self.channel_id,
+                channel_id: self.channel_id.0,
             })
             .log_err();
     }
@@ -200,7 +202,7 @@ impl ChannelChat {
         Ok(cx.spawn(move |this, mut cx| async move {
             let outgoing_message_guard = outgoing_messages_lock.lock().await;
             let request = rpc.request(proto::SendChannelMessage {
-                channel_id,
+                channel_id: channel_id.0,
                 body: message.text,
                 nonce: Some(nonce.into()),
                 mentions: mentions_to_proto(&message.mentions),
@@ -220,7 +222,7 @@ impl ChannelChat {
 
     pub fn remove_message(&mut self, id: u64, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         let response = self.rpc.request(proto::RemoveChannelMessage {
-            channel_id: self.channel_id,
+            channel_id: self.channel_id.0,
             message_id: id,
         });
         cx.spawn(move |this, mut cx| async move {
@@ -245,7 +247,7 @@ impl ChannelChat {
             async move {
                 let response = rpc
                     .request(proto::GetChannelMessages {
-                        channel_id,
+                        channel_id: channel_id.0,
                         before_message_id,
                     })
                     .await?;
@@ -323,7 +325,7 @@ impl ChannelChat {
             {
                 self.rpc
                     .send(proto::AckChannelMessage {
-                        channel_id: self.channel_id,
+                        channel_id: self.channel_id.0,
                         message_id: latest_message_id,
                     })
                     .ok();
@@ -401,7 +403,11 @@ impl ChannelChat {
         let channel_id = self.channel_id;
         cx.spawn(move |this, mut cx| {
             async move {
-                let response = rpc.request(proto::JoinChannelChat { channel_id }).await?;
+                let response = rpc
+                    .request(proto::JoinChannelChat {
+                        channel_id: channel_id.0,
+                    })
+                    .await?;
                 Self::handle_loaded_messages(
                     this.clone(),
                     user_store.clone(),
@@ -418,7 +424,7 @@ impl ChannelChat {
 
                 for pending_message in pending_messages {
                     let request = rpc.request(proto::SendChannelMessage {
-                        channel_id,
+                        channel_id: channel_id.0,
                         body: pending_message.body,
                         mentions: mentions_to_proto(&pending_message.mentions),
                         nonce: Some(pending_message.nonce.into()),
@@ -461,7 +467,7 @@ impl ChannelChat {
         if self.acknowledged_message_ids.insert(id) {
             self.rpc
                 .send(proto::AckChannelMessage {
-                    channel_id: self.channel_id,
+                    channel_id: self.channel_id.0,
                     message_id: id,
                 })
                 .ok();

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -3,7 +3,7 @@ mod channel_index;
 use crate::{channel_buffer::ChannelBuffer, channel_chat::ChannelChat, ChannelMessage};
 use anyhow::{anyhow, Result};
 use channel_index::ChannelIndex;
-use client::{Client, Subscription, User, UserId, UserStore};
+use client::{ChannelId, Client, Subscription, User, UserId, UserStore};
 use collections::{hash_map, HashMap, HashSet};
 use futures::{channel::mpsc, future::Shared, Future, FutureExt, StreamExt};
 use gpui::{
@@ -19,15 +19,14 @@ use rpc::{
 use std::{mem, sync::Arc, time::Duration};
 use util::{async_maybe, maybe, ResultExt};
 
+pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn init(client: &Arc<Client>, user_store: Model<UserStore>, cx: &mut AppContext) {
     let channel_store =
         cx.new_model(|cx| ChannelStore::new(client.clone(), user_store.clone(), cx));
     cx.set_global(GlobalChannelStore(channel_store));
 }
 
-pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-
-pub type ChannelId = u64;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct HostedProjectId(pub u64);
 
@@ -49,7 +48,7 @@ impl From<proto::HostedProject> for HostedProject {
     fn from(project: proto::HostedProject) -> Self {
         Self {
             id: HostedProjectId(project.id),
-            channel_id: project.channel_id,
+            channel_id: ChannelId(project.channel_id),
             _visibility: project.visibility(),
             name: project.name.into(),
         }
@@ -80,7 +79,7 @@ pub struct Channel {
     pub id: ChannelId,
     pub name: SharedString,
     pub visibility: proto::ChannelVisibility,
-    pub parent_path: Vec<u64>,
+    pub parent_path: Vec<ChannelId>,
 }
 
 #[derive(Default)]
@@ -115,10 +114,7 @@ impl Channel {
     }
 
     pub fn root_id(&self) -> ChannelId {
-        self.parent_path
-            .first()
-            .map(|id| *id as ChannelId)
-            .unwrap_or(self.id)
+        self.parent_path.first().copied().unwrap_or(self.id)
     }
 
     pub fn slug(str: &str) -> String {
@@ -316,10 +312,7 @@ impl ChannelStore {
             .map(|state| state.projects.clone())
             .unwrap_or_default()
             .into_iter()
-            .flat_map(|id| {
-                dbg!(&id, &self.hosted_projects.get(&id));
-                Some((self.hosted_projects.get(&id)?.name.clone(), id))
-            })
+            .flat_map(|id| Some((self.hosted_projects.get(&id)?.name.clone(), id)))
             .collect();
         projects.sort();
         projects
@@ -602,13 +595,16 @@ impl ChannelStore {
         let name = name.trim_start_matches("#").to_owned();
         cx.spawn(move |this, mut cx| async move {
             let response = client
-                .request(proto::CreateChannel { name, parent_id })
+                .request(proto::CreateChannel {
+                    name,
+                    parent_id: parent_id.map(|cid| cid.0),
+                })
                 .await?;
 
             let channel = response
                 .channel
                 .ok_or_else(|| anyhow!("missing channel in response"))?;
-            let channel_id = channel.id;
+            let channel_id = ChannelId(channel.id);
 
             this.update(&mut cx, |this, cx| {
                 let task = this.update_channels(
@@ -640,7 +636,10 @@ impl ChannelStore {
         let client = self.client.clone();
         cx.spawn(move |_, _| async move {
             let _ = client
-                .request(proto::MoveChannel { channel_id, to })
+                .request(proto::MoveChannel {
+                    channel_id: channel_id.0,
+                    to: to.0,
+                })
                 .await?;
 
             Ok(())
@@ -657,7 +656,7 @@ impl ChannelStore {
         cx.spawn(move |_, _| async move {
             let _ = client
                 .request(proto::SetChannelVisibility {
-                    channel_id,
+                    channel_id: channel_id.0,
                     visibility: visibility.into(),
                 })
                 .await?;
@@ -682,7 +681,7 @@ impl ChannelStore {
         cx.spawn(move |this, mut cx| async move {
             let result = client
                 .request(proto::InviteChannelMember {
-                    channel_id,
+                    channel_id: channel_id.0,
                     user_id,
                     role: role.into(),
                 })
@@ -714,7 +713,7 @@ impl ChannelStore {
         cx.spawn(move |this, mut cx| async move {
             let result = client
                 .request(proto::RemoveChannelMember {
-                    channel_id,
+                    channel_id: channel_id.0,
                     user_id,
                 })
                 .await;
@@ -744,7 +743,7 @@ impl ChannelStore {
         cx.spawn(move |this, mut cx| async move {
             let result = client
                 .request(proto::SetChannelMemberRole {
-                    channel_id,
+                    channel_id: channel_id.0,
                     user_id,
                     role: role.into(),
                 })
@@ -770,7 +769,10 @@ impl ChannelStore {
         let name = new_name.to_string();
         cx.spawn(move |this, mut cx| async move {
             let channel = client
-                .request(proto::RenameChannel { channel_id, name })
+                .request(proto::RenameChannel {
+                    channel_id: channel_id.0,
+                    name,
+                })
                 .await?
                 .channel
                 .ok_or_else(|| anyhow!("missing channel in response"))?;
@@ -803,7 +805,10 @@ impl ChannelStore {
         let client = self.client.clone();
         cx.background_executor().spawn(async move {
             client
-                .request(proto::RespondToChannelInvite { channel_id, accept })
+                .request(proto::RespondToChannelInvite {
+                    channel_id: channel_id.0,
+                    accept,
+                })
                 .await?;
             Ok(())
         })
@@ -818,7 +823,9 @@ impl ChannelStore {
         let user_store = self.user_store.downgrade();
         cx.spawn(move |_, mut cx| async move {
             let response = client
-                .request(proto::GetChannelMembers { channel_id })
+                .request(proto::GetChannelMembers {
+                    channel_id: channel_id.0,
+                })
                 .await?;
 
             let user_ids = response.members.iter().map(|m| m.user_id).collect();
@@ -846,7 +853,11 @@ impl ChannelStore {
     pub fn remove_channel(&self, channel_id: ChannelId) -> impl Future<Output = Result<()>> {
         let client = self.client.clone();
         async move {
-            client.request(proto::DeleteChannel { channel_id }).await?;
+            client
+                .request(proto::DeleteChannel {
+                    channel_id: channel_id.0,
+                })
+                .await?;
             Ok(())
         }
     }
@@ -883,19 +894,23 @@ impl ChannelStore {
             for buffer_version in message.payload.observed_channel_buffer_version {
                 let version = language::proto::deserialize_version(&buffer_version.version);
                 this.acknowledge_notes_version(
-                    buffer_version.channel_id,
+                    ChannelId(buffer_version.channel_id),
                     buffer_version.epoch,
                     &version,
                     cx,
                 );
             }
             for message_id in message.payload.observed_channel_message_id {
-                this.acknowledge_message_id(message_id.channel_id, message_id.message_id, cx);
+                this.acknowledge_message_id(
+                    ChannelId(message_id.channel_id),
+                    message_id.message_id,
+                    cx,
+                );
             }
             for membership in message.payload.channel_memberships {
                 if let Some(role) = ChannelRole::from_i32(membership.role) {
                     this.channel_states
-                        .entry(membership.channel_id)
+                        .entry(ChannelId(membership.channel_id))
                         .or_insert_with(|| ChannelState::default())
                         .set_role(role)
                 }
@@ -928,7 +943,7 @@ impl ChannelStore {
                     let channel_buffer = buffer.read(cx);
                     let buffer = channel_buffer.buffer().read(cx);
                     buffer_versions.push(proto::ChannelBufferVersion {
-                        channel_id: channel_buffer.channel_id,
+                        channel_id: channel_buffer.channel_id.0,
                         epoch: channel_buffer.epoch(),
                         version: language::proto::serialize_version(&buffer.version()),
                     });
@@ -959,7 +974,7 @@ impl ChannelStore {
                             if let Some(remote_buffer) = response
                                 .buffers
                                 .iter_mut()
-                                .find(|buffer| buffer.channel_id == channel_id)
+                                .find(|buffer| buffer.channel_id == channel_id.0)
                             {
                                 let channel_id = channel_buffer.channel_id;
                                 let remote_version =
@@ -995,7 +1010,7 @@ impl ChannelStore {
                                             {
                                                 client
                                                     .send(proto::UpdateChannelBuffer {
-                                                        channel_id,
+                                                        channel_id: channel_id.0,
                                                         operations: chunk,
                                                     })
                                                     .ok();
@@ -1050,12 +1065,12 @@ impl ChannelStore {
     ) -> Option<Task<Result<()>>> {
         if !payload.remove_channel_invitations.is_empty() {
             self.channel_invitations
-                .retain(|channel| !payload.remove_channel_invitations.contains(&channel.id));
+                .retain(|channel| !payload.remove_channel_invitations.contains(&channel.id.0));
         }
         for channel in payload.channel_invitations {
             match self
                 .channel_invitations
-                .binary_search_by_key(&channel.id, |c| c.id)
+                .binary_search_by_key(&channel.id, |c| c.id.0)
             {
                 Ok(ix) => {
                     Arc::make_mut(&mut self.channel_invitations[ix]).name = channel.name.into()
@@ -1063,10 +1078,14 @@ impl ChannelStore {
                 Err(ix) => self.channel_invitations.insert(
                     ix,
                     Arc::new(Channel {
-                        id: channel.id,
+                        id: ChannelId(channel.id),
                         visibility: channel.visibility(),
                         name: channel.name.into(),
-                        parent_path: channel.parent_path,
+                        parent_path: channel
+                            .parent_path
+                            .into_iter()
+                            .map(|cid| ChannelId(cid))
+                            .collect(),
                     }),
                 ),
             }
@@ -1081,16 +1100,21 @@ impl ChannelStore {
 
         if channels_changed {
             if !payload.delete_channels.is_empty() {
-                self.channel_index.delete_channels(&payload.delete_channels);
+                let delete_channels: Vec<ChannelId> = payload
+                    .delete_channels
+                    .into_iter()
+                    .map(|cid| ChannelId(cid))
+                    .collect();
+                self.channel_index.delete_channels(&delete_channels);
                 self.channel_participants
-                    .retain(|channel_id, _| !&payload.delete_channels.contains(channel_id));
+                    .retain(|channel_id, _| !delete_channels.contains(&channel_id));
 
-                for channel_id in &payload.delete_channels {
+                for channel_id in &delete_channels {
                     let channel_id = *channel_id;
                     if payload
                         .channels
                         .iter()
-                        .any(|channel| channel.id == channel_id)
+                        .any(|channel| channel.id == channel_id.0)
                     {
                         continue;
                     }
@@ -1106,7 +1130,7 @@ impl ChannelStore {
 
             let mut index = self.channel_index.bulk_insert();
             for channel in payload.channels {
-                let id = channel.id;
+                let id = ChannelId(channel.id);
                 let channel_changed = index.insert(channel);
 
                 if channel_changed {
@@ -1121,14 +1145,14 @@ impl ChannelStore {
             for latest_buffer_version in payload.latest_channel_buffer_versions {
                 let version = language::proto::deserialize_version(&latest_buffer_version.version);
                 self.channel_states
-                    .entry(latest_buffer_version.channel_id)
+                    .entry(ChannelId(latest_buffer_version.channel_id))
                     .or_default()
                     .update_latest_notes_version(latest_buffer_version.epoch, &version)
             }
 
             for latest_channel_message in payload.latest_channel_message_ids {
                 self.channel_states
-                    .entry(latest_channel_message.channel_id)
+                    .entry(ChannelId(latest_channel_message.channel_id))
                     .or_default()
                     .update_latest_message_id(latest_channel_message.message_id);
             }
@@ -1161,7 +1185,6 @@ impl ChannelStore {
                 }
             }
         }
-        dbg!(&self.hosted_projects);
 
         cx.notify();
         if payload.channel_participants.is_empty() {
@@ -1200,7 +1223,7 @@ impl ChannelStore {
                     participants.sort_by_key(|u| u.id);
 
                     this.channel_participants
-                        .insert(entry.channel_id, participants);
+                        .insert(ChannelId(entry.channel_id), participants);
                 }
 
                 cx.notify();

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -28,6 +28,8 @@ pub fn init(client: &Arc<Client>, user_store: Model<UserStore>, cx: &mut AppCont
 pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub type ChannelId = u64;
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct HostedProjectId(pub u64);
 
 #[derive(Debug, Clone, Default)]
 struct NotesVersion {
@@ -35,11 +37,31 @@ struct NotesVersion {
     version: clock::Global,
 }
 
+#[derive(Debug, Clone)]
+pub struct HostedProject {
+    id: HostedProjectId,
+    channel_id: ChannelId,
+    name: SharedString,
+    _visibility: proto::ChannelVisibility,
+}
+
+impl From<proto::HostedProject> for HostedProject {
+    fn from(project: proto::HostedProject) -> Self {
+        Self {
+            id: HostedProjectId(project.id),
+            channel_id: project.channel_id,
+            _visibility: project.visibility(),
+            name: project.name.into(),
+        }
+    }
+}
+
 pub struct ChannelStore {
     pub channel_index: ChannelIndex,
     channel_invitations: Vec<Arc<Channel>>,
     channel_participants: HashMap<ChannelId, Vec<Arc<User>>>,
     channel_states: HashMap<ChannelId, ChannelState>,
+    hosted_projects: HashMap<HostedProjectId, HostedProject>,
 
     outgoing_invites: HashSet<(ChannelId, UserId)>,
     update_channels_tx: mpsc::UnboundedSender<proto::UpdateChannels>,
@@ -68,6 +90,7 @@ pub struct ChannelState {
     observed_chat_message: Option<u64>,
     observed_notes_versions: Option<NotesVersion>,
     role: Option<ChannelRole>,
+    projects: HashSet<HostedProjectId>,
 }
 
 impl Channel {
@@ -199,6 +222,7 @@ impl ChannelStore {
             channel_invitations: Vec::default(),
             channel_index: ChannelIndex::default(),
             channel_participants: Default::default(),
+            hosted_projects: Default::default(),
             outgoing_invites: Default::default(),
             opened_buffers: Default::default(),
             opened_chats: Default::default(),
@@ -283,6 +307,22 @@ impl ChannelStore {
 
     pub fn channel_for_id(&self, channel_id: ChannelId) -> Option<&Arc<Channel>> {
         self.channel_index.by_id().get(&channel_id)
+    }
+
+    pub fn projects_for_id(&self, channel_id: ChannelId) -> Vec<(SharedString, HostedProjectId)> {
+        let mut projects: Vec<(SharedString, HostedProjectId)> = self
+            .channel_states
+            .get(&channel_id)
+            .map(|state| state.projects.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|id| {
+                dbg!(&id, &self.hosted_projects.get(&id));
+                Some((self.hosted_projects.get(&id)?.name.clone(), id))
+            })
+            .collect();
+        projects.sort();
+        projects
     }
 
     pub fn has_open_channel_buffer(&self, channel_id: ChannelId, _cx: &AppContext) -> bool {
@@ -1035,7 +1075,9 @@ impl ChannelStore {
         let channels_changed = !payload.channels.is_empty()
             || !payload.delete_channels.is_empty()
             || !payload.latest_channel_message_ids.is_empty()
-            || !payload.latest_channel_buffer_versions.is_empty();
+            || !payload.latest_channel_buffer_versions.is_empty()
+            || !payload.hosted_projects.is_empty()
+            || !payload.deleted_hosted_projects.is_empty();
 
         if channels_changed {
             if !payload.delete_channels.is_empty() {
@@ -1090,7 +1132,36 @@ impl ChannelStore {
                     .or_default()
                     .update_latest_message_id(latest_channel_message.message_id);
             }
+
+            for hosted_project in payload.hosted_projects {
+                let hosted_project: HostedProject = hosted_project.into();
+                if let Some(old_project) = self
+                    .hosted_projects
+                    .insert(hosted_project.id, hosted_project.clone())
+                {
+                    self.channel_states
+                        .entry(old_project.channel_id)
+                        .or_default()
+                        .remove_hosted_project(old_project.id);
+                }
+                self.channel_states
+                    .entry(hosted_project.channel_id)
+                    .or_default()
+                    .add_hosted_project(hosted_project.id);
+            }
+
+            for hosted_project_id in payload.deleted_hosted_projects {
+                let hosted_project_id = HostedProjectId(hosted_project_id);
+
+                if let Some(old_project) = self.hosted_projects.remove(&hosted_project_id) {
+                    self.channel_states
+                        .entry(old_project.channel_id)
+                        .or_default()
+                        .remove_hosted_project(old_project.id);
+                }
+            }
         }
+        dbg!(&self.hosted_projects);
 
         cx.notify();
         if payload.channel_participants.is_empty() {
@@ -1206,5 +1277,13 @@ impl ChannelState {
             epoch,
             version: version.clone(),
         });
+    }
+
+    fn add_hosted_project(&mut self, project_id: HostedProjectId) {
+        self.projects.insert(project_id);
+    }
+
+    fn remove_hosted_project(&mut self, project_id: HostedProjectId) {
+        self.projects.remove(&project_id);
     }
 }

--- a/crates/channel/src/channel_store/channel_index.rs
+++ b/crates/channel/src/channel_store/channel_index.rs
@@ -1,4 +1,5 @@
-use crate::{Channel, ChannelId};
+use crate::Channel;
+use client::ChannelId;
 use collections::BTreeMap;
 use rpc::proto;
 use std::sync::Arc;
@@ -50,27 +51,32 @@ pub struct ChannelPathsInsertGuard<'a> {
 impl<'a> ChannelPathsInsertGuard<'a> {
     pub fn insert(&mut self, channel_proto: proto::Channel) -> bool {
         let mut ret = false;
-        if let Some(existing_channel) = self.channels_by_id.get_mut(&channel_proto.id) {
+        let parent_path = channel_proto
+            .parent_path
+            .iter()
+            .map(|cid| ChannelId(*cid))
+            .collect();
+        if let Some(existing_channel) = self.channels_by_id.get_mut(&ChannelId(channel_proto.id)) {
             let existing_channel = Arc::make_mut(existing_channel);
 
             ret = existing_channel.visibility != channel_proto.visibility()
                 || existing_channel.name != channel_proto.name
-                || existing_channel.parent_path != channel_proto.parent_path;
+                || existing_channel.parent_path != parent_path;
 
             existing_channel.visibility = channel_proto.visibility();
             existing_channel.name = channel_proto.name.into();
-            existing_channel.parent_path = channel_proto.parent_path.into();
+            existing_channel.parent_path = parent_path;
         } else {
             self.channels_by_id.insert(
-                channel_proto.id,
+                ChannelId(channel_proto.id),
                 Arc::new(Channel {
-                    id: channel_proto.id,
+                    id: ChannelId(channel_proto.id),
                     visibility: channel_proto.visibility(),
                     name: channel_proto.name.into(),
-                    parent_path: channel_proto.parent_path,
+                    parent_path,
                 }),
             );
-            self.insert_root(channel_proto.id);
+            self.insert_root(ChannelId(channel_proto.id));
         }
         ret
     }
@@ -94,7 +100,7 @@ impl<'a> Drop for ChannelPathsInsertGuard<'a> {
 fn channel_path_sorting_key<'a>(
     id: ChannelId,
     channels_by_id: &'a BTreeMap<ChannelId, Arc<Channel>>,
-) -> impl Iterator<Item = (&str, u64)> {
+) -> impl Iterator<Item = (&str, ChannelId)> {
     let (parent_path, name) = channels_by_id
         .get(&id)
         .map_or((&[] as &[_], None), |channel| {

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -1,6 +1,6 @@
 mod event_coalescer;
 
-use crate::TelemetrySettings;
+use crate::{ChannelId, TelemetrySettings};
 use chrono::{DateTime, Utc};
 use clock::SystemClock;
 use futures::Future;
@@ -278,12 +278,12 @@ impl Telemetry {
         self: &Arc<Self>,
         operation: &'static str,
         room_id: Option<u64>,
-        channel_id: Option<u64>,
+        channel_id: Option<ChannelId>,
     ) {
         let event = Event::Call(CallEvent {
             operation: operation.to_string(),
             room_id,
-            channel_id,
+            channel_id: channel_id.map(|cid| cid.0),
         });
 
         self.report_event(event)

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -15,6 +15,15 @@ use util::TryFutureExt as _;
 
 pub type UserId = u64;
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct ChannelId(pub u64);
+
+impl std::fmt::Display for ChannelId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParticipantIndex(pub u32);
 

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -375,3 +375,13 @@ CREATE TABLE extension_versions (
 
 CREATE UNIQUE INDEX "index_extensions_external_id" ON "extensions" ("external_id");
 CREATE INDEX "index_extensions_total_download_count" ON "extensions" ("total_download_count");
+
+CREATE TABLE hosted_projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel_id INTEGER NOT NULL REFERENCES channels(id),
+    name TEXT NOT NULL,
+    visibility TEXT NOT NULL,
+    deleted_at TIMESTAMP NULL
+);
+CREATE INDEX idx_hosted_projects_on_channel_id ON hosted_projects (channel_id);
+CREATE UNIQUE INDEX uix_hosted_projects_on_channel_id_and_name ON hosted_projects (channel_id, name) WHERE (deleted_at IS NULL);

--- a/crates/collab/migrations/20240226163408_hosted_projects.sql
+++ b/crates/collab/migrations/20240226163408_hosted_projects.sql
@@ -1,0 +1,11 @@
+-- Add migration script here
+
+CREATE TABLE hosted_projects (
+    id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    channel_id INT NOT NULL REFERENCES channels(id),
+    name TEXT NOT NULL,
+    visibility TEXT NOT NULL,
+    deleted_at TIMESTAMP NULL
+);
+CREATE INDEX idx_hosted_projects_on_channel_id ON hosted_projects (channel_id);
+CREATE UNIQUE INDEX uix_hosted_projects_on_channel_id_and_name ON hosted_projects (channel_id, name) WHERE (deleted_at IS NULL);

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -587,6 +587,7 @@ pub struct ChannelsForUser {
     pub channels: Vec<Channel>,
     pub channel_memberships: Vec<channel_member::Model>,
     pub channel_participants: HashMap<ChannelId, Vec<UserId>>,
+    pub hosted_projects: Vec<proto::HostedProject>,
 
     pub observed_buffer_versions: Vec<proto::ChannelBufferVersion>,
     pub observed_channel_messages: Vec<proto::ChannelMessageId>,

--- a/crates/collab/src/db/ids.rs
+++ b/crates/collab/src/db/ids.rs
@@ -88,6 +88,7 @@ id_type!(FlagId);
 id_type!(ExtensionId);
 id_type!(NotificationId);
 id_type!(NotificationKindId);
+id_type!(HostedProjectId);
 
 /// ChannelRole gives you permissions for both channels and calls.
 #[derive(Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Default, Hash)]

--- a/crates/collab/src/db/queries.rs
+++ b/crates/collab/src/db/queries.rs
@@ -6,6 +6,7 @@ pub mod channels;
 pub mod contacts;
 pub mod contributors;
 pub mod extensions;
+pub mod hosted_projects;
 pub mod messages;
 pub mod notifications;
 pub mod projects;

--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -652,9 +652,14 @@ impl Database {
             .observed_channel_messages(&channel_ids, user_id, &*tx)
             .await?;
 
+        let hosted_projects = self
+            .get_hosted_projects(&channel_ids, &roles_by_channel_id, &*tx)
+            .await?;
+
         Ok(ChannelsForUser {
             channel_memberships,
             channels,
+            hosted_projects,
             channel_participants,
             latest_buffer_versions,
             latest_channel_messages,

--- a/crates/collab/src/db/queries/hosted_projects.rs
+++ b/crates/collab/src/db/queries/hosted_projects.rs
@@ -1,0 +1,42 @@
+use rpc::proto;
+
+use super::*;
+
+impl Database {
+    pub async fn get_hosted_projects(
+        &self,
+        channel_ids: &Vec<ChannelId>,
+        roles: &HashMap<ChannelId, ChannelRole>,
+        tx: &DatabaseTransaction,
+    ) -> Result<Vec<proto::HostedProject>> {
+        Ok(hosted_project::Entity::find()
+            .filter(hosted_project::Column::ChannelId.is_in(channel_ids.iter().map(|id| id.0)))
+            .all(&*tx)
+            .await?
+            .into_iter()
+            .flat_map(|project| {
+                if project.deleted_at.is_some() {
+                    return None;
+                }
+                match project.visibility {
+                    ChannelVisibility::Public => {}
+                    ChannelVisibility::Members => {
+                        let is_visible = roles
+                            .get(&project.channel_id)
+                            .map(|role| role.can_see_all_descendants())
+                            .unwrap_or(false);
+                        if !is_visible {
+                            return None;
+                        }
+                    }
+                };
+                Some(proto::HostedProject {
+                    id: project.id.to_proto(),
+                    channel_id: project.channel_id.to_proto(),
+                    name: project.name.clone(),
+                    visibility: project.visibility.into(),
+                })
+            })
+            .collect())
+    }
+}

--- a/crates/collab/src/db/tables.rs
+++ b/crates/collab/src/db/tables.rs
@@ -14,6 +14,7 @@ pub mod extension;
 pub mod extension_version;
 pub mod feature_flag;
 pub mod follower;
+pub mod hosted_project;
 pub mod language_server;
 pub mod notification;
 pub mod notification_kind;

--- a/crates/collab/src/db/tables/hosted_project.rs
+++ b/crates/collab/src/db/tables/hosted_project.rs
@@ -1,0 +1,18 @@
+use crate::db::{ChannelId, ChannelVisibility, HostedProjectId};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "hosted_projects")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: HostedProjectId,
+    pub channel_id: ChannelId,
+    pub name: String,
+    pub visibility: ChannelVisibility,
+    pub deleted_at: Option<DateTime>,
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -3396,6 +3396,9 @@ fn build_channels_update(
     for channel in channel_invites {
         update.channel_invitations.push(channel.to_proto());
     }
+    for project in channels.hosted_projects {
+        update.hosted_projects.push(project);
+    }
 
     update
 }

--- a/crates/collab/src/tests.rs
+++ b/crates/collab/src/tests.rs
@@ -1,4 +1,5 @@
 use call::Room;
+use client::ChannelId;
 use gpui::{Model, TestAppContext};
 
 mod channel_buffer_tests;
@@ -43,6 +44,6 @@ fn room_participants(room: &Model<Room>, cx: &mut TestAppContext) -> RoomPartici
     })
 }
 
-fn channel_id(room: &Model<Room>, cx: &mut TestAppContext) -> Option<u64> {
+fn channel_id(room: &Model<Room>, cx: &mut TestAppContext) -> Option<ChannelId> {
     cx.read(|cx| room.read(cx).channel_id())
 }

--- a/crates/collab/src/tests/channel_guest_tests.rs
+++ b/crates/collab/src/tests/channel_guest_tests.rs
@@ -183,7 +183,7 @@ async fn test_channel_requires_zed_cla(cx_a: &mut TestAppContext, cx_b: &mut Tes
     server
         .app_state
         .db
-        .set_channel_requires_zed_cla(ChannelId::from_proto(parent_channel_id), true)
+        .set_channel_requires_zed_cla(ChannelId::from_proto(parent_channel_id.0), true)
         .await
         .unwrap();
 

--- a/crates/collab/src/tests/channel_message_tests.rs
+++ b/crates/collab/src/tests/channel_message_tests.rs
@@ -100,13 +100,13 @@ async fn test_basic_channel_messages(
             Notification::ChannelMessageMention {
                 message_id,
                 sender_id: client_a.id(),
-                channel_id,
+                channel_id: channel_id.0,
             }
         );
         assert_eq!(
             store.notification_at(1).unwrap().notification,
             Notification::ChannelInvitation {
-                channel_id,
+                channel_id: channel_id.0,
                 channel_name: "the-channel".to_string(),
                 inviter_id: client_a.id()
             }

--- a/crates/collab/src/tests/channel_tests.rs
+++ b/crates/collab/src/tests/channel_tests.rs
@@ -4,8 +4,8 @@ use crate::{
     tests::{room_participants, RoomParticipants, TestServer},
 };
 use call::ActiveCall;
-use channel::{ChannelId, ChannelMembership, ChannelStore};
-use client::User;
+use channel::{ChannelMembership, ChannelStore};
+use client::{ChannelId, User};
 use futures::future::try_join_all;
 use gpui::{BackgroundExecutor, Model, SharedString, TestAppContext};
 use rpc::{
@@ -281,7 +281,7 @@ async fn test_core_channels(
         .app_state
         .db
         .rename_channel(
-            db::ChannelId::from_proto(channel_a_id),
+            db::ChannelId::from_proto(channel_a_id.0),
             UserId::from_proto(client_a.id()),
             "channel-a-renamed",
         )
@@ -1444,7 +1444,7 @@ fn assert_channels(
 fn assert_channels_list_shape(
     channel_store: &Model<ChannelStore>,
     cx: &TestAppContext,
-    expected_channels: &[(u64, usize)],
+    expected_channels: &[(ChannelId, usize)],
 ) {
     let actual = cx.read(|cx| {
         channel_store.read_with(cx, |store, _| {

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -1,5 +1,6 @@
 use crate::{rpc::RECONNECT_TIMEOUT, tests::TestServer};
 use call::{ActiveCall, ParticipantLocation};
+use client::ChannelId;
 use collab_ui::{
     channel_view::ChannelView,
     notifications::project_shared_notification::ProjectSharedNotification,
@@ -2000,7 +2001,7 @@ async fn test_following_to_channel_notes_without_a_shared_project(
 }
 
 async fn join_channel(
-    channel_id: u64,
+    channel_id: ChannelId,
     client: &TestClient,
     cx: &mut TestAppContext,
 ) -> anyhow::Result<()> {

--- a/crates/collab/src/tests/notification_tests.rs
+++ b/crates/collab/src/tests/notification_tests.rs
@@ -137,7 +137,7 @@ async fn test_notifications(
         assert_eq!(
             entry.notification,
             Notification::ChannelInvitation {
-                channel_id,
+                channel_id: channel_id.0,
                 channel_name: "the-channel".to_string(),
                 inviter_id: client_a.id()
             }

--- a/crates/collab/src/tests/random_channel_buffer_tests.rs
+++ b/crates/collab/src/tests/random_channel_buffer_tests.rs
@@ -253,7 +253,7 @@ impl RandomizedTest for RandomChannelBufferTest {
                         .channel_buffers()
                         .deref()
                         .iter()
-                        .find(|b| b.read(cx).channel_id == channel_id.to_proto())
+                        .find(|b| b.read(cx).channel_id.0 == channel_id.to_proto())
                     {
                         let channel_buffer = channel_buffer.read(cx);
 

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use call::report_call_event_for_channel;
-use channel::{Channel, ChannelBuffer, ChannelBufferEvent, ChannelId, ChannelStore};
+use channel::{Channel, ChannelBuffer, ChannelBufferEvent, ChannelStore};
 use client::{
     proto::{self, PeerId},
-    Collaborator, ParticipantIndex,
+    ChannelId, Collaborator, ParticipantIndex,
 };
 use collections::HashMap;
 use editor::{
@@ -454,7 +454,7 @@ impl FollowableItem for ChannelView {
 
         Some(proto::view::Variant::ChannelView(
             proto::view::ChannelView {
-                channel_id: channel_buffer.channel_id,
+                channel_id: channel_buffer.channel_id.0,
                 editor: if let Some(proto::view::Variant::Editor(proto)) =
                     self.editor.read(cx).to_state_proto(cx)
                 {
@@ -480,7 +480,8 @@ impl FollowableItem for ChannelView {
             unreachable!()
         };
 
-        let open = ChannelView::open_in_pane(state.channel_id, None, pane, workspace, cx);
+        let open =
+            ChannelView::open_in_pane(ChannelId(state.channel_id), None, pane, workspace, cx);
 
         Some(cx.spawn(|mut cx| async move {
             let this = open.await?;

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -2,7 +2,7 @@ use crate::{collab_panel, ChatPanelSettings};
 use anyhow::Result;
 use call::{room, ActiveCall};
 use channel::{ChannelChat, ChannelChatEvent, ChannelMessage, ChannelMessageId, ChannelStore};
-use client::Client;
+use client::{ChannelId, Client};
 use collections::HashMap;
 use db::kvp::KEY_VALUE_STORE;
 use editor::Editor;
@@ -169,7 +169,7 @@ impl ChatPanel {
         })
     }
 
-    pub fn channel_id(&self, cx: &AppContext) -> Option<u64> {
+    pub fn channel_id(&self, cx: &AppContext) -> Option<ChannelId> {
         self.active_chat
             .as_ref()
             .map(|(chat, _)| chat.read(cx).channel_id)
@@ -710,7 +710,7 @@ impl ChatPanel {
 
     pub fn select_channel(
         &mut self,
-        selected_channel_id: u64,
+        selected_channel_id: ChannelId,
         scroll_to_message_id: Option<u64>,
         cx: &mut ViewContext<ChatPanel>,
     ) -> Task<Result<()>> {

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use channel::{ChannelId, ChannelMembership, ChannelStore, MessageParams};
-use client::UserId;
+use channel::{ChannelMembership, ChannelStore, MessageParams};
+use client::{ChannelId, UserId};
 use collections::{HashMap, HashSet};
 use editor::{AnchorRangeExt, CompletionProvider, Editor, EditorElement, EditorStyle};
 use fuzzy::StringMatchCandidate;
@@ -131,7 +131,7 @@ impl MessageEditor {
 
     pub fn set_channel(
         &mut self,
-        channel_id: u64,
+        channel_id: ChannelId,
         channel_name: Option<SharedString>,
         cx: &mut ViewContext<Self>,
     ) {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -7,7 +7,7 @@ use crate::{
     CollaborationPanelSettings,
 };
 use call::ActiveCall;
-use channel::{Channel, ChannelEvent, ChannelId, ChannelStore};
+use channel::{Channel, ChannelEvent, ChannelId, ChannelStore, HostedProjectId};
 use client::{Client, Contact, User, UserStore};
 use contact_finder::ContactFinder;
 use db::kvp::KEY_VALUE_STORE;
@@ -183,6 +183,10 @@ enum ListEntry {
     },
     ChannelEditor {
         depth: usize,
+    },
+    HostedProject {
+        id: HostedProjectId,
+        name: SharedString,
     },
     Contact {
         contact: Arc<Contact>,
@@ -563,6 +567,8 @@ impl CollabPanel {
                     }
                 }
 
+                let hosted_projects = channel_store.projects_for_id(channel.id);
+                dbg!(&channel.id, &hosted_projects);
                 let has_children = channel_store
                     .channel_at_index(mat.candidate_id + 1)
                     .map_or(false, |next_channel| {
@@ -595,6 +601,10 @@ impl CollabPanel {
                             has_children,
                         });
                     }
+                }
+
+                for (name, id) in hosted_projects {
+                    self.entries.push(ListEntry::HostedProject { id, name })
                 }
             }
         }
@@ -1021,6 +1031,33 @@ impl CollabPanel {
             )
             .child(Label::new("chat"))
             .tooltip(move |cx| Tooltip::text("Open Chat", cx))
+    }
+
+    fn render_channel_project(
+        &self,
+        id: HostedProjectId,
+        name: &SharedString,
+        is_selected: bool,
+        cx: &mut ViewContext<Self>,
+    ) -> impl IntoElement {
+        ListItem::new(ElementId::NamedInteger(
+            "channel-project".into(),
+            id.0 as usize,
+        ))
+        .indent_level(2)
+        .indent_step_size(px(20.))
+        .selected(is_selected)
+        .on_click(cx.listener(move |_this, _, _cx| {
+            todo!();
+        }))
+        .start_slot(
+            h_flex()
+                .relative()
+                .gap_1()
+                .child(IconButton::new(0, IconName::FileTree)),
+        )
+        .child(Label::new(name.clone()))
+        .tooltip(move |cx| Tooltip::text("Open Project", cx))
     }
 
     fn has_subchannels(&self, ix: usize) -> bool {
@@ -1485,6 +1522,12 @@ impl CollabPanel {
                     }
                     ListEntry::ChannelChat { channel_id } => {
                         self.join_channel_chat(*channel_id, cx)
+                    }
+                    ListEntry::HostedProject {
+                        id: _id,
+                        name: _name,
+                    } => {
+                        todo!()
                     }
 
                     ListEntry::OutgoingRequest(_) => {}
@@ -2088,6 +2131,10 @@ impl CollabPanel {
                 .into_any_element(),
             ListEntry::ChannelChat { channel_id } => self
                 .render_channel_chat(*channel_id, is_selected, cx)
+                .into_any_element(),
+
+            ListEntry::HostedProject { id, name } => self
+                .render_channel_project(*id, name, is_selected, cx)
                 .into_any_element(),
         }
     }
@@ -2824,6 +2871,11 @@ impl PartialEq for ListEntry {
                 } = other
                 {
                     return channel_1.id == channel_2.id;
+                }
+            }
+            ListEntry::HostedProject { id, .. } => {
+                if let ListEntry::HostedProject { id: other_id, .. } = other {
+                    return id == other_id;
                 }
             }
             ListEntry::ChannelNotes { channel_id } => {

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -1,7 +1,7 @@
-use channel::{ChannelId, ChannelMembership, ChannelStore};
+use channel::{ChannelMembership, ChannelStore};
 use client::{
     proto::{self, ChannelRole, ChannelVisibility},
-    User, UserId, UserStore,
+    ChannelId, User, UserId, UserStore,
 };
 use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -1,7 +1,7 @@
 use crate::{chat_panel::ChatPanel, NotificationPanelSettings};
 use anyhow::Result;
 use channel::ChannelStore;
-use client::{Client, Notification, User, UserStore};
+use client::{ChannelId, Client, Notification, User, UserStore};
 use collections::HashMap;
 use db::kvp::KEY_VALUE_STORE;
 use futures::StreamExt;
@@ -357,7 +357,7 @@ impl NotificationPanel {
                         "{} invited you to join the #{channel_name} channel",
                         inviter.github_login
                     ),
-                    needs_response: channel_store.has_channel_invitation(channel_id),
+                    needs_response: channel_store.has_channel_invitation(ChannelId(channel_id)),
                     actor: Some(inviter),
                     can_navigate: false,
                 })
@@ -368,7 +368,7 @@ impl NotificationPanel {
                 message_id,
             } => {
                 let sender = user_store.get_cached_user(sender_id)?;
-                let channel = channel_store.channel_for_id(channel_id)?;
+                let channel = channel_store.channel_for_id(ChannelId(channel_id))?;
                 let message = self
                     .notification_store
                     .read(cx)
@@ -432,7 +432,7 @@ impl NotificationPanel {
                         if let Some(panel) = workspace.focus_panel::<ChatPanel>(cx) {
                             panel.update(cx, |panel, cx| {
                                 panel
-                                    .select_channel(channel_id, Some(message_id), cx)
+                                    .select_channel(ChannelId(channel_id), Some(message_id), cx)
                                     .detach_and_log_err(cx);
                             });
                         }
@@ -454,7 +454,7 @@ impl NotificationPanel {
                     panel.is_scrolled_to_bottom()
                         && panel
                             .active_chat()
-                            .map_or(false, |chat| chat.read(cx).channel_id == *channel_id)
+                            .map_or(false, |chat| chat.read(cx).channel_id.0 == *channel_id)
                 } else {
                     false
                 };

--- a/crates/notifications/src/notification_store.rs
+++ b/crates/notifications/src/notification_store.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use channel::{ChannelMessage, ChannelMessageId, ChannelStore};
-use client::{Client, UserStore};
+use client::{ChannelId, Client, UserStore};
 use collections::HashMap;
 use db::smol::stream::StreamExt;
 use gpui::{
@@ -413,7 +413,7 @@ impl NotificationStore {
             Notification::ChannelInvitation { channel_id, .. } => {
                 self.channel_store
                     .update(cx, |store, cx| {
-                        store.respond_to_channel_invite(channel_id, response, cx)
+                        store.respond_to_channel_invite(ChannelId(channel_id), response, cx)
                     })
                     .detach();
             }

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -12,7 +12,7 @@ message Envelope {
     uint32 id = 1;
     optional uint32 responding_to = 2;
     optional PeerId original_sender_id = 3;
-    
+
     /*
         When you are adding a new message type, instead of adding it in semantic order
         and bumping the message ID's of everything that follows, add it at the end of the
@@ -56,7 +56,7 @@ message Envelope {
         GetDefinitionResponse get_definition_response = 33;
         GetTypeDefinition get_type_definition = 34;
         GetTypeDefinitionResponse get_type_definition_response = 35;
-        
+
         GetReferences get_references = 36;
         GetReferencesResponse get_references_response = 37;
         GetDocumentHighlights get_document_highlights = 38;
@@ -192,7 +192,7 @@ message Envelope {
         LspExtExpandMacroResponse lsp_ext_expand_macro_response = 155;
         SetRoomParticipantRole set_room_participant_role = 156;
 
-        UpdateUserChannels update_user_channels = 157; 
+        UpdateUserChannels update_user_channels = 157;
 
         GetImplementation get_implementation = 162;
         GetImplementationResponse get_implementation_response = 163;
@@ -1026,6 +1026,9 @@ message UpdateChannels {
     repeated ChannelParticipants channel_participants = 7;
     repeated ChannelMessageId latest_channel_message_ids = 8;
     repeated ChannelBufferVersion latest_channel_buffer_versions = 9;
+
+    repeated HostedProject hosted_projects = 10;
+    repeated uint64 deleted_hosted_projects = 11;
 }
 
 message UpdateUserChannels {
@@ -1052,6 +1055,13 @@ message ChannelPermission {
 message ChannelParticipants {
     uint64 channel_id = 1;
     repeated uint64 participant_user_ids = 2;
+}
+
+message HostedProject {
+    uint64 id = 1;
+    uint64 channel_id = 2;
+    string name = 3;
+    ChannelVisibility visibility = 4;
 }
 
 message JoinChannel {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15,7 +15,7 @@ use anyhow::{anyhow, Context as _, Result};
 use call::{call_settings::CallSettings, ActiveCall};
 use client::{
     proto::{self, ErrorCode, PeerId},
-    Client, ErrorExt, Status, TypedEnvelope, UserStore,
+    ChannelId, Client, ErrorExt, Status, TypedEnvelope, UserStore,
 };
 use collections::{hash_map, HashMap, HashSet};
 use derive_more::{Deref, DerefMut};
@@ -4117,7 +4117,7 @@ pub async fn last_opened_workspace_paths() -> Option<WorkspaceLocation> {
 actions!(collab, [OpenChannelNotes]);
 
 async fn join_channel_internal(
-    channel_id: u64,
+    channel_id: ChannelId,
     app_state: &Arc<AppState>,
     requesting_window: Option<WindowHandle<Workspace>>,
     active_call: &Model<ActiveCall>,
@@ -4257,7 +4257,7 @@ async fn join_channel_internal(
 }
 
 pub fn join_channel(
-    channel_id: u64,
+    channel_id: ChannelId,
     app_state: Arc<AppState>,
     requesting_window: Option<WindowHandle<Workspace>>,
     cx: &mut AppContext,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -323,8 +323,10 @@ fn main() {
                 cx.spawn(|cx| async move {
                     // ignore errors here, we'll show a generic "not signed in"
                     let _ = authenticate(client, &cx).await;
-                    cx.update(|cx| workspace::join_channel(channel_id, app_state, None, cx))?
-                        .await?;
+                    cx.update(|cx| {
+                        workspace::join_channel(client::ChannelId(channel_id), app_state, None, cx)
+                    })?
+                    .await?;
                     anyhow::Ok(())
                 })
                 .detach_and_log_err(cx);
@@ -343,7 +345,7 @@ fn main() {
                         workspace::get_any_active_workspace(app_state, cx.clone()).await?;
                     let workspace = workspace_window.root_view(&cx)?;
                     cx.update_window(workspace_window.into(), |_, cx| {
-                        ChannelView::open(channel_id, heading, workspace, cx)
+                        ChannelView::open(client::ChannelId(channel_id), heading, workspace, cx)
                     })?
                     .await?;
                     anyhow::Ok(())
@@ -378,7 +380,12 @@ fn main() {
                         cx.update(|mut cx| {
                             cx.spawn(|cx| async move {
                                 cx.update(|cx| {
-                                    workspace::join_channel(channel_id, app_state, None, cx)
+                                    workspace::join_channel(
+                                        client::ChannelId(channel_id),
+                                        app_state,
+                                        None,
+                                        cx,
+                                    )
                                 })?
                                 .await?;
                                 anyhow::Ok(())
@@ -397,7 +404,12 @@ fn main() {
                                 workspace::get_any_active_workspace(app_state, cx.clone()).await?;
                             let workspace = workspace_window.root_view(&cx)?;
                             cx.update_window(workspace_window.into(), |_, cx| {
-                                ChannelView::open(channel_id, heading, workspace, cx)
+                                ChannelView::open(
+                                    client::ChannelId(channel_id),
+                                    heading,
+                                    workspace,
+                                    cx,
+                                )
                             })?
                             .await?;
                             anyhow::Ok(())


### PR DESCRIPTION
Add plumbing for hosted projects. This will currently show them if they exist
but provides no UX to create/rename/delete them.

Also changed the `ChannelId` type to not auto-cast to u64; this avoids type
confusion if you have multiple id types.


Release Notes:

- N/A
