### PR TITLE
gpui: Don't impl IntoElement on ()

### DIFF
--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -1,9 +1,9 @@
 use crate::{
     Action, AnyElement, AnyView, AnyWindowHandle, AppCell, AppContext, AsyncAppContext,
-    AvailableSpace, BackgroundExecutor, Bounds, ClipboardItem, Context, Entity, EventEmitter,
-    ForegroundExecutor, Global, InputEvent, Keystroke, Model, ModelContext, Modifiers,
-    ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
-    Platform, Point, Render, Result, Size, Task, TestDispatcher, TestPlatform, TestWindow,
+    AvailableSpace, BackgroundExecutor, Bounds, ClipboardItem, Context, Empty, Entity,
+    EventEmitter, ForegroundExecutor, Global, InputEvent, Keystroke, Model, ModelContext,
+    Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    Pixels, Platform, Point, Render, Result, Size, Task, TestDispatcher, TestPlatform, TestWindow,
     TextSystem, View, ViewContext, VisualContext, WindowContext, WindowHandle, WindowOptions,
 };
 use anyhow::{anyhow, bail};
@@ -177,7 +177,7 @@ impl TestAppContext {
     /// Adds a new window with no content.
     pub fn add_empty_window(&mut self) -> &mut VisualTestContext {
         let mut cx = self.app.borrow_mut();
-        let window = cx.open_window(WindowOptions::default(), |cx| cx.new_view(|_| ()));
+        let window = cx.open_window(WindowOptions::default(), |cx| cx.new_view(|_| Empty));
         drop(cx);
         let cx = VisualTestContext::from_window(*window.deref(), self).as_mut();
         cx.run_until_parked();

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -132,8 +132,10 @@ pub trait Render: 'static + Sized {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement;
 }
 
-impl Render for () {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {}
+impl Render for Empty {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        Empty
+    }
 }
 
 /// You can derive [`IntoElement`] on any type that implements this trait.
@@ -514,9 +516,9 @@ impl IntoElement for AnyElement {
 }
 
 /// The empty element, which renders nothing.
-pub type Empty = ();
+pub struct Empty;
 
-impl IntoElement for () {
+impl IntoElement for Empty {
     type Element = Self;
 
     fn element_id(&self) -> Option<ElementId> {
@@ -528,7 +530,7 @@ impl IntoElement for () {
     }
 }
 
-impl Element for () {
+impl Element for Empty {
     type State = ();
 
     fn request_layout(

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -1,5 +1,6 @@
 use crate::{
-    point, seal::Sealed, IntoElement, Keystroke, Modifiers, Pixels, Point, Render, ViewContext,
+    point, seal::Sealed, Empty, IntoElement, Keystroke, Modifiers, Pixels, Point, Render,
+    ViewContext,
 };
 use smallvec::SmallVec;
 use std::{any::Any, fmt::Debug, ops::Deref, path::PathBuf};
@@ -343,7 +344,8 @@ impl ExternalPaths {
 
 impl Render for ExternalPaths {
     fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
-        // Intentionally left empty because the platform will render icons for the dragged files
+        // the platform will render icons for the dragged files
+        Empty
     }
 }
 

--- a/crates/gpui_macros/src/derive_render.rs
+++ b/crates/gpui_macros/src/derive_render.rs
@@ -12,7 +12,7 @@ pub fn derive_render(input: TokenStream) -> TokenStream {
         #where_clause
         {
             fn render(&mut self, _cx: &mut gpui::ViewContext<Self>) -> impl gpui::Element {
-                ()
+                gpui::Empty
             }
         }
     };

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1477,7 +1477,7 @@ mod tests {
                 buffer_text,
             )
         });
-        let window = cx.add_window(|_| ());
+        let window = cx.add_window(|_| gpui::Empty);
 
         let editor = window.build_view(cx, |cx| Editor::for_buffer(buffer.clone(), None, cx));
 


### PR DESCRIPTION
Although it's kinda cute, rust makes it too easy to accidentally return
() from a function.

/cc @nathansobo

Release Notes:

- N/A
