### PR TITLE
Move note about screenshots up in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@ Release Notes:
 
 - Added/Fixed/Improved ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).
 
+Optionally, include screenshots / media showcasing your addition that can be included in the release notes.
+
 **or**
 
 - N/A
-
-Optionally, include screenshots / media showcasing your addition that can be included in the release notes.


### PR DESCRIPTION
This PR rearranges the PR template to move the line about including screenshots or media up underneath the `Added/Fixed/Improved` section.

This makes it easier to delete one section or the other depending on what kind of change you're making.

Release Notes:

- N/A
