### PR TITLE
Implement workspace_configuration for Dart LSP

### DIFF
--- a/crates/languages/src/dart.rs
+++ b/crates/languages/src/dart.rs
@@ -1,8 +1,15 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use gpui::AppContext;
 use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::LanguageServerBinary;
-use std::{any::Any, path::PathBuf};
+use project::project_settings::ProjectSettings;
+use serde_json::Value;
+use settings::Settings;
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+};
 
 pub struct DartLanguageServer;
 
@@ -50,5 +57,17 @@ impl LspAdapter for DartLanguageServer {
 
     async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
         None
+    }
+
+    fn workspace_configuration(&self, _workspace_root: &Path, cx: &mut AppContext) -> Value {
+        let settings = ProjectSettings::get_global(cx)
+            .lsp
+            .get("dart")
+            .and_then(|s| s.settings.clone())
+            .unwrap_or_default();
+
+        serde_json::json!({
+            "dart": settings
+        })
     }
 }


### PR DESCRIPTION
This PR addressed https://github.com/zed-industries/zed/issues/8558 and allows the [Dart Client Workspace Configuration](https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/tool/lsp_spec/README.md#client-workspace-configuration).

Differing from the issue, the settings are used from the LSP settings section, example: 

```
{
 "lsp": {
    "dart": {
      "settings": {
        "lineLength": 200
      }
    }
  }
}
```

Note: this only works for the global settings (not folder specific)


Release Notes:

- Fixed missing client workspace configuration of Dart LSP. Those can now be configured by setting `{"lsp":  {"dart": { "settings: { "your-settings-here": "here"} } }` in the Zed settings. ([#8858](https://github.com/zed-industries/zed/issues/8558)).

