### PR TITLE
Use `Pointer` cursor style on Recent Projects, VCS Menu.

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -111,6 +111,7 @@ impl Render for RecentProjects {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex()
             .w(rems(self.rem_width))
+            .cursor_pointer()
             .child(self.picker.clone())
             .on_mouse_down_out(cx.listener(|this, _, cx| {
                 this.picker.update(cx, |this, cx| {

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -67,6 +67,7 @@ impl Render for BranchList {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex()
             .w(rems(self.rem_width))
+            .cursor_pointer()
             .child(self.picker.clone())
             .on_mouse_down_out(cx.listener(|this, _, cx| {
                 this.picker.update(cx, |this, cx| {


### PR DESCRIPTION

Release Notes:

- Improved to use `Pointer` style cursor on VCS and Recent Projects menu.


https://github.com/zed-industries/zed/assets/5518/4f638c6a-00b8-4fa8-b469-4d3109827bc2

