### PR TITLE
Setting to show/hide terminal title

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -458,6 +458,10 @@
         // Can also be 'csh', 'fish', and `nushell`
         "activate_script": "default"
       }
+    },
+    "toolbar": {
+      // Whether to display the terminal title in its toolbar.
+      "title": true
     }
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -18,6 +18,11 @@ pub enum TerminalDockPosition {
     Right,
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct Toolbar {
+    pub title: bool,
+}
+
 #[derive(Deserialize)]
 pub struct TerminalSettings {
     pub shell: Shell,
@@ -36,6 +41,7 @@ pub struct TerminalSettings {
     pub default_height: Pixels,
     pub detect_venv: VenvSettings,
     pub max_scroll_history_lines: Option<usize>,
+    pub toolbar: Toolbar,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -155,6 +161,8 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: 10_000
     pub max_scroll_history_lines: Option<usize>,
+    /// Toolbar related settings
+    pub toolbar: Option<ToolbarContent>,
 }
 
 impl settings::Settings for TerminalSettings {
@@ -273,4 +281,13 @@ pub enum WorkingDirectory {
     /// If this path is not a valid directory the terminal will default to
     /// this platform's home directory  (if it can be found).
     Always { directory: String },
+}
+
+// Toolbar related settings
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ToolbarContent {
+    /// Whether to display the terminal title in its toolbar.
+    ///
+    /// Default: true
+    pub title: Option<bool>,
 }

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -681,6 +681,9 @@ These values take in the same options as the root-level settings with the same n
   "font_size": null,
   "option_as_meta": false,
   "shell": {},
+  "toolbar": {
+    "title": true
+  },
   "working_directory": "current_project_directory"
 }
 ```
@@ -838,6 +841,22 @@ See Buffer Font Features
   }
 }
 ```
+
+## Terminal Toolbar
+
+- Description: Whether or not to show various elements in the terminal toolbar. It only affects terminals placed in the editor pane.
+- Setting: `toolbar`
+- Default:
+
+```json
+"toolbar": {
+  "title": true,
+},
+```
+
+**Options**
+
+At the moment, only the `title` option is available, it controls displaying of the terminal title that can be changed via `PROMPT_COMMAND`. If the title is hidden, the terminal toolbar is not displayed.
 
 ### Working Directory
 


### PR DESCRIPTION
This PR adds settings for hiding title (breadcrumbs) from the terminal toolbar. If the title is hidden, the toolbar disappears completely.

Example:

```json
"terminal": {
  "toolbar": {
    "title": true,
  }
}
```

[The PR that added the "toolbar" setting](https://github.com/zed-industries/zed/pull/7338) didn't affect toolbars of the terminals that are placed in the editor pane. This PR fixes that.

Related Issues:

- Fixes #8125

Release Notes:

- Added support for configuring the terminal toolbar.