### PR TITLE
Bind ctrl-w to DeleteToPreviousWordStart

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -49,6 +49,7 @@
       "cmd-backspace": "editor::DeleteToBeginningOfLine",
       "cmd-delete": "editor::DeleteToEndOfLine",
       "alt-backspace": "editor::DeleteToPreviousWordStart",
+      "ctrl-w": "editor::DeleteToPreviousWordStart",
       "alt-delete": "editor::DeleteToNextWordEnd",
       "alt-h": "editor::DeleteToPreviousWordStart",
       "alt-d": "editor::DeleteToNextWordEnd",


### PR DESCRIPTION
Even though I use Vim mode, I'd love to have this in the command palette/fuzzy finder. It's an Emacs keybinding, but also supported by macOS nearly everywhere.

Release Notes:

- N/A
