### PR TITLE
Adjust Cargo caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,16 +107,12 @@ jobs:
           clean: false
           submodules: "recursive"
 
-      - name: Restore from cache
-        uses: actions/cache@v4
+      - run: rustup toolchain install stable --profile minimal
+
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: configure linux
         shell: bash -euxo pipefail {0}
@@ -140,16 +136,12 @@ jobs:
           clean: false
           submodules: "recursive"
 
-      - name: Restore from cache
-        uses: actions/cache@v4
+      - run: rustup toolchain install stable --profile minimal
+
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: cargo clippy
         shell: bash -euxo pipefail {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
           clean: false
           submodules: "recursive"
 
-      - run: rustup toolchain install stable --profile minimal
-
       - name: Cache dependencies
         uses: swatinem/rust-cache@v2
         with:
@@ -135,8 +133,6 @@ jobs:
         with:
           clean: false
           submodules: "recursive"
-
-      - run: rustup toolchain install stable --profile minimal
 
       - name: Cache dependencies
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
This PR adjusts the way we cache Cargo dependencies in CI.

We're trying out [swatinem/rust-cache](https://github.com/swatinem/rust-cache) to see if it can improve our caching strategy such that we're able to get more cache hits on PRs.

We'll only write to the cache on `main` in the hopes that it will mitigate the amount of thrashing of the cache.

Release Notes:

- N/A
