### PR TITLE
macOS: Fix center window with fixed bounds size

### DIFF
--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -23,7 +23,15 @@ impl Render for HelloWorld {
 
 fn main() {
     App::new().run(|cx: &mut AppContext| {
-        cx.open_window(WindowOptions::default(), |cx| {
+        let options = WindowOptions {
+            bounds: WindowBounds::Fixed(Bounds {
+                size: size(px(600.0), px(600.0)).into(),
+                origin: Default::default(),
+            }),
+            center: true,
+            ..Default::default()
+        };
+        cx.open_window(options, |cx| {
             cx.new_view(|_cx| HelloWorld {
                 text: "World".into(),
             })

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -530,8 +530,27 @@ impl MacWindow {
                 }
             }
 
+            let window_rect = match options.bounds {
+                WindowBounds::Fullscreen => {
+                    // Set a temporary size as we will asynchronously resize the window
+                    NSRect::new(NSPoint::new(0., 0.), NSSize::new(1024., 768.))
+                }
+                WindowBounds::Maximized => {
+                    let display_bounds = display.bounds();
+                    global_bounds_to_ns_rect(display_bounds)
+                }
+                WindowBounds::Fixed(bounds) => {
+                    let display_bounds = display.bounds();
+                    if bounds.intersects(&display_bounds) {
+                        global_bounds_to_ns_rect(bounds)
+                    } else {
+                        global_bounds_to_ns_rect(display_bounds)
+                    }
+                }
+            };
+
             let native_window = native_window.initWithContentRect_styleMask_backing_defer_screen_(
-                NSRect::new(NSPoint::new(0., 0.), NSSize::new(1024., 768.)),
+                window_rect,
                 style_mask,
                 NSBackingStoreBuffered,
                 NO,
@@ -685,25 +704,10 @@ impl MacWindow {
                 native_window.orderFront_(nil);
             }
 
-            let screen = native_window.screen();
-            match options.bounds {
-                WindowBounds::Fullscreen => {
-                    // We need to toggle full screen asynchronously as doing so may
-                    // call back into the platform handlers.
-                    window.toggle_full_screen()
-                }
-                WindowBounds::Maximized => {
-                    native_window.setFrame_display_(screen.visibleFrame(), YES);
-                }
-                WindowBounds::Fixed(bounds) => {
-                    let display_bounds = display.bounds();
-                    let frame = if bounds.intersects(&display_bounds) {
-                        global_bounds_to_ns_rect(bounds)
-                    } else {
-                        global_bounds_to_ns_rect(display_bounds)
-                    };
-                    native_window.setFrame_display_(frame, YES);
-                }
+            if options.bounds == WindowBounds::Fullscreen {
+                // We need to toggle full screen asynchronously as doing so may
+                // call back into the platform handlers.
+                window.toggle_full_screen();
             }
 
             window.0.lock().move_traffic_light();


### PR DESCRIPTION
This PR fixes window showing up in the center of the monitor when `center: true` option is provided.

The idea is to set the `window_wize` when creating the `window` using `native_window.initWithContentRect_styleMask_backing_defer_screen_()`

Before: 

<img width="851" alt="SCR-20240227-qokf" src="https://github.com/zed-industries/zed/assets/20229808/27494966-2e97-4771-8837-ccb6658ced78">

After:

<img width="1132" alt="SCR-20240227-qlmg" src="https://github.com/zed-industries/zed/assets/20229808/439568da-d380-4331-8d19-cd501f211c4c">


Release Notes:

- N/A
