### PR TITLE
Revert "Introduce a new `ToggleGraphicsProfiler` command (#7607)"

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -195,8 +195,8 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn is_topmost_for_position(&self, position: Point<Pixels>) -> bool;
     fn draw(&self, scene: &Scene);
+
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
-    fn set_graphics_profiler_enabled(&self, enabled: bool);
 
     #[cfg(any(test, feature = "test-support"))]
     fn as_test(&mut self) -> Option<&mut TestWindow> {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -396,10 +396,6 @@ impl PlatformWindow for WaylandWindow {
         let inner = self.0.inner.lock();
         inner.renderer.sprite_atlas().clone()
     }
-
-    fn set_graphics_profiler_enabled(&self, enabled: bool) {
-        //todo!(linux)
-    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -513,8 +513,4 @@ impl PlatformWindow for X11Window {
         let inner = self.0.inner.lock();
         inner.renderer.sprite_atlas().clone()
     }
-
-    fn set_graphics_profiler_enabled(&self, enabled: bool) {
-        unimplemented!("linux")
-    }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1060,27 +1060,6 @@ impl PlatformWindow for MacWindow {
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.0.lock().renderer.sprite_atlas().clone()
     }
-
-    /// Enables or disables the Metal HUD for debugging purposes. Note that this only works
-    /// when the app is bundled and it has the `MetalHudEnabled` key set to true in Info.plist.
-    fn set_graphics_profiler_enabled(&self, enabled: bool) {
-        let this_lock = self.0.lock();
-        let layer = this_lock.renderer.layer();
-
-        unsafe {
-            if enabled {
-                let hud_properties = NSDictionary::dictionaryWithObject_forKey_(
-                    nil,
-                    ns_string("default"),
-                    ns_string("mode"),
-                );
-                let _: () = msg_send![layer, setDeveloperHUDProperties: hud_properties];
-            } else {
-                let _: () =
-                    msg_send![layer, setDeveloperHUDProperties: NSDictionary::dictionary(nil)];
-            }
-        }
-    }
 }
 
 impl HasWindowHandle for MacWindow {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -251,8 +251,6 @@ impl PlatformWindow for TestWindow {
         self.0.lock().sprite_atlas.clone()
     }
 
-    fn set_graphics_profiler_enabled(&self, _enabled: bool) {}
-
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         Some(self)
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -280,7 +280,6 @@ pub struct Window {
     pub(crate) focus: Option<FocusId>,
     focus_enabled: bool,
     pending_input: Option<PendingInput>,
-    graphics_profiler_enabled: bool,
 }
 
 #[derive(Default, Debug)]
@@ -474,7 +473,6 @@ impl Window {
             focus: None,
             focus_enabled: true,
             pending_input: None,
-            graphics_profiler_enabled: false,
         }
     }
     fn new_focus_listener(
@@ -1517,14 +1515,6 @@ impl<'a> WindowContext<'a> {
                 }
             }
         }
-    }
-
-    /// Toggle the graphics profiler to debug your application's rendering performance.
-    pub fn toggle_graphics_profiler(&mut self) {
-        self.window.graphics_profiler_enabled = !self.window.graphics_profiler_enabled;
-        self.window
-            .platform_window
-            .set_graphics_profiler_enabled(self.window.graphics_profiler_enabled);
     }
 
     /// Register the given handler to be invoked whenever the global of the given type

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -121,7 +121,6 @@ actions!(
         ToggleRightDock,
         ToggleBottomDock,
         CloseAllDocks,
-        ToggleGraphicsProfiler,
     ]
 );
 
@@ -3583,7 +3582,6 @@ impl Workspace {
                     workspace.reopen_closed_item(cx).detach();
                 }),
             )
-            .on_action(|_: &ToggleGraphicsProfiler, cx| cx.toggle_graphics_profiler())
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/zed/resources/info/Permissions.plist
+++ b/crates/zed/resources/info/Permissions.plist
@@ -22,5 +22,3 @@
 <string>An application in Zed wants to use speech recognition.</string>
 <key>NSRemindersUsageDescription</key>
 <string>An application in Zed wants to use your reminders.</string>
-<key>MetalHudEnabled</key>
-<true />

--- a/crates/zed/src/app_menus.rs
+++ b/crates/zed/src/app_menus.rs
@@ -156,10 +156,6 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::action("View Telemetry", crate::OpenTelemetryLog),
                 MenuItem::action("View Dependency Licenses", crate::OpenLicenses),
                 MenuItem::action("Show Welcome", workspace::Welcome),
-                MenuItem::action(
-                    "Toggle Graphics Profiler",
-                    workspace::ToggleGraphicsProfiler,
-                ),
                 MenuItem::separator(),
                 MenuItem::action(
                     "Documentation",


### PR DESCRIPTION
This reverts commit 0cebf68306ab0ef08693701532260e1fdc0f1ee9.

Although this thing is very cool, it is a top source of crashes.

Example crash:
```
Segmentation fault: 11 on thread 26
  objc_retain +16
  invocation function for block in Overlay::onCommandBufferCommit(id<MTLCommandBuffer>) +60
  MTLDispatchListApply +52
```

Release Notes:

- Removed "Toggle Graphics Profiler" as it crashes too much.
