### PR TITLE
Add advanced markdown support via markdown-oxide LSP

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -26,6 +26,7 @@ mod haskell;
 mod html;
 mod json;
 mod lua;
+mod markdown_lsp;
 mod nu;
 mod ocaml;
 mod php;
@@ -43,7 +44,6 @@ mod uiua;
 mod vue;
 mod yaml;
 mod zig;
-mod markdown_lsp;
 
 // 1. Add tree-sitter-{language} parser to zed crate
 // 2. Create a language directory in zed/crates/zed/src/languages and add the language to init function below
@@ -202,7 +202,10 @@ pub fn init(
             languages.clone(),
         ))],
     );
-    language("markdown", vec![Arc::new(markdown_lsp::MarkdownOxideLanguageServer)]);
+    language(
+        "markdown",
+        vec![Arc::new(markdown_lsp::MarkdownOxideLanguageServer)],
+    );
     language(
         "python",
         vec![Arc::new(python::PythonLspAdapter::new(

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -43,6 +43,7 @@ mod uiua;
 mod vue;
 mod yaml;
 mod zig;
+mod markdown_lsp;
 
 // 1. Add tree-sitter-{language} parser to zed crate
 // 2. Create a language directory in zed/crates/zed/src/languages and add the language to init function below
@@ -201,7 +202,7 @@ pub fn init(
             languages.clone(),
         ))],
     );
-    language("markdown", vec![]);
+    language("markdown", vec![Arc::new(markdown_lsp::MarkdownOxideLanguageServer)]);
     language(
         "python",
         vec![Arc::new(python::PythonLspAdapter::new(

--- a/crates/languages/src/markdown_lsp.rs
+++ b/crates/languages/src/markdown_lsp.rs
@@ -1,0 +1,57 @@
+use std::{any::Any, path::PathBuf};
+
+use async_trait::async_trait;
+use language::{LspAdapter, LanguageServerName, LspAdapterDelegate};
+use anyhow::{anyhow, Result};
+use lsp::LanguageServerBinary;
+
+pub struct MarkdownOxideLanguageServer;
+
+#[async_trait]
+impl LspAdapter for MarkdownOxideLanguageServer {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("Markdown Oxide".into())
+    }
+
+    fn short_name(&self) -> &'static str {
+        "markdown-oxide"
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Any + Send>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!(
+            "Markdown Oxide must be availiable in $PATH"
+        ))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "markdown-oxide".into(),
+            env: None,
+            arguments: vec![],
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
+        None
+    }
+}

--- a/crates/languages/src/markdown_lsp.rs
+++ b/crates/languages/src/markdown_lsp.rs
@@ -31,7 +31,7 @@ impl LspAdapter for MarkdownOxideLanguageServer {
         _: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
         Err(anyhow!(
-            "Markdown Oxide must be availiable in $PATH"
+            "Markdown Oxide must be available in $PATH"
         ))
     }
 
@@ -41,7 +41,7 @@ impl LspAdapter for MarkdownOxideLanguageServer {
         _: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
-            path: "markdown-oxide".into(),
+            path: "/home/felix/coding/LargerIdeas/ObsidianLS/obsidian-ls/target/release/markdown-oxide".into(),
             env: None,
             arguments: vec![],
         })

--- a/crates/languages/src/markdown_lsp.rs
+++ b/crates/languages/src/markdown_lsp.rs
@@ -1,8 +1,8 @@
 use std::{any::Any, path::PathBuf};
 
-use async_trait::async_trait;
-use language::{LspAdapter, LanguageServerName, LspAdapterDelegate};
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::LanguageServerBinary;
 
 pub struct MarkdownOxideLanguageServer;
@@ -30,9 +30,7 @@ impl LspAdapter for MarkdownOxideLanguageServer {
         _container_dir: PathBuf,
         _: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
-        Err(anyhow!(
-            "Markdown Oxide must be available in $PATH"
-        ))
+        Err(anyhow!("Markdown Oxide must be available in $PATH"))
     }
 
     async fn cached_server_binary(


### PR DESCRIPTION

Release Notes:

- Add advanced markdown support through supporting Obsidian syntax, completions, and backlinks for Obsidian vaults (and other collections of md files). 


(I assume this will not be merged any time soon as the language server is so new and not packaged for macos. However, I am happy that I got my language server [markdown oxide](https://github.com/Feel-ix-343/markdown-oxide) working with zed on linux, and I wanted to share; it can be installed with `paru -S markdown-oxide-git` and with this PR, opening a MD file in a folder of MD files will activate the server)

![Zedmoxidepreview](https://github.com/zed-industries/zed/assets/88951499/6dd31ccf-508d-47a5-b705-295c87baa760)
