### PR TITLE
Enable cherry-pick-bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: false


### PR DESCRIPTION
You will now be able to say `/cherry-pick v0.123.x` to cherry-pick to a different branch.

Release Notes:

- N/A
