### PR TITLE
Replace todo calls with error values in linux/platform

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -362,7 +362,9 @@ impl Platform for LinuxPlatform {
     }
 
     fn app_path(&self) -> Result<PathBuf> {
-        unimplemented!()
+        Err(anyhow::Error::msg(
+            "Platform<LinuxPlatform>::app_path is not implemented yet",
+        ))
     }
 
     //todo!(linux)
@@ -372,8 +374,11 @@ impl Platform for LinuxPlatform {
         UtcOffset::UTC
     }
 
+    //todo!(linux)
     fn path_for_auxiliary_executable(&self, name: &str) -> Result<PathBuf> {
-        unimplemented!()
+        Err(anyhow::Error::msg(
+            "Platform<LinuxPlatform>::path_for_auxiliary_executable is not implemented yet",
+        ))
     }
 
     //todo!(linux)
@@ -392,16 +397,25 @@ impl Platform for LinuxPlatform {
         None
     }
 
+    //todo!(linux)
     fn write_credentials(&self, url: &str, username: &str, password: &[u8]) -> Task<Result<()>> {
-        unimplemented!()
+        Task::Ready(Some(Err(anyhow::Error::msg(
+            "Platform<LinuxPlatform>::with_credentials is not implemented yet",
+        ))))
     }
 
+    //todo!(linux)
     fn read_credentials(&self, url: &str) -> Task<Result<Option<(String, Vec<u8>)>>> {
-        unimplemented!()
+        Task::Ready(Some(Err(anyhow::Error::msg(
+            "Platform<LinuxPlatform>::read_credentials is not implemented yet",
+        ))))
     }
 
+    //todo!(linux)
     fn delete_credentials(&self, url: &str) -> Task<Result<()>> {
-        unimplemented!()
+        Task::Ready(Some(Err(anyhow::Error::msg(
+            "Platform<LinuxPlatform>::delete_credentials is not implemented yet",
+        ))))
     }
 
     fn window_appearance(&self) -> crate::WindowAppearance {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -361,6 +361,7 @@ impl Platform for LinuxPlatform {
         })
     }
 
+    //todo!(linux)
     fn app_path(&self) -> Result<PathBuf> {
         Err(anyhow::Error::msg(
             "Platform<LinuxPlatform>::app_path is not implemented yet",


### PR DESCRIPTION
We currently use a mix of unimplemented methods with empty bodies and `todo!()` calls in linux/platform.

`todo!()`s cause crashes in runtime with accidental key presses or clicks.

To avoid this, this PR replaces `todo!()`s in linux/platform with error values.

This helps when working on Zed itself, testing PRs etc.

Release Notes:

- N/A