### PR TITLE
Fix default Vim keybinds for GoTo(Type)DefinitionSplit

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -289,10 +289,10 @@
       "ctrl-w n": ["workspace::NewFileInDirection", "Up"],
       "ctrl-w ctrl-n": ["workspace::NewFileInDirection", "Up"],
 
-      "ctrl-w d": "editorGoToDefinitionSplit",
-      "ctrl-w g d": "editorGoToDefinitionSplit",
-      "ctrl-w shift-d": "editorGoToTypeDefinitionSplit",
-      "ctrl-w g shift-d": "editorGoToTypeDefinitionSplit",
+      "ctrl-w d": "editor::GoToDefinitionSplit",
+      "ctrl-w g d": "editor::GoToDefinitionSplit",
+      "ctrl-w shift-d": "editor::GoToTypeDefinitionSplit",
+      "ctrl-w g shift-d": "editor::GoToTypeDefinitionSplit",
       "ctrl-w space": "editor::OpenExcerptsSplit",
       "ctrl-w g space": "editor::OpenExcerptsSplit",
       "-": "pane::RevealInProjectPanel"


### PR DESCRIPTION
Follow-up to #8574

Release Notes:

- N/A
