### PR TITLE
Do not set rules by default for eslint

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -241,7 +241,6 @@ impl LspAdapter for EsLintLspAdapter {
             // We enable this, but without also configuring `code_actions_on_format`
             // in the Zed configuration, it doesn't have an effect.
             "enable": true,
-            "rules": []
         });
 
         if let Some(code_action_settings) = eslint_user_settings


### PR DESCRIPTION
Follow-up to and fix for #8537.

Turns out that if you set `rules: []` it doesn't mean "no matchers", but it means "no rules". So let's not set a default here.

Release Notes:

- N/A, see #8537
