### PR TITLE
Ensure more Zed files are formatted uniformly

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -9,6 +9,11 @@
       "format_on_save": "off"
     },
     "YAML": {
+      "tab_size": 2,
+      "formatter": "prettier"
+    },
+    "JSON": {
+      "tab_size": 2,
       "formatter": "prettier"
     }
   },


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/8500#issuecomment-1967522477

Now things are much better, but I still reformat the default.json settings file:

```diff
diff --git a/assets/settings/default.json b/assets/settings/default.json
index c60c53026..67bf4505b 100644
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -75,14 +75,7 @@
   // Hide the values of in variables from visual display in private files
   "redact_private_values": false,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
```

For me, Zed's doing that with the default prettier:
```
['/Users/someonetoignore/work/zed/zed/assets/settings/default.json' with options: {"printWidth":120,"tabWidth":2,"parser":"json","plugins":[],"path":"/Users/someonetoignore/work/zed/zed/assets/settings/default.json"}](stderr: Resolved config: {}, will format file '/Users/someonetoignore/work/zed/zed/assets/settings/default.json' with options: {"printWidth":120,"tabWidth":2,"parser":"json","plugins":[],"path":"/Users/someonetoignore/work/zed/zed/assets/settings/default.json"})
```

and `!/Library/Application Support/Zed/prettier/package-lock.json` states that I have
```
    "node_modules/prettier": {
      "version": "3.2.5",
      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
      "bin": {
        "prettier": "bin/prettier.cjs"
      },
      "engines": {
        "node": ">=14"
      },
      "funding": {
        "url": "https://github.com/prettier/prettier?sponsor=1"
      }
    },
```

Release Notes:


- N/A
