### PR TITLE
Added `menu::UseSelectedQuery` command that populates task modal query with the selected task name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9146,6 +9146,7 @@ dependencies = [
  "picker",
  "project",
  "serde",
+ "serde_json",
  "task",
  "ui",
  "util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9140,8 +9140,10 @@ name = "tasks_ui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "editor",
  "fuzzy",
  "gpui",
+ "language",
  "menu",
  "picker",
  "project",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -16,6 +16,7 @@
       "ctrl-enter": "menu::SecondaryConfirm",
       "escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
+      "shift-enter": "menu::UseSelectedQuery",
       "ctrl-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "ctrl-o": "workspace::Open",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -17,6 +17,7 @@
       "cmd-enter": "menu::SecondaryConfirm",
       "escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
+      "shift-enter": "menu::UseSelectedQuery",
       "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "cmd-o": "workspace::Open",

--- a/crates/menu/src/menu.rs
+++ b/crates/menu/src/menu.rs
@@ -19,6 +19,7 @@ actions!(
         SelectNext,
         SelectFirst,
         SelectLast,
-        ShowContextMenu
+        ShowContextMenu,
+        UseSelectedQuery,
     ]
 );

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -99,6 +99,8 @@ pub use language::Location;
 pub use prettier::FORMAT_SUFFIX as TEST_PRETTIER_FORMAT_SUFFIX;
 pub use project_core::project_settings;
 pub use project_core::worktree::{self, *};
+#[cfg(feature = "test-support")]
+pub use task_inventory::test_inventory::*;
 pub use task_inventory::{Inventory, TaskSourceKind};
 
 const MAX_SERVER_REINSTALL_ATTEMPT_COUNT: u64 = 4;

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -227,9 +227,12 @@ pub mod test_inventory {
     };
 
     use gpui::{AppContext, Context as _, Model, ModelContext, TestAppContext};
+    use project_core::worktree::WorktreeId;
     use task::{Task, TaskId, TaskSource};
 
     use crate::Inventory;
+
+    use super::TaskSourceKind;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct TestTask {
@@ -255,11 +258,11 @@ pub mod test_inventory {
         }
     }
 
