### PR TITLE
Support Bitbucket.org in permalinks

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8625,8 +8625,6 @@ impl Editor {
     }
 
     fn get_permalink_to_line(&mut self, cx: &mut ViewContext<Self>) -> Result<url::Url> {
-        use git::permalink::{build_permalink, BuildPermalinkParams};
-
         let project = self.project.clone().ok_or_else(|| anyhow!("no project"))?;
         let project = project.read(cx);
 
@@ -8651,7 +8649,6 @@ impl Editor {
             .lock()
             .head_sha()
             .ok_or_else(|| anyhow!("failed to read HEAD SHA"))?;
-
         let path = maybe!({
             let buffer = self.buffer().read(cx).as_singleton()?;
             let file = buffer.read(cx).file().and_then(|f| f.as_local())?;
@@ -8662,12 +8659,12 @@ impl Editor {
         let selections = self.selections.all::<Point>(cx);
         let selection = selections.iter().peekable().next();
 
-        build_permalink(BuildPermalinkParams {
-            remote_url: &origin_url,
-            sha: &sha,
-            path: &path,
-            selection: selection.map(|selection| selection.range()),
-        })
+        git::permalink::build_permalink(
+            &origin_url,
+            &sha,
+            &path,
+            selection.map(|selection| selection.range()),
+        )
     }
 
     pub fn copy_permalink_to_line(&mut self, _: &CopyPermalinkToLine, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
This adds support for Bitbucket.org/Bitbucket Cloud repositories to the `editor: copy permalink to line` and `editor: open permalink to line` actions.

Fixes #5110.



Release Notes:

- Added support for repositories hosted on Bitbucket.org (Bitbucket Cloud) to the `editor: copy permalink to line` and `editor: open permalink to line` actions. ([#5110](https://github.com/zed-industries/zed/issues/5110)).