### PR TITLE
fix vim repeat

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -492,7 +492,9 @@
       "ctrl-x ctrl-l": "editor::ToggleCodeActions", // zed specific
       "ctrl-x ctrl-z": "editor::Cancel",
       "ctrl-w": "editor::DeleteToPreviousWordStart",
-      "ctrl-u": "editor::DeleteToBeginningOfLine"
+      "ctrl-u": "editor::DeleteToBeginningOfLine",
+      "ctrl-t": "vim::Indent",
+      "ctrl-d": "vim::Outdent"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -460,8 +460,8 @@
       "ctrl-c": ["vim::SwitchMode", "Normal"],
       "escape": ["vim::SwitchMode", "Normal"],
       "ctrl-[": ["vim::SwitchMode", "Normal"],
-      ">": "editor::Indent",
-      "<": "editor::Outdent",
+      ">": "vim::Indent",
+      "<": "vim::Outdent",
       "i": [
         "vim::PushOperator",
         {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -342,8 +342,8 @@
       "r": ["vim::PushOperator", "Replace"],
       "s": "vim::Substitute",
       "shift-s": "vim::SubstituteLine",
-      "> >": "editor::Indent",
-      "< <": "editor::Outdent",
+      "> >": "vim::Indent",
+      "< <": "vim::Outdent",
       "ctrl-pagedown": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem"
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4474,6 +4474,9 @@ impl Editor {
     }
 
     pub fn indent(&mut self, _: &Indent, cx: &mut ViewContext<Self>) {
+        if self.read_only(cx) {
+            return;
+        }
         let mut selections = self.selections.all::<Point>(cx);
         let mut prev_edited_row = 0;
         let mut row_delta = 0;
@@ -4567,6 +4570,9 @@ impl Editor {
     }
 
     pub fn outdent(&mut self, _: &Outdent, cx: &mut ViewContext<Self>) {
+        if self.read_only(cx) {
+            return;
+        }
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(cx);
         let mut deletion_ranges = Vec::new();
@@ -4707,6 +4713,9 @@ impl Editor {
     }
 
     pub fn join_lines(&mut self, _: &JoinLines, cx: &mut ViewContext<Self>) {
+        if self.read_only(cx) {
+            return;
+        }
         let mut row_ranges = Vec::<Range<u32>>::new();
         for selection in self.selections.all::<Point>(cx) {
             let start = selection.start.row;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4519,7 +4519,7 @@ impl Editor {
 
         // If a selection ends at the beginning of a line, don't indent
         // that last line.
-        if selection.end.column == 0 {
+        if selection.end.column == 0 && selection.end.row > selection.start.row {
             end_row -= 1;
         }
 

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -51,6 +51,8 @@ actions!(
         ConvertToUpperCase,
         ConvertToLowerCase,
         JoinLines,
+        Indent,
+        Outdent,
     ]
 );
 
@@ -125,6 +127,24 @@ pub(crate) fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace
                         editor.join_lines(&Default::default(), cx)
                     }
                 })
+            })
+        });
+    });
+
+    workspace.register_action(|_: &mut Workspace, _: &Indent, cx| {
+        Vim::update(cx, |vim, cx| {
+            vim.record_current_action(cx);
+            vim.update_active_editor(cx, |_, editor, cx| {
+                editor.transact(cx, |editor, cx| editor.indent(&Default::default(), cx))
+            })
+        });
+    });
+
+    workspace.register_action(|_: &mut Workspace, _: &Outdent, cx| {
+        Vim::update(cx, |vim, cx| {
+            vim.record_current_action(cx);
+            vim.update_active_editor(cx, |_, editor, cx| {
+                editor.transact(cx, |editor, cx| editor.outdent(&Default::default(), cx))
             })
         });
     });

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -127,7 +127,10 @@ pub(crate) fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace
                         editor.join_lines(&Default::default(), cx)
                     }
                 })
-            })
+            });
+            if vim.state().mode.is_visual() {
+                vim.switch_mode(Mode::Normal, false, cx)
+            }
         });
     });
 
@@ -136,7 +139,10 @@ pub(crate) fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace
             vim.record_current_action(cx);
             vim.update_active_editor(cx, |_, editor, cx| {
                 editor.transact(cx, |editor, cx| editor.indent(&Default::default(), cx))
-            })
+            });
+            if vim.state().mode.is_visual() {
+                vim.switch_mode(Mode::Normal, false, cx)
+            }
         });
     });
 
@@ -145,7 +151,10 @@ pub(crate) fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace
             vim.record_current_action(cx);
             vim.update_active_editor(cx, |_, editor, cx| {
                 editor.transact(cx, |editor, cx| editor.outdent(&Default::default(), cx))
-            })
+            });
+            if vim.state().mode.is_visual() {
+                vim.switch_mode(Mode::Normal, false, cx)
+            }
         });
     });
 

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -163,9 +163,9 @@ async fn test_indent_outdent(cx: &mut gpui::TestAppContext) {
     cx.simulate_keystrokes(["<", "<"]);
     cx.assert_editor_state("aa\nbˇb\ncc");
 
-    // works in visuial mode
+    // works in visual mode
     cx.simulate_keystrokes(["shift-v", "down", ">"]);
-    cx.assert_editor_state("aa\n    b«b\n    ccˇ»");
+    cx.assert_editor_state("aa\n    bb\n    cˇc");
 }
 
 #[gpui::test]

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -67,7 +67,6 @@ impl VimTestContext {
 
         // Setup search toolbars and keypress hook
         cx.update_workspace(|workspace, cx| {
-            observe_keystrokes(cx);
             workspace.active_pane().update(cx, |pane, cx| {
                 pane.toolbar().update(cx, |toolbar, cx| {
                     let buffer_search_bar = cx.new_view(BufferSearchBar::new);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -142,8 +142,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
 
         auto_update::notify_of_any_new_update(cx);
 
-        vim::observe_keystrokes(cx);
-
         let handle = cx.view().downgrade();
         cx.on_window_should_close(move |cx| {
             handle


### PR DESCRIPTION
Release Notes:

- vim: Fixed `.` when multiple windows are open ([#7446](https://github.com/zed-industries/zed/issues/7446)).
- vim: Fixed switching to normal mode after `J`, `<` or `>` in visual mode ([#4439](https://github.com/zed-industries/zed/issues/4439))
- vim: Added `ctrl-t` and `ctrl-d` for indent/outdent in insert mode.

- Fixed indent/outdent/join lines appearing to work in read-only buffers ([#8423](https://github.com/zed-industries/zed/issues/8423))
- Fixed indent with an empty selection when the cursor was in column 0
