### PR TITLE
project: enable missing project_core/test-support feature when test-support is enabled

### DIFF
--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -16,6 +16,7 @@ test-support = [
     "settings/test-support",
     "text/test-support",
     "prettier/test-support",
+    "project_core/test-support",
     "gpui/test-support",
 ]
 


### PR DESCRIPTION
This fixes collab's test build failure that @ConradIrwin has spotted.


Release Notes:

- N/A