### PR TITLE
Fix copying folders into themselves to create copies

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -908,7 +908,8 @@ impl ProjectPanel {
                 .to_os_string();
 
             let mut new_path = entry.path.to_path_buf();
-            if entry.is_file() {
+            // If we're pasting into a file, or a directory into itself, go up one level.
+            if entry.is_file() || (entry.is_dir() && entry.id == clipboard_entry.entry_id()) {
                 new_path.pop();
             }
 


### PR DESCRIPTION
This fixes #7314 and #7778.

The problem was copying a folder into itself, which is actually quite a common operation in macOS's `Finder.app`: you select a folder, hit `cmd-c` and `cmd-v` and have a copy. That's also how it works in VS Code.

The fix here is to detect when we're copying a folder into itself and treating it like we're copying a file into itself: we don't want to copy into the target, we want to copy into the folder one level higher up, which will then automatically add a ` copy` to the end of the name.

Release Notes:

- Fixed ability to copy folders into themselves by selecting them in project panel and hitting `copy` and `paste`. Instead of endless recursion, a copy of the folder is now created. ([#7314](https://github.com/zed-industries/zed/issues/7314)).

Demo:


https://github.com/zed-industries/zed/assets/1185253/2141310a-991d-491d-8498-eb766275a1f5

