### PR TITLE
Clean up and refactor X11 refresh loop

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -96,8 +96,7 @@ objc = "0.2"
 flume = "0.11"
 open = "5.0.1"
 ashpd = "0.7.0"
-# todo(linux) - Technically do not use `randr`, but it doesn't compile otherwise
-xcb = { version = "1.3", features = ["as-raw-xcb-connection", "present", "randr", "xkb"] }
+xcb = { version = "1.3", features = ["as-raw-xcb-connection", "randr", "xkb"] }
 wayland-client= { version = "0.31.2" }
 wayland-protocols = { version = "0.31.2", features = ["client", "staging", "unstable"] }
 wayland-backend = { version = "0.3.3", features = ["client_system"] }

--- a/crates/gpui/src/platform/linux/client.rs
+++ b/crates/gpui/src/platform/linux/client.rs
@@ -11,4 +11,5 @@ pub trait Client {
         handle: AnyWindowHandle,
         options: WindowOptions,
     ) -> Box<dyn PlatformWindow>;
+    fn handle_idle(&self);
 }

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -122,18 +122,18 @@ impl Platform for LinuxPlatform {
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {
         on_finish_launching();
+        let client = Rc::clone(&self.client);
+
         self.inner
             .event_loop
             .borrow_mut()
-            .run(None, &mut (), |data| {})
+            .run(None, &mut (), |&mut ()| {
+                client.handle_idle();
+            })
             .expect("Run loop failed");
 
-        let mut lock = self.inner.callbacks.borrow_mut();
-        if let Some(mut fun) = lock.quit.take() {
-            drop(lock);
+        if let Some(mut fun) = self.inner.callbacks.borrow_mut().quit.take() {
             fun();
-            let mut lock = self.inner.callbacks.borrow_mut();
-            lock.quit = Some(fun);
         }
     }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -217,6 +217,8 @@ impl Client for WaylandClient {
         state.windows.push((xdg_surface, Rc::clone(&window_state)));
         Box::new(WaylandWindow(window_state))
     }
+
+    fn handle_idle(&self) {}
 }
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for WaylandClientState {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1,11 +1,11 @@
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
 use xcb::{x, Xid as _};
 use xkbcommon::xkb;
 
-use collections::{HashMap, HashSet};
+use collections::HashMap;
 
 use crate::platform::linux::client::Client;
 use crate::platform::{LinuxPlatformInner, PlatformWindow};
@@ -15,11 +15,19 @@ use crate::{
 };
 
 use super::{X11Display, X11Window, X11WindowState, XcbAtoms};
-use calloop::generic::{FdWrapper, Generic};
+use calloop::{
+    generic::{FdWrapper, Generic},
+    RegistrationToken,
+};
 
-pub(crate) struct X11ClientState {
-    pub(crate) windows: HashMap<x::Window, Rc<X11WindowState>>,
-    pub(crate) windows_to_refresh: HashSet<x::Window>,
+struct WindowRef {
+    state: Rc<X11WindowState>,
+    needs_refresh: bool,
+    refresh_event_token: RegistrationToken,
+}
+
+struct X11ClientState {
+    windows: HashMap<x::Window, WindowRef>,
     xkb: xkbcommon::xkb::State,
 }
 
@@ -28,7 +36,6 @@ pub(crate) struct X11Client {
     xcb_connection: Rc<xcb::Connection>,
     x_root_index: i32,
     atoms: XcbAtoms,
-    refresh_millis: Cell<u64>,
     state: RefCell<X11ClientState>,
 }
 
@@ -36,11 +43,7 @@ impl X11Client {
     pub(crate) fn new(inner: Rc<LinuxPlatformInner>) -> Rc<Self> {
         let (xcb_connection, x_root_index) = xcb::Connection::connect_with_extensions(
             None,
-            &[
-                xcb::Extension::Present,
-                xcb::Extension::Xkb,
-                xcb::Extension::RandR,
-            ],
+            &[xcb::Extension::RandR, xcb::Extension::Xkb],
             &[],
         )
         .unwrap();
@@ -55,33 +58,32 @@ impl X11Client {
 
         let atoms = XcbAtoms::intern_all(&xcb_connection).unwrap();
         let xcb_connection = Rc::new(xcb_connection);
-        let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
-        let xkb_device_id = xkb::x11::get_core_keyboard_device_id(&xcb_connection);
-        let xkb_keymap = xkb::x11::keymap_new_from_device(
-            &xkb_context,
-            &xcb_connection,
-            xkb_device_id,
-            xkb::KEYMAP_COMPILE_NO_FLAGS,
-        );
 
-        let xkb_state =
-            xkb::x11::state_new_from_device(&xkb_keymap, &xcb_connection, xkb_device_id);
+        let xkb_state = {
+            let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+            let xkb_device_id = xkb::x11::get_core_keyboard_device_id(&xcb_connection);
+            let xkb_keymap = xkb::x11::keymap_new_from_device(
+                &xkb_context,
+                &xcb_connection,
+                xkb_device_id,
+                xkb::KEYMAP_COMPILE_NO_FLAGS,
+            );
+            xkb::x11::state_new_from_device(&xkb_keymap, &xcb_connection, xkb_device_id)
+        };
 
         let client: Rc<X11Client> = Rc::new(Self {
             platform_inner: inner.clone(),
-            xcb_connection: xcb_connection.clone(),
+            xcb_connection: Rc::clone(&xcb_connection),
             x_root_index,
             atoms,
-            refresh_millis: Cell::new(16),
             state: RefCell::new(X11ClientState {
                 windows: HashMap::default(),
-                windows_to_refresh: HashSet::default(),
                 xkb: xkb_state,
             }),
         });
 
         // Safety: Safe if xcb::Connection always returns a valid fd
-        let fd = unsafe { FdWrapper::new(xcb_connection.clone()) };
+        let fd = unsafe { FdWrapper::new(Rc::clone(&xcb_connection)) };
 
         inner
             .loop_handle
@@ -92,12 +94,10 @@ impl X11Client {
                     calloop::Mode::Level,
                 ),
                 {
-                    let client = client.clone();
-                    move |readiness, _, _| {
-                        if readiness.readable || readiness.error {
-                            while let Some(event) = xcb_connection.poll_for_event()? {
-                                client.handle_event(event);
-                            }
+                    let client = Rc::clone(&client);
+                    move |_readiness, _, _| {
+                        while let Some(event) = xcb_connection.poll_for_event()? {
+                            client.handle_event(event);
                         }
                         Ok(calloop::PostAction::Continue)
                     }
@@ -105,37 +105,12 @@ impl X11Client {
             )
             .expect("Failed to initialize x11 event source");
 
-        inner
-            .loop_handle
-            .insert_source(
-                calloop::timer::Timer::from_duration(Duration::from_millis(
-                    client.refresh_millis.get(),
-                )),
-                {
-                    let client = client.clone();
-                    move |_, _, _| {
-                        client.present();
-                        calloop::timer::TimeoutAction::ToDuration(Duration::from_millis(
-                            client.refresh_millis.get(),
-                        ))
-                    }
-                },
-            )
-            .expect("Failed to initialize refresh timer");
-
         client
     }
 
     fn get_window(&self, win: x::Window) -> Option<Rc<X11WindowState>> {
         let state = self.state.borrow();
-        state.windows.get(&win).cloned()
-    }
-
-    fn present(&self) {
-        let state = self.state.borrow_mut();
-        for window_state in state.windows.values() {
-            window_state.refresh();
-        }
+        state.windows.get(&win).map(|wr| Rc::clone(&wr.state))
     }
 
     fn handle_event(&self, event: xcb::Event) -> Option<()> {
@@ -143,20 +118,20 @@ impl X11Client {
             xcb::Event::X(x::Event::ClientMessage(event)) => {
                 if let x::ClientMessageData::Data32([atom, ..]) = event.data() {
                     if atom == self.atoms.wm_del_window.resource_id() {
-                        self.state
-                            .borrow_mut()
-                            .windows_to_refresh
-                            .remove(&event.window());
                         // window "x" button clicked by user, we gracefully exit
-                        let window = self
+                        let window_ref = self
                             .state
                             .borrow_mut()
                             .windows
                             .remove(&event.window())
                             .unwrap();
-                        window.destroy();
-                        let state = self.state.borrow();
-                        if state.windows.is_empty() {
+
+                        self.platform_inner
+                            .loop_handle
+                            .remove(window_ref.refresh_event_token);
+                        window_ref.state.destroy();
+
+                        if self.state.borrow().windows.is_empty() {
                             self.platform_inner.loop_signal.stop();
                         }
                     }
@@ -175,6 +150,12 @@ impl X11Client {
                 };
                 let window = self.get_window(event.window())?;
                 window.configure(bounds);
+            }
+            xcb::Event::X(x::Event::Expose(event)) => {
+                let mut state = self.state.borrow_mut();
+                if let Some(ref mut window_ref) = state.windows.get_mut(&event.window()) {
+                    window_ref.needs_refresh = true;
+                }
             }
             xcb::Event::X(x::Event::FocusIn(event)) => {
                 let window = self.get_window(event.event())?;
@@ -322,7 +303,6 @@ impl Client for X11Client {
             x_window,
             &self.atoms,
         ));
-        window_ptr.request_refresh();
 
         let cookie = self
             .xcb_connection
@@ -343,21 +323,49 @@ impl Client for X11Client {
             .find(|m| m.id == mode_id)
             .expect("Missing screen mode for crtc specified mode id");
 
-        let refresh_millies = mode_refresh_rate_millis(mode);
+        let refresh_event_token = self
+            .platform_inner
+            .loop_handle
+            .insert_source(calloop::timer::Timer::immediate(), {
+                let refresh_duration = mode_refresh_rate(mode);
+                let xcb_connection = Rc::clone(&self.xcb_connection);
+                move |instant, (), _| {
+                    xcb_connection.send_request(&x::SendEvent {
+                        propagate: false,
+                        destination: x::SendEventDest::Window(x_window),
+                        event_mask: x::EventMask::EXPOSURE,
+                        event: &x::ExposeEvent::new(x_window, 0, 0, 0, 0, 1),
+                    });
+                    let _ = xcb_connection.flush();
+                    calloop::timer::TimeoutAction::ToInstant(instant + refresh_duration)
+                }
+            })
+            .expect("Failed to initialize refresh timer");
 
-        self.refresh_millis.set(refresh_millies);
-
-        self.state
-            .borrow_mut()
-            .windows
-            .insert(x_window, Rc::clone(&window_ptr));
+        let window_ref = WindowRef {
+            state: Rc::clone(&window_ptr),
+            needs_refresh: true,
+            refresh_event_token,
+        };
+        self.state.borrow_mut().windows.insert(x_window, window_ref);
         Box::new(X11Window(window_ptr))
+    }
+
+    fn handle_idle(&self) {
+        for window_ref in self.state.borrow_mut().windows.values_mut() {
+            if window_ref.needs_refresh {
+                window_ref.needs_refresh = false;
+                window_ref.state.refresh();
+            }
+        }
     }
 }
 
 // Adatpted from:
 // https://docs.rs/winit/0.29.11/src/winit/platform_impl/linux/x11/monitor.rs.html#103-111
-pub fn mode_refresh_rate_millis(mode: &xcb::randr::ModeInfo) -> u64 {
+pub fn mode_refresh_rate(mode: &xcb::randr::ModeInfo) -> Duration {
     let millihertz = mode.dot_clock as u64 * 1_000 / (mode.htotal as u64 * mode.vtotal as u64);
-    (millihertz as f64 / 1_000_000.) as u64
+    let micros = 1_000_000_000 / millihertz;
+    log::info!("Refreshing at {} micros", micros);
+    Duration::from_micros(micros)
 }


### PR DESCRIPTION
Associates every window with its own refresh event. Removes the use of X11 present and a couple other things.
Includes the original fix suggested by @gabydd , just done in the new `handle_idle`.
See also - #8655

Note that the presentation is involves the following steps with this change:
  1. refresh rate event triggers in the event loop. It sends an Expose message to the window.
  2. idle callback picks up the dirty bit and calls `refresh`.
  3. this goes through "user-defined" function and ends up doing draw() + present()
  4. it's on screen! profit!

Release Notes:
- N/A
