### PR TITLE
Avoid an unwrap when loading languages

### DIFF
--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -97,14 +97,14 @@ fn test_select_language() {
     // matching file extension
     assert_eq!(
         registry
-            .language_for_file("zed/lib.rs", None)
+            .language_for_file("zed/lib.rs".as_ref(), None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Rust".into())
     );
     assert_eq!(
         registry
-            .language_for_file("zed/lib.mk", None)
+            .language_for_file("zed/lib.mk".as_ref(), None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
@@ -113,7 +113,7 @@ fn test_select_language() {
     // matching filename
     assert_eq!(
         registry
-            .language_for_file("zed/Makefile", None)
+            .language_for_file("zed/Makefile".as_ref(), None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         Some("Make".into())
@@ -122,21 +122,21 @@ fn test_select_language() {
     // matching suffix that is not the full file extension or filename
     assert_eq!(
         registry
-            .language_for_file("zed/cars", None)
+            .language_for_file("zed/cars".as_ref(), None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
         registry
-            .language_for_file("zed/a.cars", None)
+            .language_for_file("zed/a.cars".as_ref(), None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None
     );
     assert_eq!(
         registry
-            .language_for_file("zed/sumk", None)
+            .language_for_file("zed/sumk".as_ref(), None)
             .now_or_never()
             .and_then(|l| Some(l.ok()?.name())),
         None

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1522,16 +1522,16 @@ mod tests {
         });
 
         languages
-            .language_for_file("the/script", None)
+            .language_for_file("the/script".as_ref(), None)
             .await
             .unwrap_err();
         languages
-            .language_for_file("the/script", Some(&"nothing".into()))
+            .language_for_file("the/script".as_ref(), Some(&"nothing".into()))
             .await
             .unwrap_err();
         assert_eq!(
             languages
-                .language_for_file("the/script", Some(&"#!/bin/env node".into()))
+                .language_for_file("the/script".as_ref(), Some(&"#!/bin/env node".into()))
                 .await
                 .unwrap()
                 .name()

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -315,10 +315,13 @@ impl Peer {
                             "incoming response: requester resumed"
                         );
                     } else {
+                        let message_type = proto::build_typed_envelope(connection_id, incoming)
+                            .map(|p| p.payload_type_name());
                         tracing::warn!(
                             %connection_id,
                             message_id,
                             responding_to,
+                            message_type,
                             "incoming response: unknown request"
                         );
                     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2751,18 +2751,20 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_bundled_languages(cx: &mut AppContext) {
-        let settings = SettingsStore::test(cx);
+    async fn test_bundled_languages(cx: &mut TestAppContext) {
+        let settings = cx.update(|cx| SettingsStore::test(cx));
         cx.set_global(settings);
         let mut languages = LanguageRegistry::test();
-        languages.set_executor(cx.background_executor().clone());
+        languages.set_executor(cx.executor().clone());
         let languages = Arc::new(languages);
         let node_runtime = node_runtime::FakeNodeRuntime::new();
-        languages::init(languages.clone(), node_runtime, cx);
+        cx.update(|cx| {
+            languages::init(languages.clone(), node_runtime, cx);
+        });
         for name in languages.language_names() {
-            languages.language_for_name(&name);
+            languages.language_for_name(&name).await.unwrap();
         }
-        cx.background_executor().run_until_parked();
+        cx.run_until_parked();
     }
 
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {


### PR DESCRIPTION
We couldn't reproduce the panic, but I believe it was possible when uninstalling an extension while one if its grammars was still loading.

Release Notes:
- Fixed a crash that could happen when uninstalling a language extension while its grammar was loading.