### PR TITLE
Revert "Add support of auto folded directories"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -187,10 +187,7 @@
     // Whether to reveal it in the project panel automatically,
     // when a corresponding project entry becomes active.
     // Gitignored entries are never auto revealed.
-    "auto_reveal_entries": true,
-    /// Whether to fold directories automatically
-    /// when directory has only one directory inside.
-    "auto_fold_dirs": true
+    "auto_reveal_entries": true
   },
   "collaboration_panel": {
     // Whether to show the collaboration panel button in the status bar.

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -20,7 +20,6 @@ pub struct ProjectPanelSettings {
     pub git_status: bool,
     pub indent_size: f32,
     pub auto_reveal_entries: bool,
-    pub auto_fold_dirs: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -55,11 +54,6 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub auto_reveal_entries: Option<bool>,
-    /// Whether to fold directories automatically
-    /// when directory has only one directory inside.
-    ///
-    /// Default: true
-    pub auto_fold_dirs: Option<bool>,
 }
 
 impl Settings for ProjectPanelSettings {


### PR DESCRIPTION
Reverts zed-industries/zed#7674

@ABckh: reverting this as it introduced a significant performance slowdown, most likely caused by iterating through all the snapshot entries to determine whether a directory is foldable/unfoldable/omitted. It would be great if you could open a new PR that reverts this revert and addresses the performance issues. Thank you!

/cc: @maxbrunsfeld 

Release notes:

- N/A