-    pub struct TestSource {
+    pub struct StaticTestSource {
         pub tasks: Vec<TestTask>,
     }
 
-    impl TestSource {
+    impl StaticTestSource {
         pub fn new(
             task_names: impl IntoIterator<Item = String>,
             cx: &mut AppContext,
@@ -279,7 +282,7 @@ pub mod test_inventory {
         }
     }
 
-    impl TaskSource for TestSource {
+    impl TaskSource for StaticTestSource {
         fn tasks_for_path(
             &mut self,
             _path: Option<&Path>,
@@ -300,14 +303,15 @@ pub mod test_inventory {
     pub fn list_task_names(
         inventory: &Model<Inventory>,
         path: Option<&Path>,
+        worktree: Option<WorktreeId>,
         lru: bool,
         cx: &mut TestAppContext,
     ) -> Vec<String> {
         inventory.update(cx, |inventory, cx| {
             inventory
-                .list_tasks(path, lru, cx)
+                .list_tasks(path, worktree, lru, cx)
                 .into_iter()
-                .map(|task| task.name().to_string())
+                .map(|(_, task)| task.name().to_string())
                 .collect()
         })
     }
@@ -319,12 +323,28 @@ pub mod test_inventory {
     ) {
         inventory.update(cx, |inventory, cx| {
             let task = inventory
-                .list_tasks(None, false, cx)
+                .list_tasks(None, None, false, cx)
                 .into_iter()
-                .find(|task| task.name() == task_name)
+                .find(|(_, task)| task.name() == task_name)
                 .unwrap_or_else(|| panic!("Failed to find task with name {task_name}"));
-            inventory.task_scheduled(task.id().clone());
+            inventory.task_scheduled(task.1.id().clone());
         });
+    }
+
+    pub fn list_tasks(
+        inventory: &Model<Inventory>,
+        path: Option<&Path>,
+        worktree: Option<WorktreeId>,
+        lru: bool,
+        cx: &mut TestAppContext,
+    ) -> Vec<(TaskSourceKind, String)> {
+        inventory.update(cx, |inventory, cx| {
+            inventory
+                .list_tasks(path, worktree, lru, cx)
+                .into_iter()
+                .map(|(source_kind, task)| (source_kind, task.name().to_string()))
+                .collect()
+        })
     }
 }
 
@@ -639,115 +659,5 @@ mod tests {
                 "Path {path:?} choice should not adjust static runnables for worktree_2"
             );
         }
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    struct TestTask {
-        id: TaskId,
-        name: String,
-    }
-
-    impl Task for TestTask {
-        fn id(&self) -> &TaskId {
-            &self.id
-        }
-
-        fn name(&self) -> &str {
-            &self.name
-        }
-
-        fn cwd(&self) -> Option<&Path> {
-            None
-        }
-
-        fn exec(&self, _cwd: Option<PathBuf>) -> Option<task::SpawnInTerminal> {
-            None
-        }
-    }
-
-    struct StaticTestSource {
-        tasks: Vec<TestTask>,
-    }
-
-    impl StaticTestSource {
-        fn new(
-            task_names: impl IntoIterator<Item = String>,
-            cx: &mut AppContext,
-        ) -> Model<Box<dyn TaskSource>> {
-            cx.new_model(|_| {
-                Box::new(Self {
-                    tasks: task_names
-                        .into_iter()
-                        .enumerate()
-                        .map(|(i, name)| TestTask {
-                            id: TaskId(format!("task_{i}_{name}")),
-                            name,
-                        })
-                        .collect(),
-                }) as Box<dyn TaskSource>
-            })
-        }
-    }
-
-    impl TaskSource for StaticTestSource {
-        fn tasks_for_path(
-            &mut self,
-            // static task source does not depend on path input
-            _: Option<&Path>,
-            _cx: &mut ModelContext<Box<dyn TaskSource>>,
-        ) -> Vec<Arc<dyn Task>> {
-            self.tasks
-                .clone()
-                .into_iter()
-                .map(|task| Arc::new(task) as Arc<dyn Task>)
-                .collect()
-        }
-
-        fn as_any(&mut self) -> &mut dyn std::any::Any {
-            self
-        }
-    }
-
-    fn list_task_names(
-        inventory: &Model<Inventory>,
-        path: Option<&Path>,
-        worktree: Option<WorktreeId>,
-        lru: bool,
-        cx: &mut TestAppContext,
-    ) -> Vec<String> {
-        inventory.update(cx, |inventory, cx| {
-            inventory
-                .list_tasks(path, worktree, lru, cx)
-                .into_iter()
-                .map(|(_, task)| task.name().to_string())
-                .collect()
-        })
-    }
-
-    fn list_tasks(
-        inventory: &Model<Inventory>,
-        path: Option<&Path>,
-        worktree: Option<WorktreeId>,
-        lru: bool,
-        cx: &mut TestAppContext,
-    ) -> Vec<(TaskSourceKind, String)> {
-        inventory.update(cx, |inventory, cx| {
-            inventory
-                .list_tasks(path, worktree, lru, cx)
-                .into_iter()
-                .map(|(source_kind, task)| (source_kind, task.name().to_string()))
-                .collect()
-        })
-    }
-
-    fn register_task_used(inventory: &Model<Inventory>, task_name: &str, cx: &mut TestAppContext) {
-        inventory.update(cx, |inventory, cx| {
-            let (_, task) = inventory
-                .list_tasks(None, None, false, cx)
-                .into_iter()
-                .find(|(_, task)| task.name() == task_name)
-                .unwrap_or_else(|| panic!("Failed to find task with name {task_name}"));
-            inventory.task_scheduled(task.id().clone());
-        });
     }
 }

--- a/crates/tasks_ui/Cargo.toml
+++ b/crates/tasks_ui/Cargo.toml
@@ -19,5 +19,8 @@ util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
+editor = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
+serde_json.workspace = true
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/tasks_ui/Cargo.toml
+++ b/crates/tasks_ui/Cargo.toml
@@ -17,3 +17,7 @@ serde.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+project = { workspace = true, features = ["test-support"] }

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -276,35 +276,171 @@ impl PickerDelegate for TasksModalDelegate {
 
 #[cfg(test)]
 mod tests {
-    use gpui::TestAppContext;
-    use project::{FakeFs, Project, TestSource, TestTask};
+    use gpui::{TestAppContext, VisualTestContext};
+    use project::{FakeFs, Project};
     use serde_json::json;
+    use workspace::AppState;
 
     use super::*;
 
     #[gpui::test]
     async fn test_name(cx: &mut TestAppContext) {
+        init_test(cx);
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
             "/dir",
             json!({
+                ".zed": {
+                    "tasks.json": r#"[
+                        {
+                            "label": "example task",
+                            "command": "echo",
+                            "args": ["4"]
+                        },
+                        {
+                            "label": "another one",
+                            "command": "echo",
+                            "args": ["55"]
+                        },
+                    ]"#,
+                },
                 "a.ts": "a"
             }),
         )
         .await;
 
         let project = Project::test(fs, ["/dir".as_ref()], cx).await;
-        let workspace = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
-        let pane = workspace
-            .update(cx, |workspace, cx| {
-                workspace
-                    .toggle_modal(cx, |cx| {
-                        TasksModal::new(Inventory::new(cx), cx.view().downgrade(), cx)
-                    })
-                    .clone()
+        project.update(cx, |project, cx| {
+            project.task_inventory().update(cx, |inventory, cx| {
+                inventory.add_source(TaskSourceKind::UserInput, |cx| OneshotSource::new(cx), cx)
             })
-            .unwrap();
+        });
 
-        todo!("TODO kb")
+        let (workspace, cx) = cx.add_window_view(|cx| Workspace::test_new(project, cx));
+
+        let tasks_picker = open_spawn_tasks(&workspace, cx);
+        assert_eq!(
+            query(&tasks_picker, cx),
+            "",
+            "Initial query should be empty"
+        );
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec!["another one", "example task"],
+            "Initial tasks should be listed in alphabetical order"
+        );
+
+        let query_str = "tas";
+        cx.simulate_input(query_str);
+        assert_eq!(query(&tasks_picker, cx), query_str);
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec!["example task"],
+            "Only one task should match the query {query_str}"
+        );
+
+        cx.dispatch_action(menu::UseSelectedQuery);
+        assert_eq!(
+            query(&tasks_picker, cx),
+            "example task",
+            "Query should be set to the selected task's name"
+        );
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec!["example task"],
+            "No other tasks should be listed"
+        );
+        cx.dispatch_action(menu::Confirm);
+
+        let tasks_picker = open_spawn_tasks(&workspace, cx);
+        assert_eq!(
+            query(&tasks_picker, cx),
+            "",
+            "Query should be reset after confirming"
+        );
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec!["example task", "another one"],
+            "Last recently used task should be listed first"
+        );
+
+        let query_str = "echo 4";
+        cx.simulate_input(query_str);
+        assert_eq!(query(&tasks_picker, cx), query_str);
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            Vec::<String>::new(),
+            "No tasks should match custom command query"
+        );
+
+        cx.dispatch_action(menu::SecondaryConfirm);
+        let tasks_picker = open_spawn_tasks(&workspace, cx);
+        assert_eq!(
+            query(&tasks_picker, cx),
+            "",
+            "Query should be reset after confirming"
+        );
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec![query_str, "example task", "another one"],
+            "Last recently used one show task should be listed first"
+        );
+
+        cx.dispatch_action(menu::UseSelectedQuery);
+        assert_eq!(
+            query(&tasks_picker, cx),
+            query_str,
+            "Query should be set to the custom task's name"
+        );
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec![query_str],
+            "Only custom task should be listed"
+        );
+    }
+
+    fn open_spawn_tasks(
+        workspace: &View<Workspace>,
+        cx: &mut VisualTestContext,
+    ) -> View<Picker<TasksModalDelegate>> {
+        cx.dispatch_action(crate::modal::Spawn);
+        workspace.update(cx, |workspace, cx| {
+            workspace
+                .active_modal::<TasksModal>(cx)
+                .unwrap()
+                .read(cx)
+                .picker
+                .clone()
+        })
+    }
+
+    fn query(spawn_tasks: &View<Picker<TasksModalDelegate>>, cx: &mut VisualTestContext) -> String {
+        spawn_tasks.update(cx, |spawn_tasks, cx| spawn_tasks.query(cx))
+    }
+
+    fn task_names(
+        spawn_tasks: &View<Picker<TasksModalDelegate>>,
+        cx: &mut VisualTestContext,
+    ) -> Vec<String> {
+        spawn_tasks.update(cx, |spawn_tasks, _| {
+            spawn_tasks
+                .delegate
+                .matches
+                .iter()
+                .map(|hit| hit.string.clone())
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
+        cx.update(|cx| {
+            let state = AppState::test(cx);
+            language::init(cx);
+            crate::init(cx);
+            editor::init(cx);
+            workspace::init_settings(cx);
+            Project::init_settings(cx);
+            state
+        })
     }
 }

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -4,6 +4,8 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
 
 Currently, two kinds of tasks are supported, but more will be added in the future.
 
+All tasks are are sorted in LRU order and their names can be used (with `menu::UseSelectedQuery`, `shift-enter` by default) as an input text for quicker oneshot task edit-spawn cycle.
+
 ## Static tasks
 
 Tasks, defined in a config file (`tasks.json` in the Zed config directory) that do not depend on the current editor or its content.


### PR DESCRIPTION
Calling `menu::UseSelectedQuery` (`shift-enter` by default) now puts task name into the spawn task modal, allowing to edit-spawn looks for custom, bash-like tasks.

Also test task modal functionality.


Release Notes:

- Added `menu::UseSelectedQuery` command that populates task modal query with the selected task name