### PR TITLE
Add libssl-dev for apt dependencies

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -12,7 +12,6 @@ if [[ -n $apt ]]; then
     libfontconfig-dev
     libwayland-dev
     libxkbcommon-x11-dev
-    openssl
     libssl-dev
   )
   $maysudo "$apt" install -y "${deps[@]}"

--- a/script/linux
+++ b/script/linux
@@ -13,6 +13,7 @@ if [[ -n $apt ]]; then
     libwayland-dev
     libxkbcommon-x11-dev
     openssl
+    libssl-dev
   )
   $maysudo "$apt" install -y "${deps[@]}"
   exit 0


### PR DESCRIPTION
While building on Ubuntu (arm64). I had to manually install `libssl-dev`.
Just added that in `script/linux`.
